### PR TITLE
groupsize consistency

### DIFF
--- a/benchmarks/dora/bench_utils.py
+++ b/benchmarks/dora/bench_utils.py
@@ -111,7 +111,7 @@ def setup_dora_base_layers(layer_type, in_features, out_features, dtype):
         # HQQ
         quant_config = BaseQuantizeConfig(
             nbits=4,
-            group_size=64,
+            groupsize=64,
             quant_zero=False,
             quant_scale=False,
             offload_meta=True,

--- a/test/dora/test_dora_layer.py
+++ b/test/dora/test_dora_layer.py
@@ -91,7 +91,7 @@ def test_dora_layer(
     elif model_type == "HQQDoRALinear":
         quant_config = BaseQuantizeConfig(
             nbits=4,
-            group_size=64,
+            groupsize=64,
             quant_zero=False,
             quant_scale=False,
             offload_meta=True,

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -12,7 +12,7 @@ class TestAffineQuantized(TestCase):
     def test_tensor_core_layout_transpose(self):
         t = torch.rand(128, 256, dtype=torch.bfloat16, device="cuda")
         shape = t.shape
-        apply_int4_weight_only_quant = int4_weight_only(group_size=32)
+        apply_int4_weight_only_quant = int4_weight_only(groupsize=32)
         aqt = apply_int4_weight_only_quant(t)
         aqt_shape = aqt.shape
         self.assertEqual(aqt_shape, shape)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -833,7 +833,7 @@ class TestSubclass(unittest.TestCase):
                     def api(mod):
                         if TORCH_VERSION_AFTER_2_4:
                             kwargs_copy = kwargs.copy()
-                            kwargs_copy["group_size"] = groupsize
+                            kwargs_copy["groupsize"] = groupsize
                             del kwargs_copy["groupsize"]
                             quantize(mod, int4_weight_only(**kwargs_copy))
                             unwrap_tensor_subclass(mod)

--- a/test/quantization/test_galore_quant.py
+++ b/test/quantization/test_galore_quant.py
@@ -42,7 +42,7 @@ def test_galore_quantize_blockwise(dim1, dim2, dtype, signed, blocksize):
     bnb_norm = (g.reshape(-1, blocksize) / qstate.absmax[:, None]).reshape(g.shape)
 
     tt_q, tt_norm, tt_absmax = triton_quantize_blockwise(
-        g, qmap, group_size=blocksize, return_normalized=True
+        g, qmap, groupsize=blocksize, return_normalized=True
     )
     tt_check = torch.allclose(ref_bnb, tt_q)
 
@@ -87,5 +87,5 @@ def test_galore_dequant_blockwise(dim1, dim2, dtype, signed, blocksize):
     q, qstate = F.quantize_blockwise(g, code=qmap, blocksize=blocksize)
 
     dq_ref = F.dequantize_blockwise(q, qstate)
-    dq = triton_dequant_blockwise(q, qmap, qstate.absmax, group_size=blocksize)
+    dq = triton_dequant_blockwise(q, qmap, qstate.absmax, groupsize=blocksize)
     assert torch.allclose(dq, dq_ref)

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -499,11 +499,11 @@ class TestQuantFlow(TestCase):
     # TODO: move to a separate test file
     @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "Test only enabled for 2.4+")
     def test_quantized_tensor_subclass_8da4w(self):
-        group_size = 32
+        groupsize = 32
         m = ToyLinearModel().eval()
         m_copy = copy.deepcopy(m)
         example_inputs = m.example_inputs()
-        m = quantize(m, int8_dynamic_activation_int4_weight(group_size=group_size))
+        m = quantize(m, int8_dynamic_activation_int4_weight(groupsize=groupsize))
 
         assert isinstance(m.linear1.weight, LinearActQuantizedTensor)
         assert isinstance(m.linear2.weight, LinearActQuantizedTensor)
@@ -514,7 +514,7 @@ class TestQuantFlow(TestCase):
         from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
         from torchao.quantization.GPTQ import Int8DynActInt4WeightLinear
 
-        quantizer = Int8DynActInt4WeightQuantizer(groupsize=group_size)
+        quantizer = Int8DynActInt4WeightQuantizer(groupsize=groupsize)
         m_copy = quantizer.quantize(m_copy)
         assert isinstance(m_copy.linear1, Int8DynActInt4WeightLinear)
         assert isinstance(m_copy.linear2, Int8DynActInt4WeightLinear)
@@ -531,13 +531,13 @@ class TestQuantFlow(TestCase):
         m_copy = copy.deepcopy(m)
         example_inputs = m.example_inputs(dtype=torch.bfloat16, device="cuda")
 
-        group_size = 32
-        m = quantize(m, int4_weight_only(group_size=group_size))
+        groupsize = 32
+        m = quantize(m, int4_weight_only(groupsize=groupsize))
         assert isinstance(m.linear1.weight, AffineQuantizedTensor)
         assert isinstance(m.linear2.weight, AffineQuantizedTensor)
 
         # reference
-        _ref_change_linear_weights_to_int4_woqtensors(m_copy, groupsize=group_size)
+        _ref_change_linear_weights_to_int4_woqtensors(m_copy, groupsize=groupsize)
 
         res = m(*example_inputs)
         ref = m_copy(*example_inputs)

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -286,14 +286,14 @@ class TestQuantPrimitives(unittest.TestCase):
         quantized = quantize_affine(input, block_size, scale, zero_point, dtype)
         dequantized = check_idempotent(self, dequantize_affine, quantized, block_size, scale, zero_point, dtype, output_dtype=torch.float32)
 
-        group_size = 2
+        groupsize = 2
         quant_min = -128
         quant_max = 127
         quantized_ref = torch.ops.quantized_decomposed.quantize_per_channel_group(
-            input, scale, zero_point, quant_min, quant_max, torch.int8, group_size
+            input, scale, zero_point, quant_min, quant_max, torch.int8, groupsize
         )
         dequantized_ref = torch.ops.quantized_decomposed.dequantize_per_channel_group(
-            quantized_ref, scale, zero_point, quant_min, quant_max, torch.int8, group_size, output_dtype=torch.float32
+            quantized_ref, scale, zero_point, quant_min, quant_max, torch.int8, groupsize, output_dtype=torch.float32
         )
 
         self.assertTrue(torch.equal(quantized, quantized_ref))

--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -13,7 +13,7 @@ from generate import (
 
 )
 from torchao.quantization.quant_api import (
-    quantize, int4wo, int8wo, int8da_int8w, unwrap_tensor_subclass
+    quantize, int4_weight_only, int8_weight_only, int8_dynamic_activation_int8_weight, unwrap_tensor_subclass
 
 )
 from torchao._models._eval import TransformerEvalWrapper, InputRecorder
@@ -60,13 +60,13 @@ def run_evaluation(
 
     if quantization:
         if "int8wo" in quantization:
-            quantize(model, int8wo())
+            quantize(model, int8_weight_only())
         if "int8dq" in quantization:
-            quantize(model, int8da_int8w())
+            quantize(model, int8_dynamic_activation_int8_weight())
         if "int4wo" in quantization and not "gptq" in quantization:
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
-            quantize(model, int4wo(groupsize=groupsize))
+            quantize(model, int4_weight_only(groupsize=groupsize))
         if "int4wo" in quantization and "gptq" in quantization:
             groupsize=int(quantization.split("-")[-2])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -189,21 +189,21 @@ def main(
     if quantization:
         from torchao.quantization.quant_api import (
             quantize,
-            int8wo,
-            int8da_int8w,
-            int4wo,
+            int8_weight_only,
+            int8_dynamic_activation_int8_weight,
+            int4_weight_only,
             autoquant,
             unwrap_tensor_subclass
     )
 
         if "int8wo" in quantization:
-            quantize(model, int8wo())
+            quantize(model, int8_weight_only())
         if "int8dq" in quantization:
-            quantize(model, int8da_int8w())
+            quantize(model, int8_dynamic_activation_int8_weight())
         if "int4wo" in quantization:
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
-            quantize(model, int4wo(groupsize=groupsize))
+            quantize(model, int4_weight_only(groupsize=groupsize))
         if "autoquant" == quantization:
             model = autoquant(model, manual=True)
 
@@ -339,7 +339,7 @@ if __name__ == '__main__':
     parser.add_argument('--max_new_tokens', type=int, default=200, help='Maximum number of new tokens.')
     parser.add_argument('--top_k', type=int, default=200, help='Top-k for sampling.')
     parser.add_argument('--temperature', type=float, default=0.8, help='Temperature for sampling.')
-    parser.add_argument('--checkpoint_path', type=Path, default=Path("checkpoints/meta-Transformer/Transformer-2-7b-chat-hf/model.pth"), help='Model checkpoint path.')
+    parser.add_argument('--checkpoint_path', type=Path, default=Path("../../../checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth"), help='Model checkpoint path.')
     parser.add_argument("--quantization", type=str, help='Which quantization techniques to apply: int8dq, int8wo, int4wo-<groupsize>, autoquant')
     parser.add_argument('--compile', action='store_true', help='Whether to compile the model.')
     parser.add_argument('--compile_prefill', action='store_true', help='Whether to compile the prefill (improves prefill perf, but higher compile times)')

--- a/torchao/kernel/intmm_triton.py
+++ b/torchao/kernel/intmm_triton.py
@@ -199,9 +199,9 @@ def scaled_matmul_kernel_with_block_pointers(
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)

--- a/torchao/prototype/dora/dora_profile.py
+++ b/torchao/prototype/dora/dora_profile.py
@@ -62,7 +62,7 @@ def run(args):
     elif args.layer_type == "hqq":
         quant_config = BaseQuantizeConfig(
             nbits=4,
-            group_size=64,
+            groupsize=64,
             quant_zero=False,
             quant_scale=False,
             offload_meta=True,

--- a/torchao/prototype/dora/kernels/common.py
+++ b/torchao/prototype/dora/kernels/common.py
@@ -161,9 +161,9 @@ def swizzle_tile(
         # re-order program ID for better L2 performance
         width = GROUP_M * grid_n
         group_id = pid // width
-        group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
-        pid_m = group_id * GROUP_M + (pid % group_size)
-        pid_n = (pid % width) // (group_size)
+        groupsize = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+        pid_m = group_id * GROUP_M + (pid % groupsize)
+        pid_n = (pid % width) // (groupsize)
     elif SWIZZLE == tl.constexpr(SwizzleType.COLUMN_MAJOR):
         pid_m = pid % grid_m
         pid_n = pid // grid_m

--- a/torchao/prototype/dora/kernels/smallk.py
+++ b/torchao/prototype/dora/kernels/smallk.py
@@ -156,9 +156,9 @@ def swizzle_tile(
         # re-order program ID for better L2 performance
         width = GROUP_M * grid_n
         group_id = pid // width
-        group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
-        pid_m = group_id * GROUP_M + (pid % group_size)
-        pid_n = (pid % width) // (group_size)
+        groupsize = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+        pid_m = group_id * GROUP_M + (pid % groupsize)
+        pid_n = (pid % width) // (groupsize)
     else:
         tl.static_assert(False, "swizzle type not supported")
 

--- a/torchao/prototype/fp8/splitk_gemm.py
+++ b/torchao/prototype/fp8/splitk_gemm.py
@@ -14,10 +14,10 @@ def grouped_launch(pid,
 
     width = group_m * grid_n
     group_id = pid // width
-    group_size = tl.minimum(grid_m - group_id * group_m, group_m)
+    groupsize = tl.minimum(grid_m - group_id * group_m, group_m)
 
-    pid_m = group_id * group_m + (pid % group_size)
-    pid_n = (pid % width) // group_size
+    pid_m = group_id * group_m + (pid % groupsize)
+    pid_n = (pid % width) // groupsize
 
     return pid_m, pid_n
 

--- a/torchao/prototype/galore/kernels/adam_downproj_fused.py
+++ b/torchao/prototype/galore/kernels/adam_downproj_fused.py
@@ -67,9 +67,9 @@ def _fused_adam_mm_kernel(
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
     # do matrix multiplication
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)

--- a/torchao/prototype/galore/kernels/matmul.py
+++ b/torchao/prototype/galore/kernels/matmul.py
@@ -229,9 +229,9 @@ def _matmul_kernel(
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
     # do matrix multiplication
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)

--- a/torchao/prototype/hqq/hqq_tinygemm_linear.py
+++ b/torchao/prototype/hqq/hqq_tinygemm_linear.py
@@ -37,7 +37,7 @@ class HQQLinearTorchWeightOnlyInt4(torch.nn.Module):
         self.del_orig = del_orig
 
         weight_quant_params = self.quant_config["weight_quant_params"]
-        self.groupsize = weight_quant_params["group_size"]
+        self.groupsize = weight_quant_params["groupsize"]
         self.nbits = weight_quant_params["nbits"]
         self.inner_k_tiles = inner_k_tiles
         self.padding = padding
@@ -120,10 +120,10 @@ class HQQLinearTorchWeightOnlyInt4(torch.nn.Module):
 
     # TODO: move these to utils
     @torch.no_grad()
-    def reshape_meta_axis1(self, meta_tensor, new_group_size, shape):
+    def reshape_meta_axis1(self, meta_tensor, new_groupsize, shape):
         meta_tensor = meta_tensor.repeat([1, shape[1]]).reshape(shape)
         meta_tensor = torch.mean(
-            meta_tensor.reshape([-1, new_group_size]), axis=1, keepdim=True
+            meta_tensor.reshape([-1, new_groupsize]), axis=1, keepdim=True
         )
         return meta_tensor
 

--- a/torchao/prototype/hqq/kernels.py
+++ b/torchao/prototype/hqq/kernels.py
@@ -239,9 +239,9 @@ def _mixed_mm_kernel(
 
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // group_size
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // groupsize
 
     rm = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
     if not DEBUG:

--- a/torchao/prototype/hqq/mixed_mm.py
+++ b/torchao/prototype/hqq/mixed_mm.py
@@ -38,7 +38,7 @@ def triton_mixed_mm(
     b,
     scales,
     zeros,
-    group_size,
+    groupsize,
     transposed=False,
     acc_dtype=None,
     input_precision="ieee",
@@ -54,9 +54,9 @@ def triton_mixed_mm(
     Args:
         a (torch.Tensor): M x K if not transposed, M x N if transposed
         b (torch.Tensor): (K // 2) x N, packed such that 2 int4's are packed into 1 uint8 (see pack_2xint4)
-        scales (torch.Tensor): (num_groups x N), where num_groups = (N * K / group_size)
+        scales (torch.Tensor): (num_groups x N), where num_groups = (N * K / groupsize)
         zeros (torch.Tensor): same shape as scales
-        group_size (torch.Tensor): size of group in groupwise quantization -- MUST be along axis 1 of an N x K matrix
+        groupsize (torch.Tensor): size of group in groupwise quantization -- MUST be along axis 1 of an N x K matrix
         transposed (bool, optional): Whether to run a transposed matmul where shapes are (M x N) x (K x N) => (M x K)
         acc_dtype (_type_, optional): dtype of accumulator. Defaults to None, which corresponds to tl.float32.
         input_precision (str, optional): Only relevant when dtype of a is torch.float32. Defaults to "ieee".
@@ -88,7 +88,7 @@ def triton_mixed_mm(
     M, K = a.shape
     N = b.shape[1] if not transposed else b.shape[0] * 2
     # assert scales.shape[1] == N if not transposed else scales.shape[0] == N
-    # assert scales.shape[0] == K // group_size if not transposed else scales.shape[1] == K // group_size
+    # assert scales.shape[0] == K // groupsize if not transposed else scales.shape[1] == K // groupsize
     assert scales.dtype == a.dtype
     assert scales.shape == zeros.shape
     assert zeros.dtype == a.dtype
@@ -132,7 +132,7 @@ def triton_mixed_mm(
             scales.stride(1),
             TRANSPOSED=transposed,
             IS_BFLOAT16=a.dtype == torch.bfloat16,
-            QGROUP_SIZE=group_size,
+            QGROUP_SIZE=groupsize,
             acc_dtype=acc_dtype,
             input_precision=input_precision,
             fp8_fast_accum=fp8_fast_accum,
@@ -164,7 +164,7 @@ def triton_mixed_mm(
             EVEN_K=True,
             TRANSPOSED=transposed,
             IS_BFLOAT16=a.dtype == torch.bfloat16,
-            QGROUP_SIZE=group_size,
+            QGROUP_SIZE=groupsize,
             acc_dtype=acc_dtype,
             input_precision=input_precision,
             fp8_fast_accum=fp8_fast_accum,

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -104,8 +104,8 @@ example_inputs = m.example_inputs(dtype=dtype, device="cuda")
 
 m_bf16 = torch.compile(m_bf16, mode='max-autotune')
 # apply int4 weight only quant (compatible with tinygemm int4 weight only quant mm kernel in torchao)
-group_size = 32
-m = quantize(m, int4_weight_only(group_size=group_size))
+groupsize = 32
+m = quantize(m, int4_weight_only(groupsize=groupsize))
 
 torch._inductor.config.force_fuse_int_mm_with_mul = True
 torch._inductor.config.use_mixed_mm = True

--- a/torchao/quantization/prototype/qat.py
+++ b/torchao/quantization/prototype/qat.py
@@ -227,7 +227,7 @@ class _GenericFakeQuantize(torch.autograd.Function):
 # TODO: move this to core
 quantized_decomposed_lib.define(
     "fake_quantize_per_channel_group(Tensor input, Tensor scales, Tensor zero_points, "
-    "int quant_min, int quant_max, int group_size) -> Tensor"
+    "int quant_min, int quant_max, int groupsize) -> Tensor"
 )
 
 @impl(quantized_decomposed_lib, "fake_quantize_per_channel_group", "CompositeImplicitAutograd")
@@ -237,12 +237,12 @@ def fake_quantize_per_channel_group(
     zero_points: torch.Tensor,
     quant_min: int,
     quant_max: int,
-    group_size: int,
+    groupsize: int,
 ) -> torch.Tensor:
-    assert group_size > 1
-    assert input.shape[-1] % group_size == 0
+    assert groupsize > 1
+    assert input.shape[-1] % groupsize == 0
     assert input.dim() == 2
-    grouped_input = input.reshape(-1, group_size).to(torch.float32)
+    grouped_input = input.reshape(-1, groupsize).to(torch.float32)
     scales = scales.reshape(-1, 1)
     zero_points = zero_points.reshape(-1, 1)
     fq = _GenericFakeQuantize.apply(

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -305,13 +305,13 @@ def quantize(model: torch.nn.Module, apply_tensor_subclass: Callable[[torch.Tens
     )
     return model
 
-def int8_dynamic_activation_int4_weight(group_size=32):
+def int8_dynamic_activation_int4_weight(groupsize=32):
     """Applies int8 dynamic per token asymmetric activation quantization and int4 per group weight symmetric quantization to linear
     This is used to produce a model for executorch backend, but currently executorch did not
     support lowering for the quantized model from this flow yet
 
     Args:
-        `group_size`: parameter for quantization, controls the granularity of quantization, smaller
+        `groupsize`: parameter for quantization, controls the granularity of quantization, smaller
          size is more fine grained
     """
     def apply_int8_dynamic_activation_int4_weight_quant(weight):
@@ -320,7 +320,7 @@ def int8_dynamic_activation_int4_weight(group_size=32):
 
         # weight settings
         mapping_type = MappingType.SYMMETRIC
-        block_size = (1, group_size)
+        block_size = (1, groupsize)
         target_dtype = torch.int8
         eps = torch.finfo(torch.float32).eps
         quant_min = -8
@@ -347,13 +347,13 @@ def int8_dynamic_activation_int4_weight(group_size=32):
     return apply_int8_dynamic_activation_int4_weight_quant
 
 
-def int4_weight_only(group_size=128, inner_k_tiles=8):
+def int4_weight_only(groupsize=128, inner_k_tiles=8):
     """
     Applies uint4 weight-only asymmetric per-group quantization to linear layers, using
     "tensor_core_tiled" layout for speedup with tinygemm kernel
 
     Args:
-        `group_size`: parameter for quantization, controls the granularity of quantization, smaller
+        `groupsize`: parameter for quantization, controls the granularity of quantization, smaller
          size is more fine grained, choices are [256, 128, 64, 32]
         `inner_k_tiles`: parameter for int4 mm kernel, choices are [8, 4, 2]
     """
@@ -362,7 +362,7 @@ def int4_weight_only(group_size=128, inner_k_tiles=8):
         from torchao.dtypes import to_affine_quantized
 
         mapping_type = MappingType.ASYMMETRIC
-        block_size = (1, group_size)
+        block_size = (1, groupsize)
         target_dtype = torch.int32
         quant_min = 0
         quant_max = 15

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -417,10 +417,10 @@ def get_group_qparams_symmetric(w, n_bit=4, groupsize=128, precision=torch.float
 def group_quantize_tensor_symmetric(
     w,
     n_bit=4,
-    group_size=128,
+    groupsize=128,
     precision=torch.float32,
 ):
-    scales, zeros = get_group_qparams_symmetric(w, n_bit, group_size, precision)
+    scales, zeros = get_group_qparams_symmetric(w, n_bit, groupsize, precision)
     n_bit = 4
     max_int = 2 ** (n_bit - 1) - 1
     min_int = -(2 ** (n_bit - 1))
@@ -428,7 +428,7 @@ def group_quantize_tensor_symmetric(
     # add torch.int4 to core later
     from torchao._executorch_ops import _quantized_decomposed_quantize_per_channel_group_wrapper
     w_int8 = _quantized_decomposed_quantize_per_channel_group_wrapper(
-        w, scales, zeros, min_int, max_int, torch.int8, group_size
+        w, scales, zeros, min_int, max_int, torch.int8, groupsize
     )
 
     return w_int8, scales, zeros

--- a/tutorials/quantize_vit/bfloat16_code.py
+++ b/tutorials/quantize_vit/bfloat16_code.py
@@ -693,9 +693,9 @@ def triton_(in_ptr0, arg_A, arg_B, out_ptr0):
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)

--- a/tutorials/quantize_vit/quant_code.py
+++ b/tutorials/quantize_vit/quant_code.py
@@ -458,9 +458,9 @@ def triton_(arg_A, arg_B, in_ptr2, out_ptr0):
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -669,9 +669,9 @@ def triton_(arg_A, arg_B, in_ptr2, out_ptr0):
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -862,9 +862,9 @@ def triton_(arg_A, arg_B, in_ptr2, out_ptr0):
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
@@ -1226,9 +1226,9 @@ def triton_(arg_A, arg_B, in_ptr2, in_ptr3, in_ptr4, out_ptr1):
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
-    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (pid % group_size)
-    pid_n = (pid % width) // (group_size)
+    groupsize = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % groupsize)
+    pid_n = (pid % width) // (groupsize)
 
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)


### PR DESCRIPTION
Summary:

half of the apis used groupsize and half used group_size, swapping them all to groupsize

Test Plan:

python eval.py -q int8wo --limit 1
wikitext: {'word_perplexity,none': 12.204889603121593, 'byte_perplexity,none': 1.5965674184201175, 'bits_per_byte,none': 0.6749734750293632, 'alias': 'wikitext'}

python generate.py --quantization int4wo-64
Average tokens/sec: 13.93
Average Bandwidth: 52.04 GB/s
Peak Memory Usage: 15.92 GB
Model Size: 3.74 GB

Reviewers:

Subscribers:

Tasks:

Tags: