### PR TITLE
Fixing cuda device check

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -21,6 +21,7 @@ from torchao.dtypes.utils import (
     _register_layout_cls,
     _get_layout_tensor_constructor,
     LayoutType,
+    is_device,
 )
 from typing import ClassVar
 from dataclasses import dataclass
@@ -544,7 +545,7 @@ class TensorCoreTiledAQTLayout(AQTLayout):
     def to(self, *args, **kwargs):
         kwargs = self._get_to_kwargs(*args, **kwargs)
         device = kwargs["device"]
-        if device != "cuda" and (isinstance(device, torch.device) and device.type != "cuda"):
+        if not is_device("cuda", device):
             raise ValueError(f"TensorCoreTiledAQTLayout is only available for cuda device, can't convert to {device}")
         return self.__class__(
             self.packed_weight.to(device),

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Dict, Callable
+from typing import Dict, Callable, Union
 from collections import defaultdict
 import functools
 from dataclasses import dataclass
@@ -89,3 +89,6 @@ def _get_layout_tensor_constructor(cls: Callable, layout_type_class: type(Layout
         raise ValueError(f"layout_name: {layout_type_class} is not supported yet for {cls}")
 
     return _LAYOUT_CONSTRUCTOR_TABLE[cls][layout_type_class]
+
+def is_device(target_device_str: str, device: Union[str, torch.device]):
+    return torch.device(device).type == target_device_str


### PR DESCRIPTION
Summary:
Previous cuda device check is not general enough, this adds a better check that works for more cases like "cuda:0"

Test Plan:
python test/quantization/test_quant_api.py -k test_int4wo_quantized_model_to_device

(local test with `pip install torch==2.5.0.dev20240630 --extra-index-url https://download.pytorch.org/whl/nightly/cu121`)

Reviewers:

Subscribers:

Tasks:

Tags: