### PR TITLE
testing

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,71 @@
+###### int4wo + dyn ######
+
+# echo "int4wo dyn gptq"
+# wikitext: {'word_perplexity,none': 12.812570926788453, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6111408960535434, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6880826648386306, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+# echo "int4wo dyn"
+# wikitext: {'word_perplexity,none': 13.231905415833804, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6208730195318632, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6967710734172881, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+
+###### int4wo ######
+
+# echo "int4wo gptq"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_gptq_quantizer_int4wo
+# echo "int4wo gptq"
+# # wikitext: {'word_perplexity,none': 12.798085443034763, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6108001089599417, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.687777474985057, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+
+# echo "int4wo"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_quantizer_int4wo
+# echo "int4wo"
+# # wikitext: {'word_perplexity,none': 13.158980323604943, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.619198724726618, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6952800588854063, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+###### 8da4w ######
+
+# echo "8da4w gptq"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_8da4w_gptq_quantizer
+# echo "8da4w gptq"
+# # wikitext: {'word_perplexity,none': 15.652681759772047, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6726076112218886, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.7420990330980423, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+# echo "8da4w"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_8da4w_quantizer_eval
+# echo "8da4w"
+# # wikitext: {'word_perplexity,none': 13.331669008220858, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6231513927415857, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6987975675823629, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+###### 8da4w no dynamic act ######
+
+# echo "8da4w gptq"
+# # wikitext: {'word_perplexity,none': 12.826275573373177, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6114630248462083, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6883710860189309, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+# echo "8da4w"
+# wikitext: {'word_perplexity,none': 13.284947841658525, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6220861196463254, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6978504170203109, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+###### 8da4w gptq ignore act quant ######
+
+###### 8da4w experiments ######
+
+# echo "8da4w gptq ignore act"
+# wikitext: {'word_perplexity,none': 16.847579811963474, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6957766378049428, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.7619461553063979, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+###### new activation ######
+
+# echo "8da4w new dynamic_act"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_8da4w_quantizer_eval
+# echo "8da4w new dynamic_act"
+# # wikitext: {'word_perplexity,none': 13.404829017406016, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6248134072268074, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.7002740492640743, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+
+# echo "8da4w new dynamic_act gptq"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_8da4w_gptq_quantizer
+# echo "8da4w new dynamic_act gptq"
+# # wikitext: {'word_perplexity,none': 186.35249273879637, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 2.658055424531603, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 1.4103711873316307, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+# # echo "int4wo newdyn gptq"
+# # python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_gptq_quantizer_int4wo
+# # echo "int4wo newdyn gptq"
+# wikitext: {'word_perplexity,none': 12.861107615954907, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6122804971230007, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6891027591294213, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
+
+
+# echo "int4wo newdyn"
+# python /home/cdhernandez/local/ao/test/quantization/test_quant_api.py -k test_quantizer_int4wo
+# echo "int4wo newdyn"
+# # wikitext: {'word_perplexity,none': 13.386525729748959, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6243982948142355, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6999054179299502, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -555,22 +555,26 @@ if TORCH_VERSION_AFTER_2_3:
 
 
     def per_token_dynamic_quant(input: torch.Tensor) -> torch.Tensor:
-        orig_dtype = input.dtype
-        # TODO: we may need to make the choose_qparams op configurable
-        (
-            scales,
-            zero_points,
-        ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
-            input, torch.int8
-        )
+        x_int, scales =  quantize_activation_per_token_absmax(input)
+        return (x_int*scales).to(input.dtype)
 
-        # TODO: get these from torch.int8
-        quant_min = -128
-        quant_max = 127
-        input = torch.ops.quantized_decomposed.quantize_per_token(
-            input, scales, zero_points, quant_min, quant_max, torch.int8
-        )
-        input = torch.ops.quantized_decomposed.dequantize_per_token(
-            input, scales, zero_points, quant_min, quant_max, torch.int8, orig_dtype
-        )
-        return input.to(orig_dtype)
+
+        # orig_dtype = input.dtype
+        # # TODO: we may need to make the choose_qparams op configurable
+        # (
+        #     scales,
+        #     zero_points,
+        # ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
+        #     input, torch.int8
+        # )
+
+        # # TODO: get these from torch.int8
+        # quant_min = -128
+        # quant_max = 127
+        # input = torch.ops.quantized_decomposed.quantize_per_token(
+        #     input, scales, zero_points, quant_min, quant_max, torch.int8
+        # )
+        # input = torch.ops.quantized_decomposed.dequantize_per_token(
+        #     input, scales, zero_points, quant_min, quant_max, torch.int8, orig_dtype
+        # )
+        # return input.to(orig_dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #129

Summary: unable to determine what is going on with 8da4w

summary of experiments

8da4w -  13.33
8da4w + gptq - 15.65

why is gptq performing worse than vanilla quant here?

int4wo - 13.15
in4wo + gptq - 12.798

seems like this works. Maybe i'll try to remove the dynamic activation
from 8da4w:

8da4w no act_q - 13.284
8da4w no act_q + gptq - 12.826

this looks fine. Maybe the issue is the dynamic activation then, will do
int4wo but add dynamic activation quantization to it to see if that
breaks it

int4wo act_q - 13.23
int4wo act_q + gptq - 12.81

that didn't break it, which is surprising, maybe i'll change the dynamic
activation to something different (symmetric per token dynamic
quantization) and rerun the experiments and see what i get

8da4w new act_q - 13.404
8da4w new act_q + gptq - 186.352
int4wo new act_q - 13.386
int4wo new act_q + gptq - 12.861

seems like once again 8da4w isn't working as expected. Perhaps we can
avoid the issue by doing gptq and ignoring the activation quantization?

8da4w gptq ignore act - 16.847

(didn't work)

next steps are probably to mimic padding/dtypes/qparam format compared to initial
gpt-fast work and see if that fixes the issue?

Tes Plan: see run.sh

Reviewers:

Subscribers:

Tasks:

Tags: