### PR TITLE
Update nightly build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install torchao
 
 Nightly Release
 ```Shell
-pip install torchao-nightly
+pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/
 ```
 
 From source

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ pip install torchao
 ```
 
 Nightly Release
-```Shell
-pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/
+```Shell 
+pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/ # CUDA builds
+pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/cpu # CPU only builds
 ```
 
 From source


### PR DESCRIPTION
Test plan

Important part is the date: Successfully installed torchao-nightly-2024.6.7+cu124

```
(ao) [marksaroufim@devgpu003.cco3 ~]$ pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/ 
Looking in indexes: https://download.pytorch.org/whl/nightly/
Collecting torchao-nightly
  Downloading https://download.pytorch.org/whl/nightly/cu124/torchao_nightly-2024.6.7%2Bcu124-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 3.1 MB/s eta 0:00:00
Requirement already satisfied: torch in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (2.3.1)
Requirement already satisfied: numpy in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (1.26.4)
Requirement already satisfied: sentencepiece in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (0.2.0)
Requirement already satisfied: packaging in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (24.0)
Requirement already satisfied: expecttest in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (0.2.1)
Requirement already satisfied: hypothesis in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torchao-nightly) (6.103.1)
Requirement already satisfied: attrs>=22.2.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from hypothesis->torchao-nightly) (23.2.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from hypothesis->torchao-nightly) (2.4.0)
Requirement already satisfied: exceptiongroup>=1.0.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from hypothesis->torchao-nightly) (1.2.1)
Requirement already satisfied: filelock in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (3.14.0)
Requirement already satisfied: typing-extensions>=4.8.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (4.12.1)
Requirement already satisfied: sympy in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (1.12.1)
Requirement already satisfied: networkx in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (3.3)
Requirement already satisfied: jinja2 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (3.1.4)
Requirement already satisfied: fsspec in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (2024.6.0)
Requirement already satisfied: nvidia-cuda-nvrtc-cu12==12.1.105 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.105)
Requirement already satisfied: nvidia-cuda-runtime-cu12==12.1.105 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.105)
Requirement already satisfied: nvidia-cuda-cupti-cu12==12.1.105 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.105)
Requirement already satisfied: nvidia-cudnn-cu12==8.9.2.26 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (8.9.2.26)
Requirement already satisfied: nvidia-cublas-cu12==12.1.3.1 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.3.1)
Requirement already satisfied: nvidia-cufft-cu12==11.0.2.54 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (11.0.2.54)
Requirement already satisfied: nvidia-curand-cu12==10.3.2.106 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (10.3.2.106)
Requirement already satisfied: nvidia-cusolver-cu12==11.4.5.107 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (11.4.5.107)
Requirement already satisfied: nvidia-cusparse-cu12==12.1.0.106 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.0.106)
Requirement already satisfied: nvidia-nccl-cu12==2.20.5 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (2.20.5)
Requirement already satisfied: nvidia-nvtx-cu12==12.1.105 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (12.1.105)
Requirement already satisfied: triton==2.3.1 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from torch->torchao-nightly) (2.3.1)
Requirement already satisfied: nvidia-nvjitlink-cu12 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from nvidia-cusolver-cu12==11.4.5.107->torch->torchao-nightly) (12.5.40)
Requirement already satisfied: MarkupSafe>=2.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from jinja2->torch->torchao-nightly) (2.1.5)
Requirement already satisfied: mpmath<1.4.0,>=1.1.0 in ./anaconda3/envs/ao/lib/python3.10/site-packages (from sympy->torch->torchao-nightly) (1.3.0)
Installing collected packages: torchao-nightly
Successfully installed torchao-nightly-2024.6.7+cu124
```

Importing the package succeeds

```
(ao) [marksaroufim@devgpu003.cco3 ~]$ python
Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torchao
>>> 
```

If someone else wants to import `torchao` in their requirements.txt and use the nightlies they would have

```
# in requirements.txt
-index-url https://download.pytorch.org/whl/nightly/
torchao-nightly
```

Although not sure how this would work with a pyproject.toml based flow, I know that's considered more modern but seems like there's no way I can find to set an extra index up without the help of something like poetry