### PR TITLE
Fix failing uint4 test

### DIFF
--- a/test/dtypes/test_uint4.py
+++ b/test/dtypes/test_uint4.py
@@ -4,18 +4,13 @@ from torchao.dtypes.uint4 import (
     PerChannelSymmetricWeightUInt4Tensor,
 )
 import unittest
-from unittest import TestCase, main
 from torch.ao.quantization.quantize_pt2e import prepare_pt2e, convert_pt2e
 from torch.ao.quantization.quantizer import QuantizationSpec, Quantizer
 
 from torch._export import capture_pre_autograd_graph
-from torch._export import dynamic_dim
 from torch.testing._internal.common_quantization import (
     NodeSpec as ns,
     QuantizationTestCase,
-)
-from torchao.quantization.utils import (
-    compute_error,
 )
 from torchao.quantization.quant_api import (
     _replace_with_custom_fn_if_matches_filter,
@@ -30,7 +25,6 @@ from torch.ao.quantization.quantizer import (
     QuantizationAnnotation,
 )
 import copy
-from packaging import version
 
 
 def _apply_weight_only_uint4_quant(model):
@@ -229,4 +223,4 @@ class TestUInt4(QuantizationTestCase):
         )
 
 if __name__ == "__main__":
-    main()
+    unittest.main()


### PR DESCRIPTION
torch nightly CI is failing with the following error

```
  test/dtypes/test_uint4.py:12: in <module>
      from torch._export import dynamic_dim
  E   ImportError: cannot import name 'dynamic_dim' from 'torch._export' (/opt/conda/envs/venv/lib/python3.9/site-packages/torch/_export/__init__.py)
```

Turns out `dynamic_dim` is not used by the test, hence can be removed. I also remove other unused imports.

New error is due to this: https://github.com/pytorch/pytorch/pull/129940. `_convert_weight_to_int4pack` inputs should be uint8 now. @jerryzh168 do you want to handle it instead? I'm not too familiar with that part of the code, afraid to break things. Might need to update the custom unpack kernel by @jeromeku also.