### PR TITLE
Scale to fp32 to make sure scaled_mm get float scalar scale input

### DIFF
--- a/torchao/float8/float8_python_api.py
+++ b/torchao/float8/float8_python_api.py
@@ -36,8 +36,8 @@ def addmm_float8_unwrapped(
     as inputs. This is used to standardize the logic between subclassed and non subclassed
     versions of the linear module.
     """
-    a_inverse_scale = a_scale.reciprocal()
-    b_inverse_scale = b_scale.reciprocal()
+    a_inverse_scale = a_scale.float().reciprocal()
+    b_inverse_scale = b_scale.float().reciprocal()
     if output_dtype == torch.float32 and bias is not None:
         # Bias is not supported by _scaled_mm when output is fp32
         output = torch._scaled_mm(


### PR DESCRIPTION
Scale to fp32 to make sure scaled_mm get float scalar scale input. This is helpful if our tensor is loaded with bf16 param type. Otherwise scale will be bf16 causing failure.

Need double check `preprocess_addmm` should extract the fp32 scale ideally