### PR TITLE
Change dispatch key for `_register_custom_op`

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -190,7 +190,7 @@ def _register_custom_op(lib):
             op_name = fn.__name__[1:]
             schema = op_name + infer_schema(fn, mutates_args={})
             lib.define(schema)
-            lib.impl(op_name, fn, "CompositeImplicitAutograd")
+            lib.impl(op_name, fn, "CompositeExplicitAutograd")
 
             lib_namespace = lib.ns
             op = getattr(getattr(torch.ops, lib_namespace), op_name)


### PR DESCRIPTION
Summary:
`_register_custom_op` is a util for the ops to be preserved in torch.export for executorch, but after testing, Max found that the ops are decomposed during to_edge, and it's because of the dispatch key we are using, so we changed it to `CompositeExplicitAutograd` following https://github.com/pytorch/pytorch/blob/86aa327e4afba5b883341ed14d1c9a80e2441aaa/torch/ao/quantization/fx/_decomposed.py#L50

Test Plan:
python test/quantization/test_quant_api.py
python test/integration/test_integration.py

confirmed `python tutorials/quantize_vit/run_vit_b_quant.py` also does not regress:
before:
elapsed_time:  9.0510380859375  milliseconds
after:
elapsed_time:  8.6919443359375  milliseconds

Reviewers:

Subscribers:

Tasks:

Tags: