### PR TITLE
Add repr method on tensor subclass

### DIFF
--- a/torchao/dtypes/aqt.py
+++ b/torchao/dtypes/aqt.py
@@ -498,8 +498,6 @@ class TensorCoreTiledAQTLayout(AQTLayout):
             """
             args[0].transposed = not args[0].transposed
             return return_and_correct_aliasing(func, args, kwargs, args[0])
-        
-        breakpoint()
 
         raise NotImplementedError(
             f"TensorCoreTiledAQTLayout dispatch: attempting to run {func}, this is not supported"

--- a/torchao/dtypes/aqt.py
+++ b/torchao/dtypes/aqt.py
@@ -481,7 +481,8 @@ class TensorCoreTiledAQTLayout(AQTLayout):
         return self
 
     def __repr__(self):
-        return f"TensorCoreTiledAQTLayout(packed_weight={self.packed_weight}, scale_and_zero={self.scale_and_zero})"
+        int_data, scale, zero_point = self.get_plain()
+        return f"TensorCoreTiledAQTLayout(int_data={int_data}, scale={scale}, zero_point={zero_point})"
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs):

--- a/torchao/dtypes/aqt.py
+++ b/torchao/dtypes/aqt.py
@@ -480,6 +480,9 @@ class TensorCoreTiledAQTLayout(AQTLayout):
         self.scale_and_zero = fn(self.scale_and_zero)
         return self
 
+    def __repr__(self):
+        return f"TensorCoreTiledAQTLayout(packed_weight={self.packed_weight}, scale_and_zero={self.scale_and_zero})"
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs):
         kwargs = {} if kwargs is None else kwargs
@@ -495,6 +498,8 @@ class TensorCoreTiledAQTLayout(AQTLayout):
             """
             args[0].transposed = not args[0].transposed
             return return_and_correct_aliasing(func, args, kwargs, args[0])
+        
+        breakpoint()
 
         raise NotImplementedError(
             f"TensorCoreTiledAQTLayout dispatch: attempting to run {func}, this is not supported"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #397

Without this, it will go through default tensor __repr__ method which has some aten ops to print the tensor. This results in triggerring subclass's torch_dispatch.

Differential Revision: [D58786586](https://our.internmc.facebook.com/intern/diff/D58786586)