### PR TITLE
Add torchao.__version__

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -1,11 +1,20 @@
 import torch
 import logging
 
+# We use this "hack" to set torchao.__version__ correctly
+# For local development this will default to whatever is version.txt
+# For release builds this will be set the version+architecture_postfix
+import pkg_resources
+try:
+    __version__ = pkg_resources.get_distribution('torchao').version
+except pkg_resources.DistributionNotFound:
+    __version__ = 'unknown'
+
+
 _IS_FBCODE = (
     hasattr(torch._utils_internal, "IS_FBSOURCE") and
     torch._utils_internal.IS_FBSOURCE
 )
-
 if not _IS_FBCODE:
     try:
         from . import _C

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -2,14 +2,14 @@ import torch
 import logging
 
 # We use this "hack" to set torchao.__version__ correctly
+# the version of ao is dependent on environment variables for multiple architectures
 # For local development this will default to whatever is version.txt
 # For release builds this will be set the version+architecture_postfix
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 try:
-    __version__ = pkg_resources.get_distribution('torchao').version
-except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
-
+    __version__ = version("torchao")
+except PackageNotFoundError:
+    __version__ = 'unknown'  # In case this logic breaks don't break the build
 
 _IS_FBCODE = (
     hasattr(torch._utils_internal, "IS_FBSOURCE") and


### PR DESCRIPTION
For local binaries `pip install .`

```
  Created wheel for torchao: filename=torchao-0.3.0-py3-none-any.whl size=210859 sha256=eafc2d9a34b457c1a5ddd802fde99469dc6aa9fbdbbdec33d23e50d77217e444
  Stored in directory: /tmp/pip-ephem-wheel-cache-btg7wdte/wheels/98/63/17/f0c8348dc6feec64a509f5107bbf0075300ccb8e8619b8a8b0
Successfully built torchao
Installing collected packages: torchao
Successfully installed torchao-0.3.0
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/__version__)]$ python
Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torchao
torchao.__vers>>> torchao.__version__
'0.3.0'
```

For release binaries

```
(ao) [marksaroufim@devgpu003.cco3 ~]$ pip install https://download.pytorch.org/whl/test/cu121/torchao-0.3.0%2Bcu121-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl^C
(ao) [marksaroufim@devgpu003.cco3 ~]$ pip uninstall torchao^C
(ao) [marksaroufim@devgpu003.cco3 ~]$ python
Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>     from importlib.metadata import version
  File "<stdin>", line 1
    from importlib.metadata import version
IndentationError: unexpected indent
>>> from importlib.metadata import version
>>> version("torchao")
'0.3.0+cu121'
```