### PR TITLE
Export env var in the doc build

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -50,7 +50,7 @@ jobs:
           # conf.py to display the version in the
           # site dropdown
           GITHUB_REF=${{ github.ref }}
-          TORCHAO_VERSION_DOCS="${GITHUB_REF}"
+          export TORCHAO_VERSION_DOCS="${GITHUB_REF}"
           echo "$TORCHAO_VERSION_DOCS"
       - name: Build docs
         run: |

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Build docs
         env:
-          ET_VERSION_DOCS: ${{ github.ref }}
+          TORCHAO_VERSION_DOCS: ${{ github.ref }}
         run: |
           cd docs
           make html

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -43,16 +43,9 @@ jobs:
           python -m pip install -e .
           cd docs
           python -m pip install -r requirements.txt
-      - name: Get the torchtune version
-        run: |
-          # Get the github.ref_name and save into the
-          # REF_NAME variable. This will be passed in
-          # conf.py to display the version in the
-          # site dropdown
-          GITHUB_REF=${{ github.ref }}
-          export TORCHAO_VERSION_DOCS="${GITHUB_REF}"
-          echo "$TORCHAO_VERSION_DOCS"
       - name: Build docs
+        env:
+          ET_VERSION_DOCS: ${{ github.ref }}
         run: |
           cd docs
           make html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,8 @@ if torchao_version_docs:
         version = ".".join(
             torchao_version_docs.split("/")[-1].split("-")[0].lstrip("v").split(".")[:2]
         )
+    elif et_version_docs.startswith("refs/heads/release/"):
+        version = et_version_docs.split("/")[-1]
 print(f"Version: {version}")
 html_title = " ".join((project, version, "documentation"))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ project = "torchao"
 
 # Get TORCHAO_VERSION_DOCS during the build.
 torchao_version_docs = os.environ.get("TORCHAO_VERSION_DOCS", None)
+print(f"et_version_docs: {et_version_docs}")
 
 # The code below will cut version displayed in the dropdown like this:
 # by default "main" is set.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ project = "torchao"
 
 # Get TORCHAO_VERSION_DOCS during the build.
 torchao_version_docs = os.environ.get("TORCHAO_VERSION_DOCS", None)
-print(f"et_version_docs: {et_version_docs}")
+print(f"torchao_version_docs: {torchao_version_docs}")
 
 # The code below will cut version displayed in the dropdown like this:
 # by default "main" is set.
@@ -77,8 +77,8 @@ if torchao_version_docs:
         version = ".".join(
             torchao_version_docs.split("/")[-1].split("-")[0].lstrip("v").split(".")[:2]
         )
-    elif et_version_docs.startswith("refs/heads/release/"):
-        version = et_version_docs.split("/")[-1]
+    elif torchao_version_docs.startswith("refs/heads/release/"):
+        version = torchao_version_docs.split("/")[-1]
 print(f"Version: {version}")
 html_title = " ".join((project, version, "documentation"))
 


### PR DESCRIPTION
Need to export the TORCHAO_VERSION_DOCS env in the build job so it's correctly propagated to the `make html` command.
This:
```
Running Sphinx v5.0.0
torchao_version_docs: refs/pull/177/merge
Version: main
```
Will become this on tags and release:
```
Running Sphinx v5.0.0
torchao_version_docs: refs/heads/release/0.1
Version: 0.1
```
```
Running Sphinx v5.0.0
torchao_version_docs: refs/tags/v0.1.0-rc2
Version: 0.1
```
This will be reflected in the left nav version dropdown. 