### PR TITLE
Allow quantized linear registration in a different file

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -90,8 +90,8 @@ class TestAffineQuantized(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_register_new_dispatch(self):
         from torchao.dtypes.affine_quantized_tensor import (
-            _register_aqt_quantized_linear_dispatch,
-            _deregister_aqt_quantized_linear_dispatch,
+            register_aqt_quantized_linear_dispatch,
+            deregister_aqt_quantized_linear_dispatch,
         )
         from torchao.dtypes import to_affine_quantized_intx
         from torchao.dtypes import AffineQuantizedTensor
@@ -109,7 +109,7 @@ class TestAffineQuantized(TestCase):
             # quantized linear operator here
             assert False, "dispatching to my impl for uint6 weight only quant"
 
-        _register_aqt_quantized_linear_dispatch(dispatch_condition, impl)
+        register_aqt_quantized_linear_dispatch(dispatch_condition, impl)
 
         def apply_uint6_weight_only_quant(linear):
             linear.weight = torch.nn.Parameter(to_affine_quantized_intx(linear.weight, MappingType.ASYMMETRIC, (1, linear.weight.shape[-1]), torch.uint8, 0, 2**6-1), requires_grad=False)
@@ -122,7 +122,7 @@ class TestAffineQuantized(TestCase):
         with self.assertRaisesRegex(AssertionError, "dispatching to my impl for uint6 weight only quant"):
             l(example_input)
 
-        _deregister_aqt_quantized_linear_dispatch(dispatch_condition)
+        deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
 
 

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -89,7 +89,10 @@ class TestAffineQuantized(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_register_new_dispatch(self):
-        from torchao.dtypes.affine_quantized_tensor import _register_aqt_quantized_linear_dispatch
+        from torchao.dtypes.affine_quantized_tensor import (
+            _register_aqt_quantized_linear_dispatch,
+            _deregister_aqt_quantized_linear_dispatch,
+        )
         from torchao.dtypes import to_affine_quantized_intx
         from torchao.dtypes import AffineQuantizedTensor
         from torchao.quantization.quant_primitives import MappingType
@@ -118,6 +121,8 @@ class TestAffineQuantized(TestCase):
         example_input = torch.randn(1, 128, dtype=torch.bfloat16, device="cuda")
         with self.assertRaisesRegex(AssertionError, "dispatching to my impl for uint6 weight only quant"):
             l(example_input)
+
+        _deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
 
 

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -87,6 +87,39 @@ class TestAffineQuantized(TestCase):
         ql = apply_quant(l)
         ql.cuda()
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_register_new_dispatch(self):
+        from torchao.dtypes.affine_quantized_tensor import _register_aqt_quantized_linear_dispatch
+        from torchao.dtypes import to_affine_quantized_intx
+        from torchao.dtypes import AffineQuantizedTensor
+        from torchao.quantization.quant_primitives import MappingType
+
+        def dispatch_condition(input_tensor, weight_tensor, bias):
+            return (
+                isinstance(weight_tensor, AffineQuantizedTensor) and
+                weight_tensor.quant_min == 0 and
+                weight_tensor.quant_max == 2**6-1
+            )
+
+        def impl(input_tensor, weight_tensor, bias):
+            # this is just for testing, normally people will call into uint6 weight only
+            # quantized linear operator here
+            assert False, "dispatching to my impl for uint6 weight only quant"
+
+        _register_aqt_quantized_linear_dispatch(dispatch_condition, impl)
+
+        def apply_uint6_weight_only_quant(linear):
+            linear.weight = torch.nn.Parameter(to_affine_quantized_intx(linear.weight, MappingType.ASYMMETRIC, (1, linear.weight.shape[-1]), torch.uint8, 0, 2**6-1), requires_grad=False)
+            return linear
+
+        l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
+        apply_uint6_weight_only_quant(l)
+
+        example_input = torch.randn(1, 128, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaisesRegex(AssertionError, "dispatching to my impl for uint6 weight only quant"):
+            l(example_input)
+
+
 
 common_utils.instantiate_parametrized_tests(TestAffineQuantized)
 

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -92,7 +92,7 @@ class QuantizedLinearNotImplementedError(NotImplementedError):
 
 
 _AQT_QLINEAR_DISPATCH_TABLE = {}
-def _register_aqt_quantized_linear_dispatch(dispatch_condition, impl):
+def register_aqt_quantized_linear_dispatch(dispatch_condition, impl):
     """Register a dispatch for quantized linear op with dispatch_condition function and impl function
     both takes three arguments:
       input_tensor: dimension is (M1, M2, ..., in_features)
@@ -108,7 +108,7 @@ def _register_aqt_quantized_linear_dispatch(dispatch_condition, impl):
     """
     _AQT_QLINEAR_DISPATCH_TABLE[dispatch_condition] = impl
 
-def _deregister_aqt_quantized_linear_dispatch(dispatch_condition):
+def deregister_aqt_quantized_linear_dispatch(dispatch_condition):
     if dispatch_condition in _AQT_QLINEAR_DISPATCH_TABLE:
         del _AQT_QLINEAR_DISPATCH_TABLE[dispatch_condition]
     else:

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -1203,7 +1203,7 @@ def _register_aqt_quantized_linear_dispatches():
         (_linear_fp_act_int8_weight_check, _linear_fp_act_int8_weight_impl),
         (_linear_f16_act_fpx_weight_check, _linear_f16_act_fpx_weight_impl),
     ]:
-        _register_aqt_quantized_linear_dispatch(dispatch_condition, impl)
+        register_aqt_quantized_linear_dispatch(dispatch_condition, impl)
 
 _register_aqt_quantized_linear_dispatches()
 

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -39,6 +39,9 @@ from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
     _is_float8_type
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 from torchao.float8.float8_tensor import ScaledMMConfig
 aten = torch.ops.aten
@@ -104,6 +107,12 @@ def _register_aqt_quantized_linear_dispatch(dispatch_condition, impl):
             quantized linear implementation
     """
     _AQT_QLINEAR_DISPATCH_TABLE[dispatch_condition] = impl
+
+def _deregister_aqt_quantized_linear_dispatch(dispatch_condition):
+    if dispatch_condition in _AQT_QLINEAR_DISPATCH_TABLE:
+        del _AQT_QLINEAR_DISPATCH_TABLE[dispatch_condition]
+    else:
+        logger.warn(f"Attempting to remove non-existant dispatch condition {dispatch_condition}")
 
 class AffineQuantizedTensor(TorchAOBaseTensor):
     """

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -1214,8 +1214,8 @@ def _(func, types, args, kwargs):
     try:
         return weight_tensor._quantized_linear_op(input_tensor, weight_tensor, bias)
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfiic quantized linear implementation
-        if isinstance(weight_tensor, AffineQuantizedTensor) and weight_tensor.layout_type.quantized_linear_impl is not None:
+        # fallback path is only called when user did not specify a specfic quantized linear implementation with `layout_type.quantized_linear_impl`
+        if isinstance(weight_tensor, AffineQuantizedTensor) and hasattr(weight_tensor.layout_type, "quantized_linear_impl") and weight_tensor.layout_type.quantized_linear_impl is not None:
             raise e
 
         if isinstance(input_tensor, AffineQuantizedTensor):
@@ -1241,8 +1241,8 @@ def _(func, types, args, kwargs):
         weight_tensor = weight_tensor.t()
         return weight_tensor._quantized_linear_op(input_tensor, weight_tensor, bias)
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfiic quantized linear implementation
-        if isinstance(weight_tensor, AffineQuantizedTensor) and weight_tensor.layout_type.quantized_linear_impl is not None:
+        # fallback path is only called when user did not specify a specfic quantized linear implementation with `layout_type.quantized_linear_impl`
+        if isinstance(weight_tensor, AffineQuantizedTensor) and hasattr(weight_tensor.layout_type, "quantized_linear_impl") and weight_tensor.layout_type.quantized_linear_impl is not None:
             raise e
 
         if isinstance(input_tensor, AffineQuantizedTensor):
@@ -1265,8 +1265,8 @@ def _(func, types, args, kwargs):
         weight_tensor = weight_tensor.t()
         return weight_tensor._quantized_linear_op(input_tensor, weight_tensor, bias)
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfiic quantized linear implementation
-        if isinstance(weight_tensor, AffineQuantizedTensor) and weight_tensor.layout_type.quantized_linear_impl is not None:
+        # fallback path is only called when user did not specify a specfic quantized linear implementation with `layout_type.quantized_linear_impl`
+        if isinstance(weight_tensor, AffineQuantizedTensor) and hasattr(weight_tensor.layout_type, "quantized_linear_impl") and weight_tensor.layout_type.quantized_linear_impl is not None:
             raise e
 
         if isinstance(input_tensor, AffineQuantizedTensor):

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Dict, Callable, Union, Tuple
+from typing import Dict, Callable, Union, Tuple, Optional
 from collections import defaultdict
 import functools
 from dataclasses import dataclass
@@ -73,6 +73,12 @@ def _dispatch__torch_dispatch__(cls, func, types, args, kwargs):
 
 """
 Base class for different LayoutType, should not be instantiated directly
+used to allow users to pass around configurations for the layout tensor, e.g. inner_k_tiles
+for int4 tensor core tiled layout
+
+Note: layout is an abstraction not only for custom data representation, it is also used for how the
+layout interacts with different operators, e.g. the same data representation can have different
+behaviors when running the same operator, e.g. transpose, quantized_linear.
 """
 @dataclass(frozen=True)
 class LayoutType:

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -498,7 +498,7 @@ def int8_dynamic_activation_int8_semi_sparse_weight():
 def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
     """
     Applies float8 weight-only symmetric per-channel quantization to linear layers.
-    
+
     Args:
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m3fn.
 


### PR DESCRIPTION
Summary:

Previously there was some ordering that we need to maintain for quantized linear dispatch table in AffineQuantizedTensor, the reason is there is a fallback entry that dequantizes the input: https://github.com/pytorch/ao/blob/ba2d3b1333b90ccd0186216649a1c58c6a17ce56/torchao/dtypes/affine_quantized_tensor.py#L1195

so the dispatches with two inputs quantized (static or dynamic quantization) must come before this entry and dispatches with weight only quantization, however the fallback is not really used/needed in practice, since people typically just want to call into a very specific kernel.

From offline discussions with @drisspg and @HDCharles, it might be useful to have a "quantized_linear_impl" for `LayoutType`, this allows people to specify and check which quantized_linear_impl they want to use to make sure they can call into the specific kernel, when this field is set, we'll not run the fallback path for quantized linear either (dequantize all activation and weight tensors and run the floating point linear op) 
I think this can be added for a specific layout type if people want to and we don't have to enforce this in the base `LayoutType`, otherwise we'd have to specify this for all LayoutType which seems a bit cumbersome. The contract here is when people want to skip the fallback path, they can do:
```
class MyLayoutType:
    quantized_linear_impl = "some_impl"
    ...
```
and have the dispatch_condition function check for this: 
```
def dispatch_condition(...):
    return weight_tensor.layout_type.quantized_linear_impl == "some_impl" and ...
```
if there are some issues with the implementation, it will not call the fallback in this case

Test Plan:
python test/dtypes/test_affine_quantized.py -k test_register_new_dispatch

Reviewers:

Subscribers:

Tasks:

Tags: