### PR TITLE
Add more information to quantized linear module and added some logs

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -125,6 +125,7 @@ class TestAffineQuantized(TestCase):
         deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
     @common_utils.parametrize("apply_quant", get_quantization_functions(True, True))
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_print_quantized_module(self, apply_quant):
         l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
         ql = apply_quant(l)

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -2,7 +2,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
 )
-from torchao.quantization.quant_api import (
+from torchao.quantization import (
     int4_weight_only,
     int8_weight_only,
     int8_dynamic_activation_int4_weight,
@@ -124,6 +124,11 @@ class TestAffineQuantized(TestCase):
 
         deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
+    @common_utils.parametrize("apply_quant", get_quantization_functions(True, True))
+    def test_print_quantized_module(self):
+        l = torch.nn.Linear(128, 256, dtype=torch.bfloat16)
+        ql = apply_quant(l)
+        assert "AffineQuantizedTensor" in str(ql)
 
 
 common_utils.instantiate_parametrized_tests(TestAffineQuantized)

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -125,8 +125,8 @@ class TestAffineQuantized(TestCase):
         deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
     @common_utils.parametrize("apply_quant", get_quantization_functions(True, True))
-    def test_print_quantized_module(self):
-        l = torch.nn.Linear(128, 256, dtype=torch.bfloat16)
+    def test_print_quantized_module(self, apply_quant):
+        l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
         ql = apply_quant(l)
         assert "AffineQuantizedTensor" in str(ql)
 

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -78,7 +78,7 @@ class AQTLayout(TorchAOBaseTensor):
     def __repr__(self):
         data, scale, zero_point = self.get_plain()
         layout_type = self.get_layout_type()
-        return f"{self.__class__.__name__}(data={data}, scale={scale}, zero_point={zero_point}, layout_type={layout_type})"
+        return f"{self.__class__.__name__}(data={str(data)[:100]}... , scale={str(scale)[:100]}... , zero_point={str(zero_point)[:100]}... , layout_type={layout_type})"
 
 
 ##############################
@@ -128,7 +128,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
          and operator/kernel
       block_size (Tuple[int, ...]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
          e.g. when size is the same as the input tensor dimension, we are using per tensor quantization
-      shape (torch.Size): the shape for the Tensor
+      shape (torch.Size): the shape for the original high precision Tensor
       quant_min (Optional[int]): minimum quantized value for the Tensor, if not specified, it will be derived from dtype of `int_data`
       quant_max (Optional[int]): maximum quantized value for the Tensor, if not specified, it will be derived from dtype of `int_data`
       zero_point_domain (ZeroPointDomain): the domain that zero_point is in, should be either integer or float
@@ -137,8 +137,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         if zero_point is in floating point domain, zero point is subtracted from the floating point (unquantized)
         value during quantization
         default is ZeroPointDomain.INT
-      input_quant_func (Optional[Callable]): function for quantizing the input float Tensor to a quantized tensor subclass object, that takes float Tensor as input and outputs an AffineQuantizedTensor object
-      dtype: dtype for external representation of the tensor, e.g. torch.float32
+      dtype: dtype for original high precision tensor, e.g. torch.float32
     """
 
     @staticmethod
@@ -183,8 +182,8 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
 
     def __repr__(self):
         return (
-            f"{self.__class__.__name__}(data={self.dequantize()}, shape={self.shape}, "
-            f"device={self.device}, dtype={self.dtype}, requires_grad={self.requires_grad})"
+            f"{self.__class__.__name__}(data={str(self.dequantize())[:100]}..., shape={self.shape}, block_size={self.block_size}, "
+            f"device={self.device}, dtype={self.dtype}, requires_grad={self.requires_grad}, \nlayout_tensor={self.layout_tensor})"
         )
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -78,7 +78,7 @@ class AQTLayout(TorchAOBaseTensor):
     def __repr__(self):
         data, scale, zero_point = self.get_plain()
         layout_type = self.get_layout_type()
-        return f"{self.__class__.__name__}(data={str(data)[:100]}... , scale={str(scale)[:100]}... , zero_point={str(zero_point)[:100]}... , layout_type={layout_type})"
+        return f"{self.__class__.__name__}(data={str(data)}... , scale={str(scale)}... , zero_point={str(zero_point)}... , layout_type={layout_type})"
 
 
 ##############################
@@ -182,9 +182,12 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
 
     def __repr__(self):
         return (
-            f"{self.__class__.__name__}(data={str(self.dequantize())[:100]}..., shape={self.shape}, block_size={self.block_size}, "
-            f"device={self.device}, dtype={self.dtype}, requires_grad={self.requires_grad}, \nlayout_tensor={self.layout_tensor})"
+            f"{self.__class__.__name__}(data={str(self.dequantize())}..., shape={self.shape}, block_size={self.block_size}, "
+            f"device={self.device}, dtype={self.dtype}, requires_grad={self.requires_grad}, layout_tensor={self.layout_tensor})"
         )
+
+    def _quantization_type(self):
+        return f"shape={self.shape}, block_size={self.block_size}, device={self.device}, layout_type={self.layout_type}, layout_tensor_dtype={self.layout_tensor.dtype}, quant_min={self.quant_min}, quant_max={self.quant_max}"
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -119,6 +119,10 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
     Affine quantized tensor subclass. Affine quantization means we quantize the floating point tensor with an affine transformation:
        quantized_tensor = float_tensor / scale + zero_point
 
+    To see what happens during choose_qparams, quantization and dequantization for affine quantization,
+    please checkout https://github.com/pytorch/ao/blob/main/torchao/quantization/quant_primitives.py
+    and check the three quant primitive ops: choose_qparams_affine, quantize_affine qand dequantize_affine
+
     The shape and dtype of the tensor subclass represent how the tensor subclass looks externally,
     regardless of the internal representation's type or orientation.
 

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -63,7 +63,7 @@ with open("quantization-cache.pkl", "rb") as f:
     AUTOQUANT_CACHE.update(pickle.load(f))
 ```
 ## Affine Quantization
-Affine quantization refers to the type of quantization that maps from floating point numbers to quantized numbers (typically integer) with an affine transformation, i.e.: `quantized_val = float_val / scale + zero_point` where `scale` and `zero_point` are quantization parameters for some granularity and based on some data.
+Affine quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtypes) with an affine transformation, i.e.: `quantized_val = high_preicsion_float_val / scale + zero_point` where `scale` and `zero_point` are quantization parameters for some granularity and based on some data (also some dtypes may not require a `zero_point`)
 
 ### Quantization Primitives
 We used to have different quantize and dequantize operators for quantization with different granularities. But in the end these can all be expressed with a `block_size` argument with different settings, so we unified existing quant primitives to `choose_qparams_affine`, `quantize_affine` and `dequantize_affine` that can represent symmetric/asymmetric per tensor/channel/token/channel_group quantization, this can be used to implement the unified quantized tensor subclass.

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "int4_weight_only",
     "int8_weight_only",
     "uintx_weight_only",
+    "float8_weight_only",
     "fpx_weight_only",
     "LinearActivationQuantizedTensor",
     "to_linear_activation_quantized",

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -282,8 +282,20 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
         model, replace_conv2d_1x1, filter_fn=filter_fn
     )
 
+def _quantization_type(weight: torch.Tensor):
+    if isinstance(weight, AffineQuantizedTensor):
+        return f"{weight.__class__.__name__}({weight._quantization_type()})"
+
+    if isinstance(weight, LinearActivationQuantizedTensor):
+        return f"{weight.__class__.__name__}(activation={weight.input_quant_func}, weight={_quantization_type(weight.original_weight_tensor)})"
+
+    if type(weight) is torch.Tensor:
+        return "not quantized"
+
+    return "not recognized"
+
 def _linear_extra_repr(self):
-    return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={str(self.weight)}, bias={str(self.bias)[:100]}..."
+    return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={_quantization_type(self.weight)}"
 
 def _get_linear_subclass_inserter(constructor, **kwargs):
     """Helper function to apply the constructor that quantizes the weight Tensor (with additional kwargs)

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -20,6 +20,7 @@ import torchao
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Any, Callable, Union, Dict, Optional
+import types
 
 from torchao.dtypes.uintx.Uintx import UintxLayoutType
 from torchao.dtypes import (
@@ -60,6 +61,8 @@ from .utils import _get_per_token_block_size
 import logging
 from .autoquant import autoquant, AutoQuantizableLinearWeight
 from torchao.float8.float8_tensor import ScaledMMConfig
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "swap_conv2d_1x1_to_linear",
@@ -279,10 +282,16 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
         model, replace_conv2d_1x1, filter_fn=filter_fn
     )
 
+def _linear_extra_repr(self):
+    return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={str(self.weight)}, bias={str(self.bias)[:100]}..."
 
-def _get_linear_subclass_inserter(constructor):
+def _get_linear_subclass_inserter(constructor, **kwargs):
+    """Helper function to apply the constructor that quantizes the weight Tensor (with additional kwargs)
+    to the weight of linear module
+    """
     def insert_subclass(lin):
-        lin.weight = torch.nn.Parameter(constructor(lin.weight), requires_grad=False)
+        lin.weight = torch.nn.Parameter(constructor(lin.weight, **kwargs), requires_grad=False)
+        lin.extra_repr = types.MethodType(_linear_extra_repr, lin)
         return lin
 
     return insert_subclass
@@ -359,11 +368,15 @@ def quantize_(
     )
 
 def _int8_asymm_per_token_quant(x: torch.Tensor) -> torch.Tensor:
+    """This is defined here instead of local function to support serialization
+    """
     mapping_type = MappingType.ASYMMETRIC
     target_dtype = torch.int8
     return to_affine_quantized_intx(x, mapping_type, _get_per_token_block_size(x), target_dtype)
 
 def apply_int8_dynamic_activation_int4_weight_quant(weight, group_size=32):
+    """This is defined here instead of local function to support serialization
+    """
     if weight.shape[-1] % group_size != 0:
         return weight
 
@@ -391,11 +404,7 @@ def int8_dynamic_activation_int4_weight(group_size=32):
         `group_size`: parameter for quantization, controls the granularity of quantization, smaller
          size is more fine grained
     """
-    def insert_subclass(lin):
-        lin.weight = torch.nn.Parameter(apply_int8_dynamic_activation_int4_weight_quant(lin.weight, group_size), requires_grad=False)
-        return lin
-
-    return insert_subclass
+    return _get_linear_subclass_inserter(apply_int8_dynamic_activation_int4_weight_quant, group_size=group_size)
 
 
 def int4_weight_only(group_size=128, layout_type=TensorCoreTiledLayoutType(inner_k_tiles=8)):
@@ -418,6 +427,9 @@ def int4_weight_only(group_size=128, layout_type=TensorCoreTiledLayoutType(inner
     """
     def apply_int4_weight_only_quant(weight, use_hqq=False):
         if weight.shape[-1] % group_size != 0:
+            logger.info(
+                f"Skipping quantizing weight with int4 weight only quantization because the shape of weight {weight.shape} is not compatible with group_size {group_size}"
+            )
             return weight
 
         mapping_type = MappingType.ASYMMETRIC
@@ -466,6 +478,9 @@ def int8_dynamic_activation_int8_weight(layout_type=PlainLayoutType()):
         in_features = weight.shape[1]
         # int8 dynamic quantization only has benefit when in_feature > 16
         if in_features <= 16:
+            logger.info(
+                f"Skipping applying int8_dynamic_activation_int8_weight to weight of shape {weight.shape}"
+                f" because `in_feature` is <= 16: {in_features}")
             return weight
 
         # weight settings
@@ -614,10 +629,13 @@ def fpx_weight_only(ebits: int, mbits: int):
         assert weight.dim() == 2, f"fpx only works for 2-d Tensor, got: {weight.dim()}"
         out_dim, in_dim = weight.shape
         if (in_dim % 64 != 0) or (out_dim % 256 != 0):
+            logger.info(
+                f"Skipping floatx quantization float{ebits + mbits + 1}_{ebits}_{mbits} because "
+                f"the shape is not compatible with the kernel: in_dim={in_dim}, out_dim={out_dim} "
+                "expected in_dim % 64 == 0 and out_dim % 256 == 0")
             return weight
 
         layout_type = FpxTensorCoreLayoutType(ebits, mbits)
-        print("layout type:", layout_type)
         return to_affine_quantized_fpx(weight, layout_type)
     return _get_linear_subclass_inserter(apply_quant_llm)
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/ao/issues/771

Test Plan:
python test/dtypes/test_affine_quantized_tensor.py -k test_print_quantized_module

Example output:
```
Linear(in_features=128, out_features=256, weight=AffineQuantizedTensor(shape=torch.Size([256, 128]), block_size=(1, 128), device=cuda:0, layout_type=PlainLayoutType(), layout_tensor_dtype=torch.int8, quant_min=None, quant_max=None))
.Linear(in_features=128, out_features=256, weight=LinearActivationQuantizedTensor(activation=<function _int8_asymm_per_token_quant at 0x7feb1d146820>, weight=AffineQuantizedTensor(shape=torch.Size([256, 128]), block_size=(1, 32), device=cuda:0, layout_type=PlainLayoutType(), layout_tensor_dtype=torch.int8, quant_min=-8, quant_max=7)))
.Linear(in_features=128, out_features=256, weight=LinearActivationQuantizedTensor(activation=<function _int8_symm_per_token_reduced_range_quant at 0x7feb1d146af0>, weight=AffineQuantizedTensor(shape=torch.Size([256, 128]), block_size=(1, 128), device=cuda:0, layout_type=PlainLayoutType(), layout_tensor_dtype=torch.int8, quant_min=None, quant_max=None)))
.Linear(in_features=128, out_features=256, weight=AffineQuantizedTensor(shape=torch.Size([256, 128]), block_size=(1, 32), device=cuda:0, layout_type=TensorCoreTiledLayoutType(inner_k_tiles=8), layout_tensor_dtype=torch.int32, quant_min=0, quant_max=15))
.Linear(in_features=128, out_features=256, weight=LinearActivationQuantizedTensor(activation=<function _int8_symm_per_token_reduced_range_quant at 0x7feb1d146af0>, weight=AffineQuantizedTensor(shape=torch.Size([256, 128]), block_size=(1, 128), device=cuda:0, layout_type=SemiSparseLayoutType(), layout_tensor_dtype=torch.int8, quant_min=None, quant_max=None)))
```

Reviewers:

Subscribers:

Tasks:

Tags: