### PR TITLE
Fix source version check

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+from torchao.utils import torch_version_at_least
+
+class TestTorchVersionAtLeast(unittest.TestCase):
+    def test_torch_version_at_least(self):
+        test_cases = [
+            ("2.5.0a0+git9f17037", "2.5.0", True),
+            ("2.5.0a0+git9f17037", "2.4.0", True),
+            ("2.5.0.dev20240708+cu121", "2.5.0", True),
+            ("2.5.0.dev20240708+cu121", "2.4.0", True),
+            ("2.5.0", "2.4.0", True),
+            ("2.5.0", "2.5.0", True),
+            ("2.4.0", "2.4.0", True),
+            ("2.4.0", "2.5.0", False),
+        ]
+
+        for torch_version, compare_version, expected_result in test_cases:
+            with patch('torch.__version__', torch_version):
+                result = torch_version_at_least(compare_version)
+
+                self.assertEqual(result, expected_result, f"Failed for torch.__version__={torch_version}, comparing with {compare_version}")
+                print(f"{torch_version}: {result}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@crcrpar can you try this instead?

Fixes https://github.com/pytorch/ao/pull/679#issuecomment-2290444713

This just basically takes advantage of the fact that every PyTorch version has the format `X.Y.Z` and then some stuff


```python

# Test cases
import torch
from torchao.utils import torch_version_at_least

torch.__version__ = "2.5.0a0+git9f17037"
print(f"{torch.__version__}: {torch_version_at_least('2.5.0')}")  # Should be True
print(f"{torch.__version__}: {torch_version_at_least('2.4.0')}")  # Should be True


torch.__version__ = "2.5.0.dev20240708+cu121"
print(f"{torch.__version__}: {torch_version_at_least('2.5.0')}")  # Should be True
print(f"{torch.__version__}: {torch_version_at_least('2.4.0')}")  # Should be True


torch.__version__ = "2.5.0"
print(f"{torch.__version__}: {torch_version_at_least('2.4.0')}")  # Should be True
print(f"{torch.__version__}: {torch_version_at_least('2.5.0')}")  # Should be True

torch.__version__ = "2.4.0"
print(f"{torch.__version__}: {torch_version_at_least('2.4.0')}")  # Should be True
print(f"{torch.__version__}: {torch_version_at_least('2.5.0')}")  # Should be False

```