### PR TITLE
update float8 benchmarks to be more useful for smaller shapes

### DIFF
--- a/benchmarks/float8/bench_matmul.py
+++ b/benchmarks/float8/bench_matmul.py
@@ -13,6 +13,8 @@ import torch
 import torch.nn as nn
 import torch.utils.benchmark as benchmark
 
+from utils import get_name_to_shapes_iter
+
 # estimating TOPs for matmuls in fp32, fp16, fp8
 # assuming A * B = C, with A being M * K, B being K * N, C being M * N
 
@@ -46,67 +48,6 @@ def do_benchmarks(tops, peak_tops, f, *args, **kwargs):
     tops_sec = float(tops) / time_sec
     pct_top_peak = tops_sec / peak_tops
     return time_sec, tops_sec, pct_top_peak
-
-
-def get_name_to_shapes_iter(
-    shape_gen_name: str,
-    M: Optional[int],
-    K: Optional[int],
-    N: Optional[int],
-):
-    if shape_gen_name == 'llama':
-        assert M == K == N == None, \
-            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
-        bsz, seq_len = 4, 4096
-        M = bsz * seq_len
-        # LLaMa 2 70B single-node weight shapes
-        # assumes fused attn.wqkv and ffn.w13
-        # source: https://fburl.com/gsheet/g8onr7rh
-        name_to_shapes_70b = {
-            "attn.wqkv": (M, 8192, 1280),
-            "attn.w0": (M, 1024, 8192),
-            "ffn.w13": (M, 8192, 7168),
-            "ffn.w2": (M, 3584, 8192),
-        }
-        return name_to_shapes_70b.items()
-
-    elif shape_gen_name == 'square':
-        assert M == K == N == None, \
-            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
-        name_to_shapes = {}
-        min_power_of_2 = 5  # 32
-        max_power_of_2 = 16  # 65,536
-        for idx, power_of_2 in enumerate(range(min_power_of_2, max_power_of_2 + 1)):
-            val = 2 ** power_of_2
-            name_to_shapes[idx] = val, val, val
-        return name_to_shapes.items()
-
-    elif shape_gen_name == 'sweep':
-        assert M == K == N == None, \
-            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
-        name_to_shapes = {}
-        min_p2 = 5  # 32
-        max_p2 = 16  # 65,536
-        counter = 0
-        for M_p2 in range(min_p2, max_p2 + 1):
-            M = 2 ** M_p2
-            for K_p2 in range(min_p2, max_p2 + 1):
-                K = 2 ** K_p2
-                for N_p2 in range(min_p2, max_p2 + 1):
-                    N = 2 ** N_p2
-                    name_to_shapes[counter] = M, K, N
-                    counter += 1
-        return name_to_shapes.items()
-
-    elif shape_gen_name == 'custom':
-        assert M is not None and K is not None and N is not None, \
-            'M, K, N must be specified for custom shape_gen'
-        name_to_shapes = {
-            1: (M, K, N),
-        }
-        return name_to_shapes.items()
-
-    raise AssertionError(f'unknown shape_gen_name {shape_gen_name}')
 
 
 @torch.inference_mode()

--- a/benchmarks/float8/profile_linear_float8.py
+++ b/benchmarks/float8/profile_linear_float8.py
@@ -210,7 +210,7 @@ def main(
     model_type: str = "linear",
     dtype_filter: str = "both",
 ):
-    assert model_type in ("linear", "ln_linear", "norm_ffn_norm"), "unsupported"
+    assert model_type in ("linear", "ln_linear", "norm_ffn_norm", "norm_ffn_norm_small"), "unsupported"
     assert dtype_filter in ("both", "float8", "bfloat16")
 
     scaling_type_input = ScalingType(scaling_type_input)
@@ -250,8 +250,18 @@ def main(
         input_tensor = torch.randn(
             1, 8192, 4096, device=device, dtype=ref_dtype
         ).requires_grad_()
+    elif model_type == "norm_ffn_norm_small":
+        m_ref = NormFFNResidualNorm(
+            dim=4096,
+            hidden_dim=4096,
+            multiple_of=1024,
+            ffn_dim_multiplier=1.0,
+        )
+        input_tensor = torch.randn(
+            1, 2048, 4096, device=device, dtype=ref_dtype
+        ).requires_grad_()
     else:
-        M, K, N = 4 * 4096, 8192, 7168
+        M, K, N = 4096, 4096, 4096
         m_ref = torch.nn.Sequential(
             torch.nn.Linear(K, N, bias=False),
         )

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -6,6 +6,7 @@
 
 import collections
 import re
+from typing import Optional
 
 
 def profiler_output_to_time_by_kernel_name(prof):
@@ -81,3 +82,64 @@ def parse_bw_and_kernel_name(line):
         return result.group(1), result.group(2)
     else:
         return None, None
+
+
+def get_name_to_shapes_iter(
+    shape_gen_name: str,
+    M: Optional[int],
+    K: Optional[int],
+    N: Optional[int],
+):
+    if shape_gen_name == 'llama':
+        assert M == K == N == None, \
+            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
+        bsz, seq_len = 4, 4096
+        M = bsz * seq_len
+        # LLaMa 2 70B single-node weight shapes
+        # assumes fused attn.wqkv and ffn.w13
+        # source: https://fburl.com/gsheet/g8onr7rh
+        name_to_shapes_70b = {
+            "attn.wqkv": (M, 8192, 1280),
+            "attn.w0": (M, 1024, 8192),
+            "ffn.w13": (M, 8192, 7168),
+            "ffn.w2": (M, 3584, 8192),
+        }
+        return name_to_shapes_70b.items()
+
+    elif shape_gen_name == 'square':
+        assert M == K == N == None, \
+            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
+        name_to_shapes = {}
+        min_power_of_2 = 5  # 32
+        max_power_of_2 = 16  # 65,536
+        for idx, power_of_2 in enumerate(range(min_power_of_2, max_power_of_2 + 1)):
+            val = 2 ** power_of_2
+            name_to_shapes[idx] = val, val, val
+        return name_to_shapes.items()
+
+    elif shape_gen_name == 'sweep':
+        assert M == K == N == None, \
+            f'M, K, N arguments not supported for shape_gen_name {shape_gen_name}'
+        name_to_shapes = {}
+        min_p2 = 5  # 32
+        max_p2 = 16  # 65,536
+        counter = 0
+        for M_p2 in range(min_p2, max_p2 + 1):
+            M = 2 ** M_p2
+            for K_p2 in range(min_p2, max_p2 + 1):
+                K = 2 ** K_p2
+                for N_p2 in range(min_p2, max_p2 + 1):
+                    N = 2 ** N_p2
+                    name_to_shapes[counter] = M, K, N
+                    counter += 1
+        return name_to_shapes.items()
+
+    elif shape_gen_name == 'custom':
+        assert M is not None and K is not None and N is not None, \
+            'M, K, N must be specified for custom shape_gen'
+        name_to_shapes = {
+            1: (M, K, N),
+        }
+        return name_to_shapes.items()
+
+    raise AssertionError(f'unknown shape_gen_name {shape_gen_name}')


### PR DESCRIPTION
Summary:

1. adds ability to select various shape gen strategies to
   `benchmarks/float/bench_matmul.py`
2. adds options to profile smaller building blocks in
   `benchmarks/float8/profile_linear_float8.py`, targeting ~50% GPU time
   between gemms and float8 overhead

This will make it easier to hunt for performance improvements relevant
to small shapes.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: