### PR TITLE
Add int4 groupwise quantization metal kernels for linear layers

### DIFF
--- a/torchao/csrc/metal/CMakeLists.txt
+++ b/torchao/csrc/metal/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# set(_common_compile_options -Wno-deprecated-declarations)
+
+find_library(FOUNDATION_FRAMEWORK Foundation)
+find_library(METAL_FRAMEWORK Metal)
+
+add_compile_options("-Wall" "-Werror")
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+set(_common_compile_options -Wno-deprecated-declarations -Os)
+
+# ios can only build library but not binary
+if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
+  # portable_ops_lib
+
+  #set(mps_executor_runner_libs
+  #    "-framework Foundation" "-weak_framework MetalPerformanceShaders"
+  #    "-weak_framework MetalPerformanceShadersGraph" "-weak_framework Metal"
+  #)
+
+  add_executable(test_int4_q_kernels test_int4_q_kernels.mm)
+
+  target_link_libraries(
+    test_int4_q_kernels
+    ${FOUNDATION_FRAMEWORK}
+    ${METAL_FRAMEWORK}
+  )
+
+  target_compile_options(test_int4_q_kernels PUBLIC ${_common_compile_options})
+endif()

--- a/torchao/csrc/metal/int4_quantized_kernels.metal
+++ b/torchao/csrc/metal/int4_quantized_kernels.metal
@@ -1,0 +1,128 @@
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T> struct Vec4Type {};
+
+template <> struct Vec4Type<float> { using type = float4; };
+
+template <> struct Vec4Type<half> { using type = half4; };
+
+#if __METAL_VERSION__ >= 310
+template <> struct Vec4Type<bfloat> { using type = bfloat4; };
+#endif
+
+template <typename T, unsigned groupSize>
+kernel void int4pack_mv(constant T *A [[buffer(0)]],
+                        constant uchar *B [[buffer(1)]],
+                        constant T *scalesAndZeros [[buffer(2)]],
+                        device T *outputData [[buffer(3)]],
+                        constant uint3 &sizes [[buffer(4)]], // M, K, N
+                        uint thread_index [[thread_position_in_grid]],
+                        uint tid_in_simdgroup [[thread_index_in_simdgroup]]) {
+  constexpr uint threads_per_channel = 32;
+  constexpr uint ks_per_thread = 4;
+  constexpr uint k_pack_factor = 2;
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  uint n = thread_index; // 0..N/4-1
+  n = n / threads_per_channel;
+  n = n * 4;
+  uint k = (tid_in_simdgroup % threads_per_channel) * ks_per_thread;
+  constexpr int k_jump = threads_per_channel * ks_per_thread;
+
+  using vecT = typename Vec4Type<T>::type;
+  constant vecT *A_ptr = reinterpret_cast<constant vecT *>(A);
+  constant uchar *B_ptr = B + ((n * K) / k_pack_factor);
+
+  thread float4 rc = float4(0.0);
+  float4 act_div_scales = {1.f, 1 / 16.f, 1 / 256.f, 1 / 4096.f};
+
+  uint k_block_index = k / groupSize;
+  uint scales_n_offset = (k_block_index * N + n) * 2;
+  uint zeros_n_offset = scales_n_offset + 1;
+  uint scales_jump =
+      N * 2 *
+      (k_jump /
+       groupSize); /* the last term accounts for identifying the group this
+                      thread will have to process in each iteration. This mean
+                      each iteration it must jump to a different group. Thus
+                      k_jump must be > grupSize */
+  for (; k < K; k += k_jump) {
+    const T scale0 = scalesAndZeros[scales_n_offset];
+    // Adding zero point results in 10% perf penalty.
+    const T zero0 = scalesAndZeros[zeros_n_offset] - scale0 * T(8);
+
+    const T scale1 = scalesAndZeros[scales_n_offset + 2];
+    const T zero1 = scalesAndZeros[zeros_n_offset + 2] - scale1 * T(8);
+
+    const T scale2 = scalesAndZeros[scales_n_offset + 4];
+    const T zero2 = scalesAndZeros[zeros_n_offset + 4] - scale2 * T(8);
+
+    const T scale3 = scalesAndZeros[scales_n_offset + 6];
+    const T zero3 = scalesAndZeros[zeros_n_offset + 6] - scale3 * T(8);
+
+    scales_n_offset += scales_jump;
+    zeros_n_offset += scales_jump;
+
+    const float4 zeros = float4(zero0, zero1, zero2, zero3);
+
+    float4 a_val = float4(A_ptr[k / 4]);   // * k_scales;
+    float4 a_vec = a_val * act_div_scales; // * k_scales;
+    float a_val_sum = a_val[0] + a_val[1] + a_val[2] + a_val[3];
+
+    float4x4 b_mat;
+    ushort b_val0 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 0 * K) / k_pack_factor))[0];
+    ushort b_val1 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 1 * K) / k_pack_factor))[0];
+    ushort b_val2 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 2 * K) / k_pack_factor))[0];
+    ushort b_val3 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 3 * K) / k_pack_factor))[0];
+    b_mat[0] = scale0 * float4(float(b_val0 & 0x000f), float(b_val0 & 0x00f0),
+                               float(b_val0 & 0x0f00), float(b_val0 & 0xf000));
+    b_mat[1] = scale1 * float4(float(b_val1 & 0x000f), float(b_val1 & 0x00f0),
+                               float(b_val1 & 0x0f00), float(b_val1 & 0xf000));
+    b_mat[2] = scale2 * float4(float(b_val2 & 0x000f), float(b_val2 & 0x00f0),
+                               float(b_val2 & 0x0f00), float(b_val2 & 0xf000));
+    b_mat[3] = scale3 * float4(float(b_val3 & 0x000f), float(b_val3 & 0x00f0),
+                               float(b_val3 & 0x0f00), float(b_val3 & 0xf000));
+
+    rc += a_vec * b_mat;
+    rc += a_val_sum * zeros;
+  }
+  rc += simd_shuffle_down(rc, 1);
+  rc += simd_shuffle_down(rc, 2);
+  rc += simd_shuffle_down(rc, 4);
+  rc += simd_shuffle_down(rc, 8);
+  rc += simd_shuffle_down(rc, 16);
+  if (tid_in_simdgroup % threads_per_channel == 0) {
+    reinterpret_cast<device vecT *>(outputData)[n / 4] = vecT(rc);
+  }
+}
+
+#define INSTANTIATE_INT4MV(DTYPE, GSIZE)                                       \
+  template [[host_name("int4pack_mv_" #GSIZE "_" #DTYPE)]] kernel void         \
+  int4pack_mv<DTYPE, GSIZE>(                                                   \
+      constant DTYPE * A [[buffer(0)]], constant uchar * B [[buffer(1)]],      \
+      constant DTYPE * scalesAndZeros [[buffer(2)]],                           \
+      device DTYPE * outputData [[buffer(3)]],                                 \
+      constant uint3 & sizes [[buffer(4)]],                                    \
+      uint thread_index [[thread_position_in_grid]],                           \
+      uint tid_in_simdgroup [[thread_index_in_simdgroup]])
+
+INSTANTIATE_INT4MV(float, 32);
+INSTANTIATE_INT4MV(half, 32);
+INSTANTIATE_INT4MV(float, 64);
+INSTANTIATE_INT4MV(half, 64);
+INSTANTIATE_INT4MV(float, 128);
+INSTANTIATE_INT4MV(half, 128);
+INSTANTIATE_INT4MV(float, 256);
+INSTANTIATE_INT4MV(half, 256);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_INT4MV(bfloat, 32);
+INSTANTIATE_INT4MV(bfloat, 64);
+INSTANTIATE_INT4MV(bfloat, 128);
+INSTANTIATE_INT4MV(bfloat, 256);
+#endif

--- a/torchao/csrc/metal/int4_quantized_kernels.metal
+++ b/torchao/csrc/metal/int4_quantized_kernels.metal
@@ -13,7 +13,7 @@ template <> struct Vec4Type<bfloat> { using type = bfloat4; };
 #endif
 
 /*
-   This code takes heavy inspiration from MLX qmv kernel here:
+   This code takes heavy inspiration from MLX qvm kernel here:
    https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/quantized.metal#L381
    Specifically:
      - Multiplying activation by inverse scaling factor to reduce compute
@@ -84,7 +84,7 @@ TODOs:
    Right now code handles only M = 1 case. Fix that.
 */
 template <typename T, unsigned groupSize>
-kernel void int4pack_mv(constant T *A [[buffer(0)]],
+kernel void int4pack_vm(constant T *A [[buffer(0)]],
                         constant uchar *B [[buffer(1)]],
                         constant T *scalesAndZeros [[buffer(2)]],
                         device T *outputData [[buffer(3)]],
@@ -185,8 +185,8 @@ kernel void int4pack_mv(constant T *A [[buffer(0)]],
 }
 
 #define INSTANTIATE_INT4MV(DTYPE, GSIZE)                                       \
-  template [[host_name("int4pack_mv_" #GSIZE "_" #DTYPE)]] kernel void         \
-  int4pack_mv<DTYPE, GSIZE>(                                                   \
+  template [[host_name("int4pack_vm_" #GSIZE "_" #DTYPE)]] kernel void         \
+  int4pack_vm<DTYPE, GSIZE>(                                                   \
       constant DTYPE * A [[buffer(0)]], constant uchar * B [[buffer(1)]],      \
       constant DTYPE * scalesAndZeros [[buffer(2)]],                           \
       device DTYPE * outputData [[buffer(3)]],                                 \

--- a/torchao/csrc/metal/int4_quantized_kernels.metal
+++ b/torchao/csrc/metal/int4_quantized_kernels.metal
@@ -37,11 +37,17 @@ template <> struct Vec4Type<bfloat> { using type = bfloat4; };
    handles 4 contiguous k values and then jumps 128 elements, k_jump =
    thread_per_channel (32) * ks_per_thread (4). Take a simpler example where
    simdgroup is of size 4. In this case threads_per_channel = 4. Assume K = 32
-   K =        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-   19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] thread      ---- 0 ---
-   ---- 1 ---  ---- 2 -----  ----- 3 ------  ------ 0 -----  ------ 1 -----
-   ----- 2 ------- ---- 3 ------- id in simd group that handle corresponding
-   k
+      k                thread
+   [0, 1, 2, 3,          0
+    4, 5, 6, 7,          1
+    8, 9, 10, 11,        2
+    12, 13, 14, 15,      3
+    16, 17, 18, 19,      0
+    20, 21, 22, 23,      1
+    24, 25, 26, 27,      2
+    28, 29, 30, 31]      3
+   thtread id in simd group that handle corresponding
+   ks
    Thread 0 here is handling (0, 1, 2, 3) and then (16, 17, 18, 19). They are
    apare by k_jump = 4 * 4 = 16 This is done improve memory access locality
    amonng threads that are working co-operatively. Once each thread has their
@@ -53,6 +59,7 @@ template <> struct Vec4Type<bfloat> { using type = bfloat4; };
    responsible for (1x4) tile of the output. We havent evaluated whether a
    different tile size is better or not. We probably will do some auto-tuning
    once initial work is done.
+
 */
 
 /*
@@ -64,7 +71,7 @@ template <> struct Vec4Type<bfloat> { using type = bfloat4; };
    @param [in] B is weight matrix of size M x K. Each byte contains 2 4bit
    values, along K dim, packed together.
    @param [in] scalesAndZeros is scales and zero points corresponding each
-   output channel x groups. These are packed as [N, groupSize, 2]. N = output
+   output channel x groups. These are packed as [groupSize, N, 2]. N = output
    channels. Last 2 correspond to packing scale and zero point together.
    @param [out] outputData is output matrix of size M x N.
    @param [in] sizes array contains values of M, N and K.
@@ -101,12 +108,21 @@ kernel void int4pack_mv(constant T *A [[buffer(0)]],
   constant vecT *A_ptr = reinterpret_cast<constant vecT *>(A);
   constant uchar *B_ptr = B + ((n * K) / k_pack_factor);
 
-  thread float4 rc = float4(0.0);
+  thread float4 result = float4(0.0);
+  // We multipy group of 4 channels with these scales.
+  // Because corresponding values from weight matrix are effectively left
+  // shifted. This is to avoid doing right shift on those values which ends up
+  // affecting performance. This is the trick applied in MLX kernels.
   float4 act_div_scales = {1.f, 1 / 16.f, 1 / 256.f, 1 / 4096.f};
 
+  // Find specific group to which group of channels handled by this thread
+  // belong.
   uint k_block_index = k / groupSize;
-  uint scales_n_offset = (k_block_index * N + n) * 2;
-  uint zeros_n_offset = scales_n_offset + 1;
+  // Since scalesAndZeros are packed as [groupSize, N, 2].
+  // Finding a specific's group's scales and zero points requires jump by factor
+  // of N*2
+  uint scales_group_offset = (k_block_index * N + n) * 2;
+  uint zeros_gruop_offset = scales_group_offset + 1;
   uint scales_jump =
       N * 2 *
       (k_jump /
@@ -115,26 +131,26 @@ kernel void int4pack_mv(constant T *A [[buffer(0)]],
                       each iteration it must jump to a different group. Thus
                       k_jump must be > grupSize */
   for (; k < K; k += k_jump) {
-    const T scale0 = scalesAndZeros[scales_n_offset];
+    const T scale0 = scalesAndZeros[scales_group_offset];
     // Adding zero point results in 10% perf penalty.
-    const T zero0 = scalesAndZeros[zeros_n_offset] - scale0 * T(8);
+    const T zero0 = scalesAndZeros[zeros_gruop_offset] - scale0 * T(8);
 
-    const T scale1 = scalesAndZeros[scales_n_offset + 2];
-    const T zero1 = scalesAndZeros[zeros_n_offset + 2] - scale1 * T(8);
+    const T scale1 = scalesAndZeros[scales_group_offset + 2];
+    const T zero1 = scalesAndZeros[zeros_gruop_offset + 2] - scale1 * T(8);
 
-    const T scale2 = scalesAndZeros[scales_n_offset + 4];
-    const T zero2 = scalesAndZeros[zeros_n_offset + 4] - scale2 * T(8);
+    const T scale2 = scalesAndZeros[scales_group_offset + 4];
+    const T zero2 = scalesAndZeros[zeros_gruop_offset + 4] - scale2 * T(8);
 
-    const T scale3 = scalesAndZeros[scales_n_offset + 6];
-    const T zero3 = scalesAndZeros[zeros_n_offset + 6] - scale3 * T(8);
+    const T scale3 = scalesAndZeros[scales_group_offset + 6];
+    const T zero3 = scalesAndZeros[zeros_gruop_offset + 6] - scale3 * T(8);
 
-    scales_n_offset += scales_jump;
-    zeros_n_offset += scales_jump;
+    scales_group_offset += scales_jump;
+    zeros_gruop_offset += scales_jump;
 
     const float4 zeros = float4(zero0, zero1, zero2, zero3);
 
-    float4 a_val = float4(A_ptr[k / 4]);   // * k_scales;
-    float4 a_vec = a_val * act_div_scales; // * k_scales;
+    float4 a_val = float4(A_ptr[k / 4]);
+    float4 a_vec = a_val * act_div_scales;
     float a_val_sum = a_val[0] + a_val[1] + a_val[2] + a_val[3];
 
     float4x4 b_mat;
@@ -155,16 +171,16 @@ kernel void int4pack_mv(constant T *A [[buffer(0)]],
     b_mat[3] = scale3 * float4(float(b_val3 & 0x000f), float(b_val3 & 0x00f0),
                                float(b_val3 & 0x0f00), float(b_val3 & 0xf000));
 
-    rc += a_vec * b_mat;
-    rc += a_val_sum * zeros;
+    result += a_vec * b_mat;
+    result += a_val_sum * zeros;
   }
-  rc += simd_shuffle_down(rc, 1);
-  rc += simd_shuffle_down(rc, 2);
-  rc += simd_shuffle_down(rc, 4);
-  rc += simd_shuffle_down(rc, 8);
-  rc += simd_shuffle_down(rc, 16);
+  result += simd_shuffle_down(result, 1);
+  result += simd_shuffle_down(result, 2);
+  result += simd_shuffle_down(result, 4);
+  result += simd_shuffle_down(result, 8);
+  result += simd_shuffle_down(result, 16);
   if (tid_in_simdgroup % threads_per_channel == 0) {
-    reinterpret_cast<device vecT *>(outputData)[n / 4] = vecT(rc);
+    reinterpret_cast<device vecT *>(outputData)[n / 4] = vecT(result);
   }
 }
 

--- a/torchao/csrc/metal/int4_quantized_kernels.metal
+++ b/torchao/csrc/metal/int4_quantized_kernels.metal
@@ -12,6 +12,70 @@ template <> struct Vec4Type<half> { using type = half4; };
 template <> struct Vec4Type<bfloat> { using type = bfloat4; };
 #endif
 
+/*
+   This code takes heavy inspiration from MLX qmv kernel here:
+   https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/quantized.metal#L381
+   Specifically:
+     - Multiplying activation by inverse scaling factor to reduce compute
+   boundedness
+     - Handling zero point by accumulating act in separate sum term. Needed with
+   optimization done above. MLX MIT License:
+   https://github.com/ml-explore/mlx/blob/main/LICENSE
+*/
+
+/*
+   A matrix is [M x K] (right now this kernel does not support M > 1 but this is
+   a very easy fix that will follow right after) B matrix is [N x K]. For 4 bit
+   2 of the k values are packed in one byte so you can think of B as [N x K/2]
+   matrix from layout perspective.
+
+   Since this kernel is optimizing for gemv case, we split work, along reduction
+   dim k, among the threads of same simdgroup. Ex: if K = 4096 and simdgroup
+   size is 32 (current algorithm should work as long as simdgroup size is > 32).
+   Then each thread will accumulate 4096/32 = 128 k values. However these 128
+   values, handled by each thread are not laid out contiguously. Each thread
+   handles 4 contiguous k values and then jumps 128 elements, k_jump =
+   thread_per_channel (32) * ks_per_thread (4). Take a simpler example where
+   simdgroup is of size 4. In this case threads_per_channel = 4. Assume K = 32
+   K =        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+   19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] thread      ---- 0 ---
+   ---- 1 ---  ---- 2 -----  ----- 3 ------  ------ 0 -----  ------ 1 -----
+   ----- 2 ------- ---- 3 ------- id in simd group that handle corresponding
+   k
+   Thread 0 here is handling (0, 1, 2, 3) and then (16, 17, 18, 19). They are
+   apare by k_jump = 4 * 4 = 16 This is done improve memory access locality
+   amonng threads that are working co-operatively. Once each thread has their
+   partial sums accumulated, we use tree reduction (Metal offers simd_sum but
+   not used because this code would also work with simdgroup size = 64). In the
+   example above we will have 4 partial sums.
+
+   Each thread also handles 4 different output rows. Thus each simdgroup will be
+   responsible for (1x4) tile of the output. We havent evaluated whether a
+   different tile size is better or not. We probably will do some auto-tuning
+   once initial work is done.
+*/
+
+/*
+   @brief This shader implements 4-bit matrix-vector multiplication where A
+   matrix is fp16, bfloat or float and B matrix is a 4-bit quantized weight
+   matrix. B matrix is quantized, with group wise quantization. As of now this
+   code is tested for group size = 32.
+   @param [in] A is activation matrix of size M x K.
+   @param [in] B is weight matrix of size M x K. Each byte contains 2 4bit
+   values, along K dim, packed together.
+   @param [in] scalesAndZeros is scales and zero points corresponding each
+   output channel x groups. These are packed as [N, groupSize, 2]. N = output
+   channels. Last 2 correspond to packing scale and zero point together.
+   @param [out] outputData is output matrix of size M x N.
+   @param [in] sizes array contains values of M, N and K.
+   @param [in] thread_index is global thread id.
+   @param [in] tid_in_simdgruop is thread id in simdgroup. e.g. in simdgroup of
+   size 32 it can be in [0-31].
+*/
+/*
+TODOs:
+   Right now code handles only M = 1 case. Fix that.
+*/
 template <typename T, unsigned groupSize>
 kernel void int4pack_mv(constant T *A [[buffer(0)]],
                         constant uchar *B [[buffer(1)]],
@@ -28,6 +92,8 @@ kernel void int4pack_mv(constant T *A [[buffer(0)]],
   uint n = thread_index; // 0..N/4-1
   n = n / threads_per_channel;
   n = n * 4;
+  // This is starting k for each thread. In the example above, for thread 1 this
+  // value will be 4.
   uint k = (tid_in_simdgroup % threads_per_channel) * ks_per_thread;
   constexpr int k_jump = threads_per_channel * ks_per_thread;
 

--- a/torchao/csrc/metal/test_int4_q_kernels.mm
+++ b/torchao/csrc/metal/test_int4_q_kernels.mm
@@ -1,0 +1,289 @@
+#include <Metal/Metal.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <stdlib.h>
+#include <string>
+
+/*
+   This code is largely copy paste from Nikit Shulga's llm_experiments repo
+*/
+
+void fail(const std::string &str) {
+  std::cerr << str << std::endl;
+  abort();
+}
+
+void fail(const std::string &str1, const std::string &str2) {
+  std::cerr << str1 << str2 << std::endl;
+  abort();
+}
+
+id<MTLDevice> getMetalDevice() {
+  NSArray *devices = [MTLCopyAllDevices() autorelease];
+  if (devices.count == 0) {
+    fail("Metal is not supported");
+  }
+  return devices[0];
+}
+
+id<MTLLibrary> compileLibraryFromSource(id<MTLDevice> device,
+                                        const std::string &source) {
+  NSError *error = nil;
+  MTLCompileOptions *options = [[MTLCompileOptions new] autorelease];
+  [options setLanguageVersion:MTLLanguageVersion3_1];
+  id<MTLLibrary> library = [device
+      newLibraryWithSource:[NSString stringWithUTF8String:source.c_str()]
+                   options:options
+                     error:&error];
+  if (library == nil) {
+    fail("Failed to compile: ", error.description.UTF8String);
+  }
+  return library;
+}
+
+id<MTLLibrary> compileLibraryFromFile(id<MTLDevice> device,
+                                      const std::string &fname) {
+  std::ifstream ifs(fname);
+  std::stringstream ss;
+  ss << ifs.rdbuf();
+  ifs.close();
+  return compileLibraryFromSource(device, ss.str());
+}
+
+id<MTLBuffer> allocSharedBuffer(id<MTLDevice> device, unsigned length) {
+  id<MTLBuffer> rc = [device newBufferWithLength:length
+                                         options:MTLResourceStorageModeShared];
+  if (rc == nil) {
+    fail("Can't allocate " + std::to_string(length) + " bytes on GPU");
+  }
+  return rc;
+}
+
+inline uint32_t float_as_int(float f) {
+  union {
+    float f;
+    uint32_t i;
+  } x;
+  x.f = f;
+  return x.i;
+}
+
+inline float int_as_float(uint32_t i) {
+  union {
+    float f;
+    uint32_t i;
+  } x;
+  x.i = i;
+  return x.f;
+}
+
+struct BFloat16 {
+  BFloat16(float x) : val(float_as_int(x) >> 16) {}
+  operator float() const { return int_as_float(val << 16); }
+
+  uint16_t val;
+};
+using Float16 = _Float16;
+
+template <unsigned groupSize> struct Int4MMBase {
+  Int4MMBase(id<MTLDevice> device, const std::string &lib_name_, unsigned M_,
+             unsigned N_, unsigned K_)
+      : Int4MMBase(device, M_, N_, K_) {
+    lib_name = lib_name_;
+    lib = compileLibraryFromFile(device, lib_name + ".metal");
+  }
+  Int4MMBase(id<MTLDevice> device, unsigned M_, unsigned N_, unsigned K_)
+      : M(M_), N(N_), K(K_), lib(nil) {
+    allocBuffers(device);
+  }
+
+  virtual void dispatchThreads(id<MTLComputeCommandEncoder> encoder,
+                               unsigned maxThreadsPerGroup) const {}
+
+  void encodeMM(id<MTLCommandBuffer> cmdBuffer,
+                id<MTLComputePipelineState> cpl) const {
+    id<MTLComputeCommandEncoder> encoder = [cmdBuffer computeCommandEncoder];
+    std::vector<unsigned> sizes = {M, K, N, 0};
+    const auto maxThreadsPerGroup =
+        static_cast<decltype(M)>([cpl maxTotalThreadsPerThreadgroup]);
+    [encoder setComputePipelineState:cpl];
+    [encoder setBuffer:buf_A offset:0 atIndex:0];
+    [encoder setBuffer:buf_B offset:0 atIndex:1];
+    [encoder setBuffer:buf_SZ offset:0 atIndex:2];
+    [encoder setBuffer:buf_C offset:0 atIndex:3];
+    [encoder setBytes:sizes.data()
+               length:sizeof(uint32_t) * sizes.size()
+              atIndex:4];
+    dispatchThreads(encoder, maxThreadsPerGroup);
+    [encoder endEncoding];
+  }
+
+  template <typename T> void init() {
+    T *a_ptr = reinterpret_cast<T *>([buf_A contents]);
+    uint8_t *b_ptr = reinterpret_cast<uint8_t *>([buf_B contents]);
+    T *c_ptr = reinterpret_cast<T *>([buf_C contents]);
+    T *s_ptr = reinterpret_cast<T *>([buf_SZ contents]);
+    std::random_device rd;
+    std::mt19937 generator(rd());
+    std::uniform_int_distribution<> int_distrib(-8, 7);
+    std::uniform_real_distribution<> real_distrib(-1.0, 1.0);
+
+    for (unsigned idx = 0; idx < M * K; ++idx) {
+      a_ptr[idx] = real_distrib(generator);
+    }
+    for (unsigned idx = 0; idx < N * K / 2; ++idx) {
+      int32_t b0 = int_distrib(generator);
+      int32_t b1 = int_distrib(generator);
+      b_ptr[idx] = ((b1 + 8) << 4) | (b0 + 8);
+    }
+    for (unsigned idx = 0; idx < N * K / groupSize; ++idx) {
+      s_ptr[2 * idx] = (idx + 1.0) / N;
+      s_ptr[2 * idx + 1] = 0;
+    }
+    for (unsigned idx = 0; idx < M * N; ++idx) {
+      c_ptr[idx] = -1.0;
+    }
+  }
+
+  template <typename T>
+  bool validate(float atol_lim = 5e-4, float rtol_lim = 5e-3) const {
+    T *a_ptr = reinterpret_cast<T *>([buf_A contents]);
+    uint8_t *b_ptr = reinterpret_cast<uint8_t *>([buf_B contents]);
+    T *c_ptr = reinterpret_cast<T *>([buf_C contents]);
+    T *sz_ptr = reinterpret_cast<T *>([buf_SZ contents]);
+
+    for (unsigned m = 0; m < M; m++) {
+      for (unsigned n = 0; n < N; n++) {
+        float expected = float(c_ptr[m * N + n]);
+        const uint32_t k_block = (K + groupSize - 1) / groupSize;
+        const T *A_ptr = a_ptr + m * K;
+
+        float rc = 0.0;
+        uint k = 0;
+        for (uint32_t kb = 0; kb < k_block; kb++) {
+          const T scale = sz_ptr[(kb * N + n) * 2 + 0];
+          const T zero = sz_ptr[(kb * N + n) * 2 + 1] - scale * T(8);
+          for (uint idx = 0; idx < groupSize && k < K; idx++, k++) {
+            const auto a_val = float(A_ptr[k]);
+            uint8_t b_val = b_ptr[(n * K + k) / 2];
+            b_val = (k & 1) == 0 ? b_val & 0x0f : (b_val >> 4);
+            rc += a_val * float(scale * T(b_val) + zero);
+          }
+        }
+
+        auto atol = std::abs(rc - expected);
+        auto rtol =
+            atol / std::max(std::min(std::abs(expected), std::abs(rc)), 1e-6f);
+        if (rtol > rtol_lim && atol > atol_lim) {
+          std::cerr << "Error at:(" << m << ", " << n << ")\n";
+          std::cerr << "Result " << expected << " vs expected " << rc
+                    << " (atol=" << atol << " ,rtol=" << rtol << ") at " << m
+                    << ":" << n << std::endl;
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  template <typename T> float run_and_validate() {
+    init<T>();
+    id<MTLFunction> func = [lib
+        newFunctionWithName:[NSString
+                                stringWithFormat:@"int4pack_mv_%u_%s",
+                                                 groupSize,
+                                                 type_string<T>().c_str()]];
+    if (func == nil) {
+      fail("Can:t get function");
+    }
+    NSError *error = nil;
+    auto cpl = [lib.device newComputePipelineStateWithFunction:func
+                                                         error:&error];
+    if (cpl == nil) {
+      fail("Failed to construct pipeline state: ",
+           error.description.UTF8String);
+    }
+    id<MTLCommandQueue> queue = [lib.device newCommandQueue];
+    auto do_compute = ^() {
+      @autoreleasepool {
+        auto desc = [MTLCommandBufferDescriptor new];
+        desc.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
+        id<MTLCommandBuffer> cmdBuffer =
+            [queue commandBufferWithDescriptor:desc];
+        encodeMM(cmdBuffer, cpl);
+        [cmdBuffer commit];
+        [cmdBuffer waitUntilCompleted];
+      }
+    };
+
+    do_compute();
+
+    if (!validate<T>()) {
+      return false;
+    }
+    return true;
+  }
+
+private:
+  template <typename T> std::string type_string() const;
+  template <> std::string type_string<BFloat16>() const { return "bfloat"; }
+  template <> std::string type_string<float>() const { return "float"; }
+  template <> std::string type_string<Float16>() const { return "half"; }
+  void allocBuffers(id<MTLDevice> device, const unsigned elem_size = 4) {
+    buf_A = allocSharedBuffer(device, M * K * elem_size);
+    buf_B = allocSharedBuffer(device, N * K / 2);
+    buf_C = allocSharedBuffer(device, M * N * elem_size);
+    buf_SZ = allocSharedBuffer(device, N * K / groupSize * 2 * elem_size);
+  }
+
+public:
+  unsigned M, N, K;     // Input-output matirx dims
+  id<MTLBuffer> buf_A;  // MxK elements
+  id<MTLBuffer> buf_B;  // NxK elements
+  id<MTLBuffer> buf_C;  // MxN elements
+  id<MTLBuffer> buf_SZ; // (K/groupSize)xNx2 elements
+  id<MTLLibrary> lib;
+  std::string lib_name;
+};
+
+template <unsigned groupSize> struct Int4MV : public Int4MMBase<groupSize> {
+  using Int4MMBase<groupSize>::M;
+  using Int4MMBase<groupSize>::N;
+  Int4MV(id<MTLDevice> device, const std::string &lib_name_, unsigned M_,
+         unsigned N_, unsigned K_)
+      : Int4MMBase<groupSize>(device, lib_name_, M_, N_, K_) {
+    if (M != 1) {
+      fail("Value of M must be 1");
+    }
+  }
+  void dispatchThreads(id<MTLComputeCommandEncoder> encoder,
+                       unsigned maxThreadsPerGroup) const override {
+    constexpr auto blockSize = 8;
+    if (maxThreadsPerGroup < blockSize * blockSize) {
+      throw std::runtime_error("Can't dispatch!");
+    }
+    [encoder dispatchThreads:MTLSizeMake(N / 4 * 32, 1, M)
+        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+  }
+};
+
+int main() {
+  unsigned M, N, K;
+  std::tie(M, N, K) = std::make_tuple(1, 4096, 4096);
+  constexpr unsigned groupSize = 32;
+  @autoreleasepool {
+    id<MTLDevice> device = getMetalDevice();
+    std::cout << "Using device " << device.name.UTF8String << std::endl;
+    Int4MV<groupSize> int4mv_tester(device, "int4_quantized_kernels", M, N, K);
+
+    // Benchmarks
+    int4mv_tester.run_and_validate<BFloat16>();
+  }
+  return 0;
+}

--- a/torchao/csrc/metal/test_int4_q_kernels.mm
+++ b/torchao/csrc/metal/test_int4_q_kernels.mm
@@ -11,7 +11,7 @@
 #include <string>
 
 /*
-   This code is largely copy paste from Nikit Shulga's llm_experiments repo
+   This code is largely copy paste from Nikita Shulga's llm_experiments repo
 */
 
 void fail(const std::string &str) {
@@ -192,7 +192,7 @@ template <unsigned groupSize> struct Int4MMBase {
     return true;
   }
 
-  template <typename T> float run_and_validate() {
+  template <typename T> bool run_and_validate() {
     init<T>();
     id<MTLFunction> func = [lib
         newFunctionWithName:[NSString
@@ -283,7 +283,9 @@ int main() {
     Int4MV<groupSize> int4mv_tester(device, "int4_quantized_kernels", M, N, K);
 
     // Benchmarks
-    int4mv_tester.run_and_validate<BFloat16>();
+    if (!int4mv_tester.run_and_validate<BFloat16>()) {
+      fail("Failed to validate");
+    };
   }
   return 0;
 }

--- a/torchao/csrc/metal/test_int4_q_kernels.mm
+++ b/torchao/csrc/metal/test_int4_q_kernels.mm
@@ -195,7 +195,7 @@ template <int groupSize> struct Int4MMBase {
     init<T>();
     id<MTLFunction> func = [lib
         newFunctionWithName:[NSString
-                                stringWithFormat:@"int4pack_mv_%u_%s",
+                                stringWithFormat:@"int4pack_vm_%u_%s",
                                                  groupSize,
                                                  type_string<T>().c_str()]];
     if (func == nil) {
@@ -279,10 +279,10 @@ int main() {
   @autoreleasepool {
     id<MTLDevice> device = getMetalDevice();
     std::cout << "Using device " << device.name.UTF8String << std::endl;
-    Int4MV<groupSize> int4mv_tester(device, "int4_quantized_kernels", M, N, K);
+    Int4MV<groupSize> int4vm_tester(device, "int4_quantized_kernels", M, N, K);
 
     // Benchmarks
-    if (!int4mv_tester.run_and_validate<BFloat16>()) {
+    if (!int4vm_tester.run_and_validate<BFloat16>()) {
       fail("Failed to validate");
     };
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #319
* #318
* #317
* __->__ #316

This diff adds:
- int4 quant metal kernels
- Add tests for it with group size = 32 using cmake build

TODO
- Adding tests to CI
- Custom op integration into pytorch (helps with testing via python)

Kernels are heavily inspired by MLX
Test runner is copied from Nikita Shulga's metal experiments repo.

Plans how this kernel will factor in end2end quant + acceleration:

Operators: wrapper operator will be added that will take in void* and launch shader code via Metal APIs. For CPU kernels this will be simpler. There are some finer issues that we will have to figure out, such as will the kernel launch be blocking and if not blocking how can we expose this.
Custom ops registration: the operators will be wrapped in custom ops API, both pytorch and executorch. Pytorch specific custom ops artifact can be part of the pip package so the ops are available via api like torchao.ops... For executorch, we will have to build separate lib for different deployment targets, e.g. android, that is distributed (method of distribution needs to be figured out)
Quantization: Specific Quantizer, e.g 4-bit, can dispatch to the custom op that support that quant scheme and backend, similar to int4pack_mm.