### PR TITLE
[float8] fuse abs/max with torch.linalg.vector_norm

### DIFF
--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -99,7 +99,7 @@ def amax_history_to_scale_stack(
 
 @torch.no_grad()
 def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False) -> torch.Tensor:
-    amax = torch.max(torch.abs(x))
+    amax = torch.linalg.vector_norm(x, ord=float("inf"))
 
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will


### PR DESCRIPTION
`torch.linalg.vector_norm` is faster
<img width="352" alt="Screenshot 2024-09-18 at 8 17 28 PM" src="https://github.com/user-attachments/assets/85537883-76f2-4190-86b5-588deeeb4e15">

`torch.max(torch.abs)` are slower because of 3 kernels
<img width="514" alt="Screenshot 2024-09-18 at 8 17 16 PM" src="https://github.com/user-attachments/assets/6ed3b70a-011d-4fd0-8140-d23715a75f4c">

generated profiler traces with following code
```
import torch
import os
import contextlib
@contextlib.contextmanager
def enable_profiling(enable=False):
    if not enable:
        torch_profiler = contextlib.nullcontext()
        yield None
    else:
        trace_dir = "./profilers"
        rank = 0
        def trace_handler(prof):
            curr_trace_dir_name = "iteration_" + str(prof.step_num)
            curr_trace_dir = os.path.join(trace_dir, curr_trace_dir_name)
            if not os.path.exists(curr_trace_dir):
                os.makedirs(curr_trace_dir, exist_ok=True)
            prof.export_chrome_trace(f"{curr_trace_dir}/rank{rank}_trace.json")
            # torch.distributed.barrier()
        if not os.path.exists(trace_dir):
            os.makedirs(trace_dir, exist_ok=True)
        warmup, active = 1, 2
        wait = 1
        with torch.profiler.profile(
            activities=[
                torch.profiler.ProfilerActivity.CPU,
                torch.profiler.ProfilerActivity.CUDA,
            ],
            schedule=torch.profiler.schedule(wait=wait, warmup=warmup, active=active),
            on_trace_ready=trace_handler,
            record_shapes=True,
        ) as torch_profiler:
            yield torch_profiler

with enable_profiling(True) as torch_profiler:
    tensor = torch.rand(256, 1024, device="cuda")
    for i in range(10):
        with torch.profiler.record_function("vector_norm"):
            # amax = torch.max(torch.abs(tensor))
            torch.linalg.vector_norm(tensor, ord=float("inf"))
        torch_profiler.step()
        

```