### PR TITLE
Fix missing dependencies in trymerge workflow

### DIFF
--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -26,6 +26,8 @@ jobs:
           check-latest: false
           cache: pip
           architecture: x64
+      # TODO (huydhn): get rid of Rockset
+      - run: pip install pyyaml==6.0 rockset==1.0.3
 
       - name: Setup committer id
         run: |


### PR DESCRIPTION
This line from PyTorch was missing in the workflow and caused failure when using mergebot https://github.com/pytorch/ao/actions/runs/9619186734/job/26534754231#step:5:41