### PR TITLE
Add test_int8_weight_only_quant_with_freeze back due to PyTorch fix

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -829,9 +829,6 @@ class TestSubclass(unittest.TestCase):
     @torch._inductor.config.patch({"freezing": True})
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_4, "freeze requires torch 2.4 and after.")
     def test_int8_weight_only_quant_with_freeze(self, device, dtype):
-        if TORCH_VERSION_AT_LEAST_2_5 and device == "cpu":
-            self.skipTest("Regression introduced in PT nightlies")
-
         self._test_lin_weight_subclass_api_impl(
             _int8wo_api, device, 40, test_dtype=dtype
         )


### PR DESCRIPTION
The issue of `test_int8_weight_only_quant_with_freeze` failure is fixed in https://github.com/pytorch/pytorch/pull/136265 according to https://github.com/pytorch/ao/issues/890#issuecomment-2364542510. I have verified in torch                2.6.0.dev20240922+cpu and torchao 0.6.0+git0bdde921.