### PR TITLE
Some missing fixes left from previous PRs

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -480,6 +480,10 @@ class TensorCoreTiledAQTLayout(AQTLayout):
         self.scale_and_zero = fn(self.scale_and_zero)
         return self
 
+    def __repr__(self):
+        int_data, scale, zero_point = self.get_plain()
+        return f"TensorCoreTiledAQTLayout(int_data={int_data}, scale={scale}, zero_point={zero_point})"
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs):
         kwargs = {} if kwargs is None else kwargs

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -310,13 +310,6 @@ def quantize(model: torch.nn.Module, apply_tensor_subclass: Callable[[torch.Tens
     """
     if set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
-    if isinstance(apply_tensor_subclass, str):
-        if apply_tensor_subclass not in _APPLY_TS_TABLE:
-            raise ValueError(f"{apply_tensor_subclass} not supported: {_APPLY_TS_TABLE.keys()}")
-        apply_tensor_subclass = _APPLY_TS_TABLE[apply_tensor_subclass]
-
-    assert not isinstance(apply_tensor_subclass, str)
-
     _replace_with_custom_fn_if_matches_filter(
         model,
         _get_linear_subclass_inserter(apply_tensor_subclass),


### PR DESCRIPTION
Summary:
* added repr for TensorCoreTiledAQTLayoutTensor: https://github.com/pytorch/ao/pull/397, this is landed in fbcode but not in OSS
* removed the str -> apply_tensor_class map that was used to implement string APIs, which is removed in https://github.com/pytorch/ao/pull/400

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: