### PR TITLE
Refactor QAT to use common fake_quantize_affine primitive

### DIFF
--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -3,7 +3,7 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -475,3 +475,10 @@ def recommended_inductor_config_setter():
     torch._inductor.config.fx_graph_cache = True
     torch._inductor.config.triton.unique_kernel_names = True
     torch.set_float32_matmul_precision("high")
+
+def _get_per_token_block_size(x: torch.Tensor) -> List[int]:
+    block_size = []
+    for i in range(len(x.shape)-1):
+        block_size.append(1)
+    block_size.append(x.shape[-1])
+    return block_size


### PR DESCRIPTION
Summary: Currently there are two QAT quantizers, 8da4w and 4w. Today, these use different autograd functions to represent their fake quantization numerics, but this is not scalable because new QAT quantizers may introduce yet another divergent code path. To address this, this commit refactors both quantizers to use the common fake_quantize_affine QAT primitive.

Test Plan:
python test/quantization/test_qat.py

Reviewers: jerryzh168

Subscribers: jerryzh168, supriyar, msaroufim