### PR TITLE
API changes to autotuner

### DIFF
--- a/torchao/kernel/README.md
+++ b/torchao/kernel/README.md
@@ -13,3 +13,8 @@ Searching a new config can take a long time and we'll save the updated data in `
 By default we load precomputed configs for A100. If we're not on an A100, we search set the path to `data.pkl`.
 
 Updated configs are always stored in the current working directory as `data.pkl` to avoid accidentally overwriting the supplied configs.
+
+## TODO
+
+* Not clear how the autotuner and autoquant related: autotuner is used in intmm_triton ./kernel/intmm_triton.py:from torchao.kernel.autotuner import get_best_config_fn which imports safe_mm in AQInt8DynamicallyQuantizedLinearWeight in autoquant.py
+* Should we reuse the triton autotuner? OR find a way of serializing the triton autotuning heuristics?

--- a/torchao/kernel/__init__.py
+++ b/torchao/kernel/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+AUTOTUNER_ENABLE = os.environ.get("TORCHAO_AUTOTUNER_ENABLE") == "1"
+
+# Enable cache with a defaul location
+current_file_dir = os.path.dirname(os.path.abspath(__file__))
+TORCHAO_AUTOTUNER_DATA_PATH = os.path.join(current_file_dir, "configs", "data_a100.pkl")

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -3,6 +3,7 @@ import os
 import torch
 
 from torchao.quantization.utils import TORCH_VERSION_AFTER_2_2
+from . import AUTOTUNER_ENABLE
 
 try:
     # Only works for torch2.2 or newer.
@@ -14,7 +15,6 @@ except ImportError:
     # On cpu-only builds might not be available.
     intmm_triton = None
 
-AUTOTUNER_ENABLE = bool(int(os.getenv("TORCHAO_AUTOTUNER_ENABLE", 0)))
 
 # torch._int_mm doesn't exist before 2.2
 if TORCH_VERSION_AFTER_2_2:

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -434,14 +434,11 @@ def change_autoquantizable_to_quantized(model, **kwargs):
 @torch.no_grad()
 def autoquant(model, example_input=None, qtensor_class_list=DEFAULT_CLASS_LIST, filter_fn=None, mode=["interpolate", .85], **aq_kwargs):
     """
-    Wraps the given model in an AutoQuantWrapper. If `example_input` is provided, performs a forward pass on the input.
-    Otherwise, returns the wrapped model. The AutoQuantWrapper manages cases where the model is torch-compiled by first
+    Wraps the given model in an AutoQuantWrapper. The AutoQuantWrapper manages cases where the model is torch-compiled by first
     performing autoquantization on the original model and then allowing the torch.compile run/tracing to occur.
 
     Args:
         model (torch.nn.Module): The model to be autoquantized.
-        example_input (Any, optional): An example input for the model. If provided, the function performs a forward pass
-                                       on this input. Defaults to None.
         qtensor_class_list (list, optional): A list of tensor classes to be used for quantization. Defaults to DEFAULT_CLASS_LIST.
         filter_fn (callable, optional): A filter function to apply to the model parameters. Defaults to None.
         mode (list, optional): A list containing mode settings for quantization. The first element is the mode type (e.g., "interpolate"),
@@ -454,7 +451,6 @@ def autoquant(model, example_input=None, qtensor_class_list=DEFAULT_CLASS_LIST, 
 
     Example usage:
         torchao.autoquant(torch.compile(model))
-        model(*example_input)
     """
     # the hook we will use to intercept the model forward and perform
     # autoquantization
@@ -504,11 +500,5 @@ def autoquant(model, example_input=None, qtensor_class_list=DEFAULT_CLASS_LIST, 
         except:
             pass
     model.clean_up_autoquant_hooks_and_attrs = clean_up_autoquant_hooks_and_attrs
-
-    # if example input was provided, check it and run it
-    if isinstance(example_input, torch.Tensor):
-        example_input = [example_input]
-    if isinstance(example_input, (tuple, list)):
-        model(*example_input)
 
     return model


### PR DESCRIPTION
Some misc changes but the more I was looking into this it seems like 
1. Triton does not yet support an autotune cache, inductor added their own support for it so should an autotuner live here or in triton?
2. Once we have some autotuned shapes we don't make it clear where people should upload them so I'd like to see a dataset that includes the GPU name as one of the keys so we can potato farm some configs out