### PR TITLE
fix version check

### DIFF
--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -9,7 +9,7 @@ from torch.utils._python_dispatch import return_and_correct_aliasing
 from .quant_primitives import (
     safe_int_mm,
 )
-from torchao.utils import TORCH_VERSION_AFTER_2_4
+from torchao.utils import TORCH_VERSION_AFTER_2_3
 from torchao.quantization.utils import quantize_activation_per_token_absmax
 
 import torch.nn.functional as F
@@ -221,7 +221,7 @@ def do_autoquant_bench(op, *args, **kwargs):
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream):
             op(*args, **kwargs)
-        if TORCH_VERSION_AFTER_2_4:
+        if TORCH_VERSION_AFTER_2_3:
             from torch._inductor.runtime.runtime_utils import do_bench_gpu
             res = do_bench_gpu(lambda: graph.replay(), warmup=warmup, rep=rep, return_mode="median")
         else:


### PR DESCRIPTION
The autoquant example was failing before on torch==2.4. I think we forgot to update this line when we were changing the VERSION semantics. 