### PR TITLE
Update old pretrained TorchVision API in ao tutorials (#313)

### DIFF
--- a/tutorials/quantize_vit/run_vit_b.py
+++ b/tutorials/quantize_vit/run_vit_b.py
@@ -1,10 +1,11 @@
 import torch
-import torchvision.models.vision_transformer as models
 
 from torchao.utils import benchmark_model, profiler_runner
+from torchvision import models
+
 torch.set_float32_matmul_precision("high")
 # Load Vision Transformer model
-model = models.vit_b_16(pretrained=True)
+model = models.vit_b_16(weights=models.ViT_B_16_Weights.IMAGENET1K_V1)
 
 # Set the model to evaluation mode
 model.eval().cuda().to(torch.bfloat16)

--- a/tutorials/quantize_vit/run_vit_b_quant.py
+++ b/tutorials/quantize_vit/run_vit_b_quant.py
@@ -1,11 +1,12 @@
 import torch
 import torchao
-import torchvision.models.vision_transformer as models
 
 from torchao.utils import benchmark_model, profiler_runner
+from torchvision import models
+
 torch.set_float32_matmul_precision("high")
 # Load Vision Transformer model
-model = models.vit_b_16(pretrained=True)
+model = models.vit_b_16(weights=models.ViT_B_16_Weights.IMAGENET1K_V1)
 
 # Set the model to evaluation mode
 model.eval().cuda().to(torch.bfloat16)


### PR DESCRIPTION
Summary:

For TorchVision models, pretrained parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html

Differential Revision: D58117114
