### PR TITLE
Shardest tests

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -22,50 +22,36 @@ jobs:
       matrix:
         include:
           - name: CUDA 2.2.2
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.2.2'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
+            runner: linux.g5.12xlarge.nvidia.gpu
+            torch_spec: 'torch==2.2.2'
+            marker: ""
           - name: CUDA 2.3
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.3.0'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
-          - name: CUDA Nightly
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: '--pre torch==2.5.0.dev20240709+cu121 --index-url https://download.pytorch.org/whl/nightly/cu121'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
+            runner: linux.g5.12xlarge.nvidia.gpu
+            torch_spec: 'torch==2.3.0'
+            marker: ""
           - name: CPU 2.2.2
-            runs-on: linux.4xlarge
-            torch-spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
+            runner: linux.4xlarge
+            torch_spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu'
+            marker: ""
           - name: CPU 2.3
-            runs-on: linux.4xlarge
-            torch-spec: 'torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
+            runner: linux.4xlarge
+            torch_spec: 'torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu'
+            marker: ""
           - name: CPU Nightly
-            runs-on: linux.4xlarge
-            torch-spec: '--pre torch==2.5.0.dev20240709+cpu --index-url https://download.pytorch.org/whl/nightly/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
+            runner: linux.4xlarge
+            torch_spec: '--pre torch==2.5.0.dev20240709+cpu --index-url https://download.pytorch.org/whl/nightly/cpu'
+            marker: ""
+          - name: CUDA Nightly Part 1
+            runner: linux.g5.12xlarge.nvidia.gpu
+            torch_spec: '--pre torch==2.5.0.dev20240709+cu121 --index-url https://download.pytorch.org/whl/nightly/cu121'
+            marker: "group1"
+          - name: CUDA Nightly Part 2
+            runner: linux.g5.12xlarge.nvidia.gpu
+            torch_spec: '--pre torch==2.5.0.dev20240709+cu121 --index-url https://download.pytorch.org/whl/nightly/cu121'
+            marker: "group2"
 
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: ./.github/workflows/reusable_test.yml
     with:
-      timeout: 60
-      runner: ${{ matrix.runs-on }}
-      gpu-arch-type: ${{ matrix.gpu-arch-type }}
-      gpu-arch-version: ${{ matrix.gpu-arch-version }}
-      script: |
-        conda create -n venv python=3.9 -y
-        conda activate venv
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
-        python -m pip install --upgrade pip
-        pip install ${{ matrix.torch-spec }}
-        pip install -r dev-requirements.txt
-        pip install .
-        pytest test --verbose -s
+      runner: ${{ matrix.runner }}
+      torch_spec: ${{ matrix.torch_spec }}
+      marker: ${{ matrix.marker }}

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -1,0 +1,38 @@
+# .github/workflows/reusable_test.yml
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      marker:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      torch_spec:
+        required: true
+        type: string
+
+jobs:
+  run-tests:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          conda create -n venv python=3.9 -y
+          conda activate venv
+          echo "::group::Install newer objcopy that supports --set-section-alignment"
+          yum install -y  devtoolset-10-binutils
+          export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+          python -m pip install --upgrade pip
+          pip install ${{ inputs.torch_spec }}
+          pip install -r dev-requirements.txt
+          pip install .
+      - name: Run tests
+        run: pytest test --verbose -s -m ${{ inputs.marker }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+# pytest.ini
+[pytest]
+markers =
+    group1: Tests in group 1
+    group2: Tests in group 2

--- a/test/dora/test_dora_fusion.py
+++ b/test/dora/test_dora_fusion.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import sys
 
 import pytest

--- a/test/dora/test_dora_layer.py
+++ b/test/dora/test_dora_layer.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import sys
 
 import pytest

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,

--- a/test/dtypes/test_bitnet.py
+++ b/test/dtypes/test_bitnet.py
@@ -1,4 +1,7 @@
 import pytest
+pytestmark = pytest.mark.group1
+
+import pytest
 import torch
 import torch.nn as nn
 from torchao.prototype.dtypes import BitnetTensor

--- a/test/dtypes/test_fp8.py
+++ b/test/dtypes/test_fp8.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import os
 import unittest
 import torch

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import copy
 import logging
 import unittest

--- a/test/dtypes/test_uint2.py
+++ b/test/dtypes/test_uint2.py
@@ -1,4 +1,7 @@
 import pytest
+pytestmark = pytest.mark.group1
+
+import pytest
 import torch
 import torch.nn as nn
 from torchao.prototype.dtypes import UInt2Tensor

--- a/test/dtypes/test_uint4.py
+++ b/test/dtypes/test_uint4.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import torch
 from torchao.dtypes.uint4 import (
     UInt4Tensor,

--- a/test/galore/memory_analysis_utils.py
+++ b/test/galore/memory_analysis_utils.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 from functools import partial
 
 import pandas as pd

--- a/test/galore/model_configs.py
+++ b/test/galore/model_configs.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 # LLAMA100M = {
 #     "architectures": ["LLaMAForCausalLM"],
 #     "attention_bias": False,

--- a/test/galore/profile_memory_usage.py
+++ b/test/galore/profile_memory_usage.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import argparse
 import contextlib
 import logging

--- a/test/galore/profiling_utils.py
+++ b/test/galore/profiling_utils.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import gc
 import logging
 import os

--- a/test/hqq/test_triton_mm.py
+++ b/test/hqq/test_triton_mm.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 # Skip entire test if following module not available, otherwise CI failure
 import pytest
 

--- a/test/hqq/test_triton_qkv_fused.py
+++ b/test/hqq/test_triton_qkv_fused.py
@@ -1,4 +1,7 @@
 import pytest
+pytestmark = pytest.mark.group1
+
+import pytest
 
 triton = pytest.importorskip(
     "triton", minversion="3.0.0", reason="Triton > 3.0.0 required to run this test"

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/kernel/galore_test_utils.py
+++ b/test/kernel/galore_test_utils.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import torch
 
 from torchao.prototype.galore.kernels.adam_downproj_fused import fused_adam_mm_launcher

--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/kernel/test_fused_kernels.py
+++ b/test/kernel/test_fused_kernels.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group1
+
 import itertools
 
 import pytest

--- a/test/kernel/test_galore_downproj.py
+++ b/test/kernel/test_galore_downproj.py
@@ -1,4 +1,7 @@
 import pytest
+pytestmark = pytest.mark.group1
+
+import pytest
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:

--- a/test/mark.py
+++ b/test/mark.py
@@ -1,0 +1,92 @@
+import os
+
+# List of all test files
+files = [
+    "./dora/test_dora_fusion.py",
+    "./dora/test_dora_layer.py",
+    "./dtypes/test_affine_quantized.py",
+    "./dtypes/test_nf4.py",
+    "./dtypes/test_bitnet.py",
+    "./dtypes/test_fp8.py",
+    "./dtypes/test_uint2.py",
+    "./dtypes/test_uint4.py",
+    "./galore/README.md",
+    "./galore/memory_analysis_utils.py",
+    "./galore/model_configs.py",
+    "./galore/profile_memory_usage.py",
+    "./galore/profiling_utils.py",
+    "./hqq/test_triton_mm.py",
+    "./hqq/test_triton_qkv_fused.py",
+    "./integration/test_integration.py",
+    "./kernel/galore_test_utils.py",
+    "./kernel/test_autotuner.py",
+    "./kernel/test_fused_kernels.py",
+    "./kernel/test_galore_downproj.py",
+    "./prototype/mx_formats/test_custom_cast.py",
+    "./prototype/mx_formats/test_mx_linear.py",
+    "./prototype/mx_formats/test_mx_tensor.py",
+    "./prototype/test_bitpacking_gen.py",
+    "./prototype/test_quant_llm.py",
+    "./prototype/test_bitpacking.py",
+    "./prototype/test_low_bit_optim.py",
+    "./quantization/test_galore_quant.py",
+    "./quantization/test_qat.py",
+    "./quantization/test_quant_api.py",
+    "./quantization/test_quant_primitives.py",
+    "./smoke_tests/smoke_tests.py",
+    "./sparsity/test_parametrization.py",
+    "./sparsity/test_scheduler.py",
+    "./sparsity/test_sparsifier.py",
+    "./sparsity/test_sparsity_utils.py",
+    "./sparsity/test_structured_sparsifier.py",
+    "./sparsity/test_wanda.py",
+    "./sparsity/test_fast_sparse_training.py",
+    "./sparsity/test_sparse_api.py",
+    "./test_ops.py"
+]
+
+# Split the files into two groups
+mid_point = len(files) // 2
+group1 = files[:mid_point]
+group2 = files[mid_point:]
+
+# Function to add pytestmark to a file
+def add_pytestmark(file_path, marker):
+    if not file_path.endswith('.py'):
+        return
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    pytestmark_line = f'pytestmark = pytest.mark.{marker}\n'
+    import_pytest_line = 'import pytest\n'
+
+    if 'import pytest' not in content:
+        content = import_pytest_line + pytestmark_line + content
+    else:
+        if 'pytestmark' not in content:
+            lines = content.split('\n')
+            for i, line in enumerate(lines):
+                if 'import pytest' in line:
+                    lines.insert(i + 1, pytestmark_line)
+                    break
+            content = '\n'.join(lines)
+        else:
+            lines = content.split('\n')
+            for i, line in enumerate(lines):
+                if 'pytestmark' in line:
+                    lines[i] = pytestmark_line
+                    break
+            content = '\n'.join(lines)
+
+    with open(file_path, 'w') as f:
+        f.write(content)
+
+# Add pytestmark to each group of files
+for file in group1:
+    add_pytestmark(file, 'group1')
+
+for file in group2:
+    add_pytestmark(file, 'group2')
+
+print(f"Group 1 files: {group1}")
+print(f"Group 2 files: {group2}")

--- a/test/prototype/mx_formats/test_custom_cast.py
+++ b/test/prototype/mx_formats/test_custom_cast.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/prototype/test_bitpacking.py
+++ b/test/prototype/test_bitpacking.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import torch
 from torchao.prototype.common.bitpacking import pack, unpack
 import pytest

--- a/test/prototype/test_bitpacking_gen.py
+++ b/test/prototype/test_bitpacking_gen.py
@@ -1,4 +1,7 @@
 import pytest
+pytestmark = pytest.mark.group2
+
+import pytest
 import torch
 
 from torchao.prototype.dtypes.uintgen import (

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import copy
 
 import pytest

--- a/test/prototype/test_quant_llm.py
+++ b/test/prototype/test_quant_llm.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import copy
 
 import pytest

--- a/test/quantization/test_galore_quant.py
+++ b/test/quantization/test_galore_quant.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import itertools
 
 import pytest

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 

--- a/test/smoke_tests/smoke_tests.py
+++ b/test/smoke_tests/smoke_tests.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 """Run smoke tests"""
 
 import torchao

--- a/test/sparsity/test_fast_sparse_training.py
+++ b/test/sparsity/test_fast_sparse_training.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import logging
 import unittest
 import copy

--- a/test/sparsity/test_parametrization.py
+++ b/test/sparsity/test_parametrization.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import logging
 import torch
 import unittest

--- a/test/sparsity/test_scheduler.py
+++ b/test/sparsity/test_scheduler.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import warnings
 import unittest
 

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import logging
 import unittest
 

--- a/test/sparsity/test_sparsifier.py
+++ b/test/sparsity/test_sparsifier.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Owner(s): ["module: unknown"]
 
 import itertools

--- a/test/sparsity/test_sparsity_utils.py
+++ b/test/sparsity/test_sparsity_utils.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import logging
 import unittest
 

--- a/test/sparsity/test_structured_sparsifier.py
+++ b/test/sparsity/test_structured_sparsifier.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 # Owner(s): ["module: unknown"]
 import copy
 import logging

--- a/test/sparsity/test_wanda.py
+++ b/test/sparsity/test_wanda.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import logging
 import unittest
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.group2
+
 import itertools
 
 import torchao


### PR DESCRIPTION
Today our nightly CUDA regression tests take twice as long as other tests to run. This PR specifically shards tests into 1 of two buckets that way when we launch a nightly cuda job we can launch half the tests on each shard.