### PR TITLE
float8 gemm benchmarks: add option for gpu time

### DIFF
--- a/benchmarks/float8/profile_linear_float8.py
+++ b/benchmarks/float8/profile_linear_float8.py
@@ -360,7 +360,7 @@ def main(
 
     # if the `TORCHINDUCTOR_PROFILE` env var is enabled, parse its output
     # to populate triton kernel bandwidth further down in the script
-    if os.environ.get("TORCHINDUCTOR_PROFILE", "") != "":
+    if os.environ.get("TORCHINDUCTOR_PROFILE", "") == "":
         context = nullcontext()
         f = None 
     else:


### PR DESCRIPTION
Summary:

Adds the option to run bf16 gemm vs float8 gemm benchmark with gpu kernel time instead of e2e time.  This is useful for upcoming work on float8 roofline estimation.

Test Plan:

```
python benchmarks/float8/bench_matmul.py --shape_gen_name square --use_gpu_kernel_time True
// results: https://gist.github.com/vkuzo/2f09182b795fa4156939ad707966d6c3
```

Reviewers:

Subscribers:

Tasks:

Tags: