### PR TITLE
[reland] Refactor quant_llm to work with affine quantized tensor (#696)

### DIFF
--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -1,16 +1,16 @@
 import torch
 import pandas as pd
 import torch.nn.functional as F
-from torchao.prototype.quant_llm import QuantLlmLinearWeight
+# from torchao.prototype.quant_llm import QuantLlmLinearWeight
+from torchao.dtypes import to_affine_quantized_fpx
+from torchao.dtypes.fpx import FpxTensorCoreAQTLayout, FpxTensorCoreLayoutType
 from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
 
 
 def benchmark(m: int, k: int, n: int):
-    fp6_data = torch.randint(256, size=(n, k * 3 // 4), dtype=torch.uint8, device="cuda")
-    scale = torch.rand(n, dtype=torch.half, device="cuda") + 0.5
-    fp6_weight = QuantLlmLinearWeight(fp6_data, scale, 3, 2)
-
+    float_data = torch.randn(n, k, dtype=torch.half, device="cuda")
+    fp6_weight = to_affine_quantized_fpx(float_data, FpxTensorCoreLayoutType(3, 2))
     fp16_weight = fp6_weight.dequantize(torch.half)
 
     fp16_act = torch.randn(m, k, dtype=torch.half, device="cuda")

--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -1,7 +1,6 @@
 import torch
 import pandas as pd
 import torch.nn.functional as F
-# from torchao.prototype.quant_llm import QuantLlmLinearWeight
 from torchao.dtypes import to_affine_quantized_fpx
 from torchao.dtypes.fpx import FpxTensorCoreAQTLayout, FpxTensorCoreLayoutType
 from torchao.utils import benchmark_torch_function_in_microseconds

--- a/scripts/hf_eval.py
+++ b/scripts/hf_eval.py
@@ -20,6 +20,7 @@ from torchao.quantization import (
     int8_dynamic_activation_int8_weight,
     quantize_,
     autoquant,
+    fpx_weight_only,
 )
 from torchao.sparsity import (
     sparsify_,
@@ -59,6 +60,8 @@ def run_evaluation(repo_id, tasks, limit, device, precision, quantization, spars
     elif quantization == "int4wo":
         # note cannot quantize this model on cpu and run it on cuda at this time
         quantize_(model.to(device=device), int4_weight_only())
+    elif quantization == "fp6":
+        quantize_(model, fpx_weight_only(3, 2))
     elif quantization == "autoquant":
         model = autoquant(model.to(device=device))
 
@@ -79,7 +82,7 @@ def run_evaluation(repo_id, tasks, limit, device, precision, quantization, spars
             return False
         torch.sparse.semi_structured._FORCE_CUTLASS = False
         sparsify_(model, semi_sparse_weight(), filter_fn=all_linear)
-    
+
     if sparsity and compile:
         model = torch.compile(model, mode="max-autotune", fullgraph=True)
 
@@ -111,7 +114,7 @@ if __name__ == '__main__':
     parser.add_argument('--limit', type=int, default=None, help='Number of eval samples to evaluate')
     parser.add_argument('--precision', type=lambda x: getattr(torch, x.split(".")[-1]), default=torch.bfloat16, help='dtype precision to use')
     parser.add_argument('--device', type=str, default="cuda", help='Device to use for evaluation')
-    parser.add_argument('-q', '--quantization', default = "None", choices=["int8dq", "int8wo", "int4wo","autoquant", "None"], help='Which quantization technique to apply')
+    parser.add_argument('-q', '--quantization', default = "None", choices=["int8dq", "int8wo", "int4wo","autoquant", "fp6", "None"], help='Which quantization technique to apply')
     parser.add_argument('-s', '--sparsity', default = "None", choices=["semi_sparse", "semi_sparse_mlp_only", "None"], help='Which sparsity technique to apply')
     parser.add_argument('--compile', action='store_true', help='Whether to compile the model.')
     parser.add_argument('--save', action='store_true', help='Whether to save the model.')

--- a/test/dtypes/test_fpx.py
+++ b/test/dtypes/test_fpx.py
@@ -8,23 +8,27 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
-from torchao.prototype.quant_llm import (
-    QuantLlmLinearWeight,
-    quant_llm_fpx_weight_only,
-    fp6_llm_weight_only,
+from torchao.dtypes.fpx import (
+    FpxTensorCoreAQTLayout,
+    FpxTensorCoreLayoutType,
     to_scaled_tc_fpx,
     from_scaled_tc_fpx,
 )
-from torchao.prototype.quant_llm.quant_llm import _pack_tc_fpx, _pack_tc_fp6
+from torchao.dtypes.fpx.fpx import _pack_tc_fpx, _pack_tc_fp6
 from torchao.prototype.custom_fp_utils import _f32_to_fpx_unpacked, _fpx_unpacked_to_f32
-from torchao.quantization.quant_api import quantize_
+from torchao.quantization import (
+    quantize_,
+    fpx_weight_only,
+)
+
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 
 _DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 _FPx_DTYPES = [(3, 2), (2, 2)]
 
 
-class TestQuantLlmLinearWeight(TestCase):
+class TestFpxTensorCoreAQTLayout(TestCase):
     @parametrize("device", _DEVICES)
     def test_pack_tc_fp6_correctness(self, device):
         x = torch.randint(256, size=(256, 64), dtype=torch.uint8, device=device)
@@ -69,61 +73,40 @@ class TestQuantLlmLinearWeight(TestCase):
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     def test_to_copy_device(self, ebits, mbits):
+        from torchao.quantization.quant_primitives import (
+            choose_qparams_affine_fpx,
+            quantize_affine_fpx,
+        )
+
         x = torch.randn(256, 64)
-        fpx = QuantLlmLinearWeight.from_float(x, ebits, mbits).cuda()
-        assert fpx.device.type == "cuda"
-        fpx = fpx.cpu()
-        assert fpx.device.type == "cpu"
+        scale = choose_qparams_affine_fpx(x, ebits, mbits)
+        x = quantize_affine_fpx(x, scale, ebits, mbits)
+        layout_type = FpxTensorCoreLayoutType(ebits, mbits)
+        fpx_layout_tensor = FpxTensorCoreAQTLayout.from_plain(x, scale, None, layout_type).cuda()
+        assert fpx_layout_tensor.device.type == "cuda"
+        fpx_layout_tensor = fpx_layout_tensor.cpu()
+        assert fpx_layout_tensor.device.type == "cpu"
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    @parametrize("ebits,mbits", _FPx_DTYPES)
-    @parametrize("leading_dims", [(4,), (2, 4)])
-    @parametrize("bias", [False, True])
-    def test_quant_llm_linear_weight(self, ebits, mbits, bias, leading_dims):
-        OC, IC = 256, 64
-        device = "cuda"
-
-        fp16_weight = torch.randn(OC, IC, device=device, dtype=torch.half)
-        fp16_bias = torch.randn(OC, device=device, dtype=torch.half) if bias else None
-
-        fpx_weight = QuantLlmLinearWeight.from_float(fp16_weight, ebits, mbits)
-
-        x = torch.randn(*leading_dims, IC, device=device, dtype=torch.half)
-        out = torch.nn.functional.linear(x, fpx_weight, fp16_bias)
-        assert out.shape == leading_dims + (OC,)
-
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="quantization only works with torch.compile for 2.5+")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     @parametrize("bias", [False, True])
-    def test_quant_llm_quantize(self, ebits, mbits, bias):
+    def test_fpx_weight_only(self, ebits, mbits, bias):
         N, OC, IC = 4, 256, 64
         device = "cuda"
 
-        linear = torch.nn.Linear(IC, OC, bias=bias, device=device)
+        linear = torch.nn.Linear(IC, OC, bias=bias, device=device, dtype=torch.half)
         fpx_linear = copy.deepcopy(linear)
-        quantize_(fpx_linear, quant_llm_fpx_weight_only(ebits, mbits))
+        quantize_(fpx_linear, fpx_weight_only(ebits, mbits))
 
         x = torch.randn(N, IC, device=device, dtype=torch.half)
         expected = fpx_linear(x)
         actual = torch.compile(fpx_linear, fullgraph=True)(x)
-        torch.testing.assert_close(actual, expected)
-
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_fp6_llm_quantize(self):
-        N, OC, IC = 4, 256, 64
-        device = "cuda"
-
-        linear = torch.nn.Linear(IC, OC, device=device)
-        fpx_linear = copy.deepcopy(linear)
-        quantize_(fpx_linear, fp6_llm_weight_only())
-
-        x = torch.randn(N, IC, device=device, dtype=torch.half)
-        expected = fpx_linear(x)
-        actual = torch.compile(fpx_linear, fullgraph=True)(x)
+        # somehow compile now changes the result a bit
         torch.testing.assert_close(actual, expected)
 
 
-instantiate_parametrized_tests(TestQuantLlmLinearWeight)
+instantiate_parametrized_tests(TestFpxTensorCoreAQTLayout)
 
 
 if __name__ == "__main__":

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.optests import opcheck
 from torchao.utils import is_fbcode, TORCH_VERSION_AT_LEAST_2_5, compute_max_diff
-from torchao.prototype.quant_llm import from_scaled_tc_fpx
+from torchao.dtypes.fpx import from_scaled_tc_fpx
 from torchao.sparsity.marlin import marlin_24_workspace, pack_to_marlin_24, inject_24
 import pytest
 
@@ -318,7 +318,7 @@ MARLIN_24_SUPPORTED_NUM_BITS = [4, 8]
 MARLIN_24_SUPPORTED_GROUP_SIZES = [-1, 128]
 
 MARLIN_TEST_PARAMS = list(itertools.product(
-    MARLIN_24_K_CHUNKS, MARLIN_24_N_CHUNKS, MARLIN_24_SUPPORTED_NUM_BITS, 
+    MARLIN_24_K_CHUNKS, MARLIN_24_N_CHUNKS, MARLIN_24_SUPPORTED_NUM_BITS,
     MARLIN_24_SUPPORTED_GROUP_SIZES, MNK_FACTORS
 ))
 
@@ -399,7 +399,7 @@ def test_marlin_24(k_chunk, n_chunk, num_bits, group_size, mnk_factors):
     workspace_24 = marlin_24_workspace(size_n)
 
     fn_inputs = (
-        a_input, marlin_24_q_w_comp, meta, marlin_24_scale, workspace_24, 
+        a_input, marlin_24_q_w_comp, meta, marlin_24_scale, workspace_24,
         num_bits, a_input.shape[0], b_weight.shape[1], a_input.shape[1],
     )
     output = torchao.ops.marlin_24_gemm(*fn_inputs)

--- a/torchao/_models/_eval.py
+++ b/torchao/_models/_eval.py
@@ -13,223 +13,222 @@ import torch.nn.functional as F
 
 from torchao.quantization.utils import _lm_eval_available, _MultiInput
 
-if _lm_eval_available:
-    import lm_eval
-    try:  # lm_eval version 0.4
-        from lm_eval.evaluator import evaluate  # pyre-ignore[21]
-        from lm_eval.models.huggingface import HFLM as eval_wrapper  # pyre-ignore[21]
-        from lm_eval.tasks import get_task_dict  # pyre-ignore[21]
-    except:  # lm_eval version 0.3
-        from lm_eval import base, evaluator, tasks
+import lm_eval
+try:  # lm_eval version 0.4
+    from lm_eval.evaluator import evaluate  # pyre-ignore[21]
+    from lm_eval.models.huggingface import HFLM as eval_wrapper  # pyre-ignore[21]
+    from lm_eval.tasks import get_task_dict  # pyre-ignore[21]
+except:  # lm_eval version 0.3
+    from lm_eval import base, evaluator, tasks
 
-        eval_wrapper = base.BaseLM
-        get_task_dict = tasks.get_task_dict
-        evaluate = evaluator.evaluate
+    eval_wrapper = base.BaseLM
+    get_task_dict = tasks.get_task_dict
+    evaluate = evaluator.evaluate
 
-    class InputRecorder(eval_wrapper):
-        """
-        This is a fake evaluation wrapper from the lm_eval library that just records the inputs
-        so that they can be used in calibration.
+class InputRecorder(eval_wrapper):
+    """
+    This is a fake evaluation wrapper from the lm_eval library that just records the inputs
+    so that they can be used in calibration.
 
-        If pad_calibration_inputs is enabled, the input recorder will take
-        each input and pad/truncate it down to the calibration_seq_length.
-        (if using padding you should set the embeddings for the pad_token to 0
-        in the model)
+    If pad_calibration_inputs is enabled, the input recorder will take
+    each input and pad/truncate it down to the calibration_seq_length.
+    (if using padding you should set the embeddings for the pad_token to 0
+    in the model)
 
-        Note: after padding/truncation, input_prep_function is called to bring
-        it to the proper form to be inserted into a given model.
+    Note: after padding/truncation, input_prep_function is called to bring
+    it to the proper form to be inserted into a given model.
 
-        If not, it will only truncate inputs to the desired length.
-        """
+    If not, it will only truncate inputs to the desired length.
+    """
 
-        def __init__(
-            self,
-            tokenizer,
-            calibration_seq_length,
-            input_prep_func=None,
-            pad_calibration_inputs=False,
-            vocab_size=32000,
-            pad_token=0,
-            device="cpu",
-        ):
+    def __init__(
+        self,
+        tokenizer,
+        calibration_seq_length,
+        input_prep_func=None,
+        pad_calibration_inputs=False,
+        vocab_size=32000,
+        pad_token=0,
+        device="cpu",
+    ):
+        try:
+            super().__init__()
+        except TypeError:
+            # lm_eval 0.4.2 removed the default init
+            super().__init__("gpt2", device="cpu")
+
+        self.tokenizer = tokenizer
+        self._device = torch.device(device)
+        self.vocab_size = vocab_size
+        self._max_seq_length = calibration_seq_length
+        self.calibration_seq_length = calibration_seq_length
+
+        # need to take inps and convert to corrent input
+        # for model
+        self.input_prep_func = (
+            input_prep_func if input_prep_func is not None
+            else lambda x: (x,)
+        )
+
+        self.pad_calibration_inputs = pad_calibration_inputs
+        self.pad_token = pad_token
+
+        self.inputs = None
+
+    @property
+    def eot_token_id(self):
+        try:
+            return self.tokenizer.eos_id()
+        except:
+            return self.tokenizer.eos_id
+
+    @property
+    def max_length(self):
+        return self._max_seq_length
+
+    @property
+    def max_gen_toks(self):
+        return 50
+
+    @property
+    def batch_size(self):
+        return 1
+
+    @property
+    def device(self):
+        return self._device
+
+    def tok_encode(self, string: str, **kwargs):
+        # TODO: verify this for multi-batch as well
+        tokens = self.tokenizer.encode(string)
+        if hasattr(self.tokenizer, "bos_id"):
             try:
-                super().__init__()
-            except TypeError:
-                # lm_eval 0.4.2 removed the default init
-                super().__init__("gpt2", device="cpu")
-
-            self.tokenizer = tokenizer
-            self._device = torch.device(device)
-            self.vocab_size = vocab_size
-            self._max_seq_length = calibration_seq_length
-            self.calibration_seq_length = calibration_seq_length
-
-            # need to take inps and convert to corrent input
-            # for model
-            self.input_prep_func = (
-                input_prep_func if input_prep_func is not None
-                else lambda x: (x,)
-            )
-
-            self.pad_calibration_inputs = pad_calibration_inputs
-            self.pad_token = pad_token
-
-            self.inputs = None
-
-        @property
-        def eot_token_id(self):
-            try:
-                return self.tokenizer.eos_id()
+                tokens = [self.tokenizer.bos_id()] + tokens
             except:
-                return self.tokenizer.eos_id
+                tokens = [self.tokenizer.bos_id] + tokens
+        return tokens
 
-        @property
-        def max_length(self):
-            return self._max_seq_length
+    def tok_decode(self, tokens):
+        decoded = self.tokenizer.decode(tokens)
+        return decoded
 
-        @property
-        def max_gen_toks(self):
-            return 50
+    def add_input(self, args):
+        if self.inputs is None:
+            self.inputs = [_MultiInput([arg]) for arg in args]
+        else:
+            self.inputs = [
+                multi.add_input(arg) for (multi, arg) in zip(self.inputs, args)
+            ]
 
-        @property
-        def batch_size(self):
-            return 1
+    def record_inputs(
+        self,
+        calibration_tasks,
+        calibration_limit,
+    ):
+        try:
+            lm_eval.tasks.initialize_tasks()
+        except:
+            pass
 
-        @property
-        def device(self):
-            return self._device
+        task_dict = get_task_dict(calibration_tasks)
+        print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
 
-        def tok_encode(self, string: str, **kwargs):
-            # TODO: verify this for multi-batch as well
-            tokens = self.tokenizer.encode(string)
-            if hasattr(self.tokenizer, "bos_id"):
-                try:
-                    tokens = [self.tokenizer.bos_id()] + tokens
-                except:
-                    tokens = [self.tokenizer.bos_id] + tokens
-            return tokens
-
-        def tok_decode(self, tokens):
-            decoded = self.tokenizer.decode(tokens)
-            return decoded
-
-        def add_input(self, args):
-            if self.inputs is None:
-                self.inputs = [_MultiInput([arg]) for arg in args]
-            else:
-                self.inputs = [
-                    multi.add_input(arg) for (multi, arg) in zip(self.inputs, args)
-                ]
-
-        def record_inputs(
+        evaluate(
             self,
-            calibration_tasks,
-            calibration_limit,
+            task_dict,
+            limit=calibration_limit,
+        )
+        return self
+
+    def get_inputs(self):
+        return self.inputs
+
+    def _model_call(self, inps):
+        inps = inps.squeeze(0)
+        T = len(inps)
+        if (
+            # can't use inputs that are too short when padding disabled
+            (T < self.calibration_seq_length and not self.pad_calibration_inputs)
+            or
+            # can't use inputs that actually use token we use for padding
+            (self.pad_calibration_inputs and self.pad_token in inps)
         ):
-            try:
-                lm_eval.tasks.initialize_tasks()
-            except:
-                pass
-
-            task_dict = get_task_dict(calibration_tasks)
-            print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
-
-            evaluate(
-                self,
-                task_dict,
-                limit=calibration_limit,
-            )
-            return self
-
-        def get_inputs(self):
-            return self.inputs
-
-        def _model_call(self, inps):
-            inps = inps.squeeze(0)
-            T = len(inps)
-            if (
-                # can't use inputs that are too short when padding disabled
-                (T < self.calibration_seq_length and not self.pad_calibration_inputs)
-                or
-                # can't use inputs that actually use token we use for padding
-                (self.pad_calibration_inputs and self.pad_token in inps)
-            ):
-                # give random output
-                return torch.randn(
-                    (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
-                )
-
-            # pad or truncate to the right size
-            if T >= self.calibration_seq_length:
-                inps = inps[: self.calibration_seq_length]
-            else:
-                inps = F.pad(inps, (self.pad_token, self.calibration_seq_length - T))
-
-            inps = inps.unsqueeze(0)
-            model_in = self.input_prep_func(inps)
-
-            self.add_input(model_in)
-
-            # output `something` with correct shape to keep eval going
+            # give random output
             return torch.randn(
                 (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
             )
 
-        def _model_generate(self, context, max_length, eos_token_id):
-            raise Exception("unimplemented")
+        # pad or truncate to the right size
+        if T >= self.calibration_seq_length:
+            inps = inps[: self.calibration_seq_length]
+        else:
+            inps = F.pad(inps, (self.pad_token, self.calibration_seq_length - T))
 
-    class TransformerEvalWrapper(InputRecorder):
-        """
-        A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
-        """
-        def __init__(
-            self,
-            model,
-            tokenizer,
-            max_seq_length,
-            input_prep_func=None,
-            device="cuda"
-        ):
-            super().__init__(tokenizer, None)
-            self._model = model
-            # self.tokenizer = tokenizer
-            self._device = torch.device(device)
-            self._max_seq_length = max_seq_length
+        inps = inps.unsqueeze(0)
+        model_in = self.input_prep_func(inps)
 
-            # need to take inps and convert to corrent input
-            # for model
-            self.input_prep_func = (
-                input_prep_func if input_prep_func is not None
-                else lambda x: (x,)
+        self.add_input(model_in)
+
+        # output `something` with correct shape to keep eval going
+        return torch.randn(
+            (1, T, self.vocab_size), dtype=torch.bfloat16, device=self._device
+        )
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise Exception("unimplemented")
+
+class TransformerEvalWrapper(InputRecorder):
+    """
+    A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
+    """
+    def __init__(
+        self,
+        model,
+        tokenizer,
+        max_seq_length,
+        input_prep_func=None,
+        device="cuda"
+    ):
+        super().__init__(tokenizer, None)
+        self._model = model
+        # self.tokenizer = tokenizer
+        self._device = torch.device(device)
+        self._max_seq_length = max_seq_length
+
+        # need to take inps and convert to corrent input
+        # for model
+        self.input_prep_func = (
+            input_prep_func if input_prep_func is not None
+            else lambda x: (x,)
+        )
+
+    def _model_call(self, inps):
+        # TODO: make batches work
+        input = self.input_prep_func(inps)
+
+        max_seq_length = min(max(inps.size()), self.max_length)
+        with torch.device(self._device):
+            self._model.setup_caches(self.batch_size, max_seq_length)
+        logits = self._model(*input)
+        return logits
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        raise Exception('unimplemented')
+
+    def run_eval(self, tasks, limit):
+        try:
+            lm_eval.tasks.initialize_tasks()
+        except:
+            pass
+
+        task_dict = get_task_dict(tasks)
+        print("Evaluating Model On: ", task_dict)
+        with torch.no_grad():
+            result = evaluate(
+                self,
+                task_dict,
+                limit=limit,
             )
-
-        def _model_call(self, inps):
-            # TODO: make batches work
-            input = self.input_prep_func(inps)
-
-            max_seq_length = min(max(inps.size()), self.max_length)
-            with torch.device(self._device):
-                self._model.setup_caches(self.batch_size, max_seq_length)
-            logits = self._model(*input)
-            return logits
-
-        def _model_generate(self, context, max_length, eos_token_id):
-            raise Exception('unimplemented')
-
-        def run_eval(self, tasks, limit):
-            try:
-                lm_eval.tasks.initialize_tasks()
-            except:
-                pass
-
-            task_dict = get_task_dict(tasks)
-            print("Evaluating Model On: ", task_dict)
-            with torch.no_grad():
-                result = evaluate(
-                    self,
-                    task_dict,
-                    limit=limit,
-                )
-            for task, res in result["results"].items():
-                print(f"{task}: {res}")
-            return result
+        for task, res in result["results"].items():
+            print(f"{task}: {res}")
+        return result

--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -13,8 +13,12 @@ from generate import (
 
 )
 from torchao.quantization.quant_api import (
-    quantize_, int4_weight_only, int8_weight_only, int8_dynamic_activation_int8_weight, unwrap_tensor_subclass
-
+    quantize_,
+    int4_weight_only,
+    int8_weight_only,
+    int8_dynamic_activation_int8_weight,
+    fpx_weight_only,
+    unwrap_tensor_subclass,
 )
 from torchao._models._eval import TransformerEvalWrapper, InputRecorder
 
@@ -68,6 +72,8 @@ def run_evaluation(
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
             quantize_(model.to(device), int4_weight_only(group_size=groupsize))
+        if "fp6" in quantization:
+            quantize_(model, fpx_weight_only(3, 2))
         if "int4wo" in quantization and "gptq" in quantization:
             groupsize=int(quantization.split("-")[-2])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -207,10 +207,10 @@ def main(
             int8_weight_only,
             int8_dynamic_activation_int8_weight,
             int4_weight_only,
+            fpx_weight_only,
             autoquant,
             unwrap_tensor_subclass
-    )
-
+        )
         if "int8wo" in quantization:
             quantize_(model, int8_weight_only())
         if "int8dq" in quantization:
@@ -219,6 +219,8 @@ def main(
             groupsize=int(quantization.split("-")[-1])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
             quantize_(model, int4_weight_only(group_size=groupsize))
+        if "fp6" in quantization:
+            quantize_(model, fpx_weight_only(3, 2))
         if "autoquant" == quantization:
             model = autoquant(model, manual=True)
 

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -5,6 +5,8 @@ from .affine_quantized_tensor import (
     AffineQuantizedTensor,
     to_affine_quantized_intx,
     to_affine_quantized_intx_static,
+    # experimental, will be merged into floatx in the future
+    to_affine_quantized_fpx,
     to_affine_quantized_floatx,
     LayoutType,
     PlainLayoutType,
@@ -19,6 +21,7 @@ __all__ = [
     "AffineQuantizedTensor",
     "to_affine_quantized_intx",
     "to_affine_quantized_intx_static",
+    "to_affine_quantized_fpx",
     "to_affine_quantized_floatx",
     "LayoutType",
     "PlainLayoutType",

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -307,10 +307,11 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         else:
             raise NotImplementedError(f"Unsupported dtype {target_dtype} for from_float_to_floatx")
 
+    @classmethod
     def from_float_fpx(
         cls,
         input_float: torch.Tensor,
-        layout_type: LayoutType = PlainLayoutType()
+        layout_type: LayoutType,
     ):
         from torchao.dtypes.fpx import FpxTensorCoreLayoutType
         assert isinstance(layout_type, FpxTensorCoreLayoutType), f"Only FpxTensorCoreLayoutType is supported for fpx, got {layout_type}"
@@ -755,7 +756,7 @@ def _aqt_is_uint4(aqt):
 implements = AffineQuantizedTensor.implements
 
 # following are a list of (dispatch_condition, implementation) functions that takes the following args:
-# input_tensor: dimension is (batch_size, in_features)
+# input_tensor: dimension is (M1, M2, ..., in_features)
 # weight_tensor: dimension is (out_features, in_features)
 # bias: dimension is (out_features,)
 # so that these can be shared by F.linear, aten.mm, aten.addmm dispatches

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -305,10 +305,10 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
                 use_hqq=False,
             )
         else:
-            raise NotImplementedError(f"Unsupported dtype {target_dtype} for from_float_to_floatx")
+            raise NotImplementedError(f"Unsupported dtype {target_dtype} for from_hp_to_floatx")
 
     @classmethod
-    def from_float_fpx(
+    def from_hp_to_fpx(
         cls,
         input_float: torch.Tensor,
         layout_type: LayoutType,
@@ -1103,7 +1103,7 @@ to_affine_quantized_intx = AffineQuantizedTensor.from_hp_to_intx
 to_affine_quantized_intx_static = AffineQuantizedTensor.from_hp_to_intx_static
 to_affine_quantized_floatx = AffineQuantizedTensor.from_hp_to_floatx
 # experimental will be merged in to floatx
-to_affine_quantized_fpx = AffineQuantizedTensor.from_float_fpx
+to_affine_quantized_fpx = AffineQuantizedTensor.from_hp_to_fpx
 
 if TORCH_VERSION_AT_LEAST_2_5:
     # Allow a model with AffineQuantizedTensor weights to be loaded with `weights_only=True`

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -12,12 +12,12 @@ from torchao.quantization.quant_primitives import (
     int_scaled_matmul,
     quantize_affine_hqq,
     FP8_TYPES,
-)
-from torchao.quantization.utils import (
-    pack_tinygemm_scales_and_zeros,
     choose_qparams_affine_fpx,
     quantize_affine_fpx,
     dequantize_affine_fpx,
+)
+from torchao.quantization.utils import (
+    pack_tinygemm_scales_and_zeros,
 )
 from torch.utils._python_dispatch import return_and_correct_aliasing
 from torchao.dtypes.utils import (

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -37,7 +37,6 @@ from torchao.utils import (
     TorchAOBaseTensor,
     TORCH_VERSION_AT_LEAST_2_5,
 )
-from torchao.ops import quant_llm_linear
 
 aten = torch.ops.aten
 
@@ -962,6 +961,8 @@ def _linear_f16_act_fpx_weight_check(input_tensor, weight_tensor, bias):
 
 def _linear_f16_act_fpx_weight_impl(input_tensor, weight_tensor, bias):
     from torchao.dtypes.fpx import _SPLIT_K_MAP
+    from torchao.ops import quant_llm_linear
+
     act = input_tensor
     weight = weight_tensor
 

--- a/torchao/dtypes/fpx/README.md
+++ b/torchao/dtypes/fpx/README.md
@@ -5,15 +5,17 @@ This is a FP16 x FPx mixed matmul kernel optimized for io bound workloads per [F
 ## Usage
 
 ```python
-from torchao.quantization.quant_api import quantize_
-from torchao.prototype.quant_llm import fp6_llm_weight_only, quant_llm_fpx_weight_only
+from torchao.quantization import (
+    quantize_,
+    fpx_weight_only,
+)
 
 model = ...
 model.half()  # not necessary, but recommeneded to maintain accuracy
-quantize_(model, fp6_llm_weight_only())  # convert nn.Lineaer.weight to FP6 E3M2 in-place
 
 # for generic FPx EyMz where x = 1 + y + z
-# quantize_(model, quant_llm_fpx_weight_only(2, 2))  # use FP5 E2M2 instead
+# fp6 with ebits = 3 and mbits = 2
+quantize_(model, fpx_weight_only(3, 2))
 
 # fully compatible with torch.compile()
 model.compile(mode="max-autotune", fullgraph=True)
@@ -23,7 +25,7 @@ It's also possible to pre-process the weight and call the kernel directly.
 
 ```python
 import torch
-from torchao.prototype.quant_llm import to_scaled_tc_fpx
+from torchao.dtypes.fpx import to_scaled_tc_fpx
 from torchao.ops import quant_llm_linear
 
 fp32_weight = torch.randn(1024, 512).cuda()

--- a/torchao/dtypes/fpx/__init__.py
+++ b/torchao/dtypes/fpx/__init__.py
@@ -1,0 +1,1 @@
+from .fpx import FpxTensorCoreLayoutType, FpxTensorCoreAQTLayout, to_scaled_tc_fpx, from_scaled_tc_fpx, _SPLIT_K_MAP

--- a/torchao/prototype/quant_llm/__init__.py
+++ b/torchao/prototype/quant_llm/__init__.py
@@ -1,1 +1,0 @@
-from .quant_llm import QuantLlmLinearWeight, fp6_llm_weight_only, quant_llm_fpx_weight_only, to_scaled_tc_fpx, from_scaled_tc_fpx

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -39,6 +39,8 @@ __all__ = [
     "int8_dynamic_activation_int8_semi_sparse_weight",
     "int4_weight_only",
     "int8_weight_only",
+    "uintx_weight_only",
+    "fpx_weight_only",
     "LinearActivationQuantizedTensor",
     "to_linear_activation_quantized",
 ]

--- a/torchao/quantization/prototype/mixed_precision/scripts/hessian_vhp.py
+++ b/torchao/quantization/prototype/mixed_precision/scripts/hessian_vhp.py
@@ -45,7 +45,7 @@ def set_attr(obj, names, val):
         set_attr(getattr(obj, names[0]), names[1:], val)
 
 def make_functional(mod, layer_id):
-    orig_params = tuple(mod.parameters())        
+    orig_params = tuple(mod.parameters())
     # remove all the parameters in the model
     selected_params=[]
     selected_params_names=[]
@@ -62,7 +62,7 @@ def make_functional(mod, layer_id):
 
 
 def main(layer_id, checkpoint, max_seqlen, max_iter, nsamples):
-    
+
     # use the functional model to load the weights back
     def load_weights(mod, names, params, selected_params, selected_params_names):
         for name, p in zip(names, params):
@@ -103,10 +103,10 @@ def main(layer_id, checkpoint, max_seqlen, max_iter, nsamples):
 
         # make the model functional
         params, names, selected_params, selected_params_names = make_functional(model, layer_id)
-        
+
         # make params regular Tensors instead of nn.Parameter
         params = tuple(p.detach() for p in params)
-        
+
         # set requires_grad to True for the selected parameters
         selected_params_tuple = tuple(p.detach().requires_grad_() for p in selected_params)
 
@@ -121,7 +121,7 @@ def main(layer_id, checkpoint, max_seqlen, max_iter, nsamples):
             v = [torch.randint_like(p, high=2) for p in selected_params_tuple]
             for v_i in v:
                 v_i[v_i == 0] = -1
-                
+
             for i in tqdm(range(nsamples)):
                 inputs, labels = trainloader[i]
                 inputs = inputs.to(device)
@@ -134,10 +134,10 @@ def main(layer_id, checkpoint, max_seqlen, max_iter, nsamples):
                 _, vH = vhp(f, selected_params_tuple, tuple(v))
 
                 if i==0:
-                    TvH = [torch.zeros(p.size()).to(device) for p in selected_params_tuple] 
+                    TvH = [torch.zeros(p.size()).to(device) for p in selected_params_tuple]
                 TvH = [TvH1 + vH1 + 0.0 for TvH1, vH1 in zip(TvH, vH)]
 
-            
+
             TvH = [TvH1 / float(nsamples) for TvH1 in TvH]
             # get vHv
             vHv = group_product(TvH, v)
@@ -148,7 +148,7 @@ def main(layer_id, checkpoint, max_seqlen, max_iter, nsamples):
             trace_history.append(trace)
 
         print("Iteration Done")
-        print("Avg Hessian trace for layer", layer_id, "is:" np.mean(trace_history))
+        print("Avg Hessian trace for layer", layer_id, "is:", np.mean(trace_history))
         print("trace_history,", trace_history)
 
 
@@ -160,6 +160,6 @@ if __name__ == '__main__':
     parser.add_argument('--checkpoint', type=str, default="/tmp/Meta-Llama-3-8B", help='Path to load model')
     parser.add_argument('--max_seqlen', type=int, default=2048, help='Max sequence length')
     parser.add_argument('--max_iter', type=int, default=100, help='The number of iterations to calculate Hessian trace')
-    parser.add_argument('--nsamples', type=int, default=128, help='The number of samples in calibration dataset') 
+    parser.add_argument('--nsamples', type=int, default=128, help='The number of samples in calibration dataset')
     args = parser.parse_args()
     main(args.layer_id, args.checkpoint, args.max_seqlen, args.max_iter, args.nsamples)

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -15,6 +15,7 @@ from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
 )
 from torchao.utils import _register_custom_op
+from torchao.prototype.custom_fp_utils import _f32_to_fpx_unpacked, _fpx_unpacked_to_f32, _n_ones
 
 
 __all__ = [
@@ -22,8 +23,11 @@ __all__ = [
     "int_scaled_matmul",
     "choose_qparams_affine",
     "choose_qparams_affine_with_min_max",
+    "choose_qparams_affine_fpx",
     "quantize_affine",
     "dequantize_affine",
+    "quantize_affine_fpx",
+    "dequantize_affine_fpx",
     "fake_quantize_affine",
     "fake_quantize_affine_cachemask",
     "quantize_affine_hqq",
@@ -90,6 +94,8 @@ if TORCH_VERSION_AT_LEAST_2_3:
         _SUB_BYTE_DTYPE_BOUNDS
     )
 
+
+_ONES_TABLE = [_n_ones(i) for i in range(8)]
 
 quant_lib = torch.library.Library("quant", "FRAGMENT")
 
@@ -707,7 +713,6 @@ def _choose_qparams_affine(
 
     return scale.to(dtype=scale_dtype), zero_point.to(dtype=zero_point_dtype)
 
-
 #HQQ
 ############################################################################
 # Shrinking operator (proximal operator for the lp norm)
@@ -875,3 +880,32 @@ def quantize_affine_hqq(
     torch.cuda.empty_cache()
 
     return W_q, scale, zero, shape
+
+
+def choose_qparams_affine_fpx(tensor: torch.Tensor, ebits: int, mbits: int) -> torch.Tensor:
+    # _n_ones() is not compatible with torch.compile() due to << operator
+    # https://github.com/pytorch/pytorch/issues/119152
+    # exp_bias = _n_ones(ebits - 1)
+    # max_normal = 2 ** (_n_ones(ebits) - exp_bias) * (_n_ones(mbits + 1) / (2 ** mbits))
+
+    # workaround: global lookup table
+    exp_bias = _ONES_TABLE[ebits - 1]
+    max_normal = 2 ** (_ONES_TABLE[ebits] - exp_bias) * (_ONES_TABLE[mbits + 1] / (2 ** mbits))
+
+    tensor = tensor.float()
+    scale = tensor.abs().amax(1).clamp(min=1e-12) / max_normal
+    return scale.half()
+
+def quantize_affine_fpx(tensor: torch.Tensor, scale: torch.Tensor, ebits: int, mbits: int) -> torch.Tensor:
+    """Quantizes the float32 high precision floating point tensor to low precision floating point number and
+    converts the result to unpacked floating point format with the format of 00SEEEMM (for fp6_e3m2) where S means sign bit, e means exponent bit and m means mantissa bit
+    """
+    tensor = tensor.float()
+    tensor_fpx = _f32_to_fpx_unpacked(tensor / scale.view(-1, 1), ebits, mbits)
+    return tensor_fpx
+
+def dequantize_affine_fpx(tensor: torch.Tensor, scale: torch.Tensor, ebits: int, mbits: int, output_dtype: torch.dtype = torch.float32) -> torch.Tensor:
+    tensor = _fpx_unpacked_to_f32(tensor, ebits, mbits)
+    tensor = tensor * scale.float().view(-1, 1)
+    tensor = tensor.to(dtype=output_dtype)
+    return tensor

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 import torch.nn.utils.parametrize as parametrize
 from torchao.utils import find_multiple
-from .quant_primitives import (
+from torchao.quantization.quant_primitives import (
     MappingType,
     ZeroPointDomain,
     choose_qparams_affine,


### PR DESCRIPTION
Summary:
We want to add quant_llm to affine quantized tensor as a general fp2-fp7 dtype, before that we need to refactor the current implementation to work with AffineQuantizedTensor first

Test Plan:
python test/prototype/test_quant_llm.py

Reviewers:

Subscribers:

Tasks:

Tags: