### PR TITLE
Change print() to logging in Quantizer so that the caller can have control

### DIFF
--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -960,7 +960,7 @@ class Int8DynActInt4WeightQuantizer(Quantizer):
                 out_features = mod.out_features
                 in_features = mod.in_features
                 # assert out_features % 8 == 0, "require out_features % 8 == 0"
-                print(f"linear: {fqn}, in={in_features}, out={out_features}")
+                logging.info(f"linear: {fqn}, in={in_features}, out={out_features}")
 
                 assert (
                     in_features % self.groupsize == 0
@@ -971,11 +971,11 @@ class Int8DynActInt4WeightQuantizer(Quantizer):
                     if self.padding_allowed:
                         from .utils import find_multiple
                         import torch.nn.functional as F
-                        print(f"warning: {fqn} is padded to satisfy in_features % 1024 == 0")
+                        logging.warn(f"warning: {fqn} is padded to satisfy in_features % 1024 == 0")
                         padded_in_features = find_multiple(in_features, 1024)
                         weight = F.pad(weight, pad=(0, padded_in_features - in_features))
                     else:
-                        print(f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, " +
+                        logging.warn(f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, " +
                               "and that groupsize and inner_k_tiles*16 evenly divide into it")
                         continue
                 (

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -621,7 +621,7 @@ class Int4WeightOnlyQuantizer(Quantizer):
                 out_features = mod.out_features
                 in_features = mod.in_features
                 # assert out_features % 8 == 0, "require out_features % 8 == 0"
-                print(f"linear: {fqn}, in={in_features}, out={out_features}")
+                logging.info(f"linear: {fqn}, in={in_features}, out={out_features}")
 
                 assert (
                     in_features % self.groupsize == 0
@@ -634,11 +634,11 @@ class Int4WeightOnlyQuantizer(Quantizer):
                     if self.padding_allowed:
                         from .utils import find_multiple
                         import torch.nn.functional as F
-                        print(f"warning: {fqn} is padded to satisfy in_features % 1024 == 0")
+                        logging.warn(f"warning: {fqn} is padded to satisfy in_features % 1024 == 0")
                         padded_in_features = find_multiple(in_features, 1024)
                         weight = F.pad(weight, pad=(0, padded_in_features - in_features))
                     else:
-                        print(f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, " +
+                        logging.warn(f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, " +
                                 "and that groupsize and inner_k_tiles*16 evenly divide into it")
                         continue
                 (


### PR DESCRIPTION
For `Int4WeightOnlyQuantizer` users, we should allow them to choose whether to print the logging or not. Currently the following logs are printed unconditionally:

```
linear: layers.0.attention.wq, in=4096, out=4096
linear: layers.0.attention.wk, in=4096, out=4096
...
```