### PR TITLE
Fix FP6-LLM API and add .to(device) op

### DIFF
--- a/torchao/prototype/quant_llm/quant_llm.py
+++ b/torchao/prototype/quant_llm/quant_llm.py
@@ -10,6 +10,7 @@ from torchao.dtypes.utils import _implements, _dispatch__torch_function__, _disp
 from torchao.quantization.quant_api import _get_linear_subclass_inserter
 
 
+aten = torch.ops.aten
 _ONES_TABLE = [_n_ones(i) for i in range(8)]
 
 
@@ -430,9 +431,25 @@ def _(func, types, args, kwargs):
     return out.view(*act.shape[:-1], out_dim).to(act.dtype)
 
 
-@QuantLlmLinearWeight.implements(torch.ops.aten.detach.default)
+@QuantLlmLinearWeight.implements(aten.detach.default)
 def _(func, types, args, kwargs):
     return return_and_correct_aliasing(func, args, kwargs, args[0]._apply_fn_to_data(torch.detach))
+
+
+@QuantLlmLinearWeight.implements(aten.clone.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(func, args, kwargs, args[0]._apply_fn_to_data(torch.clone))
+
+
+@QuantLlmLinearWeight.implements(aten._to_copy.default)
+def _(func, types, args, kwargs):
+    # only support device kwargs, ignore the rest
+    return return_and_correct_aliasing(
+        func,
+        args,
+        kwargs,
+        args[0]._apply_fn_to_data(lambda x: x.to(device=kwargs.pop("device", None))),
+    )
 
 
 def quant_llm_fpx_weight_only(ebits: int, mbits: int):
@@ -445,4 +462,4 @@ def quant_llm_fpx_weight_only(ebits: int, mbits: int):
 
 
 def fp6_llm_weight_only():
-    return _get_linear_subclass_inserter(quant_llm_fpx_weight_only(3, 2))
+    return quant_llm_fpx_weight_only(3, 2)


### PR DESCRIPTION
Fix a bug introduced in https://github.com/pytorch/ao/pull/542 which breaks fp6_llm_weight_only. Add a test to make sure we won't break the API in the future.

I also added support for .to(device) since it was required to work with CPU model offloading in [diffusers](https://github.com/huggingface/diffusers) (I was playing with [Flux](https://huggingface.co/black-forest-labs/FLUX.1-schnell))