### PR TITLE
[StaticQuant] add a linear observer class and test

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,4 +8,6 @@ include = [
     "torchao/dtypes/nf4tensor.py",
     "test/dtypes/test_nf4.py",
     "torchao/float8/float8_tensor.py",
+    "torchao/quantization/linear_activation_weight_observer.py",
+    "test/quantization/test_observer.py",
 ]

--- a/torchao/quantization/linear_activation_weight_observer.py
+++ b/torchao/quantization/linear_activation_weight_observer.py
@@ -1,0 +1,152 @@
+import torch
+from typing import Callable, Optional, Dict
+from torch.utils._python_dispatch import return_and_correct_aliasing
+from torchao.utils import (
+    TorchAOBaseTensor,
+    TORCH_VERSION_AT_LEAST_2_5,
+)
+
+from torchao.quantization.observer import AffineQuantizedObserverBase
+
+__all__ = [
+    "LinearActivationWeightObservedTensor",
+]
+
+aten = torch.ops.aten
+Tensor = torch.Tensor
+
+
+class LinearActivationWeightObservedTensor(TorchAOBaseTensor):
+    """
+    This subclass of Tensor is used in conjuction with a static calibration flow.
+    The flow is broken up into 3 parts;
+        1. Insert the LinearActivationWeightObservedTensor subclass into the model's nn.Linear layers
+        2. Run the model with a calibration dataset, the observer will record the min/max of the input and weight
+        3. quantize_ the model to static using the statistics recorded by the observer
+
+    This subclass wraps the original weight tensor on the nn.Linear layer. When forward is called, the observer
+    will first calculat statistics on BOTH the input and weight, and then run the linear op.
+    """
+
+    original_weight_tensor: torch.Tensor
+    input_observer: Optional[AffineQuantizedObserverBase]
+    weight_observer: Optional[AffineQuantizedObserverBase]
+
+    def __new__(
+        cls,
+        original_weight_tensor: torch.Tensor,
+        input_observer: Optional[AffineQuantizedObserverBase] = None,
+        weight_observer: Optional[AffineQuantizedObserverBase] = None,
+    ):
+        kwargs = {}
+        dtype = original_weight_tensor.dtype
+        kwargs["dtype"] = dtype
+        kwargs["requires_grad"] = False
+        kwargs["device"] = original_weight_tensor.device
+        shape = original_weight_tensor.shape
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        original_weight_tensor: torch.Tensor,
+        input_observer: Optional[AffineQuantizedObserverBase] = None,
+        weight_observer: Optional[AffineQuantizedObserverBase] = None,
+    ):
+        self.original_weight_tensor = original_weight_tensor
+        self.input_observer = input_observer
+        self.weight_observer = weight_observer
+
+    def __repr__(self):
+        return (
+            f"LinearActivationWeightObservedTensor(\n"
+            f"original_weight={self.original_weight_tensor}\n"
+            f"input_observer={self.input_observer.__class__.__name__ if self.input_observer else None}\n"
+            f"weight_observer={self.weight_observer.__class__.__name__ if self.weight_observer else None}\n)"
+        )
+
+    def __tensor_flatten__(self):
+        return ["original_weight_tensor"], [self.input_observer, self.weight_observer]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls,
+        tensor_data_dict: Dict[str, Tensor],
+        tensor_attributes,
+        outer_size,
+        outer_stride,
+    ):
+        original_weight_tensor = tensor_data_dict["original_weight_tensor"]
+        (input_observer, weight_observer) = tensor_attributes
+        return cls(original_weight_tensor, input_observer, weight_observer)
+
+    @classmethod
+    def from_float(
+        cls,
+        original_weight_tensor: Tensor,
+        input_observer: Optional[AffineQuantizedObserverBase] = None,
+        weight_observer: Optional[AffineQuantizedObserverBase] = None,
+    ):
+        return cls(original_weight_tensor, input_observer, weight_observer)
+
+    def _apply_fn_to_data(self, fn: Callable):
+        """Applies a fn to the tensor component of the LinearActivationWeightObservedTensor"""
+        return self.__class__(
+            fn(self.original_weight_tensor),
+            self.input_observer,
+            self.weight_observer,
+        )
+
+    def to(self, *args, **kwargs):
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        return self._apply_fn_to_data(lambda x: x.to(**kwargs))
+
+
+implements = LinearActivationWeightObservedTensor.implements
+
+
+@implements(torch.nn.functional.linear)
+def _(func, types, args, kwargs):
+    input_tensor, weight_tensor, bias = (
+        args[0],
+        args[1],
+        args[2] if len(args) > 2 else None,
+    )
+    if weight_tensor.input_observer is not None:
+        input_tensor = weight_tensor.input_observer(input_tensor)
+    if weight_tensor.weight_observer is not None:
+        weight_tensor = weight_tensor.weight_observer(
+            weight_tensor.original_weight_tensor
+        )
+    else:
+        weight_tensor = weight_tensor.original_weight_tensor
+
+    return torch.nn.functional.linear(input_tensor, weight_tensor, bias)
+
+
+@implements(aten.detach.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
+    )
+
+
+@implements(aten.clone.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+    )
+
+
+@implements(aten._to_copy.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func,
+        args,
+        kwargs,
+        args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
+    )
+
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    # Allow a model with LinearActivationQuantizedTensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals([LinearActivationWeightObservedTensor])

--- a/torchao/quantization/observer.py
+++ b/torchao/quantization/observer.py
@@ -8,9 +8,10 @@ from .quant_primitives import (
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, List, Tuple, Optional, Any
+from typing import Tuple, Optional, Any
 from functools import partial
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,6 +53,7 @@ class PerAxis(GranularityType):
     """
     axis: int
 
+
 # borrowed from torch.ao.quantization.observer
 class _PartialWrapper:
     def __init__(self, p):
@@ -65,6 +67,7 @@ class _PartialWrapper:
 
     def with_args(self, *args, **kwargs):
         return _with_args(self, *args, **kwargs)
+
 
 def _with_args(cls_or_self, *args, **kwargs):
     r"""Wrapper that allows creation of class factories.
@@ -103,7 +106,9 @@ def get_block_size(
         return tuple(block_size)
     raise ValueError(f"Unsupported GranularityType: {granularity_type}")
 
+
 ABC: Any = ABCMeta("ABC", (object,), {})  # compatible with Python 2 *and* 3:
+
 
 class AffineQuantizedObserverBase(ABC, torch.nn.Module):
     """Observer module for affine quantization (https://github.com/pytorch/ao/tree/main/torchao/quantization#affine-quantization)
@@ -114,9 +119,11 @@ class AffineQuantizedObserverBase(ABC, torch.nn.Module):
         Current supported granularity type are `PerTensor` and `PerAxis`
       other args: please see `:class:torchao.dtypes.AffineQuantizedTensor`
     """
+
     with_args = classmethod(_with_args)
 
-    def __init__(self,
+    def __init__(
+        self,
         mapping_type: MappingType,
         target_dtype: torch.dtype,
         granularity_type: GranularityType,
@@ -126,7 +133,7 @@ class AffineQuantizedObserverBase(ABC, torch.nn.Module):
         scale_dtype: Optional[torch.dtype] = None,
         zero_point_dtype: Optional[torch.dtype] = None,
         preserve_zero: bool = True,
-        zero_point_domain = ZeroPointDomain.INT,
+        zero_point_domain: Optional[ZeroPointDomain] = ZeroPointDomain.INT,
     ):
         super().__init__()
         assert granularity_type is not None, "granularity_type is None"
@@ -144,7 +151,7 @@ class AffineQuantizedObserverBase(ABC, torch.nn.Module):
 
     @abstractmethod
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        """ forward function should take the input tensor
+        """forward function should take the input tensor
         and updates internal stats and return the original input Tensor
         """
         pass
@@ -155,6 +162,7 @@ class AffineQuantizedObserverBase(ABC, torch.nn.Module):
         and returns a tuple of scale and zero_point Tensor
         """
         pass
+
 
 class AffineQuantizedMinMaxObserver(AffineQuantizedObserverBase):
     def forward(self, input: torch.Tensor):
@@ -200,5 +208,5 @@ class AffineQuantizedMinMaxObserver(AffineQuantizedObserverBase):
             self.scale_dtype,
             self.zero_point_dtype,
             self.preserve_zero,
-            self.zero_point_domain
+            self.zero_point_domain,
         )

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -60,6 +60,10 @@ from .GPTQ import (
 from .utils import _get_per_token_block_size
 import logging
 from .autoquant import autoquant, AutoQuantizableLinearWeight
+from torchao.quantization.observer import AffineQuantizedObserverBase
+from torchao.quantization.linear_activation_weight_observer import (
+    LinearActivationWeightObservedTensor,
+)
 from torchao.float8.inference import Float8MMConfig
 
 logger = logging.getLogger(__name__)
@@ -281,6 +285,86 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
     _replace_with_custom_fn_if_matches_filter(
         model, replace_conv2d_1x1, filter_fn=filter_fn
     )
+def insert_observers_(
+    model: nn.Module,
+    input_observer: Optional[AffineQuantizedObserverBase],
+    weight_observer: Optional[AffineQuantizedObserverBase],
+    *,
+    filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
+):
+    """
+    Converts the weight of a linear module to a LinearActivationWeightObservedTensor.
+
+    This function wraps the weight of the given linear module with a LinearActivationWeightObservedTensor,
+    which enables observation of both input and weight tensors during forward passes.
+    The wrapped weight is then re-wrapped as a nn.Parameter to maintain compatibility
+    with PyTorch's module system.
+
+    Example::
+
+    ```
+        import torch
+        import torch.nn as nn
+        from torchao.quantization.linear_observer_tensor import insert_observers_
+        from torchao.quantization.observer import (
+            AffineQuantizedMinMaxObserver,
+            PerTensor,
+            MappingType
+        )
+
+        # Create observers
+        input_observer = AffineQuantizedMinMaxObserver(
+            MappingType.SYMMETRIC,
+            torch.float8_e4m3fn,
+            granularity_type=PerTensor(),
+            eps=torch.finfo(torch.float32).eps,
+            scale_dtype=torch.float,
+            zero_point_dtype=torch.int,
+            zero_point_domain=None,
+        )
+
+        # Create a linear module
+        linear_module = nn.Linear(10, 20)
+
+        # Convert the linear module's weight to an observed tensor
+        insert_observers_(linear_module, input_observer, weight_observer=None)
+
+        # The linear_module can now be used as usual, with observers calculating statistics
+        output = linear_module(torch.randn(10, 10))
+
+        # Get the scale and zero point of the input observer
+        scale, zero_point = linear_module.weight.input_observer.calculate_qparams()
+    ```
+
+    Args:
+        model (nn.Module): The nn.Module to convert.
+        input_observer (Optional[AffineQuantizedObserverBase]): Observer for input tensor.
+        weight_observer (Optional[AffineQuantizedObserverBase]): Observer for weight tensor.
+        filter_fn (Optional[Callable[[torch.nn.Module, str], bool]]): Filter function to select which modules to convert.
+            If not provided, all linear modules will be converted. This function should take a module and its fully qualified name.
+
+    Returns:
+        nn.Linear: The modified linear module with its weight wrapped in a LinearActivationWeightObservedTensor.
+    """
+
+    def convert_to_linear_observer(linear_module: nn.Linear):
+        # Wrap the weight with LinearActivationWeightObservedTensor and then with nn.Parameter
+        linear_module.weight = nn.Parameter(
+            LinearActivationWeightObservedTensor.from_float(
+                linear_module.weight,
+                input_observer=input_observer,
+                weight_observer=weight_observer,
+            ),
+            requires_grad=linear_module.weight.requires_grad,
+        )
+        return linear_module
+
+    _replace_with_custom_fn_if_matches_filter(
+        model,
+        convert_to_linear_observer,
+        _is_linear if filter_fn is None else filter_fn,
+    )
+
 
 def _quantization_type(weight: torch.Tensor):
     if isinstance(weight, AffineQuantizedTensor):

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -580,7 +580,7 @@ def choose_qparams_affine(
    scale_dtype: Optional[torch.dtype] = None,
    zero_point_dtype: Optional[torch.dtype] = None,
    preserve_zero: bool = True,
-   zero_point_domain = ZeroPointDomain.INT,
+   zero_point_domain: Optional[ZeroPointDomain] = ZeroPointDomain.INT,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Args:
@@ -641,7 +641,7 @@ def choose_qparams_affine_with_min_max(
    scale_dtype: Optional[torch.dtype] = None,
    zero_point_dtype: Optional[torch.dtype] = None,
    preserve_zero: bool = True,
-   zero_point_domain = ZeroPointDomain.INT,
+   zero_point_domain: Optional[ZeroPointDomain] = ZeroPointDomain.INT,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """A variant of :func:`~torchao.quantization.quant_primitives.choose_qparams_affine`
     operator that pass in min_val and max_val directly instead of deriving these from a single input.


### PR DESCRIPTION
Stacked PRs:
 * __->__#807


--- --- ---

[StaticQuant] add a linear observer class and test

This adds a new flow for calculating static activation scales. Rough example of flow:
```Python
import torch
import torch.nn as nn
from torchao.quantization.linear_observer_tensor import insert_observers_
from torchao.quantization.observer import (
    AffineQuantizedMinMaxObserver,
    PerTensor,
    MappingType
)

# Create observers
input_observer = AffineQuantizedMinMaxObserver(
    MappingType.SYMMETRIC,
    torch.float8_e4m3fn,
    granularity_type=PerTensor(),
    eps=torch.finfo(torch.float32).eps,
    scale_dtype=torch.float,
    zero_point_dtype=torch.int,
    zero_point_domain=None,
)

# Create a linear module
linear_module = nn.Linear(10, 20)

# Convert the linear module's weight to an observed tensor
insert_observers_(linear_module, input_observer, weight_observer=None)

# The linear_module can now be used as usual, with observers calculating statistics
output = linear_module(torch.randn(10, 10))

# Get the scale and zero point of the input observer
scale, zero_point = linear_module.weight.input_observer.calculate_qparams()
```