### PR TITLE
Fix inference_mode

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -1483,7 +1483,7 @@ def _register_aqt_quantized_linear_dispatches():
 
 _register_aqt_quantized_linear_dispatches()
 
-@implements(torch.nn.functional.linear)
+@implements([torch.nn.functional.linear, aten.linear.default])
 def _(func, types, args, kwargs):
     input_tensor, weight_tensor, bias = (
         args[0],

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -91,7 +91,7 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
 
 implements = LinearActivationQuantizedTensor.implements
 
-@implements(torch.nn.functional.linear)
+@implements([torch.nn.functional.linear, aten.linear.default])
 def _(func, types, args, kwargs):
     input_tensor, weight_tensor, bias = (
         args[0],


### PR DESCRIPTION
Summary:
Fixes: https://github.com/pytorch/ao/issues/875

Test Plan:
Test locally with tutorials/quantize_vit/run_vit_b_quant.py with:
```
with torch.inference_mode():
    benchmark_model(model, 20, inputs)
```

but can't repro the issue in unit tests

Reviewers:

Subscribers:

Tasks:

Tags: