### PR TITLE
Add option to move param to `device` before quantization

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -698,7 +698,6 @@ class TestQuantFlow(TestCase):
         torch.cuda.synchronize()
         time_baseline = time.perf_counter() - time0
         memory_baseline = torch.cuda.max_memory_allocated()
-        print(memory_baseline)
 
         del m
         reset_memory()
@@ -707,7 +706,6 @@ class TestQuantFlow(TestCase):
         quantize_(m, int8_weight_only(), device="cuda")
         time_streaming = time.perf_counter() - time0
         memory_streaming = torch.cuda.max_memory_allocated()
-        print(memory_streaming)
 
         for param in m.parameters():
             assert param.is_cuda

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -55,7 +55,6 @@ from torchao.utils import unwrap_tensor_subclass
 import copy
 import tempfile
 import gc
-import time
 from torch.testing._internal.common_utils import TestCase
 
 
@@ -692,25 +691,17 @@ class TestQuantFlow(TestCase):
 
         reset_memory()
         m = ToyLinearModel()
-        time0 = time.perf_counter()
-        m.to(device="cuda")
-        quantize_(m, int8_weight_only())
-        torch.cuda.synchronize()
-        time_baseline = time.perf_counter() - time0
+        quantize_(m.to(device="cuda"), int8_weight_only())
         memory_baseline = torch.cuda.max_memory_allocated()
 
         del m
         reset_memory()
         m = ToyLinearModel()
-        time0 = time.perf_counter()
         quantize_(m, int8_weight_only(), device="cuda")
-        torch.cuda.synchronize()
-        time_streaming = time.perf_counter() - time0
         memory_streaming = torch.cuda.max_memory_allocated()
 
         for param in m.parameters():
             assert param.is_cuda
-        self.assertLess(time_streaming, time_baseline * 1.5)
         self.assertLess(memory_streaming, memory_baseline)
 
 

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -704,12 +704,13 @@ class TestQuantFlow(TestCase):
         m = ToyLinearModel()
         time0 = time.perf_counter()
         quantize_(m, int8_weight_only(), device="cuda")
+        torch.cuda.synchronize()
         time_streaming = time.perf_counter() - time0
         memory_streaming = torch.cuda.max_memory_allocated()
 
         for param in m.parameters():
             assert param.is_cuda
-        self.assertLess(time_streaming, time_baseline * 1.1)
+        self.assertLess(time_streaming, time_baseline * 1.5)
         self.assertLess(memory_streaming, memory_baseline)
 
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -178,7 +178,8 @@ def _replace_with_custom_fn_if_matches_filter(
         None
     """
     if filter_fn(model, cur_fqn[:-1]):
-        model.to(device=device)  # move to device before quantization
+        if device is not None:
+            model.to(device=device)  # move to device before quantization
         model = replacement_fn(model)
         return model
     else:
@@ -188,7 +189,8 @@ def _replace_with_custom_fn_if_matches_filter(
             )
             if new_child is not child:
                 setattr(model, name, new_child)
-        model.to(device=device)  # move parent module to device
+        if device is not None:
+            model.to(device=device)  # move parent module to device
         return model
 
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -161,6 +161,7 @@ def _replace_with_custom_fn_if_matches_filter(
     replacement_fn,
     filter_fn,
     cur_fqn="",
+    device=None,
 ) -> None:
     """
     Recursively replaces each child module in `model` with the result of `replacement_fn(child)`
@@ -171,20 +172,23 @@ def _replace_with_custom_fn_if_matches_filter(
         replacement_fn (Callable[[torch.nn.Module], torch.nn.Module]): The function to replace matching modules.
         filter_fn (Callable[[torch.nn.Module], bool]): The filter function to determine which modules to replace.
         cur_fqn (str, optional): The current fully qualified name of the module being processed. Defaults to "".
+        device (device, optional): Device to move the model to before applying `filter_fn`. Defaults to None.
 
     Returns:
         None
     """
     if filter_fn(model, cur_fqn[:-1]):
+        model.to(device=device)  # move to device before quantization
         model = replacement_fn(model)
         return model
     else:
         for name, child in model.named_children():
             new_child = _replace_with_custom_fn_if_matches_filter(
-                child, replacement_fn, filter_fn, f"{cur_fqn}{name}."
+                child, replacement_fn, filter_fn, f"{cur_fqn}{name}.", device
             )
             if new_child is not child:
                 setattr(model, name, new_child)
+        model.to(device=device)  # move parent module to device
         return model
 
 
@@ -269,7 +273,13 @@ def _get_linear_subclass_inserter(constructor):
 
     return insert_subclass
 
-def quantize_(model: torch.nn.Module, apply_tensor_subclass: Callable[[torch.nn.Module], torch.nn.Module], filter_fn: Optional[Callable[[torch.nn.Module, str], bool]]=None, set_inductor_config: bool=True):
+def quantize_(
+    model: torch.nn.Module,
+    apply_tensor_subclass: Callable[[torch.nn.Module], torch.nn.Module],
+    filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
+    set_inductor_config: bool = True,
+    device: Optional[torch.types.Device] = None,
+):
     """Convert the weight of linear modules in the model with `apply_tensor_subclass`, model is modified inplace
 
     Args:
@@ -278,6 +288,8 @@ def quantize_(model: torch.nn.Module, apply_tensor_subclass: Callable[[torch.nn.
         filter_fn (Optional[Callable[[torch.nn.Module, str], bool]]): function that takes a nn.Module instance and fully qualified name of the module, returns True if we want to run `apply_tensor_subclass` on
         the weight of the module
         set_inductor_config (bool, optional): Whether to automatically use recommended inductor config settings (defaults to True)
+        device (device, optional): Device to move module to before applying `filter_fn`. This can be set to `"cuda"` to speed up quantization. The final model will be on the specified `device`.
+            Defaults to None (do not change device).
 
     Example::
 
@@ -329,6 +341,7 @@ def quantize_(model: torch.nn.Module, apply_tensor_subclass: Callable[[torch.nn.
         model,
         apply_tensor_subclass,
         _is_linear if filter_fn is None else filter_fn,
+        device=device,
     )
 
 def _int8_asymm_per_token_quant(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Fixes #655 

Test

```python
import torch
from torchao._models.llama.model import Transformer, ModelArgs
from torchao.quantization.quant_api import quantize_, int8_weight_only
import time
import gc

def get_model():
    with torch.device("meta"):
        model = Transformer(ModelArgs())
    model.to_empty(device="cpu").bfloat16()
    return model

def clear_cuda():
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()
    assert torch.cuda.max_memory_reserved() == 0

model = get_model()
time0 = time.perf_counter()
quantize_(model, int8_weight_only())
model.to("cuda")
torch.cuda.synchronize()
duration = time.perf_counter() - time0
print("Quantize on CPU:")
print(f"  - Time taken: {duration:.2f} s")
print(f"  - Peak memory: {torch.cuda.max_memory_reserved() / 1e9:.2f} GiB")
del model
clear_cuda()

model = get_model()
time0 = time.perf_counter()
model.to("cuda")
quantize_(model, int8_weight_only())
torch.cuda.synchronize()
duration = time.perf_counter() - time0
print("Quantize on CUDA:")
print(f"  - Time taken: {duration:.2f} s")
print(f"  - Peak memory: {torch.cuda.max_memory_reserved() / 1e9:.2f} GiB")
del model
clear_cuda()

model = get_model()
time0 = time.perf_counter()
quantize_(model, int8_weight_only(), device="cuda")
torch.cuda.synchronize()
duration = time.perf_counter() - time0
print("Move to CUDA and quantize each param individually:")
print(f"  - Time taken: {duration:.2f} s")
print(f"  - Peak memory: {torch.cuda.max_memory_reserved() / 1e9:.2f} GiB")
del model
clear_cuda()
```

```
Quantize on CPU:
  - Time taken: 10.48 s
  - Peak memory: 6.99 GiB
Quantize on CUDA:
  - Time taken: 1.96 s
  - Peak memory: 14.50 GiB
Move to CUDA and quantize each param individually:
  - Time taken: 1.94 s
  - Peak memory: 8.29 GiB
```

@jerryzh168 Do you have any suggestions what tests I should add for this?

This PR may help the slow NF4 quantization issue observed in torchtune too #642 (though I'm not sure what is the NF4 quantization API. Does it use `quantize_()`?)