### PR TITLE
Move non-NF4 tensor to device prior to quantization on copy

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -339,7 +339,7 @@ def copy_(func, *args, **kwargs):
     # Convert Non NF4Tensor into NF4 for copy in
     if not isinstance(copy_in, NF4Tensor):
         copy_in_nf4 = NF4Tensor.from_tensor(
-            copy_in,to(original.device), original.block_size, original.scaler_block_size
+            copy_in.to(original.device), original.block_size, original.scaler_block_size
         )
         return original.copy_(copy_in_nf4)
 

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -339,7 +339,7 @@ def copy_(func, *args, **kwargs):
     # Convert Non NF4Tensor into NF4 for copy in
     if not isinstance(copy_in, NF4Tensor):
         copy_in_nf4 = NF4Tensor.from_tensor(
-            copy_in, original.block_size, original.scaler_block_size
+            copy_in,to(original.device), original.block_size, original.scaler_block_size
         )
         return original.copy_(copy_in_nf4)
 


### PR DESCRIPTION
Addressing #642 based on @gau-nernst's suggestion [here](https://github.com/pytorch/ao/issues/642?fbclid=IwY2xjawE06rVleHRuA2FlbQIxMQABHeqAG5ilqjGCL65xhjpVunMwfgtD4GHuJUt6KfAG84tE8rpjjOrDDWB10A_aem_1VhfNEB_xvhVI-hlCLXKNg#issuecomment-2306089086). Tested in torchtune that (a) init time and memory are similar to torchtune's inplace copy [here](https://github.com/pytorch/torchtune/blob/f9f75bb563ecae371492a9d49da4a9f514c081b3/torchtune/modules/low_precision/_register_nf4_dispatch_ops.py#L35) and (b) FSDP2 recipes still succeed (since they don't with torchtune copy enabled).