### PR TITLE
Factor out dispatch and layout registration table

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -7,7 +7,7 @@ import torch
 import unittest
 
 
-class TestAQ(TestCase):
+class TestAffineQuantized(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_tensor_core_layout_transpose(self):
         t = torch.rand(128, 256, dtype=torch.bfloat16, device="cuda")

--- a/torchao/dtypes/aqt.py
+++ b/torchao/dtypes/aqt.py
@@ -15,6 +15,12 @@ from torchao.quantization.utils import (
 )
 from torch.utils._python_dispatch import return_and_correct_aliasing
 from torchao.utils import find_multiple
+from torchao.dtypes.utils import (
+    _implements,
+    _ATEN_OP_OR_TORCH_FN_TABLE,
+    _register_layout_cls,
+    _get_layout_tensor_constructor,
+)
 
 aten = torch.ops.aten
 
@@ -41,57 +47,6 @@ def _aqt_is_uint4(aqt):
         aqt.quant_min is None or aqt.quant_min == 0 and
         aqt.quant_max is None or aqt.quant_max == 15
     )
-
-# TODO: merge with nf4 implements decorator
-# aten op to their __torch_dispatch__ implemnetations for the tensor subclass
-_ATEN_OPS_TABLE: Dict[Callable, Dict[Any, Any]] = defaultdict(dict)
-
-def implements_aten_ops(cls, aten_ops):
-    """Use this decorator to implement a function for an aten op in __torch_dispatch__"""
-
-    def decorator(func):
-        for op in aten_ops:
-            _ATEN_OPS_TABLE[cls][op] = func
-        return func
-
-    return decorator
-
-_TORCH_FUNCTIONS_TABLE: Dict[Callable, Dict[Any, Any]] = defaultdict(dict)
-
-def implements_torch_function(cls, torch_function):
-    def decorator(func):
-        functools.update_wrapper(func, torch_function)
-        _TORCH_FUNCTIONS_TABLE[cls][torch_function] = func
-        return func
-
-    return decorator
-
-def implements_aqt_aten_ops(aten_ops):
-    return implements_aten_ops(AffineQuantizedTensor, aten_ops)
-
-def implements_aqt_torch_function(torch_function):
-    return implements_torch_function(AffineQuantizedTensor, torch_function)
-
-"""
-dict mapping from aqt layout type to the corresponding constructor (AQTLayout.from_plain)
-"""
-_AQT_LAYOUT_TO_CTR: Dict[str, Callable] = {}
-
-def register_aqt_layout_cls(extended_layout: str):
-    """ Register AQTLayout class
-    """
-    def decorator(layout_cls):
-        layout_cls.extended_layout = extended_layout
-        _AQT_LAYOUT_TO_CTR[extended_layout] = layout_cls.from_plain
-        return layout_cls
-    return decorator
-
-def get_aqt_layout_cls_ctr(extended_layout: str) -> Callable:
-    """Get Layout class constructor (LayoutClass.from_plain) for AffineQuantizedTensor
-    """
-    if extended_layout not in _AQT_LAYOUT_TO_CTR:
-        raise ValueError(f"extended_layout: {extended_layout} is not supported yet")
-    return _AQT_LAYOUT_TO_CTR.get(extended_layout)
 
 class AQTLayout(torch.Tensor):
     """
@@ -126,237 +81,13 @@ class AQTLayout(torch.Tensor):
         }
         return kwargs
 
-@register_aqt_layout_cls("plain")
-class PlainAQTLayout(AQTLayout):
-    """
-    Layout storage class for plain layout for affine quantized tensor, it stores int_data, scale, zero_point
-    tensors directly as plain tensors.
-
-    fields:
-      int_data (torch.Tensor): the quantized integer data Tensor
-      scale (torch.Tensor): the scale Tensor used to map between floating point tensor to quantized tensor
-      zero_point (torch.Tensor): the zero_point Tensor used to map between floating point tensor to quantized tensor
-    """
-    def __new__(
-        cls,
-        int_data: torch.Tensor,
-        scale: torch.Tensor,
-        zero_point: torch.Tensor,
-    ):
-        kwargs = {}
-        kwargs["device"] = int_data.device
-        kwargs["layout"] = (
-            kwargs.get("layout") if kwargs.get("layout", False) else int_data.layout
-        )
-        kwargs["dtype"] = int_data.dtype
-        kwargs["requires_grad"] = False
-        shape = int_data.shape
-        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
-
-    def __init__(
-        self,
-        int_data: torch.Tensor,
-        scale: torch.Tensor,
-        zero_point: torch.Tensor,
-    ):
-        self.int_data = int_data
-        self.scale = scale
-        self.zero_point = zero_point
-
-    def __tensor_flatten__(self):
-        return ["int_data", "scale", "zero_point"], []
-
-    @classmethod
-    def __tensor_unflatten__(
-        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
-    ):
-        int_data, scale, zero_point = tensor_data_dict["int_data"], tensor_data_dict["scale"], tensor_data_dict["zero_point"]
-        return cls(int_data, scale, zero_point)
-
-    def to(self, *args, **kwargs):
-        kwargs = self._get_to_kwargs(*args, **kwargs)
-        return self.__class__(
-            self.int_data.to(kwargs["device"]),
-            self.scale.to(kwargs["device"]),
-            self.zero_point.to(kwargs["device"]),
-        )
-
-    def _apply_fn_to_data(self, fn):
-        return self.__class__(
-            fn(self.int_data),
-            fn(self.scale),
-            fn(self.zero_point),
-        )
-
-    @classmethod
-    def __torch_dispatch__(cls, func, types, args, kwargs):
-        kwargs = {} if kwargs is None else kwargs
-
-        if func is aten.detach.default:
-            return return_and_correct_aliasing(
-                func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
-            )
-
-        if func is aten.t.default:
-            tensor = args[0]
-            new = tensor.__class__(
-                tensor.int_data.view(tensor.shape[::-1]), tensor.scale, tensor.zero_point
-            )
-            return return_and_correct_aliasing(func, args, kwargs, new)
-
-        raise NotImplementedError(
-            f"PlainAQTLayout dispatch: attempting to run {func}, this is not supported"
-        )
-
-    __torch_function__ = torch._C._disabled_torch_function_impl
-
-    def get_plain(self):
-        return self.int_data, self.scale, self.zero_point
-
-    @classmethod
-    def from_plain(
-        cls,
-        int_data: torch.Tensor,
-        scale: torch.Tensor,
-        zero_point: torch.Tensor,
-    ):
-        return cls(int_data, scale, zero_point)
-
-@register_aqt_layout_cls("tensor_core_tiled")
-class TensorCoreTiledAQTLayout(AQTLayout):
-    """
-    Layout storage class for tensor_core_tiled layout for affine quantized tensor, this is for int4 only,
-    it stores the original tensor of dimension [n][k] (int32 dtype) as packed weight of 4-d tensor of
-    dimension: [n / 8][k / (inner_k_tiles * 16)][32][inner_k_tiles / 2]
-
-    fields:
-      packed_weight (torch.Tensor): the 4-d packed tensor in a tensor_core_tiled layout
-      scale_and_zero (torch.Tensor): the combined scale Tensor used to map between floating point tensor to quantized tensor and zero_point Tensor
-    """
-
-    def __new__(
-        cls,
-        packed_weight: torch.Tensor,
-        scale_and_zero: torch.Tensor,
-        transposed: bool,
-    ):
-        kwargs = {}
-        kwargs["device"] = packed_weight.device
-        kwargs["layout"] = (
-            kwargs.get("layout") if kwargs.get("layout", False) else packed_weight.layout
-        )
-        kwargs["dtype"] = packed_weight.dtype
-        kwargs["requires_grad"] = False
-        shape = packed_weight.shape
-        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
-
-    def __init__(
-        self,
-        packed_weight: torch.Tensor,
-        scale_and_zero: torch.Tensor,
-        transposed: bool,
-    ):
-        self.packed_weight = packed_weight
-        self.scale_and_zero = scale_and_zero
-        self.transposed = False
-
-    def __tensor_flatten__(self):
-        return ["packed_weight", "scale_and_zero"], [self.transposed]
-
-    @classmethod
-    def __tensor_unflatten__(
-        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
-    ):
-        packed_weight, scale_and_zero = tensor_data_dict["packed_weight"], tensor_data_dict["scale_and_zero"]
-        transposed, = tensor_attributes
-        return cls(packed_weight, scale_and_zero, transposed)
-
-    @classmethod
-    def from_plain(cls, int_data, scale, zero_point, inner_k_tiles=8):
-        packed_weight = torch.ops.aten._convert_weight_to_int4pack(int_data.to(torch.int32), inner_k_tiles)
-        scale = scale.reshape(int_data.shape[0], -1)
-        zero_point = zero_point.reshape(int_data.shape[0], -1)
-        scale_and_zero = pack_tinygemm_scales_and_zeros(scale, zero_point)
-        return cls(packed_weight, scale_and_zero, False)
-
-    def to(self, *args, **kwargs):
-        kwargs = self._get_to_kwargs(*args, **kwargs)
-        device = kwargs["device"]
-        if device != "cuda" or (isinstance(device, torch.device) and device.type != "cuda"):
-            raise ValueError(f"TensorCoreTiledAQTLayout is only available for cuda device")
-        return self.__class__(
-            self.packed_weight.to(kwargs["device"]),
-            self.scale_and_zero.to(kwargs["device"]),
-            self.transposed
-        )
-
-    def _apply_fn_to_data(self, fn):
-        self.packed_weight = fn(self.packed_weight)
-        self.scale_and_zero = fn(self.scale_and_zero)
-        return self
-
-    @classmethod
-    def __torch_dispatch__(cls, func, types, args, kwargs):
-        kwargs = {} if kwargs is None else kwargs
-
-        if func is aten.detach.default:
-            return return_and_correct_aliasing(
-                func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
-            )
-
-        if func is aten.t.default:
-            """we don't need to repack the weight and just rely on external
-            shape being changed and record the status of transpose/no-transpose
-            """
-            args[0].transposed = not args[0].transposed
-            return return_and_correct_aliasing(func, args, kwargs, args[0])
-
-        raise NotImplementedError(
-            f"TensorCoreTiledAQTLayout dispatch: attempting to run {func}, this is not supported"
-        )
-
-    __torch_function__ = torch._C._disabled_torch_function_impl
-
-    def get_plain(self):
-        from torchao.quantization.quant_primitives import (
-            ZeroPointDomain,
-            unpack_tinygemm_scales_and_zeros,
-            quantize_affine,
-        )
-        cur_shape = self.shape
-        assert len(cur_shape) == 4
-        inner_k_tiles = cur_shape[-1] * 2
-        original_shape = (cur_shape[0] * 8, cur_shape[1] * (inner_k_tiles * 16))
-        eye_shape = original_shape[1]
-        block_size = (1, 32)
-        device = self.device
-        original_dtype = torch.bfloat16
-        groupsize = 32
-        target_dtype = torch.int32
-        quant_min = 0
-        quant_max = 15
-        zero_point_domain = ZeroPointDomain.FLOAT
-        assert len(block_size) == 2 and block_size[0] == 1
-        groupsize = block_size[-1]
-        dequantized = torch.ops.aten._weight_int4pack_mm(torch.eye(eye_shape, device=device, dtype=original_dtype), self.packed_weight, groupsize, self.scale_and_zero)
-        dequantized = dequantized.t().contiguous()
-        scale, zero = unpack_tinygemm_scales_and_zeros(self.scale_and_zero)
-        # TODO: move this to `unpack_tinygemm_scales_and_zeros`?
-        scale = scale.reshape(scale.shape[:-1]).contiguous()
-        zero = zero.reshape(zero.shape[:-1]).contiguous()
-        int_data = quantize_affine(dequantized, block_size, scale, zero, target_dtype, quant_min, quant_max, zero_point_domain)
-        return int_data, scale, zero
-
 class AffineQuantizedTensor(torch.Tensor):
     """
-    Base affine quantized tensor subclass. When the from_float method is used,
-    to create an instance of any AffineQuantizedTensor
+    Affine quantized tensor subclass. Affine quantization means we quantize the floating point tensor with an affine transformation:
+       quantized_tensor = float_tensor / scale + zero_point
 
     The shape and dtype of the tensor subclass represent how the tensor subclass looks externally,
     regardless of the internal representation's type or orientation.
-
-    Affine quantization means we quantize the floating point tensor with an affine transformation:
-       quantized_tensor = float_tensor / scale + zero_point
 
     fields:
       layout_tensor (AQTLayout): tensor that serves as a general layout storage for the quantized data,
@@ -481,7 +212,7 @@ class AffineQuantizedTensor(torch.Tensor):
         scale, zero_point = choose_qparams_affine(input_float, mapping_type, block_size, target_dtype, quant_min, quant_max, eps, scale_dtype, zero_point_dtype, preserve_zero, zero_point_domain)
         int_data = quantize_affine(input_float, block_size, scale, zero_point, target_dtype, quant_min, quant_max, zero_point_domain)
 
-        layout_cls_ctr = get_aqt_layout_cls_ctr(extended_layout)
+        layout_cls_ctr = get_layout_tensor_constructor(extended_layout)
         # TODO: this is temporary, need to come up with the proper UX
         if extended_layout == "tensor_core_tiled":
             layout_tensor = layout_cls_ctr(int_data, scale, zero_point, inner_k_tiles)
@@ -505,8 +236,8 @@ class AffineQuantizedTensor(torch.Tensor):
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
 
-        if func in _TORCH_FUNCTIONS_TABLE[cls]:
-            return _TORCH_FUNCTIONS_TABLE[cls][func](*args, **kwargs)
+        if func in _ATEN_OP_OR_TORCH_FN_TABLE[cls]:
+            return _ATEN_OP_OR_TORCH_FN_TABLE[cls][func](*args, **kwargs)
 
         with torch._C.DisableTorchFunctionSubclass():
             return func(*args, **kwargs)
@@ -564,12 +295,242 @@ class AffineQuantizedTensor(torch.Tensor):
         #     kernels in CPU as well, see the note above
         # 2 - we're given non-floats - quantizing long to int8 is crazy
 
-        if func in _ATEN_OPS_TABLE[cls]:
-            return _ATEN_OPS_TABLE[cls][func](func, *args, **kwargs)
+        if func in _ATEN_OP_OR_TORCH_FN_TABLE[cls]:
+            return _ATEN_OP_OR_TORCH_FN_TABLE[cls][func](func, *args, **kwargs)
 
         raise NotImplementedError(
             f"AffineQuantizedTensor dispatch: attempting to run {func}, this is not supported"
         )
+
+def implements(aten_ops_or_torch_fn):
+    return _implements(AffineQuantizedTensor, aten_ops_or_torch_fn)
+
+def register_layout_cls(extended_layout: str):
+    return _register_layout_cls(AffineQuantizedTensor, extended_layout)
+
+def get_layout_tensor_constructor(extended_layout: str):
+    return _get_layout_tensor_constructor(AffineQuantizedTensor, extended_layout)
+
+@register_layout_cls("plain")
+class PlainAQTLayout(AQTLayout):
+    """
+    Layout storage class for plain layout for affine quantized tensor, it stores int_data, scale, zero_point
+    tensors directly as plain tensors.
+
+    fields:
+      int_data (torch.Tensor): the quantized integer data Tensor
+      scale (torch.Tensor): the scale Tensor used to map between floating point tensor to quantized tensor
+      zero_point (torch.Tensor): the zero_point Tensor used to map between floating point tensor to quantized tensor
+    """
+    def __new__(
+        cls,
+        int_data: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+    ):
+        kwargs = {}
+        kwargs["device"] = int_data.device
+        kwargs["layout"] = (
+            kwargs.get("layout") if kwargs.get("layout", False) else int_data.layout
+        )
+        kwargs["dtype"] = int_data.dtype
+        kwargs["requires_grad"] = False
+        shape = int_data.shape
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        int_data: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+    ):
+        self.int_data = int_data
+        self.scale = scale
+        self.zero_point = zero_point
+
+    def __tensor_flatten__(self):
+        return ["int_data", "scale", "zero_point"], []
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        int_data, scale, zero_point = tensor_data_dict["int_data"], tensor_data_dict["scale"], tensor_data_dict["zero_point"]
+        return cls(int_data, scale, zero_point)
+
+    def to(self, *args, **kwargs):
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        return self.__class__(
+            self.int_data.to(kwargs["device"]),
+            self.scale.to(kwargs["device"]),
+            self.zero_point.to(kwargs["device"]),
+        )
+
+    def _apply_fn_to_data(self, fn):
+        return self.__class__(
+            fn(self.int_data),
+            fn(self.scale),
+            fn(self.zero_point),
+        )
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs):
+        kwargs = {} if kwargs is None else kwargs
+
+        if func is aten.detach.default:
+            return return_and_correct_aliasing(
+                func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
+            )
+
+        if func is aten.t.default:
+            tensor = args[0]
+            new = tensor.__class__(
+                tensor.int_data.view(tensor.shape[::-1]), tensor.scale, tensor.zero_point
+            )
+            return return_and_correct_aliasing(func, args, kwargs, new)
+
+        raise NotImplementedError(
+            f"PlainAQTLayout dispatch: attempting to run {func}, this is not supported"
+        )
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    def get_plain(self):
+        return self.int_data, self.scale, self.zero_point
+
+    @classmethod
+    def from_plain(
+        cls,
+        int_data: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+    ):
+        return cls(int_data, scale, zero_point)
+
+@register_layout_cls("tensor_core_tiled")
+class TensorCoreTiledAQTLayout(AQTLayout):
+    """
+    Layout storage class for tensor_core_tiled layout for affine quantized tensor, this is for int4 only,
+    it stores the original tensor of dimension [n][k] (int32 dtype) as packed weight of 4-d tensor of
+    dimension: [n / 8][k / (inner_k_tiles * 16)][32][inner_k_tiles / 2]
+
+    fields:
+      packed_weight (torch.Tensor): the 4-d packed tensor in a tensor_core_tiled layout
+      scale_and_zero (torch.Tensor): the combined scale Tensor used to map between floating point tensor to quantized tensor and zero_point Tensor
+    """
+
+    def __new__(
+        cls,
+        packed_weight: torch.Tensor,
+        scale_and_zero: torch.Tensor,
+        transposed: bool,
+    ):
+        kwargs = {}
+        kwargs["device"] = packed_weight.device
+        kwargs["layout"] = (
+            kwargs.get("layout") if kwargs.get("layout", False) else packed_weight.layout
+        )
+        kwargs["dtype"] = packed_weight.dtype
+        kwargs["requires_grad"] = False
+        shape = packed_weight.shape
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        packed_weight: torch.Tensor,
+        scale_and_zero: torch.Tensor,
+        transposed: bool,
+    ):
+        self.packed_weight = packed_weight
+        self.scale_and_zero = scale_and_zero
+        self.transposed = False
+
+    def __tensor_flatten__(self):
+        return ["packed_weight", "scale_and_zero"], [self.transposed]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        packed_weight, scale_and_zero = tensor_data_dict["packed_weight"], tensor_data_dict["scale_and_zero"]
+        transposed, = tensor_attributes
+        return cls(packed_weight, scale_and_zero, transposed)
+
+    @classmethod
+    def from_plain(cls, int_data, scale, zero_point, inner_k_tiles=8):
+        packed_weight = torch.ops.aten._convert_weight_to_int4pack(int_data.to(torch.int32), inner_k_tiles)
+        scale = scale.reshape(int_data.shape[0], -1)
+        zero_point = zero_point.reshape(int_data.shape[0], -1)
+        scale_and_zero = pack_tinygemm_scales_and_zeros(scale, zero_point)
+        return cls(packed_weight, scale_and_zero, False)
+
+    def to(self, *args, **kwargs):
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        device = kwargs["device"]
+        if device != "cuda" or (isinstance(device, torch.device) and device.type != "cuda"):
+            raise ValueError(f"TensorCoreTiledAQTLayout is only available for cuda device")
+        return self.__class__(
+            self.packed_weight.to(kwargs["device"]),
+            self.scale_and_zero.to(kwargs["device"]),
+            self.transposed
+        )
+
+    def _apply_fn_to_data(self, fn):
+        self.packed_weight = fn(self.packed_weight)
+        self.scale_and_zero = fn(self.scale_and_zero)
+        return self
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs):
+        kwargs = {} if kwargs is None else kwargs
+
+        if func is aten.detach.default:
+            return return_and_correct_aliasing(
+                func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
+            )
+
+        if func is aten.t.default:
+            """we don't need to repack the weight and just rely on external
+            shape being changed and record the status of transpose/no-transpose
+            """
+            args[0].transposed = not args[0].transposed
+            return return_and_correct_aliasing(func, args, kwargs, args[0])
+
+        raise NotImplementedError(
+            f"TensorCoreTiledAQTLayout dispatch: attempting to run {func}, this is not supported"
+        )
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    def get_plain(self):
+        from torchao.quantization.quant_primitives import (
+            ZeroPointDomain,
+            unpack_tinygemm_scales_and_zeros,
+            quantize_affine,
+        )
+        cur_shape = self.shape
+        assert len(cur_shape) == 4
+        inner_k_tiles = cur_shape[-1] * 2
+        original_shape = (cur_shape[0] * 8, cur_shape[1] * (inner_k_tiles * 16))
+        eye_shape = original_shape[1]
+        block_size = (1, 32)
+        device = self.device
+        original_dtype = torch.bfloat16
+        groupsize = 32
+        target_dtype = torch.int32
+        quant_min = 0
+        quant_max = 15
+        zero_point_domain = ZeroPointDomain.FLOAT
+        assert len(block_size) == 2 and block_size[0] == 1
+        groupsize = block_size[-1]
+        dequantized = torch.ops.aten._weight_int4pack_mm(torch.eye(eye_shape, device=device, dtype=original_dtype), self.packed_weight, groupsize, self.scale_and_zero)
+        dequantized = dequantized.t().contiguous()
+        scale, zero = unpack_tinygemm_scales_and_zeros(self.scale_and_zero)
+        # TODO: move this to `unpack_tinygemm_scales_and_zeros`?
+        scale = scale.reshape(scale.shape[:-1]).contiguous()
+        zero = zero.reshape(zero.shape[:-1]).contiguous()
+        int_data = quantize_affine(dequantized, block_size, scale, zero, target_dtype, quant_min, quant_max, zero_point_domain)
+        return int_data, scale, zero
 
 def _quantized_linear_op(input_tensor, weight_qtensor, bias):
     """
@@ -705,7 +666,7 @@ def _quantized_linear_op(input_tensor, weight_qtensor, bias):
     raise NotImplementedError("No specialized dispatch found for quantized linear op")
 
 
-@implements_aqt_torch_function(torch.nn.functional.linear)
+@implements(torch.nn.functional.linear)
 def functional_linear(*args, **kwargs):
     input_tensor, weight_tensor, bias = (
         args[0],
@@ -724,7 +685,7 @@ def functional_linear(*args, **kwargs):
             weight_tensor = weight_tensor.dequantize()
         return torch.nn.functional.linear(input_tensor, weight_tensor, bias)
 
-@implements_aqt_aten_ops([aten.mm.default, aten.addmm.default])
+@implements([aten.mm.default, aten.addmm.default])
 def aten_mm(func, *args, **kwargs):
     if not args[0].is_floating_point():
         raise NotImplementedError(f"{func} is not implemented for non floating point input")
@@ -763,21 +724,21 @@ def aten_mm(func, *args, **kwargs):
                 weight_tensor = weight_tensor.dequantize()
             return func(input_tensor, weight_tensor)
 
-@implements_aqt_aten_ops([aten.detach.default])
+@implements([aten.detach.default])
 def detach(func, *args, **kwargs):
     return return_and_correct_aliasing(
         func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
     )
 
 
-@implements_aqt_aten_ops([aten.clone.default])
+@implements([aten.clone.default])
 def clone(func, *args, **kwargs):
     return return_and_correct_aliasing(
         func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
     )
 
 
-@implements_aqt_aten_ops([aten._to_copy.default])
+@implements([aten._to_copy.default])
 def _to_copy(func, *args, **kwargs):
     return return_and_correct_aliasing(
         func,
@@ -786,7 +747,7 @@ def _to_copy(func, *args, **kwargs):
         args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
     )
 
-@implements_aqt_aten_ops([aten.t.default])
+@implements([aten.t.default])
 def t(func, *args, **kwargs):
     block_size = args[0].block_size
     assert len(block_size) == 2

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -11,6 +11,10 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch._prims_common import make_contiguous_strides_for
+from torchao.dtypes.utils import (
+    _implements,
+    _ATEN_OP_OR_TORCH_FN_TABLE,
+)
 
 
 aten = torch.ops.aten
@@ -18,9 +22,6 @@ aten = torch.ops.aten
 c10d_functional = torch.ops.c10d_functional
 
 from typing import Any, Optional, Tuple, Union, List
-
-NF4_OPS_TABLE: Dict[Any, Any] = {}
-
 
 _INNER_TENSOR_NAMES_FOR_SHARDING = ["quantized_scalers", "quantization_factor", "quantized_data"]
 
@@ -41,17 +42,6 @@ def same_metadata(a: "NF4Tensor", b: "NF4Tensor"):
         and a.scaler_block_size == b.scaler_block_size
         and a.n_blocks == b.n_blocks
     )
-
-
-def implements(aten_ops):
-    """Use this decorator to implement a function for an aten op in __torch_dispatch__"""
-
-    def decorator(func):
-        for op in aten_ops:
-            NF4_OPS_TABLE[op] = func
-        return func
-
-    return decorator
 
 
 def construct_nf4_args(nf4tensor: "NF4Tensor", kwargs: Optional[Dict[str, Any]] = None):
@@ -129,248 +119,6 @@ def expect_args_len_at_k(k: int, op: CompareOp, value: Any, msg: str):
             return func(aten_op, args, kwargs)
         return wrapper
     return decorator
-
-
-@implements([torch.ops.aten.detach])
-def noop_detach(func, *args, **kwargs):
-    return args[0][0]
-
-
-@implements(
-    [
-        aten.detach.default,
-    ]
-)
-def nf4_detach(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
-    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
-
-
-@implements(
-    [
-        aten.split.Tensor,
-    ]
-)
-def nf4_split(aten_op, args, kwargs=None):
-    if len(args) == 3 and args[2] != 0:
-        raise NotImplementedError(f"aten.split(NF4Tensor, dim={args[2]})")
-    nf4tensor = args[0]
-    num_chunks = nf4tensor.size(0) // args[1]
-
-    attr_to_chunks = {}
-    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
-        inner_tensor = getattr(nf4tensor, attr)
-        assert inner_tensor.numel() % num_chunks == 0, f"{attr}.numel() not divisible by {num_chunks}"
-        chunks = aten_op(inner_tensor, inner_tensor.numel() // num_chunks, **kwargs)
-        attr_to_chunks[attr] = chunks
-
-    orig_dim = nf4tensor.dim()
-    if orig_dim == 1:
-        chunked_size = (nf4tensor.size(0) // num_chunks, )
-    elif orig_dim == 2:
-        chunked_size = (nf4tensor.size(0) // num_chunks, nf4tensor.size(1))
-    else:
-        chunked_size = ()
-        raise NotImplementedError(f"aten.split(NF4Tensor) wherer NF4Tensor.dim() = {orig_dim}")
-
-    nf4_chunks = []
-    for idx in range(num_chunks):
-        updated_attrs = {
-            "size": chunked_size
-        }
-        for attr, chunks in attr_to_chunks.items():
-            updated_attrs[attr] = chunks[idx]
-        nf4_chunks.append(NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs)))
-    return nf4_chunks
-
-@implements(
-    [
-        aten.new_zeros.default,
-    ]
-)
-@expect_args_len_at_k(1, CompareOp.LT, 3, "aten.view(NF4Tensor) with len(size)=")
-def nf4_new_zeros(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    new_size = tuple(args[1])
-    new_size_dim = len(new_size)
-    if nf4tensor.numel() % math.prod(new_size) != 0:
-        raise NotImplementedError(f"aten.new_zeros(NF4Tensor) with new size {new_size}")
-    ratio = nf4tensor.numel() // math.prod(new_size)
-
-    updated_attrs = {}
-    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
-        inner_tensor = getattr(nf4tensor, attr)
-        assert inner_tensor.size(0) % ratio == 0, f"{attr}.numel() must be divisible by {ratio}"
-        inner_tensor = aten_op(inner_tensor, [inner_tensor.size(0) // ratio], **kwargs)
-        updated_attrs[attr] = inner_tensor
-    updated_attrs["size"] = new_size
-
-    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
-
-@implements(
-    [
-        aten.slice.Tensor,
-    ]
-)
-@expect_num_of_args(CompareOp.LT, 5, "aten.slice(NF4Tensor) with customized step")
-@expect_arg_value_at_k(1, CompareOp.EQ, 0, "aten.slice(NF4Tensor) with dim=")
-@expect_arg_value_at_k(2, CompareOp.EQ, 0, "aten.slice(NF4Tensor) with start=")
-def nf4_slice(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    # for tensor 512 x 512, tensor[:, :512] dispatch to
-    # aten.slice(dim = 0, end=sys.maxsize)
-    if not args[3] in [nf4tensor.size(0), sys.maxsize]:
-        raise NotImplementedError(f"aten.slice(NF4Tensor) with end={args[3]}")
-    return NF4Tensor(*construct_nf4_args(nf4tensor))
-
-@implements(
-    [
-        aten.view.default,
-    ]
-)
-@expect_args_len_at_k(1, CompareOp.EQ, 1, "aten.view(NF4Tensor) with len(size)=")
-def nf4_view(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    size = args[1]
-    if size[0] != -1:
-        raise NotImplementedError(f"aten.view(NF4Tensor) with size={size}")
-    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
-    updated_attrs.update({
-        "size": [nf4tensor.numel()],
-        "stride": (1, ),
-    })
-    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
-
-@implements(
-    [
-        aten.as_strided.default,
-    ]
-)
-@expect_args_len_at_k(1, CompareOp.LT, 3, "aten.as_strided(NF4Tensor) only support dim <= 2 but got dim=")
-def nf4_as_strided(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    size = args[1]
-    stride = tuple(args[2])
-    storage_offset = args[3]
-    if math.prod(size) != nf4tensor.numel():
-        raise NotImplementedError(f"aten.as_strided(NF4Tensor) different numel={nf4tensor.numel()} and size={size}")
-    if stride != make_contiguous_strides_for(size):
-        raise NotImplementedError(f"aten.as_strided(NF4Tensor) only support continuous stride={make_contiguous_strides_for(size)} but got stride={stride}")
-    if nf4tensor.storage_offset() != storage_offset:
-        raise NotImplementedError(f"aten.as_strided(NF4Tensor) only support original storage offset {nf4tensor.storage_offset()} but got {storage_offset}")
-    kwargs = {
-        "size": torch.Size(size),
-        "stride": stride,
-        "storage_offset": storage_offset,
-    }
-    return NF4Tensor(*construct_nf4_args(nf4tensor, kwargs))
-
-
-@implements([torch.ops.aten._to_copy.default])
-def _to_copy(func, *args, **kwargs):
-    if not args[0][0].is_contiguous():
-        assert args[0][0].t().is_contiguous()
-        return func(args[0][0].t()).t()
-    out = args[0][0].get_original_weight().to(args[1]["dtype"])
-    if "device" in args[1]:
-        out = out.to(args[1]["device"])
-    return out
-
-
-@implements([torch.ops.aten.to.dtype])
-def to_dtype(func, *args, **kwargs):
-    if not args[0][0].is_contiguous():
-        assert args[0][0].t().is_contiguous()
-        return torch.ops.aten.to.dtype(args[0][0].t(), args[0][1]).t()
-    return args[0][0].get_original_weight().to(args[0][1])
-
-
-@implements([torch.ops.aten.t.default])
-def t_default(func, *args, **kwargs):
-    a = args[0][0]
-    tensor_meta = SubclassTensorArgs(
-        a.size(),
-        (a.stride(1), a.stride(0)),
-        a.storage_offset(),
-        a.dtype,
-        a.device,
-        a.requires_grad,
-    )
-    b = NF4Tensor(
-        tensor_meta,
-        a.block_size,
-        a.n_blocks,
-        a.scaler_block_size,
-        a.quantized_scalers,
-        a.quantization_factor,
-        a.scaler_mean,
-        a.quantized_data,
-        a.nf4,
-    )
-    return b
-
-
-@implements([torch.ops.aten.mm.default])
-def mm_default(func, *args, **kwargs):
-    return linear_nf4(args[0][0], args[0][1])
-
-
-@implements(
-    [
-        aten.copy_.default,
-    ]
-)
-def copy_(func, *args, **kwargs):
-    original: NF4Tensor = args[0][0]
-    copy_in: torch.Tensor = args[0][1]
-
-    # Base Case
-
-    if same_metadata(original, copy_in):
-        original_tensors = original.__tensor_flatten__()[0]
-        for tensor_name in original_tensors:
-            getattr(original, tensor_name).copy_(getattr(copy_in, tensor_name))
-        return
-
-    # Convert Non NF4Tensor into NF4 for copy in
-    if not isinstance(copy_in, NF4Tensor):
-        copy_in_nf4 = NF4Tensor.from_tensor(
-            copy_in, original.block_size, original.scaler_block_size
-        )
-        return original.copy_(copy_in_nf4)
-
-    # Other Tensor is not a NF4Tensor
-    full_precision = copy_in.get_original_weight()
-    same_meta_nf4 = NF4Tensor.from_tensor(
-        full_precision, original.block_size, original.scaler_block_size
-    )
-    return original.copy_(same_meta_nf4)
-
-
-@implements(
-    [
-        aten.is_pinned.default,
-    ]
-)
-def nf4_is_pinned(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
-        inner_tensor = getattr(nf4tensor, attr)
-        if not aten_op(inner_tensor, *(args[1:]), **kwargs):
-            return False
-    return True
-
-
-@implements(
-    [
-        aten._pin_memory.default,
-    ]
-)
-def nf4_pin_memory(aten_op, args, kwargs=None):
-    nf4tensor = args[0]
-    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
-    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
 
 
 @dataclass
@@ -759,7 +507,7 @@ class NF4Tensor(torch.Tensor):
         """TODO we are not supporting torch dispatch at the moment
         instead we have created a Autograd.Function to handle the linear
         """
-        # All ops in the  NF4_OPS_TABLE expect NF4 Tensors as inputs
+        # All ops in the _ATEN_OP_OR_TORCH_FN_TABLE expect NF4 Tensors as inputs
         # And don't support mixed tensor subclasses. This will trigger the handler for
         # the next type in the dispatch list
 
@@ -775,8 +523,8 @@ class NF4Tensor(torch.Tensor):
         if not all(allowed_subclasses(t) for t in types):
             return NotImplemented("Up to the next one to handle")
 
-        if func in NF4_OPS_TABLE:
-            return NF4_OPS_TABLE[func](func, args, kwargs)
+        if func in _ATEN_OP_OR_TORCH_FN_TABLE[cls]:
+            return _ATEN_OP_OR_TORCH_FN_TABLE[cls][func](func, args, kwargs)
         raise NotImplementedError(
             f"NF4Tensor dispatch: attempting to run {func}, this is not supported"
         )
@@ -789,8 +537,8 @@ class NF4Tensor(torch.Tensor):
             kwargs = {}
 
         try:
-            if func in NF4_TORCH_FUNCTIONS:
-                return NF4_TORCH_FUNCTIONS[func](*args, **kwargs)
+            if func in _ATEN_OP_OR_TORCH_FN_TABLE[cls]:
+                return _ATEN_OP_OR_TORCH_FN_TABLE[cls][func](*args, **kwargs)
         except NotImplementedError:
             pass
 
@@ -886,20 +634,251 @@ def linear_nf4(input: torch.Tensor, weight: NF4Tensor) -> torch.Tensor:
 def to_nf4(tensor, block_size: int = 64, scaler_block_size: int = 256):
     return NF4Tensor.from_tensor(tensor, block_size, scaler_block_size)
 
+def implements(aten_ops_or_torch_fn):
+    return _implements(NF4Tensor, aten_ops_or_torch_fn)
 
-NF4_TORCH_FUNCTIONS = {}
-
-
-def implements_torch_function(torch_function):
-    def decorator(func):
-        functools.update_wrapper(func, torch_function)
-        NF4_TORCH_FUNCTIONS[torch_function] = func
-        return func
-
-    return decorator
+@implements([torch.ops.aten.detach])
+def noop_detach(func, *args, **kwargs):
+    return args[0][0]
 
 
-@implements_torch_function(torch.Tensor.to)
+@implements(
+    [
+        aten.detach.default,
+    ]
+)
+def nf4_detach(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
+    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
+
+
+@implements(
+    [
+        aten.split.Tensor,
+    ]
+)
+def nf4_split(aten_op, args, kwargs=None):
+    if len(args) == 3 and args[2] != 0:
+        raise NotImplementedError(f"aten.split(NF4Tensor, dim={args[2]})")
+    nf4tensor = args[0]
+    num_chunks = nf4tensor.size(0) // args[1]
+
+    attr_to_chunks = {}
+    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
+        inner_tensor = getattr(nf4tensor, attr)
+        assert inner_tensor.numel() % num_chunks == 0, f"{attr}.numel() not divisible by {num_chunks}"
+        chunks = aten_op(inner_tensor, inner_tensor.numel() // num_chunks, **kwargs)
+        attr_to_chunks[attr] = chunks
+
+    orig_dim = nf4tensor.dim()
+    if orig_dim == 1:
+        chunked_size = (nf4tensor.size(0) // num_chunks, )
+    elif orig_dim == 2:
+        chunked_size = (nf4tensor.size(0) // num_chunks, nf4tensor.size(1))
+    else:
+        chunked_size = ()
+        raise NotImplementedError(f"aten.split(NF4Tensor) wherer NF4Tensor.dim() = {orig_dim}")
+
+    nf4_chunks = []
+    for idx in range(num_chunks):
+        updated_attrs = {
+            "size": chunked_size
+        }
+        for attr, chunks in attr_to_chunks.items():
+            updated_attrs[attr] = chunks[idx]
+        nf4_chunks.append(NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs)))
+    return nf4_chunks
+
+@implements(
+    [
+        aten.new_zeros.default,
+    ]
+)
+@expect_args_len_at_k(1, CompareOp.LT, 3, "aten.view(NF4Tensor) with len(size)=")
+def nf4_new_zeros(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    new_size = tuple(args[1])
+    new_size_dim = len(new_size)
+    if nf4tensor.numel() % math.prod(new_size) != 0:
+        raise NotImplementedError(f"aten.new_zeros(NF4Tensor) with new size {new_size}")
+    ratio = nf4tensor.numel() // math.prod(new_size)
+
+    updated_attrs = {}
+    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
+        inner_tensor = getattr(nf4tensor, attr)
+        assert inner_tensor.size(0) % ratio == 0, f"{attr}.numel() must be divisible by {ratio}"
+        inner_tensor = aten_op(inner_tensor, [inner_tensor.size(0) // ratio], **kwargs)
+        updated_attrs[attr] = inner_tensor
+    updated_attrs["size"] = new_size
+
+    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
+
+@implements(
+    [
+        aten.slice.Tensor,
+    ]
+)
+@expect_num_of_args(CompareOp.LT, 5, "aten.slice(NF4Tensor) with customized step")
+@expect_arg_value_at_k(1, CompareOp.EQ, 0, "aten.slice(NF4Tensor) with dim=")
+@expect_arg_value_at_k(2, CompareOp.EQ, 0, "aten.slice(NF4Tensor) with start=")
+def nf4_slice(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    # for tensor 512 x 512, tensor[:, :512] dispatch to
+    # aten.slice(dim = 0, end=sys.maxsize)
+    if not args[3] in [nf4tensor.size(0), sys.maxsize]:
+        raise NotImplementedError(f"aten.slice(NF4Tensor) with end={args[3]}")
+    return NF4Tensor(*construct_nf4_args(nf4tensor))
+
+@implements(
+    [
+        aten.view.default,
+    ]
+)
+@expect_args_len_at_k(1, CompareOp.EQ, 1, "aten.view(NF4Tensor) with len(size)=")
+def nf4_view(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    size = args[1]
+    if size[0] != -1:
+        raise NotImplementedError(f"aten.view(NF4Tensor) with size={size}")
+    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
+    updated_attrs.update({
+        "size": [nf4tensor.numel()],
+        "stride": (1, ),
+    })
+    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
+
+@implements(
+    [
+        aten.as_strided.default,
+    ]
+)
+@expect_args_len_at_k(1, CompareOp.LT, 3, "aten.as_strided(NF4Tensor) only support dim <= 2 but got dim=")
+def nf4_as_strided(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    size = args[1]
+    stride = tuple(args[2])
+    storage_offset = args[3]
+    if math.prod(size) != nf4tensor.numel():
+        raise NotImplementedError(f"aten.as_strided(NF4Tensor) different numel={nf4tensor.numel()} and size={size}")
+    if stride != make_contiguous_strides_for(size):
+        raise NotImplementedError(f"aten.as_strided(NF4Tensor) only support continuous stride={make_contiguous_strides_for(size)} but got stride={stride}")
+    if nf4tensor.storage_offset() != storage_offset:
+        raise NotImplementedError(f"aten.as_strided(NF4Tensor) only support original storage offset {nf4tensor.storage_offset()} but got {storage_offset}")
+    kwargs = {
+        "size": torch.Size(size),
+        "stride": stride,
+        "storage_offset": storage_offset,
+    }
+    return NF4Tensor(*construct_nf4_args(nf4tensor, kwargs))
+
+
+@implements([torch.ops.aten._to_copy.default])
+def _to_copy(func, *args, **kwargs):
+    if not args[0][0].is_contiguous():
+        assert args[0][0].t().is_contiguous()
+        return func(args[0][0].t()).t()
+    out = args[0][0].get_original_weight().to(args[1]["dtype"])
+    if "device" in args[1]:
+        out = out.to(args[1]["device"])
+    return out
+
+
+@implements([torch.ops.aten.to.dtype])
+def to_dtype(func, *args, **kwargs):
+    if not args[0][0].is_contiguous():
+        assert args[0][0].t().is_contiguous()
+        return torch.ops.aten.to.dtype(args[0][0].t(), args[0][1]).t()
+    return args[0][0].get_original_weight().to(args[0][1])
+
+
+@implements([torch.ops.aten.t.default])
+def t_default(func, *args, **kwargs):
+    a = args[0][0]
+    tensor_meta = SubclassTensorArgs(
+        a.size(),
+        (a.stride(1), a.stride(0)),
+        a.storage_offset(),
+        a.dtype,
+        a.device,
+        a.requires_grad,
+    )
+    b = NF4Tensor(
+        tensor_meta,
+        a.block_size,
+        a.n_blocks,
+        a.scaler_block_size,
+        a.quantized_scalers,
+        a.quantization_factor,
+        a.scaler_mean,
+        a.quantized_data,
+        a.nf4,
+    )
+    return b
+
+
+@implements([torch.ops.aten.mm.default])
+def mm_default(func, *args, **kwargs):
+    return linear_nf4(args[0][0], args[0][1])
+
+
+@implements(
+    [
+        aten.copy_.default,
+    ]
+)
+def copy_(func, *args, **kwargs):
+    original: NF4Tensor = args[0][0]
+    copy_in: torch.Tensor = args[0][1]
+
+    # Base Case
+
+    if same_metadata(original, copy_in):
+        original_tensors = original.__tensor_flatten__()[0]
+        for tensor_name in original_tensors:
+            getattr(original, tensor_name).copy_(getattr(copy_in, tensor_name))
+        return
+
+    # Convert Non NF4Tensor into NF4 for copy in
+    if not isinstance(copy_in, NF4Tensor):
+        copy_in_nf4 = NF4Tensor.from_tensor(
+            copy_in, original.block_size, original.scaler_block_size
+        )
+        return original.copy_(copy_in_nf4)
+
+    # Other Tensor is not a NF4Tensor
+    full_precision = copy_in.get_original_weight()
+    same_meta_nf4 = NF4Tensor.from_tensor(
+        full_precision, original.block_size, original.scaler_block_size
+    )
+    return original.copy_(same_meta_nf4)
+
+
+@implements(
+    [
+        aten.is_pinned.default,
+    ]
+)
+def nf4_is_pinned(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
+        inner_tensor = getattr(nf4tensor, attr)
+        if not aten_op(inner_tensor, *(args[1:]), **kwargs):
+            return False
+    return True
+
+
+@implements(
+    [
+        aten._pin_memory.default,
+    ]
+)
+def nf4_pin_memory(aten_op, args, kwargs=None):
+    nf4tensor = args[0]
+    updated_attrs = apply_to_inner_tensors(nf4tensor, aten_op, args[1:], kwargs)
+    return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
+
+@implements(torch.Tensor.to)
 def function_to_dtype(*args, **kwargs):
     tensor = args[0]
     if isinstance(args[1], torch.dtype):
@@ -925,7 +904,7 @@ def function_to_dtype(*args, **kwargs):
         )
 
 
-@implements_torch_function(torch.Tensor.cpu)
+@implements(torch.Tensor.cpu)
 def function_cpu(*args, **kwargs):
     nf4tensor = args[0]
     updated_attrs = call_from_inner_tensors(nf4tensor, "cpu", args[1:], kwargs)

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -1,0 +1,65 @@
+from typing import Dict, Callable
+from collections import defaultdict
+import functools
+
+"""
+torch_function and torch_dispatch operator dispatch registrations
+
+first key is a tensor subclass type like AffineQuantizedTensor,
+second key is a `func` in __torhc_function__ or __torch_dispatch__,
+value is a function that implements the dispatch
+"""
+_ATEN_OP_OR_TORCH_FN_TABLE: Dict[Callable, Dict[Callable, Callable]] = defaultdict(dict)
+
+def _implements(cls, aten_ops_or_torch_fns):
+    """Use this decorator to implement a function for an aten ops in __torch_dispatch__
+    (if user passed in a list of ops)
+    or torch function in __torch_function__ (if user passed in a single object)
+    """
+    if not isinstance(aten_ops_or_torch_fns, (list, tuple)):
+        aten_ops_or_torch_fns = [aten_ops_or_torch_fns]
+    def decorator(func):
+        for op in aten_ops_or_torch_fns:
+            @functools.wraps(op)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            _ATEN_OP_OR_TORCH_FN_TABLE[cls][op] = wrapper
+        return func
+    return decorator
+
+"""
+layout tensor constructor registration for different tensor subclassesa
+
+first key is a tensor subclass type like AffineQuantizedTensor
+second key is an extended layout string, like tensor_core_tiled
+value is a constructor for the LayoutTensor class, e.g. TensorCoreTiledAQTLayout.from_plain
+"""
+_LAYOUT_CONSTRUCTOR_TABLE: Dict[Callable, Dict[str, Callable]] = defaultdict(dict)
+
+def _register_layout_cls(cls: Callable, extended_layout: str):
+    """Helper function for layout registrations, this is used to implement
+    register_layout_cls decorator for each tensor subclass, see aqt.py for example usage
+
+    Args:
+        cls: Tensor subclass type
+        extended_layout: string name for the layout type
+
+    Returns:
+        a decorator that registers the layout tensor constructor in the table
+    """
+    def decorator(layout_cls):
+        layout_cls.extended_layout = extended_layout
+        _LAYOUT_CONSTRUCTOR_TABLE[cls][extended_layout] = layout_cls.from_plain
+        return layout_cls
+    return decorator
+
+def _get_layout_tensor_constructor(cls: Callable, extended_layout: str) -> Callable:
+    """Get Layout class constructor (LayoutClass.from_plain) for `cls` based on `extended_layout`
+    """
+    if cls not in _LAYOUT_CONSTRUCTOR_TABLE:
+        raise ValueError(f"no registered layout class constructor for: {cls}")
+    if extended_layout not in _LAYOUT_CONSTRUCTOR_TABLE[cls]:
+        raise ValueError(f"extended_layout: {extended_layout} is not supported yet for {cls}")
+
+    return _LAYOUT_CONSTRUCTOR_TABLE[cls][extended_layout]


### PR DESCRIPTION
Summary:
att, after the refactor we can use common utils for new dtypes as well

```
# added for adding ops to op dispatch table, works for both aten and torch function
def _implements(cls, aten_ops_or_torch_fns):
   ...

# added for registering new layout class
def _register_layout_cls(cls, extended_layout: str):
 ...

# get layout tensor constructor
def _get_layout_tensor_constructor(cls, extended_layout: str) -> Callable:
 ...
```

Test Plan:
python test/dtypes/test_nf4.py
python test/dtypes/test_aqt.py
python test/integration/test_integration.py

Reviewers:

Subscribers:

Tasks:

Tags: