### PR TITLE
cast `local_scale_tensor` to fp32 for precompute of fp8 dynamic scaling

### DIFF
--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 import threading
 import unittest
-from typing import Any, List
+from typing import Any, List, Optional
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
@@ -59,7 +59,7 @@ class TestFloat8Common:
         self.broadcast_module(module)
         return module
 
-    def init_transformer(self, weight_tying: bool, dtype: torch.dtype | None = None) -> nn.Module:
+    def init_transformer(self, weight_tying: bool, dtype: Optional[torch.dtype] = None) -> nn.Module:
         torch.manual_seed(42)
         args = ModelArgs(
             n_layers=3,

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -109,7 +109,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         precompute: bool,
         scaling_type_weight: ScalingType,
         compile_transformer_block: bool,
-        dtype: torch.dtype | None = None,
+        dtype: Optional[torch.dtype] = None,
     ):
         if not enable_fsdp_float8_all_gather and precompute:
             return

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -59,7 +59,7 @@ class TestFloat8Common:
         self.broadcast_module(module)
         return module
 
-    def init_transformer(self, weight_tying: bool) -> nn.Module:
+    def init_transformer(self, weight_tying: bool, dtype: torch.dtype | None = None) -> nn.Module:
         torch.manual_seed(42)
         args = ModelArgs(
             n_layers=3,
@@ -70,6 +70,8 @@ class TestFloat8Common:
             vocab_size=32,
         )
         module = Transformer(args).cuda()
+        if dtype is not None:
+            module = module.to(dtype=dtype)
         self.broadcast_module(module)
         return module
 
@@ -96,6 +98,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
                     ScalingType.DELAYED,
                 ],
                 "compile_transformer_block": [False, True],
+                "dtype": [torch.float32, torch.bfloat16],
             },
             self._test_transformer_parity,
         )
@@ -106,6 +109,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         precompute: bool,
         scaling_type_weight: ScalingType,
         compile_transformer_block: bool,
+        dtype: torch.dtype | None = None,
     ):
         if not enable_fsdp_float8_all_gather and precompute:
             return
@@ -117,7 +121,7 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         # latter uses fp8 compute. With fp8 all-gather, FSDP would pre-cast to
         # fp8 for that tied weight, incorrectly using fp8 for the embedding.
         weight_tying = not enable_fsdp_float8_all_gather
-        module = self.init_transformer(weight_tying=weight_tying).cuda()
+        module = self.init_transformer(weight_tying=weight_tying, dtype=dtype)
         ref_module = copy.deepcopy(module)
         float8_linear_config1 = Float8LinearConfig(
             cast_config_weight=CastConfig(scaling_type=scaling_type_weight),

--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -67,7 +67,7 @@ def precompute_float8_dynamic_scale_for_fsdp(module: nn.Module) -> None:
     scale_tensor = torch.finfo(torch.float8_e4m3fn).max / amax_tensor  # Replicate
     if amax_tensor.dtype is torch.float16:
         scale_tensor = torch.clamp(scale_tensor, max=torch.finfo(torch.float16).max)
-    local_scale_tensor = scale_tensor.to_local()
+    local_scale_tensor = scale_tensor.to_local().to(dtype=torch.float32)
     for i, float8_linear in enumerate(float8_linears):
         float8_linear.weight._local_tensor._precomputed_scale = local_scale_tensor[i]
 


### PR DESCRIPTION
When a model is in bfloat16, precomputed scales seem to be in bfloat16.
This seems to cause the dtype mismatch, especially `scale_b` being bf16, after the first call of precompute:

```
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torchao/float8/float8_linear.py", line 363, in forward
# [rank0]:[rank0]:     output = manual_float8_matmul.apply(input_fp8, weight_fp8.t())
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/autograd/function.py", line 575, in apply
# [rank0]:[rank0]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torchao/float8/float8_linear.py", line 60, in forward
# [rank0]:[rank0]:     res_bits = torch.mm(input_fp8_reshaped, weight_fp8_t)
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torchao/float8/float8_tensor.py", line 359, in __torch_dispatch__
# [rank0]:[rank0]:     return FLOAT8_OPS_TABLE[func](func, args, kwargs)
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torchao/float8/float8_ops.py", line 181, in float8_mm
# [rank0]:[rank0]:     tensor_out = addmm_float8_unwrapped(
# [rank0]:[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torchao/float8/float8_python_api.py", line 54, in addmm_float8_unwrapped
# [rank0]:[rank0]:     output = torch._scaled_mm(
# [rank0]:[rank0]: RuntimeError: Both scale_a and scale_b must be float (fp32) tensors.
```