### PR TITLE
Make fp8 test explicit

### DIFF
--- a/test/dtypes/test_fp8.py
+++ b/test/dtypes/test_fp8.py
@@ -15,20 +15,7 @@ try:
 except ImportError:
     triton_available = False
 
-def get_compute_capability():
-    if torch.cuda.is_available():
-        capability = torch.cuda.get_device_capability()
-        return float(f"{capability[0]}.{capability[1]}")
-    return 0.0
-
-def skip_if_compute_capability_less_than(min_capability):
-    def decorator(test_func):
-        def wrapper(*args, **kwargs):
-            if get_compute_capability() < min_capability:
-                raise unittest.SkipTest(f"Compute capability is less than {min_capability}")
-            return test_func(*args, **kwargs)
-        return wrapper
-    return decorator
+from torchao.utils import skip_if_compute_capability_less_than
 
 @unittest.skipIf(not triton_available, "Triton is required but not available")
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")

--- a/test/dtypes/test_fp8.py
+++ b/test/dtypes/test_fp8.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_utils import (
 )
 from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
 try:
-    from torchao.prototype.fp8 import gemm_split_k
+    from torchao.prototype.fp8 import gemm_split_k, to_float8
     triton_available = True
 except ImportError:
     triton_available = False
@@ -19,27 +19,40 @@ except ImportError:
 class TestFP8Gemm(TestCase):
     # @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_gemm_split_k(self):
-        m, n, k = 256, 256, 512
+        dtype = torch.float16
+        qdtype = torch.float8_e4m3fn
 
-        a = torch.randn((m, k), dtype=torch.float16, device="cuda")
-        b = torch.randn((k, n), dtype=torch.float16, device="cuda")
-        c = gemm_split_k(a, b)
-        c_expected = torch.matmul(a, b)
-        assert torch.allclose(c, c_expected, atol=0.07) # less than this and the accuracy check fails
+        torch.cuda.manual_seed(0)
+
+        m = 64
+        n = 4096
+        k = 4096
+
+        # create test inputs
+        x = torch.randn((m, k), dtype=dtype, device='cuda')
+        w = torch.randn((n, k), dtype=dtype, device='cuda')
+
+        x_fp8, x_inv_s = to_float8(x, dtype=qdtype)
+        w_fp8, w_inv_s = to_float8(w, dtype=qdtype)
+
+        y_torch, _ = torch._scaled_mm(x_fp8, w_fp8.t(), out_dtype=dtype, scale_a=x_inv_s, scale_b=w_inv_s)
+        y_triton = gemm_split_k(x_fp8, w_fp8.t(), scale_a=x_inv_s.item(), scale_b=w_inv_s.item())
+        y_fp16 = torch.nn.functional.linear(x, w)
+
+        cos_sim_torch = torch.nn.functional.cosine_similarity(y_fp16.reshape(-1), y_torch.reshape(-1), dim=0)
+        cos_sim_triton = torch.nn.functional.cosine_similarity(y_fp16.reshape(-1), y_triton.reshape(-1), dim=0)
+
+        assert cos_sim_torch > 0.99, f"fp16 vs torch cos_sim is too low: {cos_sim_torch}"
+        assert cos_sim_triton > 0.99, f"fp16 vs triton cos_sim is too low: {cos_sim_triton}"
 
     # https://pytorch.org/tutorials/recipes/torch_compile_user_defined_triton_kernel_tutorial.html
     @unittest.skip("fp8 kernel compilation does not work on a10g")
     def test_user_defined_triton_function(self):
-        import torch._inductor.config
-        torch._inductor.config.force_disable_caches = True
-        os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
         m, n, k = 256, 256, 512
 
         a = torch.randn((m, k), dtype=torch.float16, device="cuda")
         b = torch.randn((k, n), dtype=torch.float16, device="cuda")
         compiled_function = torch.compile(gemm_split_k, fullgraph=True)(a,b)
-
-
 
 if __name__ == "__main__":
     run_tests()

--- a/torchao/prototype/fp8/__init__.py
+++ b/torchao/prototype/fp8/__init__.py
@@ -1,1 +1,1 @@
-from .splitk_gemm import gemm_split_k
+from .splitk_gemm import gemm_split_k, to_float8

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -32,6 +32,7 @@ def get_compute_capability():
     return 0.0
 
 def skip_if_compute_capability_less_than(min_capability):
+    import unittest
     def decorator(test_func):
         def wrapper(*args, **kwargs):
             if get_compute_capability() < min_capability:

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -6,12 +6,12 @@ def benchmark_model(model, num_runs, input_tensor):
     start_event = torch.cuda.Event(enable_timing=True)
     end_event = torch.cuda.Event(enable_timing=True)
     start_event.record()
-    
+
     # benchmark
     for _ in range(num_runs):
         with torch.autograd.profiler.record_function("timed region"):
             model(input_tensor)
-    
+
     end_event.record()
     torch.cuda.synchronize()
     return start_event.elapsed_time(end_event) / num_runs
@@ -24,3 +24,18 @@ def profiler_runner(path, fn, *args, **kwargs):
         result = fn(*args, **kwargs)
     prof.export_chrome_trace(path)
     return result
+
+def get_compute_capability():
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability()
+        return float(f"{capability[0]}.{capability[1]}")
+    return 0.0
+
+def skip_if_compute_capability_less_than(min_capability):
+    def decorator(test_func):
+        def wrapper(*args, **kwargs):
+            if get_compute_capability() < min_capability:
+                raise unittest.SkipTest(f"Compute capability is less than {min_capability}")
+            return test_func(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
Per @lessw2020 

This test just makes things more explicit

fp8 is auto enabled if you are on Hopper and have block_m >= 64 andnum_warps >= 4

And then looking a the triton.ttir I do indeed see fp8 kicking in example this line, that's not test in CI explicitly since we don't have fp8 support on A10G

    %35 = tt.splat %arg0 : !tt.ptr<f8E4M3FNUZ, 1> -> tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>> loc(#loc31)


```
#loc = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0)
module {
  tt.func public @gemm_split_k_kernel(%arg0: !tt.ptr<f8E4M3FNUZ, 1> {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg1: !tt.ptr<f8E4M3FNUZ, 1> {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg2: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg3: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg4: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg5: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg6: f32 loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg7: f32 loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg8: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg9: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0), %arg10: i32 {tt.divisibility = 16 : i32} loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":25:0)) attributes {noinline = false} {
    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32> loc(#loc1)
    %c63_i32 = arith.constant 63 : i32 loc(#loc1)
    %c8_i32 = arith.constant 8 : i32 loc(#loc1)
    %c2047_i32 = arith.constant 2047 : i32 loc(#loc1)
    %c1_i32 = arith.constant 1 : i32 loc(#loc1)
    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
    %cst_0 = arith.constant dense<2048> : tensor<512x64xi32> loc(#loc1)
    %cst_1 = arith.constant dense<2048> : tensor<64x512xi32> loc(#loc1)
    %cst_2 = arith.constant dense<0.000000e+00> : tensor<512x64xf32> loc(#loc1)
    %cst_3 = arith.constant dense<0.000000e+00> : tensor<64x512xf32> loc(#loc1)
    %c2048_i32 = arith.constant 2048 : i32 loc(#loc1)
    %c512_i32 = arith.constant 512 : i32 loc(#loc1)
    %c64_i32 = arith.constant 64 : i32 loc(#loc1)
    %0 = tt.get_program_id x : i32 loc(#loc2)
    %1 = tt.get_program_id y : i32 loc(#loc3)
    %2 = arith.addi %arg10, %c2047_i32 : i32 loc(#loc64)
    %3 = arith.divsi %2, %c2048_i32 : i32 loc(#loc65)
    %4 = arith.addi %arg8, %c63_i32 : i32 loc(#loc79)
    %5 = arith.divsi %4, %c64_i32 : i32 loc(#loc80)
    %6 = arith.addi %arg9, %c63_i32 : i32 loc(#loc81)
    %7 = arith.divsi %6, %c64_i32 : i32 loc(#loc82)
    %8 = arith.muli %7, %c8_i32 : i32 loc(#loc70)
    %9 = arith.divsi %0, %8 : i32 loc(#loc71)
    %10 = arith.muli %9, %c8_i32 : i32 loc(#loc72)
    %11 = arith.subi %5, %10 : i32 loc(#loc73)
    %12 = arith.minsi %11, %c8_i32 : i32 loc(#loc74)
    %13 = arith.remsi %0, %12 : i32 loc(#loc75)
    %14 = arith.addi %10, %13 : i32 loc(#loc76)
    %15 = arith.remsi %0, %8 : i32 loc(#loc77)
    %16 = arith.divsi %15, %12 : i32 loc(#loc78)
    %17 = arith.muli %14, %c64_i32 : i32 loc(#loc19)
    %18 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32> loc(#loc20)
    %19 = tt.splat %17 : i32 -> tensor<64xi32> loc(#loc21)
    %20 = arith.addi %19, %18 {tt.contiguity = dense<64> : tensor<1xi32>, tt.divisibility = dense<64> : tensor<1xi32>} : tensor<64xi32> loc(#loc21)
    %21 = arith.muli %16, %c64_i32 : i32 loc(#loc22)
    %22 = tt.splat %21 : i32 -> tensor<64xi32> loc(#loc23)
    %23 = arith.addi %22, %18 {tt.contiguity = dense<64> : tensor<1xi32>, tt.divisibility = dense<64> : tensor<1xi32>} : tensor<64xi32> loc(#loc23)
    %24 = arith.muli %1, %c512_i32 : i32 loc(#loc24)
    %25 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32> loc(#loc25)
    %26 = tt.splat %24 : i32 -> tensor<512xi32> loc(#loc26)
    %27 = arith.addi %26, %25 : tensor<512xi32> loc(#loc26)
    %28 = tt.expand_dims %20 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> loc(#loc27)
    %29 = tt.splat %arg3 : i32 -> tensor<64x1xi32> loc(#loc28)
    %30 = arith.muli %28, %29 : tensor<64x1xi32> loc(#loc28)
    %31 = tt.expand_dims %27 {axis = 0 : i32} : tensor<512xi32> -> tensor<1x512xi32> loc(#loc29)
    %32 = tt.broadcast %30 : tensor<64x1xi32> -> tensor<64x512xi32> loc(#loc30)
    %33 = tt.broadcast %31 : tensor<1x512xi32> -> tensor<64x512xi32> loc(#loc30)
    %34 = arith.addi %32, %33 : tensor<64x512xi32> loc(#loc30)
    %35 = tt.splat %arg0 : !tt.ptr<f8E4M3FNUZ, 1> -> tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>> loc(#loc31)
    %36 = tt.addptr %35, %34 : tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<64x512xi32> loc(#loc31)
    %37 = tt.expand_dims %27 {axis = 1 : i32} : tensor<512xi32> -> tensor<512x1xi32> loc(#loc32)
    %38 = tt.expand_dims %23 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32> loc(#loc33)
    %39 = tt.splat %arg4 : i32 -> tensor<1x64xi32> loc(#loc34)
    %40 = arith.muli %38, %39 : tensor<1x64xi32> loc(#loc34)
    %41 = tt.broadcast %37 : tensor<512x1xi32> -> tensor<512x64xi32> loc(#loc35)
    %42 = tt.broadcast %40 : tensor<1x64xi32> -> tensor<512x64xi32> loc(#loc35)
    %43 = arith.addi %41, %42 : tensor<512x64xi32> loc(#loc35)
    %44 = tt.splat %arg1 : !tt.ptr<f8E4M3FNUZ, 1> -> tensor<512x64x!tt.ptr<f8E4M3FNUZ, 1>> loc(#loc36)
    %45 = tt.addptr %44, %43 : tensor<512x64x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<512x64xi32> loc(#loc36)
    %46 = tt.fp_to_fp %cst_3 {rounding = 1 : i32} : tensor<64x512xf32> -> tensor<64x512xf8E4M3FNUZ> loc(#loc37)
    %47 = tt.fp_to_fp %cst_2 {rounding = 1 : i32} : tensor<512x64xf32> -> tensor<512x64xf8E4M3FNUZ> loc(#loc38)
    %48:3 = scf.for %arg11 = %c0_i32 to %3 step %c1_i32 iter_args(%arg12 = %cst, %arg13 = %36, %arg14 = %45) -> (tensor<64x64xf32>, tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<512x64x!tt.ptr<f8E4M3FNUZ, 1>>)  : i32 {
      %74 = arith.muli %arg11, %c2048_i32 : i32 loc(#loc40)
      %75 = arith.subi %arg10, %74 : i32 loc(#loc41)
      %76 = tt.splat %75 : i32 -> tensor<1x512xi32> loc(#loc42)
      %77 = arith.cmpi slt, %31, %76 : tensor<1x512xi32> loc(#loc42)
      %78 = tt.broadcast %77 : tensor<1x512xi1> -> tensor<64x512xi1> loc(#loc37)
      %79 = tt.load %arg13, %78, %46 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x512xf8E4M3FNUZ> loc(#loc37)
      %80 = tt.splat %75 : i32 -> tensor<512x1xi32> loc(#loc43)
      %81 = arith.cmpi slt, %37, %80 : tensor<512x1xi32> loc(#loc43)
      %82 = tt.broadcast %81 : tensor<512x1xi1> -> tensor<512x64xi1> loc(#loc38)
      %83 = tt.load %arg14, %82, %47 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x64xf8E4M3FNUZ> loc(#loc38)
      %84 = tt.dot %79, %83, %arg12 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 1073741824 : i32} : tensor<64x512xf8E4M3FNUZ> * tensor<512x64xf8E4M3FNUZ> -> tensor<64x64xf32> loc(#loc44)
      %85 = tt.addptr %arg13, %cst_1 : tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<64x512xi32> loc(#loc45)
      %86 = tt.addptr %arg14, %cst_0 : tensor<512x64x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<512x64xi32> loc(#loc46)
      scf.yield %84, %85, %86 : tensor<64x64xf32>, tensor<64x512x!tt.ptr<f8E4M3FNUZ, 1>>, tensor<512x64x!tt.ptr<f8E4M3FNUZ, 1>> loc(#loc47)
    } loc(#loc39)
    %49 = arith.mulf %arg6, %arg7 : f32 loc(#loc48)
    %50 = tt.splat %49 : f32 -> tensor<64x64xf32> loc(#loc49)
    %51 = arith.mulf %50, %48#0 : tensor<64x64xf32> loc(#loc49)
    %52 = arith.addi %19, %18 : tensor<64xi32> loc(#loc50)
    %53 = arith.addi %22, %18 : tensor<64xi32> loc(#loc51)
    %54 = tt.expand_dims %52 {axis = 1 : i32} : tensor<64xi32> -> tensor<64x1xi32> loc(#loc52)
    %55 = tt.splat %arg5 : i32 -> tensor<64x1xi32> loc(#loc53)
    %56 = arith.muli %54, %55 : tensor<64x1xi32> loc(#loc53)
    %57 = tt.expand_dims %53 {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32> loc(#loc54)
    %58 = tt.broadcast %56 : tensor<64x1xi32> -> tensor<64x64xi32> loc(#loc55)
    %59 = tt.broadcast %57 : tensor<1x64xi32> -> tensor<64x64xi32> loc(#loc55)
    %60 = arith.addi %58, %59 : tensor<64x64xi32> loc(#loc55)
    %61 = tt.splat %arg2 : !tt.ptr<f16, 1> -> tensor<64x64x!tt.ptr<f16, 1>> loc(#loc56)
    %62 = tt.addptr %61, %60 : tensor<64x64x!tt.ptr<f16, 1>>, tensor<64x64xi32> loc(#loc56)
    %63 = tt.splat %arg8 : i32 -> tensor<64xi32> loc(#loc57)
    %64 = arith.cmpi slt, %52, %63 : tensor<64xi32> loc(#loc57)
    %65 = tt.expand_dims %64 {axis = 1 : i32} : tensor<64xi1> -> tensor<64x1xi1> loc(#loc58)
    %66 = tt.splat %arg9 : i32 -> tensor<64xi32> loc(#loc59)
    %67 = arith.cmpi slt, %53, %66 : tensor<64xi32> loc(#loc59)
    %68 = tt.expand_dims %67 {axis = 0 : i32} : tensor<64xi1> -> tensor<1x64xi1> loc(#loc60)
    %69 = tt.broadcast %65 : tensor<64x1xi1> -> tensor<64x64xi1> loc(#loc61)
    %70 = tt.broadcast %68 : tensor<1x64xi1> -> tensor<64x64xi1> loc(#loc61)
    %71 = arith.andi %69, %70 : tensor<64x64xi1> loc(#loc61)
    %72 = arith.truncf %51 : tensor<64x64xf32> to tensor<64x64xf16> loc(#loc62)
    %73 = "tt.atomic_rmw"(%62, %72, %71) <{atomic_rmw_op = 5 : i32, scope = 1 : i32, sem = 4 : i32}> : (tensor<64x64x!tt.ptr<f16, 1>>, tensor<64x64xf16>, tensor<64x64xi1>) -> tensor<64x64xf16> loc(#loc62)
    tt.return loc(#loc63)
  } loc(#loc)
} loc(#loc)
#loc1 = loc(unknown)
#loc2 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":34:24)
#loc3 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":35:26)
#loc4 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/triton/language/standard.py":44:22)
#loc5 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":36:24)
#loc6 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/triton/language/standard.py":44:28)
#loc7 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":12:24)
#loc8 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":40:52)
#loc9 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":13:24)
#loc10 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":15:22)
#loc11 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":16:22)
#loc12 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":17:48)
#loc13 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":17:37)
#loc14 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":17:57)
#loc15 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":19:40)
#loc16 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":19:34)
#loc17 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":20:19)
#loc18 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":20:29)
#loc19 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":42:19)
#loc20 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":42:42)
#loc21 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":42:29)
#loc22 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":43:19)
#loc23 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":43:29)
#loc24 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":44:19)
#loc25 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":44:42)
#loc26 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":44:29)
#loc27 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":49:30)
#loc28 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":49:41)
#loc29 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":49:60)
#loc30 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":49:53)
#loc31 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":49:22)
#loc32 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":50:29)
#loc33 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":50:60)
#loc34 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":50:71)
#loc35 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":50:52)
#loc36 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":50:22)
#loc37 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":58:20)
#loc38 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":59:20)
#loc39 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":54:23)
#loc40 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":56:32)
#loc41 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":56:26)
#loc42 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":58:51)
#loc43 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":59:51)
#loc44 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":61:27)
#loc45 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":63:18)
#loc46 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":64:18)
#loc47 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":64:8)
#loc48 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":66:20)
#loc49 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":66:30)
#loc50 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":69:29)
#loc51 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":70:29)
#loc52 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":72:29)
#loc53 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":72:40)
#loc54 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":72:59)
#loc55 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":72:52)
#loc56 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":72:22)
#loc57 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":73:21)
#loc58 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":73:24)
#loc59 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":73:45)
#loc60 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":73:48)
#loc61 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":73:35)
#loc62 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":75:26)
#loc63 = loc("/home/marksaroufim/.local/lib/python3.10/site-packages/torchao/prototype/fp8/splitk_gemm.py":75:4)
#loc64 = loc(callsite(#loc4 at #loc5))
#loc65 = loc(callsite(#loc6 at #loc5))
#loc66 = loc(callsite(#loc4 at #loc7))
#loc67 = loc(callsite(#loc6 at #loc7))
#loc68 = loc(callsite(#loc4 at #loc9))
#loc69 = loc(callsite(#loc6 at #loc9))
#loc70 = loc(callsite(#loc10 at #loc8))
#loc71 = loc(callsite(#loc11 at #loc8))
#loc72 = loc(callsite(#loc12 at #loc8))
#loc73 = loc(callsite(#loc13 at #loc8))
#loc74 = loc(callsite(#loc14 at #loc8))
#loc75 = loc(callsite(#loc15 at #loc8))
#loc76 = loc(callsite(#loc16 at #loc8))
#loc77 = loc(callsite(#loc17 at #loc8))
#loc78 = loc(callsite(#loc18 at #loc8))
#loc79 = loc(callsite(#loc66 at #loc8))
#loc80 = loc(callsite(#loc67 at #loc8))
#loc81 = loc(callsite(#loc68 at #loc8))
#loc82 = loc(callsite(#loc69 at #loc8))

```