### PR TITLE
[test] Fix regression tests

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name: CUDA 2.2.2
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.2.2'
+            torch-spec: 'torch==2.2.2 numpy<2'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
           - name: CUDA 2.3

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name: CUDA 2.2.2
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.2.2 numpy==1.26'
+            torch-spec: 'torch==2.2.2 "numpy<2" '
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
           - name: CUDA 2.3
@@ -38,7 +38,7 @@ jobs:
             gpu-arch-version: "12.1"
           - name: CPU 2.2.2
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu numpy==1.26'
+            torch-spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu "numpy<2" '
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
           - name: CPU 2.3

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name: CUDA 2.2.2
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.2.2 numpy<2'
+            torch-spec: 'torch==2.2.2 numpy==1.26'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
           - name: CUDA 2.3
@@ -38,7 +38,7 @@ jobs:
             gpu-arch-version: "12.1"
           - name: CPU 2.2.2
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu'
+            torch-spec: 'torch==2.2.2 --index-url https://download.pytorch.org/whl/cpu numpy==1.26'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
           - name: CPU 2.3


### PR DESCRIPTION
Summary:

Torch 2.2 is compiled with numpy 1.x, but when we `pip install -r requirements-dev.txt` we download a higher version of numpy (2.0)

This causes an error with the .numpy() calls and importing torch in general. I don't think we want to pin the versions in requirements-dev.txt, so instead I pinned the numpy version when we pin the torch version, so it'll only run for 2.2.

PT 2.3+ support numpy 2.0+ which is why those test don't fail.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: