### PR TITLE
Add decorator for custom op and inductor decomp registration

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -13,6 +13,7 @@ __all__ = [
     "skip_if_compute_capability_less_than",
     "benchmark_torch_function_in_microseconds",
     "find_multiple",
+    "_register_custom_op",
     "get_model_size_in_bytes",
     "unwrap_tensor_subclass",
     "TORCH_VERSION_AFTER_2_2",
@@ -65,7 +66,7 @@ def skip_if_compute_capability_less_than(min_capability):
 
 def benchmark_torch_function_in_microseconds(f, *args, **kwargs):
     import torch.utils.benchmark as benchmark # this avoids importing numpy when torchao module is loaded
-    
+
     # Manual warmup
     f(*args, **kwargs)
     f(*args, **kwargs)
@@ -83,6 +84,55 @@ def find_multiple(n: int, *args: Tuple[int]) -> int:
     if n % k == 0:
         return n
     return n + k - (n % k)
+
+def _register_custom_op(lib):
+    """This decorator is used to preserve some high level operators for torch.export.export
+    while still allow them to be decomposed for inductor path
+
+    requirement: make sure `fn.__name__[1:]` is the operator name you want to register
+
+    NOTE: This should be applied at the top, after all other decorators have been applied
+    NOTE: We haven't tested the case when `fn` accepts tensor subclass instance as input,
+    e.g. uint4 tensor subclass instance, and we'll probably need to figure out what would make
+    sense for downstream system (like executorch) to accept as well
+
+    Example:
+        lib = torch.library.Library("my_namespace', "FRAGMENT")
+
+        register_custom_op = _register_custom_op(lib)
+
+        @register_custom_op
+        def _the_op_that_needs_to_be_preserved(...)
+            ...
+
+        # after this, `_the_op_that_needs_to_be_preserved` will be preserved as
+        # torch.ops.my_namespace.the_op_that_needs_to_be_preserved operator after
+        # torch.export.export / torch._export.capture_pre_autograd_graph
+
+    """
+    from torch._inductor.decomposition import register_decomposition
+
+    def decorator(fn):
+        if TORCH_VERSION_AFTER_2_5:
+            from torch._library.infer_schema import infer_schema
+
+            # expecting fn.__name__ starts with `_` and we want to take the rest
+            # to be the name of the custom op
+            assert fn.__name__[0] == "_", f"Expecting function name starts with `_`, got {fn.__name__}"
+            assert not any(c in fn.__name__ for c in ".<>"), f"Expecting op to be defined in normal functions, not lambda or local: {fn.__name__}"
+            op_name = fn.__name__[1:]
+            schema = op_name + infer_schema(fn)
+            lib.define(schema)
+            lib.impl(op_name, fn, "CompositeImplicitAutograd")
+
+            lib_namespace = lib.ns
+            op = getattr(getattr(torch.ops, lib_namespace), op_name)
+            register_decomposition([op])(fn)
+            return op
+        else:
+            return fn
+
+    return decorator
 
 def get_model_size_in_bytes(model, ignore_embeddings=False):
     """


### PR DESCRIPTION
Summary:
This PR adds a decorator to register custom op and also an inductor dcomposition.

The goal is for torch.export path to be able to see high level ops like quantize_affine instead of breaking down the op, this is because some backends like xnnpack wants to work with these higher level ops.

This is a redo for https://github.com/pytorch/ao/pull/408, difference is we can preserve the enums on the python side in this PR

Test Plan:
regression tests:
python test/quantization/test_quant_api.py
python test/integration/test_integration.py

also need to check performance with python tutorials/quantize_vit/run_vit_b_quant.py

Reviewers:

Subscribers:

Tasks:

Tags: