### PR TITLE
Update and rename nightly-build.yml to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirementst.txt
         pip install setuptools wheel twine
     - name: Build package
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: PyPI Nightly Build
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 0 * * *'  # Runs at midnight UTC every day
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: PyPI Nightly Build
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *'  # Runs at midnight UTC every day
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,12 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
         repository_url: https://upload.pypi.org/legacy/
         packages_dir: dist/
+
+    - name: Open issue on failure
+      if: ${{ failure() && github.event_name  == 'schedule' }}
+      uses: dacbd/create-issue-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: Nightly Build failed
+        body:  Commit ${{ github.sha }} daily scheduled [CI run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
+        assignees: ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Runs at midnight UTC every day
   workflow_dispatch:
+    inputs:
+      build-type:
+        description: 'Choose build type: nightly or release'
+        required: true
+        default: 'nightly'
+        options:
+          - nightly
+          - release
 
 jobs:
   build-and-publish:
@@ -20,8 +28,10 @@ jobs:
         pip install setuptools wheel twine
     - name: Build package
       run: |
-        export TORCHAO_NIGHTLY=1
-        python setup.py sdist bdist_wheel
+        if [ "${{ github.event.inputs['build-type'] }}" = "nightly" ]; then
+          export TORCHAO_NIGHTLY=1
+        fi
+        pip install .
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirementst.txt
+        pip install -r requirements.txt
         pip install setuptools wheel twine
     - name: Build package
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Build package
       run: |
-        if [ "${{ github.event.inputs['build-type'] }}" = "nightly" ]; then
+        if [ "${{ github.event_name }}" = "schedule" ]; then
+          export TORCHAO_NIGHTLY=1
+        elif [ "${{ github.event.inputs['build-type'] }}" = "nightly" ]; then
           export TORCHAO_NIGHTLY=1
         fi
         pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,22 @@ on:
       build-type:
         description: 'Choose build type: nightly or release'
         required: true
-        default: 'nightly'
+        default: 'release'
         options:
           - nightly
           - release
+      ref:
+        description: 'Branch or tag name'
+        required: false
+        default: 'main'
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.ref }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -25,7 +31,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install setuptools wheel twine
     - name: Build package
       run: |


### PR DESCRIPTION
Let me merge this PR

So this github action makes it possible to push out our latest release binaries on pypi while also still doing our nightly releases by navigating to this tab https://github.com/pytorch/ao/actions/workflows/nightly-build.yml

The key changes are
1. An optional ref argument to the github action where we'd pass in a branch a branch name e.g v0.02
2. A flag for either release or nightly. Nightly is the default
3. Install our dependencies like requirements.txt otherwise CI was breaking with missing torch dependency
4. Because we missed this error for 3 weeks adding a louder notification on issues if we miss this 