### PR TITLE
[do not land] profiler not working with torch.compile

### DIFF
--- a/torchao/profiler/device_spec.py
+++ b/torchao/profiler/device_spec.py
@@ -239,6 +239,8 @@ def get_chip_name(device: int = 0) -> str:
         chip = "a6000"
     elif "a100" in chip:
         chip = "a100"
+    elif "pg509-210" in chip:
+        chip = "a100"
     elif "a40" in chip:
         chip = "a40"
     elif "a10g" in chip:


### PR DESCRIPTION
Summary:
Current profiler only supports eager mdoe, putting up the PR so people can repro the issue Right now the best way to do perf analysis is still chrome trace I think

on compile mode:
Before turning on profiler
Average tokens/sec: 107.64
After:
Average tokens/sec: 5.39

Test Plan:
cd torchao/_models/llama
python generate.py --compile

Reviewers:

Subscribers:

Tasks:

Tags: