### PR TITLE
Graceful handling of cpp extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ pip install -r dev-requirements.txt
 There are two options;
 -If you plan to be developing the library run:
 ```Shell
-pip install -e .
+python setup.py develop
 ```
 
 If you want to install from source run
 ```Shell
-pip install .
+python setup.py install 
 ```
 
 ** Note:
 If you are running into any issues while building `ao` cpp extensions you can instead build using
 
 ```shell
-USE_CPP=0 pip install .
+USE_CPP=0 python setup.py install
 ```
 
 ### Quantization

--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ pip install -r dev-requirements.txt
 There are two options;
 -If you plan to be developing the library run:
 ```Shell
-python setup.py develop
+pip install -e .
 ```
 
 If you want to install from source run
 ```Shell
-python setup.py install
+pip install .
 ```
 
 ** Note:
-Since we are building pytorch c++/cuda extensions by default, running `pip install .` will
-not work.
+If you are running into any issues while building `ao` cpp extensions you can instead build using
+
+```shell
+USE_CPP=0 pip install .
+```
 
 ### Quantization
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ def read_requirements(file_path):
 # Determine the package name based on the presence of an environment variable
 package_name = "torchao-nightly" if os.environ.get("TORCHAO_NIGHTLY") else "torchao"
 version_suffix = os.getenv("VERSION_SUFFIX", "")
+use_cpp = os.getenv('USE_CPP')
+
 
 # Version is year.month.date if using nightlies
 version = current_date if package_name == "torchao-nightly" else "0.2.0"
@@ -92,7 +94,7 @@ setup(
     package_data={
         "torchao.kernel.configs": ["*.pkl"],
     },
-    ext_modules=get_extensions(),
+    ext_modules=get_extensions() if use_cpp != "0" else None,
     install_requires=read_requirements("requirements.txt"),
     extras_require={"dev": read_requirements("dev-requirements.txt")},
     description="Package for applying ao techniques to GPU models",

--- a/test/dtypes/test_float6_e3m2.py
+++ b/test/dtypes/test_float6_e3m2.py
@@ -5,6 +5,13 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
+
+try:
+    import torchao.ops
+except RuntimeError:
+    pytest.skip("torchao.ops not available")
+
+
 from torchao.dtypes.float6_e3m2 import to_float6_e3m2, from_float6_e3m2
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,7 +6,12 @@ from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
 import unittest
 from parameterized import parameterized
 import pytest
+import os
 
+use_cpp = os.getenv('USE_CPP')
+
+if use_cpp:
+    pytest.skip("skipping cpp extensions")
 
 # torch.testing._internal.optests.generate_tests.OpCheckError: opcheck(op, ...):
 # test_faketensor failed with module 'torch' has no attribute '_custom_ops' (scroll up for stack trace)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -8,10 +8,11 @@ from parameterized import parameterized
 import pytest
 import os
 
-use_cpp = os.getenv('USE_CPP')
+try:
+    import torchao.ops
+except RuntimeError:
+    pytest.skip("torchao.ops not available")
 
-if use_cpp:
-    pytest.skip("skipping cpp extensions")
 
 # torch.testing._internal.optests.generate_tests.OpCheckError: opcheck(op, ...):
 # test_faketensor failed with module 'torch' has no attribute '_custom_ops' (scroll up for stack trace)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,7 +6,6 @@ from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
 import unittest
 from parameterized import parameterized
 import pytest
-import os
 
 try:
     import torchao.ops

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -1,12 +1,18 @@
 import torch
+import logging
+
 _IS_FBCODE = (
     hasattr(torch._utils_internal, "IS_FBSOURCE") and
     torch._utils_internal.IS_FBSOURCE
 )
 
 if not _IS_FBCODE:
-    from . import _C
-    from . import ops
+    try:
+        from . import _C
+        from . import ops
+    except:
+        _C = None
+        logging.info("Skipping import of cpp extensions")
 
 from torchao.quantization import (
     apply_weight_only_int8_quant,

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -1,7 +1,11 @@
 from .nf4tensor import NF4Tensor, to_nf4
 from .uint4 import UInt4Tensor
 from .aqt import AffineQuantizedTensor, to_aq
-from .float6_e3m2 import to_float6_e3m2, from_float6_e3m2
+
+try:
+    from .float6_e3m2 import to_float6_e3m2, from_float6_e3m2
+except RuntimeError:
+    pass
 
 __all__ = [
     "NF4Tensor",

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -8,8 +8,6 @@ __all__ = [
     "UInt4Tensor"
     "AffineQuantizedTensor",
     "to_aq",
-    "to_float6_e3m2",
-    "from_float6_e3m2",
 ]
 
 # CPP extensions

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -15,6 +15,6 @@ __all__ = [
 # CPP extensions
 try:
     from .float6_e3m2 import to_float6_e3m2, from_float6_e3m2
-    __all__.extend(["to_float6_e3m2", "from_float6_e3m2")
+    __all__.extend(["to_float6_e3m2", "from_float6_e3m2"])
 except RuntimeError:
     pass

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -2,11 +2,6 @@ from .nf4tensor import NF4Tensor, to_nf4
 from .uint4 import UInt4Tensor
 from .aqt import AffineQuantizedTensor, to_aq
 
-try:
-    from .float6_e3m2 import to_float6_e3m2, from_float6_e3m2
-except RuntimeError:
-    pass
-
 __all__ = [
     "NF4Tensor",
     "to_nf4",
@@ -16,3 +11,10 @@ __all__ = [
     "to_float6_e3m2",
     "from_float6_e3m2",
 ]
+
+# CPP extensions
+try:
+    from .float6_e3m2 import to_float6_e3m2, from_float6_e3m2
+    __all__.extend(["to_float6_e3m2", "from_float6_e3m2")
+except RuntimeError:
+    pass

--- a/torchao/dtypes/float6_e3m2.py
+++ b/torchao/dtypes/float6_e3m2.py
@@ -3,6 +3,7 @@ from torch import Tensor
 from torch.utils._triton import has_triton
 from torchao.ops import to_float6_e3m2_packed_cpu, to_float6_e3m2_unpacked_cpu, from_float6_e3m2_packed_cpu, from_float6_e3m2_unpacked_cpu
 
+
 # some useful constants
 FLOAT6_E3M2_MAX = 28.0
 FLOAT6_E3M2_SMALLEST_SUBNORMAL = 0.0625
@@ -120,7 +121,7 @@ def to_float6_e3m2(tensor: Tensor, no_bit_packing: bool = False) -> Tensor:
     if tensor.is_cpu:
       if no_bit_packing:
         return to_float6_e3m2_unpacked_cpu(tensor)
-
+      
       *leading_dims, last_dim = tensor.shape
       return to_float6_e3m2_packed_cpu(tensor.view(-1, last_dim)).view(*leading_dims, -1)
 

--- a/torchao/dtypes/float6_e3m2.py
+++ b/torchao/dtypes/float6_e3m2.py
@@ -3,11 +3,6 @@ from torch import Tensor
 from torch.utils._triton import has_triton
 from torchao.ops import to_float6_e3m2_packed_cpu, to_float6_e3m2_unpacked_cpu, from_float6_e3m2_packed_cpu, from_float6_e3m2_unpacked_cpu
 
-try:
-    import torchao.ops
-except RuntimeError:
-    pytest.skip("torchao.ops not available")
-
 # some useful constants
 FLOAT6_E3M2_MAX = 28.0
 FLOAT6_E3M2_SMALLEST_SUBNORMAL = 0.0625

--- a/torchao/dtypes/float6_e3m2.py
+++ b/torchao/dtypes/float6_e3m2.py
@@ -3,6 +3,10 @@ from torch import Tensor
 from torch.utils._triton import has_triton
 from torchao.ops import to_float6_e3m2_packed_cpu, to_float6_e3m2_unpacked_cpu, from_float6_e3m2_packed_cpu, from_float6_e3m2_unpacked_cpu
 
+try:
+    import torchao.ops
+except RuntimeError:
+    pytest.skip("torchao.ops not available")
 
 # some useful constants
 FLOAT6_E3M2_MAX = 28.0
@@ -121,7 +125,7 @@ def to_float6_e3m2(tensor: Tensor, no_bit_packing: bool = False) -> Tensor:
     if tensor.is_cpu:
       if no_bit_packing:
         return to_float6_e3m2_unpacked_cpu(tensor)
-      
+
       *leading_dims, last_dim = tensor.shape
       return to_float6_e3m2_packed_cpu(tensor.view(-1, last_dim)).view(*leading_dims, -1)
 


### PR DESCRIPTION
This fixes issues from https://github.com/pytorch/ao/issues/288

More specifically
1. We introduce a new env variable so we can install ao locally without building cpp extensions `USE_CPP=0 pip install .` this is useful out of convenience for faster iteration cycles 
2. If the extensions were built but failed for whatever reason on a host device then importing those extensions will be skipped and ao will not crash. This also means you can `import torchao` from inside `torchao/`
3. If cpp extensions aren't build then the fp6 and ops tests are skipped