### PR TITLE
Fix build error - error: function "torchao::marlin_24_gemm" has already been defined (previous definition at line 83)

### DIFF
--- a/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu
+++ b/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu
@@ -852,8 +852,6 @@ __global__ void Marlin_24(
   }
 }
 
-#endif
-
 #define CALL_IF_2_4(NUM_BITS, THREAD_M_BLOCKS, THREAD_N_BLOCKS,               \
                     THREAD_K_BLOCKS, GROUP_BLOCKS)                            \
   else if (num_bits == NUM_BITS && thread_m_blocks == THREAD_M_BLOCKS &&      \
@@ -1118,6 +1116,8 @@ torch::Tensor marlin_24_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
 
   return c;
 }
+
+#endif
 
 TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
   m.impl("torchao::marlin_24_gemm", &marlin_24_gemm);


### PR DESCRIPTION
For CUDA_ARCH < 800

https://github.com/pytorch/ao/blob/3ac2ab8c9ffb0a624b48a51c105b0a780cafe483/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu#L55-L57

we get multiple definition of `marlin_24_gemm` due to incorrect placement on `endif`.

https://github.com/pytorch/ao/blob/3ac2ab8c9ffb0a624b48a51c105b0a780cafe483/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu#L83-L92

https://github.com/pytorch/ao/blob/3ac2ab8c9ffb0a624b48a51c105b0a780cafe483/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu#L1012-L1019

Fix - Move the `endif` to the appropriate location.