### PR TITLE
Remove sparse test collection warning

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -145,8 +145,6 @@ class TestOptim(TestCase):
     def test_optim_fp8_smoke(self, optim_name, device):
         if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
             pytest.skip("FP8 requires compute capability >= 8.9")
-        if device == "cpu" and not TORCH_VERSION_AFTER_2_4:
-            pytest.skip("fill_cpu not implemented for 'Float8_e4m3fn")
 
         model = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
         optim = getattr(low_bit_optim, optim_name)(model.parameters())

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -145,6 +145,8 @@ class TestOptim(TestCase):
     def test_optim_fp8_smoke(self, optim_name, device):
         if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
             pytest.skip("FP8 requires compute capability >= 8.9")
+        if device == "cpu" and not TORCH_VERSION_AFTER_2_4:
+            pytest.skip("fill_cpu not implemented for 'Float8_e4m3fn")
 
         model = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
         optim = getattr(low_bit_optim, optim_name)(model.parameters())

--- a/test/sparsity/test_fast_sparse_training.py
+++ b/test/sparsity/test_fast_sparse_training.py
@@ -14,7 +14,7 @@ from torchao.sparsity.training import (
 )
 from torchao.utils import TORCH_VERSION_AFTER_2_4, is_fbcode
 
-class TestModel(nn.Module):
+class ToyModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear1 = nn.Linear(128, 256, bias=False)
@@ -36,7 +36,7 @@ class TestRuntimeSemiStructuredSparsity(TestCase):
         from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
         input = torch.rand((128, 128)).half().cuda()
         grad = torch.rand((128, 128)).half().cuda()
-        model = TestModel().half().cuda()
+        model = ToyModel().half().cuda()
         model_c = copy.deepcopy(model)
 
         for name, mod in model.named_modules():
@@ -77,7 +77,7 @@ class TestRuntimeSemiStructuredSparsity(TestCase):
         from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
         input = torch.rand((128, 128)).half().cuda()
         grad = torch.rand((128, 128)).half().cuda()
-        model = TestModel().half().cuda()
+        model = ToyModel().half().cuda()
         model_c = copy.deepcopy(model)
 
         for name, mod in model.named_modules():


### PR DESCRIPTION
Renamed the model from TestModel to ToyModel this is because pytest will by default try to collect any classes that start with the name Test

So this removes this warning

```
  test/sparsity/test_fast_sparse_training.py:17
    /pytorch/ao/test/sparsity/test_fast_sparse_training.py:17: PytestCollectionWarning: cannot collect test class 'TestModel' because it has a __init__ constructor (from: test/sparsity/test_fast_sparse_training.py)
      class TestModel(nn.Module):
```