### PR TITLE
add expecttest to requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 # Test utilities
 pytest==7.4.0
-expecttest
 unittest-xml-reporting
 parameterized
 packaging
@@ -9,7 +8,7 @@ transformers
 # For prototype features and benchmarks
 bitsandbytes #needed for testing triton quant / dequant ops for 8-bit optimizers
 matplotlib
-pandas 
+pandas
 
 # Custom CUDA Extensions
 ninja

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 sentencepiece
 packaging
 expecttest # So we can use IS_FBCODE flag
+hypothesis # Avoid test derandomization warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 numpy
 sentencepiece
 packaging
+expecttest # So we can use IS_FBCODE flag


### PR DESCRIPTION
Fixes https://github.com/pytorch/ao/issues/222

Tested locally

```
(new) [marksaroufim@devvm17057.vll0 ~]$ pip uninstall expecttest
Found existing installation: expecttest 0.2.1
Uninstalling expecttest-0.2.1:
  Would remove:
    /home/marksaroufim/.local/lib/python3.10/site-packages/expecttest-0.2.1.dist-info/*
    /home/marksaroufim/.local/lib/python3.10/site-packages/expecttest/*
Proceed (Y/n)? Y
  Successfully uninstalled expecttest-0.2.1
(new) [marksaroufim@devvm17057.vll0 ~]$ python -c "import torchao"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/__init__.py", line 8, in <module>
    from torch.testing._internal.common_utils import IS_FBCODE
  File "/home/marksaroufim/.local/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 62, in <module>
    import expecttest
```

Which is fixed if you pip install expecttest but then you get a warning for hypothesis on every import

```
new) [marksaroufim@devvm17057.vll0 ~/ao (msaroufim/expectest)]$ python -c "import torchao"
Fail to import hypothesis in common_utils, tests are not derandomized
(new) [marksaroufim@devvm17057.vll0 ~/ao (msaroufim/expectest)]$ pip install hypothesis
Collecting hypothesis
  Downloading hypothesis-6.100.5-py3-none-any.whl.metadata (6.3 kB)
Collecting attrs>=22.2.0 (from hypothesis)
  Using cached attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
Collecting sortedcontainers<3.0.0,>=2.1.0 (from hypothesis)
  Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl.metadata (10 kB)
Requirement already satisfied: exceptiongroup>=1.0.0 in /home/marksaroufim/.local/lib/python3.10/site-packages (from hypothesis) (1.2.0)
Downloading hypothesis-6.100.5-py3-none-any.whl (459 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 459.1/459.1 kB 6.1 MB/s eta 0:00:00
Using cached attrs-23.2.0-py3-none-any.whl (60 kB)
Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Installing collected packages: sortedcontainers, attrs, hypothesis
Successfully installed attrs-23.2.0 hypothesis-6.100.5 sortedcontainers-2.4.0
(new) [marksaroufim@devvm17057.vll0 ~/ao (msaroufim/expectest)]$ python -c "import torchao"
(new) [marksaroufim@devvm17057.vll0 ~/ao (msaroufim/expectest)]$ 
```