### PR TITLE
Low-bit optim support for DTensor [to be closed]

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -169,7 +169,7 @@ class TestFSDP2(FSDPTest):
 
     @pytest.mark.skipif(not TORCH_VERSION_AFTER_2_4, reason="torch >= 2.4 required")
     @skip_if_lt_x_gpu(2)
-    def test_qlora_fsdp2(self):
+    def test_fsdp2(self):
         from torch.distributed._composable.fsdp import CPUOffloadPolicy, OffloadPolicy
 
         self.run_subtests(

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -177,18 +177,14 @@ class TestFSDP2(FSDPTest):
                 "enable_activation_checkpointing": [False, True],
                 "offload_policy": [
                     OffloadPolicy(),
-                    CPUOffloadPolicy(pin_memory=True),
-                    CPUOffloadPolicy(pin_memory=False),
+                    # CPUOffloadPolicy(pin_memory=True),
+                    # CPUOffloadPolicy(pin_memory=False),
                 ],
             },
             self._test_fsdp2,
         )
 
-    def _test_fsdp2(
-        self,
-        enable_activation_checkpointing: bool,
-        offload_policy: "OffloadPolicy",
-    ):
+    def _test_fsdp2(self, enable_activation_checkpointing, offload_policy):
         from torch.distributed._composable.fsdp import fully_shard
         from torch.testing._internal.distributed._tensor.common_dtensor import (
             ModelArgs,

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -226,7 +226,7 @@ class TestFSDP2(FSDPTest):
                 if isinstance(m, TransformerBlock):
                     fully_shard(m, **fsdp_kwargs)
         fully_shard(fsdp_model, **fsdp_kwargs)
-        fsdp_optim = torch.optim.AdamW(fsdp_model.parameters(), lr=1e-2)
+        fsdp_optim = low_bit_optim.Adam8bit(fsdp_model.parameters(), lr=1e-2)
 
         torch.manual_seed(42 + self.rank + 1)
         for iter_idx in range(5):

--- a/torchao/prototype/low_bit_optim/adam.py
+++ b/torchao/prototype/low_bit_optim/adam.py
@@ -50,12 +50,13 @@ class _Adam(Optimizer):
                     raise RuntimeError("Sparse gradient is not supported")
 
                 # unwrap DTensor
+                # set requires_grad for unwrapped param to avoid torch.compile() recompilation 
                 if isinstance(p, DTensor):
                     p = p._local_tensor.requires_grad_(True)
                 if isinstance(grad, DTensor):
                     grad = grad._local_tensor
 
-                # flatten p and grad so that torch.compile won't recompile for tensors with different ndim
+                # flatten p and grad to avoid torch.compile() recompilation
                 p = p.view(-1)
                 grad = grad.view(-1)
                 state = self.state[p]

--- a/torchao/prototype/low_bit_optim/adam.py
+++ b/torchao/prototype/low_bit_optim/adam.py
@@ -56,18 +56,16 @@ class _Adam(Optimizer):
                 if isinstance(grad, DTensor):
                     grad = grad._local_tensor
 
-                # flatten p and grad to avoid torch.compile() recompilation
-                p = p.view(-1)
-                grad = grad.view(-1)
                 state = self.state[p]
 
                 # State initialization
+                # flatten buffer to avoid torch.compile() recompilation
                 if len(state) == 0:
                     state["step"] = torch.tensor(0.0, device=p.device)
-                    state["exp_avg"] = self._new_buffer(p, True, self.block_size)
-                    state["exp_avg_sq"] = self._new_buffer(p, False, self.block_size)
+                    state["exp_avg"] = self._new_buffer(p.view(-1), True, self.block_size)
+                    state["exp_avg_sq"] = self._new_buffer(p.view(-1), False, self.block_size)
                     if group["amsgrad"]:
-                        state["max_exp_avg_sq"] = self._new_buffer(p, False, self.block_size)
+                        state["max_exp_avg_sq"] = self._new_buffer(p.view(-1), False, self.block_size)
 
                 state["step"] += 1
 
@@ -77,9 +75,10 @@ class _Adam(Optimizer):
                 if not isinstance(group["lr"], Tensor):
                     group["lr"] = torch.tensor(group["lr"], device=p.device)
 
+                # flatten p and grad to avoid torch.compile() recompilation
                 single_param_adam(
-                    p,
-                    grad,
+                    p.view(-1),
+                    grad.view(-1),
                     state["step"],
                     state["exp_avg"],
                     state["exp_avg_sq"],

--- a/torchao/prototype/low_bit_optim/adamw.py
+++ b/torchao/prototype/low_bit_optim/adamw.py
@@ -3,6 +3,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 from torch.optim import Optimizer
+from torch.distributed._tensor import DTensor
 
 from .subclass_8bit import maybe_new_8bit_zero_buffer
 from .subclass_4bit import maybe_new_4bit_zero_buffer
@@ -48,16 +49,25 @@ class _AdamW(Optimizer):
                 if grad.is_sparse:
                     raise RuntimeError("Sparse gradient is not supported")
 
+                # unwrap DTensor
+                # set requires_grad for unwrapped param to avoid torch.compile() recompilation 
+                if isinstance(p, DTensor):
+                    p = p._local_tensor.requires_grad_(True)
+                if isinstance(grad, DTensor):
+                    grad = grad._local_tensor
+
+                # flatten p and grad to avoid torch.compile() recompilation
+                p = p.view(-1)
+                grad = grad.view(-1)
                 state = self.state[p]
 
                 # State initialization
-                # state is flattened so that torch.compile won't recompile for tensors with different ndim
                 if len(state) == 0:
                     state["step"] = torch.tensor(0.0, device=p.device)
-                    state["exp_avg"] = self._new_buffer(p.view(-1), True, self.block_size)
-                    state["exp_avg_sq"] = self._new_buffer(p.view(-1), False, self.block_size)
+                    state["exp_avg"] = self._new_buffer(p, True, self.block_size)
+                    state["exp_avg_sq"] = self._new_buffer(p, False, self.block_size)
                     if group["amsgrad"]:
-                        state["max_exp_avg_sq"] = self._new_buffer(p.view(-1), False, self.block_size)
+                        state["max_exp_avg_sq"] = self._new_buffer(p, False, self.block_size)
 
                 state["step"] += 1
 
@@ -67,7 +77,6 @@ class _AdamW(Optimizer):
                 if not isinstance(group["lr"], Tensor):
                     group["lr"] = torch.tensor(group["lr"], device=p.device)
 
-                # flatten p and grad so that torch.compile won't recompile for tensors with different ndim
                 single_param_adamw(
                     p.view(-1),
                     grad.view(-1),

--- a/torchao/prototype/low_bit_optim/subclass_8bit.py
+++ b/torchao/prototype/low_bit_optim/subclass_8bit.py
@@ -1,6 +1,5 @@
 import torch
 from torch import Tensor
-
 from torchao.dtypes.utils import _implements, _ATEN_OP_OR_TORCH_FN_TABLE
 
 

--- a/torchao/prototype/low_bit_optim/subclass_8bit.py
+++ b/torchao/prototype/low_bit_optim/subclass_8bit.py
@@ -1,5 +1,7 @@
 import torch
 from torch import Tensor
+from torch.utils._python_dispatch import return_and_correct_aliasing
+
 from torchao.dtypes.utils import _implements, _ATEN_OP_OR_TORCH_FN_TABLE
 
 
@@ -157,6 +159,14 @@ class OptimState8bit(Tensor):
             f"shape={tuple(self.shape)}, device={self.device}, requires_grad={self.requires_grad})"
         )
 
+    def _apply_fn_to_data(self, fn, *args, **kwargs):
+        return self.__class__(
+            fn(self.codes, *args, **kwargs),
+            fn(self.scale, *args, **kwargs),
+            fn(self.qmap, *args, **kwargs),
+            self.signed,
+        )
+
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs):
         if func in _ATEN_OP_OR_TORCH_FN_TABLE[cls]:
@@ -191,6 +201,50 @@ def _(func, *args, **kwargs):
 def _(func, *args, **kwargs):
     args = [x.dequantize() if isinstance(x, OptimState8bit) else x for x in args]
     return func(*args, **kwargs)
+
+
+# the following ops are required for FSDP
+@OptimState8bit.implements(aten._to_copy.default)
+def _(func, *args, **kwargs):
+    # ignore dtype and layout
+    kwargs.pop("dtype")  
+    kwargs.pop("layout")
+    return args[0]._apply_fn_to_data(func, **kwargs)
+
+
+@OptimState8bit.implements(aten.detach.default)
+def _(func, *args, **kwargs):
+    return return_and_correct_aliasing(func, args, kwargs, args[0]._apply_fn_to_data(torch.detach))
+
+
+@OptimState8bit.implements(aten.split.Tensor)
+def _(func, *args, **kwargs):
+    tensor: OptimState8bit = args[0]
+    split_size = args[1]
+    dim = args[2] if len(args) >= 3 else 0
+
+    assert dim == 0  # only support splitting dim=0
+    assert isinstance(split_size, int)  # don't support list
+    assert tensor.numel() % split_size == 0
+
+    codes_list = torch.split(tensor.codes, split_size, dim)
+    scale_list = torch.split(tensor.scale, split_size, dim)
+
+    outputs = []
+    for codes, scale in zip(codes_list, scale_list):
+        outputs.append(OptimState8bit(codes, scale, tensor.qmap.clone(), tensor.signed))
+    return tuple(outputs)
+
+
+@OptimState8bit.implements(aten.empty_like.default)
+def _(func, *args, **kwargs):
+    tensor: OptimState8bit = args[0]
+    return OptimState8bit(
+        torch.empty_like(tensor.codes),
+        torch.empty_like(tensor.scale),
+        tensor.qmap.clone(),
+        tensor.signed,
+    )
 
 
 # follow bitsandbytes


### PR DESCRIPTION
I only opened this so it's easy to see the diff. Refer to #484

@awgu @wanchaol @weifengpy

If I don't `.view(-1)` to the DTensor, I will hit cache size limit. A min repro shows that torch.compile cannot generate dynamic kernel for the sharded dimension?

```python
# Modified from https://github.com/pytorch/pytorch/tree/main/torch/distributed/_tensor
# to run this file (i.e. dtensor_example.py):
# TORCH_LOGS="recompiles" torchrun --standalone --nnodes=1 --nproc-per-node=4 dtensor_example.py
import os
import torch
from torch.distributed._tensor import init_device_mesh, Shard, distribute_tensor, _dtensor_init_helper

# Create a mesh topology with the available devices:
# 1. We can directly create the mesh using elastic launcher, (recommended)
# 2. If using mp.spawn, one need to initialize the world process_group first and set device
#   i.e. torch.distributed.init_process_group(backend="nccl", world_size=world_size)

@torch.compile(fullgraph=True, dynamic=True)
def f(x):
    return torch.sin(x) + torch.cos(x)

mesh = init_device_mesh("cuda", (int(os.environ["WORLD_SIZE"]),))

for shape in [(1024, 2048), (2048, 1024)]:
    big_tensor = torch.randn(shape)

    # Shard this tensor over the mesh by sharding `big_tensor`'s 0th dimension over the 0th dimension of `mesh`.
    my_dtensor = distribute_tensor(big_tensor, mesh, [Shard(dim=0)])
    f(my_dtensor)
```

```
[rank0]: torch/_dynamo/guards.py:2584] [0/1] [__recompiles] Recompiling function f in /home/ubuntu/code/ao/debug.py:12
[rank0]: torch/_dynamo/guards.py:2584] [0/1] [__recompiles]     triggered by the following guard failure(s):
[rank0]: torch/_dynamo/guards.py:2584] [0/1] [__recompiles]     - tensor 'L['x']' size mismatch at index 0. expected 1024, actual 2048
```

If I add `.view(-1)`, torch compile will throw the following error

> AssertionError: s8 (could be from ["L['grad']._base._local_tensor.size()[0]"]) not in {s3: ["L['exp_avg']._local_tensor.scale.size()[0]", "L['exp_avg']._local_tensor.scale.size()[0]", "L['exp_avg']._local_tensor.scale.size()[0]", "L['exp_avg']._local_tensor.scale.size()[0]", "L['exp_avg']._local_tensor.scale.size()[0]"], s4: ["L['exp_avg']._local_tensor.qmap.size()[0]", "L['exp_avg']._local_tensor.qmap.size()[0]", "L['exp_avg']._local_tensor.qmap.size()[0]", "L['exp_avg']._local_tensor.qmap.size()[0]", "L['exp_avg']._local_tensor.qmap.size()[0]", "L['exp_avg_sq']._local_tensor.qmap.size()[0]", "L['exp_avg_sq']._local_tensor.qmap.size()[0]", "L['exp_avg_sq']._local_tensor.qmap.size()[0]", "L['exp_avg_sq']._local_tensor.qmap.size()[0]", "L['exp_avg_sq']._local_tensor.qmap.size()[0]"], s12: ["L['grad']._local_tensor.size()[0]", "L['grad']._local_tensor.size()[0]"], s10: ["L['grad']._local_tensor.storage_offset()", "L['grad']._local_tensor.storage_offset()"], s16: ["L['exp_avg_sq']._local_tensor.scale.size()[0]", "L['exp_avg_sq']._local_tensor.scale.size()[0]", "L['exp_avg_sq']._local_tensor.scale.size()[0]", "L['exp_avg_sq']._local_tensor.scale.size()[0]", "L['exp_avg_sq']._local_tensor.scale.size()[0]"], s23: ["L['p']._local_tensor.size()[0]", "L['p']._local_tensor.size()[0]"]}.  If this assert is failing, it could be due to the issue described in https://github.com/pytorch/pytorch/pull/90665

I'm seeing 2 ways to solve this (with optim state being DTensor)
1. Just increase cache size limit (and don't do `.view(-1)`)
2. Unwrap all DTensor before calling adam step

cc @msaroufim @janeyx99 