### PR TITLE
Switch back to supported CI runners

### DIFF
--- a/.github/workflows/float8_test.yml
+++ b/.github/workflows/float8_test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - name: SM-89
-            runs-on: amz2023.linux.g6.4xlarge.experimental.nvidia.gpu
+            runs-on: linux.g6.4xlarge.experimental.nvidia.gpu
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"


### PR DESCRIPTION
During the Linux Amazon 2023 AMI (base OS) migration these jobs had been temporarily shifted to use the new experimental AMI

Now that the new AMI has become the base AMI, shifting these back to use the default runners