### PR TITLE
float8 training: add static scaling

### DIFF
--- a/benchmarks/float8/profile_linear_float8.py
+++ b/benchmarks/float8/profile_linear_float8.py
@@ -263,13 +263,35 @@ def main(
     scaling_type_input = ScalingType(scaling_type_input)
     scaling_type_weight = ScalingType(scaling_type_weight)
     scaling_type_grad_output = ScalingType(scaling_type_grad_output)
+
+    if scaling_type_input is ScalingType.STATIC:
+        cast_config_input=CastConfig(
+            scaling_type=scaling_type_input,
+            static_scale=torch.tensor([1.0], device="cuda"),
+        )
+    else:
+        cast_config_input=CastConfig(scaling_type=scaling_type_input)
+    if scaling_type_weight is ScalingType.STATIC:
+        cast_config_weight=CastConfig(
+            scaling_type=scaling_type_weight,
+            static_scale=torch.tensor([1.0], device="cuda"),
+        )
+    else:
+        cast_config_weight=CastConfig(scaling_type=scaling_type_weight)
+    if scaling_type_grad_output is ScalingType.STATIC:
+        cast_config_grad_output=CastConfig(
+            scaling_type=scaling_type_grad_output,
+            static_scale=torch.tensor([1.0], device="cuda"),
+        )
+    else:
+        cast_config_grad_output=CastConfig(scaling_type=scaling_type_grad_output)
+
     config = Float8LinearConfig(
-        cast_config_input=CastConfig(scaling_type=scaling_type_input),
-        cast_config_weight=CastConfig(scaling_type=scaling_type_weight),
-        cast_config_grad_output=CastConfig(scaling_type=scaling_type_grad_output),
-        enable_amax_init=False,
-        enable_pre_and_post_forward=False,
+        cast_config_input=cast_config_input,
+        cast_config_weight=cast_config_weight,
+        cast_config_grad_output=cast_config_grad_output,
     )
+
     scaling_repr = "_".join(
         [
             s.short_str()

--- a/test/float8/test_everything.sh
+++ b/test/float8/test_everything.sh
@@ -15,7 +15,7 @@ then
 ./test/float8/test_fsdp.sh
 ./test/float8/test_fsdp_compile.sh
 ./test/float8/test_dtensor.sh
-pytest test/float8/test_fsdp2/test_fsdp2.py
+python test/float8/test_fsdp2/test_fsdp2.py
 fi
 
 echo "all tests successful"

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -426,16 +426,25 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         """
         choices = itertools.product(
             [False, True],
-            [ScalingType.DYNAMIC, ScalingType.DELAYED],
+            [ScalingType.DYNAMIC, ScalingType.DELAYED, ScalingType.STATIC],
         )
         for enable_fsdp_float8_all_gather, scaling_type_weight in choices:
+
+            if scaling_type_weight is ScalingType.STATIC:
+                cast_config_weight = CastConfig(
+                    scaling_type=scaling_type_weight,
+                    static_scale=torch.tensor([1.0], device="cuda"),
+                )
+            else:
+                cast_config_weight = CastConfig(scaling_type=scaling_type_weight)
+
             float8_linear_config1 = Float8LinearConfig(
                 enable_fsdp_float8_all_gather=False,
-                cast_config_weight=CastConfig(scaling_type=scaling_type_weight),
+                cast_config_weight=cast_config_weight,
             )
             float8_linear_config2 = Float8LinearConfig(
                 enable_fsdp_float8_all_gather=enable_fsdp_float8_all_gather,
-                cast_config_weight=CastConfig(scaling_type=scaling_type_weight),
+                cast_config_weight=cast_config_weight,
             )
             module_fp32 = self.init_single_module()
             ref_module = copy.deepcopy(module_fp32)

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -14,7 +14,7 @@ will change rapidly.</em>
 
 # Single GPU User API
 
-We provide two per-tensor scaling strategies: dynamic and delayed.  See https://arxiv.org/pdf/2209.05433.pdf, Section 4.3 for more details. These strategies are configurable separately for activations (`input`), weights (`weight`) and gradients (`grad_output`).
+We provide three per-tensor scaling strategies: dynamic, delayed and static.  See https://arxiv.org/pdf/2209.05433.pdf, Section 4.3 for more details. These strategies are configurable separately for activations (`input`), weights (`weight`) and gradients (`grad_output`).
 
 ## float8 linear with dynamic scaling for `input`, `weight` and `grad_output`
 

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -6,18 +6,24 @@
 
 import enum
 from dataclasses import dataclass
+from typing import Optional
+
+import torch
 
 
 class ScalingType(enum.Enum):
     DELAYED = "delayed"
     DYNAMIC = "dynamic"
+    STATIC = "static"
 
     def short_str(self):
         if self is ScalingType.DELAYED:
             return "del"
-        else:
-            assert self is ScalingType.DYNAMIC
+        elif self is ScalingType.DYNAMIC:
             return "dyn"
+        else:
+            assert self is ScalingType.STATIC
+            return "sta"
 
 
 @dataclass(frozen=True)
@@ -27,7 +33,12 @@ class CastConfig:
     """
 
     scaling_type: ScalingType = ScalingType.DYNAMIC
+    static_scale: Optional[torch.Tensor] = None
 
+    def __post_init__(self):
+        if self.scaling_type is ScalingType.STATIC:
+            assert self.static_scale is not None, \
+                "static_scale must be specified for static scaling"
 
 @dataclass(frozen=True)
 class DelayedScalingConfig:


### PR DESCRIPTION
Summary:

This is useful for things such as:
* activation_with_bounded_range -> linear (can set static scale to activation range)
* bounding weight scales to known quantities if the modeling user can guarantee their magnitude throughout training

We don't have signal yet that this is useful for production things, but it would be good to land this to enable easy experimentation.

Test Plan:

Unit and integration tests pass:
```
./test/test_everything.sh
// note that there is a failure in `test_fsdp2.py` which is present on main
```

Use float8 profiling script to see GPU kernel time go down as we enable static scaling on a toy model:
https://gist.github.com/vkuzo/b2cf46f7cccb691125566873859ca39d

Reviewers:

Subscribers:

Tasks:

Tags: