### PR TITLE
Bug fixes

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
@@ -218,7 +218,21 @@ void kernel_impl(
       if constexpr (has_clamp) {
         res = clamp(res, clamp_min, clamp_max);
       }
-      vst1q_f32(output + m_idx * output_m_stride + n_idx, res);
+
+      // Store result
+      int remaining = n - n_idx;
+      float* store_loc = output + m_idx * output_m_stride + n_idx;
+      if (remaining >= 4) {
+        vst1q_f32(store_loc, res);
+      } else if (remaining >= 3) {
+        vst1_f32(store_loc, vget_low_f32(res));
+        *(store_loc + 2) = res[2];
+      } else if (remaining >= 2) {
+        vst1_f32(store_loc, vget_low_f32(res));
+      } else {
+        *(store_loc) = res[0];
+      }
+
     } // n_idx
     activation_data_byte_ptr += (activation_ptr - activation_data_byte_ptr);
   } // m_idx

--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
@@ -290,8 +290,34 @@ void kernel_impl(
         res_0123 = vec_clamp(res_0123, vec_min, vec_max);
         res_4567 = vec_clamp(res_4567, vec_min, vec_max);
       }
-      vst1q_f32(output + m_idx * output_m_stride + n_idx, res_0123);
-      vst1q_f32(output + m_idx * output_m_stride + n_idx + 4, res_4567);
+
+      // Store result
+      int remaining = n - n_idx;
+      float* store_loc = output + m_idx * output_m_stride + n_idx;
+      if (remaining >= 8) {
+        vst1q_f32(store_loc, res_0123);
+        vst1q_f32(store_loc + 4, res_4567);
+      } else if (remaining >= 7) {
+        vst1q_f32(store_loc, res_0123);
+        vst1_f32(store_loc + 4, vget_low_f32(res_4567));
+        *(store_loc + 6) = res_4567[2];
+      } else if (remaining >= 6) {
+        vst1q_f32(store_loc, res_0123);
+        vst1_f32(store_loc + 4, vget_low_f32(res_4567));
+      } else if (remaining >= 5) {
+        vst1q_f32(store_loc, res_0123);
+        *(store_loc + 4) = res_4567[0];
+      } else if (remaining >= 4) {
+        vst1q_f32(store_loc, res_0123);
+      } else if (remaining >= 3) {
+        vst1_f32(store_loc, vget_low_f32(res_0123));
+        *(store_loc + 2) = res_0123[2];
+      } else if (remaining >= 2) {
+        vst1_f32(store_loc, vget_low_f32(res_0123));
+      } else {
+        *store_loc = res_0123[0];
+      }
+
     } // n_idx
     activation_data_byte_ptr += (activation_ptr - activation_data_byte_ptr);
   } // m_idx

--- a/torchao/experimental/kernels/cpu/aarch64/reduction/compute_sum.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/reduction/compute_sum.cpp
@@ -1,15 +1,18 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
+#include <cassert>
 
 int32_t torchao::kernels::cpu::aarch64::reduction::compute_sum(
     const int8_t* vals,
     int size) {
+  assert(size >= 1);
+
   int32_t res = 0;
   int i = 0;
 
 #pragma unroll(4)
-  for (; i < size; i += 16) {
+  for (; i + 15 < size; i += 16) {
     int8x16_t vec_vals = vld1q_s8(vals + i);
     res += (int)(vaddlvq_s8(vec_vals));
   }

--- a/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
@@ -35,6 +35,14 @@ target_link_libraries(
     dep
 )
 
+add_executable(test_reduction test_reduction.cpp)
+target_link_libraries(
+  test_reduction
+    PRIVATE
+    GTest::gtest_main
+    dep
+)
+
 add_executable(test_bitpacking test_bitpacking.cpp)
 target_link_libraries(
   test_bitpacking
@@ -61,6 +69,7 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(test_quantization)
+gtest_discover_tests(test_reduction)
 gtest_discover_tests(test_bitpacking)
 gtest_discover_tests(test_linear)
 gtest_discover_tests(test_valpacking)

--- a/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
@@ -7,7 +7,8 @@ cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} -S ${TORCHAO_LIBRARIES}/torchao/e
 cmake --build  ${CMAKE_OUT}
 
 # Run
- ${CMAKE_OUT}/test_quantization
- ${CMAKE_OUT}/test_bitpacking
- ${CMAKE_OUT}/test_linear
- ${CMAKE_OUT}/test_valpacking
+${CMAKE_OUT}/test_quantization
+${CMAKE_OUT}/test_reduction
+${CMAKE_OUT}/test_bitpacking
+${CMAKE_OUT}/test_linear
+${CMAKE_OUT}/test_valpacking

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
@@ -10,12 +10,11 @@
 float kTol = 0.0001;
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
-void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot() {
-  int m = 7;
-  int k = 128;
-  int n = 13;
-  int group_size = 32;
-
+void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot(
+    int m,
+    int k,
+    int n,
+    int group_size) {
   auto test_case = torchao::
       channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
           m,
@@ -50,7 +49,7 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot
       test_case.weight_scales.data(),
       /*weight_zeros=*/test_case.weight_zeros.data());
 
-  std::vector<float> output(m * k);
+  std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
       output.data(),
       /*output_m_stride=*/n,
@@ -72,70 +71,53 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot,
     Standard) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/128, /*n=*/13, /*group_size=*/32);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot,
     HasWeightZeros) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = true;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/128, /*n=*/13, /*group_size=*/32);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot,
     HasBias) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = true;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/128, /*n=*/13, /*group_size=*/32);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot,
     HasClamp) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = true;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/7, /*k=*/128, /*n=*/13, /*group_size=*/32);
 }
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
-void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot() {
-  int m = 7;
-  int k = 64;
-  int n = 13;
-  int group_size = 16;
-
+void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot(
+    int m,
+    int k,
+    int n,
+    int group_size) {
   auto test_case = torchao::
       channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
           m,
@@ -170,7 +152,7 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot
       test_case.weight_scales.data(),
       /*weight_zeros=*/test_case.weight_zeros.data());
 
-  std::vector<float> output(m * k);
+  std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
       output.data(),
       /*output_m_stride=*/n,
@@ -192,70 +174,66 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot,
     Standard) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot,
     HasWeightZeros) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = true;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot,
     HasBias) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = true;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot,
     HasClamp) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = true;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
+}
+
+TEST(
+    test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot,
+    NLessThan4) {
+  for (int n = 1; n < 4; n++) {
+    test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot<
+        4 /*weight_nbit*/,
+        false /*has_weight_zeros*/,
+        false /*has_bias*/,
+        true /*has_clamp*/>(
+        /*m=*/7, /*k=*/64, /*n=*/n, /*group_size=*/16);
+  }
 }
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
-void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot() {
-  int m = 7;
-  int k = 64;
-  int n = 13;
-  int group_size = 16;
-
+void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot(
+    int m,
+    int k,
+    int n,
+    int group_size) {
   auto test_case = torchao::
       channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
           m,
@@ -290,7 +268,7 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot
       test_case.weight_scales.data(),
       /*weight_zeros=*/test_case.weight_zeros.data());
 
-  std::vector<float> output(m * k);
+  std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
       output.data(),
       /*output_m_stride=*/n,
@@ -312,59 +290,56 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot,
     Standard) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot,
     HasWeightZeros) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = true;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot,
     HasBias) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = true;
-  constexpr bool has_clamp = false;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
 }
 
 TEST(
     test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot,
     HasClamp) {
-  constexpr int weight_nbit = 4;
-  constexpr bool has_weight_zeros = false;
-  constexpr bool has_bias = false;
-  constexpr bool has_clamp = true;
-
   test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot<
-      weight_nbit,
-      has_weight_zeros,
-      has_bias,
-      has_clamp>();
+      4 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/7, /*k=*/64, /*n=*/13, /*group_size=*/16);
+}
+
+TEST(
+    test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot,
+    NLessThan8) {
+  for (int n = 1; n < 8; n++) {
+    test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot<
+        4 /*weight_nbit*/,
+        false /*has_weight_zeros*/,
+        false /*has_bias*/,
+        true /*has_clamp*/>(
+        /*m=*/7, /*k=*/64, /*n=*/n, /*group_size=*/16);
+  }
 }

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_reduction.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_reduction.cpp
@@ -1,0 +1,56 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <arm_neon.h>
+#include <gtest/gtest.h>
+#include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+#include <algorithm>
+#include <vector>
+
+TEST(test_find_min_and_sum, SizeHasRemainderAfterDivideBy4) {
+  auto vals = torchao::get_random_vector(19, -1.0, 1.0);
+  float vmin, vmax;
+  torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
+      vmin, vmax, vals.data(), vals.size());
+
+  auto expected_vmin = *std::min_element(vals.begin(), vals.end());
+  auto expected_vmax = *std::max_element(vals.begin(), vals.end());
+  EXPECT_EQ(vmin, expected_vmin);
+  EXPECT_EQ(vmax, expected_vmax);
+}
+
+TEST(test_find_min_and_sum, SizeSmallerThan4) {
+  auto vals = torchao::get_random_vector(3, -1.0, 1.0);
+  float vmin, vmax;
+  torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
+      vmin, vmax, vals.data(), vals.size());
+
+  auto expected_vmin = *std::min_element(vals.begin(), vals.end());
+  auto expected_vmax = *std::max_element(vals.begin(), vals.end());
+  EXPECT_EQ(vmin, expected_vmin);
+  EXPECT_EQ(vmax, expected_vmax);
+}
+
+TEST(test_compute_sum, ExpectedOutput) {
+  auto vals = torchao::get_random_lowbit_vector(/*size=*/19, /*int8*/ 3);
+  int sum = torchao::kernels::cpu::aarch64::reduction::compute_sum(
+      (int8_t*)vals.data(), vals.size());
+  int expected_sum = std::accumulate(vals.begin(), vals.end(), 0);
+  EXPECT_EQ(sum, expected_sum);
+}
+
+TEST(test_compute_sum, SizeHasRemainderAfterDivideBy16) {
+  auto vals = torchao::get_random_lowbit_vector(/*size=*/17, /*int8*/ 3);
+  int sum = torchao::kernels::cpu::aarch64::reduction::compute_sum(
+      (int8_t*)vals.data(), vals.size());
+  int expected_sum = std::accumulate(vals.begin(), vals.end(), 0);
+  EXPECT_EQ(sum, expected_sum);
+}
+
+TEST(test_compute_sum, SizeSmallerThan16) {
+  auto vals = torchao::get_random_lowbit_vector(/*size=*/3, /*int8*/ 3);
+  int sum = torchao::kernels::cpu::aarch64::reduction::compute_sum(
+      (int8_t*)vals.data(), vals.size());
+  int expected_sum = std::accumulate(vals.begin(), vals.end(), 0);
+  EXPECT_EQ(sum, expected_sum);
+}

--- a/torchao/experimental/kernels/cpu/linear/examples/build_and_run_examples.sh
+++ b/torchao/experimental/kernels/cpu/linear/examples/build_and_run_examples.sh
@@ -4,8 +4,11 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
 
+export CMAKE_PREFIX_PATH="$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')"
+echo "CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}"
 export CMAKE_OUT=/tmp/cmake-out/torch_ao/examples
 cmake -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
     -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/linear/examples \
     -B ${CMAKE_OUT} \
     -DOpenMP_ROOT=$(brew --prefix libomp)

--- a/torchao/experimental/kernels/cpu/linear/tests/test_linear_operator.cpp
+++ b/torchao/experimental/kernels/cpu/linear/tests/test_linear_operator.cpp
@@ -30,7 +30,8 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight(
           has_weight_zeros,
           has_bias,
           has_clamp);
-  float output[m * n];
+
+  auto output = std::vector<float>(m * n);
 
   for (auto linear_scheduling_policy :
        {LinearTileSchedulingPolicy::single_mc_parallel_nc,
@@ -82,7 +83,7 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight(
           linear_tiling_params,
           linear_scheduling_policy,
           activation_data_buffer.get(),
-          output,
+          output.data(),
           m,
           n,
           k,


### PR DESCRIPTION
Summary:
This diff fixes two bugs that I found when creating a custom op and comparing results to PyTorch python implementations (next diff).

1) There is a segfault that occurred when n % 8 != 0 because the ukernel was storing out of bounds.  There was an existing test for this case, but it passed because the output shape in the test was mistakenly too big and so no out of bound memory was written to in the test (it had shape m x k instead of shape m x n).  This diff fixes the out-of-bound writes and the existing test.

2) The find_min_and_max function was incorrect.  This corrects the function and adds tests for the reduction functions (find_min_and_max and compute_sum).  (The find_min_and_max function is only used for dynamic quantization; there are existing tests for the quantization, but they passed because the existing find_min_and_max happened to return correct results in the tested case.)

Reviewed By: digantdesai

Differential Revision: D60773448
