### PR TITLE
Allow `benchmark_model` to accept args and kwargs

### DIFF
--- a/benchmarks/benchmark_aq.py
+++ b/benchmarks/benchmark_aq.py
@@ -93,15 +93,14 @@ def _bench_quantized_tensor_subclass_perf(api, ref_api, kwargs=None):
     # warmup
     WARMUP = 5
     RUNS = 100
-    input_tensor = example_inputs[0]
     m = torch.compile(m, mode='max-autotune', fullgraph=True)
 
-    benchmark_model(m, WARMUP, input_tensor)
-    elapsed_time = benchmark_model(m, RUNS, input_tensor)
+    benchmark_model(m, WARMUP, example_inputs)
+    elapsed_time = benchmark_model(m, RUNS, example_inputs)
 
     m_ref = torch.compile(m_ref, mode='max-autotune', fullgraph=True)
-    benchmark_model(m_ref, WARMUP, input_tensor)
-    ref_elapsed_time = benchmark_model(m_ref, RUNS, input_tensor)
+    benchmark_model(m_ref, WARMUP, example_inputs)
+    ref_elapsed_time = benchmark_model(m_ref, RUNS, example_inputs)
 
     print(f"elapsed time: {elapsed_time}, ref elapsed time: {ref_elapsed_time}")
     assert elapsed_time < 1.05 * ref_elapsed_time

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1532,7 +1532,7 @@ class TestBenchmarkModel(unittest.TestCase):
         example_inputs = m.example_inputs(dtype=dtype, device=device)
         m_bf16 = torch.compile(m_bf16, mode='max-autotune')
         num_runs = 1
-        return benchmark_model(m_bf16, num_runs, example_inputs[0])
+        return benchmark_model(m_bf16, num_runs, example_inputs)
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_benchmark_model_cuda(self):

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -119,9 +119,9 @@ from torchao.utils import benchmark_model
 
 num_runs = 100
 torch._dynamo.reset()
-bf16_time = benchmark_model(m_bf16, num_runs, example_inputs[0])
+bf16_time = benchmark_model(m_bf16, num_runs, example_inputs)
 print(f"bf16 mean time: {bf16_time}")
-int4_time = benchmark_model(m, num_runs, example_inputs[0])
+int4_time = benchmark_model(m, num_runs, example_inputs)
 print(f"int4 weight only quantized mean time: {int4_time}")
 print(f"speedup: {bf16_time / int4_time}")
 

--- a/tutorials/quantize_vit/run_vit_b.py
+++ b/tutorials/quantize_vit/run_vit_b.py
@@ -11,15 +11,15 @@ model = models.vit_b_16(weights=models.ViT_B_16_Weights.IMAGENET1K_V1)
 model.eval().cuda().to(torch.bfloat16)
 
 # Input tensor (batch_size, channels, height, width)
-input_tensor = torch.randn(1, 3, 224, 224, dtype=torch.bfloat16, device='cuda')
+inputs = (torch.randn(1, 3, 224, 224, dtype=torch.bfloat16, device='cuda'),)
 
 model = torch.compile(model, mode='max-autotune')
 
 # Must run with no_grad when optimizing for inference
 with torch.no_grad():
     # warmup
-    benchmark_model(model, 5, input_tensor)
+    benchmark_model(model, 5, inputs)
     # benchmark
-    print("elapsed_time: ", benchmark_model(model, 100, input_tensor), " milliseconds")
+    print("elapsed_time: ", benchmark_model(model, 100, inputs), " milliseconds")
     # Create a trace
-    profiler_runner("bfloat16.json.gz", benchmark_model, model, 5, input_tensor)
+    profiler_runner("bfloat16.json.gz", benchmark_model, model, 5, inputs)

--- a/tutorials/quantize_vit/run_vit_b_quant.py
+++ b/tutorials/quantize_vit/run_vit_b_quant.py
@@ -12,7 +12,7 @@ model = models.vit_b_16(weights=models.ViT_B_16_Weights.IMAGENET1K_V1)
 model.eval().cuda().to(torch.bfloat16)
 
 # Input tensor (batch_size, channels, height, width)
-input_tensor = torch.randn(1, 3, 224, 224, dtype=torch.bfloat16, device='cuda')
+inputs = (torch.randn(1, 3, 224, 224, dtype=torch.bfloat16, device='cuda'),)
 
 ## Quantization code - start
 # int8 dynamic quantization act, int8 weight, see ao/torchao/quantization/README.md
@@ -39,8 +39,8 @@ model = torch.compile(model, mode='max-autotune')
 # Must run with no_grad when optimizing for inference
 with torch.no_grad():
     # warmup
-    benchmark_model(model, 20, input_tensor)
+    benchmark_model(model, 20, inputs)
     # benchmark
-    print("elapsed_time: ", benchmark_model(model, 1000, input_tensor), " milliseconds")
+    print("elapsed_time: ", benchmark_model(model, 1000, inputs), " milliseconds")
     # Create a trace
-    profiler_runner("quant.json.gz", benchmark_model, model, 5, input_tensor)
+    profiler_runner("quant.json.gz", benchmark_model, model, 5, inputs)


### PR DESCRIPTION
Summary:
Previously it accepts a single input_tensor, changing it to accept args and kwargs

Test Plan:
python test/integration/test_integration.py -k test_benchmark_model_cuda python test/integration/test_integration.py -k test_benchmark_model_cpu Reviewers:

Subscribers:

Tasks:

Tags: