### PR TITLE
Skip depending on torch testing package

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -5,8 +5,12 @@ from torchao.quantization import (
 )
 from . import dtypes
 import torch
-from torch.testing._internal.common_utils import IS_FBCODE
-if not IS_FBCODE:
+_IS_FBCODE = (
+    hasattr(torch._utils_internal, "IS_FBSOURCE") and
+    torch._utils_internal.IS_FBSOURCE
+)
+
+if not _IS_FBCODE:
     from . import _C
     from . import ops
 


### PR DESCRIPTION
Summary:
We used to do
```
from torch.testing._internal.common_utils import IS_FBCODE
```
but this caused some internal failures, so we'll just copy paste the code for `IS_FBCODE` so that we don't depend on the testing package

Test Plan:
internal CI

Reviewers:

Subscribers:

Tasks:

Tags: