### PR TITLE
[Release Only] Pin generate-matrix to release 2.3.1

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.3
     with:
       package-type: wheel
       os: linux


### PR DESCRIPTION
This way we make sure we build torchao against pytorch 2.3.1