### PR TITLE
Fixed f-string printing of `NF4Tensor`s

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -272,7 +272,10 @@ def _to_copy(func, *args, **kwargs):
     if not args[0][0].is_contiguous():
         assert args[0][0].t().is_contiguous()
         return func(args[0][0].t()).t()
-    return args[0][0].get_original_weight().to(args[1]["dtype"]).to(args[1]["device"])
+    out = args[0][0].get_original_weight().to(args[1]["dtype"])
+    if "device" in args[1]:
+        out = out.to(args[1]["device"])
+    return out
 
 
 @implements([torch.ops.aten.to.dtype])


### PR DESCRIPTION
```
import torch
from torchao.dtypes import NF4Tensor

weight = torch.randn((16, 16), device="cuda", dtype=torch.bfloat16)
block_size, scaler_block_size = 2, 2
nf4_weight = NF4Tensor.from_tensor(weight, block_size, scaler_block_size)
print(f"{nf4_weight}")
```

```
File "/data/users/andgu/pytorch/test_nf4.py", line 13, in main
    print(f"{nf4_weight}")
  File "/data/users/andgu/pytorch/torch/_tensor.py", line 986, in __format__
    return handle_torch_function(Tensor.__format__, (self,), self, format_spec)
  File "/data/users/andgu/pytorch/torch/overrides.py", line 1646, in handle_torch_function
    result = torch_func_method(public_api, types, args, kwargs)
  File "/data/users/andgu/ao/torchao/dtypes/nf4tensor.py", line 797, in __torch_function__
    return func(*args, **kwargs)
  File "/data/users/andgu/pytorch/torch/_tensor.py", line 989, in __format__
    return object.__format__(self, format_spec)
  File "/data/users/andgu/ao/torchao/dtypes/nf4tensor.py", line 754, in __str__
    return self.to(torch.float32).__str__()
  File "/data/users/andgu/ao/torchao/dtypes/nf4tensor.py", line 778, in __torch_dispatch__
    return NF4_OPS_TABLE[func](func, args, kwargs)
  File "/data/users/andgu/ao/torchao/dtypes/nf4tensor.py", line 277, in _to_copy
    return args[0][0].get_original_weight().to(args[1]["dtype"]).to(args[1]["device"])
KeyError: 'device'
```

Note that `args[1]` only has a `"dtype"` key, not `"device"`:
```
args[1]: {'dtype': torch.float32}
```