### PR TITLE
[8da4w] Add support to skip quantizing some layers

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -299,6 +299,30 @@ class TestQAT(unittest.TestCase):
         torch.testing.assert_close(nn_model.linear2.weight, qat_model.linear2.weight, atol=0, rtol=0)
         torch.testing.assert_close(nn_model.sub.linear.weight, qat_model.sub.linear.weight, atol=0, rtol=0)
 
+    @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    def test_qat_8da4w_quantizer_skip_quantize_filter(self):
+        from torchao.quantization.GPTQ import Int8DynActInt4WeightLinear
+        from torchao.quantization.prototype.qat import (
+            Int8DynActInt4WeightQATLinear,
+            Int8DynActInt4WeightQATQuantizer,
+        )
+
+        def my_skip_quantize(fqn):
+            return fqn.startswith("sub") or fqn == "linear2"
+
+        group_size = 16
+        torch.manual_seed(self.SEED)
+        m = M()
+        qat_quantizer = Int8DynActInt4WeightQATQuantizer(groupsize=group_size)
+        qat_model = qat_quantizer.prepare(m, skip_quantize_filter=my_skip_quantize)
+        self.assertEqual(type(qat_model.linear1), Int8DynActInt4WeightQATLinear)
+        self.assertEqual(type(qat_model.sub.linear), torch.nn.Linear)
+        self.assertEqual(type(qat_model.linear2), torch.nn.Linear)
+        quantized_model = qat_quantizer.convert(m, skip_quantize_filter=my_skip_quantize)
+        self.assertEqual(type(qat_model.linear1), Int8DynActInt4WeightLinear)
+        self.assertEqual(type(qat_model.sub.linear), torch.nn.Linear)
+        self.assertEqual(type(qat_model.linear2), torch.nn.Linear)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -442,7 +442,21 @@ class TestQuantFlow(unittest.TestCase):
         ref = m_copy(*example_inputs)
         self.assertTrue(torch.equal(res, ref))
 
+    @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    def test_8da4w_quantizer_skip_quantize_filter(self):
+        from torchao.quantization.GPTQ import (
+            Int8DynActInt4WeightLinear,
+            Int8DynActInt4WeightQuantizer,
+        )
 
+        def my_skip_quantize(fqn):
+            return fqn == "linear2"
+
+        m = ToyLinearModel()
+        quantizer = Int8DynActInt4WeightQuantizer(groupsize=16)
+        m = quantizer.quantize(m, skip_quantize_filter=my_skip_quantize)
+        self.assertEqual(type(m.linear1), Int8DynActInt4WeightLinear)
+        self.assertEqual(type(m.linear2), torch.nn.Linear)
 
 
 if __name__ == "__main__":

--- a/torchao/quantization/prototype/qat.py
+++ b/torchao/quantization/prototype/qat.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib
@@ -47,6 +47,15 @@ if TORCH_VERSION_AFTER_2_3:
             *args: Any,
             **kwargs: Any
         ) -> torch.nn.Module:
+            """
+            Prepare a model for QAT by swapping `torch.nn.Linear` with
+            `Int8DynActInt4WeightQATLinear`, which performs 8da4w fake quantize.
+
+            Users may optionally specify `skip_quantize_filter`, a function
+            that takes in a fully-qualified name corresponding to a submodule,
+            and returns True if we should skip quantizing that submodule.
+            """
+            skip_quantize_filter = kwargs.get("skip_quantize_filter")
             _replace_linear_8da4w(
                 model,
                 self.groupsize,
@@ -55,6 +64,7 @@ if TORCH_VERSION_AFTER_2_3:
                 self.scales_precision,
                 Int8DynActInt4WeightQATLinear,
                 copy_weights = True,
+                skip_quantize_filter = skip_quantize_filter,
             )
             return model
 
@@ -64,14 +74,29 @@ if TORCH_VERSION_AFTER_2_3:
             *args: Any,
             **kwargs: Any
         ) -> torch.nn.Module:
-            _convert_qat_linear_8da4w(model)
+            """
+            Convert a float QAT model to a 8da4w quantized model.
+
+            Users may optionally specify `skip_quantize_filter`, a function
+            that takes in a fully-qualified name corresponding to a submodule,
+            and returns True if we should skip quantizing that submodule.
+            """
+            skip_quantize_filter = kwargs.get("skip_quantize_filter")
+            _convert_qat_linear_8da4w(model, skip_quantize_filter)
             return model
 
-    def _convert_qat_linear_8da4w(module: torch.nn.Module):
+    def _convert_qat_linear_8da4w(
+        module: torch.nn.Module,
+        skip_quantize_filter: Optional[Callable] = None,
+        fqn: str = "",
+    ):
         """
         Replace all `Int8DynActInt4WeightQATLinear` with `Int8DynActInt4WeightLinear`.
         """
         for name, child in module.named_children():
+            new_fqn = (fqn + "." + name).lstrip(".")
+            if skip_quantize_filter is not None and skip_quantize_filter(new_fqn):
+                continue
             if isinstance(child, Int8DynActInt4WeightQATLinear):
                 quantized_linear = Int8DynActInt4WeightLinear(
                     child.in_features,
@@ -94,7 +119,7 @@ if TORCH_VERSION_AFTER_2_3:
                 quantized_linear.scales = s
                 quantized_linear.zeros = zp
             else:
-                _convert_qat_linear_8da4w(child)
+                _convert_qat_linear_8da4w(child, skip_quantize_filter, new_fqn)
     
     class Int8DynActInt4WeightQATLinear(torch.nn.Linear):
         """


### PR DESCRIPTION
Summary: Certain layers in llama3 are more sensitive to quantization than others. In general, we need a mechanism to skip quantizing certain parts of the model. This commit adds such a mechanism by allowing users to pass in a function that filters out layers to be skipped during module swap.

Test Plan:
python test/quantization/test_quant_api.py -k test_8da4w_quantizer_skip_quantize_filter python test/quantization/test_qat.py -k test_qat_8da4w_quantizer_skip_quantize_filter

Reviewers: jerryzh168, cpuhrsch

Subscribers: jerryzh168, cpuhrsch, supriyar