### PR TITLE
Move some util functions from quantization.utils to torchao.utils

### DIFF
--- a/test/dtypes/test_fp8.py
+++ b/test/dtypes/test_fp8.py
@@ -7,7 +7,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 try:
     from torchao.prototype.fp8 import gemm_split_k, to_float8

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -70,7 +70,7 @@ import os
 from parameterized import parameterized
 import itertools
 import logging
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
 
 logger = logging.getLogger("INFO")
 

--- a/test/prototype/mx_formats/test_custom_cast.py
+++ b/test/prototype/mx_formats/test_custom_cast.py
@@ -44,7 +44,7 @@ from torchao.prototype.mx_formats.fp_format_spec import (
 )
 
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 if not TORCH_VERSION_AFTER_2_4:
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -19,7 +19,8 @@ from torchao.prototype.mx_formats.mx_linear import (
     swap_linear_with_mx_linear,
 )
 
-from torchao.quantization.utils import compute_error, TORCH_VERSION_AFTER_2_4
+from torchao.quantization.utils import compute_error
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 # trying to outsmart flake8
 __has_cuda = torch.cuda.is_available()

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -23,7 +23,8 @@ from torchao.prototype.mx_formats.mx_tensor import (
     to_dtype,
 )
 
-from torchao.quantization.utils import compute_error, TORCH_VERSION_AFTER_2_4
+from torchao.quantization.utils import compute_error
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 # trying to outsmart flake8
 __has_cuda = torch.cuda.is_available()

--- a/test/prototype/test_bitpacking.py
+++ b/test/prototype/test_bitpacking.py
@@ -2,7 +2,7 @@ import torch
 from torchao.prototype.common.bitpacking import pack, unpack
 import pytest
 from torch.utils._triton import has_triton
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 if not TORCH_VERSION_AFTER_2_4:
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)
@@ -20,7 +20,7 @@ def test_uint3_to_int16_col_wise_cpu():
     unpacked = unpack(packed, 3, False, device='cpu')
     unpadded = unpacked[:test_tensor.shape[0], ...]
     assert(unpadded.allclose(test_tensor))
-    
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_uint4_to_uint8():
     test_tensor = torch.randint(0, 15, (4, 4), dtype=torch.uint8).cuda()
@@ -28,7 +28,7 @@ def test_uint4_to_uint8():
     unpacked = unpack(packed, 4)
     unpadded = unpacked[:test_tensor.shape[0], ...]
     assert(unpadded.allclose(test_tensor))
-     
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 def test_uint4_to_uint8_compile():
@@ -40,7 +40,7 @@ def test_uint4_to_uint8_compile():
     unpacked = unpack_compiled(packed, 4)
     unpadded = unpacked[:test_tensor.shape[0], ...]
     assert(unpadded.allclose(test_tensor))
-    
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_uint3_to_int16():
     test_tensor = torch.randint(0, 7, (5, 8), dtype=torch.int16).cuda()

--- a/test/quantization/model.py
+++ b/test/quantization/model.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn import functional as F
-from torchao.quantization.utils import find_multiple
+from torchao.utils import find_multiple
 
 def prepare_inputs_for_model(inps, max_new_tokens=1):
     # this is because input from lm-eval is 2d

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -19,7 +19,7 @@ from torchao.quantization.prototype.qat import (
     fake_quantize_per_token,
 )
 from torchao.quantization.quant_primitives import get_group_qparams_symmetric
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 
 # TODO: put this in a common test utils file

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -44,7 +44,7 @@ from torchao.quantization.quant_api import (
     get_apply_int8wo_quant,
     get_apply_int8dyn_quant,
 )
-from torchao.quantization.utils import (
+from torchao.utils import (
     TORCH_VERSION_AFTER_2_3,
     TORCH_VERSION_AFTER_2_4,
 )
@@ -556,7 +556,7 @@ class TestQuantFlow(unittest.TestCase):
         self.assertTrue(torch.equal(res, ref))
 
         # workaround for export path
-        from torchao.quantization.utils import unwrap_tensor_subclass
+        from torchao.utils import unwrap_tensor_subclass
         m_unwrapped = unwrap_tensor_subclass(m)
 
         m = torch.export.export(m_unwrapped, example_inputs).module()

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -19,7 +19,7 @@ from torchao.quantization.quant_primitives import (
     MappingType,
 )
 
-from torchao.quantization.utils import (
+from torchao.utils import (
     TORCH_VERSION_AFTER_2_3,
     TORCH_VERSION_AFTER_2_4,
 )

--- a/test/sparsity/test_fast_sparse_training.py
+++ b/test/sparsity/test_fast_sparse_training.py
@@ -12,7 +12,7 @@ from torchao.sparsity.training import (
     swap_semi_sparse_linear_with_linear,
     SemiSparseLinear
 )
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 class TestModel(nn.Module):
     def __init__(self):
@@ -42,7 +42,7 @@ class TestRuntimeSemiStructuredSparsity(TestCase):
             if isinstance(mod, torch.nn.Linear):
                 sparse = SparseSemiStructuredTensorCUSPARSELT.prune_dense_static_sort(mod.weight.detach()).to_dense()
                 mod.weight = nn.Parameter(sparse)
-        
+
         dense_result = model(input)
 
         # map from fqn to replacement linear module

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -11,7 +11,7 @@ from torchao.quantization.quant_api import (
     _get_subclass_inserter,
     _is_linear,
 )
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 from torch.testing._internal.common_utils import TestCase
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2,7 +2,7 @@ import torch
 from torch.testing._internal.common_utils import TestCase, IS_FBCODE
 from torch.testing._internal.optests import opcheck
 import torchao
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 import unittest
 from parameterized import parameterized
 import pytest

--- a/torchao/_executorch_ops.py
+++ b/torchao/_executorch_ops.py
@@ -9,7 +9,7 @@ def _quantized_decomposed_quantize_per_channel_group_wrapper(*args, **kwargs):
     torch.ops.quantized_decomposed.quantize_per_channel_group is only available
     in PyTorch 2.3+ and recently changed signatures.
     """
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+    from torchao.utils import TORCH_VERSION_AFTER_2_3
     if TORCH_VERSION_AFTER_2_3:
         return torch.ops.quantized_decomposed.quantize_per_channel_group(*args, **kwargs)
     raise ImportError("Need torch.ops.quantized_decomposed.quantize_per_channel_group, which is only available with PyTorch 2.3 or later.")
@@ -23,7 +23,7 @@ def _quantized_decomposed_choose_qparams_per_token_asymmetric_wrapper(*args, **k
     torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric is only available
     in PyTorch 2.3+ and recently changed signatures.
     """
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+    from torchao.utils import TORCH_VERSION_AFTER_2_3
     if TORCH_VERSION_AFTER_2_3:
         return torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(*args, **kwargs)
     raise ImportError("Need torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric, which is only available with PyTorch 2.3 or later.")
@@ -37,7 +37,7 @@ def _quantized_decomposed_dequantize_per_channel_group_wrapper(*args, **kwargs):
     torch.ops.quantized_decomposed.dequantize_per_channel_group is only available
     in PyTorch 2.3+ and recently changed signatures.
     """
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+    from torchao.utils import TORCH_VERSION_AFTER_2_3
     if TORCH_VERSION_AFTER_2_3:
         return torch.ops.quantized_decomposed.dequantize_per_channel_group(*args, **kwargs)
     raise ImportError("Need torch.ops.quantized_decomposed.dequantize_per_channel_group, which is only available with PyTorch 2.3 or later.")
@@ -51,7 +51,7 @@ def _quantized_decomposed_quantize_per_token_wrapper(*args, **kwargs):
     torch.ops.quantized_decomposed.quantize_per_token is only available
     in PyTorch 2.3+ and recently changed signatures.
     """
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+    from torchao.utils import TORCH_VERSION_AFTER_2_3
     if TORCH_VERSION_AFTER_2_3:
         return torch.ops.quantized_decomposed.quantize_per_token(*args, **kwargs)
     raise ImportError("Need torch.ops.quantized_decomposed.quantize_per_token, which is only available with PyTorch 2.3 or later.")
@@ -65,7 +65,7 @@ def _quantized_decomposed_dequantize_per_token_wrapper(*args, **kwargs):
     torch.ops.quantized_decomposed.dequantize_per_token is only available
     in PyTorch 2.3+ and recently changed signatures.
     """
-    from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+    from torchao.utils import TORCH_VERSION_AFTER_2_3
     if TORCH_VERSION_AFTER_2_3:
         return torch.ops.quantized_decomposed.dequantize_per_token(*args, **kwargs)
     raise ImportError("Need torch.ops.quantized_decomposed.dequantize_per_token, which is only available with PyTorch 2.3 or later.")

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -2,7 +2,7 @@ import itertools
 import os
 import torch
 
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_2
+from torchao.utils import TORCH_VERSION_AFTER_2_2
 
 try:
     # Only works for torch2.2 or newer.

--- a/torchao/ops.py
+++ b/torchao/ops.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 
 def register_custom_op(name):

--- a/torchao/prototype/mx_formats/custom_cast.py
+++ b/torchao/prototype/mx_formats/custom_cast.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 from torch.utils._triton import has_triton
 
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 
 # TODO(future): if needed, make the below work on previous PyTorch versions,
 # just need to hunt down the previous location of `libdevice`. An assert

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -22,9 +22,11 @@ from torch.utils._pytree import tree_flatten, tree_unflatten
 from .utils import (
     _lm_eval_available,
     _MultiInput,
-    TORCH_VERSION_AFTER_2_3,
+)
+from torchao.utils import (
     find_multiple,
 )
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 from typing import Any, Dict, Optional
 from .unified import Quantizer
 

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -44,7 +44,6 @@ __all__ = [
     "Int8WeightOnlyQuantizedLinearWeight",
     "Int4WeightOnlyQuantizedLinearWeight",
     "compute_error",
-    "get_model_size_in_bytes",
     "WeightOnlyInt8QuantLinear",
     "Int4WeightOnlyGPTQQuantizer",
     "Int4WeightOnlyQuantizer",

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -9,7 +9,7 @@ from .quant_primitives import (
     quantize_activation_per_token_absmax,
     safe_int_mm,
 )
-from .utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4
 import torch.nn.functional as F
 try:
     from torch._inductor.utils import do_bench

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 from typing import Any, Callable
 
 from .dynamic_quant import DynamicallyPerAxisQuantizedLinear
-from .utils import (
+from torchao.utils import (
     TORCH_VERSION_AFTER_2_4,
     unwrap_tensor_subclass,
 )

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -14,7 +14,7 @@ from torch.library import impl
 
 from torchao.kernel.intmm import int_scaled_matmul
 from torchao.kernel.intmm import safe_int_mm
-from .utils import TORCH_VERSION_AFTER_2_3
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 
 
 __all__ = [

--- a/torchao/quantization/subclass.py
+++ b/torchao/quantization/subclass.py
@@ -18,7 +18,7 @@ from .quant_primitives import (
     groupwise_affine_quantize_tensor_from_qparams,
     MappingType,
 )
-from .utils import find_multiple
+from torchao.utils import find_multiple
 from typing import Tuple, Optional, Callable, Dict, Any
 
 

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -7,20 +7,10 @@ from typing import Dict, Optional, Tuple
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
-from packaging import version
-import torch.nn.utils.parametrize as parametrize
-from torchao.utils import find_multiple
-
 
 __all__ = [
-    "find_multiple",
     "compute_error",
     "_apply_logging_hook",
-    "get_model_size_in_bytes",
-    "unwrap_tensor_subclass",
-    "TORCH_VERSION_AFTER_2_2",
-    "TORCH_VERSION_AFTER_2_3",
-    "TORCH_VERSION_AFTER_2_4",
 ]
 
 try:
@@ -87,67 +77,6 @@ class LoggingTensorMode(TorchDispatchMode):
 
         return rs
 
-
-class UnwrapTensorSubclass(torch.nn.Module):
-    def forward(self, *tensors):
-        todo = list(tensors)
-        for tp, meta, inner_tensors in reversed(self.rebuild_stack):
-            nb_tensor = len(inner_tensors)
-            inner_tensors = {a: b for a, b in zip(inner_tensors, todo[-nb_tensor:])}
-            todo = todo[nb_tensor:]
-            rebuilt = tp.__tensor_unflatten__(inner_tensors, meta, None, None)
-            todo.append(rebuilt)
-
-        assert len(todo) == 1
-        return todo[0]
-
-    def right_inverse(self, tensor):
-        assert type(tensor) is not torch.Tensor
-        rebuild_stack = []
-        plain_tensors = []
-        todo = [tensor]
-        while todo:
-            obj = todo.pop()
-            inner_tensors, metadata = obj.__tensor_flatten__()
-            rebuild_stack.append((type(obj), metadata, inner_tensors))
-            for attr_name in inner_tensors:
-                val = getattr(obj, attr_name)
-                if type(val) is torch.Tensor:
-                    plain_tensors.append(val)
-                else:
-                    assert isinstance(val, torch.Tensor)
-                    todo.append(val)
-
-        self.rebuild_stack = rebuild_stack
-
-        return plain_tensors
-
-def unwrap_tensor_subclass(model, filter_fn=None):
-    for name, child in model.named_children():
-        # make sure child.weight is a tensor subclass
-        if (
-            isinstance(child, torch.nn.Linear) and
-            hasattr(child, "weight") and
-            type(child.weight) is not torch.Tensor and
-            type(child.weight) is not torch.nn.Parameter and
-            isinstance(child.weight, torch.Tensor) and
-            issubclass(type(child.weight), torch.Tensor)
-        ):
-            parametrize.register_parametrization(child, "weight", UnwrapTensorSubclass())
-        unwrap_tensor_subclass(child)
-    return model
-
-
-# https://discuss.pytorch.org/t/finding-model-size/130275
-def get_model_size_in_bytes(model):
-    s = 0
-    for p in model.parameters():
-        s += p.nelement() * p.element_size()
-    for b in model.buffers():
-        s += b.nelement() * b.element_size()
-    return s
-
-
 class _MultiInput:
 
     def __init__(self, inputs):
@@ -165,20 +94,3 @@ class _MultiInput:
         self.values = [
             val.cuda() if isinstance(val, torch.Tensor) else val for val in self.values
         ]
-
-
-# TODO: quantization namespace is not the right place ot have this
-if version.parse(torch.__version__) >= version.parse("2.4.0.dev"):
-    TORCH_VERSION_AFTER_2_4 = True
-else:
-    TORCH_VERSION_AFTER_2_4 = False
-
-if version.parse(torch.__version__) >= version.parse("2.3.0.dev"):
-    TORCH_VERSION_AFTER_2_3 = True
-else:
-    TORCH_VERSION_AFTER_2_3 = False
-
-if version.parse(torch.__version__) >= version.parse("2.2.0.dev"):
-    TORCH_VERSION_AFTER_2_2 = True
-else:
-    TORCH_VERSION_AFTER_2_2 = False

--- a/torchao/sparsity/training/__init__.py
+++ b/torchao/sparsity/training/__init__.py
@@ -7,7 +7,7 @@ import torch
 from torchao.sparsity.training.autograd import semi_structured_sparsify
 from torchao.sparsity.training.pointwise_ops import CUTLASS_POINTWISE_OP_DISPATCH_TABLE
 
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 
 # load pointwise op support, which exists only for CUTLASS
 if TORCH_VERSION_AFTER_2_3:

--- a/torchao/sparsity/training/autograd.py
+++ b/torchao/sparsity/training/autograd.py
@@ -2,7 +2,7 @@ from enum import Enum
 import torch
 from torch.sparse import SparseSemiStructuredTensor
 
-from torchao.quantization.utils import TORCH_VERSION_AFTER_2_3
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 
 if TORCH_VERSION_AFTER_2_3:
     from torch.sparse import SparseSemiStructuredTensorCUTLASS, SparseSemiStructuredTensorCUSPARSELT
@@ -120,7 +120,7 @@ def semi_structured_sparsify(
     backend: str = "cutlass",
 ) -> SparseSemiStructuredTensor:
     """
-    Sparsifies a dense tensor into a semi-structured tensor, according to the algo and backend passed. 
+    Sparsifies a dense tensor into a semi-structured tensor, according to the algo and backend passed.
     """
     return _SparsifyFunc.apply(x, algo, backend)
 
@@ -131,6 +131,6 @@ def semi_structured_sparsify_like(
     gradient: GRADIENT_TYPE = GRADIENT_TYPE.SPARSE,
 ) -> SparseSemiStructuredTensor:
     """
-    Sparsifies a dense tensor into a semi-structured tensor, using the mask of the provided pattern. 
+    Sparsifies a dense tensor into a semi-structured tensor, using the mask of the provided pattern.
     """
     return _SparsifyLikeFunc.apply(x, pattern, gradient)

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -3,6 +3,22 @@ import torch.utils.benchmark as benchmark
 from typing import Tuple
 from functools import reduce
 from math import gcd
+from packaging import version
+import torch.nn.utils.parametrize as parametrize
+
+__all__ = [
+    "benchmark_model",
+    "profiler_runner",
+    "get_compute_capability",
+    "skip_if_compute_capability_less_than",
+    "benchmark_torch_function_in_microseconds",
+    "find_multiple",
+    "get_model_size_in_bytes",
+    "unwrap_tensor_subclass",
+    "TORCH_VERSION_AFTER_2_2",
+    "TORCH_VERSION_AFTER_2_3",
+    "TORCH_VERSION_AFTER_2_4",
+]
 
 
 def benchmark_model(model, num_runs, input_tensor):
@@ -65,3 +81,76 @@ def find_multiple(n: int, *args: Tuple[int]) -> int:
     if n % k == 0:
         return n
     return n + k - (n % k)
+
+# https://discuss.pytorch.org/t/finding-model-size/130275
+def get_model_size_in_bytes(model):
+    s = 0
+    for p in model.parameters():
+        s += p.nelement() * p.element_size()
+    for b in model.buffers():
+        s += b.nelement() * b.element_size()
+    return s
+
+class UnwrapTensorSubclass(torch.nn.Module):
+    def forward(self, *tensors):
+        todo = list(tensors)
+        for tp, meta, inner_tensors in reversed(self.rebuild_stack):
+            nb_tensor = len(inner_tensors)
+            inner_tensors = {a: b for a, b in zip(inner_tensors, todo[-nb_tensor:])}
+            todo = todo[nb_tensor:]
+            rebuilt = tp.__tensor_unflatten__(inner_tensors, meta, None, None)
+            todo.append(rebuilt)
+
+        assert len(todo) == 1
+        return todo[0]
+
+    def right_inverse(self, tensor):
+        assert type(tensor) is not torch.Tensor
+        rebuild_stack = []
+        plain_tensors = []
+        todo = [tensor]
+        while todo:
+            obj = todo.pop()
+            inner_tensors, metadata = obj.__tensor_flatten__()
+            rebuild_stack.append((type(obj), metadata, inner_tensors))
+            for attr_name in inner_tensors:
+                val = getattr(obj, attr_name)
+                if type(val) is torch.Tensor:
+                    plain_tensors.append(val)
+                else:
+                    assert isinstance(val, torch.Tensor)
+                    todo.append(val)
+
+        self.rebuild_stack = rebuild_stack
+
+        return plain_tensors
+
+def unwrap_tensor_subclass(model, filter_fn=None):
+    for name, child in model.named_children():
+        # make sure child.weight is a tensor subclass
+        if (
+            isinstance(child, torch.nn.Linear) and
+            hasattr(child, "weight") and
+            type(child.weight) is not torch.Tensor and
+            type(child.weight) is not torch.nn.Parameter and
+            isinstance(child.weight, torch.Tensor) and
+            issubclass(type(child.weight), torch.Tensor)
+        ):
+            parametrize.register_parametrization(child, "weight", UnwrapTensorSubclass())
+        unwrap_tensor_subclass(child)
+    return model
+
+if version.parse(torch.__version__) >= version.parse("2.4.0.dev"):
+    TORCH_VERSION_AFTER_2_4 = True
+else:
+    TORCH_VERSION_AFTER_2_4 = False
+
+if version.parse(torch.__version__) >= version.parse("2.3.0.dev"):
+    TORCH_VERSION_AFTER_2_3 = True
+else:
+    TORCH_VERSION_AFTER_2_3 = False
+
+if version.parse(torch.__version__) >= version.parse("2.2.0.dev"):
+    TORCH_VERSION_AFTER_2_2 = True
+else:
+    TORCH_VERSION_AFTER_2_2 = False


### PR DESCRIPTION
Summary:

Moved
```
TORCH_VERSION_AFTER_2_(2/3/4)
get_model_size_in_bytes
unwrap_tensor_subclass
```

from quantization/utils.py to torchao/utils.py

Test Plan:
python test/integration/test_integration.py

Reviewers:

Subscribers:

Tasks:

Tags: