### PR TITLE
Remove numpy as bitpack dependency

### DIFF
--- a/torchao/dtypes/uintx/bitpacking.py
+++ b/torchao/dtypes/uintx/bitpacking.py
@@ -1,5 +1,4 @@
 import torch
-import numpy as np
 from typing import Optional, List
 from functools import reduce
 


### PR DESCRIPTION
main builds are broken because we are now accidentally dependending on numpy https://github.com/pytorch/ao/commits/main/

AO as of now has no dependencies

Tests seem fine

```
(ao) [marksaroufim@devvm4567.ash0 ~/test/ebs-torchtune (debug)]$ pip list | grep numpy
(ao) [marksaroufim@devvm4567.ash0 ~/test/ebs-torchtune (debug)]$ 
```

```
test_uintx.py ....................................................................................               [100%]

=================================================== warnings summary ===================================================
../../../.conda/envs/ao/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:271
  /home/marksaroufim/.conda/envs/ao/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:271: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at ../torch/csrc/utils/tensor_numpy.cpp:84.)
    cpu = _conversion_method_template(device=torch.device("cpu"))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 84 passed, 1 warning in 291.43s (0:04:51) =======================================
(ao) [marksaroufim@devvm4567.ash0 ~/ao/test/dtypes (main)]$ 
```

