### PR TITLE
use `torch.compiler.is_compiling`

### DIFF
--- a/torchao/float8/float8_linear_utils.py
+++ b/torchao/float8/float8_linear_utils.py
@@ -162,7 +162,7 @@ def get_float8_layers(model: torch.nn.Module):
 
     # Get all fp8 layers and tensors
     fp8_layers = [child for child in model.modules() if isinstance(child, Float8Linear)]
-    if not torch._dynamo.is_compiling():
+    if not torch.compiler.is_compiling():
         for layer in fp8_layers:
             for buf in layer.buffers():
                 torch._dynamo.mark_static_address(buf, guard=True)


### PR DESCRIPTION
following
```
/path/to/ao/torchao/float8/float8_linear_utils.py:165: FutureWarning: `torch._dynamo.external_utils.is_compiling` is deprecated. Use `torch.compiler.is_compiling` instead.
  if not torch._dynamo.is_compiling():
```