### PR TITLE
add FSDP QLoRA test and revert failing PR

### DIFF
--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -1,39 +1,36 @@
-import logging
-import unittest
-from packaging import version
-import math
 import copy
+import io
+import logging
+import math
+import unittest
+from collections import OrderedDict
+from typing import Tuple, Union
+
+import pytest
 import torch
+import torch.nn.functional as F
+import torchao
+from packaging import version
 from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+    CheckpointWrapper,
+)
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
-from torch.testing._internal.distributed._tensor.common_dtensor import (
-    ModelArgs,
-    Transformer,
-    TransformerBlock,
-)
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    CheckpointWrapper,
-)
-from torch.distributed._composable.fsdp import fully_shard
-import pytest
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_fsdp import FSDPTest
 from torchao.dtypes.nf4tensor import (
+    _INNER_TENSOR_NAMES_FOR_SHARDING,
     linear_nf4,
     NF4Tensor,
     to_nf4,
-    _INNER_TENSOR_NAMES_FOR_SHARDING,
 )
-import torch.nn.functional as F
-import io
-from collections import OrderedDict
-import torchao
-from typing import Tuple, Union
 
 
 bnb_available = False
@@ -52,17 +49,16 @@ logging.basicConfig(
 
 def _build_input_weight(embed_dim: int, device: torch.device, dtype: torch.dtype):
     torch.manual_seed(0)
-    input_weight = torch.empty(
-        embed_dim, embed_dim, device=device, dtype=dtype
-    )
+    input_weight = torch.empty(embed_dim, embed_dim, device=device, dtype=dtype)
     input_weight.normal_(0, 1)
     return input_weight
 
+
 def _build_bnb_linear(input_weight, device):
     assert bnb_available, "Needs bitsandbytes support"
-    param = bnb.nn.Params4bit(
-        input_weight, requires_grad=False, quant_type="nf4"
-    ).cuda(device)
+    param = bnb.nn.Params4bit(input_weight, requires_grad=False, quant_type="nf4").cuda(
+        device
+    )
     bnb_linear = bnb.nn.LinearNF4(
         input_weight.size(0), input_weight.size(1), bias=False
     )
@@ -70,11 +66,14 @@ def _build_bnb_linear(input_weight, device):
     bnb_linear.to(device)
     return bnb_linear
 
+
 class TestNF4Linear(TestCase):
     class TestMod(nn.Module):
         def __init__(self, tensor, block_size, scaler_block_size):
             super().__init__()
-            self.param = torch.nn.Parameter(to_nf4(tensor, block_size, scaler_block_size))
+            self.param = torch.nn.Parameter(
+                to_nf4(tensor, block_size, scaler_block_size)
+            )
 
     def save_state_dict_to_buffer(self, state_dict: OrderedDict):
         buffer = io.BytesIO()
@@ -92,7 +91,7 @@ class TestNF4Linear(TestCase):
         assert not param.requires_grad
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_output_dtype_match(self, dtype:torch.dtype):
+    def test_output_dtype_match(self, dtype: torch.dtype):
         # Test to ensure W4 A16 produces A16
         inp = torch.randn(2, 512, dtype=dtype, requires_grad=True)
         nf4_tensor = to_nf4(torch.randn(512, 512, dtype=dtype))
@@ -100,7 +99,7 @@ class TestNF4Linear(TestCase):
         assert out.dtype == dtype
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_backward_dtype_match(self, dtype:torch.dtype):
+    def test_backward_dtype_match(self, dtype: torch.dtype):
         # Test to ensure backward pass gives activation a bf16 gradient and no gradient
         # to the linear's weight, as it is frozen.
         nf4_tensor = to_nf4(torch.randn(512, 512, dtype=dtype))
@@ -161,7 +160,7 @@ class TestNF4Linear(TestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_load_from_state_dicts(self, dtype: torch.dtype):
         """Tests loading to and from different module state dicts"""
-        inpt_tensor = torch.rand(64, device='cuda', dtype=dtype)
+        inpt_tensor = torch.rand(64, device="cuda", dtype=dtype)
         base_mod = self.TestMod(inpt_tensor, 32, 2)
 
         dummy_dict = {"param": inpt_tensor}
@@ -174,7 +173,7 @@ class TestNF4Linear(TestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_load_from_nf4_same_meta(self, dtype: torch.dtype):
         """Tests loading to and from different module state dicts"""
-        inpt_tensor = torch.rand(64, device='cuda', dtype=dtype)
+        inpt_tensor = torch.rand(64, device="cuda", dtype=dtype)
         base_mod = self.TestMod(inpt_tensor, 32, 2)
         state_dict = base_mod.state_dict()
         saved_state_dict = self.save_state_dict_to_buffer(state_dict)
@@ -188,7 +187,7 @@ class TestNF4Linear(TestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_load_from_nf4_diff_meta(self, dtype: torch.dtype):
         """Tests loading to and from different module state dicts"""
-        inpt_tensor = torch.rand(128, device='cuda', dtype=dtype)
+        inpt_tensor = torch.rand(128, device="cuda", dtype=dtype)
         base_mod = self.TestMod(inpt_tensor, 32, 2)
         state_dict = base_mod.state_dict()
         saved_state_dict = self.save_state_dict_to_buffer(state_dict)
@@ -200,28 +199,30 @@ class TestNF4Linear(TestCase):
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_to_copy(self, dtype: torch.dtype):
-        inpt_tensor = torch.rand(128, device='cpu')
+        inpt_tensor = torch.rand(128, device="cpu")
         inpt_tensor_nf4 = to_nf4(inpt_tensor, 32, 2)
         nf4_to_dtype = inpt_tensor_nf4.to(dtype)
         torch.testing.assert_allclose(inpt_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
 
         if torch.cuda.is_available():
-            inpt_tensor = torch.rand(128, device='cuda')
+            inpt_tensor = torch.rand(128, device="cuda")
             inpt_tensor_nf4 = to_nf4(inpt_tensor, 32, 2)
             nf4_to_dtype = inpt_tensor_nf4.to(dtype)
-            torch.testing.assert_allclose(inpt_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
+            torch.testing.assert_allclose(
+                inpt_tensor, nf4_to_dtype, atol=0.13, rtol=0.13
+            )
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need cuda for test")
     def test_to_copy_device(self):
-        inpt_tensor = torch.rand(128, device='cpu')
+        inpt_tensor = torch.rand(128, device="cpu")
         t = to_nf4(inpt_tensor, 32, 2)
-        assert t.device == torch.device('cpu')
+        assert t.device == torch.device("cpu")
         z = t.cuda()
-        assert z.device.type == "cuda" # Because the device could be cuda:0
+        assert z.device.type == "cuda"  # Because the device could be cuda:0
         x = z.cpu()
-        assert x.device == torch.device('cpu')
+        assert x.device == torch.device("cpu")
 
-        inpt_tensor = torch.rand(128, device='cuda')
+        inpt_tensor = torch.rand(128, device="cuda")
         t = to_nf4(inpt_tensor, 32, 2)
         assert t.device.type == "cuda"
 
@@ -236,7 +237,7 @@ class TestNF4Linear(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_smoketest_linear(self, dtype: torch.dtype):
-        a = torch.randn(32, 32, dtype=dtype, device='cuda')
+        a = torch.randn(32, 32, dtype=dtype, device="cuda")
         a_nf4 = torchao.dtypes.to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
         out1 = torch.nn.functional.linear(inp, a)
@@ -245,28 +246,33 @@ class TestNF4Linear(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_smoketest_linear_compile(self, dtype: torch.dtype):
-        if torch.cuda.is_available() and torch.cuda.get_device_capability() < (8, 0) and dtype == torch.bfloat16:
+        if (
+            torch.cuda.is_available()
+            and torch.cuda.get_device_capability() < (8, 0)
+            and dtype == torch.bfloat16
+        ):
             self.skipTest("test requires SM capability of at least (8, 0).")
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest("test requires 2.3.0 and above for tracing NF4Tensor")
-        a = torch.randn(32, 32, dtype=dtype, device='cuda')
+        a = torch.randn(32, 32, dtype=dtype, device="cuda")
         a_nf4 = torchao.dtypes.to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
-        out3 = torch.compile(torch.nn.functional.linear, mode='max-autotune')(inp, a_nf4)
+        out3 = torch.compile(torch.nn.functional.linear, mode="max-autotune")(
+            inp, a_nf4
+        )
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("shape", [(16, 16), (32, 16)])
     @parametrize("chunk_size", [8, 16, 32])
     def test_chunk_size_equivalence(self, dtype: torch.dtype, shape, chunk_size):
-        a = torch.randn(shape, device='cuda', dtype=dtype)
+        a = torch.randn(shape, device="cuda", dtype=dtype)
         with unittest.mock.patch("torchao.dtypes.nf4tensor.CHUNK_SIZE", chunk_size):
             nf4_patched = to_nf4(a, 16, 2)
         # This will be essentially no chunking since the numel is alot smaller than default chunk_size
         nf4_base = to_nf4(a, 16, 2)
 
         torch.testing.assert_close(nf4_patched.quantized_data, nf4_base.quantized_data)
-
 
 
 class TestFSDPOps(TestCase):
@@ -286,7 +292,9 @@ class TestFSDPOps(TestCase):
     @parametrize("input_size", [511 * 512, (511 * 512,), (511, 512)])
     def test_torch_chunk_invalid_divide(self, input_size: Union[Tuple[int], int]):
         num_chunks = 2
-        with self.assertRaisesRegex(AssertionError, "Number of scalers must be divisible by scaler block size"):
+        with self.assertRaisesRegex(
+            AssertionError, "Number of scalers must be divisible by scaler block size"
+        ):
             nf4_tensor = to_nf4(torch.randn(input_size))
             torch.chunk(nf4_tensor, num_chunks)
 
@@ -304,7 +312,7 @@ class TestFSDPOps(TestCase):
         for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
             inner_tensor = getattr(nf4_tensor_zeros, attr)
             self.assertEqual(torch.count_nonzero(inner_tensor), 0)
-        expected_size = input_size if not isinstance(input_size, int) else (input_size, )
+        expected_size = input_size if not isinstance(input_size, int) else (input_size,)
         self.assertEqual(nf4_tensor_zeros.size(), torch.Size(expected_size))
 
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
@@ -312,18 +320,22 @@ class TestFSDPOps(TestCase):
         if isinstance(input_size, int):
             new_size = input_size + 1
         elif len(input_size) == 1:
-            new_size = (input_size[0] + 1, )
+            new_size = (input_size[0] + 1,)
         else:
             new_size = (input_size[0] + 1, input_size[1])
         nf4_tensor = to_nf4(torch.randn(input_size))
-        with self.assertRaisesRegex(NotImplementedError, "aten.new_zeros\\(NF4Tensor\\) with new size"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.new_zeros\\(NF4Tensor\\) with new size"
+        ):
             nf4_tensor_zeros = nf4_tensor.new_zeros(new_size)
 
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
     def test_tensor_slice_valid(self, input_size: Union[Tuple[int], int]):
         nf4_tensor = to_nf4(torch.randn(input_size))
         orig_attrs, _ = nf4_tensor.__tensor_flatten__()
-        orig_sizes = dict([(attr, getattr(nf4_tensor, attr).size()) for attr in orig_attrs])
+        orig_sizes = dict(
+            [(attr, getattr(nf4_tensor, attr).size()) for attr in orig_attrs]
+        )
         end_idx = input_size if isinstance(input_size, int) else input_size[0]
         sliced_tensor = nf4_tensor[:end_idx]
         self.assertEqual(nf4_tensor.size(), sliced_tensor.size())
@@ -331,25 +343,39 @@ class TestFSDPOps(TestCase):
         for attr in attrs:
             orig_storage = getattr(nf4_tensor, attr).untyped_storage().data_ptr()
             sliced_tensor_inner = getattr(sliced_tensor, attr)
-            self.assertEqual(sliced_tensor_inner.untyped_storage().data_ptr(), orig_storage)
+            self.assertEqual(
+                sliced_tensor_inner.untyped_storage().data_ptr(), orig_storage
+            )
             self.assertEqual(sliced_tensor_inner.size(), orig_sizes[attr])
 
     def test_tensor_slice_1d_invalid(self):
         nf4_tensor = to_nf4(torch.randn(512 * 512))
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with customized step"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with customized step"
+        ):
             nf4_tensor[..., ::2]
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with start"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with start"
+        ):
             nf4_tensor[1:]
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with end"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with end"
+        ):
             nf4_tensor[:2]
 
     def test_tensor_slice_2d_invalid(self):
         nf4_tensor = to_nf4(torch.randn((512, 512)))
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with dim"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with dim"
+        ):
             nf4_tensor[:, :511]
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with start"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with start"
+        ):
             nf4_tensor[1:]
-        with self.assertRaisesRegex(NotImplementedError, "aten.slice\\(NF4Tensor\\) with end"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.slice\\(NF4Tensor\\) with end"
+        ):
             nf4_tensor[:2]
 
     @parametrize("input_size", [(512 * 512,), (512, 512)])
@@ -366,43 +392,68 @@ class TestFSDPOps(TestCase):
     def test_tensor_view_invalid(self, input_size: Union[Tuple[int], int]):
         nf4_tensor = to_nf4(torch.randn(input_size))
         if len(input_size) == 1:
-            with self.assertRaisesRegex(NotImplementedError, "aten.view\\(NF4Tensor\\) with size"):
+            with self.assertRaisesRegex(
+                NotImplementedError, "aten.view\\(NF4Tensor\\) with size"
+            ):
                 nf4_tensor.view(input_size)
         if len(input_size) == 2:
-            with self.assertRaisesRegex(NotImplementedError, "aten.view\\(NF4Tensor\\) with len\\(size\\)"):
+            with self.assertRaisesRegex(
+                NotImplementedError, "aten.view\\(NF4Tensor\\) with len\\(size\\)"
+            ):
                 nf4_tensor.view(input_size)
 
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
     def test_tensor_as_strided_valid(self, input_size: Union[Tuple[int], int]):
         nf4_tensor = to_nf4(torch.randn(input_size))
-        nf4_tensor_strided = torch.as_strided(nf4_tensor, nf4_tensor.size(), nf4_tensor.stride(), nf4_tensor.storage_offset())
+        nf4_tensor_strided = torch.as_strided(
+            nf4_tensor,
+            nf4_tensor.size(),
+            nf4_tensor.stride(),
+            nf4_tensor.storage_offset(),
+        )
         self.assertEqual(nf4_tensor_strided.size(), nf4_tensor.size())
         self.assertEqual(nf4_tensor_strided.stride(), nf4_tensor.stride())
-        self.assertEqual(nf4_tensor_strided.storage_offset(), nf4_tensor.storage_offset())
+        self.assertEqual(
+            nf4_tensor_strided.storage_offset(), nf4_tensor.storage_offset()
+        )
         for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
             inner_tensor_orig = getattr(nf4_tensor, attr)
             inner_tensor_strided = getattr(nf4_tensor_strided, attr)
             self.assertEqual(inner_tensor_strided.size(), inner_tensor_orig.size())
             self.assertEqual(inner_tensor_strided.stride(), inner_tensor_orig.stride())
-            self.assertEqual(inner_tensor_strided.storage_offset(), inner_tensor_orig.storage_offset())
-
+            self.assertEqual(
+                inner_tensor_strided.storage_offset(),
+                inner_tensor_orig.storage_offset(),
+            )
 
     @parametrize("input_size", [(512 * 512,), (512, 512)])
     def test_tensor_as_strided_invalid(self, input_size: Union[Tuple[int], int]):
         nf4_tensor = to_nf4(torch.randn(input_size))
         if len(input_size) == 1:
-            size = (input_size[0] - 1, )
+            size = (input_size[0] - 1,)
         else:
             size = (input_size[0] - 1, input_size[1])
-        with self.assertRaisesRegex(NotImplementedError, "aten.as_strided\\(NF4Tensor\\) different numel"):
-            torch.as_strided(nf4_tensor, size, nf4_tensor.stride(), nf4_tensor.storage_offset())
-        with self.assertRaisesRegex(NotImplementedError, "aten.as_strided\\(NF4Tensor\\) only support original storage offset"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "aten.as_strided\\(NF4Tensor\\) different numel"
+        ):
+            torch.as_strided(
+                nf4_tensor, size, nf4_tensor.stride(), nf4_tensor.storage_offset()
+            )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "aten.as_strided\\(NF4Tensor\\) only support original storage offset",
+        ):
             torch.as_strided(nf4_tensor, nf4_tensor.size(), nf4_tensor.stride(), 1)
 
         if len(input_size) == 2:
-            with self.assertRaisesRegex(NotImplementedError, "aten.as_strided\\(NF4Tensor\\) only support continuous stride"):
+            with self.assertRaisesRegex(
+                NotImplementedError,
+                "aten.as_strided\\(NF4Tensor\\) only support continuous stride",
+            ):
                 stride = (nf4_tensor.stride()[1], nf4_tensor.stride()[0])
-                torch.as_strided(nf4_tensor, nf4_tensor.size(), stride, nf4_tensor.storage_offset())
+                torch.as_strided(
+                    nf4_tensor, nf4_tensor.size(), stride, nf4_tensor.storage_offset()
+                )
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_pin_memory(self):
@@ -412,9 +463,8 @@ class TestFSDPOps(TestCase):
         nf4_tensor = nf4_tensor.pin_memory()
         self.assertTrue(nf4_tensor.is_pinned())
 
-        nf4_tensor = to_nf4(torch.randn(512 * 512, device='cuda'))
+        nf4_tensor = to_nf4(torch.randn(512 * 512, device="cuda"))
         self.assertFalse(nf4_tensor.is_pinned())
-
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_to_cuda(self):
@@ -436,18 +486,21 @@ class TestFSDPOps(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_to_cpu(self):
-        nf4_tensor = to_nf4(torch.randn(512 * 512, device='cuda'))
+        nf4_tensor = to_nf4(torch.randn(512 * 512, device="cuda"))
         nf4_tensor = nf4_tensor.cpu()
         self.assertEqual(nf4_tensor.device.type, "cpu")
         for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
             inner_tensor = getattr(nf4_tensor, attr)
             self.assertEqual(inner_tensor.device.type, "cpu")
-    
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
     def test_tensor_deepcopy(self, input_size: Union[Tuple[int], int]):
-        nf4_orig = to_nf4(torch.randn(input_size, device='cuda'))
+        nf4_orig = to_nf4(torch.randn(input_size, device="cuda"))
         nf4_clone = copy.deepcopy(nf4_orig)
-        self.assertEqual(nf4_clone.get_original_weight(), nf4_orig.get_original_weight())
+        self.assertEqual(
+            nf4_clone.get_original_weight(), nf4_orig.get_original_weight()
+        )
 
 
 class LoRALinear(nn.Module):
@@ -493,14 +546,32 @@ class TestQLoRA(FSDPTest):
     )
     @skip_if_lt_x_gpu(2)
     def test_qlora_fsdp2(self):
+        from torch.distributed._composable.fsdp import CPUOffloadPolicy, OffloadPolicy
+
         self.run_subtests(
             {
                 "enable_activation_checkpointing": [False, True],
+                "offload_policy": [
+                    OffloadPolicy(),
+                    CPUOffloadPolicy(pin_memory=True),
+                    CPUOffloadPolicy(pin_memory=False),
+                ],
             },
             self._test_qlora_fsdp2,
         )
-    
-    def _test_qlora_fsdp2(self, enable_activation_checkpointing: bool):
+
+    def _test_qlora_fsdp2(
+        self,
+        enable_activation_checkpointing: bool,
+        offload_policy: "OffloadPolicy",
+    ):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.testing._internal.distributed._tensor.common_dtensor import (
+            ModelArgs,
+            Transformer,
+            TransformerBlock,
+        )
+
         batch_size = 3
         lora_r = 8
         lora_alpha = 16
@@ -519,30 +590,56 @@ class TestQLoRA(FSDPTest):
             base_model = Transformer(model_args)
             for layer in base_model.layers:
                 # attention with lora adapters
-                for attr in ['wq', 'wk', 'wv', 'wo']:
+                for attr in ["wq", "wk", "wv", "wo"]:
                     orig_linear = getattr(layer.attention, attr)
-                    setattr(layer.attention, attr, LoRALinear(orig_linear.weight.shape[1], orig_linear.weight.shape[0], orig_linear.weight, lora_r, lora_alpha))
-                for attr in ['w1', 'w2']:
+                    setattr(
+                        layer.attention,
+                        attr,
+                        LoRALinear(
+                            orig_linear.weight.shape[1],
+                            orig_linear.weight.shape[0],
+                            orig_linear.weight,
+                            lora_r,
+                            lora_alpha,
+                        ),
+                    )
+                for attr in ["w1", "w2"]:
                     orig_linear = getattr(layer.feed_forward, attr)
-                    setattr(layer.feed_forward, attr, LoRALinear(orig_linear.weight.shape[1], orig_linear.weight.shape[0], orig_linear.weight, lora_r, lora_alpha))
+                    setattr(
+                        layer.feed_forward,
+                        attr,
+                        LoRALinear(
+                            orig_linear.weight.shape[1],
+                            orig_linear.weight.shape[0],
+                            orig_linear.weight,
+                            lora_r,
+                            lora_alpha,
+                        ),
+                    )
         for name, param in base_model.named_parameters():
-            param.requires_grad_(name.endswith('lora_a.weight') or name.endswith('lora_b.weight'))
+            param.requires_grad_(
+                name.endswith("lora_a.weight") or name.endswith("lora_b.weight")
+            )
+        if enable_activation_checkpointing:
+            apply_activation_checkpointing(
+                base_model, auto_wrap_policy=ModuleWrapPolicy({TransformerBlock})
+            )
         base_optim = torch.optim.AdamW(base_model.parameters(), lr=1e-2)
-            
-        # fsdp model for saving state dict
+
+        fsdp_kwargs = {"offload_policy": offload_policy}
         fsdp_model = copy.deepcopy(base_model)
         for m in fsdp_model.modules():
             if enable_activation_checkpointing:
                 if isinstance(m, CheckpointWrapper):
-                    fully_shard(m)
+                    fully_shard(m, **fsdp_kwargs)
             else:
                 if isinstance(m, TransformerBlock):
-                    fully_shard(m)
-        fully_shard(fsdp_model)
+                    fully_shard(m, **fsdp_kwargs)
+        fully_shard(fsdp_model, **fsdp_kwargs)
         fsdp_optim = torch.optim.AdamW(fsdp_model.parameters(), lr=1e-2)
 
         torch.manual_seed(42 + self.rank + 1)
-        for iter_idx in range(10):
+        for iter_idx in range(5):
             inp = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
             fsdp_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
             fsdp_loss = fsdp_model(inp).sum()
@@ -554,9 +651,12 @@ class TestQLoRA(FSDPTest):
             base_loss.backward()
             for param in base_model.parameters():
                 if param.grad is not None:
-                    torch.distributed.all_reduce(param.grad, op=torch.distributed.ReduceOp.AVG)
+                    torch.distributed.all_reduce(
+                        param.grad, op=torch.distributed.ReduceOp.AVG
+                    )
             base_optim.step()
             self.assertEqual(fsdp_loss, base_loss)
+
 
 instantiate_parametrized_tests(TestNF4Linear)
 instantiate_parametrized_tests(TestFSDPOps)

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -2,7 +2,7 @@ import logging
 import unittest
 from packaging import version
 import math
-
+import copy
 import torch
 from torch import nn
 from torch.testing._internal.common_utils import (
@@ -11,6 +11,18 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
+from torch.testing._internal.distributed._tensor.common_dtensor import (
+    ModelArgs,
+    Transformer,
+    TransformerBlock,
+)
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointWrapper,
+)
+from torch.distributed._composable.fsdp import fully_shard
+import pytest
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
 from torchao.dtypes.nf4tensor import (
     linear_nf4,
     NF4Tensor,
@@ -430,7 +442,121 @@ class TestFSDPOps(TestCase):
         for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
             inner_tensor = getattr(nf4_tensor, attr)
             self.assertEqual(inner_tensor.device.type, "cpu")
+    
+    @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
+    def test_tensor_deepcopy(self, input_size: Union[Tuple[int], int]):
+        nf4_orig = to_nf4(torch.randn(input_size, device='cuda'))
+        nf4_clone = copy.deepcopy(nf4_orig)
+        self.assertEqual(nf4_clone.get_original_weight(), nf4_orig.get_original_weight())
 
+
+class LoRALinear(nn.Module):
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        weight: torch.Tensor,
+        rank: int,
+        alpha: float,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.rank = rank
+        self.alpha = alpha
+        self.out_dim = out_dim
+        self.register_parameter("weight", nn.Parameter(to_nf4(weight)))
+        self.dropout = nn.Dropout(p=dropout)
+        self.lora_a = nn.Linear(in_features=in_dim, out_features=rank, bias=False)
+        self.lora_b = nn.Linear(in_features=rank, out_features=out_dim, bias=False)
+        self.initialize_parameters()
+
+    def initialize_parameters(self):
+        nn.init.kaiming_uniform_(self.lora_a.weight, a=math.sqrt(5))
+        nn.init.kaiming_uniform_(self.lora_b.weight, a=math.sqrt(5))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = linear_nf4(input=x, weight=self.weight)
+        lora_out = self.lora_a(self.dropout(x))
+        lora_out = (self.alpha / self.rank) * self.lora_b(lora_out)
+        return out + lora_out
+
+
+class TestQLoRA(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @pytest.mark.skipif(
+        version.parse(torch.__version__).base_version < "2.4.0",
+        reason="torch >= 2.4 required",
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_qlora_fsdp2(self):
+        self.run_subtests(
+            {
+                "enable_activation_checkpointing": [False, True],
+            },
+            self._test_qlora_fsdp2,
+        )
+    
+    def _test_qlora_fsdp2(self, enable_activation_checkpointing: bool):
+        batch_size = 3
+        lora_r = 8
+        lora_alpha = 16
+        vocab_size = 1024
+        seq_len = 64
+        model_args = ModelArgs(
+            n_layers=3,
+            n_heads=4,
+            dim=1024,
+            vocab_size=vocab_size,
+            max_seq_len=seq_len,
+            dropout_p=0,
+        )
+        torch.manual_seed(42)
+        with torch.device("cuda"):
+            base_model = Transformer(model_args)
+            for layer in base_model.layers:
+                # attention with lora adapters
+                for attr in ['wq', 'wk', 'wv', 'wo']:
+                    orig_linear = getattr(layer.attention, attr)
+                    setattr(layer.attention, attr, LoRALinear(orig_linear.weight.shape[1], orig_linear.weight.shape[0], orig_linear.weight, lora_r, lora_alpha))
+                for attr in ['w1', 'w2']:
+                    orig_linear = getattr(layer.feed_forward, attr)
+                    setattr(layer.feed_forward, attr, LoRALinear(orig_linear.weight.shape[1], orig_linear.weight.shape[0], orig_linear.weight, lora_r, lora_alpha))
+        for name, param in base_model.named_parameters():
+            param.requires_grad_(name.endswith('lora_a.weight') or name.endswith('lora_b.weight'))
+        base_optim = torch.optim.AdamW(base_model.parameters(), lr=1e-2)
+            
+        # fsdp model for saving state dict
+        fsdp_model = copy.deepcopy(base_model)
+        for m in fsdp_model.modules():
+            if enable_activation_checkpointing:
+                if isinstance(m, CheckpointWrapper):
+                    fully_shard(m)
+            else:
+                if isinstance(m, TransformerBlock):
+                    fully_shard(m)
+        fully_shard(fsdp_model)
+        fsdp_optim = torch.optim.AdamW(fsdp_model.parameters(), lr=1e-2)
+
+        torch.manual_seed(42 + self.rank + 1)
+        for iter_idx in range(10):
+            inp = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+            fsdp_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            fsdp_loss = fsdp_model(inp).sum()
+            fsdp_loss.backward()
+            fsdp_optim.step()
+
+            base_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            base_loss = base_model(inp).sum()
+            base_loss.backward()
+            for param in base_model.parameters():
+                if param.grad is not None:
+                    torch.distributed.all_reduce(param.grad, op=torch.distributed.ReduceOp.AVG)
+            base_optim.step()
+            self.assertEqual(fsdp_loss, base_loss)
 
 instantiate_parametrized_tests(TestNF4Linear)
 instantiate_parametrized_tests(TestFSDPOps)


### PR DESCRIPTION
fix error when running torchtune QLoRA + FSDP2 https://github.com/pytorch/ao/issues/380
`TypeError: nf4_detach() missing 1 required positional argument: 'args'`

torchtune command
```
tune download meta-llama/Llama-2-7b-hf --output-dir /tmp/Llama-2-7b-hf --hf-token <HF_TOKEN>
tune run --nnodes 1 --nproc_per_node 4 lora_finetune_fsdp2 --config llama2/7B_qlora enable_activation_checkpointing=False
```


* revert NF4 changes from https://github.com/pytorch/ao/pull/360
* FSDP2 + QLoRA multi-gpu test: `pytest -s test/dtypes/test_nf4.py -k test_qlora`: e2e fsdp2 + qlora test
* NF4.clone test `pytest -s test/dtypes/test_nf4.py -k test_tensor_copy`: torchtune implemented `NF4.clone`, upstream it to TorchAO. This is needed by unit test `copy.deepcopy(model)`


