### PR TITLE
use pytorch version env variable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-torch
-numpy
 sentencepiece
 packaging
 expecttest # So we can use IS_FBCODE flag

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,10 @@ from setuptools import find_packages, setup
 
 current_date = datetime.now().strftime("%Y.%m.%d")
 
+def read_requirements(file_path):
+    with open(file_path, "r") as file:
+        return file.read().splitlines()
+
 def read_version(file_path="version.txt"):
     with open(file_path, "r") as file:
         return file.readline().strip()

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,6 @@ from setuptools import find_packages, setup
 
 current_date = datetime.now().strftime("%Y.%m.%d")
 
-def read_requirements(file_path):
-    with open(file_path, "r") as file:
-        return file.read().splitlines()
-
 def read_version(file_path="version.txt"):
     with open(file_path, "r") as file:
         return file.readline().strip()
@@ -88,6 +84,16 @@ def get_extensions():
 
     return ext_modules
 
+# Mimic code from torchvision https://github.com/pytorch/vision/blob/143d078b28f00471156a4e562dd3836370acc9ee/setup.py#L58
+pytorch_dep = "torch"
+if os.getenv("PYTORCH_VERSION"):
+    pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
+
+requirements = [
+    "numpy",
+    pytorch_dep,
+]
+
 setup(
     name=package_name,
     version=version+version_suffix,
@@ -97,7 +103,7 @@ setup(
         "torchao.kernel.configs": ["*.pkl"],
     },
     ext_modules=get_extensions() if use_cpp != "0" else None,
-    install_requires=read_requirements("requirements.txt"),
+    install_requires=requirements,
     extras_require={"dev": read_requirements("dev-requirements.txt")},
     description="Package for applying ao techniques to GPU models",
     long_description=open("README.md").read(),


### PR DESCRIPTION
Big thanks to @atalman  for finding this trick


Because this was the right incantation to make sure the fp6 kernels are correctly build and packaged using pypi

```
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/req)]$ pip install torchao torch==2.3.1 --extra-index-url https://download.pytorch.org/whl/test/cu121 --force-reinstall
Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/test/cu121
Collecting torchao
  Using cached https://download.pytorch.org/whl/test/cu121/torchao-0.3.0%2Bcu121-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (395 kB)
Collecting torch==2.3.1
  Downloading https://download.pytorch.org/whl/test/cu121/torch-2.3.1%2Bcu121-cp310-cp310-linux_x86_64.whl (781.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 781.0/781.0 MB 7.9 MB/s eta 0:00:00
Collecting filelock (from torch==2.3.1)
  Using cached filelock-3.15.1-py3-none-any.whl.metadata (2.8 kB)
Collecting typing-extensions>=4.8.0 (from torch==2.3.1)
  Using cached typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
Collecting sympy (from torch==2.3.1)
  Using cached sympy-1.12.1-py3-none-any.whl.metadata (12 kB)
Collecting networkx (from torch==2.3.1)
  Using cached networkx-3.3-py3-none-any.whl.metadata (5.1 kB)
Collecting jinja2 (from torch==2.3.1)
  Using cached jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch==2.3.1)
  Using cached fsspec-2024.6.0-py3-none-any.whl.metadata (11 kB)
Collecting nvidia-cuda-nvrtc-cu12==12.1.105 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (23.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 23.7/23.7 MB 62.7 MB/s eta 0:00:00
Collecting nvidia-cuda-runtime-cu12==12.1.105 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (823 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 823.6/823.6 kB 2.8 MB/s eta 0:00:00
Collecting nvidia-cuda-cupti-cu12==12.1.105 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (14.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 14.1/14.1 MB 42.8 MB/s eta 0:00:00
Collecting nvidia-cudnn-cu12==8.9.2.26 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl (731.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 731.7/731.7 MB 8.0 MB/s eta 0:00:00
Collecting nvidia-cublas-cu12==12.1.3.1 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl (410.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 410.6/410.6 MB 17.5 MB/s eta 0:00:00
Collecting nvidia-cufft-cu12==11.0.2.54 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl (121.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 121.6/121.6 MB 41.9 MB/s eta 0:00:00
Collecting nvidia-curand-cu12==10.3.2.106 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl (56.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 56.5/56.5 MB 97.4 MB/s eta 0:00:00
Collecting nvidia-cusolver-cu12==11.4.5.107 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl (124.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 124.2/124.2 MB 20.0 MB/s eta 0:00:00
Collecting nvidia-cusparse-cu12==12.1.0.106 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl (196.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 196.0/196.0 MB 21.6 MB/s eta 0:00:00
Collecting nvidia-nccl-cu12==2.20.5 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl (176.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 176.2/176.2 MB 11.0 MB/s eta 0:00:00
Collecting nvidia-nvtx-cu12==12.1.105 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/cu121/nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (99 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 99.1/99.1 kB 29.7 MB/s eta 0:00:00
Collecting triton==2.3.1 (from torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/triton-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (168.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 168.1/168.1 MB 24.3 MB/s eta 0:00:00
Collecting nvidia-nvjitlink-cu12 (from nvidia-cusolver-cu12==11.4.5.107->torch==2.3.1)
  Using cached nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting numpy (from torchao)
  Using cached numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (61 kB)
Collecting sentencepiece (from torchao)
  Using cached sentencepiece-0.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.7 kB)
Collecting packaging (from torchao)
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting expecttest (from torchao)
  Using cached expecttest-0.2.1-py3-none-any.whl.metadata (2.5 kB)
Collecting hypothesis (from torchao)
  Downloading hypothesis-6.103.2-py3-none-any.whl.metadata (6.3 kB)
Collecting attrs>=22.2.0 (from hypothesis->torchao)
  Downloading https://download.pytorch.org/whl/test/attrs-23.2.0-py3-none-any.whl (60 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 799.3 kB/s eta 0:00:00
Collecting sortedcontainers<3.0.0,>=2.1.0 (from hypothesis->torchao)
  Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl.metadata (10 kB)
Collecting exceptiongroup>=1.0.0 (from hypothesis->torchao)
  Using cached exceptiongroup-1.2.1-py3-none-any.whl.metadata (6.6 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting mpmath<1.4.0,>=1.1.0 (from sympy->torch==2.3.1)
  Downloading https://download.pytorch.org/whl/test/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 536.2/536.2 kB 52.2 MB/s eta 0:00:00
Using cached typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Using cached expecttest-0.2.1-py3-none-any.whl (7.4 kB)
Using cached filelock-3.15.1-py3-none-any.whl (15 kB)
Using cached fsspec-2024.6.0-py3-none-any.whl (176 kB)
Downloading hypothesis-6.103.2-py3-none-any.whl (461 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 461.3/461.3 kB 17.0 MB/s eta 0:00:00
Using cached jinja2-3.1.4-py3-none-any.whl (133 kB)
Using cached networkx-3.3-py3-none-any.whl (1.7 MB)
Using cached numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (18.2 MB)
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached sentencepiece-0.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.3 MB)
Using cached sympy-1.12.1-py3-none-any.whl (5.7 MB)
Using cached exceptiongroup-1.2.1-py3-none-any.whl (16 kB)
Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Using cached nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_x86_64.whl (21.3 MB)
Installing collected packages: sortedcontainers, sentencepiece, mpmath, typing-extensions, sympy, packaging, nvidia-nvtx-cu12, nvidia-nvjitlink-cu12, nvidia-nccl-cu12, nvidia-curand-cu12, nvidia-cufft-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, numpy, networkx, MarkupSafe, fsspec, filelock, expecttest, exceptiongroup, attrs, triton, nvidia-cusparse-cu12, nvidia-cudnn-cu12, jinja2, hypothesis, nvidia-cusolver-cu12, torch, torchao
  Attempting uninstall: sortedcontainers
    Found existing installation: sortedcontainers 2.4.0
    Uninstalling sortedcontainers-2.4.0:
      Successfully uninstalled sortedcontainers-2.4.0
  Attempting uninstall: sentencepiece
    Found existing installation: sentencepiece 0.1.99
    Uninstalling sentencepiece-0.1.99:
      Successfully uninstalled sentencepiece-0.1.99
  Attempting uninstall: mpmath
    Found existing installation: mpmath 1.3.0
    Uninstalling mpmath-1.3.0:
      Successfully uninstalled mpmath-1.3.0
  Attempting uninstall: typing-extensions
    Found existing installation: typing_extensions 4.12.1
    Uninstalling typing_extensions-4.12.1:
      Successfully uninstalled typing_extensions-4.12.1
  Attempting uninstall: sympy
    Found existing installation: sympy 1.12.1
    Uninstalling sympy-1.12.1:
      Successfully uninstalled sympy-1.12.1
  Attempting uninstall: packaging
    Found existing installation: packaging 24.0
    Uninstalling packaging-24.0:
      Successfully uninstalled packaging-24.0
  Attempting uninstall: nvidia-nvtx-cu12
    Found existing installation: nvidia-nvtx-cu12 12.1.105
    Uninstalling nvidia-nvtx-cu12-12.1.105:
      Successfully uninstalled nvidia-nvtx-cu12-12.1.105
  Attempting uninstall: nvidia-nvjitlink-cu12
    Found existing installation: nvidia-nvjitlink-cu12 12.5.40
    Uninstalling nvidia-nvjitlink-cu12-12.5.40:
      Successfully uninstalled nvidia-nvjitlink-cu12-12.5.40
  Attempting uninstall: nvidia-nccl-cu12
    Found existing installation: nvidia-nccl-cu12 2.20.5
    Uninstalling nvidia-nccl-cu12-2.20.5:
      Successfully uninstalled nvidia-nccl-cu12-2.20.5
  Attempting uninstall: nvidia-curand-cu12
    Found existing installation: nvidia-curand-cu12 10.3.2.106
    Uninstalling nvidia-curand-cu12-10.3.2.106:
      Successfully uninstalled nvidia-curand-cu12-10.3.2.106
  Attempting uninstall: nvidia-cufft-cu12
    Found existing installation: nvidia-cufft-cu12 11.0.2.54
    Uninstalling nvidia-cufft-cu12-11.0.2.54:
      Successfully uninstalled nvidia-cufft-cu12-11.0.2.54
  Attempting uninstall: nvidia-cuda-runtime-cu12
    Found existing installation: nvidia-cuda-runtime-cu12 12.1.105
    Uninstalling nvidia-cuda-runtime-cu12-12.1.105:
      Successfully uninstalled nvidia-cuda-runtime-cu12-12.1.105
  Attempting uninstall: nvidia-cuda-nvrtc-cu12
    Found existing installation: nvidia-cuda-nvrtc-cu12 12.1.105
    Uninstalling nvidia-cuda-nvrtc-cu12-12.1.105:
      Successfully uninstalled nvidia-cuda-nvrtc-cu12-12.1.105
  Attempting uninstall: nvidia-cuda-cupti-cu12
    Found existing installation: nvidia-cuda-cupti-cu12 12.1.105
    Uninstalling nvidia-cuda-cupti-cu12-12.1.105:
      Successfully uninstalled nvidia-cuda-cupti-cu12-12.1.105
  Attempting uninstall: nvidia-cublas-cu12
    Found existing installation: nvidia-cublas-cu12 12.1.3.1
    Uninstalling nvidia-cublas-cu12-12.1.3.1:
      Successfully uninstalled nvidia-cublas-cu12-12.1.3.1
  Attempting uninstall: numpy
    Found existing installation: numpy 1.26.4
    Uninstalling numpy-1.26.4:
      Successfully uninstalled numpy-1.26.4
  Attempting uninstall: networkx
    Found existing installation: networkx 3.3
    Uninstalling networkx-3.3:
      Successfully uninstalled networkx-3.3
  Attempting uninstall: MarkupSafe
    Found existing installation: MarkupSafe 2.1.5
    Uninstalling MarkupSafe-2.1.5:
      Successfully uninstalled MarkupSafe-2.1.5
  Attempting uninstall: fsspec
    Found existing installation: fsspec 2024.6.0
    Uninstalling fsspec-2024.6.0:
      Successfully uninstalled fsspec-2024.6.0
  Attempting uninstall: filelock
    Found existing installation: filelock 3.14.0
    Uninstalling filelock-3.14.0:
      Successfully uninstalled filelock-3.14.0
  Attempting uninstall: expecttest
    Found existing installation: expecttest 0.2.1
    Uninstalling expecttest-0.2.1:
      Successfully uninstalled expecttest-0.2.1
  Attempting uninstall: exceptiongroup
    Found existing installation: exceptiongroup 1.2.1
    Uninstalling exceptiongroup-1.2.1:
      Successfully uninstalled exceptiongroup-1.2.1
  Attempting uninstall: attrs
    Found existing installation: attrs 23.2.0
    Uninstalling attrs-23.2.0:
      Successfully uninstalled attrs-23.2.0
  Attempting uninstall: triton
    Found existing installation: triton 2.3.1
    Uninstalling triton-2.3.1:
      Successfully uninstalled triton-2.3.1
  Attempting uninstall: nvidia-cusparse-cu12
    Found existing installation: nvidia-cusparse-cu12 12.1.0.106
    Uninstalling nvidia-cusparse-cu12-12.1.0.106:
      Successfully uninstalled nvidia-cusparse-cu12-12.1.0.106
  Attempting uninstall: nvidia-cudnn-cu12
    Found existing installation: nvidia-cudnn-cu12 8.9.2.26
    Uninstalling nvidia-cudnn-cu12-8.9.2.26:
      Successfully uninstalled nvidia-cudnn-cu12-8.9.2.26
  Attempting uninstall: jinja2
    Found existing installation: Jinja2 3.1.4
    Uninstalling Jinja2-3.1.4:
      Successfully uninstalled Jinja2-3.1.4
  Attempting uninstall: hypothesis
    Found existing installation: hypothesis 6.103.1
    Uninstalling hypothesis-6.103.1:
      Successfully uninstalled hypothesis-6.103.1
  Attempting uninstall: nvidia-cusolver-cu12
    Found existing installation: nvidia-cusolver-cu12 11.4.5.107
    Uninstalling nvidia-cusolver-cu12-11.4.5.107:
      Successfully uninstalled nvidia-cusolver-cu12-11.4.5.107
  Attempting uninstall: torch
    Found existing installation: torch 2.3.1+cu121
    Uninstalling torch-2.3.1+cu121:
      Successfully uninstalled torch-2.3.1+cu121
  Attempting uninstall: torchao
    Found existing installation: torchao 0.3.0
    Uninstalling torchao-0.3.0:
      Successfully uninstalled torchao-0.3.0
Successfully installed MarkupSafe-2.1.5 attrs-23.2.0 exceptiongroup-1.2.1 expecttest-0.2.1 filelock-3.15.1 fsspec-2024.6.0 hypothesis-6.103.2 jinja2-3.1.4 mpmath-1.3.0 networkx-3.3 numpy-1.26.4 nvidia-cublas-cu12-12.1.3.1 nvidia-cuda-cupti-cu12-12.1.105 nvidia-cuda-nvrtc-cu12-12.1.105 nvidia-cuda-runtime-cu12-12.1.105 nvidia-cudnn-cu12-8.9.2.26 nvidia-cufft-cu12-11.0.2.54 nvidia-curand-cu12-10.3.2.106 nvidia-cusolver-cu12-11.4.5.107 nvidia-cusparse-cu12-12.1.0.106 nvidia-nccl-cu12-2.20.5 nvidia-nvjitlink-cu12-12.5.40 nvidia-nvtx-cu12-12.1.105 packaging-24.1 sentencepiece-0.2.0 sortedcontainers-2.4.0 sympy-1.12.1 torch-2.3.1+cu121 torchao-0.3.0+cu121 triton-2.3.1 typing-extensions-4.12.2
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/req)]$ pyth^C
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/req)]$ cd ..
(ao) [marksaroufim@devgpu003.cco3 ~]$ python
Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torchao
>>> torchao.ops
<module 'torchao.ops' from '/home/marksaroufim/anaconda3/envs/ao/lib/python3.10/site-packages/torchao/ops.py'>
>>> exit()
```
