### PR TITLE
Add high-level operator interface

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/benchmarks/build_and_run_benchmarks.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/benchmarks/build_and_run_benchmarks.sh
@@ -2,7 +2,7 @@
 # Call script with sh build_and_run_benchmarks.sh {BENCHAMRK}
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../..
+export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
 export CMAKE_OUT=/tmp/cmake-out/torch_ao/benchmarks
 cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
     -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/benchmarks \

--- a/torchao/experimental/kernels/cpu/aarch64/bitpacking/bitpack.h
+++ b/torchao/experimental/kernels/cpu/aarch64/bitpacking/bitpack.h
@@ -5,6 +5,7 @@
 #include <torchao/experimental/kernels/cpu/aarch64/bitpacking/macro.h>
 #include <torchao/experimental/kernels/cpu/aarch64/bitpacking/uint3.h>
 #include <torchao/experimental/kernels/cpu/aarch64/bitpacking/uint4.h>
+#include <cassert>
 
 namespace torchao {
 namespace bitpacking {

--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
@@ -6,6 +6,7 @@
 #include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
 #include <torchao/experimental/kernels/cpu/aarch64/valpacking/valpack.h>
 #include <cassert>
+#include <cstring>
 
 namespace torchao::kernels::cpu::aarch64::linear {
 namespace channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot::
@@ -251,7 +252,7 @@ int inline weight_data_size_impl(
   }
 
   // Replace n with next multiple of 4 >= n
-  n = ((n + 3) >> 2) << 2;
+  n = ((n + 3) / 4) * 4;
 
   return col_size * n;
 }

--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
@@ -6,6 +6,7 @@
 #include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
 #include <torchao/experimental/kernels/cpu/aarch64/valpacking/valpack.h>
 #include <cassert>
+#include <cstring>
 
 namespace torchao::kernels::cpu::aarch64::linear {
 namespace channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot::
@@ -324,7 +325,7 @@ int inline weight_data_size_impl(
   }
 
   // Replace n with next multiple of 8 >= n
-  n = ((n + 3) >> 3) << 3;
+  n = ((n + 7) / 8) * 8;
 
   return col_size * n;
 }

--- a/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../..
+export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
 export CMAKE_OUT=/tmp/cmake-out/torch_ao/tests
 cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/tests -B ${CMAKE_OUT}
 

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <torchao/experimental/kernels/cpu/aarch64/quantization/quantize.h>
 #include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
+#include <cassert>
 #include <functional>
 #include <random>
 #include <vector>

--- a/torchao/experimental/kernels/cpu/linear/benchmarks/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/linear/benchmarks/CMakeLists.txt
@@ -1,0 +1,53 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+cmake_minimum_required(VERSION 3.19)
+project(benchmarks)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Release)
+
+include(FetchContent)
+FetchContent_Declare(googlebenchmark
+        GIT_REPOSITORY https://github.com/google/benchmark.git
+        GIT_TAG main) # need main for benchmark::benchmark
+
+set(BENCHMARK_ENABLE_TESTING OFF)
+FetchContent_MakeAvailable(
+  googlebenchmark)
+
+add_compile_options("-Wall" "-Werror")
+
+include(CMakePrintHelpers)
+message("TORCHAO_LIBRARIES: ${TORCHAO_LIBRARIES}")
+include_directories(${TORCHAO_LIBRARIES})
+
+add_library(
+  dep
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/find_min_and_max.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/compute_sum.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/quantization/quantize.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/valpacking/interleave.cpp
+)
+
+add_executable(benchmark_linear_operator benchmark_linear_operator.cpp)
+target_link_libraries(
+    benchmark_linear_operator
+    PRIVATE
+    benchmark::benchmark
+    dep
+)
+
+option(TORCHAO_PARALLEL_OMP "" OFF)
+option(TORCHAO_PARALLEL_SINGLE_THREADED "" ON)
+
+if (TORCHAO_PARALLEL_OMP)
+  message("OpenMP_ROOT: ${OpenMP_ROOT}")
+  add_definitions(-DTORCHAO_PARALLEL_OMP=1)
+  find_package(OpenMP REQUIRED)
+  if(OpenMP_CXX_FOUND)
+    target_link_libraries(benchmark_linear_operator PUBLIC OpenMP::OpenMP_CXX)
+  endif()
+endif()
+
+if (TORCHAO_PARALLEL_SINGLE_THREADED)
+  add_definitions(-DTORCHAO_PARALLEL_SINGLE_THREADED=1)
+endif()

--- a/torchao/experimental/kernels/cpu/linear/benchmarks/benchmark_linear_operator.cpp
+++ b/torchao/experimental/kernels/cpu/linear/benchmarks/benchmark_linear_operator.cpp
@@ -1,0 +1,138 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <benchmark/benchmark.h>
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+#include <torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h>
+#include <torchao/experimental/kernels/cpu/memory.h>
+#include <vector>
+
+template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
+static void channelwise_8bit_activation_groupwise_lowbit_weight(
+    benchmark::State& state) {
+  int m = state.range(0);
+  int n = state.range(1);
+  int k = state.range(2);
+  int group_size = state.range(3);
+  int num_threads = state.range(4);
+
+  // OMP appears to cache when repeating the same task in the benchmark
+  // To prevent this, we benchmark a number of tasks
+  int num_test_cases = state.range(5);
+
+  // Initialize config and tiling params
+  using namespace torchao::operators::cpu::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight;
+
+  auto ukernel_config =
+      get_ukernel_config<weight_nbit, has_weight_zeros, has_bias, has_clamp>();
+  auto pack_weight_data_tiling_params =
+      get_default_pack_weight_data_tiling_params(ukernel_config, n);
+  auto linear_tiling_params =
+      get_default_linear_tiling_params(ukernel_config, m, n);
+  auto linear_scheduling_policy =
+      LinearTileSchedulingPolicy::single_mc_parallel_nc;
+
+  // Set number of threads
+  torchao::set_num_threads(num_threads);
+  assert(num_threads == torchao::get_num_threads());
+
+  // Generate test cases
+  std::vector<
+      torchao::channelwise_8bit_activation_groupwise_lowbit_weight_test_case>
+      test_cases;
+  for (int i = 0; i < num_test_cases; ++i) {
+    test_cases.emplace_back(
+        torchao::channelwise_8bit_activation_groupwise_lowbit_weight_test_case::
+            generate(
+                m,
+                k,
+                n,
+                group_size,
+                weight_nbit,
+                has_weight_zeros,
+                has_bias,
+                has_clamp));
+  }
+
+  // Pack test case weights
+  size_t packed_weight_data_size =
+      get_packed_weight_data_size(ukernel_config, n, k, group_size);
+  size_t packed_weight_data_alignment =
+      get_packed_weight_data_alignment(ukernel_config);
+
+  std::vector<std::unique_ptr<char[], void (*)(void*)>> packed_weight_data;
+  for (int i = 0; i < test_cases.size(); i++) {
+    packed_weight_data.emplace_back(torchao::make_aligned_byte_array_unique_ptr(
+        packed_weight_data_alignment, packed_weight_data_size));
+    pack_weight_data_operator(
+        ukernel_config,
+        pack_weight_data_tiling_params,
+        packed_weight_data[i].get(),
+        n,
+        k,
+        group_size,
+        test_cases[i].weight_qvals.data(),
+        test_cases[i].weight_scales.data(),
+        test_cases[i].weight_zeros.data());
+  }
+
+  // Allocate activation data buffer for test cases
+  size_t activation_data_buffer_size = get_activation_data_buffer_size(
+      ukernel_config,
+      linear_tiling_params,
+      linear_scheduling_policy,
+      m,
+      k,
+      group_size);
+  size_t activation_data_buffer_alignment =
+      get_activation_data_buffer_alignment(ukernel_config);
+
+  auto activation_data_buffer = torchao::make_aligned_byte_array_unique_ptr(
+      activation_data_buffer_alignment, activation_data_buffer_size);
+
+  auto output = std::vector<float>(m * n);
+  for (auto _ : state) {
+    for (int i = 0; i < test_cases.size(); i++) {
+      linear_operator(
+          ukernel_config,
+          linear_tiling_params,
+          linear_scheduling_policy,
+          activation_data_buffer.get(),
+          output.data(),
+          m,
+          n,
+          k,
+          group_size,
+          packed_weight_data[i].get(),
+          test_cases[i].activations.data(),
+          test_cases[i].bias.data(),
+          test_cases[i].clamp_min,
+          test_cases[i].clamp_max);
+    }
+  }
+}
+
+#define BENCHMARK_PARAMS                                                 \
+  {                                                                      \
+    /*m*/ {1}, /*n*/ {4096}, /*k*/ {4096}, /*group_size*/ {16, 32, 256}, \
+        /*num_threads*/ {1, 2, 4, 6, 8}, /*num_test_cases*/ {            \
+      10                                                                 \
+    }                                                                    \
+  }
+
+#define BENCHMARK_CHANNELWISE_8BIT_ACTIVATION_GROUPWISE_LOWBIT_WEIGHT( \
+    weight_nbit)                                                       \
+  BENCHMARK(channelwise_8bit_activation_groupwise_lowbit_weight<       \
+                weight_nbit,                                           \
+                false /*has_weight_zeros*/,                            \
+                false /*has_bias*/,                                    \
+                false /*has_clamp*/>)                                  \
+      ->ArgsProduct(BENCHMARK_PARAMS)                                  \
+      ->ArgNames(                                                      \
+          {"m", "n", "k", "group_size", "num_threads", "num_test_cases"});
+
+BENCHMARK_CHANNELWISE_8BIT_ACTIVATION_GROUPWISE_LOWBIT_WEIGHT(3);
+BENCHMARK_CHANNELWISE_8BIT_ACTIVATION_GROUPWISE_LOWBIT_WEIGHT(4);
+
+// Run the benchmark
+BENCHMARK_MAIN();

--- a/torchao/experimental/kernels/cpu/linear/benchmarks/build_and_run_benchmarks.sh
+++ b/torchao/experimental/kernels/cpu/linear/benchmarks/build_and_run_benchmarks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# Call script with sh build_and_run_benchmarks.sh {BENCHAMRK}
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
+export CMAKE_OUT=/tmp/cmake-out/torch_ao/benchmarks
+cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
+    -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/linear/benchmarks \
+    -B ${CMAKE_OUT} \
+    -DOpenMP_ROOT=$(brew --prefix libomp) \
+    -DTORCHAO_PARALLEL_OMP=ON
+
+cmake --build ${CMAKE_OUT}
+
+# Run
+case "$1" in
+    linear_operator) ${CMAKE_OUT}/benchmark_linear_operator; ;;
+    *) echo "Unknown benchmark: $1. Please specify one of: linear_operator."; exit 1; ;;
+esac

--- a/torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight-impl.h
+++ b/torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight-impl.h
@@ -1,0 +1,385 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+#include <torchao/experimental/kernels/cpu/macro.h>
+#include <torchao/experimental/kernels/cpu/parallel.h>
+#include <cassert>
+#include <cstdlib>
+
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+
+PackWeightDataTilingParams get_default_pack_weight_data_tiling_params(
+    const UKernelConfig& ukernel_config,
+    int n,
+    int target_panels_per_thread) {
+  TORCHAO_CHECK(n >= 1, "n must be >= 1");
+  TORCHAO_CHECK(target_panels_per_thread >= 1, "target_panels_per_thread must be >= 1");
+
+  PackWeightDataTilingParams tiling_params;
+  int nr = ukernel_config.nr;
+  int num_threads = torchao::get_num_threads();
+  int numerator = n;
+  int denominator = num_threads * target_panels_per_thread;
+
+  // Set nc = ceil(numerator / denominator)
+  int nc = (numerator + denominator - 1) / denominator;
+  assert(nc >= 1);
+
+  // Replace nc with the next number nr divides
+  nc = ((nc + ukernel_config.nr - 1) / ukernel_config.nr) * ukernel_config.nr;
+  tiling_params.nc_by_nr = nc / nr;
+
+  return tiling_params;
+}
+
+void pack_weight_data_operator(
+    const UKernelConfig& ukernel_config,
+    const PackWeightDataTilingParams& tiling_params,
+    // Outputs
+    void* weight_data,
+    // Inputs
+    int n,
+    int k,
+    int group_size,
+    const int8_t* weight_qvals,
+    const float* weight_scales,
+    const int8_t* weight_zeros) {
+  TORCHAO_CHECK(group_size % 16 == 0, "group_size must be a multiple of 16");
+  TORCHAO_CHECK(k % group_size == 0, "group_size must divide k");
+
+  int nr = ukernel_config.nr;
+  int nc = std::min(n, tiling_params.nc_by_nr * ukernel_config.nr);
+  int num_nc_panels = (n + nc - 1) / nc;
+
+  torchao::parallel_for(0, num_nc_panels, 1, [&](int64_t begin, int64_t end) {
+    int nc_tile_idx = begin;
+    int n_idx = nc_tile_idx * nc;
+    int nc_tile_size = std::min(nc, n - n_idx);
+
+    int weight_data_offset =
+        (n_idx / nr) * ukernel_config.weight_data_size_fn(nr, k, group_size);
+    int weight_qvals_offset = n_idx * k;
+    int weight_scales_and_zeros_offset = (n_idx * k / group_size);
+
+    ukernel_config.prepare_weight_data_fn(
+        (char*)weight_data + weight_data_offset,
+        /*n=*/nc_tile_size,
+        k,
+        group_size,
+        weight_qvals + weight_qvals_offset,
+        weight_scales + weight_scales_and_zeros_offset,
+        weight_zeros + weight_scales_and_zeros_offset);
+  });
+}
+
+// This default mimics XNNPACK behavior if target_tiles_per_thread = 5
+LinearTilingParams get_default_linear_tiling_params(
+    const UKernelConfig& ukernel_config,
+    int m,
+    int n,
+    int target_tiles_per_thread) {
+  TORCHAO_CHECK(m >= 1, "m must be >= 1");
+  TORCHAO_CHECK(n >= 1, "n must be >= 1");
+  TORCHAO_CHECK(target_tiles_per_thread >= 1, "target_tiles_per_thread must be >= 1");
+
+  LinearTilingParams tiling_params;
+  auto num_threads = torchao::get_num_threads();
+  assert(num_threads >= 1);
+
+  tiling_params.mc_by_mr = 1;
+  int mc = tiling_params.mc_by_mr * ukernel_config.mr;
+  int num_mc_panels = (m + mc - 1) / mc;
+
+  int numerator = n * num_mc_panels;
+  int denominator = num_threads * target_tiles_per_thread;
+
+  // Set nc = ceil(numerator / denominator)
+  int nc = (numerator + denominator - 1) / denominator;
+  assert(nc >= 1);
+
+  // Replace nc with next number nr divides
+  nc = ((nc + ukernel_config.nr - 1) / ukernel_config.nr) * ukernel_config.nr;
+  assert(nc % ukernel_config.nr == 0);
+  tiling_params.nc_by_nr = nc / ukernel_config.nr;
+
+  assert(tiling_params.mc_by_mr >= 1);
+  assert(tiling_params.nc_by_nr >= 1);
+  return tiling_params;
+}
+
+namespace internal {
+
+inline int
+get_activation_data_buffer_size_with_tile_schedule_policy_single_mc_parallel_nc(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    int m,
+    int k,
+    int group_size) {
+  return ukernel_config.activation_data_size_fn(
+      tiling_params.mc_by_mr * ukernel_config.mr, k, group_size);
+}
+
+inline int
+get_activation_data_buffer_size_with_tile_schedule_policy_parallel_mc_parallel_nc(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    int m,
+    int k,
+    int group_size) {
+  return ukernel_config.activation_data_size_fn(m, k, group_size);
+}
+
+void linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    char* activation_data_buffer,
+    // Outputs
+    float32_t* output,
+    // Inputs
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const float* activations,
+    // const void* activation_data,
+    // Not applied if nullptr
+    const float* bias,
+    // Ignored if has_clamp = false
+    float clamp_min,
+    float clamp_max) {
+  int nr = ukernel_config.nr;
+  int mc = std::min(m, tiling_params.mc_by_mr * ukernel_config.mr);
+  int nc = std::min(n, tiling_params.nc_by_nr * ukernel_config.nr);
+  int num_mc_panels = (m + mc - 1) / mc;
+  int num_nc_panels = (n + nc - 1) / nc;
+
+  for (int mc_tile_idx = 0; mc_tile_idx < num_mc_panels; mc_tile_idx++) {
+    int m_idx = mc_tile_idx * mc;
+    int mc_tile_size = std::min(mc, m - m_idx);
+    int activations_offset = m_idx * k;
+    ukernel_config.prepare_activation_data_fn(
+        activation_data_buffer,
+        /*m=*/mc_tile_size,
+        k,
+        group_size,
+        activations + activations_offset);
+
+    torchao::parallel_for(0, num_nc_panels, 1, [&](int64_t begin, int64_t end) {
+      int nc_tile_idx = begin;
+      int n_idx = nc_tile_idx * nc;
+      int nc_tile_size = std::min(nc, n - n_idx);
+
+      int output_offset = m_idx * n + n_idx;
+      int weight_data_offset =
+          (n_idx / nr) * ukernel_config.weight_data_size_fn(nr, k, group_size);
+      int bias_offset = m_idx;
+
+      ukernel_config.kernel_fn(
+          output + output_offset,
+          /*output_m_stride=*/n,
+          /*m=*/mc_tile_size,
+          /*n=*/nc_tile_size,
+          k,
+          group_size,
+          /*weight_data=*/(char*)weight_data + weight_data_offset,
+          /*activation_data=*/activation_data_buffer,
+          /*bias=*/bias + bias_offset,
+          clamp_min,
+          clamp_max);
+    });
+  }
+}
+
+void linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    char* activation_data_buffer,
+    // Outputs
+    float32_t* output,
+    // Inputs
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const float* activations,
+    const float* bias,
+    float clamp_min,
+    float clamp_max) {
+  int mr = ukernel_config.mr;
+  int nr = ukernel_config.nr;
+  int mc = std::min(m, tiling_params.mc_by_mr * ukernel_config.mr);
+  int nc = std::min(n, tiling_params.nc_by_nr * ukernel_config.nr);
+  int num_mc_panels = (m + mc - 1) / mc;
+  int num_nc_panels = (n + nc - 1) / nc;
+
+  torchao::parallel_for(0, num_mc_panels, 1, [&](int64_t begin, int64_t end) {
+    int mc_tile_idx = begin;
+    int m_idx = mc_tile_idx * mc;
+    int mc_tile_size = std::min(mc, m - m_idx);
+    int activations_offset = m_idx * k;
+    int activation_data_offset = (m_idx / mr) *
+        ukernel_config.activation_data_size_fn(mr, k, group_size);
+
+    ukernel_config.prepare_activation_data_fn(
+        activation_data_buffer + activation_data_offset,
+        /*m=*/mc_tile_size,
+        k,
+        group_size,
+        activations + activations_offset);
+  });
+
+  torchao::parallel_for(
+      0, num_mc_panels * num_nc_panels, 1, [&](int64_t begin, int64_t end) {
+        int mc_tile_idx = begin / num_nc_panels;
+        int m_idx = mc_tile_idx * mc;
+        int mc_tile_size = std::min(mc, m - m_idx);
+
+        int nc_tile_idx = begin % num_nc_panels;
+        int n_idx = nc_tile_idx * nc;
+        int nc_tile_size = std::min(nc, n - n_idx);
+
+        int activation_data_offset = (m_idx / mr) *
+            ukernel_config.activation_data_size_fn(mr, k, group_size);
+        int output_offset = m_idx * n + n_idx;
+        int weight_data_offset = (n_idx / nr) *
+            ukernel_config.weight_data_size_fn(nr, k, group_size);
+        int bias_offset = m_idx;
+
+        ukernel_config.kernel_fn(
+            output + output_offset,
+            /*output_m_stride=*/n,
+            /*m=*/mc_tile_size,
+            /*n=*/nc_tile_size,
+            k,
+            group_size,
+            /*weight_data=*/(char*)weight_data + weight_data_offset,
+            /*activation_data=*/activation_data_buffer + activation_data_offset,
+            /*bias=*/bias + bias_offset,
+            clamp_min,
+            clamp_max);
+      });
+}
+} // namespace internal
+
+void linear_operator(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    LinearTileSchedulingPolicy scheduling_policy,
+    char* activation_data_buffer,
+    // Outputs
+    float* output,
+    // Inputs
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const float* activations,
+    // const void* activation_data,
+    // Not applied if nullptr
+    const float* bias,
+    // Ignored if has_clamp = false
+    float clamp_min,
+    float clamp_max) {
+  TORCHAO_CHECK(group_size % 16 == 0, "group_size must be a multiple of 16");
+  TORCHAO_CHECK(k % group_size == 0, "group_size must divide k");
+  switch (scheduling_policy) {
+    case LinearTileSchedulingPolicy::single_mc_parallel_nc:
+      internal::linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
+          ukernel_config,
+          tiling_params,
+          activation_data_buffer,
+          output,
+          m,
+          n,
+          k,
+          group_size,
+          weight_data,
+          activations,
+          bias,
+          clamp_min,
+          clamp_max);
+      break;
+    case LinearTileSchedulingPolicy::parallel_mc_parallel_nc:
+      internal::
+          linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
+              ukernel_config,
+              tiling_params,
+              activation_data_buffer,
+              output,
+              m,
+              n,
+              k,
+              group_size,
+              weight_data,
+              activations,
+              bias,
+              clamp_min,
+              clamp_max);
+      break;
+    default:
+      TORCHAO_CHECK(false, "Unimplemented LinearTileSchedulingPolicy");
+  }
+}
+
+inline int get_activation_data_buffer_size(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    LinearTileSchedulingPolicy scheduling_policy,
+    int m,
+    int k,
+    int group_size) {
+  switch (scheduling_policy) {
+    case LinearTileSchedulingPolicy::single_mc_parallel_nc:
+      return internal::
+          get_activation_data_buffer_size_with_tile_schedule_policy_single_mc_parallel_nc(
+              ukernel_config, tiling_params, m, k, group_size);
+    case LinearTileSchedulingPolicy::parallel_mc_parallel_nc:
+      return internal::
+          get_activation_data_buffer_size_with_tile_schedule_policy_parallel_mc_parallel_nc(
+              ukernel_config, tiling_params, m, k, group_size);
+    default:
+      TORCHAO_CHECK(false, "Unimplemented LinearTileSchedulingPolicy");
+  }
+}
+
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight
+
+// TODO: may move to different fil or namespace.  This method is not part of the
+// high-level interface, but specific to the universal kernels we wrote in
+// torchao
+#include <torchao/experimental/kernels/cpu/aarch64/linear/linear.h>
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
+
+UKernelConfig get_ukernel_config() {
+  UKernelConfig config;
+
+  namespace ukernel = torchao::kernels::cpu::aarch64::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot;
+  config.mr = 1;
+  config.nr = 8;
+  config.activation_data_size_fn =
+      &ukernel::activation_data_size<has_weight_zeros>;
+  config.activation_data_alignment = alignof(char*);
+  config.prepare_activation_data_fn =
+      &ukernel::prepare_activation_data<has_weight_zeros>;
+  config.weight_data_size_fn =
+      &ukernel::weight_data_size<weight_nbit, has_weight_zeros>;
+  config.weight_data_alignment = alignof(char*);
+  config.prepare_weight_data_fn =
+      &ukernel::prepare_weight_data<weight_nbit, has_weight_zeros>;
+  config.kernel_fn =
+      &ukernel::kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>;
+
+  return config;
+}
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight
+  // torchao::kernels::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight

--- a/torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -1,0 +1,155 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// TODO: maybe move to operator directory
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+
+struct UKernelConfig {
+  using activation_data_size_fn_type =
+      int (*)(int m, int k, int group_size);
+  using prepare_activation_data_fn_type = void (*)(
+      void* activation_data,
+      int m,
+      int k,
+      int group_size,
+      const float* activations);
+  using weight_data_size_fn_type =
+      int (*)(int n, int k, int group_size);
+  using prepare_weight_data_fn_type = void (*)(
+      void* weight_data,
+      int n,
+      int k,
+      int group_size,
+      const int8_t* weight_qvals,
+      const float* weight_scales,
+      const int8_t* weight_zeros);
+  using kernel_fn_type = void (*)(
+      float* output,
+      int output_m_stride,
+      int m,
+      int n,
+      int k,
+      int group_size,
+      const void* weight_data,
+      const void* activation_data,
+      const float* bias,
+      float clamp_min,
+      float clamp_max);
+
+  activation_data_size_fn_type activation_data_size_fn{nullptr};
+  int activation_data_alignment{0};
+  prepare_activation_data_fn_type prepare_activation_data_fn{nullptr};
+
+  weight_data_size_fn_type weight_data_size_fn{nullptr};
+  int weight_data_alignment{0};
+  prepare_weight_data_fn_type prepare_weight_data_fn{nullptr};
+
+  kernel_fn_type kernel_fn{nullptr};
+  int mr{0};
+  int nr{0};
+};
+
+// Pack weight functions
+struct PackWeightDataTilingParams {
+  int nc_by_nr{1};
+};
+
+PackWeightDataTilingParams get_default_pack_weight_data_tiling_params(
+    const UKernelConfig& ukernel_config,
+    int n,
+    int target_panels_per_thread = 1);
+
+inline int get_packed_weight_data_size(
+    const UKernelConfig& ukernel_config,
+    int n,
+    int k,
+    int group_size) {
+  return ukernel_config.weight_data_size_fn(n, k, group_size);
+}
+
+inline int get_packed_weight_data_alignment(
+    const UKernelConfig& ukernel_config) {
+  return ukernel_config.weight_data_alignment;
+}
+
+void pack_weight_data_operator(
+    const UKernelConfig& ukernel_config,
+    const PackWeightDataTilingParams& tiling_params,
+    // Outputs
+    void* weight_data,
+    // Inputs
+    int n,
+    int k,
+    int group_size,
+    const int8_t* weight_qvals,
+    const float* weight_scales,
+    const int8_t* weight_zeros);
+
+// Linear functions
+struct LinearTilingParams {
+  int mc_by_mr{1};
+  int nc_by_nr{1};
+};
+
+LinearTilingParams get_default_linear_tiling_params(
+    const UKernelConfig& ukernel_config,
+    int m,
+    int n,
+    int target_tiles_per_thread = 5);
+
+enum class LinearTileSchedulingPolicy {
+  single_mc_parallel_nc,
+  parallel_mc_parallel_nc
+};
+
+int get_activation_data_buffer_size(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    LinearTileSchedulingPolicy scheduling_policy,
+    int m,
+    int k,
+    int group_size);
+
+inline int get_activation_data_buffer_alignment(
+    const UKernelConfig& ukernel_config) {
+  return ukernel_config.activation_data_alignment;
+}
+
+void linear_operator(
+    const UKernelConfig& ukernel_config,
+    const LinearTilingParams& tiling_params,
+    LinearTileSchedulingPolicy scheduling_policy,
+    char* activation_data_buffer,
+    // Outputs
+    float* output,
+    // Inputs
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const float* activations,
+    const float* bias,
+    float clamp_min,
+    float clamp_max);
+
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight
+
+// TODO: may move to different file or namespace
+// It is not part of the high-level interface, but specific to the universal
+// kernels in torchao.
+// Kleidi will need to implement their own get_ukernel_config
+// In future, we may build a high-level get_ukernel_config with CPU-runtime
+// selection
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
+UKernelConfig get_ukernel_config();
+
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight
+
+#include <torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight-impl.h>

--- a/torchao/experimental/kernels/cpu/linear/examples/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/linear/examples/CMakeLists.txt
@@ -1,0 +1,49 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+project(examples)
+
+cmake_minimum_required(VERSION 3.19)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Release)
+
+add_compile_options("-Wall" "-Werror")
+
+include(CMakePrintHelpers)
+message("TORCHAO_LIBRARIES: ${TORCHAO_LIBRARIES}")
+include_directories(${TORCHAO_LIBRARIES})
+
+add_library(
+  torchao_dep
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/find_min_and_max.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/compute_sum.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/quantization/quantize.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/valpacking/interleave.cpp
+)
+
+
+add_executable(separate_function_wrappers separate_function_wrappers.cpp)
+target_link_libraries(
+  separate_function_wrappers
+    PRIVATE
+    torchao_dep
+)
+
+add_executable(stateful_class_wrapper stateful_class_wrapper.cpp)
+target_link_libraries(
+  stateful_class_wrapper
+    PRIVATE
+    torchao_dep
+)
+
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(separate_function_wrappers PUBLIC OpenMP::OpenMP_CXX)
+  target_compile_definitions(separate_function_wrappers PRIVATE TORCHAO_PARALLEL_OMP=1)
+
+  target_link_libraries(stateful_class_wrapper PUBLIC OpenMP::OpenMP_CXX)
+  target_compile_definitions(stateful_class_wrapper PRIVATE TORCHAO_PARALLEL_OMP=1)
+else()
+  target_compile_definitions(separate_function_wrappers PRIVATE TORCHAO_PARALLEL_SINGLE_THREADED=1)
+  target_compile_definitions(stateful_class_wrapper PRIVATE TORCHAO_PARALLEL_SINGLE_THREADED=1)
+endif()

--- a/torchao/experimental/kernels/cpu/linear/examples/Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator.h
+++ b/torchao/experimental/kernels/cpu/linear/examples/Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator.h
@@ -1,0 +1,193 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+#include <torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h>
+#include <torchao/experimental/kernels/cpu/macro.h>
+#include <torchao/experimental/kernels/cpu/memory.h>
+#include <cassert>
+#include <optional>
+
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+
+class Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator {
+ private:
+  torchao::aligned_byte_ptr packed_weight_data_{
+      nullptr,
+      nullptr};
+
+  torchao::aligned_byte_ptr activation_data_buffer_{
+      nullptr,
+      nullptr};
+
+  int m_{0};
+  int n_{0};
+  int k_{0};
+  int group_size_{0};
+
+  // The class does not own this data
+  const int8_t* weight_qvals_{nullptr};
+  const float* weight_scales_{nullptr};
+  const int8_t* weight_zeros_{nullptr};
+
+  bool initialized_{false};
+
+  UKernelConfig ukernel_config_;
+  PackWeightDataTilingParams pack_weight_tiling_params_;
+  LinearTilingParams linear_tiling_params_;
+  LinearTileSchedulingPolicy linear_scheduling_policy_;
+
+ public:
+  Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator(
+      UKernelConfig ukernel_config,
+      int n,
+      int k,
+      int group_size,
+      const int8_t* weight_qvals,
+      const float* weight_scales,
+      const int8_t* weight_zeros,
+      int initial_m = 1,
+      std::optional<PackWeightDataTilingParams> pack_weight_tiling_params = {},
+      std::optional<LinearTilingParams> linear_tiling_params = {},
+      std::optional<LinearTileSchedulingPolicy> linear_scheduling_policy = {})
+      : m_{initial_m},
+        n_{n},
+        k_{k},
+        group_size_(group_size),
+        weight_qvals_{weight_qvals},
+        weight_scales_{weight_scales},
+        weight_zeros_{weight_zeros} {
+    TORCHAO_CHECK(n_ >= 1, "n must be >= 1");
+    TORCHAO_CHECK(k_ >= 1, "k must be >= 1");
+    TORCHAO_CHECK(group_size_ >= 1, "group_size must be >= 1");
+    TORCHAO_CHECK(m_ >= 1, "initial_m must be >= 1");
+
+    ukernel_config_ = ukernel_config;
+    if (pack_weight_tiling_params.has_value()) {
+      pack_weight_tiling_params_ = pack_weight_tiling_params.value();
+    } else {
+      pack_weight_tiling_params_ = get_default_pack_weight_data_tiling_params(
+          ukernel_config_, n_, /*target_panels_per_thread=*/1);
+    }
+
+    if (linear_tiling_params.has_value()) {
+      linear_tiling_params_ = linear_tiling_params.value();
+    } else {
+      linear_tiling_params_ = get_default_linear_tiling_params(
+          ukernel_config_, m_, n_, /*target_tiles_per_thread=*/5);
+    }
+
+    if (linear_scheduling_policy.has_value()) {
+      linear_scheduling_policy_ = linear_scheduling_policy.value();
+    } else {
+      linear_scheduling_policy_ =
+          LinearTileSchedulingPolicy::single_mc_parallel_nc;
+    }
+  }
+
+  int get_m() {
+    return m_;
+  }
+  int get_n() {
+    return n_;
+  }
+  int get_k() {
+    return k_;
+  }
+  int get_group_size() {
+    return group_size_;
+  }
+
+  void initialize() {
+    if (initialized_) {
+      return;
+    }
+
+    // Pack weight data
+    auto packed_weight_data_size =
+        get_packed_weight_data_size(ukernel_config_, n_, k_, group_size_);
+    auto packed_weight_data_alignment =
+        get_packed_weight_data_alignment(ukernel_config_);
+    packed_weight_data_ = torchao::make_aligned_byte_ptr(
+        packed_weight_data_alignment, packed_weight_data_size);
+
+    pack_weight_data_operator(
+        ukernel_config_,
+        pack_weight_tiling_params_,
+        packed_weight_data_.get(),
+        n_,
+        k_,
+        group_size_,
+        weight_qvals_,
+        weight_scales_,
+        weight_zeros_);
+
+    // Pre-allocate space for quantized/packed activations
+    // This buffer may be resized when calling the operator if m is changed
+    auto activation_data_buffer_size = get_activation_data_buffer_size(
+        ukernel_config_,
+        linear_tiling_params_,
+        linear_scheduling_policy_,
+        m_,
+        k_,
+        group_size_);
+    auto activation_data_buffer_alignment =
+        get_activation_data_buffer_alignment(ukernel_config_);
+    activation_data_buffer_ = torchao::make_aligned_byte_ptr(
+        activation_data_buffer_alignment, activation_data_buffer_size);
+
+    // Mark as initialized
+    initialized_ = true;
+  }
+
+  void operator()(
+      float* output,
+      const float* activations,
+      int m,
+      int k,
+      const float* bias,
+      float clamp_min,
+      float clamp_max) {
+    TORCHAO_CHECK(initialized_, "kernel is not initialized.");
+    TORCHAO_CHECK(
+        k == this->k_,
+        "activations have incompatible size with initialized kernel.");
+
+    // Resize activation buffer if needed
+    if (m > m_) {
+      m_ = m;
+      auto activation_data_buffer_size = get_activation_data_buffer_size(
+          ukernel_config_,
+          linear_tiling_params_,
+          linear_scheduling_policy_,
+          m_,
+          k_,
+          group_size_);
+      auto activation_data_buffer_alignment =
+          get_activation_data_buffer_alignment(ukernel_config_);
+      activation_data_buffer_ = torchao::make_aligned_byte_ptr(
+          activation_data_buffer_alignment, activation_data_buffer_size);
+    }
+
+    // Run linear operator
+    linear_operator(
+        ukernel_config_,
+        linear_tiling_params_,
+        linear_scheduling_policy_,
+        activation_data_buffer_.get(),
+        output,
+        // To support dynamic shapes, we use m from args, not m_
+        // Note m_ can be larger than m
+        m,
+        n_,
+        k_,
+        group_size_,
+        packed_weight_data_.get(),
+        activations,
+        bias,
+        clamp_min,
+        clamp_max);
+  }
+};
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight

--- a/torchao/experimental/kernels/cpu/linear/examples/build_and_run_examples.sh
+++ b/torchao/experimental/kernels/cpu/linear/examples/build_and_run_examples.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
+
+export CMAKE_OUT=/tmp/cmake-out/torch_ao/examples
+cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
+    -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/linear/examples \
+    -B ${CMAKE_OUT} \
+    -DOpenMP_ROOT=$(brew --prefix libomp)
+cmake --build  ${CMAKE_OUT}
+
+# Run
+case "$1" in
+    separate_function_wrappers) ${CMAKE_OUT}/separate_function_wrappers; ;;
+    stateful_class_wrapper) ${CMAKE_OUT}/stateful_class_wrapper; ;;
+    *) echo "Unknown example: $1. Please specify one of: separate_function_wrappers, stateful_class_wrapper."; exit 1; ;;
+esac

--- a/torchao/experimental/kernels/cpu/linear/examples/separate_function_wrappers.cpp
+++ b/torchao/experimental/kernels/cpu/linear/examples/separate_function_wrappers.cpp
@@ -1,0 +1,195 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+#include <torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h>
+#include <torchao/experimental/kernels/cpu/memory.h>
+#include <iostream>
+// This file contains an example of wrapping the torchao weight packing and
+// linear operators into two operators: one for weight packing and another
+// for running the linear operator.  Each surface (PyTorch custom class, PyTorch
+// operator, ExecuTorch operator, ExecuTorch delegate) will need to write its
+// own wrapper).  In the example here, std::vector is used for storage, but in
+// PyTorch a PyTorch Tensor would be used and in ExecuTorch, an ExecuTorch
+// Tensor would be used.
+//
+// It is more efficient to combine weight-packing and the linear operator into
+// one stateful class, but not all surfaces support this (see
+// examples/stateful_class_wrapper.cpp for an example of this).
+
+namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight {
+
+torchao::aligned_byte_ptr pack_weight_data_operator(
+    UKernelConfig ukernel_config,
+    int n,
+    int k,
+    int group_size,
+    const int8_t* weight_qvals,
+    const float* weight_scales,
+    const int8_t* weight_zeros,
+    std::optional<PackWeightDataTilingParams> tiling_params = {}) {
+  PackWeightDataTilingParams tiling_params_;
+  if (tiling_params.has_value()) {
+    tiling_params_ = tiling_params.value();
+  } else {
+    tiling_params_ = get_default_pack_weight_data_tiling_params(
+        ukernel_config, n, /*target_panels_per_thread=*/1);
+  }
+
+  auto packed_weight_data_size =
+      get_packed_weight_data_size(ukernel_config, n, k, group_size);
+  auto packed_weight_data_alignment =
+      get_packed_weight_data_alignment(ukernel_config);
+  auto packed_weight_data = torchao::make_aligned_byte_ptr(
+      packed_weight_data_alignment, packed_weight_data_size);
+
+  pack_weight_data_operator(
+      ukernel_config,
+      tiling_params_,
+      packed_weight_data.get(),
+      n,
+      k,
+      group_size,
+      weight_qvals,
+      weight_scales,
+      weight_zeros);
+
+  return packed_weight_data;
+}
+
+void linear_operator(
+    UKernelConfig ukernel_config,
+    float* output,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    void* packed_weight_data,
+    float* activations,
+    const float* bias,
+    float clamp_min,
+    float clamp_max,
+    std::optional<LinearTilingParams> tiling_params = {},
+    std::optional<LinearTileSchedulingPolicy> scheduling_policy = {}) {
+  LinearTilingParams tiling_params_;
+  if (tiling_params.has_value()) {
+    tiling_params_ = tiling_params.value();
+  } else {
+    tiling_params_ = get_default_linear_tiling_params(
+        ukernel_config, m, n, /*target_tiles_per_thread=*/5);
+  }
+
+  LinearTileSchedulingPolicy scheduling_policy_;
+  if (scheduling_policy.has_value()) {
+    scheduling_policy_ = scheduling_policy.value();
+  } else {
+    scheduling_policy_ = LinearTileSchedulingPolicy::single_mc_parallel_nc;
+  }
+
+  auto activation_data_buffer_size = get_activation_data_buffer_size(
+      ukernel_config, tiling_params_, scheduling_policy_, m, k, group_size);
+  auto activation_data_buffer_alignment =
+      get_activation_data_buffer_alignment(ukernel_config);
+  auto activation_data_buffer = torchao::make_aligned_byte_ptr(
+      activation_data_buffer_alignment, activation_data_buffer_size);
+
+  linear_operator(
+      ukernel_config,
+      tiling_params_,
+      scheduling_policy_,
+      activation_data_buffer.get(),
+      output,
+      m,
+      n,
+      k,
+      group_size,
+      packed_weight_data,
+      activations,
+      bias,
+      clamp_min,
+      clamp_max);
+}
+
+} // namespace
+  // torchao::operators::cpu::linear::channelwise_8bit_activation_groupwise_lowbit_weight
+
+int main() {
+  using namespace torchao::operators::cpu::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight;
+
+  torchao::set_num_threads(8);
+  std::cout << "Using " << torchao::get_num_threads() << " threads."
+            << std::endl;
+
+  constexpr int weight_nbit = 3;
+  constexpr bool has_weight_zeros = false;
+  constexpr bool has_bias = false;
+  constexpr bool has_clamp = false;
+
+  int m = 1;
+  int n = 4096 + 1;
+  int k = 4096;
+  int group_size = 16;
+
+  std::cout << "Generating random test case." << std::endl;
+  auto test_case = torchao::
+      channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
+          m,
+          k,
+          n,
+          group_size,
+          weight_nbit,
+          has_weight_zeros,
+          has_bias,
+          has_clamp);
+
+  auto output = std::vector<float>(m * n);
+
+  auto ukernel_config =
+      get_ukernel_config<weight_nbit, has_weight_zeros, has_bias, has_clamp>();
+
+  std::cout << "Running pack_weight_data_operator." << std::endl;
+  auto packed_weight_data = pack_weight_data_operator(
+      ukernel_config,
+      n,
+      k,
+      group_size,
+      test_case.weight_qvals.data(),
+      test_case.weight_scales.data(),
+      test_case.weight_zeros.data());
+
+  std::cout << "Running linear_operator." << std::endl;
+  linear_operator(
+      ukernel_config,
+      output.data(),
+      m,
+      n,
+      k,
+      group_size,
+      packed_weight_data.get(),
+      test_case.activations.data(),
+      test_case.bias.data(),
+      test_case.clamp_min,
+      test_case.clamp_max);
+
+  std::cout << "Checking results." << std::endl;
+
+  bool passed = true;
+  float tol = 0.001;
+  for (int i = 0; i < output.size(); i++) {
+    if (std::abs(test_case.expected_output[i] - output[i]) > tol) {
+      std::cout << "Bad result at index " << i << ".";
+      std::cout << " Output: " << output[i]
+                << ". Expected: " << test_case.expected_output[i] << "."
+                << std::endl;
+      passed = false;
+    }
+  }
+  if (passed) {
+    std::cout << "Test passed." << std::endl;
+  } else {
+    std::cout << "Test failed." << std::endl;
+  }
+
+  return 0;
+}

--- a/torchao/experimental/kernels/cpu/linear/examples/stateful_class_wrapper.cpp
+++ b/torchao/experimental/kernels/cpu/linear/examples/stateful_class_wrapper.cpp
@@ -1,0 +1,99 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+#include <torchao/experimental/kernels/cpu/linear/examples/Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator.h>
+#include <torchao/experimental/kernels/cpu/parallel.h>
+#include <iostream>
+#include <vector>
+
+// This file contains an example of wrapping the torchao weight packing and
+// linear operators into one stateful LinearOperator class. Each surface
+// (PyTorch custom class, PyTorch operator, ExecuTorch operator, ExecuTorch
+// delegate) will need to write its own wrapper.  In the example here,
+// std::vector is used for storage, but in PyTorch a PyTorch Tensor would be
+// used and in ExecuTorch, an ExecuTorch Tensor would be used.
+//
+// Although more efficient, not all surfaces support stateful operators.  See
+// examples/separate_function_wrappers.cpp for an example of how to split the
+// operations into two steps.
+
+using namespace torchao::operators::cpu::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight;
+
+int main() {
+  int m = 13;
+  int n = 4096 + 1;
+  int k = 4096;
+  int group_size = 16;
+
+  constexpr int weight_nbit = 4;
+  constexpr bool has_weight_zeros = false;
+  constexpr bool has_bias = false;
+  constexpr bool has_clamp = false;
+
+  std::cout << "Generating random test case." << std::endl;
+  auto test_case = torchao::
+      channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
+          m,
+          k,
+          n,
+          group_size,
+          weight_nbit,
+          has_weight_zeros,
+          has_bias,
+          has_clamp);
+
+  torchao::set_num_threads(8);
+  std::cout << "Using " << torchao::get_num_threads() << " threads."
+            << std::endl;
+
+  std::cout << "Initializing linear_operator." << std::endl;
+  auto ukernel_config =
+      get_ukernel_config<weight_nbit, has_weight_zeros, has_bias, has_clamp>();
+  auto linear_operator =
+      Channelwise8BitActivationGroupwiseLowbitWeightLinearOperator(
+          ukernel_config,
+          n,
+          k,
+          group_size,
+          test_case.weight_qvals.data(),
+          test_case.weight_scales.data(),
+          test_case.weight_zeros.data(),
+          // m may be resized during call to support dynamic shapes
+          /*initial_m=*/1);
+
+  linear_operator.initialize();
+
+  std::cout << "Calling linear_operator." << std::endl;
+  auto output = std::vector<float>(m * n);
+  linear_operator(
+      output.data(),
+      test_case.activations.data(),
+      m,
+      k,
+      test_case.bias.data(),
+      test_case.clamp_min,
+      test_case.clamp_max);
+
+  std::cout << "Checking results." << std::endl;
+
+  bool passed = true;
+  float tol = 0.001;
+  for (int i = 0; i < output.size(); i++) {
+    if (std::abs(test_case.expected_output[i] - output[i]) > tol) {
+      std::cout << "Bad result at index " << i << ".";
+      std::cout << " Output: " << output[i]
+                << ". Expected: " << test_case.expected_output[i] << "."
+                << std::endl;
+      passed = false;
+      break;
+    }
+  }
+  if (passed) {
+    std::cout << "Test passed." << std::endl;
+  } else {
+    std::cout << "Test failed." << std::endl;
+  }
+
+  return 0;
+}

--- a/torchao/experimental/kernels/cpu/linear/tests/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/linear/tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+cmake_minimum_required(VERSION 3.19)
+project(tests)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_BUILD_TYPE Debug)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+add_compile_options("-Wall" "-Werror")
+
+include(CMakePrintHelpers)
+message("TORCHAO_LIBRARIES: ${TORCHAO_LIBRARIES}")
+include_directories(${TORCHAO_LIBRARIES})
+
+add_library(
+  dep
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/find_min_and_max.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/reduction/compute_sum.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/quantization/quantize.cpp
+  ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/valpacking/interleave.cpp
+)
+
+enable_testing()
+
+add_definitions(-DTORCHAO_PARALLEL_TEST_DUMMY=1)
+add_executable(test_linear_operator test_linear_operator.cpp)
+target_link_libraries(
+    test_linear_operator
+    PRIVATE
+    GTest::gtest_main
+    dep
+)
+
+include(GoogleTest)
+gtest_discover_tests(test_linear_operator)

--- a/torchao/experimental/kernels/cpu/linear/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/linear/tests/build_and_run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
+export CMAKE_OUT=/tmp/cmake-out/torch_ao/tests
+cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/linear/tests -B ${CMAKE_OUT}
+
+cmake --build  ${CMAKE_OUT}
+
+# Run
+${CMAKE_OUT}/test_linear_operator

--- a/torchao/experimental/kernels/cpu/linear/tests/test_linear_operator.cpp
+++ b/torchao/experimental/kernels/cpu/linear/tests/test_linear_operator.cpp
@@ -1,0 +1,213 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+// TODO: move test_utils.h out of aarch64
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+#include <torchao/experimental/kernels/cpu/linear/channelwise_8bit_activation_groupwise_lowbit_weight.h>
+#include <torchao/experimental/kernels/cpu/memory.h>
+#include <torchao/experimental/kernels/cpu/parallel.h>
+
+const float kTol = 1.0e-5;
+
+template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
+void test_channelwise_8bit_activation_groupwise_lowbit_weight(
+    int m,
+    int n,
+    int k,
+    int group_size) {
+  using namespace torchao::operators::cpu::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight;
+  auto ukernel_config =
+      get_ukernel_config<weight_nbit, has_weight_zeros, has_bias, has_clamp>();
+
+  auto test_case = torchao::
+      channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
+          m,
+          k,
+          n,
+          group_size,
+          weight_nbit,
+          has_weight_zeros,
+          has_bias,
+          has_clamp);
+  float output[m * n];
+
+  for (auto linear_scheduling_policy :
+       {LinearTileSchedulingPolicy::single_mc_parallel_nc,
+        LinearTileSchedulingPolicy::parallel_mc_parallel_nc}) {
+    for (auto num_threads : {1, 4, 500}) {
+      torchao::set_num_threads(num_threads);
+      EXPECT_EQ(torchao::get_num_threads(), num_threads);
+
+      // Pack weights
+      auto pack_weight_data_tiling_params =
+          get_default_pack_weight_data_tiling_params(ukernel_config, n);
+      auto packed_weight_data_size =
+          get_packed_weight_data_size(ukernel_config, n, k, group_size);
+      auto packed_weight_data_alignment =
+          get_packed_weight_data_alignment(ukernel_config);
+      auto packed_weight_data = torchao::make_aligned_byte_array_unique_ptr(
+          packed_weight_data_alignment, packed_weight_data_size);
+
+      pack_weight_data_operator(
+          ukernel_config,
+          pack_weight_data_tiling_params,
+          packed_weight_data.get(),
+          n,
+          k,
+          group_size,
+          test_case.weight_qvals.data(),
+          test_case.weight_scales.data(),
+          test_case.weight_zeros.data());
+
+      // Allocate activation buffer
+      auto linear_tiling_params =
+          get_default_linear_tiling_params(ukernel_config, m, n);
+
+      auto activation_data_buffer_size = get_activation_data_buffer_size(
+          ukernel_config,
+          linear_tiling_params,
+          linear_scheduling_policy,
+          m,
+          k,
+          group_size);
+      auto activation_data_buffer_alignment =
+          get_activation_data_buffer_alignment(ukernel_config);
+      auto activation_data_buffer = torchao::make_aligned_byte_array_unique_ptr(
+          activation_data_buffer_alignment, activation_data_buffer_size);
+
+      // Run linear
+      linear_operator(
+          ukernel_config,
+          linear_tiling_params,
+          linear_scheduling_policy,
+          activation_data_buffer.get(),
+          output,
+          m,
+          n,
+          k,
+          group_size,
+          packed_weight_data.get(),
+          test_case.activations.data(),
+          test_case.bias.data(),
+          test_case.clamp_min,
+          test_case.clamp_max);
+
+      // Test correctness
+      for (int i = 0; i < m * n; i++) {
+        EXPECT_NEAR(output[i], test_case.expected_output[i], kTol);
+      }
+    }
+  }
+}
+
+TEST(test_channelwise_8bit_activation_groupwise_lowbit_weight, Standard) {
+  test_channelwise_8bit_activation_groupwise_lowbit_weight<
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_channelwise_8bit_activation_groupwise_lowbit_weight, HasWeightZeros) {
+  test_channelwise_8bit_activation_groupwise_lowbit_weight<
+      4 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_channelwise_8bit_activation_groupwise_lowbit_weight, HasBias) {
+  test_channelwise_8bit_activation_groupwise_lowbit_weight<
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_channelwise_8bit_activation_groupwise_lowbit_weight, HasClamp) {
+  test_channelwise_8bit_activation_groupwise_lowbit_weight<
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_channelwise_8bit_activation_groupwise_lowbit_weight, SmallDimension) {
+  test_channelwise_8bit_activation_groupwise_lowbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/1, /*n=*/1, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(
+    test_channelwise_8bit_activation_groupwise_lowbit_weight,
+    KNotDivisibleByGroupSize) {
+  int n = 1;
+  int k = 16 + 1;
+  int group_size = 16;
+
+  using namespace torchao::operators::cpu::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight;
+  auto ukernel_config = get_ukernel_config<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>();
+  auto pack_weight_data_tiling_params =
+      get_default_pack_weight_data_tiling_params(ukernel_config, n);
+
+  EXPECT_THROW(
+      {
+        pack_weight_data_operator(
+            ukernel_config,
+            pack_weight_data_tiling_params,
+            /*packed_weight_data=*/nullptr,
+            n,
+            k,
+            group_size,
+            /*weight_qvals=*/nullptr,
+            /*weight_scales=*/nullptr,
+            /*weight_zeros=*/nullptr);
+      },
+      std::runtime_error);
+}
+
+TEST(
+    test_channelwise_8bit_activation_groupwise_lowbit_weight,
+    GroupSizeNotDivisibleBy16) {
+  int n = 1;
+  int k = 20;
+  int group_size = 10;
+
+  using namespace torchao::operators::cpu::linear::
+      channelwise_8bit_activation_groupwise_lowbit_weight;
+  auto ukernel_config = get_ukernel_config<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>();
+  auto pack_weight_data_tiling_params =
+      get_default_pack_weight_data_tiling_params(ukernel_config, n);
+
+  EXPECT_THROW(
+      {
+        pack_weight_data_operator(
+            ukernel_config,
+            pack_weight_data_tiling_params,
+            /*packed_weight_data=*/nullptr,
+            n,
+            k,
+            group_size,
+            /*weight_qvals=*/nullptr,
+            /*weight_scales=*/nullptr,
+            /*weight_zeros=*/nullptr);
+      },
+      std::runtime_error);
+}

--- a/torchao/experimental/kernels/cpu/macro.h
+++ b/torchao/experimental/kernels/cpu/macro.h
@@ -1,0 +1,8 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#define TORCHAO_CHECK(cond, message)   \
+  if (!(cond)) {                       \
+    throw std::runtime_error(message); \
+  }

--- a/torchao/experimental/kernels/cpu/memory.h
+++ b/torchao/experimental/kernels/cpu/memory.h
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace torchao {
+
+using aligned_byte_ptr =
+    std::unique_ptr<char[], void (*)(void*)>;
+
+aligned_byte_ptr make_aligned_byte_ptr(
+    size_t alignment,
+    size_t size) {
+  // Adjust size to next multiple of alignment >= size
+  size_t adjusted_size = ((size + alignment - 1) / alignment) * alignment;
+
+  char* ptr = static_cast<char*>(std::aligned_alloc(alignment, adjusted_size));
+  if (!ptr) {
+    throw std::runtime_error(
+        "Failed to allocate memory. Requested size: " + std::to_string(size) +
+        ". Requested alignment: " + std::to_string(alignment) +
+        ". Adjusted size: " + std::to_string(adjusted_size) + ".");
+  }
+  return std::unique_ptr<char[], void (*)(void*)>(ptr, std::free);
+}
+} // namespace torchao

--- a/torchao/experimental/kernels/cpu/parallel.h
+++ b/torchao/experimental/kernels/cpu/parallel.h
@@ -1,0 +1,140 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace torchao {
+// F has  [&](int64_t begin, int64_t end)
+template <typename F>
+void parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f);
+
+void set_num_threads(int num_threads);
+
+int get_num_threads();
+
+} // namespace torchao
+
+#ifdef TORCHAO_PARALLEL_ATEN
+#pragma message("TORCHAO_PARALLEL_ATEN is set.  Using ATen parallel backend.")
+
+#include <ATen/ATen.h>
+#include <torch/torch.h>
+
+template <typename F>
+void torchao::parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f) {
+  at::parallel_for(begin, end, grain_size, f);
+}
+
+void torchao::set_num_threads(int num_threads) {
+  torch::set_num_threads(num_threads);
+}
+
+int torchao::get_num_threads() {
+  return torch::get_num_threads();
+}
+
+#else
+#ifdef TORCHAO_PARALLEL_EXECUTORCH
+#pragma message( \
+    "TORCHAO_PARALLEL_EXECUTORCH is set.  Using ExecuTorch parallel backend.")
+
+#error "TORCHAO_PARALLEL_EXECUTORCH is not implemented yet"
+
+#else
+#ifdef TORCHAO_PARALLEL_PTHREADPOOL
+#pragma message( \
+    "TORCHAO_PARALLEL_PTHREADPOOL is set.  Using pthreadpool parallel backend.")
+
+#error "TORCHAO_PARALLEL_PTHREADPOOL is not implemented yet"
+
+#else
+#ifdef TORCHAO_PARALLEL_OMP
+#pragma message("TORCHAO_PARALLEL_OMP is set.  Using OMP parallel backend.")
+
+#include <omp.h>
+
+template <typename F>
+void torchao::parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f) {
+#pragma omp parallel
+  {
+#pragma omp for
+    for (int i = begin; i < end; i += grain_size) {
+      f(i, i + grain_size);
+    }
+  }
+}
+
+void torchao::set_num_threads(int num_threads) {
+  omp_set_num_threads(num_threads);
+}
+int torchao::get_num_threads() {
+  // omp_get_num_threads returns the number of threads
+  // in the current code section, which will be 1 in the routines
+  // that select tiling params
+  return omp_get_max_threads();
+}
+
+#else
+#if defined TORCHAO_PARALLEL_SINGLE_THREADED || \
+    defined TORCHAO_PARALLEL_TEST_DUMMY
+
+template <typename F>
+void torchao::parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f) {
+  for (int i = begin; i < end; i += grain_size) {
+    f(i, i + grain_size);
+  }
+}
+
+#ifdef TORCHAO_PARALLEL_SINGLE_THREADED
+#pragma message( \
+    "TORCHAO_PARALLEL_SINGLE_THREADED is set.  Using single-threaded parallel backend.")
+void torchao::set_num_threads(int num_threads) {}
+int torchao::get_num_threads() {
+  return 1;
+}
+#else // TORCHAO_PARALLEL_TEST_DUMMY
+#pragma message( \
+    "TORCHAO_PARALLEL_TEST_DUMMY is set.  Using test dummy parallel backend.")
+
+namespace torchao {
+static int _dummy_num_threads{1};
+}
+
+void torchao::set_num_threads(int num_threads) {
+  torchao::_dummy_num_threads = num_threads;
+}
+int torchao::get_num_threads() {
+  return torchao::_dummy_num_threads;
+}
+#endif // TORCHAO_PARALLEL_SINGLE_THREADED
+
+#else
+#error \
+    "Set parallel backend by defining one of the following: \
+ TORCHAO_PARALLEL_ATEN, \
+ TORCHAO_PARALLEL_EXECUTORCH, \
+ TORCHAO_PARALLEL_PTHREADPOOL, \
+ TORCHAO_PARALLEL_OMP, \
+ TORCHAO_PARALLEL_SINGLE_THREADED, \
+ TORCHAO_PARALLEL_TEST_DUMMY"
+#endif // TORCHAO_PARALLEL_SINGLE_THREADED || TORCHAO_PARALLEL_TEST_DUMMY
+
+#endif // TORCHAO_PARALLEL_OMP
+#endif // TORCHAO_PARALLEL_PTHREADPOOL
+#endif // TORCHAO_PARALLEL_EXECUTORCH
+#endif // TORCHAO_PARALLEL_ATEN


### PR DESCRIPTION
Summary:
Here is a draft of the high-level kernel operator.  This is something I quickly put together to get early feedback, and it will be iterated.  It closely follows what I had in the design doc, but I think it's easier to see how things fit together in the code.

The operator uses parallel_for and get_num_threads.  At build time, we need to link these to ET/PT implementations.  In this diff, they are single-threaded or OMP-backed implementations that I threw together.

The operator (inside channelwise_8bit_activation_groupwise_lowbit_weight.h) depends on a ukernel_config and tiling configs.  But in the wrapper, these can be hidden if desired (see examples/ for how).

Reviewed By: digantdesai

Differential Revision: D60321449
