### PR TITLE
[i will merge] Upgrade pytorch version to 3.9

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -59,7 +59,7 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
-        conda create -n venv python=3.8 -y
+        conda create -n venv python=3.11 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -59,7 +59,7 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
-        conda create -n venv python=3.11 -y
+        conda create -n venv python=3.10 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -59,7 +59,7 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
-        conda create -n venv python=3.10 -y
+        conda create -n venv python=3.9 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
         yum install -y  devtoolset-10-binutils

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A key design principle for us is composability as in any new dtype or layout we 
 
 `torchao` makes liberal use of several new features in Pytorch, it's recommended to use it with the current nightly or latest stable version of PyTorch.
 
-Our minimum supported Python version is 3.11
+Our minimum supported Python version is 3.10
 
 #### Install torch
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ A key design principle for us is composability as in any new dtype or layout we 
 
 `torchao` makes liberal use of several new features in Pytorch, it's recommended to use it with the current nightly or latest stable version of PyTorch.
 
+Our minimum supported Python version is 3.11
+
 #### Install torch
 
 Install torch stable

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A key design principle for us is composability as in any new dtype or layout we 
 
 `torchao` makes liberal use of several new features in Pytorch, it's recommended to use it with the current nightly or latest stable version of PyTorch.
 
-Our minimum supported Python version is 3.10
+Our minimum supported Python version is 3.9 since 3.8 has reached end of life
 
 #### Install torch
 

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -145,8 +145,6 @@ class TestOptim(TestCase):
     def test_optim_fp8_smoke(self, optim_name, device):
         if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
             pytest.skip("FP8 requires compute capability >= 8.9")
-        if device == "cpu" and not TORCH_VERSION_AFTER_2_4:
-            pytest.skip("fill_cpu not implemented for 'Float8_e4m3fn")
 
         model = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
         optim = getattr(low_bit_optim, optim_name)(model.parameters())

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -145,6 +145,8 @@ class TestOptim(TestCase):
     def test_optim_fp8_smoke(self, optim_name, device):
         if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
             pytest.skip("FP8 requires compute capability >= 8.9")
+        if device == "cpu" and not TORCH_VERSION_AFTER_2_4:
+            pytest.skip("fill_cpu not implemented for 'Float8_e4m3fn")
 
         model = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
         optim = getattr(low_bit_optim, optim_name)(model.parameters())


### PR DESCRIPTION
We're trying to upgrade from 3.8 to a more modern Python version  to use some newer features like
* https://medium.com/@aniscampos/python-dataclass-inheritance-finally-686eaf60fbb5 in 3.10
* and StrEnum in 3.11

3.8 is reaching EOL imminently so we must upgrade to at least 3.9 https://devguide.python.org/versions/ 

If we were to do what PyTorch does we'd simply upgrade to 3.9 and try to avoid using 3.10+ features https://github.com/pytorch/rfcs/pull/65

**Upgrading to 3.9**
This also works and is probably the least controversial thing to merge

**Upgrading to 3.10**
This just works, CI is green so we can merge this PR as is

**Upgrading to 3.11**
This made the dora optimizer crash - cc @jeromeku  in case you're interested

```
  FAILED test/dora/test_dora_fusion.py::test_dora_column_norm[4096x4096x16-False-True-True-True-torch.float32] - AttributeError: 'CudaDriver' object has no attribute 'active'
  FAILED test/dora/test_dora_fusion.py::test_dora_column_norm[4096x4096x16-False-True-True-True-torch.float16] - AttributeError: 'CudaDriver' object has no attribute 'active'
  FAILED test/dora/test_dora_fusion.py::test_dora_column_norm[4096x4096x16-False-True-True-True-torch.bfloat16] - AttributeError: 'CudaDriver' object has no attribute 'active'
  FAILED test/dora/test_dora_fusion.py::test_dora_matmul[512x4096x4096-torch.float32-True-True] - triton.compiler.errors.CompilationError: at 69:29:            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
              a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
              b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
          if AB_DTYPE is not None:
              a = a.to(AB_DTYPE)
              b = b.to(AB_DTYPE)
          if fp8_fast_accum:
              acc = tl.dot(
                  a, b, acc, out_dtype=acc_dtype, input_precision=input_precision
              )
          else:
              acc += tl.dot(a, b, out_dtype=acc_dtype, input_precision=input_precision)
                               ^
  TypeError("dot() got an unexpected keyword argument 'input_precision'")
  FAILED test/dora/test_dora_fusion.py::test_dora_matmul[512x4096x4096-torch.float16-True-True] - triton.compiler.errors.CompilationError: at 69:29:            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
              a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
              b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
          if AB_DTYPE is not None:
              a = a.to(AB_DTYPE)
              b = b.to(AB_DTYPE)
          if fp8_fast_accum:
              acc = tl.dot(
                  a, b, acc, out_dtype=acc_dtype, input_precision=input_precision
              )
          else:
              acc += tl.dot(a, b, out_dtype=acc_dtype, input_precision=input_precision)
                               ^
  TypeError("dot() got an unexpected keyword argument 'input_precision'")
  FAILED test/dora/test_dora_fusion.py::test_dora_matmul[512x4096x4096-torch.bfloat16-True-True] - triton.compiler.errors.CompilationError: at 69:29:            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
              a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
              b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
          if AB_DTYPE is not None:
              a = a.to(AB_DTYPE)
              b = b.to(AB_DTYPE)
          if fp8_fast_accum:
              acc = tl.dot(
                  a, b, acc, out_dtype=acc_dtype, input_precision=input_precision
              )
          else:
              acc += tl.dot(a, b, out_dtype=acc_dtype, input_precision=input_precision)
                               ^
  TypeError("dot() got an unexpected keyword argument 'input_precision'")
```