### PR TITLE
[int8 woq] make the scale type the same as input for bf16 autocast

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -730,17 +730,15 @@ def _quantized_linear_op(input_tensor, weight_qtensor, bias):
             w_vals_int8_t = weight_qtensor.layout_tensor.int_data.t()
             scale = weight_qtensor.layout_tensor.scale
             orig_dtype = input_tensor.dtype
-            y = (
-                torch.mm(
+            m = torch.mm(
                     input_tensor.reshape(-1, input_tensor.shape[-1]),
                     w_vals_int8_t.to(input_tensor.dtype),
                 )
-                * scale
-            )
+            y = m * scale.to(m.dtype)
             y = y.reshape(*input_tensor.shape[:-1], y.shape[-1])
             if bias is not None:
-                y += bias
-            return y.to(orig_dtype)
+                y += bias.to(m.dtype)
+            return y
 
             # is_cpu and is_mps only, some issue with is_contiguous() currently
             # return torch.ops.aten._weight_int8pack_mm(input_tensor.contiguous(), w_vals_int8_t, weight_qtensor.layout_tensor.scale)


### PR DESCRIPTION
Under bf16 autocast, input's type would convert from fp32 to bf16 because of torch.mm. However, scale's type is still fp32, so as the final output. To fix the issue, we make scale's type the same as the output of torch.mm, to get a bf16 scale.

FX graph before:
```
permute_2: "i8[4096, 4096]" = torch.ops.aten.permute.default(arg68_1, [1, 0]);  arg68_1 = None
view_3: "f32[128, 4096]" = torch.ops.aten.view.default(mul_1, [-1, 4096])
convert_element_type_default_190: "bf16[4096, 4096]" = torch.ops.prims.convert_element_type.default(permute_2, torch.bfloat16);  permute_2 = None
convert_element_type_7: "bf16[128, 4096]" = torch.ops.prims.convert_element_type.default(view_3, torch.bfloat16);  view_3 = None
mm_1: "bf16[128, 4096]" = torch.ops.aten.mm.default(convert_element_type_7, convert_element_type_default_190);  convert_element_type_7 = convert_element_type_default_190 = None
mul_3: "f32[128, 4096]" = torch.ops.aten.mul.Tensor(mm_1, arg69_1);  mm_1 = arg69_1 = None
view_4: "f32[4, 32, 4096]" = torch.ops.aten.view.default(mul_3, [4, 32, 4096]);  mul_3 = None
```

FX graph after:
```
permute_2: "i8[4096, 4096]" = torch.ops.aten.permute.default(arg68_1, [1, 0]);  arg68_1 = None
view_3: "f32[128, 4096]" = torch.ops.aten.view.default(mul_1, [-1, 4096])
convert_element_type_default_158: "bf16[4096, 4096]" = torch.ops.prims.convert_element_type.default(permute_2, torch.bfloat16);  permute_2 = None
convert_element_type_8: "bf16[128, 4096]" = torch.ops.prims.convert_element_type.default(view_3, torch.bfloat16);  view_3 = None
mm_1: "bf16[128, 4096]" = torch.ops.aten.mm.default(convert_element_type_8, convert_element_type_default_158);  convert_element_type_8 = convert_element_type_default_158 = None
convert_element_type_11: "bf16[4096]" = torch.ops.prims.convert_element_type.default(arg69_1, torch.bfloat16);  arg69_1 = None
mul_3: "bf16[128, 4096]" = torch.ops.aten.mul.Tensor(mm_1, convert_element_type_11);  mm_1 = convert_element_type_11 = None
view_4: "bf16[4, 32, 4096]" = torch.ops.aten.view.default(mul_3, [4, 32, 4096]);  mul_3 = None
```