### PR TITLE
Add git version suffix to package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,18 @@
 import os
 import glob
 from datetime import datetime
+import subprocess
 
 from setuptools import find_packages, setup
 
 current_date = datetime.now().strftime("%Y.%m.%d")
+
+
+def get_git_commit_id():
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+    except Exception:
+        return ""
 
 def read_requirements(file_path):
     with open(file_path, "r") as file:
@@ -21,7 +29,12 @@ def read_version(file_path="version.txt"):
 
 # Determine the package name based on the presence of an environment variable
 package_name = "torchao-nightly" if os.environ.get("TORCHAO_NIGHTLY") else "torchao"
-version_suffix = os.getenv("VERSION_SUFFIX", "")
+
+# Use Git commit ID if VERSION_SUFFIX is not set
+version_suffix = os.getenv("VERSION_SUFFIX")
+if version_suffix is None:
+    version_suffix = f"+{get_git_commit_id()}"
+
 use_cpp = os.getenv('USE_CPP')
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ package_name = "torchao-nightly" if os.environ.get("TORCHAO_NIGHTLY") else "torc
 # Use Git commit ID if VERSION_SUFFIX is not set
 version_suffix = os.getenv("VERSION_SUFFIX")
 if version_suffix is None:
-    version_suffix = f"+{get_git_commit_id()}"
+    version_suffix = f"+git{get_git_commit_id()}"
 
 use_cpp = os.getenv('USE_CPP')
 


### PR DESCRIPTION
fixes https://github.com/pytorch/ao/issues/546 

## Problem
It's not clear when you install ao looking at the version number if it was installed from source or not

## This PR
We add the latest commit ID of the current branch to the name. So you can unambiguously tell if ao is installed from source or not by checking if there's a `+git` in the name

I'm not sure if this breaks internal in some mysterious way and I think this is safe as far as naming official binaries go

## Proof
```
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/git)]$ USE_CPP=0 pip install .
Processing /home/marksaroufim/ao
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: torchao
  Building wheel for torchao (setup.py) ... done
  Created wheel for torchao: filename=torchao-0.3.1+gitd1c3046-py3-none-any.whl size=245573 sha256=22e3b8d62c8d1eef9486cc267471bfcf138dcd7430b12b4f1e715708e1c01b5b
  Stored in directory: /tmp/pip-ephem-wheel-cache-xwwsb6vd/wheels/98/63/17/f0c8348dc6feec64a509f5107bbf0075300ccb8e8619b8a8b0
Successfully built torchao
Installing collected packages: torchao
  Attempting uninstall: torchao
    Found existing installation: torchao 0.3.1+gitd1c3046
    Uninstalling torchao-0.3.1+gitd1c3046:
      Successfully uninstalled torchao-0.3.1+gitd1c3046
Successfully installed torchao-0.3.1+gitd1c3046
(ao) [marksaroufim@devgpu003.cco3 ~/ao (msaroufim/git)]$ pip show torchao
Name: torchao
Version: 0.3.1+gitd1c3046
```