### PR TITLE
Fix github CI error

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -54,7 +54,7 @@ jobs:
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      timeout-minutes: 60
+      timeout: 60
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -54,6 +54,7 @@ jobs:
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
+      timeout-minutes: 60
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}


### PR DESCRIPTION
Summary:
Recently the cuda nightly job failed with "Error: The operation was canceled." Probably due to timeout, so we can increase the time a bit"

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: