### PR TITLE
Refactor custom FPx cast

### DIFF
--- a/test/prototype/test_fp6_llm.py
+++ b/test/prototype/test_fp6_llm.py
@@ -34,7 +34,7 @@ class TestFp6LlmLinear(TestCase):
         x = torch.randn(256, 64, device=device)
 
         expected = to_tc_float6_e3m2(x)
-        actual = torch.compile(to_tc_float6_e3m2)(x)
+        actual = torch.compile(to_tc_float6_e3m2, fullgraph=True)(x)
         torch.testing.assert_close(actual, expected)
 
     @parametrize("device", _DEVICES)
@@ -53,7 +53,7 @@ class TestFp6LlmLinear(TestCase):
         x = torch.randint(256, size=(M, N * 3 // 4), dtype=torch.uint8, device=device)
 
         expected = from_tc_float6_e3m2(x)
-        actual = torch.compile(from_tc_float6_e3m2)(x)
+        actual = torch.compile(from_tc_float6_e3m2, fullgraph=True)(x)
         torch.testing.assert_close(actual, expected)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -81,7 +81,7 @@ class TestFp6LlmLinear(TestCase):
 
         x = torch.randn(N, IC, device=device, dtype=torch.half)
         expected = fp6_linear(x)
-        actual = torch.compile(fp6_linear)(x)
+        actual = torch.compile(fp6_linear, fullgraph=True)(x)
         torch.testing.assert_close(actual, expected)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -67,12 +67,8 @@ def _f32_to_fpx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     # rewrite saturate/denorm/norm branches without explicit data dependent
     # control flow, to be more compiler friendly
     saturate_mask = x >= max_normal
-    denormal_mask = torch.logical_and(
-        torch.logical_not(saturate_mask), x < min_normal
-    )  # noqa: E501
-    normal_mask = torch.logical_not(
-        torch.logical_or(saturate_mask, denormal_mask)
-    )  # noqa: E501
+    denormal_mask = torch.logical_and(torch.logical_not(saturate_mask), x < min_normal)
+    normal_mask = torch.logical_not(torch.logical_or(saturate_mask, denormal_mask))
 
     #
     # branch 1: saturate to max val - handled later in the code which combines

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import struct
+
+import torch
+from torch import Tensor
+
+
+def _n_ones(n: int) -> int:
+    return (1 << n) - 1
+
+
+EBITS_F32, MBITS_F32 = 8, 23
+F32_EXP_BIAS = _n_ones(EBITS_F32 - 1)
+
+
+def _f32_to_fpx_unpacked(x: Tensor, ebits: int, mbits: int):
+    assert x.dtype == torch.float
+
+    # calculate constants
+    exp_bias = _n_ones(ebits - 1)
+    max_int = _n_ones(ebits + mbits)
+    sign_mask = 1 << (ebits + mbits)
+
+    # TODO document this better
+    magic_adder = _n_ones(MBITS_F32 - mbits - 1)
+
+    # all E bits and M bits are 1s
+    max_normal = 2 ** (_n_ones(ebits) - exp_bias) * (_n_ones(mbits + 1) / (2 ** mbits))
+
+    # E bits = 1, M bits = 0
+    min_normal = 2 ** (1 - exp_bias)
+
+    denorm_exp = (
+        # exp bias conversion between formats
+        (F32_EXP_BIAS - exp_bias)
+        # mantissa length difference between formats
+        + (MBITS_F32 - mbits)
+        # add one to encoded exponent for denormalized numbers
+        + 1
+    )
+    denorm_mask_int = denorm_exp << MBITS_F32
+
+    # reinterpret int32 as float32 in Python
+    # see https://stackoverflow.com/a/34446112/1058521
+    denorm_mask_float = struct.unpack("!f", struct.pack("!I", denorm_mask_int))[0]
+
+    # save the sign
+    # Note that we have torch.uint32, but some ops like cpu bit shifts
+    # do not work on it. So, we stay in int32.
+    x = x.view(torch.int32)
+    sign = x & 0x80000000
+
+    # set everything to positive, will add sign back at the end
+    x = x ^ sign
+
+    # TODO: can the branch floating point comparisons below be done without
+    # converting to float? probably but need to verify
+    x = x.view(torch.float)
+
+    # rewrite saturate/denorm/norm branches without explicit data dependent
+    # control flow, to be more compiler friendly
+    saturate_mask = x >= max_normal
+    denormal_mask = torch.logical_and(
+        torch.logical_not(saturate_mask), x < min_normal
+    )  # noqa: E501
+    normal_mask = torch.logical_not(
+        torch.logical_or(saturate_mask, denormal_mask)
+    )  # noqa: E501
+
+    #
+    # branch 1: saturate to max val - handled later in the code which combines
+    #   the branches
+    #
+
+    #
+    # branch 2: to conversion to denormal as well as rounding up to normal
+    #
+    denormal_x = x + denorm_mask_float
+    denormal_x = denormal_x.view(torch.int32)
+    denormal_x -= denorm_mask_int
+    denormal_x = denormal_x.to(torch.uint8)
+
+    #
+    # branch 3: stay in normal range, adjust the exponent and round
+    #
+    normal_x = x.view(torch.int32)
+    # resulting mantissa is odd
+    mant_odd = (normal_x >> (MBITS_F32 - mbits)) & 1
+    # update exponent, rounding bias part 1
+    val_to_add = ((exp_bias - F32_EXP_BIAS) << MBITS_F32) + magic_adder
+    normal_x += val_to_add
+    # rounding bias part 2
+    normal_x += mant_odd
+    # take the bits!
+    normal_x = normal_x >> (MBITS_F32 - mbits)
+    normal_x = normal_x.to(torch.uint8)
+
+    #
+    # combine the branches
+    #
+    x = torch.full_like(x, max_int, dtype=torch.uint8)
+    x = torch.where(denormal_mask, denormal_x, x)
+    x = torch.where(normal_mask, normal_x, x)
+
+    # add sign back
+    sign_lp = sign >> (MBITS_F32 + EBITS_F32 - mbits - ebits)
+    sign_lp = sign_lp.to(torch.uint8)
+    # Right shift of a negative signed integer can fill the least significant
+    # bits with either 1s or 0s, depending on the implementation. Since PyTorch
+    # doesn't have an uint32 dtype, we mask out these bits to get just the
+    # f4 sign bit
+    sign_lp = sign_lp & sign_mask
+    x = x | sign_lp
+
+    return x.to(torch.uint8)

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -49,7 +49,8 @@ def _f32_to_fpx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
 
     # reinterpret int32 as float32 in Python
     # see https://stackoverflow.com/a/34446112/1058521
-    denorm_mask_float = struct.unpack("!f", struct.pack("!I", denorm_mask_int))[0]
+    # denorm_mask_float = struct.unpack("!f", struct.pack("!I", denorm_mask_int))[0]
+    denorm_mask_float = torch.tensor(denorm_mask_int, dtype=torch.int32).view(torch.float32)
 
     # save the sign
     # Note that we have torch.uint32, but some ops like cpu bit shifts

--- a/torchao/prototype/mx_formats/benchmarks/bench_qdq.py
+++ b/torchao/prototype/mx_formats/benchmarks/bench_qdq.py
@@ -141,7 +141,7 @@ def run(profile_folder: Optional[str] = None):
 
             torch._dynamo.reset()
 
-    print(tabulate.tabulate(results, headers=headers, floatfmt=".2f", tablefmt="github"))
+    print(tabulate.tabulate(results, headers=headers, floatfmt=".2f"))
 
 
 if __name__ == "__main__":

--- a/torchao/prototype/mx_formats/benchmarks/bench_qdq.py
+++ b/torchao/prototype/mx_formats/benchmarks/bench_qdq.py
@@ -61,8 +61,8 @@ def run(profile_folder: Optional[str] = None):
             data_lp = MXTensor.to_mx(data_hp, elem_dtype, block_size=32)
 
             if not use_fp4_custom_triton_dequant_kernel:
-                quant = torch.compile(MXTensor.to_mx)
-                dequant = torch.compile(data_lp.to_dtype)
+                quant = torch.compile(MXTensor.to_mx, fullgraph=True)
+                dequant = torch.compile(data_lp.to_dtype, fullgraph=True)
             else:
                 # As of 2024-04, torch.compile didn't work with the
                 # handwritten triton kernel,
@@ -141,7 +141,7 @@ def run(profile_folder: Optional[str] = None):
 
             torch._dynamo.reset()
 
-    print(tabulate.tabulate(results, headers=headers, floatfmt=".2f"))
+    print(tabulate.tabulate(results, headers=headers, floatfmt=".2f", tablefmt="github"))
 
 
 if __name__ == "__main__":

--- a/torchao/prototype/mx_formats/custom_cast.py
+++ b/torchao/prototype/mx_formats/custom_cast.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import struct
-
 import numpy as np
 
 import torch
@@ -25,8 +23,6 @@ from torchao.prototype.mx_formats.constants import (
     E8M0_EXPONENT_NAN_VAL,
     F32_EXP_BIAS,
     F4_E2M1_EXP_BIAS,
-    F6_E2M3_EXP_BIAS,
-    F6_E3M2_EXP_BIAS,
 )
 
 
@@ -45,78 +41,8 @@ EBITS_F4_E2M1, MBITS_F4_E2M1 = 2, 1
 EBITS_F6_E2M3, MBITS_F6_E2M3 = 2, 3
 EBITS_F6_E3M2, MBITS_F6_E3M2 = 3, 2
 
-DENORM_F32TOF4_EXP = (
-    # exp bias conversion between formats
-    (F32_EXP_BIAS - F4_E2M1_EXP_BIAS)
-    # mantissa length difference between formats
-    + (MBITS_F32 - MBITS_F4_E2M1)
-    # add one to encoded exponent for denormalized numbers
-    + 1
-)
-DENORM_F32TOF4_MASK_INT = DENORM_F32TOF4_EXP << MBITS_F32
-# reinterpret int32 as float32 in Python
-# see https://stackoverflow.com/a/34446112/1058521
-DENORM_F32TOF4_MASK_FLOAT = struct.unpack(
-    "!f", struct.pack("!I", DENORM_F32TOF4_MASK_INT)
-)[0]
-
-DENORM_F32TOF6_E2M3_EXP = (
-    # exp bias conversion between formats
-    (F32_EXP_BIAS - F6_E2M3_EXP_BIAS)
-    # mantissa length difference between formats
-    + (MBITS_F32 - MBITS_F6_E2M3)
-    # add one to encoded exponent for denormalized numbers
-    + 1
-)
-DENORM_F32TOF6_E2M3_MASK_INT = DENORM_F32TOF6_E2M3_EXP << MBITS_F32
-# reinterpret int32 as float32 in Python
-# see https://stackoverflow.com/a/34446112/1058521
-DENORM_F32TOF6_E2M3_MASK_FLOAT = struct.unpack(
-    "!f", struct.pack("!I", DENORM_F32TOF6_E2M3_MASK_INT)
-)[0]
-
-DENORM_F32TOF6_E3M2_EXP = (
-    # exp bias conversion between formats
-    (F32_EXP_BIAS - F6_E3M2_EXP_BIAS)
-    # mantissa length difference between formats
-    + (MBITS_F32 - MBITS_F6_E3M2)
-    # add one to encoded exponent for denormalized numbers
-    + 1
-)
-DENORM_F32TOF6_E3M2_MASK_INT = DENORM_F32TOF6_E3M2_EXP << MBITS_F32
-# reinterpret int32 as float32 in Python
-# see https://stackoverflow.com/a/34446112/1058521
-DENORM_F32TOF6_E3M2_MASK_FLOAT = struct.unpack(
-    "!f", struct.pack("!I", DENORM_F32TOF6_E3M2_MASK_INT)
-)[0]
-
-#
-# magic value to add during the normal path
-# TODO document this better
-#
-
-# c++ code e5m2:
-# f_bits += ((uint32_t)(15 - 127) << 23) + 0xFFFFF;
-# 0xFFFFF is 1111 1111 1111 1111 1111, 20 ones, 20 = 23 - 3 = 23 - 2 - 1
-
-# c++ code e4m3:
-# f_bits += ((uint32_t)(7 - 127) << 23) + 0x7FFFF;
-# 0x7FFFF is 0111 1111 1111 1111 1111, 19 ones, 19 = 23 - 4 = 23 - 3 - 1
-
-MAGIC_ADDER_F4_E2M1 = 0x1FFFFF  # 21 ones
-MAGIC_ADDER_F6_E2M3 = 0x7FFFF  # 19 ones
-MAGIC_ADDER_F6_E3M2 = 0xFFFFF  # 20 ones
-
-# c++ code named vars
-# f_bits += ((uint32_t)(f8_exp_bias - f32_exp_bias) << f32_mbits) + MAGIC_ADDER;  # noqa: E501
-
 SIGN_MASK_F4 = 0x8  # 1000
-SIGN_MASK_F6_E2M3 = 0x20  # 100000
-SIGN_MASK_F6_E3M2 = 0x20  # 100000
-
 MANTISSA_MASK_F4 = 0x1  # 0001
-MANTISSA_MASK_F6_E2M3 = 0x7  # 000111
-MANTISSA_MASK_F6_E3M2 = 0x3  # 000011
 
 ZERO_BITS_F32 = 0x0
 ZERO_POINT_FIVE_BITS_F32 = 0x3F000000


### PR DESCRIPTION
Closes #354

TODO:
- ~Check torch.compile~
- ~Benchmark before and after~

```
python torchao/prototype/mx_formats/benchmarks/bench_qdq.py
```

88410947 (main)

| elem_dtype          | use_fp4_custom_triton_dequant_kernel   |   q_time_us |   q_mem_bw_tb_s |   dq_time_us |   dq_mem_bw_tb_s |
|---------------------|----------------------------------------|-------------|-----------------|--------------|------------------|
| torch.float8_e4m3fn | False                                  |      532.20 |            0.26 |       554.40 |             0.25 |
| torch.float8_e5m2   | False                                  |      532.83 |            0.26 |       551.01 |             0.25 |
| fp6_e2m3            | False                                  |      574.66 |            0.24 |       258.41 |             0.53 |
| fp6_e3m2            | False                                  |      577.37 |            0.24 |       258.86 |             0.53 |
| fp4_e2m1            | False                                  |      682.13 |            0.17 |       254.72 |             0.45 |
| fp4_e2m1            | True                                   |    12251.34 |            0.01 |       190.39 |             0.60 |

2690b927 (this PR)

| elem_dtype          | use_fp4_custom_triton_dequant_kernel   |   q_time_us |   q_mem_bw_tb_s |   dq_time_us |   dq_mem_bw_tb_s |
|---------------------|----------------------------------------|-------------|-----------------|--------------|------------------|
| torch.float8_e4m3fn | False                                  |      531.62 |            0.26 |       552.91 |             0.25 |
| torch.float8_e5m2   | False                                  |      530.52 |            0.26 |       550.33 |             0.25 |
| fp6_e2m3            | False                                  |      572.89 |            0.24 |       551.21 |             0.25 |
| fp6_e3m2            | False                                  |      576.62 |            0.24 |       551.92 |             0.25 |
| fp4_e2m1            | False                                  |      680.27 |            0.17 |       255.10 |             0.45 |
| fp4_e2m1            | True                                   |    12248.68 |            0.01 |       191.09 |             0.60 |

Dequant is 2x slower because I replaced LUT-based denormal handling with a more generic logic. @vkuzo Should I add back the LUT-based logic (check specifically for E2M3 E3M2 E2M1)? If we are interested in performance then perhaps we can generate a LUT for all bit patterns and cache it.

UPDATE

95f4582 (this PR v2)

| elem_dtype          | use_fp4_custom_triton_dequant_kernel   |   q_time_us |   q_mem_bw_tb_s |   dq_time_us |   dq_mem_bw_tb_s |
|---------------------|----------------------------------------|-------------|-----------------|--------------|------------------|
| torch.float8_e4m3fn | False                                  |      531.54 |            0.26 |       554.03 |             0.25 |
| torch.float8_e5m2   | False                                  |      532.41 |            0.26 |       551.63 |             0.25 |
| fp6_e2m3            | False                                  |      574.66 |            0.24 |       258.28 |             0.53 |
| fp6_e3m2            | False                                  |      576.53 |            0.24 |       258.76 |             0.53 |
| fp4_e2m1            | False                                  |      682.26 |            0.17 |       517.65 |             0.22 |
| fp4_e2m1            | True                                   |    12247.99 |            0.01 |       190.48 |             0.60 |

Now FP4_E2M1 is slower lol. Feel like this should be bandwidth-limited. It might be register-limited also? Will do some profiling + make sure torch.compile run optimally. Interesting that native PyTorch float8 dequant is slower.

UPDATE 2

dcd5a05a (this PR v3)

| elem_dtype          | use_fp4_custom_triton_dequant_kernel   |   q_time_us |   q_mem_bw_tb_s |   dq_time_us |   dq_mem_bw_tb_s |
|---------------------|----------------------------------------|-------------|-----------------|--------------|------------------|
| torch.float8_e4m3fn | False                                  |      532.65 |            0.26 |       554.13 |             0.25 |
| torch.float8_e5m2   | False                                  |      532.07 |            0.26 |       551.30 |             0.25 |
| fp6_e2m3            | False                                  |      574.76 |            0.24 |       258.48 |             0.53 |
| fp6_e3m2            | False                                  |      576.85 |            0.24 |       258.36 |             0.53 |
| fp4_e2m1            | False                                  |      681.22 |            0.17 |       254.14 |             0.45 |
| fp4_e2m1            | True                                   |    12249.79 |            0.01 |       190.49 |             0.60 |

Speed recovered 😊