### PR TITLE
Add `register_apply_tensor_subclass`

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -25,10 +25,14 @@ if not _IS_FBCODE:
 
 from torchao.quantization import (
     autoquant,
+    quantize,
+    register_apply_tensor_subclass,
 )
 from . import dtypes
 
 __all__ = [
     "dtypes",
     "autoquant",
+    "quantize",
+    "register_apply_tensor_subclass",
 ]

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -14,12 +14,6 @@ from .unified import *
 from .autoquant import *
 
 __all__ = [
-    "DynamicallyPerAxisQuantizedLinear",
-    "apply_weight_only_int8_quant",
-    "apply_dynamic_quant",
-    "change_linear_weights_to_int8_dqtensors",
-    "change_linear_weights_to_int8_woqtensors",
-    "change_linear_weights_to_int4_woqtensors",
     "swap_conv2d_1x1_to_linear"
     "safe_int_mm",
     "autoquant",
@@ -31,14 +25,12 @@ __all__ = [
     "swap_linear_with_smooth_fq_linear",
     "smooth_fq_linear_to_inference",
     "set_smooth_fq_attribute",
-    "Int8DynamicallyQuantizedLinearWeight",
-    "Int8WeightOnlyQuantizedLinearWeight",
-    "Int4WeightOnlyQuantizedLinearWeight",
     "compute_error",
-    "WeightOnlyInt8QuantLinear",
     "Int4WeightOnlyGPTQQuantizer",
     "Int4WeightOnlyQuantizer",
     "quantize_affine",
     "dequantize_affine",
     "choose_qprams_affine",
+    "quantize",
+    "register_apply_tensor_subclass",
 ]


### PR DESCRIPTION
Summary:
`register_apply_tensor_subclass` allows users to add a string shortcut for a new apply_tensor_subclass function, they can use this to test their new dtype tensor subclass

see `test/quantization/test_quant_api.py -k test_register_apply_tensor_subclass` for detail

Test Plan:
python test/quantization/test_quant_api.py -k test_register_apply_tensor_subclass

Reviewers:

Subscribers:

Tasks:

Tags: