### PR TITLE
Update regression test to python 3.8

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -58,7 +58,7 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
-        conda create -n venv python=3.9 -y
+        conda create -n venv python=3.8 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils

--- a/torchao/quantization/fp6_llm.py
+++ b/torchao/quantization/fp6_llm.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional
+from typing import List, Optional
 
 import torch
 from torch import nn, Tensor
@@ -291,7 +291,7 @@ class Fp6LlmLinear(nn.Module):
         return f'in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}'
 
 
-def convert_fp6_llm(model: nn.Module, skip_fqn_list: Optional[list[str]] = None, cur_fqn: str = "") -> None:
+def convert_fp6_llm(model: nn.Module, skip_fqn_list: Optional[List[str]] = None, cur_fqn: str = "") -> None:
     for name, child in model.named_children():
         new_fqn = name if cur_fqn == "" else f"{cur_fqn}.{name}"
 


### PR DESCRIPTION
Right now our binaries are built for python 3.8 wheras our CI tests 3.9

This was a problem for this PR https://github.com/pytorch/ao/pull/338 where it was using some fairly innocuous typing features that are not available on python 3.8. CI passed but binary build failed which meant we had to do a revert