### PR TITLE
[Float8] Add static constructor that will be used in Observer workflow

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -11,4 +11,6 @@ include = [
     "torchao/quantization/linear_activation_weight_observer.py",
     "test/quantization/test_observer.py",
     "test/dtypes/test_affine_quantized_float.py",
+    "torchao/quantization/weight_tensor_linear_activation_quantization.py"
+
 ]

--- a/torchao/float8/__init__.py
+++ b/torchao/float8/__init__.py
@@ -23,6 +23,7 @@ from torchao.float8.float8_tensor import (
     LinearMMConfig,
     ScaledMMConfig,
 )
+from torchao.float8.inference import Float8MMConfig
 from torchao.float8.fsdp_utils import precompute_float8_dynamic_scale_for_fsdp
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
@@ -31,7 +32,7 @@ from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 if TORCH_VERSION_AT_LEAST_2_5:
     # Needed to load Float8Tensor with weights_only = True
     from torch.serialization import add_safe_globals
-    add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole, LinearMMConfig])
+    add_safe_globals([Float8Tensor, ScaledMMConfig, GemmInputRole, LinearMMConfig, Float8MMConfig])
 
 __all__ = [
     # configuration

--- a/torchao/quantization/observer.py
+++ b/torchao/quantization/observer.py
@@ -5,6 +5,7 @@ from .quant_primitives import (
     MappingType,
     ZeroPointDomain,
 )
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
@@ -222,3 +223,7 @@ class AffineQuantizedMinMaxObserver(AffineQuantizedObserverBase):
             self.preserve_zero,
             self.zero_point_domain,
         )
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    # Allow a model with LinearActivationQuantizedTensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals([PerRow, PerTensor])

--- a/torchao/quantization/weight_tensor_linear_activation_quantization.py
+++ b/torchao/quantization/weight_tensor_linear_activation_quantization.py
@@ -1,0 +1,201 @@
+import torch
+from typing import Callable, Optional, Dict, Any
+from torch.utils._python_dispatch import return_and_correct_aliasing
+from torchao.utils import (
+    TorchAOBaseTensor,
+    TORCH_VERSION_AT_LEAST_2_5,
+)
+
+__all__ = [
+    "WeightTensorWithLinearActivationQuantizationMetadata",
+    "to_weight_tensor_with_linear_activation_quantization_metadata",
+]
+
+aten = torch.ops.aten
+
+
+class WeightTensorWithLinearActivationQuantizationMetadata(TorchAOBaseTensor):
+    """
+    Tensor subclass that wraps a weight tensor and provides metadata for linear activation static quantization.
+
+    Args:
+        original_weight_tensor (torch.Tensor): The weight tensor to be wrapped.
+        input_quant_func_static (Callable): The quantization function for inputs.
+            Must have the signature: (Tensor, scale: Tensor, zero_point: Optional[Tensor], **quant_kwargs) -> Tensor
+        scale (torch.Tensor): The scale tensor for activation quantization.
+        zero_point (Optional[torch.Tensor]): The zero point tensor for activation quantization. Default is None.
+        quant_kwargs (Dict[str, Any]): Additional keyword arguments for the quantization function.
+            Restriction: Must not contain tensor values.
+    """
+
+    original_weight_tensor: torch.Tensor
+    input_quant_func_static: Callable
+    scale: torch.Tensor
+    zero_point: Optional[torch.Tensor]
+    quant_kwargs: Dict[str, Any]
+
+    def __new__(
+        cls,
+        original_weight_tensor: torch.Tensor,
+        input_quant_func_static: Callable,
+        scale: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
+        quant_kwargs: Dict[str, Any],
+    ):
+        kwargs = {}
+        dtype = original_weight_tensor.dtype
+        kwargs["dtype"] = dtype
+        kwargs["requires_grad"] = False
+        kwargs["device"] = original_weight_tensor.device
+        shape = original_weight_tensor.shape
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        original_weight_tensor: torch.Tensor,
+        input_quant_func_static: Callable[
+            [torch.Tensor, torch.Tensor, Optional[torch.Tensor], Dict[str, Any]],
+            torch.Tensor,
+        ],
+        scale: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
+        quant_kwargs: Dict[str, Any],
+    ):
+        self.original_weight_tensor = original_weight_tensor
+        self.input_quant_func_static = input_quant_func_static
+        self.scale = scale
+        self.zero_point = zero_point
+        self.quant_kwargs = quant_kwargs
+
+    def __repr__(self):
+        return f"LinearActivationQuantizedTensor({self.original_weight_tensor}, {self.input_quant_func_static}, scale={self.scale}, zero_point={self.zero_point}, quant_kwargs={self.quant_kwargs})"
+
+    def __tensor_flatten__(self):
+        tensor_data = ["original_weight_tensor", "scale"]
+        if self.zero_point is not None:
+            tensor_data.append("zero_point")
+        return tensor_data, [self.input_quant_func_static, self.quant_kwargs]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        original_weight_tensor = tensor_data_dict["original_weight_tensor"]
+        input_quant_func_static, quant_kwargs = tensor_attributes
+        zero_point = tensor_data_dict.get("zero_point", None)
+        return cls(
+            original_weight_tensor,
+            input_quant_func_static,
+            tensor_data_dict["scale"],
+            zero_point,
+            quant_kwargs,
+        )
+
+    @staticmethod
+    def _quantized_linear_op(
+        input_tensor: torch.Tensor, weight_tensor: torch.Tensor, bias: torch.Tensor
+    ):
+        input_quant_func_static = weight_tensor.input_quant_func_static
+        original_weight_tensor = weight_tensor.original_weight_tensor
+        scale = weight_tensor.scale
+        zero_point = weight_tensor.zero_point
+        quant_kwargs = weight_tensor.quant_kwargs
+        quantized_input_act = input_quant_func_static(
+            input_tensor, scale=scale, zero_point=zero_point, **quant_kwargs
+        )
+        return torch.nn.functional.linear(
+            quantized_input_act, original_weight_tensor, bias
+        )
+
+    @classmethod
+    def from_float(
+        cls,
+        input_float: torch.Tensor,
+        input_quant_func: Callable,
+        scale: torch.Tensor,
+        zero_point: Optional[torch.Tensor] = None,
+        quant_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        if quant_kwargs is None:
+            quant_kwargs = {}
+        return cls(input_float, input_quant_func, scale, zero_point, quant_kwargs)
+
+    def _apply_fn_to_data(self, fn):
+        return self.__class__(
+            fn(self.original_weight_tensor),
+            self.input_quant_func_static,
+            fn(self.scale),
+            fn(self.zero_point) if self.zero_point is not None else None,
+            self.quant_kwargs,
+        )
+
+    def to(self, *args, **kwargs):
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        device = kwargs.pop("device")
+        return self.__class__(
+            self.original_weight_tensor.to(device),
+            self.input_quant_func_static,
+            self.scale.to(device),
+            self.zero_point.to(device) if self.zero_point is not None else None,
+            self.quant_kwargs,
+        )
+
+
+implements = WeightTensorWithLinearActivationQuantizationMetadata.implements
+
+
+@implements(torch.nn.functional.linear)
+def _(func, types, args, kwargs):
+    input_tensor, weight_tensor, bias = (
+        args[0],
+        args[1],
+        args[2] if len(args) > 2 else None,
+    )
+    if isinstance(weight_tensor, WeightTensorWithLinearActivationQuantizationMetadata):
+        return weight_tensor._quantized_linear_op(input_tensor, weight_tensor, bias)
+
+    raise NotImplementedError(
+        "LinearActivationQuantizedTensor: No specialized dispatch found for linear op"
+    )
+
+
+@implements(aten.detach.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
+    )
+
+
+@implements(aten.clone.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+    )
+
+
+@implements(aten._to_copy.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func,
+        args,
+        kwargs,
+        args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
+    )
+
+
+@implements(aten.t.default)
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.t)
+    )
+
+
+to_weight_tensor_with_linear_activation_quantization_metadata = (
+    WeightTensorWithLinearActivationQuantizationMetadata.from_float
+)
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    # Allow a model with LinearActivationQuantizedTensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals(
+        [WeightTensorWithLinearActivationQuantizationMetadata]
+    )


### PR DESCRIPTION
Stacked PRs:
 * __->__#869


--- --- ---

[Float8] Add static constructor that will be used in Observer workflow

### Update
After much discussion with many folks, I think we can get the best of all the worlds
- Same serde contract
- torch.compile support
- weights only loading

#### Changes
- Introduce a new Static Subclass for activation casting: `LinearActivationQuantizedTensorStatic`
- Difference between the existing is that scale + optional zero point is stored as tensor attributes (critically not captured in the quant function)
- The input_quant func contract is `(Tensor, scale: Tensor, zero_point: `Optional[Tensor]`, **quant_kwargs)` where any additional kwargs cant contain tensors as values
- We pass the kwargs at construction in order to enable weights-only serialzation and not need a new "partial" function per instance, cc @mikaylagawarecki 
- We optionally return zero_point in the flatten if it is not None, cc @bdhirsh  ( this works idk what I was doing wrong before :) )
- 



### Previous notes
This PR explores ways to quantize_ a model with static scales. It implements 3 ways to do this:

1. using the exsitng LinearActivationTensor that where the input quant func captures a tensor
2. No activation subclass tensor, but rather registering the scale buffer on the model + adding in a forward_pre_hook
3. And A static ActivationSubclass with scale attribute updating the signature for the input_quant_func callable



The first  does not worth compile due to unlatten not knowing that tensors are in the callable
The second works with compile but changes how serde needs to be done
The third Maintains serde behavior and works with compile