### PR TITLE
Add support for using AffineQuantizedTensor with `weights_only=True`

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -2,9 +2,16 @@ from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
 )
-from torchao.quantization.quant_api import int4_weight_only
+from torchao.quantization.quant_api import (
+    int4_weight_only,
+    int8_weight_only,
+    int8_dynamic_activation_int4_weight,
+    int8_dynamic_activation_int8_weight,
+    int8_dynamic_activation_int8_semi_sparse_weight,
+)
 import torch
 import unittest
+import tempfile
 from torchao.utils import (
     TORCH_VERSION_AFTER_2_5,
 )
@@ -12,7 +19,6 @@ from torchao.utils import (
 
 class TestAffineQuantized(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    # @unittest.skipIf(TORCH_VERSION_AFTER_2_5, "int4 skipping 2.5+ for now")
     def test_tensor_core_layout_transpose(self):
         l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
         t = l.weight
@@ -30,6 +36,21 @@ class TestAffineQuantized(TestCase):
             shape = t.shape
             aqt_shape = aqt.shape
             self.assertEqual(aqt_shape, shape)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_weights_only(self):
+        for apply_quant in [int4_weight_only(group_size=32), int8_weight_only(), int8_dynamic_activation_int4_weight(), int8_dynamic_activation_int8_weight(), int8_dynamic_activation_int8_semi_sparse_weight()]:
+            l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
+            ql = apply_quant(l)
+            with tempfile.NamedTemporaryFile() as f:
+                torch.save(ql.state_dict(), f)
+                f.seek(0)
+                # `weights_only=True` is enabled for torch 2.5+
+                if TORCH_VERSION_AFTER_2_5:
+                    _ = torch.load(f, weights_only=True)
+                else:
+                    _ = torch.load(f, weights_only=False)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -916,3 +916,7 @@ def _(func, types, args, kwargs):
 
 to_affine_quantized = AffineQuantizedTensor.from_float
 to_affine_quantized_static = AffineQuantizedTensor.from_float_static
+
+if TORCH_VERSION_AFTER_2_5:
+    # Allow a model with AffineQuantizedTensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals([AffineQuantizedTensor])

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -3,6 +3,7 @@ from typing import Dict, Callable, Union
 from collections import defaultdict
 import functools
 from dataclasses import dataclass
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 
 """
 Helper function for implementing aten op or torch function dispatch
@@ -94,7 +95,6 @@ Plain LayoutType, the most basic LayoutType, also has no extra metadata, will ty
 class PlainLayoutType(LayoutType):
     pass
 
-
 """
 layout tensor constructor registration for different tensor subclassesa
 
@@ -117,6 +117,9 @@ def _register_layout_cls(cls: Callable, layout_type_class: type(LayoutType)):
     """
     def decorator(layout_cls):
         _LAYOUT_CONSTRUCTOR_TABLE[cls][layout_type_class] = layout_cls.from_plain
+        if TORCH_VERSION_AFTER_2_5:
+            # Allow serialization to work for models uses this layout tensor subclass
+            torch.serialization.add_safe_globals([layout_type_class, layout_cls])
         return layout_cls
     return decorator
 

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -6,6 +6,7 @@ from torchao.dtypes.utils import (
 )
 from typing import Callable
 from torch.utils._python_dispatch import return_and_correct_aliasing
+from torchao.utils import TORCH_VERSION_AFTER_2_5
 
 __all__ = [
     "LinearActivationQuantizedTensor",
@@ -171,3 +172,7 @@ def _(func, types, args, kwargs):
     )
 
 to_linear_activation_quantized = LinearActivationQuantizedTensor.from_float
+
+if TORCH_VERSION_AFTER_2_5:
+    # Allow a model with LinearActivationQuantizedTensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals([LinearActivationQuantizedTensor])

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -52,6 +52,9 @@ class ZeroPointDomain(Enum):
     INT = auto()
     FLOAT = auto()
 
+if TORCH_VERSION_AFTER_2_5:
+    torch.serialization.add_safe_globals([MappingType, ZeroPointDomain])
+
 """
 Map from dtype to the bound value of integers
 TODO: maybe can replace this with call to torch.iinfo


### PR DESCRIPTION
Summary:
`torch.load(file, weights_only=True)` is safer so ideally we can use that, by default it does not work with tensor subclasses, since now we have https://pytorch.org/docs/main/notes/serialization.html#torch.serialization.add_safe_globals we can add all tensor subclass classes and special types to globals so that these can work with `weights_only=True`

Test Plan:
python test/dtypes/test_affine_quantized.py

Reviewers:

Subscribers:

Tasks:

Tags: