### PR TITLE
Deprecate top level quantization APIs (#344)

### DIFF
--- a/test/dtypes/test_aq.py
+++ b/test/dtypes/test_aq.py
@@ -2,7 +2,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
 )
-from torchao.quantization.quant_api import get_apply_int4wo_quant
+from torchao.quantization.quant_api import int4wo
 import torch
 import unittest
 
@@ -12,7 +12,7 @@ class TestAQ(TestCase):
     def test_tensor_core_layout_transpose(self):
         t = torch.rand(128, 256, dtype=torch.bfloat16, device="cuda")
         shape = t.shape
-        apply_int4wo_quant = get_apply_int4wo_quant(groupsize=32)
+        apply_int4wo_quant = int4wo(groupsize=32)
         aqt = apply_int4wo_quant(t)
         aqt_shape = aqt.shape
         self.assertEqual(aqt_shape, shape)

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -189,7 +189,7 @@ def test_inference_compile_simple(elem_dtype):
     if elem_dtype is torch.float8_e4m3fn:
         assert sqnr >= 20.0
     else:
-        assert sqnr >= 14.0
+        assert sqnr >= 13.5
 
 
 def test_filter_fn():

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -1,11 +1,11 @@
 from .nf4tensor import NF4Tensor, to_nf4
 from .uint4 import UInt4Tensor
-from .aqt import AffineQuantizedTensor, to_aq
+from .aqt import AffineQuantizedTensor, to_affine_quantized
 
 __all__ = [
     "NF4Tensor",
     "to_nf4",
     "UInt4Tensor"
     "AffineQuantizedTensor",
-    "to_aq",
+    "to_affine_quantized",
 ]

--- a/torchao/dtypes/aqt.py
+++ b/torchao/dtypes/aqt.py
@@ -200,7 +200,7 @@ class PlainAQTLayout(AQTLayout):
         if func is aten.t.default:
             tensor = args[0]
             new = tensor.__class__(
-                tensor.int_data.view(tenssor.shape[::-1]), tenssor.scale, tenssor.zero_point
+                tensor.int_data.view(tensor.shape[::-1]), tensor.scale, tensor.zero_point
             )
             return return_and_correct_aliasing(func, args, kwargs, new)
 
@@ -394,8 +394,6 @@ class AffineQuantizedTensor(torch.Tensor):
         kwargs["layout"] = (
             kwargs.get("layout") if kwargs.get("layout", False) else layout_tensor.layout
         )
-        if dtype is None:
-            dtype = scale.dtype
         kwargs["dtype"] = dtype
         if strides is not None:
             kwargs["strides"] = strides
@@ -800,4 +798,4 @@ def t(func, *args, **kwargs):
     )
     return return_and_correct_aliasing(func, args, kwargs, new)
 
-to_aq = AffineQuantizedTensor.from_float
+to_affine_quantized = AffineQuantizedTensor.from_float

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -56,38 +56,157 @@ with open("quantization-cache.pkl", "wb") as f:
 with open("quantization-cache.pkl", "rb") as f:
     torchao.quantization.AUTOQUANT_CACHE.update(pickle.load(f))
 ```
+## Affine Quantization
+Affine quantization refers to the type of quantization that maps from floating point numbers to quantized numbers (typically integer) with an affine transformation, i.e.: `quantized_val = float_val / scale + zero_point` where `scale` and `zero_point` are quantization parameters for some granularity and based on some data.
+
+### Quantization Primitives
+We used to have different quantize and dequantize operators for quantization with different granularities. But in the end these can all be expressed with a `block_size` argument with different settings, so we unified existing quant primitives to `choose_qparams_affine`, `quantize_affine` and `dequantize_affine` that can represent symmetric/asymmetric per tensor/channel/token/channel_group quantization, this can be used to implement the unified quantized tensor subclass.
+
+### Quantized Tensor Subclass
+We also have a unified quantized tensor subclass that implements how to get a quantized tensor from floating point tensor and what does it mean to call linear ops on an instance of the tensor, e.g. `F.linear` and `aten.addmm`, with this we could dispatch to different operators (e.g. `int4mm` op) based on device (cpu, cuda) and quantization settings (`int4`, `int8`) and also packing formats (e.g. format optimized for cpu int4 mm kernel)
+
+### Quantization Flow Example
+Let's use int4 weight only quantization that's targeting tinygemm int4 weight only quantized matmul
+as an example:
+```python
+import torch
+from torchao.quantization.quant_primitives import MappingType, ZeroPointDomain
+from torchao.dtypes import to_affine_quantized
+from torch._inductor.runtime.runtime_utils import do_bench_gpu
+import copy
+from torchao.quantization.quant_api import (
+    quantize,
+    int4wo,
+)
+
+class ToyLinearModel(torch.nn.Module):
+    def __init__(self, m=64, n=32, k=64):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(m, n, bias=False)
+        self.linear2 = torch.nn.Linear(n, k, bias=False)
+
+    def example_inputs(self, batch_size=1, dtype=torch.float32, device="cpu"):
+        return (torch.randn(batch_size, self.linear1.in_features, dtype=dtype, device=device),)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.linear2(x)
+        return x
+
+dtype = torch.bfloat16
+m = ToyLinearModel(1024, 1024, 1024).eval().to(dtype).to("cuda")
+m_bf16 = copy.deepcopy(m)
+example_inputs = m.example_inputs(dtype=dtype, device="cuda")
+
+m_bf16 = torch.compile(m_bf16, mode='max-autotune')
+# apply int4 weight only quant (compatible with tinygemm int4 weight only quant mm kernel in torchao)
+groupsize = 32
+m = quantize(m, int4wo(groupsize=groupsize))
+
+torch._inductor.config.force_fuse_int_mm_with_mul = True
+torch._inductor.config.use_mixed_mm = True
+
+# temporary workaround for tensor subclass + torch.compile
+from torchao.quantization.utils import unwrap_tensor_subclass
+m = unwrap_tensor_subclass(m)
+# compile the model to improve performance
+m = torch.compile(m, mode='max-autotune')
+
+# benchmark to see the speedup
+from torchao.utils import benchmark_model
+
+num_runs = 100
+torch._dynamo.reset()
+bf16_time = benchmark_model(m_bf16, num_runs, example_inputs[0])
+print(f"bf16 mean time: {bf16_time}")
+int4_time = benchmark_model(m, num_runs, example_inputs[0])
+print(f"int4 weight only quantized mean time: {int4_time}")
+print(f"speedup: {bf16_time / int4_time}")
+
+# output (1xA100 GPU machine)
+bf16 mean time: 71.457685546875
+int4 weight only quantized mean time: 31.4580908203125
+speedup: 2.2715200981216173
+```
+
+What we do underlying the APIs are roughly the following:
+```
+from torchao.dtypes import to_affine_quantized
+def int8wo_quant(weight):
+    return to_affine_quantized(weight, MappingType.SYMMETRIC, (1, weight.shape[1]), torch.int8, eps=torch.finfo(torch.float32).eps, zero_point_dtype=torch.int64)
+
+for n, m in model.named_modules():
+    if isinstance(m, torch.nn.Linear):
+        # optional filtering for module name, shape etc.
+        m.weight = nn.Parameter(int8wo_quant(m.weight))
+        
+        # note: quantization for activation need to be applied after the weight quantization
+        # quantization activation (needed by dynamic quantization)
+        input_quant_func = int8wo_quant  # specify how input activation is quantized
+        m.weight = nn.Parameter(to_linear_act_quantized(m.weight, input_quant_func))
+```
+The model/tensor subclass should also be compatible with AOTI and torch.export, currently we can support
+`torch.export.export` and `torch.aot_compile` with the following workaround:
+```
+from torchao.quantization.utils import unwrap_tensor_subclass
+m_unwrapped = unwrap_tensor_subclass(m)
 
 
-## A8W8 Dynamic Quantization
+# export
+m = torch.export.export(m_unwrapped, example_inputs).module()
+
+# aot_compile
+torch._export.aot_compile(m_unwrapped, example_inputs)
+```
+
+### Other Available Quantization Techniques
+#### A8W8 Dynamic Quantization
 
 ```python
 # Fuse the int8*int8 -> int32 matmul and subsequent mul op avoiding materialization of the int32 intermediary tensor
 torch._inductor.config.force_fuse_int_mm_with_mul = True
 from torchao.quantization import quant_api
-# convert linear modules to quantized tensor subclasses
-quant_api.change_linear_weights_to_int8_dqtensors(model)
+
+# for torch 2.4+
+from torchao.quantization.quant_api import quantize
+quantize(model, "int8_dynamic_quant")
+
+# for torch 2.2.2 and 2.3
+from torchao.quantization.quant_api import change_linear_weights_to_int8_dqtensors
+change_linear_weights_to_int8_dqtensors(model)
 ```
 
-## A16W8 WeightOnly Quantization
+#### A16W8 WeightOnly Quantization
 
 ```python
-from torchao.quantization import quant_api
-quant_api.change_linear_weights_to_int8_woqtensors(model)
+# for torch 2.4+
+from torchao.quantization.quant_api import quantize
+from torchao.quantization.quant_api import int8wo
+quantize(model, "int8_weight_only")
+
+# for torch 2.2.2 and 2.3
+from torchao.quantization.quant_api import change_linear_weights_to_int8_woqtensors
+change_linear_weights_to_int8_woqtensors(model)
 ```
 
 This technique works best when the torch._inductor.config.use_mixed_mm option is enabled. This avoids dequantizing the weight tensor before the matmul, instead fusing the dequantization into the matmul, thereby avoiding materialization of a large floating point weight tensor.
 
 
-## A16W4 WeightOnly Quantization
+#### A16W4 WeightOnly Quantization
 
 ```python
-from torchao.quantization import quant_api
-quant_api.change_linear_weights_to_int4_woqtensors(model)
+# for torch 2.4+
+from torchao.quantization.quant_api import quantize
+quantize(model, "int4_weight_only")
+
+# for torch 2.2.2 and 2.3
+from torchao.quantization.quant_api import change_linear_weights_to_int4_woqtensors
+change_linear_weights_to_int4_woqtensors(model)
 ```
 
 Note: The quantization error incurred by applying int4 quantization to your model can be fairly significant, so using external techniques like GPTQ may be necessary to obtain a usable model.
 
-## A16W4 WeightOnly Quantization with GPTQ
+## (To be moved to prototype) A16W4 WeightOnly Quantization with GPTQ
 
 ```python
 from torchao._models._eval import InputRecorder, TransformerEvalWrapper
@@ -137,17 +256,17 @@ model = quantizer.quantize(model, inputs).cuda()
 
 ```
 
-## A8W8 Dynamic Quantization
+## (To be deprecated) A8W8 Dynamic Quantization
 
 ```Python
 from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
-quantizer = Int8DynActInt4WeightQuantizer(groupsize=32)
+quantizer = Int8DynActInt4WeightQuantizer(groupsize=128)
 model = quantizer.quantize(model)
 ```
 
 This is used in [ExecuTorch](https://github.com/pytorch/executorch) to quantize llama model right now.
 
-## A8W8 Dynamic Quantization with Smoothquant
+## (To be moved to prototype) A8W8 Dynamic Quantization with Smoothquant
 
 We've also implemented a version of [smoothquant](https://arxiv.org/abs/2211.10438) with the same GEMM format as above. Due to requiring calibration, the API is more complicated.
 
@@ -184,118 +303,6 @@ smooth_fq_linear_to_inference(model)
 # compile the model to improve performance
 model = torch.compile(model, mode='max-autotune')
 model(input)
-```
-
-## Affine Quantization
-Affine quantization refers to the type of quantization that maps from floating point numbers to quantized numbers (typically integer) with an affine transformation, i.e.: `quantized_val = float_val / scale + zero_point` where `scale` and `zero_point` are quantization parameters for some granularity and based on some data.
-
-### Quantization Primitives
-We used to have different quantize and dequantize operators for quantization with different granularities. But in the end these can all be expressed with a `block_size` argument with different settings, so we unified existing quant primitives to `choose_qparams_affine`, `quantize_affine` and `dequantize_affine` that can represent symmetric/asymmetric per tensor/channel/token/channel_group quantization, this can be used to implement the unified quantized tensor subclass.
-
-### Quantized Tensor Subclass
-We also have a unified quantized tensor subclass that implements how to get a quantized tensor from floating point tensor and what does it mean to call linear ops on an instance of the tensor, e.g. `F.linear` and `aten.addmm`, with this we could dispatch to different operators (e.g. `int4mm` op) based on device (cpu, cuda) and quantization settings (`int4`, `int8`) and also packing formats (e.g. format optimized for cpu int4 mm kernel)
-
-### Quantization Flow
-What we need to do afterwards is roughly the following
-
-```
-from torchao.dtypes.aqt import to_aq
-def apply_int8wo_quant(weight):
-    mapping_type = MappingType.SYMMETRIC
-    target_dtype = torch.int8
-    eps = torch.finfo(torch.float32).eps
-    zero_point_dtype = torch.int64
-    block_size = (1, weight.shape[1])
-    return to_aq(weight, mapping_type, block_size, target_dtype, eps=eps, zero_point_dtype=zero_point_dtype)
-
-for n, m in model.named_modules():
-    if isinstance(m, torch.nn.Linear):
-        # optional filtering for module name, shape etc.
-        m.weight = nn.Parameter(apply_int8wo_quant(m.weight))
-        # note: quantization for activation need to be applied after the weight quantization
-        # quantization activation (needed by dynamic quantization)
-        # input_quant_func = apply_int8wo_quant  # specify how input activation is quantized
-        # m.weight = nn.Parameter(to_laq(m.weight, input_quant_func))
-```
-The model/tensor subclass should also be compatible with AOTI and torch.export, currently we can support
-`torch.export.export` and `torch.aot_compile` with the following workaround:
-```
-from torchao.quantization.utils import unwrap_tensor_subclass
-m_unwrapped = unwrap_tensor_subclass(m)
-
-
-# export
-m = torch.export.export(m_unwrapped, example_inputs).module()
-
-# aot_compile
-torch._export.aot_compile(m_unwrapped, example_inputs)
-```
-
-But we expect this will be integrated into the export path by default in the future.
-
-
-### Example
-Let's use int4 weight only quantization that's targeting tinygemm int4 weight only quantized matmul
-as an example:
-```python
-import torch
-from torchao.quantization.quant_primitives import MappingType, ZeroPointDomain
-from torchao.dtypes import to_aq
-from torch._inductor.runtime.runtime_utils import do_bench_gpu
-import copy
-from torchao.quantization.quant_api import (
-    quantize,
-    get_apply_int4wo_quant,
-)
-
-class ToyLinearModel(torch.nn.Module):
-    def __init__(self, m=64, n=32, k=64):
-        super().__init__()
-        self.linear1 = torch.nn.Linear(m, n, bias=False)
-        self.linear2 = torch.nn.Linear(n, k, bias=False)
-
-    def example_inputs(self, batch_size=1, dtype=torch.float32, device="cpu"):
-        return (torch.randn(batch_size, self.linear1.in_features, dtype=dtype, device=device),)
-
-    def forward(self, x):
-        x = self.linear1(x)
-        x = self.linear2(x)
-        return x
-
-dtype = torch.bfloat16
-m = ToyLinearModel(1024, 1024, 1024).eval().to(dtype).to("cuda")
-m_bf16 = copy.deepcopy(m)
-example_inputs = m.example_inputs(dtype=dtype, device="cuda")
-
-m_bf16 = torch.compile(m_bf16, mode='max-autotune')
-# apply int4 weight only quant (compatible with tinygemm int4 weight only quant mm kernel in torchao)
-groupsize = 32
-m = quantize(m, get_apply_int4wo_quant(groupsize=groupsize))
-
-torch._inductor.config.force_fuse_int_mm_with_mul = True
-torch._inductor.config.use_mixed_mm = True
-
-# temporary workaround for tensor subclass + torch.compile
-from torchao.quantization.utils import unwrap_tensor_subclass
-m = unwrap_tensor_subclass(m)
-# compile the model to improve performance
-m = torch.compile(m, mode='max-autotune')
-
-# benchmark to see the speedup
-from torchao.utils import benchmark_model
-
-num_runs = 100
-torch._dynamo.reset()
-bf16_time = benchmark_model(m_bf16, num_runs, example_inputs[0])
-print(f"bf16 mean time: {bf16_time}")
-int4_time = benchmark_model(m, num_runs, example_inputs[0])
-print(f"int4 weight only quantized mean time: {int4_time}")
-print(f"speedup: {bf16_time / int4_time}")
-
-# output (1xA100 GPU machine)
-bf16 mean time: 71.457685546875
-int4 weight only quantized mean time: 31.4580908203125
-speedup: 2.2715200981216173
 ```
 
 ## Notes

--- a/torchao/quantization/subclass.py
+++ b/torchao/quantization/subclass.py
@@ -31,7 +31,7 @@ __all__ = [
     "Int8WeightOnlyQuantizedLinearWeight",
     "Int4WeightOnlyQuantizedLinearWeight",
     "LinearActQuantizedTensor",
-    "to_laq",
+    "to_linear_act_quantized",
 ]
 
 
@@ -751,4 +751,4 @@ class LinearActQuantizedTensor(torch.Tensor):
             f"LinearActQuantizedTensor dispatch: attempting to run {func}, this is not supported"
         )
 
-to_laq = LinearActQuantizedTensor.from_float
+to_linear_act_quantized = LinearActQuantizedTensor.from_float

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -126,6 +126,11 @@ class UnwrapTensorSubclass(torch.nn.Module):
         return plain_tensors
 
 def unwrap_tensor_subclass(model, filter_fn=None):
+    """Unwraps (nested) tensor subclass in the model to plain tensors
+    This is a workaround to make a model with tensor subclass to work with `torch.export.export`
+    and `torch.aot_compile`, we hope this can be integrated into compile stack soon
+    tracking issue: https://github.com/pytorch/ao/issues/345
+    """
     for name, child in model.named_children():
         # make sure child.weight is a tensor subclass
         if (

--- a/tutorials/quantize_vit/run_vit_b_quant.py
+++ b/tutorials/quantize_vit/run_vit_b_quant.py
@@ -15,8 +15,12 @@ model.eval().cuda().to(torch.bfloat16)
 input_tensor = torch.randn(1, 3, 224, 224, dtype=torch.bfloat16, device='cuda')
 
 ## Quantization code - start
-# int8 act, int8 weight dynamic quantization, see README for other APIs
-torchao.apply_dynamic_quant(model)
+# int8 dynamic quantization act, int8 weight, see ao/torchao/quantization/README.md
+# for APIs for earlier torch version and other quantization techniques
+
+# for torch 2.4+
+from torchao.quantization.quant_api import quantize
+quantize(model, "int8_dynamic")
 ## Quantization code - end
 
 ## compilation configs
@@ -24,6 +28,10 @@ torch._dynamo.config.automatic_dynamic_shapes = False
 torch._inductor.config.force_fuse_int_mm_with_mul = True
 torch._inductor.config.use_mixed_mm = True
 ## compilation configs end
+
+# temporary workaround for the API to work with torch.compile
+from torchao.utils import unwrap_tensor_subclass
+unwrap_tensor_subclass(model)
 
 model = torch.compile(model, mode='max-autotune')
 


### PR DESCRIPTION
Summary:
This PR deprecates a few quantization APIs and here are the bc-breaking notes:

1. int8 weight only quantization int8 weight only quant module swap API
```
apply_weight_only_int8_quant(model)
```

and
int8 weight only tensor subclass API
```
change_linear_weights_to_int8_woqtensors(model)
```

-->

unified tensor subclass API
```
quantize(model, get_apply_int8wo_quant()))
```

2. int8 dynamic quantization

```
apply_dynamic_quant(model)
```
or
```
change_linear_weights_to_int8_dqtensors(model)
```

-->

unified tensor subclass API
```
quantize(model, get_apply_int8dyn_quant()))
```

3. int4 weight only quantization
```
change_linear_weights_to_int4_wotensors(model)
```

-->

unified tensor subclass API
```
quantize(model, get_apply_int4wo_quant()))
```

Test Plan:
python test/quantization/test_quant_api.py
python test/integration/test_integration.py

Reviewers:

Subscribers:

Tasks:

Tags: