### PR TITLE
Print the code when the check failed

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1104,7 +1104,6 @@ class TestWeightOnlyInt8Quant(unittest.TestCase):
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @torch.no_grad()
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    @unittest.skip("This test is flaky, we'll enable later")
     def test_weight_only_quant_force_mixed_mm(self, device, dtype):
         if device != "cuda":
             self.skipTest(f"weight_only_quant_force_mixed_mm can't be constructed on {device}")
@@ -1127,7 +1126,7 @@ class TestWeightOnlyInt8Quant(unittest.TestCase):
                 sqnr = compute_error(y_ref, y_wo)
                 self.assertGreaterEqual(sqnr, 42.75)
                 if device == "cuda":
-                    self.assertTrue("mixed_mm" in code)
+                    self.assertTrue("mixed_mm" in code, f"got code: {code}")
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")


### PR DESCRIPTION
Summary:
seems `test_weight_only_quant_force_mixed_mm` is flaky, we want to see what code gets produced when it failed

Test Plan:
python test/integration/test_integration.py -k test_weight_only_quant_force_mixed_mm

Reviewers:

Subscribers:

Tasks:

Tags: