### PR TITLE
Adding example for quantized tensor + tensor parallelism

### DIFF
--- a/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
@@ -329,6 +329,8 @@ class PlainMyDTypeLayout(MyDTypeLayout):
                 )
             elif dim == 1:
                 return PlainMyDTypeLayout(aten.slice.Tensor(self.int_data, dim, start, end, step), self.scale.view(-1, 1), self.transposed, self.layout_type)
+            else:
+                raise NotImplementedError(f"PlainMyDTypeLayout dispatch: attempting to run {func}, with dim={dim}, that is not supported")
         elif func is aten.t.default:
             return return_and_correct_aliasing(func, args, kwargs, PlainMyDTypeLayout(args[0].int_data, args[0].scale, not args[0].transposed, args[0].layout_type))
 

--- a/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
@@ -394,8 +394,16 @@ to_my_dtype = MyDTypeTensor.from_float
 ########
 # Test #
 ########
-def test():
+def main():
     from torchao.utils import benchmark_model
+
+    class M(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(1024, 128)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x)
 
     m = M()
     example_inputs = (100 * torch.randn(512, 1024),)
@@ -431,4 +439,4 @@ def test():
     print("after quantization and compile:", benchmark_model(m, NUM_RUNS, example_inputs))
 
 if __name__ == "__main__":
-    test()
+    main()

--- a/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
@@ -197,7 +197,7 @@ class MyDTypeTensor(TorchAOBaseTensor):
         block_size = (1, int_data.shape[-1])
         if hasattr(self.layout_tensor, "transposed") and self.layout_tensor.transposed:
             transposed = True
-        res = dequantize_affine(int_data, block_size, scale, None, int_data.dtype)
+        res = dequantize_affine(int_data, block_size, scale, None, int_data.dtype, output_dtype=output_dtype)
         if transposed:
             res = res.t()
         return res
@@ -330,8 +330,7 @@ class PlainMyDTypeLayout(MyDTypeLayout):
             elif dim == 1:
                 return PlainMyDTypeLayout(aten.slice.Tensor(self.int_data, dim, start, end, step), self.scale.view(-1, 1), self.transposed, self.layout_type)
         elif func is aten.t.default:
-            args[0].transposed = not args[0].transposed
-            return return_and_correct_aliasing(func, args, kwargs, args[0])
+            return return_and_correct_aliasing(func, args, kwargs, PlainMyDTypeLayout(args[0].int_data, args[0].scale, not args[0].transposed, args[0].layout_type))
 
         raise NotImplementedError(
             f"PlainMyDTypeLayout dispatch: attempting to run {func}, this is not supported"

--- a/tutorials/developer_api_guide/my_trainable_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_trainable_tensor_subclass.py
@@ -61,7 +61,7 @@ class MyTrainableDTypeTensor(MyDTypeTensor):
         return _ToMyTrainableDTypeTensor.apply(input_float, layout_type)
 
 class _ToMyTrainableDTypeTensor(torch.autograd.Function):
-    """ 
+    """
     Differentiable constructor for `MyTrainableDTypeTensor`.
     """
 
@@ -163,8 +163,8 @@ def _(func, types, args, kwargs):
 ########
 
 class M(torch.nn.Module):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self) -> None:
+        super().__init__()
         self.linear = torch.nn.Linear(512, 1024, bias=False)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -145,7 +145,7 @@ def rowwise_shard(m: torch.nn.Module, mesh: DeviceMesh) -> torch.nn.Module:
 ########
 # Test #
 ########
-if __name__ == "__main__":
+def main():
     # To make sure different ranks create the same module
     torch.manual_seed(5)
 
@@ -192,3 +192,6 @@ if __name__ == "__main__":
     print("torch.compile works!")
 
     dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -64,10 +64,7 @@ def _(func, types, args, kwargs):
         args[2],
         args[0],
     )
-    transposed = weight_tensor.layout_tensor.transposed
     weight_tensor = weight_tensor.dequantize()
-    if transposed:
-        weight_tensor = weight_tensor.t()
     return aten.addmm(input_tensor, weight_tensor, bias)
 
 @implements(aten.mm.default)
@@ -77,17 +74,14 @@ def _(func, types, args, kwargs):
         args[1],
         None
     )
-    transposed = weight_tensor.layout_tensor.transposed
     weight_tensor = weight_tensor.dequantize()
-    if transposed:
-        weight_tensor = weight_tensor.t()
     return aten.mm(input_tensor, weight_tensor)
 
 
 class M(torch.nn.Module):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.linear = torch.nn.Linear(1024, 1024, bias=False, device="cuda")
+        self.linear = torch.nn.Linear(1024, 512, bias=False, device="cuda")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear(x)
@@ -141,3 +135,10 @@ if __name__ == "__main__":
     print("input dtensor:", input_dtensor)
 
     print("result:", m(input_dtensor))
+
+    # doesn't work
+    # [rank0]: torch._dynamo.exc.TorchRuntimeError: Failed running call_function <built-in function linear>(*(DTensor(local_tensor=FakeTensor(..., device='cuda:0', size=(128, 1024)), device_mesh=DeviceMesh('cuda', [0, 1,
+    # 2, 3]), placements=(Replicate(),)), DTensor(local_tensor=MyDTypeTensorTP(data=FakeTensor(..., device='cuda:0', size=(128, 1024)), shape=torch.Size([1024, 1024]), device=cuda:0, dtype=torch.float32, requires_grad=False), device_mesh=DeviceMesh('cuda', [0, 1, 2, 3]), placements=(Shard(dim=0),)), None), **{}):
+    # [rank0]: a and b must have same reduction dim, but got [128, 1024] X [128, 1024].
+    # m = torch.compile(m)
+    # print("compiled result:", m(input_dtensor))

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -177,7 +177,6 @@ if __name__ == "__main__":
 
     y_colwise = d_up(input_dtensor)
     print("y_colwise:", y_colwise.shape)
-    # doesn't work, see BUG in rowwise_shard()
     print("result:", d_dn(y_colwise))
     print("Distributed works!")
 
@@ -185,9 +184,9 @@ if __name__ == "__main__":
     # [rank0]: torch._dynamo.exc.TorchRuntimeError: Failed running call_function <built-in function linear>(*(DTensor(local_tensor=FakeTensor(..., device='cuda:0', size=(128, 1024)), device_mesh=DeviceMesh('cuda', [0, 1,
     # 2, 3]), placements=(Replicate(),)), DTensor(local_tensor=MyDTypeTensorTP(data=FakeTensor(..., device='cuda:0', size=(128, 1024)), shape=torch.Size([1024, 1024]), device=cuda:0, dtype=torch.float32, requires_grad=False), device_mesh=DeviceMesh('cuda', [0, 1, 2, 3]), placements=(Shard(dim=0),)), None), **{}):
     # [rank0]: a and b must have same reduction dim, but got [128, 1024] X [128, 1024].
-    c_up = torch.compile(d_up)
-    c_dn = torch.compile(d_dn)
-    print("compiled result:", c_dn(c_up(input_dtensor)))
-    print("torch.compile works!")
+    # c_up = torch.compile(d_up)
+    # c_dn = torch.compile(d_dn)
+    # print("compiled result:", c_dn(c_up(input_dtensor)))
+    # print("torch.compile works!")
 
     dist.destroy_process_group()

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -182,10 +182,6 @@ if __name__ == "__main__":
     print("result:", d_dn(y_colwise))
     print("Distributed works!")
 
-    # doesn't work
-    # [rank0]: torch._dynamo.exc.TorchRuntimeError: Failed running call_function <built-in function linear>(*(DTensor(local_tensor=FakeTensor(..., device='cuda:0', size=(128, 1024)), device_mesh=DeviceMesh('cuda', [0, 1,
-    # 2, 3]), placements=(Replicate(),)), DTensor(local_tensor=MyDTypeTensorTP(data=FakeTensor(..., device='cuda:0', size=(128, 1024)), shape=torch.Size([1024, 1024]), device=cuda:0, dtype=torch.float32, requires_grad=False), device_mesh=DeviceMesh('cuda', [0, 1, 2, 3]), placements=(Shard(dim=0),)), None), **{}):
-    # [rank0]: a and b must have same reduction dim, but got [128, 1024] X [128, 1024].
     c_up = torch.compile(d_up)
     y_up = c_up(input_dtensor)
     print("y_up:", y_up.shape)

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -80,8 +80,8 @@ def _(func, types, args, kwargs):
         args[1],
         None
     )
-    print("input tensor shape:", input_tensor.shape)
-    print("weight tensor shape:", weight_tensor.shape)
+    print("mm input tensor shape:", input_tensor.shape)
+    print("mm weight tensor shape:", weight_tensor.shape)
     weight_tensor = weight_tensor.dequantize()
     return aten.mm(input_tensor, weight_tensor)
 
@@ -188,10 +188,10 @@ if __name__ == "__main__":
     # [rank0]: torch._dynamo.exc.TorchRuntimeError: Failed running call_function <built-in function linear>(*(DTensor(local_tensor=FakeTensor(..., device='cuda:0', size=(128, 1024)), device_mesh=DeviceMesh('cuda', [0, 1,
     # 2, 3]), placements=(Replicate(),)), DTensor(local_tensor=MyDTypeTensorTP(data=FakeTensor(..., device='cuda:0', size=(128, 1024)), shape=torch.Size([1024, 1024]), device=cuda:0, dtype=torch.float32, requires_grad=False), device_mesh=DeviceMesh('cuda', [0, 1, 2, 3]), placements=(Shard(dim=0),)), None), **{}):
     # [rank0]: a and b must have same reduction dim, but got [128, 1024] X [128, 1024].
-    c_up = torch.compile(d_up)
+    c_up = torch.compile(d_up, backend="eager")
     y_up = c_up(input_dtensor)
     print("y_up:", y_up.shape)
-    c_dn = torch.compile(d_dn)
+    c_dn = torch.compile(d_dn, backend="eager")
     y_dn = c_dn(y_up)
     print("y_dn:", y_dn.shape)
     print("compiled result:", y_dn)

--- a/tutorials/developer_api_guide/tensor_parallel.py
+++ b/tutorials/developer_api_guide/tensor_parallel.py
@@ -1,0 +1,72 @@
+import torch
+from my_dtype_tensor_subclass import MyDTypeTensor
+from torch.utils._python_dispatch import return_and_correct_aliasing
+
+# a tensor subclass that supports tensor parallelism with DTensor
+class MyDTypeTensorTP(MyDTypeTensor):
+    pass
+
+implements = MyDTypeTensorTP.implements
+
+aten = torch.ops.aten
+
+@implements([aten._to_copy.default, aten.clone.default])
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+    )
+
+@implements([aten.split.Tensor])
+def _(func, types, args, kwargs):
+    layout_tensor_list = func(args[0].layout_tensor, *args[1:], **kwargs)
+    out = [MyDTypeTensorTP(layout_tensor, layout_tensor.shape) for layout_tensor in layout_tensor_list]
+    return out
+
+@implements([aten.empty_like.default])
+def _(func, types, args, kwargs):
+    empty_like_layout_tensor = func(args[0].layout_tensor, *args[1:], **kwargs)
+    return MyDTypeTensorTP(empty_like_layout_tensor, empty_like_layout_tensor.shape)
+
+class M(torch.nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.linear = torch.nn.Linear(1024, 1024)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+to_my_dtype_tp = MyDTypeTensorTP.from_float
+
+########
+# Test #
+########
+if __name__ == "__main__":
+    m = M()
+    example_inputs = (100 * torch.randn(128, 1024),)
+    m(*example_inputs)
+
+
+    import os
+    import torch
+    from torch.distributed._tensor import init_device_mesh, Shard, distribute_tensor
+    import torch.distributed as dist
+    # initialize a fake process group
+    store = torch.testing._internal.distributed.fake_pg.FakeStore()
+    dist.init_process_group(
+        backend="fake",
+        world_size=2,
+        rank=0,
+        store=store,
+    )
+    mesh = init_device_mesh("cuda", (int(os.environ["WORLD_SIZE"]),))
+    # Shard this tensor over the mesh by sharding `big_tensor`'s 0th dimension over the 0th dimension of `mesh`.
+    quantized_weight = to_my_dtype_tp(m.linear.weight)
+    print("quantized weight:", quantized_weight)
+    quantized_weight_dtensor = distribute_tensor(quantized_weight, mesh, [Shard(dim=0)])
+    print("quantized weight dtensor:", quantized_weight_dtensor)
+
+    m.linear.weight = torch.nn.Parameter(
+        quantized_weight_dtensor, requires_grad=False
+    )
+
+    m(*example_inputs)


### PR DESCRIPTION
Summary:
This PR adds an example of how quantized tensor subclass can work with DTensor: https://github.com/pytorch/pytorch/blob/main/torch/distributed/_tensor/README.md

End goal is to rewrite https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/llama2.py with normal llama2 implementation and show case with DTensor + AffineQuantizedTensor + torch.compile we can get on par performance with the custom tensor parallel implementation

Test Plan:
torchrun --standalone --nnodes=1 --nproc-per-node=4 tutorials/developer_api_guide/tensor_parallel.py

Reviewers:

Subscribers:

Tasks:

Tags: