### PR TITLE
torchao-nightly -> --pre torchao in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ pip install torchao --extra-index-url https://download.pytorch.org/whl/cu121 # f
 
 Nightly Release
 ```Shell
-pip install --pre torchao-nightly --index-url https://download.pytorch.org/whl/nightly/cu121 # full options are cpu/cu118/cu121/cu124
+pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu121 # full options are cpu/cu118/cu121/cu124
 ```
 
 From source


### PR DESCRIPTION
And we deleted torchao-nightly from pypi @joecummings 

Test


```
(ao) [marksaroufim@devvm4567.ash0 ~/ao (mobiusml/main)]$ pip install --pre torchao  --index-url https://download.pytorch.org/whl/nightly/c
u121 --force-reinstall
Looking in indexes: https://download.pytorch.org/whl/nightly/cu121
Collecting torchao
  Downloading https://download.pytorch.org/whl/nightly/cu121/torchao-0.4.0.dev20240821%2Bcu121-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (930 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 930.9/930.9 kB 22.2 MB/s eta 0:00:00
Installing collected packages: torchao
  Attempting uninstall: torchao
    Found existing installation: torchao 0.4.0
    Uninstalling torchao-0.4.0:
      Successfully uninstalled torchao-0.4.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
torchtune 0.0.0 requires torchao==0.3.1, but you have torchao 0.4.0.dev20240821+cu121 which is incompatible.
Successfully installed torchao-0.4.0.dev20240821+cu121
(ao) [marksaroufim@devvm4567.ash0 ~/ao (mobiusml/main)]$ 
```