### PR TITLE
[RFC] Reduce nf4 quant mem

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -690,20 +690,16 @@ class NF4Tensor(torch.Tensor):
         scaled_second = scaled_second.unsqueeze(-1).transpose(0, 1)
         return torch.stack([scaled_first, scaled_second], dim=-1).reshape(self.shape)
 
+    @torch.compile(disable = (sys.platform == "linux"))
     @staticmethod
     def quantize_tensor_nearest(
         value: torch.Tensor, nf4: torch.Tensor
     ) -> torch.Tensor:
         """Quantize a float16 tensor to nf4 format to nearest and not rounded up"""
-        branch_points = (nf4[1:] + nf4[:-1]) / 2
-        closest_nf4 = torch.full(
-            value.shape, 
-            0,
-            dtype=torch.uint8,
-            device=nf4.device
-        )
-        for i in range(len(branch_points)):
-            closest_nf4 = torch.where(value <= branch_points[i], closest_nf4, i+1)
+        value = value.unsqueeze(-1)  # (numel, 1)
+        # Compare the value tensor with the nf4 tensor element-wise
+        diff = (value - nf4).abs()
+        closest_nf4 = diff.min(dim=-1).indices.to(dtype=torch.uint8)
         return closest_nf4
 
     @staticmethod

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -698,12 +698,12 @@ class NF4Tensor(torch.Tensor):
         branch_points = (nf4[1:] + nf4[:-1]) / 2
         closest_nf4 = torch.full(
             value.shape, 
-            nf4.numel() - 1,
+            0,
             dtype=torch.uint8,
             device=nf4.device
         )
         for i in range(len(branch_points)):
-            closest_nf4 = torch.where(value < branch_points[i], closest_nf4, i+1)
+            closest_nf4 = torch.where(value <= branch_points[i], closest_nf4, i+1)
         return closest_nf4
 
     @staticmethod

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -690,7 +690,7 @@ class NF4Tensor(torch.Tensor):
         scaled_second = scaled_second.unsqueeze(-1).transpose(0, 1)
         return torch.stack([scaled_first, scaled_second], dim=-1).reshape(self.shape)
 
-    @torch.compile(disable = (sys.platform == "linux"))
+    @torch.compile(disable = (sys.platform == "win32"))
     @staticmethod
     def quantize_tensor_nearest(
         value: torch.Tensor, nf4: torch.Tensor


### PR DESCRIPTION
Currently NF4 quantization of large tensors can cause some pretty substantial memory spikes. Consider the following script for quantizing the Llama3-8B output projection weight into NF4:

```
from torch import nn
from torchtune.utils import get_memory_stats, get_device
from torchao.dtypes.nf4tensor import to_nf4

def main():
    
    device = get_device('cuda')

    # Size of Llama3-8B output projection weight
    big_linear = nn.Linear(in_features=4096, out_features=128256, bias=False, device=device)
    memory_stats = get_memory_stats(device=device)
    print(f"before quantize: {memory_stats}")
    
    # Quantize with ao
    ao_quant = to_nf4(big_linear.weight)
    memory_stats = get_memory_stats(device=device)
    print(f"after ao quant: {memory_stats}")



if __name__ == "__main__":
    main()
```

On main, this currently prints
```
before quantize: {'peak_memory_active': 2.101346304, 'peak_memory_alloc': 2.101346304, 'peak_memory_reserved': 2.101346304}
after ao quant: {'peak_memory_active': 37.865276416, 'peak_memory_alloc': 37.865276416, 'peak_memory_reserved': 37.977325568}
```

The peak memory is almost 38 GB, I think due to the fact that `diff = (value - nf4).abs()` is creating a 16x larger tensor to do the pairwise comparison of `value` to `nf4` tensors. 


**Edit**: Updated based on @gau-nernst and @cpuhrsch's suggestions. Instead of a for loop we just `torch.compile` `quantize_tensor_nearest` (conditional upon not running on windows) then cast the final indices to uint8. This results in

```
before quantize: {'peak_memory_active': 2.101346304, 'peak_memory_alloc': 2.101346304, 'peak_memory_reserved': 2.101346304}
after ao quant: {'peak_memory_active': 5.29545728, 'peak_memory_alloc': 5.29545728, 'peak_memory_reserved': 5.668601856}
```