### PR TITLE
Unpin nightly version

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -33,7 +33,7 @@ jobs:
             gpu-arch-version: "12.1"
           - name: CUDA Nightly
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: '--pre torch==2.5.0.dev20240728+cu121 --index-url https://download.pytorch.org/whl/nightly/cu121'
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
           - name: CPU 2.2.2
@@ -48,7 +48,7 @@ jobs:
             gpu-arch-version: ""
           - name: CPU Nightly
             runs-on: linux.4xlarge
-            torch-spec: '--pre torch==2.5.0.dev20240728 --index-url https://download.pytorch.org/whl/nightly/cpu'
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -101,21 +101,24 @@ COMMON_DEVICE_DTYPE = list(itertools.product(COMMON_DEVICES, COMMON_DTYPES)).cop
 def _int8wo_api(mod):
     if TORCH_VERSION_AFTER_2_4:
         quantize_(mod, int8_weight_only(), set_inductor_config=False)
-        unwrap_tensor_subclass(mod)
+        if not TORCH_VERSION_AFTER_2_5:
+            unwrap_tensor_subclass(mod)
     else:
         change_linear_weights_to_int8_woqtensors(mod)
 
 def _int8da_int8w_api(mod):
     if TORCH_VERSION_AFTER_2_4:
         quantize_(mod, int8_dynamic_activation_int8_weight(), set_inductor_config=False)
-        unwrap_tensor_subclass(mod)
+        if not TORCH_VERSION_AFTER_2_5:
+            unwrap_tensor_subclass(mod)
     else:
         change_linear_weights_to_int8_dqtensors(mod)
 
 def _int4wo_api(mod):
     if TORCH_VERSION_AFTER_2_4:
         quantize_(mod, int4_weight_only(), set_inductor_config=False)
-        unwrap_tensor_subclass(mod)
+        if not TORCH_VERSION_AFTER_2_5:
+            unwrap_tensor_subclass(mod)
     else:
         change_linear_weights_to_int4_woqtensors(mod)
 
@@ -853,7 +856,8 @@ class TestSubclass(unittest.TestCase):
                             kwargs_copy["group_size"] = groupsize
                             del kwargs_copy["groupsize"]
                             quantize_(mod, int4_weight_only(**kwargs_copy))
-                            unwrap_tensor_subclass(mod)
+                            if not TORCH_VERSION_AFTER_2_5:
+                                unwrap_tensor_subclass(mod)
                         else:
                             change_linear_weights_to_int4_woqtensors(mod, **kwargs)
 
@@ -985,6 +989,9 @@ class TestSaveLoadMeta(unittest.TestCase):
         # save quantized state_dict
         api(model)
 
+        # make sure the model is still runnable
+        model(x)
+
         torch.save(model.state_dict(), "test.pth")
         # get quantized reference
         model_qc = torch.compile(model, mode="max-autotune")
@@ -1004,7 +1011,9 @@ class TestSaveLoadMeta(unittest.TestCase):
         model.load_state_dict(state_dict, assign=True)
         model = model.to(device=test_device, dtype=test_dtype).eval()
 
-        # get quantized reference
+        # make sure the model is still runnable
+        model(x)
+
         model_qc = torch.compile(model, mode="max-autotune")
         test = model_qc(x).detach()
 
@@ -1013,6 +1022,7 @@ class TestSaveLoadMeta(unittest.TestCase):
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @unittest.skipIf(is_fbcode(), "'PlainAQTLayout' object has no attribute 'int_data'")
+    @unittest.skipIf(TORCH_VERSION_AFTER_2_5, "Can't save local lambda function for tensor subclass")
     @torch.no_grad()
     def test_save_load_dqtensors(self, device, dtype):
         if device == "cpu":

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -18,7 +18,7 @@ from torchao.quantization.quant_api import (
     int8_dynamic_activation_int8_weight,
     quantize_,
 )
-from torchao.utils import TORCH_VERSION_AFTER_2_3, unwrap_tensor_subclass
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 from torch.testing._internal.common_utils import TestCase
 
 

--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -22,6 +22,7 @@ from tokenizer import get_tokenizer
 import time
 from torchao.quantization.GPTQ import Int4WeightOnlyGPTQQuantizer
 from torchao._models.llama.model import prepare_inputs_for_model
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 
 def run_evaluation(
     checkpoint_path: Path,
@@ -88,7 +89,8 @@ def run_evaluation(
             model.setup_caches(max_batch_size=1, max_seq_length=calibration_seq_length)
             model = quantizer.quantize(model, inputs).to(device)
         else:
-            unwrap_tensor_subclass(model)
+            if not TORCH_VERSION_AFTER_2_5:
+                unwrap_tensor_subclass(model)
 
     if compile:
         model = torch.compile(model, mode="max-autotune", fullgraph=True)

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -13,6 +13,7 @@ import torchao
 import torch._dynamo.config
 import torch._inductor.config
 from torchao.utils import get_model_size_in_bytes
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 
 def device_sync(device):
     if "cuda" in device:
@@ -115,7 +116,7 @@ def generate(
             from model import AffineQuantizedKVCache
             from torchao.quantization.quant_api import _replace_with_custom_fn_if_matches_filter
             _replace_with_custom_fn_if_matches_filter(
-                model, 
+                model,
                 AffineQuantizedKVCache.from_float,
                 lambda x, y: isinstance(x, torchao._models.llama.model.KVCache),
             )
@@ -232,7 +233,8 @@ def main(
             # do autoquantization
             model.finalize_autoquant()
         else:
-            unwrap_tensor_subclass(model)
+            if not TORCH_VERSION_AFTER_2_5:
+                unwrap_tensor_subclass(model)
 
     model_size = get_model_size_in_bytes(model, ignore_embeddings=True) / 1e9
 

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -109,8 +109,11 @@ group_size = 32
 quantize_(m, int4_weight_only(group_size=group_size))
 
 # temporary workaround for tensor subclass + torch.compile
+# NOTE: this is only need for torch 2.5+
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 from torchao.utils import unwrap_tensor_subclass
-m = unwrap_tensor_subclass(m)
+if not TORCH_VERSION_AFTER_2_5:
+    unwrap_tensor_subclass(m)
 # compile the model to improve performance
 m = torch.compile(m, mode='max-autotune')
 

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -233,6 +233,7 @@ def _quantize_affine_no_dtype_cast(
     # TODO: validations
     # TODO: validate scale/zero_point dimensions are compatible with block_size
     assert input.dtype in [torch.float32, torch.float16, torch.bfloat16], f"Unsupported input dtype: {input.dtype}"
+    assert len(block_size) == input.dim(), f"Got input dim:{input.dim()}, block_size: {block_size}"
     shape_for_reduction, reduction_dims = _get_reduction_params(block_size, input.size())
     original_shape = input.shape
     input = input.view(shape_for_reduction)
@@ -349,6 +350,7 @@ def _dequantize_affine_no_dtype_check(
     zero_point_domain: str = ZeroPointDomain.INT.name,
     output_dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
+    assert len(block_size) == input.dim(), f"Got input dim:{input.dim()}, block_size: {block_size}"
     shape_for_reduction, reduction_dims = _get_reduction_params(block_size, input.size())
     original_shape = input.shape
     input = input.view(shape_for_reduction)
@@ -589,7 +591,7 @@ def _choose_qparams_affine(
     if zero_point_dtype is None:
         zero_point_dtype = input.dtype
 
-    assert len(block_size) == input.dim()
+    assert len(block_size) == input.dim(), f"Got input dim:{input.dim()}, block_size: {block_size}"
     shape_for_reduction, reduction_dims = _get_reduction_params(block_size, input.size())
     input = input.view(shape_for_reduction)
 

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -129,6 +129,13 @@ def guard_dtype_size(tensor_arg, arg_name, dtype=None, size=None):
     if size is not None and tensor_arg.size() != size:
         raise ValueError(f"Expected Tensor argument {arg_name} to have size {size}, but got {tensor_arg.size()} instead.")
 
+def _get_per_token_block_size(x: torch.Tensor) -> List[int]:
+    block_size = []
+    for _ in range(len(x.shape)-1):
+        block_size.append(1)
+    block_size.append(x.shape[-1])
+    return block_size
+
 # taken from
 # https://github.com/mit-han-lab/smoothquant/blob/2f87951dacfb9238d8d657f52ae83a82a3c9ba0c/smoothquant/fake_quant.py#L26
 # and slightly modified
@@ -492,10 +499,3 @@ def recommended_inductor_config_setter():
     torch._inductor.config.fx_graph_cache = True
     torch._inductor.config.triton.unique_kernel_names = True
     torch.set_float32_matmul_precision("high")
-
-def _get_per_token_block_size(x: torch.Tensor) -> List[int]:
-    block_size = []
-    for i in range(len(x.shape)-1):
-        block_size.append(1)
-    block_size.append(x.shape[-1])
-    return block_size

--- a/tutorials/quantize_vit/run_vit_b_quant.py
+++ b/tutorials/quantize_vit/run_vit_b_quant.py
@@ -31,8 +31,10 @@ torch._inductor.config.use_mixed_mm = True
 ## compilation configs end
 
 # temporary workaround for the API to work with torch.compile
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 from torchao.utils import unwrap_tensor_subclass
-unwrap_tensor_subclass(model)
+if not TORCH_VERSION_AFTER_2_5:
+    unwrap_tensor_subclass(model)
 
 model = torch.compile(model, mode='max-autotune')
 


### PR DESCRIPTION
Summary:
Previously there was some inductor errors so we pinned the nightly version. It should be fixed by https://github.com/pytorch/pytorch/pull/132096 and we now can't use `unwrap_tensor_subclass` before `torch.compile` now.

Test Plan:
fix CI errors

Reviewers:

Subscribers:

Tasks:

Tags: