### PR TITLE
Refactor quant_llm to work with affine quantized tensor

### DIFF
--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -1,16 +1,16 @@
 import torch
 import pandas as pd
 import torch.nn.functional as F
-from torchao.prototype.quant_llm import QuantLlmLinearWeight
+# from torchao.prototype.quant_llm import QuantLlmLinearWeight
+from torchao.dtypes import to_affine_quantized_fpx
+from torchao.dtypes.fpx import FpxTensorCoreAQTLayout, FpxTensorCoreLayoutType
 from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
 
 
 def benchmark(m: int, k: int, n: int):
-    fp6_data = torch.randint(256, size=(n, k * 3 // 4), dtype=torch.uint8, device="cuda")
-    scale = torch.rand(n, dtype=torch.half, device="cuda") + 0.5
-    fp6_weight = QuantLlmLinearWeight(fp6_data, scale, 3, 2)
-
+    float_data = torch.randn(n, k, dtype=torch.half, device="cuda")
+    fp6_weight = to_affine_quantized_fpx(float_data, FpxTensorCoreLayoutType(3, 2))
     fp16_weight = fp6_weight.dequantize(torch.half)
 
     fp16_act = torch.randn(m, k, dtype=torch.half, device="cuda")

--- a/scripts/hf_eval.py
+++ b/scripts/hf_eval.py
@@ -20,6 +20,7 @@ from torchao.quantization import (
     int8_dynamic_activation_int8_weight,
     quantize_,
     autoquant,
+    fpx_weight_only,
 )
 from torchao.sparsity import (
     sparsify_,
@@ -59,6 +60,8 @@ def run_evaluation(repo_id, tasks, limit, device, precision, quantization, spars
     elif quantization == "int4wo":
         # note cannot quantize this model on cpu and run it on cuda at this time
         quantize_(model.to(device=device), int4_weight_only())
+    elif quantization == "fp6":
+        quantize_(model, fpx_weight_only(3, 2))
     elif quantization == "autoquant":
         model = autoquant(model.to(device=device))
 
@@ -79,7 +82,7 @@ def run_evaluation(repo_id, tasks, limit, device, precision, quantization, spars
             return False
         torch.sparse.semi_structured._FORCE_CUTLASS = False
         sparsify_(model, semi_sparse_weight(), filter_fn=all_linear)
-    
+
     if sparsity and compile:
         model = torch.compile(model, mode="max-autotune", fullgraph=True)
 
@@ -111,7 +114,7 @@ if __name__ == '__main__':
     parser.add_argument('--limit', type=int, default=None, help='Number of eval samples to evaluate')
     parser.add_argument('--precision', type=lambda x: getattr(torch, x.split(".")[-1]), default=torch.bfloat16, help='dtype precision to use')
     parser.add_argument('--device', type=str, default="cuda", help='Device to use for evaluation')
-    parser.add_argument('-q', '--quantization', default = "None", choices=["int8dq", "int8wo", "int4wo","autoquant", "None"], help='Which quantization technique to apply')
+    parser.add_argument('-q', '--quantization', default = "None", choices=["int8dq", "int8wo", "int4wo","autoquant", "fp6", "None"], help='Which quantization technique to apply')
     parser.add_argument('-s', '--sparsity', default = "None", choices=["semi_sparse", "semi_sparse_mlp_only", "None"], help='Which sparsity technique to apply')
     parser.add_argument('--compile', action='store_true', help='Whether to compile the model.')
     parser.add_argument('--save', action='store_true', help='Whether to save the model.')

--- a/test/dtypes/test_fpx.py
+++ b/test/dtypes/test_fpx.py
@@ -8,23 +8,27 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
-from torchao.prototype.quant_llm import (
-    QuantLlmLinearWeight,
-    quant_llm_fpx_weight_only,
-    fp6_llm_weight_only,
+from torchao.dtypes.fpx import (
+    FpxTensorCoreAQTLayout,
+    FpxTensorCoreLayoutType,
     to_scaled_tc_fpx,
     from_scaled_tc_fpx,
 )
-from torchao.prototype.quant_llm.quant_llm import _pack_tc_fpx, _pack_tc_fp6
+from torchao.dtypes.fpx.fpx import _pack_tc_fpx, _pack_tc_fp6
 from torchao.prototype.custom_fp_utils import _f32_to_fpx_unpacked, _fpx_unpacked_to_f32
-from torchao.quantization.quant_api import quantize_
+from torchao.quantization import (
+    quantize_,
+    fpx_weight_only,
+)
+
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 
 _DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 _FPx_DTYPES = [(3, 2), (2, 2)]
 
 
-class TestQuantLlmLinearWeight(TestCase):
+class TestFpxTensorCoreAQTLayout(TestCase):
     @parametrize("device", _DEVICES)
     def test_pack_tc_fp6_correctness(self, device):
         x = torch.randint(256, size=(256, 64), dtype=torch.uint8, device=device)
@@ -69,61 +73,40 @@ class TestQuantLlmLinearWeight(TestCase):
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     def test_to_copy_device(self, ebits, mbits):
+        from torchao.quantization.quant_primitives import (
+            choose_qparams_affine_fpx,
+            quantize_affine_fpx,
+        )
+
         x = torch.randn(256, 64)
-        fpx = QuantLlmLinearWeight.from_float(x, ebits, mbits).cuda()
-        assert fpx.device.type == "cuda"
-        fpx = fpx.cpu()
-        assert fpx.device.type == "cpu"
+        scale = choose_qparams_affine_fpx(x, ebits, mbits)
+        x = quantize_affine_fpx(x, scale, ebits, mbits)
+        layout_type = FpxTensorCoreLayoutType(ebits, mbits)
+        fpx_layout_tensor = FpxTensorCoreAQTLayout.from_plain(x, scale, None, layout_type).cuda()
+        assert fpx_layout_tensor.device.type == "cuda"
+        fpx_layout_tensor = fpx_layout_tensor.cpu()
+        assert fpx_layout_tensor.device.type == "cpu"
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    @parametrize("ebits,mbits", _FPx_DTYPES)
-    @parametrize("leading_dims", [(4,), (2, 4)])
-    @parametrize("bias", [False, True])
-    def test_quant_llm_linear_weight(self, ebits, mbits, bias, leading_dims):
-        OC, IC = 256, 64
-        device = "cuda"
-
-        fp16_weight = torch.randn(OC, IC, device=device, dtype=torch.half)
-        fp16_bias = torch.randn(OC, device=device, dtype=torch.half) if bias else None
-
-        fpx_weight = QuantLlmLinearWeight.from_float(fp16_weight, ebits, mbits)
-
-        x = torch.randn(*leading_dims, IC, device=device, dtype=torch.half)
-        out = torch.nn.functional.linear(x, fpx_weight, fp16_bias)
-        assert out.shape == leading_dims + (OC,)
-
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="quantization only works with torch.compile for 2.5+")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     @parametrize("bias", [False, True])
-    def test_quant_llm_quantize(self, ebits, mbits, bias):
+    def test_fpx_weight_only(self, ebits, mbits, bias):
         N, OC, IC = 4, 256, 64
         device = "cuda"
 
-        linear = torch.nn.Linear(IC, OC, bias=bias, device=device)
+        linear = torch.nn.Linear(IC, OC, bias=bias, device=device, dtype=torch.half)
         fpx_linear = copy.deepcopy(linear)
-        quantize_(fpx_linear, quant_llm_fpx_weight_only(ebits, mbits))
+        quantize_(fpx_linear, fpx_weight_only(ebits, mbits))
 
         x = torch.randn(N, IC, device=device, dtype=torch.half)
         expected = fpx_linear(x)
         actual = torch.compile(fpx_linear, fullgraph=True)(x)
-        torch.testing.assert_close(actual, expected)
-
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_fp6_llm_quantize(self):
-        N, OC, IC = 4, 256, 64
-        device = "cuda"
-
-        linear = torch.nn.Linear(IC, OC, device=device)
-        fpx_linear = copy.deepcopy(linear)
-        quantize_(fpx_linear, fp6_llm_weight_only())
-
-        x = torch.randn(N, IC, device=device, dtype=torch.half)
-        expected = fpx_linear(x)
-        actual = torch.compile(fpx_linear, fullgraph=True)(x)
+        # somehow compile now changes the result a bit
         torch.testing.assert_close(actual, expected)
 
 
-instantiate_parametrized_tests(TestQuantLlmLinearWeight)
+instantiate_parametrized_tests(TestFpxTensorCoreAQTLayout)
 
 
 if __name__ == "__main__":

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.optests import opcheck
 from torchao.utils import is_fbcode, TORCH_VERSION_AT_LEAST_2_5, compute_max_diff
-from torchao.prototype.quant_llm import from_scaled_tc_fpx
+from torchao.dtypes.fpx import from_scaled_tc_fpx
 from torchao.sparsity.marlin import marlin_24_workspace, pack_to_marlin_24, inject_24
 import pytest
 
@@ -318,7 +318,7 @@ MARLIN_24_SUPPORTED_NUM_BITS = [4, 8]
 MARLIN_24_SUPPORTED_GROUP_SIZES = [-1, 128]
 
 MARLIN_TEST_PARAMS = list(itertools.product(
-    MARLIN_24_K_CHUNKS, MARLIN_24_N_CHUNKS, MARLIN_24_SUPPORTED_NUM_BITS, 
+    MARLIN_24_K_CHUNKS, MARLIN_24_N_CHUNKS, MARLIN_24_SUPPORTED_NUM_BITS,
     MARLIN_24_SUPPORTED_GROUP_SIZES, MNK_FACTORS
 ))
 
@@ -399,7 +399,7 @@ def test_marlin_24(k_chunk, n_chunk, num_bits, group_size, mnk_factors):
     workspace_24 = marlin_24_workspace(size_n)
 
     fn_inputs = (
-        a_input, marlin_24_q_w_comp, meta, marlin_24_scale, workspace_24, 
+        a_input, marlin_24_q_w_comp, meta, marlin_24_scale, workspace_24,
         num_bits, a_input.shape[0], b_weight.shape[1], a_input.shape[1],
     )
     output = torchao.ops.marlin_24_gemm(*fn_inputs)

--- a/torchao/_models/_eval.py
+++ b/torchao/_models/_eval.py
@@ -13,223 +13,222 @@ import torch.nn.functional as F
 
 from torchao.quantization.utils import _lm_eval_available, _MultiInput
 
-if _lm_eval_available:
-    import lm_eval
-    try:  # lm_eval version 0.4
-        from lm_eval.evaluator import evaluate  # pyre-ignore[21]
-        from lm_eval.models.huggingface import HFLM as eval_wrapper  # pyre-ignore[21]
-        from lm_eval.tasks import get_task_dict  # pyre-ignore[21]
-    except:  # lm_eval version 0.3
-        from lm_eval import base, evaluator, tasks
+import lm_eval
+try:  # lm_eval version 0.4
+    from lm_eval.evaluator import evaluate  # pyre-ignore[21]
+    from lm_eval.models.huggingface import HFLM as eval_wrapper  # pyre-ignore[21]
+    from lm_eval.tasks import get_task_dict  # pyre-ignore[21]
+except:  # lm_eval version 0.3
+    from lm_eval import base, evaluator, tasks
 
-        eval_wrapper = base.BaseLM
-        get_task_dict = tasks.get_task_dict
-        evaluate = evaluator.evaluate
+    eval_wrapper = base.BaseLM
+    get_task_dict = tasks.get_task_dict
+    evaluate = evaluator.evaluate
 
-    class InputRecorder(eval_wrapper):
-        """
-        This is a fake evaluation wrapper from the lm_eval library that just records the inputs
-        so that they can be used in calibration.
+class InputRecorder(eval_wrapper):
+    """
+    This is a fake evaluation wrapper from the lm_eval library that just records the inputs
+    so that they can be used in calibration.
 
-        If pad_calibration_inputs is enabled, the input recorder will take
-        each input and pad/truncate it down to the calibration_seq_length.
-        (if using padding you should set the embeddings for the pad_token to 0
-        in the model)
+    If pad_calibration_inputs is enabled, the input recorder will take
+    each input and pad/truncate it down to the calibration_seq_length.
+    (if using padding you should set the embeddings for the pad_token to 0
+    in the model)
 
-        Note: after padding/truncation, input_prep_function is called to bring
-        it to the proper form to be inserted into a given model.
+    Note: after padding/truncation, input_prep_function is called to bring
+    it to the proper form to be inserted into a given model.
 
-        If not, it will only truncate inputs to the desired length.
-        """
+    If not, it will only truncate inputs to the desired length.
+    """
 
-        def __init__(
-            self,
-            tokenizer,
-            calibration_seq_length,
-            input_prep_func=None,
-            pad_calibration_inputs=False,
-            vocab_size=32000,
-            pad_token=0,
-            device="cpu",
-        ):
+    def __init__(
+        self,
+        tokenizer,
+        calibration_seq_length,
+        input_prep_func=None,
+        pad_calibration_inputs=False,
+        vocab_size=32000,
+        pad_token=0,
+        device="cpu",
+    ):
+        try:
+            super().__init__()
+        except TypeError:
+            # lm_eval 0.4.2 removed the default init
+            super().__init__("gpt2", device="cpu")
+
+        self.tokenizer = tokenizer
+        self._device = torch.device(device)
+        self.vocab_size = vocab_size
+        self._max_seq_length = calibration_seq_length
+        self.calibration_seq_length = calibration_seq_length
+
+        # need to take inps and convert to corrent input
+        # for model
+        self.input_prep_func = (
+            input_prep_func if input_prep_func is not None
+            else lambda x: (x,)
+        )
+
+        self.pad_calibration_inputs = pad_calibration_inputs
+        self.pad_token = pad_token
+
+        self.inputs = None
+
+    @property
+    def eot_token_id(self):
+        try:
+            return self.tokenizer.eos_id()
+        except:
+            return self.tokenizer.eos_id
+
+    @property
+    def max_length(self):
+        return self._max_seq_length
+
+    @property
+    def max_gen_toks(self):
+        return 50
+
+    @property
+    def batch_size(self):
+        return 1
+
+    @property
+    def device(self):
+        return self._device
+
+    def tok_encode(self, string: str, **kwargs):
+        # TODO: verify this for multi-batch as well
+        tokens = self.tokenizer.encode(string)
+        if hasattr(self.tokenizer, "bos_id"):
             try:
-                super().__init__()
-            except TypeError:
-                # lm_eval 0.4.2 removed the default init
-                super().__init__("gpt2", device="cpu")
-
-            self.tokenizer = tokenizer
-            self._device = torch.device(device)
-            self.vocab_size = vocab_size
-            self._max_seq_length = calibration_seq_length
-            self.calibration_seq_length = calibration_seq_length
-
-            # need to take inps and convert to corrent input
-            # for model
-            self.input_prep_func = (
-                input_prep_func if input_prep_func is not None
-                else lambda x: (x,)
-            )
-
-            self.pad_calibration_inputs = pad_calibration_inputs
-            self.pad_token = pad_token
-
-            self.inputs = None
-
-        @property
-        def eot_token_id(self):
-            try:
-                return self.tokenizer.eos_id()
+                tokens = [self.tokenizer.bos_id()] + tokens
             except:
-                return self.tokenizer.eos_id
+                tokens = [self.tokenizer.bos_id] + tokens
+        return tokens
 
-        @property
-        def max_length(self):
-            return self._max_seq_length
+    def tok_decode(self, tokens):
+        decoded = self.tokenizer.decode(tokens)
+        return decoded
 
-        @property
-        def max_gen_toks(self):
-            return 50
+    def add_input(self, args):
+        if self.inputs is None:
+            self.inputs = [_MultiInput([arg]) for arg in args]
+        else:
+            self.inputs = [
+                multi.add_input(arg) for (multi, arg) in zip(self.inputs, args)
+            ]
 
-        @property
-        def batch_size(self):
-            return 1
+    def record_inputs(
+        self,
+        calibration_tasks,
+        calibration_limit,
+    ):
+        try:
+            lm_eval.tasks.initialize_tasks()
+        except:
+            pass
 
-        @property
-        def device(self):
-            return self._device
+        task_dict = get_task_dict(calibration_tasks)
+        print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
 
-        def tok_encode(self, string: str, **kwargs):
-            # TODO: verify this for multi-batch as well
-            tokens = self.tokenizer.encode(string)
-            if hasattr(self.tokenizer, "bos_id"):
-                try:
-                    tokens = [self.tokenizer.bos_id()] + tokens
-                except:
-                    tokens = [self.tokenizer.bos_id] + tokens
-            return tokens
-
-        def tok_decode(self, tokens):
-            decoded = self.tokenizer.decode(tokens)
-            return decoded
-
-        def add_input(self, args):
-            if self.inputs is None:
-                self.inputs = [_MultiInput([arg]) for arg in args]
-            else:
-                self.inputs = [
-                    multi.add_input(arg) for (multi, arg) in zip(self.inputs, args)
-                ]
-
-        def record_inputs(
+        evaluate(
             self,
-            calibration_tasks,
-            calibration_limit,
+            task_dict,
+            limit=calibration_limit,
+        )
+        return self
+
+    def get_inputs(self):
+        return self.inputs
+
+    def _model_call(self, inps):
+        inps = inps.squeeze(0)
+        T = len(inps)
+        if (
+            # can't use inputs that are too short when padding disabled
+            (T < self.calibration_seq_length and not self.pad_calibration_inputs)
+            or
+            # can't use inputs that actually use token we use for padding
+            (self.pad_calibration_inputs and self.pad_token in inps)
         ):
-            try:
-                lm_eval.tasks.initialize_tasks()
-            except:
-                pass
-
-            task_dict = get_task_dict(calibration_tasks)
-            print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
-
-            evaluate(
-                self,
-                task_dict,
-                limit=calibration_limit,
-            )
-            return self
-
-        def get_inputs(self):
-            return self.inputs
-
-        def _model_call(self, inps):
-            inps = inps.squeeze(0)
-            T = len(inps)
-            if (
-                # can't use inputs that are too short when padding disabled
-                (T < self.calibration_seq_length and not self.pad_calibration_inputs)
-                or
-                # can't use inputs that actually use token we use for padding
-                (self.pad_calibration_inputs and self.pad_token in inps)
-            ):
-                # give random output
-                return torch.randn(
-                    (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
-                )
-
-            # pad or truncate to the right size
-            if T >= self.calibration_seq_length:
-                inps = inps[: self.calibration_seq_length]
-            else:
-                inps = F.pad(inps, (self.pad_token, self.calibration_seq_length - T))
-
-            inps = inps.unsqueeze(0)
-            model_in = self.input_prep_func(inps)
-
-            self.add_input(model_in)
-
-            # output `something` with correct shape to keep eval going
+            # give random output
             return torch.randn(
                 (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
             )
 
-        def _model_generate(self, context, max_length, eos_token_id):
-            raise Exception("unimplemented")
+        # pad or truncate to the right size
+        if T >= self.calibration_seq_length:
+            inps = inps[: self.calibration_seq_length]
+        else:
+            inps = F.pad(inps, (self.pad_token, self.calibration_seq_length - T))
 
-    class TransformerEvalWrapper(InputRecorder):
-        """
-        A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
-        """
-        def __init__(
-            self,
-            model,
-            tokenizer,
-            max_seq_length,
-            input_prep_func=None,
-            device="cuda"
-        ):
-            super().__init__(tokenizer, None)
-            self._model = model
-            # self.tokenizer = tokenizer
-            self._device = torch.device(device)
-            self._max_seq_length = max_seq_length
+        inps = inps.unsqueeze(0)
+        model_in = self.input_prep_func(inps)
 
-            # need to take inps and convert to corrent input
-            # for model
-            self.input_prep_func = (
-                input_prep_func if input_prep_func is not None
-                else lambda x: (x,)
+        self.add_input(model_in)
+
+        # output `something` with correct shape to keep eval going
+        return torch.randn(
+            (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
+        )
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise Exception("unimplemented")
+
+class TransformerEvalWrapper(InputRecorder):
+    """
+    A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
+    """
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        max_seq_length,
+        input_prep_func=None,
+        device="cuda"
+    ):
+        super().__init__(tokenizer, None)
+        self._model = model
+        # self.tokenizer = tokenizer
+        self._device = torch.device(device)
+        self._max_seq_length = max_seq_length
+
+        # need to take inps and convert to corrent input
+        # for model
+        self.input_prep_func = (
+            input_prep_func if input_prep_func is not None
+            else lambda x: (x,)
+        )
+
+    def _model_call(self, inps):
+        # TODO: make batches work
+        input = self.input_prep_func(inps)
+
+        max_seq_length = min(max(inps.size()), self.max_length)
+        with torch.device(self._device):
+            self._model.setup_caches(self.batch_size, max_seq_length)
+        logits = self._model(*input)
+        return logits
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise Exception('unimplemented')
+
+    def run_eval(self, tasks, limit):
+        try:
+            lm_eval.tasks.initialize_tasks()
+        except:
+            pass
+
+        task_dict = get_task_dict(tasks)
+        print("Evaluating Model On: ", task_dict)
+        with torch.no_grad():
+            result = evaluate(
+                self,
+                task_dict,
+                limit=limit,
             )
-
-        def _model_call(self, inps):
-            # TODO: make batches work
-            input = self.input_prep_func(inps)
-
-            max_seq_length = min(max(inps.size()), self.max_length)
-            with torch.device(self._device):
-                self._model.setup_caches(self.batch_size, max_seq_length)
-            logits = self._model(*input)
-            return logits
-
-        def _model_generate(self, context, max_length, eos_token_id):
-            raise Exception('unimplemented')
-
-        def run_eval(self, tasks, limit):
-            try:
-                lm_eval.tasks.initialize_tasks()
-            except:
-                pass
-
-            task_dict = get_task_dict(tasks)
-            print("Evaluating Model On: ", task_dict)
-            with torch.no_grad():
-                result = evaluate(
-                    self,
-                    task_dict,
-                    limit=limit,
-                )
-            for task, res in result["results"].items():
-                print(f"{task}: {res}")
-            return result
+        for task, res in result["results"].items():
+            print(f"{task}: {res}")
+        return result

--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -13,8 +13,12 @@ from generate import (
 
 )
 from torchao.quantization.quant_api import (
-    quantize_, int4_weight_only, int8_weight_only, int8_dynamic_activation_int8_weight, unwrap_tensor_subclass
-
+    quantize_,
+    int4_weight_only,
+    int8_weight_only,
+    int8_dynamic_activation_int8_weight,
+    fpx_weight_only,
+    unwrap_tensor_subclass,
 )
 from torchao._models._eval import TransformerEvalWrapper, InputRecorder
 
@@ -68,6 +72,8 @@ def run_evaluation(
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
             quantize_(model.to(device), int4_weight_only(group_size=groupsize))
+        if "fp6" in quantization:
+            quantize_(model, fpx_weight_only(3, 2))
         if "int4wo" in quantization and "gptq" in quantization:
             groupsize=int(quantization.split("-")[-2])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -207,10 +207,10 @@ def main(
             int8_weight_only,
             int8_dynamic_activation_int8_weight,
             int4_weight_only,
+            fpx_weight_only,
             autoquant,
             unwrap_tensor_subclass
-    )
-
+        )
         if "int8wo" in quantization:
             quantize_(model, int8_weight_only())
         if "int8dq" in quantization:
@@ -219,6 +219,8 @@ def main(
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
             quantize_(model, int4_weight_only(group_size=groupsize))
+        if "fp6" in quantization:
+            quantize_(model, fpx_weight_only(3, 2))
         if "autoquant" == quantization:
             model = autoquant(model, manual=True)
 

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -4,6 +4,7 @@ from .uint4 import UInt4Tensor
 from .affine_quantized_tensor import (
     AffineQuantizedTensor,
     to_affine_quantized,
+    to_affine_quantized_fpx,
     to_affine_quantized_static,
     LayoutType,
     PlainLayoutType,
@@ -17,6 +18,7 @@ __all__ = [
     "UInt4Tensor"
     "AffineQuantizedTensor",
     "to_affine_quantized",
+    "to_affine_quantized_fpx",
     "to_affine_quantized_static",
     "LayoutType",
     "PlainLayoutType",

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -11,9 +11,9 @@ from torchao.quantization.quant_primitives import (
     MappingType,
     int_scaled_matmul,
     quantize_affine_hqq,
-)
-from torchao.quantization.utils import (
-    pack_tinygemm_scales_and_zeros,
+    choose_qparams_affine_fpx,
+    quantize_affine_fpx,
+    dequantize_affine_fpx,
 )
 from torch.utils._python_dispatch import return_and_correct_aliasing
 from torchao.dtypes.utils import (
@@ -33,6 +33,7 @@ from torchao.utils import (
     TorchAOBaseTensor,
     TORCH_VERSION_AT_LEAST_2_5,
 )
+from torchao.ops import quant_llm_linear
 
 aten = torch.ops.aten
 
@@ -45,6 +46,11 @@ class AQTLayout(TorchAOBaseTensor):
     Base class for the layout tensor for `AffineQuantizedTensor`
     """
     def get_plain(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Get the plain (unpacked) Tensor for the layout Tensor
+
+        Returns int_data, scale and zero_point
+        Can be overwritten if other types of AQTLayout Tensor has different numbers of plain tensors
+        """
         pass
 
     def get_layout_type(self) -> LayoutType:
@@ -156,8 +162,14 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
     def dequantize(self, output_dtype=None):
         if output_dtype is None:
             output_dtype = self.dtype
-        int_data, scale, zero_point = self.layout_tensor.get_plain()
-        return dequantize_affine(int_data, self.block_size, scale, zero_point, int_data.dtype, self.quant_min, self.quant_max, self.zero_point_domain, output_dtype=output_dtype)
+
+        from torchao.dtypes.fpx import FpxTensorCoreLayoutType
+        if isinstance(self.layout_type, FpxTensorCoreLayoutType):
+            int_data, scale = self.layout_tensor.get_plain()
+            return dequantize_affine_fpx(int_data, scale, self.layout_type.ebits, self.layout_type.mbits, output_dtype=output_dtype)
+        else:
+            int_data, scale, zero_point = self.layout_tensor.get_plain()
+            return dequantize_affine(int_data, self.block_size, scale, zero_point, int_data.dtype, self.quant_min, self.quant_max, self.zero_point_domain, output_dtype=output_dtype)
 
     @staticmethod
     def _quantized_linear_op(input_tensor, weight_tensor, bias):
@@ -263,6 +275,35 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
             quant_max,
             zero_point_domain,
             dtype=input_float.dtype,
+        )
+
+    @classmethod
+    def from_float_fpx(
+        cls,
+        input_float: torch.Tensor,
+        layout_type: LayoutType = PlainLayoutType()
+    ):
+        from torchao.dtypes.fpx import FpxTensorCoreLayoutType
+        assert isinstance(layout_type, FpxTensorCoreLayoutType), f"Only FpxTensorCoreLayoutType is supported for fpx, got {layout_type}"
+        original_shape = input_float.shape
+        input_float = layout_type.pre_process(input_float)
+        # per axis quantization, where axis = 1
+        block_size = list(input_float.shape)
+        block_size[1] = 1
+
+        ebits, mbits = layout_type.ebits, layout_type.mbits
+        # Note: these ops are hardcoded to have per axis quantization (axis=1) right now
+        scale = choose_qparams_affine_fpx(input_float, ebits, mbits)
+        fpx_unpacked = quantize_affine_fpx(input_float, scale, ebits, mbits)
+        fpx_packed = layout_type.post_process(fpx_unpacked)
+
+        layout_tensor_ctr = get_layout_tensor_constructor(type(layout_type))
+        layout_tensor = layout_tensor_ctr(fpx_packed, scale, None, layout_type)
+        return cls(
+            layout_tensor,
+            block_size,
+            original_shape,
+            dtype=input_float.dtype
         )
 
     @property
@@ -455,7 +496,7 @@ class PlainAQTLayout(AQTLayout):
         cls,
         int_data: torch.Tensor,
         scale: torch.Tensor,
-        zero_point: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
         layout_type: LayoutType,
     ):
         assert isinstance(layout_type, PlainLayoutType)
@@ -494,7 +535,7 @@ class SemiSparseAQTLayout(PlainAQTLayout):
         cls,
         int_data: torch.Tensor,
         scale: torch.Tensor,
-        zero_point: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
         layout_type: LayoutType,
     ):
         assert isinstance(layout_type, SemiSparseLayoutType)
@@ -559,7 +600,7 @@ class TensorCoreTiledAQTLayout(AQTLayout):
         cls,
         int_data: torch.Tensor,
         scale: torch.Tensor,
-        zero_point: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
         layout_type: LayoutType
     ):
 
@@ -573,6 +614,7 @@ class TensorCoreTiledAQTLayout(AQTLayout):
         packed_weight = torch.ops.aten._convert_weight_to_int4pack(int_data, layout_type.inner_k_tiles)
         scale = scale.reshape(int_data.shape[0], -1)
         zero_point = zero_point.reshape(int_data.shape[0], -1)
+        from torchao.quantization.utils import pack_tinygemm_scales_and_zeros
         scale_and_zero = pack_tinygemm_scales_and_zeros(scale, zero_point)
         return cls(packed_weight, scale_and_zero, False, layout_type)
 
@@ -864,6 +906,55 @@ def _linear_fp_act_int8_weight_impl(input_tensor, weight_tensor, bias):
         y += bias.to(m.dtype)
     return y
 
+def _linear_f16_act_fpx_weight_check(input_tensor, weight_tensor, bias):
+    from torchao.dtypes.fpx import FpxTensorCoreLayoutType
+    return (
+        # input is native float32 tensor
+        not is_traceable_wrapper_subclass(input_tensor) and
+        input_tensor.is_floating_point() and
+        input_tensor.dtype == torch.float16 and
+        # weight is fpx Tensor
+        isinstance(weight_tensor, AffineQuantizedTensor) and
+        isinstance(weight_tensor.layout_type, FpxTensorCoreLayoutType) and
+        (
+            # weight is using fp6 quantization
+            (weight_tensor.layout_type.ebits == 3 and
+             weight_tensor.layout_type.mbits == 2) or
+            (weight_tensor.layout_type.ebits == 2 and
+             weight_tensor.layout_type.mbits == 3) or
+            # weight is using fp5 quantization
+            (weight_tensor.layout_type.ebits == 2 and
+             weight_tensor.layout_type.mbits == 2) or
+            (weight_tensor.layout_type.ebits == 3 and
+             weight_tensor.layout_type.mbits == 1)
+        )
+    )
+
+def _linear_f16_act_fpx_weight_impl(input_tensor, weight_tensor, bias):
+    from torchao.dtypes.fpx import _SPLIT_K_MAP
+    act = input_tensor
+    weight = weight_tensor
+
+    out_dim, in_dim = weight.shape
+    act_reshaped = act.view(-1, in_dim).half()
+
+    # https://github.com/microsoft/DeepSpeed/blob/3a3a6db3332e339cc9fd94efd4982f6d60635a3d/deepspeed/inference/v2/kernels/core_ops/cuda_linear/cuda_linear.py
+    bsize = act_reshaped.shape[0]
+    splitK = _SPLIT_K_MAP[(bsize - 1) // 64].get(out_dim, 1) if bsize <= 768 else 1
+
+    out = quant_llm_linear(
+        weight.layout_type.ebits,
+        weight.layout_type.mbits,
+        act_reshaped,
+        weight.layout_tensor.packed_fpx_data,
+        weight.layout_tensor.scale,
+        splitK=splitK,
+    )
+
+    if bias is not None:
+        out += bias
+
+    return out.view(*act.shape[:-1], out_dim).to(act.dtype)
 
 def _register_quantized_linear_dispatches():
     for dispatch_condition, impl in [
@@ -872,6 +963,7 @@ def _register_quantized_linear_dispatches():
         (_linear_quantized_act_fallback_check, _linear_quantized_act_fallback_impl),
         (_linear_bf16_act_uint4_weight_check, _linear_bf16_act_uint4_weight_impl),
         (_linear_fp_act_int8_weight_check, _linear_fp_act_int8_weight_impl),
+        (_linear_f16_act_fpx_weight_check, _linear_f16_act_fpx_weight_impl),
     ]:
         _register_quantized_linear_dispatch(dispatch_condition, impl)
 
@@ -979,6 +1071,7 @@ def _(func, types, args, kwargs):
 
 to_affine_quantized = AffineQuantizedTensor.from_float
 to_affine_quantized_static = AffineQuantizedTensor.from_float_static
+to_affine_quantized_fpx = AffineQuantizedTensor.from_float_fpx
 
 if TORCH_VERSION_AT_LEAST_2_5:
     # Allow a model with AffineQuantizedTensor weights to be loaded with `weights_only=True`

--- a/torchao/dtypes/fpx/README.md
+++ b/torchao/dtypes/fpx/README.md
@@ -5,15 +5,17 @@ This is a FP16 x FPx mixed matmul kernel optimized for io bound workloads per [F
 ## Usage
 
 ```python
-from torchao.quantization.quant_api import quantize_
-from torchao.prototype.quant_llm import fp6_llm_weight_only, quant_llm_fpx_weight_only
+from torchao.quantization import (
+    quantize_,
+    fpx_weight_only,
+)
 
 model = ...
 model.half()  # not necessary, but recommeneded to maintain accuracy
-quantize_(model, fp6_llm_weight_only())  # convert nn.Lineaer.weight to FP6 E3M2 in-place
 
 # for generic FPx EyMz where x = 1 + y + z
-# quantize_(model, quant_llm_fpx_weight_only(2, 2))  # use FP5 E2M2 instead
+# fp6 with ebits = 3 and mbits = 2
+quantize_(model, fpx_weight_only(3, 2))
 
 # fully compatible with torch.compile()
 model.compile(mode="max-autotune", fullgraph=True)
@@ -23,7 +25,7 @@ It's also possible to pre-process the weight and call the kernel directly.
 
 ```python
 import torch
-from torchao.prototype.quant_llm import to_scaled_tc_fpx
+from torchao.dtypes.fpx import to_scaled_tc_fpx
 from torchao.ops import quant_llm_linear
 
 fp32_weight = torch.randn(1024, 512).cuda()

--- a/torchao/dtypes/fpx/__init__.py
+++ b/torchao/dtypes/fpx/__init__.py
@@ -1,0 +1,1 @@
+from .fpx import FpxTensorCoreLayoutType, FpxTensorCoreAQTLayout, to_scaled_tc_fpx, from_scaled_tc_fpx, _SPLIT_K_MAP

--- a/torchao/prototype/quant_llm/__init__.py
+++ b/torchao/prototype/quant_llm/__init__.py
@@ -1,1 +1,0 @@
-from .quant_llm import QuantLlmLinearWeight, fp6_llm_weight_only, quant_llm_fpx_weight_only, to_scaled_tc_fpx, from_scaled_tc_fpx

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -39,6 +39,8 @@ __all__ = [
     "int8_dynamic_activation_int8_semi_sparse_weight",
     "int4_weight_only",
     "int8_weight_only",
+    "uintx_weight_only",
+    "fpx_weight_only",
     "LinearActivationQuantizedTensor",
     "to_linear_activation_quantized",
 ]

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -21,14 +21,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from typing import Any, Callable, Union, Dict, Optional
 
-from torchao.dtypes.uintx.Uintx import UintxLayoutType
-from torchao.dtypes import (
-    to_affine_quantized, 
-    TensorCoreTiledLayoutType, 
-    PlainLayoutType,
-    AffineQuantizedTensor,
-    SemiSparseLayoutType
-)
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_4,
     TORCH_VERSION_AT_LEAST_2_5,
@@ -37,11 +29,7 @@ from torchao.utils import (
 from .subclass import (
     QuantizedLinearWeightBase,
 )
-
-from .linear_activation_quantized_tensor import (
-    LinearActivationQuantizedTensor,
-    to_linear_activation_quantized,
-)
+from torchao.dtypes import TensorCoreTiledLayoutType
 
 from .quant_primitives import (
     MappingType,
@@ -72,6 +60,8 @@ __all__ = [
     "int8_dynamic_activation_int8_semi_sparse_weight",
     "int4_weight_only",
     "int8_weight_only",
+    "uintx_weight_only",
+    "fpx_weight_only",
 ]
 
 from .GPTQ import (
@@ -202,6 +192,10 @@ def _is_linear(mod, *args):
 
     # adding weight tensor subclass isinstance check to make sure the weight is only quantized once
     # when it is shared by multiple linear modules
+    from torchao.dtypes import AffineQuantizedTensor
+    from .linear_activation_quantized_tensor import (
+        LinearActivationQuantizedTensor,
+    )
     return (
         isinstance(mod, torch.nn.Linear)
         and hasattr(mod, "weight")
@@ -353,11 +347,15 @@ def quantize_(
     )
 
 def _int8_asymm_per_token_quant(x: torch.Tensor) -> torch.Tensor:
+    from torchao.dtypes import to_affine_quantized
     mapping_type = MappingType.ASYMMETRIC
     target_dtype = torch.int8
     return to_affine_quantized(x, mapping_type, _get_per_token_block_size(x), target_dtype)
 
 def apply_int8_dynamic_activation_int4_weight_quant(weight, group_size=32):
+    from torchao.dtypes import to_affine_quantized
+    from .linear_activation_quantized_tensor import to_linear_activation_quantized
+
     if weight.shape[-1] % group_size != 0:
         return weight
 
@@ -393,6 +391,7 @@ def int8_dynamic_activation_int4_weight(group_size=32):
 
 
 def int4_weight_only(group_size=128, layout_type=TensorCoreTiledLayoutType(inner_k_tiles=8)):
+# def int4_weight_only(group_size=128, layout_type=None):
     """
     Applies uint4 weight-only asymmetric per-group quantization to linear layers, using
     "tensor_core_tiled" layout for speedup with tinygemm kernel
@@ -410,7 +409,14 @@ def int4_weight_only(group_size=128, layout_type=TensorCoreTiledLayoutType(inner
          size is more fine grained, choices are [256, 128, 64, 32]
         `layout_type`: layout type for quantized tensor, default is `TensorCoreTiledLayoutType(inner_k_tiles=8)`
     """
+    from torchao.dtypes import TensorCoreTiledLayoutType
+
+    if layout_type is None:
+        layout_type = TensorCoreTiledLayoutType(inner_k_tiles=8)
+
     def apply_int4_weight_only_quant(weight, use_hqq=False):
+        from torchao.dtypes import to_affine_quantized
+
         if weight.shape[-1] % group_size != 0:
             return weight
 
@@ -433,6 +439,8 @@ def int8_weight_only():
     Applies int8 weight-only symmetric per-channel quantization to linear layers.
     """
     def apply_int8wo_quant(weight):
+        from torchao.dtypes import to_affine_quantized
+
         mapping_type = MappingType.SYMMETRIC
         target_dtype = torch.int8
         eps = torch.finfo(torch.float32).eps
@@ -443,6 +451,8 @@ def int8_weight_only():
     return _get_linear_subclass_inserter(apply_int8wo_quant)
 
 def _int8_symm_per_token_reduced_range_quant(x: torch.Tensor) -> torch.Tensor:
+    from torchao.dtypes import to_affine_quantized
+
     mapping_type = MappingType.SYMMETRIC
     target_dtype = torch.int8
     eps = 1e-5
@@ -451,12 +461,19 @@ def _int8_symm_per_token_reduced_range_quant(x: torch.Tensor) -> torch.Tensor:
     return to_affine_quantized(x, mapping_type, _get_per_token_block_size(x), target_dtype, eps=eps, quant_min=quant_min, quant_max=quant_max, scale_dtype=torch.float32 if x.dtype == torch.float16 else None)
 
 
-def int8_dynamic_activation_int8_weight(layout_type=PlainLayoutType()):
+def int8_dynamic_activation_int8_weight(layout_type=None):
     """
     Applies int8 dynamic symmetric per-token activation and int8 per-channel weight
     quantization to linear layers
     """
+    from torchao.dtypes import PlainLayoutType
+    if layout_type is None:
+        layout_type = PlainLayoutType()
+
     def apply_int8_dynamic_activation_int8_weight_quant(weight):
+        from torchao.dtypes import to_affine_quantized
+        from .linear_activation_quantized_tensor import to_linear_activation_quantized
+
         in_features = weight.shape[1]
         # int8 dynamic quantization only has benefit when in_feature > 16
         if in_features <= 16:
@@ -486,6 +503,7 @@ def int8_dynamic_activation_int8_semi_sparse_weight():
     Applies int8 dnynamic symmetric per-token activation and int8 per-channel weight
     quantization + 2:4 sparsity to linear layers.
     """
+    from torchao.dtypes import SemiSparseLayoutType
     return int8_dynamic_activation_int8_weight(layout_type=SemiSparseLayoutType())
 
 
@@ -505,8 +523,10 @@ def uintx_weight_only(dtype, group_size=64, pack_dim=-1):
         ZeroPointDomain,
     )
     from torchao.quantization.quant_api import _get_linear_subclass_inserter
+    from torchao.dtypes import to_affine_quantized
 
     def apply_uintx_weight_only_quant(weight):
+        from torchao.dtypes.uintx.Uintx import UintxLayoutType
         layout_type = UintxLayoutType(dtype=dtype, pack_dim=pack_dim)
         mapping_type = MappingType.ASYMMETRIC
         block_size = (1, group_size)
@@ -522,6 +542,28 @@ def uintx_weight_only(dtype, group_size=64, pack_dim=-1):
         )
 
     return _get_linear_subclass_inserter(apply_uintx_weight_only_quant)
+
+def fpx_weight_only(ebits: int, mbits: int):
+    """Sub-byte floating point dtypes defined by `ebits`: exponent bits and `mbits`: mantissa bits
+    e.g. fp6_e3_m2, fp6_e2_m3, ...
+
+    The packing format and kernels are from the fp6-llm paper: https://arxiv.org/abs/2401.14112
+    github repo: https://github.com/usyd-fsalab/fp6_llm, now renamed to quant-llm
+
+    For more details for packing please see: :class:`~torchao.dtypes.fpx.FpxTensorCoreAQTLayout`
+    """
+    def apply_quant_llm(weight: torch.Tensor) -> torch.Tensor:
+        from torchao.dtypes.fpx import FpxTensorCoreLayoutType
+        from torchao.dtypes import to_affine_quantized_fpx
+
+        assert weight.dim() == 2, f"fpx only works for 2-d Tensor, got: {weight.dim()}"
+        out_dim, in_dim = weight.shape
+        if (in_dim % 64 != 0) or (out_dim % 256 != 0):
+            return weight
+
+        layout_type = FpxTensorCoreLayoutType(ebits, mbits)
+        return to_affine_quantized_fpx(weight, layout_type)
+    return _get_linear_subclass_inserter(apply_quant_llm)
 
 
 if TORCH_VERSION_AT_LEAST_2_5:

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 import torch.nn.utils.parametrize as parametrize
 from torchao.utils import find_multiple
-from .quant_primitives import (
+from torchao.quantization.quant_primitives import (
     MappingType,
     ZeroPointDomain,
     choose_qparams_affine,


### PR DESCRIPTION
Summary:
We want to add quant_llm to affine quantized tensor as a general fp2-fp7 dtype, before that we need to refactor the current implementation to work with AffineQuantizedTensor first

Test Plan:
```
python test/prototype/test_fpx.py

# perf
# in torchao/_models/llama
python generate.py --compile --quantization fp6

# accuracy
python eval.py --quantization fp6 --compile

```

tok/s is matching the original now, fp6 is:
```
==========
Average tokens/sec: 115.62
Average Bandwidth: 573.39 GB/s
Peak Memory Usage: 6.97 GB
Model Size: 4.96 GB
```
perplexity with eval in _models/llama/ is:
```
wikitext: {'word_perplexity,none': 12.360869670148428, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.6003634603882877, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6783995944569804, 'bits_per_byte_stderr,none': 'N/A', 'alias': 'wikitext'}
```
matching previous result: 
FP6 E3M2 | 12.34 | 106.76


new numbers for benchmark_fp6.py
```
|   m |     k |     n |   fp6_latency (ms) |   fp16_latency (ms) |   speedup (d/s) |   correct |
|----:|------:|------:|-------------------:|--------------------:|----------------:|----------:|
|   1 |  8192 |  8192 |            66.7578 |             93.8563 |        1.40592  |         1 |
|   1 | 10240 |  8192 |            74.4154 |            111.698  |        1.501    |         1 |
|   1 | 57344 |  8192 |           236.078  |            577.7    |        2.44707  |         1 |
|   1 |  8192 | 28672 |           132.349  |            296.613  |        2.24114  |         1 |
|   2 |  8192 |  8192 |            63.3943 |             94.0825 |        1.48408  |         1 |
|   2 | 10240 |  8192 |            62.4372 |            114.443  |        1.83294  |         1 |
|   2 | 57344 |  8192 |           237.778  |            566.592  |        2.38286  |         1 |
|   2 |  8192 | 28672 |           133.844  |            304.042  |        2.27162  |         1 |
|   4 |  8192 |  8192 |            60.7482 |             94.2242 |        1.55106  |         1 |
|   4 | 10240 |  8192 |            61.2663 |            115.321  |        1.88229  |         1 |
|   4 | 57344 |  8192 |           238.502  |            567.895  |        2.38109  |         1 |
|   4 |  8192 | 28672 |           135.851  |            305.304  |        2.24735  |         1 |
|   8 |  8192 |  8192 |            54.8235 |             95.2624 |        1.73762  |         1 |
|   8 | 10240 |  8192 |            61.5713 |            116.808  |        1.89711  |         1 |
|   8 | 57344 |  8192 |           241.506  |            569.578  |        2.35845  |         1 |
|   8 |  8192 | 28672 |           139.488  |            307.304  |        2.20309  |         1 |
|  16 |  8192 |  8192 |            61.2497 |             96.2626 |        1.57164  |         1 |
|  16 | 10240 |  8192 |            60.8278 |            114.659  |        1.88497  |         1 |
|  16 | 57344 |  8192 |           264.154  |            572.281  |        2.16647  |         1 |
|  16 |  8192 | 28672 |           145.249  |            310.304  |        2.13636  |         1 |
|  32 |  8192 |  8192 |            60.7182 |             96.0235 |        1.58146  |         1 |
|  32 | 10240 |  8192 |            67.6144 |            114.384  |        1.69172  |         1 |
|  32 | 57344 |  8192 |           289.831  |            586.451  |        2.02342  |         1 |
|  32 |  8192 | 28672 |           175.66   |            326.459  |        1.85847  |         1 |
|  64 |  8192 |  8192 |            76.7881 |             97.5357 |        1.27019  |         1 |
|  64 | 10240 |  8192 |            91.239  |            116.467  |        1.2765   |         1 |
|  64 | 57344 |  8192 |           416.322  |            602.291  |        1.44669  |         1 |
|  64 |  8192 | 28672 |           257.579  |            335.085  |        1.3009   |         1 |
| 128 |  8192 |  8192 |           129.629  |            120.611  |        0.930432 |         1 |
| 128 | 10240 |  8192 |           156.548  |            136.184  |        0.86992  |         1 |
| 128 | 57344 |  8192 |           782.291  |            690.499  |        0.882663 |         1 |
| 128 |  8192 | 28672 |           478.238  |            425.829  |        0.890412 |         1 |
| 256 |  8192 |  8192 |           251.177  |            190.626  |        0.758932 |         1 |
| 256 | 10240 |  8192 |           300.058  |            225.371  |        0.751091 |         1 |
| 256 | 57344 |  8192 |          1433.14   |           1192.71   |        0.832238 |         1 |
| 256 |  8192 | 28672 |           876.324  |            648.411  |        0.739922 |         1 |
| 512 |  8192 |  8192 |           493.372  |            367.824  |        0.745531 |         1 |
| 512 | 10240 |  8192 |           592.824  |            448.459  |        0.756479 |         1 |
| 512 | 57344 |  8192 |          2808.56   |           2191.73   |        0.780376 |         1 |
| 512 |  8192 | 28672 |          1617.37   |           1163.74   |        0.719525 |         1 |
```
Reviewers:

Subscribers:

Tasks:

Tags: