### PR TITLE
Add INT8 mixed-precision training

### DIFF
--- a/benchmarks/quantized_training/pretrain_llama2.py
+++ b/benchmarks/quantized_training/pretrain_llama2.py
@@ -120,11 +120,12 @@ if __name__ == "__main__":
     if args.activation_checkpointing:
         for layer in model.layers:
             enable_activation_checkpointing(layer)
+    # NOTE: don't apply to LM head since there are memory issues.
     if args.quantize == "int8_weight_only":
-        quantize_(model, int8_weight_only_quantized_training(), set_inductor_config=False)
+        quantize_(model.layers, int8_weight_only_quantized_training(), set_inductor_config=False)
     elif args.quantize == "int8_mixed_precision":
         cfg = Int8MixedPrecisionConfig(True, True, True)
-        quantize_(model, int8_mixed_precision_training(), set_inductor_config=False)
+        quantize_(model.layers, int8_mixed_precision_training(cfg), set_inductor_config=False)
     elif args.quantize is not None:
         raise ValueError(f"Unsupported quantize={args.quantize}")
     print(f"No. of params: {sum(p.numel() for p in model.parameters()):,}")

--- a/benchmarks/quantized_training/pretrain_llama2.py
+++ b/benchmarks/quantized_training/pretrain_llama2.py
@@ -20,7 +20,11 @@ from tqdm import tqdm
 
 from torchao._models.llama.model import ModelArgs, Transformer
 from torchao.prototype import low_bit_optim
-from torchao.prototype.quantized_training import int8_weight_only_quantized_training
+from torchao.prototype.quantized_training import (
+    Int8MixedPrecisionConfig,
+    int8_mixed_precision_training,
+    int8_weight_only_quantized_training,
+)
 from torchao.quantization.quant_api import quantize_
 
 
@@ -118,6 +122,9 @@ if __name__ == "__main__":
             enable_activation_checkpointing(layer)
     if args.quantize == "int8_weight_only":
         quantize_(model, int8_weight_only_quantized_training(), set_inductor_config=False)
+    elif args.quantize == "int8_mixed_precision":
+        cfg = Int8MixedPrecisionConfig(True, True, True)
+        quantize_(model, int8_mixed_precision_training(), set_inductor_config=False)
     elif args.quantize is not None:
         raise ValueError(f"Unsupported quantize={args.quantize}")
     print(f"No. of params: {sum(p.numel() for p in model.parameters()):,}")

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -190,9 +190,9 @@ class TestQuantizedTraining(TestCase):
 class TestFSDP2(FSDPTest):
     @property
     def world_size(self) -> int:
-        return 1
+        return 2
 
-    @skip_if_lt_x_gpu(1)
+    @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):
         # FSDP2 + compiled quantized training fails with PyTorch 2.4
         compile_layer_choices = [False]

--- a/torchao/prototype/quantized_training/__init__.py
+++ b/torchao/prototype/quantized_training/__init__.py
@@ -1,1 +1,10 @@
-from .int8 import Int8QTLinearWeight, int8_weight_only_quantized_training
+from .int8 import (
+    Int8QTLinearWeight,
+    int8_weight_only_quantized_training,
+    quantize_int8_rowwise,
+)
+from .int8_mixed_precision import (
+    Int8MixedPrecisionConfig,
+    Int8MixedPrecisionLinearWeight,
+    int8_mixed_precision_training,
+)

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -1,0 +1,125 @@
+from typing import NamedTuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.utils._triton import has_triton
+
+from .int8 import quantize_int8_rowwise
+
+if has_triton():
+    from .int8_mm import int8_mm_dequant
+
+else:
+
+    def int8_mm_dequant(A: Tensor, B: Tensor, A_scale_rowwise: Tensor, B_scale_colwise: Tensor) -> Tensor:
+        return (A * A_scale_rowwise.view(-1, 1)) @ (B * B_scale_colwise.view(1, -1))
+
+
+aten = torch.ops.aten
+
+
+class Int8MixedPrecisionConfig(NamedTuple):
+    forward: bool = False
+    backward_grad_input: bool = False
+    backward_grad_weight: bool = False
+
+
+class Int8MixedPrecisionLinearWeight(Tensor):
+    @staticmethod
+    @torch._dynamo.disable
+    def __new__(cls, data: Tensor, config: Int8MixedPrecisionConfig):
+        return Tensor._make_wrapper_subclass(
+            cls,
+            data.shape,
+            dtype=data.dtype,
+            device=data.device,
+        )
+
+    @torch._dynamo.disable
+    def __init__(self, data: Tensor, config: Int8MixedPrecisionConfig):
+        self._data = data
+        self.config = config
+
+    def __tensor_flatten__(self):
+        return ["_data"], [self.config]
+
+    @classmethod
+    def __tensor_unflatten__(cls, tensor_data_dict, tensor_attributes, outer_size=None, outer_stride=None):
+        return cls(tensor_data_dict["_data"], *tensor_attributes)
+
+    def __repr__(self):
+        return self._data.__repr__()
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        kwargs = kwargs or dict()
+
+        if func is F.linear:
+            return _Int8MixedPrecisionLinear.apply(*args, **kwargs)
+
+        with torch._C.DisableTorchFunctionSubclass():
+            return func(*args, **kwargs)
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs):
+        if func in (aten.detach.default, aten.clone.default, aten._to_copy.default):
+            return cls(func(args[0]._data, *args[1:], **kwargs), args[0].config)
+
+        # TODO: some ops should return the original class i.e. in-place ops
+        args = [x._data if isinstance(x, cls) else x for x in args]
+        return func(*args, **kwargs)
+
+
+class _Int8MixedPrecisionLinear(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input: Tensor, weight: Int8MixedPrecisionLinearWeight, bias: Tensor | None = None):
+        ctx.save_for_backward(input, weight)
+        ctx.bias = bias is not None
+
+        if weight.config.forward:
+            batch_dims = input.shape[:-1]
+            input = input.view(-1, weight.shape[1])
+            input_i8, input_scale = quantize_int8_rowwise(input)
+            weight_i8, weight_scale = quantize_int8_rowwise(weight)
+            out = int8_mm_dequant(input_i8, weight_i8.T, input_scale, weight_scale)
+            out = out.view(*batch_dims, weight.shape[0])
+        else:
+            out = input @ weight.T
+
+        out = out + bias if bias is not None else out
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, weight = ctx.saved_tensors
+        grad_input = grad_weight = grad_bias = None
+
+        weight: Int8MixedPrecisionLinearWeight
+        sr = weight.config.stochastic_rounding
+
+        batch_dims = grad_output.shape[:-1]
+        grad_output = grad_output.view(-1, weight.shape[0])
+        input = input.view(-1, weight.shape[1])
+
+        if ctx.needs_input_grad[0]:
+            if weight.config.backward_grad_input:
+                grad_output_i8, grad_output_scale = quantize_int8_rowwise(grad_output)
+                weight_i8_t, weight_scale = quantize_int8_rowwise(weight.T)
+                grad_input = int8_mm_dequant(grad_output_i8, weight_i8_t.T, grad_output_scale, weight_scale)
+            else:
+                grad_input = grad_output @ weight
+            grad_input = grad_input.view(*batch_dims, weight.shape[1])
+
+        if ctx.needs_input_grad[1]:
+            if weight.config.backward_grad_weight:
+                grad_output_i8_t, grad_output_scale = quantize_int8_rowwise(grad_output.T)
+                input_i8_t, input_scale = quantize_int8_rowwise(input.T)
+                grad_weight = int8_mm_dequant(grad_output_i8_t, input_i8_t.T, grad_output_scale, input_scale)
+            else:
+                grad_weight = grad_output.T @ input
+
+        if ctx.needs_input_grad[2] and ctx.bias:
+            grad_bias = grad_output.sum(0)
+
+        return grad_input, grad_weight, grad_bias

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -122,6 +122,8 @@ class _Int8MixedPrecisionLinear(torch.autograd.Function):
         return grad_input, grad_weight, grad_bias
 
 
+# NOTE: should default config set all to True instead? -> speedup out-of-the-box.
+# only if there are convergence issues, turn off some INT8 matmuls in backward.
 def int8_mixed_precision_training(config: Int8MixedPrecisionConfig = Int8MixedPrecisionConfig()):
     # TODO: right now `_get_linear_subclass_inserter()` will always set `requires_grad=False`
     # when we have this out of prototype (or there are stable trainable tensor subclasses),

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -1,0 +1,142 @@
+# TODO: might merge this with torchao/kernel/intmm_triton.py
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+lib = torch.library.Library("torchao", "FRAGMENT")
+
+
+# https://triton-lang.org/main/getting-started/tutorials/03-matrix-multiplication.html
+# (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps)
+configs = [
+    (128, 256, 64, 3, 8),
+    (64, 256, 32, 4, 4),
+    (128, 128, 32, 4, 4),
+    (128, 64, 32, 4, 4),
+    (64, 128, 32, 4, 4),
+    (128, 32, 32, 4, 4),
+    (64, 32, 32, 5, 2),
+    (32, 64, 32, 5, 2),
+    # Good config for fp8 inputs
+    (128, 256, 128, 3, 8),
+    (256, 128, 128, 3, 8),
+    (256, 64, 128, 4, 4),
+    (64, 256, 128, 4, 4),
+    (128, 128, 128, 4, 4),
+    (128, 64, 64, 4, 4),
+    (64, 128, 64, 4, 4),
+    (128, 32, 64, 4, 4),
+    # https://github.com/pytorch/pytorch/blob/7868b65c4d4f34133607b0166f08e9fbf3b257c4/torch/_inductor/kernel/mm_common.py#L172
+    (64, 64, 32, 2, 4),
+    (64, 128, 32, 3, 4),
+    (128, 64, 32, 3, 4),
+    (64, 128, 32, 4, 8),
+    (128, 64, 32, 4, 8),
+    (64, 32, 32, 5, 8),
+    (32, 64, 32, 5, 8),
+    (128, 128, 32, 2, 8),
+    (64, 64, 64, 3, 8),
+    (128, 256, 128, 3, 8),
+    (256, 128, 128, 3, 8),
+]
+
+configs = [
+    triton.Config(dict(BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K), num_stages=num_stages, num_warps=num_warps)
+    for BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps in configs
+]
+
+
+@triton.autotune(configs=configs, key=["M", "N", "K", "stride_ak", "stride_bk"])
+@triton.jit
+def _int8_mm_dequant_kernel(
+    # fmt: off
+    A_ptr, B_ptr, C_ptr,
+    A_scale_rowwise_ptr,
+    B_scale_colwise_ptr,
+    M, N, K,
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr = 8,
+    EVEN_K: tl.constexpr = True,
+    # fmt: on
+):
+    # based on triton.ops.matmul
+    pid = tl.program_id(0)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    rk = tl.arange(0, BLOCK_K)
+    A = A_ptr + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B_ptr + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int32)
+    for k in range(K, 0, -BLOCK_K):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            a = tl.load(A, mask=rk[None, :] < k, other=0.0)
+            b = tl.load(B, mask=rk[:, None] < k, other=0.0)
+        acc += tl.dot(a, b)
+        A += BLOCK_K * stride_ak
+        B += BLOCK_K * stride_bk
+
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    idx_m = rm[:, None]
+    idx_n = rn[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+
+    a_scale = tl.load(A_scale_rowwise_ptr + idx_m, mask=idx_m < M).to(tl.float32)
+    b_scale = tl.load(B_scale_colwise_ptr + idx_n, mask=idx_n < N).to(tl.float32)
+    acc = acc.to(tl.float32) * a_scale * b_scale
+
+    # inductor generates a suffix
+    xindex = idx_m * stride_cm + idx_n * stride_cn
+    tl.store(C_ptr + tl.broadcast_to(xindex, mask.shape), acc, mask)
+
+
+lib.define("int8_mm_dequant(Tensor A, Tensor B, Tensor A_scale, Tensor B_scale) -> Tensor")
+
+
+def int8_mm_dequant(A: Tensor, B: Tensor, A_scale_rowwise: Tensor, B_scale_colwise: Tensor) -> Tensor:
+    return torch.ops.torchao.int8_mm_dequant(A, B, A_scale_rowwise, B_scale_colwise)
+
+
+@torch.library.impl(lib, "int8_mm_dequant", "Meta")
+def _(A: Tensor, B: Tensor, A_scale_rowwise: Tensor, B_scale_colwise: Tensor):
+    return torch.empty((A.shape[0], B.shape[1]), device=A.device, dtype=A_scale_rowwise.dtype)
+
+
+@torch.library.impl(lib, "int8_mm_dequant", "CUDA")
+def int8_mm_dequant_cuda(A: Tensor, B: Tensor, A_scale_rowwise: Tensor, B_scale_colwise: Tensor):
+    assert A.dtype is torch.int8 and B.dtype is torch.int8
+    assert A.shape[1] == B.shape[0]
+    M, K = A.shape
+    _, N = B.shape
+    assert A_scale_rowwise.squeeze().shape == (M,)
+    assert B_scale_colwise.squeeze().shape == (N,)
+    C = torch.empty(M, N, device=A.device, dtype=A_scale_rowwise.dtype)
+    grid = lambda meta: (triton.cdiv(meta["M"], meta["BLOCK_M"]) * triton.cdiv(meta["N"], meta["BLOCK_N"]),)
+    _int8_mm_dequant_kernel[grid](
+        A, B, C, A_scale_rowwise, B_scale_colwise, M, N, K, *A.stride(), *B.stride(), *C.stride(), EVEN_K=K % 2 == 0
+    )
+    return C


### PR DESCRIPTION
Disclaimer: terminologies for INT8 training are generally not standardized yet. Thus, I use the terms with the following meaning:
- Quantized training: model weights are quantized. This is a strict requirement. Does not matter what is the compute precision. Examples of this: Q-GaLore, JetFire.
- INT8 mixed-precision training: model weights are in original precision, while some compute dtype might be INT8. I call it like this because it is similar to FP16/BF16 mixed-precision. One difference is that in FP16/BF16 mixed-precision, matmul will return FP16/BF16 outputs, while for INT8 mixed-precision, the returned dtype is not INT8. Examples include Google AQT and SwitchBack.

(WIP, will update PR description)