### PR TITLE
Skip fpx compile test

### DIFF
--- a/test/dtypes/test_fpx.py
+++ b/test/dtypes/test_fpx.py
@@ -37,6 +37,7 @@ class TestFpxTensorCoreAQTLayout(TestCase):
         actual = _pack_tc_fp6(x)
         torch.testing.assert_close(actual, expected)
 
+    @pytest.skipif(TORCH_VERSION_AT_LEAST_2_5, reason="upstream breaking change in PyTorch nightlies, revert skip when fixed")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     @parametrize("device", _DEVICES)
     def test_to_scaled_tc_fpx_compile(self, ebits, mbits, device):

--- a/test/dtypes/test_fpx.py
+++ b/test/dtypes/test_fpx.py
@@ -37,7 +37,7 @@ class TestFpxTensorCoreAQTLayout(TestCase):
         actual = _pack_tc_fp6(x)
         torch.testing.assert_close(actual, expected)
 
-    @pytest.skipif(TORCH_VERSION_AT_LEAST_2_5, reason="upstream breaking change in PyTorch nightlies, revert skip when fixed")
+    @pytest.mark.skipif(TORCH_VERSION_AT_LEAST_2_5, reason="upstream breaking change in PyTorch nightlies, revert skip when fixed")
     @parametrize("ebits,mbits", _FPx_DTYPES)
     @parametrize("device", _DEVICES)
     def test_to_scaled_tc_fpx_compile(self, ebits, mbits, device):


### PR DESCRIPTION
Temporary workaround for https://github.com/pytorch/ao/issues/792

Skips the offending test, might be better than pinning the torch version like in https://github.com/pytorch/ao/pull/790 because we're close to a code freeze on Sep 5 and a pinned PyTorch version means we need to delay the release