### PR TITLE
Demo metal kernel build for pytorch & executorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def get_extensions():
         print("If you'd like to compile CUDA extensions locally please install the cudatoolkit from https://anaconda.org/nvidia/cuda-toolkit")
 
     use_cuda = torch.cuda.is_available() and CUDA_HOME is not None
+    use_mps = torch.backends.mps.is_available()
     extension = CUDAExtension if use_cuda else CppExtension
 
     extra_link_args = []
@@ -77,6 +78,10 @@ def get_extensions():
     if use_cuda:
         sources += cuda_sources
 
+    if use_mps:
+        extensions_mps_dir = os.path.join(extensions_dir, "metal")
+        mps_sources = list(glob.glob(os.path.join(extensions_mps_dir, "**/*.mm"), recursive=True))
+        sources += mps_sources
     ext_modules = [
         extension(
             "torchao._C",

--- a/torchao/csrc/executorch/CMakeLists.txt
+++ b/torchao/csrc/executorch/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Used by ExecuTorch build
+cmake_minimum_required(VERSION 3.19)
+
+project(executorch_kernels)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(executorch_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/executorch)
+# include(ExternalProject)
+include(FetchContent)
+FetchContent_Declare(
+    executorch_external
+    GIT_REPOSITORY https://github.com/pytorch/executorch.git
+    GIT_TAG v0.2.1
+    SOURCE_DIR ${executorch_SOURCE_DIR}
+    GIT_SUBMODULES ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+)
+message("Downloading executorch...")
+FetchContent_GetProperties(executorch_external)
+if(NOT executorch_external_POPULATED)
+  FetchContent_Populate(executorch_external)
+endif()
+message("executorch downloaded")
+
+find_library(executorch PATH ${executorch_SOURCE_DIR})
+add_library(executorch_kernels SHARED int4mv_executorch.mm)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../metal/mps mps)
+target_link_options(executorch_kernels PUBLIC -undefined dynamic_lookup)
+target_link_libraries(executorch_kernels PUBLIC mps)
+target_include_directories(executorch_kernels PUBLIC ${executorch_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+install(
+    TARGETS executorch_kernels
+    DESTINATION lib
+    INCLUDES
+    DESTINATION ${executorch_SOURCE_DIR}
+)

--- a/torchao/csrc/executorch/int4mv_executorch.mm
+++ b/torchao/csrc/executorch/int4mv_executorch.mm
@@ -1,0 +1,81 @@
+#include "metal/int4mv_kernel.h"
+#include "metal/mps/MPSStream.h"
+#include <executorch/extension/kernel_util/make_boxed_from_unboxed_functor.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+using namespace torchao::mps;
+
+namespace mps {
+  static inline void checkSupportsBFloat16() {
+    ET_CHECK_MSG(isMacOS13OrNewer(MacOSVersion::MACOS_VER_14_0_PLUS),
+                    "MPS bfloat16 type is supported on MacOS 14.0 or newer.");
+  }
+  std::string scalarToMetalTypeString(const exec_aten::ScalarType& scalar_type) {
+    switch (scalar_type) {
+      case ScalarType::Float:
+        return "float";
+      case ScalarType::Half:
+        return "half";
+      case ScalarType::BFloat16:
+        checkSupportsBFloat16();
+        return "bfloat";
+      case ScalarType::Int:
+        return "int";
+      case ScalarType::Long:
+        return "long";
+      case ScalarType::Short:
+        return "short";
+      case ScalarType::Char:
+        return "char";
+      case ScalarType::Byte:
+        return "uchar";
+      case ScalarType::Bool:
+        return "bool";
+      default:
+        ET_CHECK_MSG(false, "Undefined type %hhd", scalar_type);
+        return "Undefined";
+    }
+  }
+} // namespace mps
+
+namespace native {
+
+using RuntimeContext = torch::executor::RuntimeContext;
+using ScalarType = torch::executor::ScalarType;
+Tensor& _int4mv_out(
+  RuntimeContext& ctx,
+  const Tensor& A, 
+  const Tensor& B,
+  int32_t groupSize,
+  const Tensor& scalesAndZeros, 
+  Tensor& C) {
+  auto M = A.size(0);
+  auto N = B.size(0);
+  auto K = A.size(1);
+
+  ET_CHECK_MSG(A.scalar_type() == ScalarType::BFloat16 || A.scalar_type() == ScalarType::Half || A.scalar_type() == ScalarType::Float,
+                "%s : expect A to be either 32-bit or 16-bit float tensor.",
+                __func__
+  );
+  ET_CHECK_MSG(A.dim() == 2, "%s : expect A to be 2D tensor.", __func__);
+
+  ET_CHECK_MSG(B.scalar_type() == ScalarType::Char, "%s : expect B to be int8 tensor.", __func__);
+  ET_CHECK_MSG(B.size(1) == K, "%s : expect B.size(1) == %zd", __func__, K);
+
+  std::array<uint32_t, 4> sizes = {static_cast<uint32_t>(M), static_cast<uint32_t>(K), static_cast<uint32_t>(N), 0};
+  std::array<uint64_t, 4> nbytes = {A.nbytes(), B.nbytes(), scalesAndZeros.nbytes(), C.nbytes()};
+  std::string A_scalar_type = mps::scalarToMetalTypeString(A.scalar_type());
+  torchao::int4mv(A.const_data_ptr<uint8_t>(), B.const_data_ptr<uint8_t>(), groupSize, scalesAndZeros.const_data_ptr<uint8_t>(), C.mutable_data_ptr<uint8_t>(), sizes, nbytes, A_scalar_type);
+  return C;
+}
+
+EXECUTORCH_LIBRARY(
+    llama_cpp,
+    "_weight_int8pack_mm.out",
+    _int4mv_out);
+} // namespace native
+} // namespace executor
+} // namespace torch
+

--- a/torchao/csrc/inv4mv.cpp
+++ b/torchao/csrc/inv4mv.cpp
@@ -1,0 +1,9 @@
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/library.h>
+#include <torch/types.h>
+
+TORCH_LIBRARY_FRAGMENT(torchao, m) {
+  m.impl_abstract_pystub("torchao.ops");
+  m.def("int4mv(Tensor A, Tensor B, int groupSize, Tensor scalesAndZeros) -> Tensor");
+  m.def("int4mv.out(Tensor A, Tensor B, int groupSize, Tensor scalesAndZeros, *, Tensor(a!) out) -> Tensor(a!)");
+}

--- a/torchao/csrc/metal/int4mv_aten.mm
+++ b/torchao/csrc/metal/int4mv_aten.mm
@@ -1,0 +1,51 @@
+#include "int4mv_kernel.h"
+
+#include <torch/extension.h>
+#include <ATen/ATen.h>
+#include <torch/library.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+namespace torchao {
+using Tensor = at::Tensor;
+
+Tensor& int4mv_out_impl(const Tensor& A, const Tensor& B, int32_t groupSize, const Tensor& scalesAndZeros, Tensor& C) {
+  auto M = A.size(0);
+  auto N = B.size(0);
+  auto K = A.size(1);
+
+  TORCH_CHECK(A.dtype() == at::kBFloat16 || A.dtype() == at::kHalf || A.dtype() == at::kFloat,
+              __func__,
+              " : expect A to be either 32-bit or 16-bit float tensor.");
+  TORCH_CHECK(A.is_contiguous(), __func__, " : expect A to be contiguous.");
+  TORCH_CHECK(A.dim() == 2, __func__, " : expect A to be 2D tensor.");
+
+  TORCH_CHECK(B.dtype() == at::kChar, __func__, " : expect B to be int8 tensor.");
+  TORCH_CHECK(B.is_contiguous(), __func__, " : expect B to be contiguous.");
+  TORCH_CHECK(B.size(1) == K, __func__, " : expect B.size(1) == ", K);
+
+  TORCH_CHECK(scalesAndZeros.dim() == 3 && scalesAndZeros.size(1) == N && scalesAndZeros.size(2) == 2,
+              __func__,
+              ": expect scalesAndZeros to be 3d tensor with sizes [:, ",
+              N,
+              ", 2]");
+
+  TORCH_CHECK(N % 32 == 0 && K % 32 == 0);
+  std::array<uint32_t, 4> sizes = {static_cast<uint32_t>(M), static_cast<uint32_t>(K), static_cast<uint32_t>(N), 0};
+  std::array<uint64_t, 4> nbytes = {A.nbytes(), B.nbytes(), scalesAndZeros.nbytes(), C.nbytes()};
+  std::string A_scalar_type = at::native::mps::scalarToMetalTypeString(A.scalar_type());
+  int4mv(A.const_data_ptr<uint8_t>(), B.const_data_ptr<uint8_t>(), groupSize, scalesAndZeros.const_data_ptr<uint8_t>(), C.mutable_data_ptr<uint8_t>(), sizes, nbytes, A_scalar_type);
+  return C;
+}
+
+Tensor int4mv_impl(const Tensor& A, const Tensor& B, int32_t groupSize, const Tensor& scalesAndZeros) {
+  auto C = at::empty({M, N}, A.options());
+  return int4mv_out_impl(A, B, groupSize, scalesAndZeros, C);
+}
+
+
+TORCH_LIBRARY_IMPL(torchao, MPS, m) {
+  m.impl("torchao::int4mv", &int4mv_impl);
+  m.impl("torchao::int4mv.out" &int4mv_out_impl)
+}
+
+} // namespace torchao

--- a/torchao/csrc/metal/int4mv_kernel.h
+++ b/torchao/csrc/metal/int4mv_kernel.h
@@ -1,0 +1,219 @@
+#include <cstdint>
+#include <array>
+#include <string>
+namespace torchao {
+
+static char* QUANTIZED_KERNEL = R"METAL_QUANTIZED(
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+template <typename T> struct Vec4Type {};
+
+template <> struct Vec4Type<float> { using type = float4; };
+
+template <> struct Vec4Type<half> { using type = half4; };
+
+#if __METAL_VERSION__ >= 310
+template <> struct Vec4Type<bfloat> { using type = bfloat4; };
+#endif
+
+/*
+   This code takes heavy inspiration from MLX qvm kernel here:
+   https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/quantized.metal#L381
+   Specifically:
+     - Multiplying activation by inverse scaling factor to reduce compute
+   boundedness
+     - Handling zero point by accumulating act in separate sum term. Needed with
+   optimization done above. MLX MIT License:
+   https://github.com/ml-explore/mlx/blob/main/LICENSE
+*/
+
+/*
+   A matrix is [M x K] (right now this kernel does not support M > 1 but this is
+   a very easy fix that will follow right after) B matrix is [N x K]. For 4 bit
+   2 of the k values are packed in one byte so you can think of B as [N x K/2]
+   matrix from layout perspective.
+
+   Since this kernel is optimizing for gemv case, we split work, along reduction
+   dim k, among the threads of same simdgroup. Ex: if K = 4096 and simdgroup
+   size is 32 (current algorithm should work as long as simdgroup size is > 32).
+   Then each thread will accumulate 4096/32 = 128 k values. However these 128
+   values, handled by each thread are not laid out contiguously. Each thread
+   handles 4 contiguous k values and then jumps 128 elements, k_jump =
+   thread_per_channel (32) * ks_per_thread (4). Take a simpler example where
+   simdgroup is of size 4. In this case threads_per_channel = 4. Assume K = 32
+      k                thread
+   [0, 1, 2, 3,          0
+    4, 5, 6, 7,          1
+    8, 9, 10, 11,        2
+    12, 13, 14, 15,      3
+    16, 17, 18, 19,      0
+    20, 21, 22, 23,      1
+    24, 25, 26, 27,      2
+    28, 29, 30, 31]      3
+   thread id in simd group that handle corresponding
+   ks
+   Thread 0 here is handling (0, 1, 2, 3) and then (16, 17, 18, 19). They are
+   apart by k_jump = 4 * 4 = 16 This is done to improve memory access locality
+   amonng threads that are working co-operatively. Once each thread has their
+   partial sums accumulated, we use tree reduction (Metal offers simd_sum but
+   not used so that we support simdgroup size = 64). In the
+   example above we will have 4 partial sums.
+
+   Each thread also handles 4 different output rows. Thus each simdgroup will be
+   responsible for (1x4) tile of the output. We haven't evaluated whether a
+   different tile size is better or not. We probably will do some auto-tuning
+   once initial work is done.
+
+*/
+
+/*
+   @brief This shader implements 4-bit matrix-vector multiplication where A
+   matrix is fp16, bfloat or float and B matrix is a 4-bit groupwise-quantized weight
+   matrix.
+   @param [in] A is activation matrix of size M x K.
+   @param [in] B is weight matrix of size M x K. Each byte contains 2 4-bit
+   values, along K dim, packed together.
+   @param [in] scales_and_zeros is scales and zero points corresponding each
+   output channel x groups. These are packed as [num_groups = ceil(K / group_size), N, 2]. N = output
+   @param [out] output_data is output matrix of size M x N.
+   @param [in] sizes array contains values of M, N and K.
+   @param [in] thread_index is global thread id.
+   @param [in] tid_in_simdgruop is thread id in simdgroup. e.g. in simdgroup of size 32 it can be in [0-31].
+*/
+/*
+TODOs:
+   Right now code handles only M = 1 case. Fix that.
+*/
+template <typename T, unsigned group_size>
+kernel void int4pack_vm(constant T *A [[buffer(0)]],
+                        constant uchar *B [[buffer(1)]],
+                        constant T *scales_and_zeros [[buffer(2)]],
+                        device T *output_data [[buffer(3)]],
+                        constant uint3 &sizes [[buffer(4)]], // M, K, N
+                        uint thread_index [[thread_position_in_grid]],
+                        uint tid_in_simdgroup [[thread_index_in_simdgroup]]) {
+  constexpr uint threads_per_channel = 32;
+  constexpr uint ks_per_thread = 4;
+  constexpr uint k_pack_factor = 2;
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  uint n = thread_index; // 0..N/4-1
+  n = n / threads_per_channel;
+  n = n * 4;
+  // This is starting k for each thread. In the example above, for thread 1 this
+  // value will be 4.
+  uint k = (tid_in_simdgroup % threads_per_channel) * ks_per_thread;
+  constexpr int k_jump = threads_per_channel * ks_per_thread;
+
+  using vecT = typename Vec4Type<T>::type;
+  constant vecT *A_ptr = reinterpret_cast<constant vecT *>(A);
+  constant uchar *B_ptr = B + ((n * K) / k_pack_factor);
+
+  thread float4 result = float4(0.0);
+  // We multipy group of 4 channels with these scales.
+  // Because corresponding values from weight matrix are effectively left
+  // shifted. This is to avoid doing right shift on those values which ends up
+  // affecting performance. This is the trick applied in MLX kernels.
+  float4 act_div_scales = {1.f, 1 / 16.f, 1 / 256.f, 1 / 4096.f};
+
+  // Find specific group to which channels handled by this thread
+  // belong.
+  uint k_block_index = k / group_size;
+  // Since scales_and_zeros are packed as [num_groups, N, 2].
+  // Finding a specific's group's scales and zero points requires jump by factor
+  // of N*2
+  uint scales_group_offset = (k_block_index * N + n) * 2;
+  uint zeros_gruop_offset = scales_group_offset + 1;
+  const uint scales_jump =
+      N * 2 *
+      (k_jump /
+       group_size); /* the last term accounts for identifying the group this
+                      thread will have to process in each iteration. This mean
+                      each iteration it must jump to a different group. Thus
+                      k_jump must be > group_size */
+  for (; k < K; k += k_jump) {
+    const T scale0 = scales_and_zeros[scales_group_offset];
+    // Adding zero point results in 10% perf penalty.
+    const T zero0 = scales_and_zeros[zeros_gruop_offset] - scale0 * T(8);
+
+    const T scale1 = scales_and_zeros[scales_group_offset + 2];
+    const T zero1 = scales_and_zeros[zeros_gruop_offset + 2] - scale1 * T(8);
+
+    const T scale2 = scales_and_zeros[scales_group_offset + 4];
+    const T zero2 = scales_and_zeros[zeros_gruop_offset + 4] - scale2 * T(8);
+
+    const T scale3 = scales_and_zeros[scales_group_offset + 6];
+    const T zero3 = scales_and_zeros[zeros_gruop_offset + 6] - scale3 * T(8);
+
+    scales_group_offset += scales_jump;
+    zeros_gruop_offset += scales_jump;
+
+    const float4 zeros = float4(zero0, zero1, zero2, zero3);
+
+    float4 a_val = float4(A_ptr[k / 4]);
+    // We are gonna skip right-shifts of the weights and hence divide by corresponding factor.
+    float4 a_vec = a_val * act_div_scales;
+    float a_val_sum = a_val[0] + a_val[1] + a_val[2] + a_val[3];
+
+    float4x4 b_mat;
+    ushort b_val0 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 0 * K) / k_pack_factor))[0];
+    ushort b_val1 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 1 * K) / k_pack_factor))[0];
+    ushort b_val2 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 2 * K) / k_pack_factor))[0];
+    ushort b_val3 = (reinterpret_cast<constant ushort *>(
+        B_ptr + (k + 3 * K) / k_pack_factor))[0];
+    b_mat[0] = scale0 * float4(float(b_val0 & 0x000f), float(b_val0 & 0x00f0),
+                               float(b_val0 & 0x0f00), float(b_val0 & 0xf000));
+    b_mat[1] = scale1 * float4(float(b_val1 & 0x000f), float(b_val1 & 0x00f0),
+                               float(b_val1 & 0x0f00), float(b_val1 & 0xf000));
+    b_mat[2] = scale2 * float4(float(b_val2 & 0x000f), float(b_val2 & 0x00f0),
+                               float(b_val2 & 0x0f00), float(b_val2 & 0xf000));
+    b_mat[3] = scale3 * float4(float(b_val3 & 0x000f), float(b_val3 & 0x00f0),
+                               float(b_val3 & 0x0f00), float(b_val3 & 0xf000));
+
+    result += a_vec * b_mat;
+    result += a_val_sum * zeros;
+  }
+  result += simd_shuffle_down(result, 1);
+  result += simd_shuffle_down(result, 2);
+  result += simd_shuffle_down(result, 4);
+  result += simd_shuffle_down(result, 8);
+  result += simd_shuffle_down(result, 16);
+  if (tid_in_simdgroup % threads_per_channel == 0) {
+    reinterpret_cast<device vecT *>(output_data)[n / 4] = vecT(result);
+  }
+}
+
+#define INSTANTIATE_INT4MV(DTYPE, GSIZE)                                       \
+  template [[host_name("int4pack_vm_" #GSIZE "_" #DTYPE)]] kernel void         \
+  int4pack_vm<DTYPE, GSIZE>(                                                   \
+      constant DTYPE * A [[buffer(0)]], constant uchar * B [[buffer(1)]],      \
+      constant DTYPE * scales_and_zeros [[buffer(2)]],                         \
+      device DTYPE * output_data [[buffer(3)]],                                 \
+      constant uint3 & sizes [[buffer(4)]],                                    \
+      uint thread_index [[thread_position_in_grid]],                           \
+      uint tid_in_simdgroup [[thread_index_in_simdgroup]])
+
+INSTANTIATE_INT4MV(float, 32);
+INSTANTIATE_INT4MV(half, 32);
+INSTANTIATE_INT4MV(float, 64);
+INSTANTIATE_INT4MV(half, 64);
+INSTANTIATE_INT4MV(float, 128);
+INSTANTIATE_INT4MV(half, 128);
+INSTANTIATE_INT4MV(float, 256);
+INSTANTIATE_INT4MV(half, 256);
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_INT4MV(bfloat, 32);
+INSTANTIATE_INT4MV(bfloat, 64);
+INSTANTIATE_INT4MV(bfloat, 128);
+INSTANTIATE_INT4MV(bfloat, 256);
+#endif
+)METAL_QUANTIZED";
+
+void int4mv(const uint8_t * A, const uint8_t * B, uint32_t groupSize, const uint8_t * scalesAndZeros, uint8_t * C, std::array<uint32_t, 4> sizes, std::array<uint64_t, 4> nbytes, std::string A_scalar_type);
+
+} // namespace torchao

--- a/torchao/csrc/metal/int4mv_kernel.mm
+++ b/torchao/csrc/metal/int4mv_kernel.mm
@@ -1,0 +1,50 @@
+#include "int4mv_kernel.h"
+#include "mps/MPSStream.h"
+#include "mps/OperationUtils.h"
+namespace torchao {
+
+void int4mv(const uint8_t * A, const uint8_t * B,  uint32_t groupSize, const uint8_t * scalesAndZeros, uint8_t * C, std::array<uint32_t, 4> sizes, std::array<uint64_t, 4> nbytes, std::string A_scalar_type) {
+  mps::MPSStream* mpsStream = mps::getCurrentMPSStream();
+  uint32_t M = sizes[0];
+  uint32_t K = sizes[1];
+  uint32_t N = sizes[2];
+
+  uint32_t A_nbytes = nbytes[0];
+  uint32_t B_nbytes = nbytes[1];
+  uint32_t scalesAndZeros_nbytes = nbytes[2];
+  uint32_t C_nbytes = nbytes[3];
+  dispatch_sync(mpsStream->queue(), ^() {
+    @autoreleasepool {
+// #if _CAPTURE_KERNEL
+//       if (getMPSProfiler().isCaptureEnabled()) {
+//         getMPSProfiler().startCapture(fmt::format("int8pack_mm_{}x{}x{}", M, N, K), mpsStream);
+//       }
+// #endif
+      id<MTLDevice> device = mpsStream->device();
+      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
+      id<MTLLibrary> customKernelLibrary = [device newLibraryWithSource:[NSString stringWithUTF8String:QUANTIZED_KERNEL]
+                                                                  options:nil
+                                                                    error:nil];
+      id<MTLFunction> customQuantizedLinearFunction = [customKernelLibrary
+        newFunctionWithName:[NSString stringWithFormat:@"int4pack_vm_%u_%s",
+                                                       groupSize,
+                                                       A_scalar_type.c_str()]];
+      id<MTLComputePipelineState> quantizedPSO = [device newComputePipelineStateWithFunction:customQuantizedLinearFunction error:nil];
+      [computeEncoder setComputePipelineState:quantizedPSO];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(A, A_nbytes) offset:0 atIndex:0];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(B, B_nbytes) offset:0 atIndex:1];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(scalesAndZeros, scalesAndZeros_nbytes) offset:0 atIndex:2];
+      [computeEncoder setBuffer:mps::getMTLBufferStorage(C, C_nbytes) offset:0 atIndex:3];
+      [computeEncoder setBytes:sizes.data() length:sizeof(uint32_t) * sizes.size() atIndex:4];
+      [computeEncoder dispatchThreads:MTLSizeMake(N / 4 * 32, 1, M)
+        threadsPerThreadgroup:MTLSizeMake(64, 1, 1)];
+// #if _CAPTURE_KERNEL
+//       if (getMPSProfiler().isCapturing()) {
+//         getMPSProfiler().stopCapture(mpsStream);
+//       }
+// #endif
+    }
+  });
+}
+
+} // namespace torchao

--- a/torchao/csrc/metal/mps/CMakeLists.txt
+++ b/torchao/csrc/metal/mps/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Used by ExecuTorch build
+cmake_minimum_required(VERSION 3.19)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+add_library(mps MPSDevice.mm MPSStream.mm OperationUtils.mm)
+
+target_include_directories(mps PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+find_library(FOUNDATION_FRAMEWORK Foundation)
+find_library(METAL_FRAMEWORK Metal)
+find_library(MPS_FRAMEWORK MetalPerformanceShaders)
+find_library(MPS_GRAPG_FRAMEWORK MetalPerformanceShadersGraph)
+
+target_link_libraries(mps PUBLIC 
+    "-framework Foundation"
+    "-weak_framework MetalPerformanceShaders"
+    "-weak_framework MetalPerformanceShadersGraph"
+    "-weak_framework Metal"
+)

--- a/torchao/csrc/metal/mps/MPSDevice.h
+++ b/torchao/csrc/metal/mps/MPSDevice.h
@@ -1,0 +1,81 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#pragma once
+
+// Obj-C headers
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+
+// MPS headers
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <unordered_map>
+#include <vector>
+
+#define MB(x) (x * 1048576UL)
+
+namespace torchao::mps {
+
+// Helper enum to check if a MPSGraph op is supported in a given macOS version
+enum class MacOSVersion : uint32_t {
+  MACOS_VER_13_0_PLUS = 0,
+  MACOS_VER_13_1_PLUS,
+  MACOS_VER_13_2_PLUS,
+  MACOS_VER_13_3_PLUS,
+  MACOS_VER_14_0_PLUS,
+};
+
+enum class LibraryType : uint32_t {
+  INDEXING_KERNELS = 0,
+  MAX = INDEXING_KERNELS,
+};
+
+class MPSDevice {
+ public:
+  /**
+   * MPSDevice should not be cloneable.
+   */
+  MPSDevice(MPSDevice& other) = delete;
+  /**
+   * MPSDevice should not be assignable.
+   */
+  void operator=(const MPSDevice&) = delete;
+  /**
+   * Gets single instance of the Device.
+   */
+  static MPSDevice* getInstance();
+  /**
+   * Returns the single device.
+   */
+  id<MTLDevice> device() {
+    return _mtl_device;
+  }
+
+  /**
+   * Returns whether running on Ventura or newer
+   */
+  bool isMacOS13Plus(MacOSVersion version) const;
+
+  ~MPSDevice();
+
+  /**
+   * Compile a PSO for a given library type.
+   * Once compiled, the library and PSOs are cached.
+   */
+//   Error compilePSO(LibraryType libraryType, const char* kernelName);
+//   Error compileLibrary(LibraryType);
+
+ private:
+  static MPSDevice* _device;
+  id<MTLDevice> _mtl_device;
+  std::unordered_map<LibraryType, id<MTLLibrary>> _m_library_cache;
+  std::unordered_map<std::string, id<MTLComputePipelineState>> _m_pso_cache;
+  MPSDevice();
+};
+
+bool isMacOS13OrNewer(MacOSVersion version = MacOSVersion::MACOS_VER_13_0_PLUS);
+
+} // namespace torchao::mps

--- a/torchao/csrc/metal/mps/MPSDevice.mm
+++ b/torchao/csrc/metal/mps/MPSDevice.mm
@@ -1,0 +1,147 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSDevice.h"
+#include <memory>
+#include <mutex>
+
+namespace torchao::mps {
+
+static std::unique_ptr<MPSDevice> mps_device;
+static std::once_flag mpsdev_init;
+
+static inline MTLLanguageVersion getMetalLanguageVersion(const id<MTLDevice>& device, bool macOS13Plus) {
+  // MPS Advanced Indexing needs at least Metal 2.0 (support for Argument Buffers and function constants)
+  // host_name attribute needs at least Metal 2.2 and ulong needs Metal 2.3 (supported on MacOS 11+)
+  MTLLanguageVersion languageVersion = MTLLanguageVersion2_3;
+#if defined(__MAC_13_0)
+  if (macOS13Plus) {
+    languageVersion = MTLLanguageVersion3_0;
+  }
+#endif
+
+  assert([device supportsFamily:MTLGPUFamilyMac2] && "Missing Metal support for MTLGPUFamilyMac2");
+  return languageVersion;
+}
+
+MPSDevice::~MPSDevice() {
+  [_mtl_device release];
+  _mtl_device = nil;
+}
+
+MPSDevice::MPSDevice(): _mtl_device(nil) {
+  @autoreleasepool {
+#if TARGET_OS_IPHONE
+    _mtl_device = MTLCreateSystemDefaultDevice();
+#else
+    NSArray* devices = MTLCopyAllDevices();
+    for (unsigned long i = 0 ; i < [devices count] ; i++) {
+      id<MTLDevice>  device = devices[i];
+      if(![device isLowPower]) { // exclude Intel GPUs
+        _mtl_device = [device retain];
+        break;
+      }
+    }
+#endif
+  }
+  // MPS TODO: Replace with `ET_CHECK_OR_RETURN_ERROR` and propagate back the error.
+  assert(_mtl_device != nil);
+}
+
+MPSDevice* MPSDevice::getInstance() {
+  std::call_once(mpsdev_init, [] {
+      mps_device = std::unique_ptr<MPSDevice>(new MPSDevice());
+  });
+  return mps_device.get();
+}
+
+bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
+  id mpsCD = NSClassFromString(@"MPSGraph");
+  static auto compileOptions = [[[MTLCompileOptions alloc] init] autorelease];
+  static bool _macos_13_0_plus = [mpsCD instancesRespondToSelector:@selector(cumulativeSumWithTensor:
+                                                                                                axis:name:)] == YES;
+  static bool _macos_13_1_plus =
+      [mpsCD instancesRespondToSelector:@selector
+             (sampleGridWithSourceTensor:
+                        coordinateTensor:layout:normalizeCoordinates:relativeCoordinates:alignCorners:paddingMode
+                                        :samplingMode:constantValue:name:)] == YES;
+  static bool _macos_13_2_plus =
+      [mpsCD instancesRespondToSelector:@selector(convolution3DWithSourceTensor:weightsTensor:descriptor:name:)] == YES;
+  static bool _macos_13_3_plus = [compileOptions respondsToSelector:@selector(maxTotalThreadsPerThreadgroup)] == YES;
+
+  static bool _macos_14_0_plus = [mpsCD instancesRespondToSelector:@selector(conjugateWithTensor:name:)] == YES;
+
+  switch (version) {
+    case MacOSVersion::MACOS_VER_13_0_PLUS:
+      return _macos_13_0_plus;
+    case MacOSVersion::MACOS_VER_13_1_PLUS:
+      return _macos_13_1_plus;
+    case MacOSVersion::MACOS_VER_13_2_PLUS:
+      return _macos_13_2_plus;
+    case MacOSVersion::MACOS_VER_13_3_PLUS:
+      return _macos_13_3_plus;
+    case MacOSVersion::MACOS_VER_14_0_PLUS:
+      return _macos_14_0_plus;
+    default:
+      return false;
+  }
+}
+
+// const char* getLibraryCString(LibraryType libraryType) {
+//   switch (libraryType) {
+//     case LibraryType::INDEXING_KERNELS:
+//       return "TODO";
+//     default:
+//       ET_CHECK_MSG(false, "Unhandled library type!");
+//   }
+// }
+
+// Error
+// MPSDevice::compileLibrary(LibraryType libraryType) {
+//   Error err = Error::Ok;
+//   NSError* error = nil;
+//   MTLCompileOptions* options = [MTLCompileOptions new];
+//   [options setLanguageVersion:getMetalLanguageVersion(_mtl_device, isMacOS13Plus(MacOSVersion::MACOS_VER_13_0_PLUS))];
+//   [options setFastMathEnabled:YES];
+//   id<MTLLibrary> lib =
+//       [_mtl_device newLibraryWithSource:[NSString stringWithCString:getLibraryCString(libraryType)
+//                                                            encoding:NSASCIIStringEncoding]
+//                                 options:options
+//                                   error:&error];
+
+//   ET_CHECK_OR_RETURN_ERROR(
+//     lib != nil,
+//     Internal,
+//     "Failed to create indexing library, error: %s", [[error description] UTF8String]
+//   );
+
+//   _m_library_cache[libraryType] = lib;
+//   return err;
+// }
+
+// Error
+// MPSDevice::compilePSO(LibraryType libraryType, const char* kernelName) {
+//   Error err = Error::Ok;
+//   if (_m_library_cache.find(libraryType) == _m_library_cache.end()) {
+//     ET_LOG(Debug, "Compiling library type: %d", libraryType);
+//     err = compileLibrary(libraryType);
+//     ET_CHECK_OR_RETURN_ERROR(
+//       err == Error::Ok,
+//       Internal,
+//       "An error occured occured while compiling library %d", libraryType
+//     );
+//   }
+//   if (_m_pso_cache.find(kernelName) == _m_pso_cache.end()) {
+//     ET_LOG(Debug, "Compiling kernel: %s", kernelName);
+//     // err = compilePSO(libraryType, kernelName);
+//   }
+//   return err;
+// }
+
+bool isMacOS13OrNewer(MacOSVersion version) {
+  return MPSDevice::getInstance()->isMacOS13Plus(version);
+}
+
+} // namespace torchao::mps

--- a/torchao/csrc/metal/mps/MPSStream.h
+++ b/torchao/csrc/metal/mps/MPSStream.h
@@ -1,0 +1,128 @@
+//  Copyright © 2022 Apple Inc.
+
+#pragma once
+
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+#include <initializer_list>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include <unordered_map>
+#include "MPSDevice.h"
+typedef id<MTLDevice> MTLDevice_t;
+
+// Fwd declarations
+namespace torchao::mps {
+enum class SyncType {
+  NONE, // no commit to command buffer
+  COMMIT, // commit and flush the command buffer
+  COMMIT_AND_WAIT, // flush and wait for command buffer execution to finish
+  COMMIT_AND_CONTINUE, // commit and continue with a new underlying command
+                       // buffer
+  COMMIT_ADAPTIVE, // commit adaptively based on available memory
+};
+
+// Helper structure to copy data between CPU <-> GPU
+struct CPUBufferWrapper {
+  void* srcBuffer;
+  void* dstBuffer;
+  size_t length;
+  size_t srcOffset;
+  size_t dstOffset;
+  union {
+    struct {
+      unsigned int srcCpu : 1;
+      unsigned int dstCpu : 1;
+    };
+    uint16_t flags;
+  };
+};
+
+class MPSStream {
+ public:
+  MPSStream();
+
+  ~MPSStream();
+  id<MTLCommandQueue> commandQueue() const {
+    return _commandQueue;
+  };
+  dispatch_queue_t queue() const {
+    return _serialQueue;
+  }
+  MTLDevice_t device() const { return [_commandQueue device];}
+
+  bool hasLiveCommandBuffer();
+  MPSCommandBuffer* commandBuffer();
+  id<MTLComputeCommandEncoder> commandEncoder();
+  void endKernelCoalescing();
+  void synchronize(SyncType syncType);
+  bool commitAndContinueEnabled();
+  void copy(
+      id<MTLBuffer> srcBuffer,
+      id<MTLBuffer> dstBuffer,
+      size_t length,
+      size_t srcOffset,
+      size_t dstOffset,
+      SyncType syncType = SyncType::NONE);
+  void copy(
+      std::vector<CPUBufferWrapper>& dataBuffers,
+      SyncType syncType = SyncType::NONE);
+  void copy_and_sync(
+      id<MTLBuffer> srcBuffer,
+      id<MTLBuffer> dstBuffer,
+      size_t length,
+      size_t srcOffset,
+      size_t dstOffset,
+      bool non_blocking);
+  void copy_and_sync(
+      std::vector<CPUBufferWrapper>& dataBuffers,
+      bool non_blocking);
+
+ private:
+  id<MTLCommandQueue> _commandQueue = nil;
+  MPSCommandBuffer* _commandBuffer = nil;
+  MPSCommandBuffer* _prevCommandBuffer = nil;
+  id<MTLComputeCommandEncoder> _commandEncoder = nil;
+  dispatch_queue_t _serialQueue = nullptr;
+  // CommitAndContinue is disabled by default
+  bool _enableCommitAndContinue = false;
+  // accumulated sizes of resources encoded on command buffer
+  size_t _commandBufferResourceSize = 0;
+  // unfortunately, there's no way to get the underlying buffer from
+  // an MPSGraphTensorData. so we need to keep a mapping of them here
+  std::unordered_map<MPSGraphTensorData*, void*> _activeResources{};
+
+  // use synchronize() to access any of these commit functions outside MPSStream
+  void commit();
+  void commitAndWait();
+  void commitAndContinue();
+  void flush();
+};
+
+/**
+ * Get the current MPS stream
+ */
+MPSStream* getCurrentMPSStream();
+
+/**
+ * Get the default MPS stream
+ */
+MPSStream* getDefaultMPSStream();
+
+//-----------------------------------------------------------------
+//  MPSStreamImpl
+//-----------------------------------------------------------------
+
+class MPSStreamImpl {
+ public:
+  /**
+   * Gets single instance of the MPSStream.
+   */
+  static MPSStream* getInstance();
+
+ private:
+  static MPSStream* _stream;
+  MPSStreamImpl();
+};
+
+} // namespace torchao::mps

--- a/torchao/csrc/metal/mps/MPSStream.mm
+++ b/torchao/csrc/metal/mps/MPSStream.mm
@@ -1,0 +1,250 @@
+//
+//  Copyright (c) 2023 Apple Inc. All rights reserved.
+//  Provided subject to the LICENSE file in the top level directory.
+//
+
+#include "MPSStream.h"
+#include <vector>
+#include <cassert>
+
+@interface MPSGraphExecutionDescriptor ()
+@property (readwrite, atomic) BOOL enableCommitAndContinue;
+@end
+
+namespace torchao::mps {
+
+//-----------------------------------------------------------------
+//  MPSStream
+//-----------------------------------------------------------------
+
+MPSStream::MPSStream() {
+  _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
+  _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
+}
+
+MPSStream::~MPSStream() {
+  [_commandQueue release];
+  _commandQueue = nil;
+
+  assert(_commandBuffer == nil);
+}
+
+bool MPSStream::hasLiveCommandBuffer() {
+  return _commandBuffer;
+}
+
+API_AVAILABLE(ios(13.0))
+MPSCommandBuffer* MPSStream::commandBuffer() {
+  if (!_commandBuffer) {
+    _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
+  }
+
+  return _commandBuffer;
+}
+
+id<MTLComputeCommandEncoder> MPSStream::commandEncoder() {
+  if (!_commandEncoder) {
+    if (@available(iOS 13.0, *)) {
+      _commandEncoder = [commandBuffer() computeCommandEncoder].retain;
+    }
+  }
+
+  return _commandEncoder;
+}
+
+void MPSStream::synchronize(SyncType syncType) {
+  endKernelCoalescing();
+  switch(syncType) {
+    case SyncType::COMMIT:
+      commit();
+      break;
+    case SyncType::COMMIT_AND_WAIT:
+      commitAndWait();
+      break;
+    case SyncType::COMMIT_ADAPTIVE:
+      break;
+    case SyncType::COMMIT_AND_CONTINUE:
+      assert(
+        _enableCommitAndContinue == true && "CommitAndContinue is called but it is disabled globally!");
+      commitAndContinue();
+      break;
+    default:
+      assert(
+        false && "Unhandled syncType type");
+  }
+
+}
+
+bool MPSStream::commitAndContinueEnabled() {
+  return _enableCommitAndContinue;
+}
+
+void MPSStream::commitAndContinue() {
+  assert(_commandBuffer);
+  [_commandBuffer commitAndContinue];
+}
+
+void MPSStream::endKernelCoalescing() {
+  if (_commandEncoder) {
+    [_commandEncoder endEncoding];
+    [_commandEncoder release];
+    _commandEncoder = nil;
+  }
+}
+
+void MPSStream::commitAndWait() {
+  if (_prevCommandBuffer) {
+    // the previous command buffer (if exists) has already been committed,
+    // so we just wait until it's completed and then dispose it.
+    [_prevCommandBuffer waitUntilCompleted];
+    [_prevCommandBuffer release];
+    _prevCommandBuffer = nil;
+  }
+
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    [_commandBuffer waitUntilCompleted];
+    [_commandBuffer release];
+    _commandBuffer = nil;
+    // reset the accumulated resource sizes for command buffer
+    _commandBufferResourceSize = 0;
+  }
+}
+
+void MPSStream::commit() {
+  if (_enableCommitAndContinue) {
+    if (@available(iOS 13.0, *)) {
+      [commandBuffer() commitAndContinue];
+    }
+  } else {
+    flush();
+  }
+  // reset the accumulated resource sizes for command buffer
+  _commandBufferResourceSize = 0;
+}
+
+void MPSStream::flush() {
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    // if commitAndContinue is disabled (e.g., for Profiler), we keep the command
+    // buffer so we could wait on it later, if required.
+    if (!_enableCommitAndContinue) {
+      _prevCommandBuffer = _commandBuffer;
+    } else {
+      [_commandBuffer release];
+    }
+    _commandBuffer = nil;
+  }
+}
+
+void MPSStream::copy(id<MTLBuffer> srcBuffer,
+                     id<MTLBuffer> dstBuffer,
+                     size_t length,
+                     size_t srcOffset,
+                     size_t dstOffset,
+                     SyncType syncType) {
+  dispatch_sync(_serialQueue, ^() {
+    @autoreleasepool {
+      endKernelCoalescing();
+      if (@available(iOS 13.0, *)) {
+        id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
+        
+        [blitEncoder copyFromBuffer:srcBuffer
+                       sourceOffset:(NSUInteger)srcOffset
+                           toBuffer:dstBuffer
+                  destinationOffset:(NSUInteger)dstOffset
+                               size:(NSUInteger)length];
+        [blitEncoder endEncoding];
+      }
+      synchronize(syncType);
+    }
+  });
+}
+
+void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer,
+                              id<MTLBuffer> dstBuffer,
+                              size_t length,
+                              size_t srcOffset,
+                              size_t dstOffset,
+                              bool non_blocking) {
+  copy(srcBuffer,
+       dstBuffer,
+       length,
+       srcOffset,
+       dstOffset,
+       !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT_ADAPTIVE);
+}
+
+void MPSStream::copy(std::vector<CPUBufferWrapper>& dataBuffers,
+                     SyncType syncType) {
+  dispatch_sync(_serialQueue, ^() {
+    @autoreleasepool {
+#if TARGET_OS_SIMULATOR
+      if (dataBuffers[0].dstCpu) {
+        // If the destination is a CPU buffer,
+        // wait for the GPU to finish executing
+        // before copying into the CPU buffers.
+        synchronize(SyncType::COMMIT_AND_WAIT);
+      }
+      for (int i = 0; i < dataBuffers.size(); i++) {
+        uint8_t* src = nil;
+        uint8_t* dst = nil;
+        if (dataBuffers[i].srcCpu) {
+          src = static_cast<uint8_t*>(dataBuffers[i].srcBuffer) + dataBuffers[i].srcOffset;
+          dst = (uint8_t*)([(id<MTLBuffer>)dataBuffers[i].dstBuffer contents]) + dataBuffers[i].dstOffset;
+        } else {
+          assert(dataBuffers[i].dstCpu);
+          src = (uint8_t*)([(id<MTLBuffer>)dataBuffers[i].srcBuffer contents]) + dataBuffers[i].srcOffset;
+          dst = static_cast<uint8_t*>(dataBuffers[i].dstBuffer) + dataBuffers[i].dstOffset;
+        }
+        memcpy(dst, src, dataBuffers[i].length);
+      }
+#else
+      endKernelCoalescing();
+      id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
+
+      for (int i = 0; i < dataBuffers.size(); i++) {
+        [blitEncoder copyFromBuffer:(id<MTLBuffer>)dataBuffers[i].srcBuffer
+                       sourceOffset:(NSUInteger)dataBuffers[i].srcOffset
+                           toBuffer:(id<MTLBuffer>)dataBuffers[i].dstBuffer
+                  destinationOffset:(NSUInteger)dataBuffers[i].dstOffset
+                               size:(NSUInteger)dataBuffers[i].length];
+      }
+      [blitEncoder endEncoding];
+      synchronize(syncType);
+#endif
+    }
+  });
+}
+
+void MPSStream::copy_and_sync(std::vector<CPUBufferWrapper>& dataBuffers,
+                              bool non_blocking) {
+  copy(dataBuffers,
+       !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT_ADAPTIVE);
+}
+
+//-----------------------------------------------------------------
+//  MPSStreamImpl
+//-----------------------------------------------------------------
+
+MPSStream* MPSStreamImpl::_stream = nullptr;
+
+MPSStream* MPSStreamImpl::getInstance() {
+  if (_stream == nullptr) {
+    _stream =
+        new MPSStream();
+  }
+  return _stream;
+}
+
+MPSStreamImpl::MPSStreamImpl() {}
+
+MPSStream* getCurrentMPSStream() {
+  return getDefaultMPSStream();
+}
+
+MPSStream* getDefaultMPSStream() {
+  return MPSStreamImpl::getInstance();
+}
+
+} // namespace torchao::mps

--- a/torchao/csrc/metal/mps/OperationUtils.h
+++ b/torchao/csrc/metal/mps/OperationUtils.h
@@ -1,0 +1,10 @@
+#include <numeric>
+
+#include <Foundation/Foundation.h>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include "MPSDevice.h"
+namespace torchao::mps {
+id<MTLBuffer> getMTLBufferStorage(const uint8_t *data, size_t nbytes);
+static inline void checkSupportsBFloat16();
+} // namespace torchao::mps

--- a/torchao/csrc/metal/mps/OperationUtils.mm
+++ b/torchao/csrc/metal/mps/OperationUtils.mm
@@ -1,0 +1,14 @@
+#include "OperationUtils.h"
+
+namespace torchao::mps {
+  id<MTLBuffer> getMTLBufferStorage(const uint8_t * data, size_t nbytes) {
+    return [MPSDevice::getInstance()->device() newBufferWithBytesNoCopy:(void*)data
+                                                                length:nbytes
+                                                                options:0
+                                                            deallocator:nil];
+  }
+  static inline void checkSupportsBFloat16() {
+    assert(isMacOS13OrNewer(MacOSVersion::MACOS_VER_14_0_PLUS) &&
+                   "MPS bfloat16 type is supported on MacOS 14.0 or newer.");
+  }
+} // namespace torchao::mps


### PR DESCRIPTION
## PyTorch access to this kernel:

Same flow: `python setup.py install`

## ExecuTorch access to this kernel:

Currently still need to manually call cmake:
```
cmake torchao/csrc/executorch -Bcmake-out/torchao/csrc/executorch
cmake --build cmake-out/torchao/csrc/executorch
```
The dylib can be found:

```
cmake-out/torchao/csrc/executorch/libexecutorch_kernels.dylib
```

TODO: add support for `python setup.py install` to install this dylib, so that it can go into pip wheel.