### PR TITLE
Disable fail-fast in CI

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  group: regression_test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: CUDA 2.2.2
@@ -31,6 +32,7 @@ jobs:
           - name: Nightly CPU
             runs-on: 32-core-ubuntu
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cpu'
+      
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
A lot of our CI failures are because there's some missing missing flag/feature available in nightlies or because some cpu of cuda skip test wheras the behavior right now is if 1 CI job fails all the other jobs get canceled. The main benefit of the old behavior is shorter queue times so we can revisit flipping this back off when/if queue times become a problem

I also add a check to disable concurrent jobs what that means is let's say you send many commits to a single PR, CI will only be evaluated on the newest commit