### PR TITLE
make torchao test discovery pass in fbcode

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -73,7 +73,7 @@ import os
 from parameterized import parameterized
 import itertools
 import logging
-from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_3, TORCH_VERSION_AFTER_2_4, is_fbcode
 
 logger = logging.getLogger("INFO")
 
@@ -760,6 +760,7 @@ class TestSubclass(unittest.TestCase):
         )
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_int8_weight_only_quant_subclass_api(self, device, dtype):
         self._test_lin_weight_subclass_api_impl(
             change_linear_weights_to_int8_woqtensors, device, 40, test_dtype=dtype
@@ -935,6 +936,7 @@ class TestSaveLoadMeta(unittest.TestCase):
         self.assertTrue(torch.equal(ref_q, test))
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(is_fbcode(), "'PlainAQTLayout' object has no attribute 'int_data'")
     @torch.no_grad()
     def test_save_load_dqtensors(self, device, dtype):
         if device == "cpu":
@@ -943,6 +945,7 @@ class TestSaveLoadMeta(unittest.TestCase):
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @torch.no_grad()
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_save_load_int8woqtensors(self, device, dtype):
         self._test_handle_save_load_meta_impl(change_linear_weights_to_int8_woqtensors, device, test_dtype=dtype)
 
@@ -1025,6 +1028,7 @@ class SmoothquantIntegrationTest(unittest.TestCase):
         self.assertTrue(isinstance(model[0], SmoothFakeDynamicallyQuantizedLinear))
 
     @torch.inference_mode()
+    @unittest.skipIf(is_fbcode(), "can't load tokenizer")
     def test_on_dummy_distilbert(self):
         # https://huggingface.co/distilbert-base-uncased#how-to-use
         from transformers import (  # type: ignore[import-untyped]

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -27,6 +27,7 @@ from torchao.quantization.utils import (
 from torchao.utils import (
     TORCH_VERSION_AFTER_2_3,
     TORCH_VERSION_AFTER_2_4,
+    is_fbcode,
 )
 
 _SEED = 1234
@@ -179,6 +180,7 @@ class TestQuantPrimitives(unittest.TestCase):
         self.assertTrue(torch.equal(zero_point, zp_ref))
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_3, "skipping when torch version is 2.3 or lower")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_choose_qparams_token_asym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.ASYMMETRIC
@@ -193,6 +195,7 @@ class TestQuantPrimitives(unittest.TestCase):
         torch.testing.assert_close(scale, scale_ref, atol=10e-3, rtol=10e-3)
         self.assertTrue(torch.equal(zero_point, zp_ref))
 
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_choose_qparams_tensor_asym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.ASYMMETRIC
@@ -211,6 +214,7 @@ class TestQuantPrimitives(unittest.TestCase):
         self.assertTrue(torch.equal(scale, scale_ref))
         self.assertTrue(torch.equal(zero_point, zp_ref))
 
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_choose_qparams_tensor_sym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.SYMMETRIC
@@ -271,6 +275,7 @@ class TestQuantPrimitives(unittest.TestCase):
 
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_quantize_dequantize_group_sym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.SYMMETRIC
@@ -295,6 +300,7 @@ class TestQuantPrimitives(unittest.TestCase):
         self.assertTrue(torch.equal(dequantized, dequantized_ref))
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_quantize_dequantize_channel_asym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.ASYMMETRIC
@@ -318,6 +324,7 @@ class TestQuantPrimitives(unittest.TestCase):
         self.assertTrue(torch.equal(dequantized, dequantized_ref))
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_quantize_dequantize_tensor_asym(self):
         input = torch.randn(10, 10)
         mapping_type = MappingType.ASYMMETRIC
@@ -341,6 +348,7 @@ class TestQuantPrimitives(unittest.TestCase):
         self.assertTrue(torch.equal(dequantized, dequantized_ref))
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch version is 2.4 or lower")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_quantize_dequantize_channel_asym_4d(self):
         input = torch.randn(3, 3, 10, 10)
         mapping_type = MappingType.ASYMMETRIC

--- a/test/sparsity/test_fast_sparse_training.py
+++ b/test/sparsity/test_fast_sparse_training.py
@@ -12,7 +12,7 @@ from torchao.sparsity.training import (
     swap_semi_sparse_linear_with_linear,
     SemiSparseLinear
 )
-from torchao.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_4, is_fbcode
 
 class TestModel(nn.Module):
     def __init__(self):
@@ -30,6 +30,7 @@ class TestRuntimeSemiStructuredSparsity(TestCase):
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "pytorch 2.4+ feature")
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_runtime_weight_sparsification(self):
         # need this import inside to not break 2.2 tests
         from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
@@ -70,6 +71,7 @@ class TestRuntimeSemiStructuredSparsity(TestCase):
 
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "pytorch 2.4+ feature")
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(is_fbcode(), "broken in fbcode")
     def test_runtime_weight_sparsification_compile(self):
         # need this import inside to not break 2.2 tests
         from torch.sparse import SparseSemiStructuredTensorCUSPARSELT

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -154,3 +154,6 @@ if version.parse(torch.__version__) >= version.parse("2.2.0.dev"):
     TORCH_VERSION_AFTER_2_2 = True
 else:
     TORCH_VERSION_AFTER_2_2 = False
+
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")


### PR DESCRIPTION
Summary:
Running `buck test @//mode/dev-nosan fbcode//pytorch/ao/test:torchao_tests` used
to work but stopped working sometime in the past ~months due to test
discovery being broken. This diff fixes test discovery and adds a blocklist
to all of the broken tests, so we can at least run the passing tests easily.

Note that for now we have some tests using `pytest` which is handled in a custom
way. In a future PR it would be great to make torchao use a single testing
framework.

Reviewed By: jerryzh168

Differential Revision: D58422127
