### PR TITLE
Generalize Model Size Code

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1409,20 +1409,20 @@ class TestUtils(unittest.TestCase):
     @parameterized.expand(
         list(itertools.product(TENSOR_SUBCLASS_APIS, COMMON_DEVICES, COMMON_DTYPES)),
     )
-    def test_get_model_size_aqt(self, api, device, dtype):
-        if dtype != torch.bfloat16:
-            self.skipTest(f"{api} in {dtype} is not supported yet")
+    def test_get_model_size_aqt(self, api, test_device, test_dtype):
+        if test_dtype != torch.bfloat16:
+            self.skipTest(f"{api} in {test_dtype} is not supported yet")
+        if test_device != "cuda" or not torch.cuda.is_available():
+            self.skipTest(f"{api} currently does not support {test_device}")
         k, n = 1024, 1024
         model = torch.nn.Sequential(
             torch.nn.ReLU(),
             torch.nn.Linear(k,n),
             torch.nn.ReLU(),
-        ).to(device).to(dtype)
+        ).to(test_device).to(test_dtype)
         size = torchao.utils.get_model_size_in_bytes(model)
         api(model)
         size2 = torchao.utils.get_model_size_in_bytes(model)
-        if size2 >= size:
-            breakpoint()
         self.assertTrue(size2 < size)
         
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1373,6 +1373,60 @@ class TestExport(unittest.TestCase):
         after_export = model(x)
         self.assertTrue(torch.equal(after_export, ref))
 
+class TestUtils(unittest.TestCase):
+    @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(not TORCH_VERSION_AFTER_2_3, "autoquant requires 2.3+.")
+    def test_get_model_size_autoquant(self, device, dtype):
+        if device != "cuda" and dtype != torch.bfloat16:
+            self.skipTest(f"autoquant currently does not support {device}")
+        if device != "cuda" or not torch.cuda.is_available():
+            self.skipTest(f"autoquant currently does not support {device}")
+        if torch.cuda.is_available() and torch.cuda.get_device_capability() < (8, 0):
+            if dtype == torch.bfloat16:
+                self.skipTest(f"bfloat16 requires sm80+")
+        m, k, n = 16, 128, 128
+        model = torch.nn.Sequential(
+            torch.nn.ReLU(),
+            torch.nn.Linear(k,n),
+            torch.nn.ReLU(),
+        ).to(device).to(dtype)
+        example_input = torch.randn(m, k, device=device, dtype=dtype)
+        size = torchao.utils.get_model_size_in_bytes(model)
+
+        from torchao.quantization.autoquant import (
+            AQWeightOnlyQuantizedLinearWeight2,
+        )
+        qtensor_class_list = (
+            AQWeightOnlyQuantizedLinearWeight2,
+
+        )
+
+        mod = torchao.autoquant(torch.compile(model), qtensor_class_list = qtensor_class_list)
+        mod(example_input)
+        size2 = torchao.utils.get_model_size_in_bytes(mod)
+        self.assertTrue(size2 < size)
+
+    @parameterized.expand(
+        list(itertools.product(TENSOR_SUBCLASS_APIS, COMMON_DEVICES, COMMON_DTYPES)),
+    )
+    def test_get_model_size_aqt(self, api, device, dtype):
+        if dtype != torch.bfloat16:
+            self.skipTest(f"{api} in {dtype} is not supported yet")
+        k, n = 1024, 1024
+        model = torch.nn.Sequential(
+            torch.nn.ReLU(),
+            torch.nn.Linear(k,n),
+            torch.nn.ReLU(),
+        ).to(device).to(dtype)
+        size = torchao.utils.get_model_size_in_bytes(model)
+        api(model)
+        size2 = torchao.utils.get_model_size_in_bytes(model)
+        if size2 >= size:
+            breakpoint()
+        self.assertTrue(size2 < size)
+        
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: previously this worked only on model swap quantized classes and the version in generate.py was specific to a few cases, this new version is significantly more general and now consolidated into a single place.

Test Plan: python test_integration.py -k "test_get_model_size"

Reviewers:

Subscribers:

Tasks:

Tags: