### PR TITLE
Parallel test with pytest-xdist

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,5 +68,5 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s -m "not multi_gpu" --dist loadfile --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
+        pytest test --verbose -s -m "not multi_gpu" --dist loadscope --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
         pytest test --verbose -s -m "multi_gpu"

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,5 +68,5 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s -m "not multi_gpu" --dist loadscope --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
+        pytest test --verbose -s -m "not multi_gpu" --dist loadfile --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
         pytest test --verbose -s -m "multi_gpu"

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,4 +68,5 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0,1 --tx popen//env:CUDA_VISIBLE_DEVICES=2,3
+        pytest test --verbose -s -m "not multi_gpu" --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
+        pytest test --verbose -s -m "multi_gpu"

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,4 +68,4 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s
+        pytest test --verbose -s --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0,1 --tx popen//env:CUDA_VISIBLE_DEVICES=2,3

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,5 +68,5 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s -m "not multi_gpu" --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
+        pytest test --verbose -s -m "not multi_gpu" --dist loadfile --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
         pytest test --verbose -s -m "multi_gpu"

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -68,5 +68,5 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install .
-        pytest test --verbose -s -m "not multi_gpu" --dist loadfile --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
+        pytest test --verbose -s -m "not multi_gpu" --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0 --tx popen//env:CUDA_VISIBLE_DEVICES=1 --tx popen//env:CUDA_VISIBLE_DEVICES=2 --tx popen//env:CUDA_VISIBLE_DEVICES=3
         pytest test --verbose -s -m "multi_gpu"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ transformers
 hypothesis # Avoid test derandomization warning
 sentencepiece # for gpt-fast tokenizer
 expecttest
+pytest-xdist
 
 # For prototype features and benchmarks
 bitsandbytes #needed for testing triton quant / dequant ops for 8-bit optimizers

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    multi_gpu: marks tests as require multi GPUs (deselect with '-m "not multi_gpu"')

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -486,6 +486,7 @@ class TestQLoRA(FSDPTest):
     def world_size(self) -> int:
         return 2
 
+    @pytest.mark.multi_gpu
     @pytest.mark.skipif(
         version.parse(torch.__version__).base_version < "2.4.0",
         reason="torch >= 2.4 required",

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -985,7 +985,10 @@ class TestSaveLoadMeta(unittest.TestCase):
         # save quantized state_dict
         api(model)
 
-        torch.save(model.state_dict(), "test.pth")
+        # unique filename to avoid collision in parallel tests
+        ckpt_name = f"{api.__name__}_{test_device}_{test_dtype}_test.pth"
+
+        torch.save(model.state_dict(), ckpt_name)
         # get quantized reference
         model_qc = torch.compile(model, mode="max-autotune")
         ref_q = model_qc(x).detach()
@@ -998,8 +1001,8 @@ class TestSaveLoadMeta(unittest.TestCase):
         api(model)
 
         # load quantized state_dict
-        state_dict = torch.load("test.pth", mmap=True)
-        os.remove("test.pth")
+        state_dict = torch.load(ckpt_name, mmap=True)
+        os.remove(ckpt_name)
 
         model.load_state_dict(state_dict, assign=True)
         model = model.to(device=test_device, dtype=test_dtype).eval()

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -163,6 +163,7 @@ class TestFSDP2(FSDPTest):
     def world_size(self) -> int:
         return 2
 
+    @pytest.mark.multi_gpu
     @pytest.mark.skipif(not TORCH_VERSION_AFTER_2_4, reason="torch >= 2.4 required")
     @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):


### PR DESCRIPTION
Currently this PR creates 2 workers, each with 2 GPUs

> pytest test --verbose -s --dist load --tx popen//env:CUDA_VISIBLE_DEVICES=0,1 --tx popen//env:CUDA_VISIBLE_DEVICES=2,3

I think only FSDP tests require 2 GPUs

https://github.com/pytorch/ao/blob/4f53882c6dfaf42daad8ca01595f44fe6d51e69c/test/dtypes/test_nf4.py#L484-L494

https://github.com/pytorch/ao/blob/4f53882c6dfaf42daad8ca01595f44fe6d51e69c/test/prototype/test_low_bit_optim.py#L161-L168

Thus, CI runtime can be further improved by 
1. Mark these tests as "require 2 GPUs"
2. Run the remaining tests with 4 workers, each with 1 GPU
3. Run the 2-GPU tests in a separate step. Can either be 2 workers with 2 GPUs each, or just normal, non-parallel pytest since there are not a lot of 2-GPU tests right now. 

UPDATE: parallel tests with 4 1-GPU workers + sequential multi-GPU tests is implemented now. Some problems I encountered along the way (for future reference and improvement). pytest-xdist provides multiple methods to distribute work across workers. Refer to [here](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) for the full list. I have tried the following
  - `--dist load` (send each test to next available worker):
    - `TestSaveLoadMeta` use the same filename `test.pth` which is problematic when multiple tests write/read the same file. I made a unique name for each test to solve it for now, though the better way is to use pytest `tmp_path` fixture (not compatible with `unittest.TestCase`).
    - `test_quant_llm_quantize_ebits_2_mbits_2` gets a strange torch.compile warning in PyTorch 2.3 only `torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py:436] [0/48] failed to eagerly compile backwards for dynamic, suppressing in case backwards not needed`. Looks harmless though.
  - `--dist loadscope` (send a TestClass to next available worker):
    - `TestSaveLoadMeta` gets a strange error - `RuntimeError: Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent forward run. Stack trace: [Could not find stack trace]. To prevent overwriting, clone the tensor outside of torch.compile() or call torch.compiler.cudagraph_mark_step_begin() before each model invocation.`. No traceback. Since tests within a class are run by the same worker, there shouldn't be filename conflict `test.py`. Perhaps some strange interaction between how pytest-xdist sends test to the subprocess worker and CUDA graphs + torch.compile?
  - `--dist loadfile` (send each file to next available worker): this should be the least error-prone. However, there is little speedup (24min vs 35min) since `test_integration.py` file is huge -> load imbalance (probably a good idea to split this into smaller files anyway).

The current approach of this PR is using `--dist load`. To summarize

Approach | CUDA nightly CI time
-----|-----
pytest sequential (baseline) | 35min
pytest-xdist with two 2-GPU workers (this PR, original) | 21min
pytest-xdist with four 1-GPU workers + sequential multi-GPU tests (this PR, latest) | 19min

I also notice that it takes 3min to pull the Docker image and another 3-4min to download and install packages. So it seems like two 2-GPU workers have pretty good scaling (7 + 14 vs 7 + 28), while four 1-GPU workers is not much of an improvement (7 + 12 vs 7 + 28). I guess the 2-GPU FSDP tests can be run in parallel too for the latest configuration.