### PR TITLE
Fix the impl for `to` for int4 weight only use case

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -544,7 +544,7 @@ class TensorCoreTiledAQTLayout(AQTLayout):
     def to(self, *args, **kwargs):
         kwargs = self._get_to_kwargs(*args, **kwargs)
         device = kwargs["device"]
-        if device != "cuda" or (isinstance(device, torch.device) and device.type != "cuda"):
+        if device != "cuda" and (isinstance(device, torch.device) and device.type != "cuda"):
             raise ValueError(f"TensorCoreTiledAQTLayout is only available for cuda device, can't convert to {device}")
         return self.__class__(
             self.packed_weight.to(device),


### PR DESCRIPTION
Summary:
Note that we can do the following right now:
* initialize and quantize the model with int4_weight_only quant in cpu
* move the model to cuda

we'll enable this in a separate PR

Test Plan:
python test/quantization/test_quant_api.py -k test_int4wo_quantized_model_to_device
Reviewers:

Subscribers:

Tasks:

Tags: