### PR TITLE
Poor man fix of the CUDA FP8 return output

### DIFF
--- a/torchao/float8/float8_python_api.py
+++ b/torchao/float8/float8_python_api.py
@@ -49,6 +49,8 @@ def addmm_float8_unwrapped(
             out_dtype=output_dtype,
             use_fast_accum=use_fast_accum,
         )
+        if output_dtype in [torch.float16, torch.float32, torch.bfloat16]:
+            output = output[0]
         output += bias
         return output
     output = torch._scaled_mm(
@@ -61,4 +63,6 @@ def addmm_float8_unwrapped(
         out_dtype=output_dtype,
         use_fast_accum=use_fast_accum,
     )
+    if output_dtype in [torch.float16, torch.float32, torch.bfloat16]:
+        output = output[0]
     return output


### PR DESCRIPTION
Poor man fix of the CUDA FP8 return output
The output should be a single tensor to be cased rather than 2 when output dtype is not FP8. Issues reported at: #643