### PR TITLE
skip fsdp2 low bit optim test in nightlies

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -230,7 +230,7 @@ class TestFSDP2(FSDPTest):
         return 2
 
     @pytest.mark.skipif(not TORCH_VERSION_AFTER_2_4, reason="torch >= 2.4 required")
-    @pyest.mark.skipif(TORCH_VERSION_AFTER_2_5, reason="https://github.com/pytorch/ao/issues/652")
+    @pytest.mark.skipif(TORCH_VERSION_AFTER_2_5, reason="https://github.com/pytorch/ao/issues/652")
     @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):
         optim_classes = [low_bit_optim.Adam8bit, low_bit_optim.Adam4bit]

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -230,7 +230,7 @@ class TestFSDP2(FSDPTest):
         return 2
 
     @pytest.mark.skipif(not TORCH_VERSION_AFTER_2_4, reason="torch >= 2.4 required")
-    @pyest.mark.skipif(TORCH_VERSION_AFTER_2.5, reason="https://github.com/pytorch/ao/issues/652")
+    @pyest.mark.skipif(TORCH_VERSION_AFTER_2_5, reason="https://github.com/pytorch/ao/issues/652")
     @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):
         optim_classes = [low_bit_optim.Adam8bit, low_bit_optim.Adam4bit]

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -230,6 +230,7 @@ class TestFSDP2(FSDPTest):
         return 2
 
     @pytest.mark.skipif(not TORCH_VERSION_AFTER_2_4, reason="torch >= 2.4 required")
+    @pyest.mark.skipif(TORCH_VERSION_AFTER_2.5, reason="https://github.com/pytorch/ao/issues/652")
     @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):
         optim_classes = [low_bit_optim.Adam8bit, low_bit_optim.Adam4bit]


### PR DESCRIPTION
Temporary workaround for https://github.com/pytorch/ao/issues/652

I didn't debug this but seems like it's some dynamic shape issue - cc @ezyang @gau-nernst 