### PR TITLE
[NF4][FSDP] return contiguous `quantization_factor`

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -596,7 +596,7 @@ class NF4Tensor(torch.Tensor):
 
         return (
             quantized_scaler_blocks.flatten().to(torch.int8),
-            quantization_factor.view(n_scaler_blocks),
+            quantization_factor.view(n_scaler_blocks).contiguous(),
             scalers_1_mean,
         )
 


### PR DESCRIPTION
before, `NF4.quantization_factor` is non-contiguous, meaning `NF4.stride()` is (16, 0)
after, `NF4.quantization_factor` contiguous with `NF4.stride()` is (1, 0). it's easy to work with FSDP since we do `.view(unit8)` and it requries contiguous tensor

```
import torch
from torchao.dtypes.nf4tensor import to_nf4
inpt_tensor = torch.rand(4096, device='cuda')
inpt_tensor_nf4 = to_nf4(inpt_tensor, 32, 16)
print(inpt_tensor_nf4.quantization_factor.stride())
```


