### PR TITLE
add axiswise scaling to Float8Linear

### DIFF
--- a/benchmarks/float8/profile_linear_float8.py
+++ b/benchmarks/float8/profile_linear_float8.py
@@ -22,7 +22,12 @@ os.environ['TORCHINDUCTOR_FORCE_DISABLE_CACHES'] = '1'
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchao.float8.config import CastConfig, Float8LinearConfig, ScalingType
+from torchao.float8.config import (
+    CastConfig, 
+    Float8LinearConfig, 
+    ScalingType,
+    ScalingGranularity,
+)
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
     linear_requires_sync,
@@ -252,6 +257,7 @@ def main(
     scaling_type_input: str = "dynamic",
     scaling_type_weight: str = "dynamic",
     scaling_type_grad_output: str = "dynamic",
+    scaling_granularity: str = "tensorwise",
     model_type: str = "linear",
     dtype_filter: str = "both",
     add_inductor_metadata_to_trace: bool = True,
@@ -263,28 +269,41 @@ def main(
     scaling_type_input = ScalingType(scaling_type_input)
     scaling_type_weight = ScalingType(scaling_type_weight)
     scaling_type_grad_output = ScalingType(scaling_type_grad_output)
+    scaling_granularity = ScalingGranularity(scaling_granularity)
 
     if scaling_type_input is ScalingType.STATIC:
         cast_config_input=CastConfig(
             scaling_type=scaling_type_input,
             static_scale=torch.tensor([1.0], device="cuda"),
+            scaling_granularity=scaling_granularity,
         )
     else:
-        cast_config_input=CastConfig(scaling_type=scaling_type_input)
+        cast_config_input=CastConfig(
+            scaling_type=scaling_type_input,
+            scaling_granularity=scaling_granularity,
+        )
     if scaling_type_weight is ScalingType.STATIC:
         cast_config_weight=CastConfig(
             scaling_type=scaling_type_weight,
             static_scale=torch.tensor([1.0], device="cuda"),
+            scaling_granularity=scaling_granularity,
         )
     else:
-        cast_config_weight=CastConfig(scaling_type=scaling_type_weight)
+        cast_config_weight=CastConfig(
+            scaling_type=scaling_type_weight,
+            scaling_granularity=scaling_granularity,
+        )
     if scaling_type_grad_output is ScalingType.STATIC:
         cast_config_grad_output=CastConfig(
             scaling_type=scaling_type_grad_output,
             static_scale=torch.tensor([1.0], device="cuda"),
+            scaling_granularity=scaling_granularity,
         )
     else:
-        cast_config_grad_output=CastConfig(scaling_type=scaling_type_grad_output)
+        cast_config_grad_output=CastConfig(
+            scaling_type=scaling_type_grad_output,
+            scaling_granularity=scaling_granularity,
+        )
 
     config = Float8LinearConfig(
         cast_config_input=cast_config_input,

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -327,6 +327,10 @@ class TestFloat8Linear:
         "scaling_type_grad_output",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
+    @pytest.mark.parametrize(
+        "scaling_granularity", 
+        [ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE],
+    )
     @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
     @pytest.mark.parametrize("linear_bias", [False, True])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
@@ -337,6 +341,7 @@ class TestFloat8Linear:
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
+        scaling_granularity: ScalingGranularity,
         linear_dtype: torch.dtype,
         linear_bias: bool,
     ):
@@ -349,30 +354,51 @@ class TestFloat8Linear:
                     f"CUDA capability {torch.cuda.get_device_capability()} < (9.0)"
                 )
                 pytest.skip()
+        if scaling_granularity is ScalingGranularity.AXISWISE:
+            if (
+                scaling_type_input != ScalingType.DYNAMIC or
+                scaling_type_weight != ScalingType.DYNAMIC or
+                scaling_type_grad_output != ScalingType.DYNAMIC or
+                linear_dtype != torch.bfloat16
+            ):
+                pytest.skip()
+
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)
 
         if scaling_type_input is ScalingType.STATIC:
             cast_config_input = CastConfig(
                 scaling_type=scaling_type_input,
+                scaling_granularity=scaling_granularity,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_input = CastConfig(scaling_type=scaling_type_input)
+            cast_config_input = CastConfig(
+                scaling_type=scaling_type_input,
+                scaling_granularity=scaling_granularity,
+            )
         if scaling_type_weight is ScalingType.STATIC:
             cast_config_weight = CastConfig(
                 scaling_type=scaling_type_weight,
+                scaling_granularity=scaling_granularity,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_weight = CastConfig(scaling_type=scaling_type_weight)
+            cast_config_weight = CastConfig(
+                scaling_type=scaling_type_weight,
+                scaling_granularity=scaling_granularity,
+            )
         if scaling_type_grad_output is ScalingType.STATIC:
             cast_config_grad_output = CastConfig(
                 scaling_type=scaling_type_grad_output,
+                scaling_granularity=scaling_granularity,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_grad_output = CastConfig(scaling_type=scaling_type_grad_output)
+            cast_config_grad_output = CastConfig(
+                scaling_type=scaling_type_grad_output,
+                scaling_granularity=scaling_granularity,
+            )
 
         config = Float8LinearConfig(
             cast_config_input=cast_config_input,

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -18,7 +18,12 @@ if not TORCH_VERSION_AT_LEAST_2_5:
 
 import torch
 import torch.nn as nn
-from torchao.float8.config import CastConfig, Float8LinearConfig, ScalingType
+from torchao.float8.config import (
+    CastConfig, 
+    Float8LinearConfig, 
+    ScalingType, 
+    ScalingGranularity,
+)
 from torchao.float8.float8_linear import Float8Linear
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
@@ -60,6 +65,8 @@ def _test_compile_base(
     y_fp8.sum().backward()
     y_ref = m_ref(x)
     y_ref.sum().backward()
+    # TODO(future PR): can also test fp8 eager vs compile here with a tigher 
+    # tolerance
     torch.testing.assert_close(y_fp8, y_ref, atol=9.5e-2, rtol=9.5e-2)
     torch.testing.assert_close(
         m_fp8.weight.grad, m_ref.weight.grad, atol=2e-1, rtol=2e-1
@@ -70,29 +77,42 @@ def _get_config(
     scaling_type_input, 
     scaling_type_weight, 
     scaling_type_grad_output, 
+    scaling_granularity,
     emulate,
 ):
     if scaling_type_input is ScalingType.STATIC:
         cast_config_input = CastConfig(
             scaling_type=scaling_type_input,
+            scaling_granularity=scaling_granularity,
             static_scale=torch.tensor([1.0], device="cuda"),
         )
     else:
-        cast_config_input = CastConfig(scaling_type=scaling_type_input)
+        cast_config_input = CastConfig(
+            scaling_type=scaling_type_input,
+            scaling_granularity=scaling_granularity,
+        )
     if scaling_type_weight is ScalingType.STATIC:
         cast_config_weight = CastConfig(
             scaling_type=scaling_type_weight,
+            scaling_granularity=scaling_granularity,
             static_scale=torch.tensor([1.0], device="cuda"),
         )
     else:
-        cast_config_weight = CastConfig(scaling_type=scaling_type_weight)
+        cast_config_weight = CastConfig(
+            scaling_type=scaling_type_weight,
+            scaling_granularity=scaling_granularity,
+        )
     if scaling_type_grad_output is ScalingType.STATIC:
         cast_config_grad_output = CastConfig(
             scaling_type=scaling_type_grad_output,
+            scaling_granularity=scaling_granularity,
             static_scale=torch.tensor([1.0], device="cuda"),
         )
     else:
-        cast_config_grad_output = CastConfig(scaling_type=scaling_type_grad_output)
+        cast_config_grad_output = CastConfig(
+            scaling_type=scaling_type_grad_output,
+            scaling_granularity=scaling_granularity,
+        )
 
     config = Float8LinearConfig(
         cast_config_input=cast_config_input,
@@ -101,6 +121,24 @@ def _get_config(
         emulate=emulate,
     )
     return config
+
+
+def is_supported(
+    scaling_granularity, 
+    scaling_type_input, 
+    scaling_type_weight, 
+    scaling_type_grad_output, 
+    dtype,
+) -> bool:
+    if scaling_granularity is ScalingGranularity.AXISWISE:
+        if (
+            scaling_type_input != ScalingType.DYNAMIC or
+            scaling_type_weight != ScalingType.DYNAMIC or
+            scaling_type_grad_output != ScalingType.DYNAMIC or
+            dtype != torch.bfloat16
+        ):
+            return False
+    return True
 
 
 @pytest.mark.parametrize("fullgraph", [True])
@@ -113,6 +151,9 @@ def _get_config(
 @pytest.mark.parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
+@pytest.mark.parametrize(
+    "scaling_granularity", [ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE]
+)
 @pytest.mark.parametrize("emulate", [False, True] if is_cuda_8_9 else [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
@@ -122,11 +163,25 @@ def test_eager_only(
     scaling_type_input: ScalingType,
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
+    scaling_granularity: ScalingGranularity,
     dtype: torch.dtype,
 ):
+    if not is_supported(
+        scaling_granularity, 
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        dtype,
+    ):
+        pytest.skip()
+
     torch._dynamo.reset()
     config = _get_config(
-        scaling_type_input, scaling_type_weight, scaling_type_grad_output, emulate,
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        scaling_granularity,
+        emulate,
     )
     _test_compile_base(
         "eager",
@@ -147,6 +202,9 @@ def test_eager_only(
 @pytest.mark.parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
+@pytest.mark.parametrize(
+    "scaling_granularity", [ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE]
+)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
 def test_aot_eager(
@@ -155,11 +213,25 @@ def test_aot_eager(
     scaling_type_input: ScalingType,
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
+    scaling_granularity: ScalingGranularity,
     dtype: torch.dtype,
 ):
+    if not is_supported(
+        scaling_granularity, 
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        dtype,
+    ):
+        pytest.skip()
+
     torch._dynamo.reset()
     config = _get_config(
-        scaling_type_input, scaling_type_weight, scaling_type_grad_output, emulate,
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        scaling_granularity, 
+        emulate,
     )
     _test_compile_base(
         "aot_eager",
@@ -180,6 +252,9 @@ def test_aot_eager(
 @pytest.mark.parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
+@pytest.mark.parametrize(
+    "scaling_granularity", [ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE]
+)
 @unittest.skipIf(not torch.cuda.is_available() or not is_cuda_8_9, "CUDA with float8 support not available")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_inductor(
@@ -188,11 +263,25 @@ def test_inductor(
     scaling_type_input: ScalingType,
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
+    scaling_granularity: ScalingGranularity,
     dtype: torch.dtype,
 ):
+    if not is_supported(
+        scaling_granularity, 
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        dtype,
+    ):
+        pytest.skip()
+
     torch._dynamo.reset()
     config = _get_config(
-        scaling_type_input, scaling_type_weight, scaling_type_grad_output, emulate,
+        scaling_type_input, 
+        scaling_type_weight, 
+        scaling_type_grad_output, 
+        scaling_granularity, 
+        emulate,
     )
     _test_compile_base(
         "inductor",

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -19,7 +19,12 @@ if not TORCH_VERSION_AT_LEAST_2_5:
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchao.float8.config import CastConfig, Float8LinearConfig, ScalingType
+from torchao.float8.config import (
+    CastConfig, 
+    Float8LinearConfig, 
+    ScalingType,
+    ScalingGranularity,
+)
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
     linear_requires_sync,
@@ -90,6 +95,10 @@ class TestFloat8NumericsIntegrationTest:
         "scaling_type_grad_output",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
+    @pytest.mark.parametrize(
+        "scaling_granularity", 
+        [ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE],
+    )
     @pytest.mark.skipif(not is_cuda_8_9, reason="requires SM89 compatible machine")
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw(
@@ -97,9 +106,19 @@ class TestFloat8NumericsIntegrationTest:
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
+        scaling_granularity: ScalingGranularity,
     ):
         # TODO(later): maybe add float16 back if it becomes important
         data_dtype = torch.bfloat16
+
+        if scaling_granularity is ScalingGranularity.AXISWISE:
+            if (
+                scaling_type_input != ScalingType.DYNAMIC or
+                scaling_type_weight != ScalingType.DYNAMIC or
+                scaling_type_grad_output != ScalingType.DYNAMIC or
+                data_dtype != torch.bfloat16
+            ):
+                pytest.skip()
 
         # LLaMa 3 70B shapes
         model_ref = (
@@ -119,24 +138,34 @@ class TestFloat8NumericsIntegrationTest:
         if scaling_type_input is ScalingType.STATIC:
             cast_config_input = CastConfig(
                 scaling_type=scaling_type_input,
+                scaling_granularity=scaling_granularity,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_input = CastConfig(scaling_type=scaling_type_input)
+            cast_config_input = CastConfig(
+                scaling_type=scaling_type_input,
+                scaling_granularity=scaling_granularity,
+            )
         if scaling_type_weight is ScalingType.STATIC:
             cast_config_weight = CastConfig(
                 scaling_type=scaling_type_weight,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_weight = CastConfig(scaling_type=scaling_type_weight)
+            cast_config_weight = CastConfig(
+                scaling_type=scaling_type_weight,
+                scaling_granularity=scaling_granularity,
+            )
         if scaling_type_grad_output is ScalingType.STATIC:
             cast_config_grad_output = CastConfig(
                 scaling_type=scaling_type_grad_output,
                 static_scale=torch.tensor([1.0], device="cuda"),
             )
         else:
-            cast_config_grad_output = CastConfig(scaling_type=scaling_type_grad_output)
+            cast_config_grad_output = CastConfig(
+                scaling_type=scaling_type_grad_output,
+                scaling_granularity=scaling_granularity,
+            )
 
         config = Float8LinearConfig(
             cast_config_input=cast_config_input,

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import torch
 
-from torchao.float8.config import Float8LinearConfig, ScalingType
+from torchao.float8.config import Float8LinearConfig, ScalingType, ScalingGranularity
 
 from torchao.float8.float8_scaling_utils import (
     _maybe_initialize_amaxes_scales_for_float8_cast,
@@ -42,11 +42,17 @@ from torchao.float8.fsdp_utils import (
 )
 
 
-# this code was resurrected from https://github.com/pytorch-labs/torchao.float8/pull/128/files
 @torch._dynamo.allow_in_graph
-class manual_float8_matmul(torch.autograd.Function):
+class manual_float8_matmul_with_args_in_float8(torch.autograd.Function):
     """
     Like torch.matmul, but with the arguments in float8
+
+    Note: this function requires all arguments to already be Float8Tensor objects,
+    which only supports tensorwise scaling granularity. The reason we didn't just make this
+    function support axiswise scaling granularity is because that would need very
+    careful testing of delayed scaling, as delayed scaling modifies buffers inplace.
+
+    In the future we'll probably have to unify, just postponing that until a future PR.
     """
 
     @staticmethod
@@ -96,6 +102,133 @@ class manual_float8_matmul(torch.autograd.Function):
         )
 
         return grad_input, grad_weight.t()
+
+@torch._dynamo.allow_in_graph
+class manual_float8_matmul_with_args_in_hp(torch.autograd.Function):
+    """
+    Like torch.matmul, but with the arguments in high precision and the cast to float8
+    defined inside of this function.
+
+    Note: this function currently only supports dynamic scaling type and 
+    axiswise granularity. We will have to unify this with other scaling types
+    and other granularities in a separate PR.
+    """
+
+    # TODO(this PR): types of inputs
+    @staticmethod
+    def forward(
+        ctx,
+        input_hp: torch.Tensor,
+        weight_hp_t: torch.Tensor,
+        linear_mm_config: LinearMMConfig,
+        input_scaling_granularity: ScalingGranularity,
+        weight_scaling_granularity: ScalingGranularity,
+        grad_output_scaling_granularity: ScalingGranularity,
+    ):
+        ctx.save_for_backward(input_hp, weight_hp_t)
+        ctx.linear_mm_config = linear_mm_config
+        ctx.input_scaling_granularity = input_scaling_granularity
+        ctx.weight_scaling_granularity = weight_scaling_granularity
+        ctx.grad_output_scaling_granularity = grad_output_scaling_granularity
+
+        input_fp8 = hp_tensor_to_float8_dynamic(
+            input_hp, 
+            e4m3_dtype, 
+            linear_mm_config,
+            gemm_input_role=GemmInputRole.INPUT,
+            scaling_granularity=input_scaling_granularity,
+            axiswise_dim=-1,
+        )
+
+        weight_fp8_t = hp_tensor_to_float8_dynamic(
+            weight_hp_t, 
+            e4m3_dtype, 
+            linear_mm_config,
+            gemm_input_role=GemmInputRole.WEIGHT,
+            scaling_granularity=weight_scaling_granularity,
+            axiswise_dim=0,
+        )
+
+        # the reshapes are needed in order to make the shapes compatible with
+        # torch.mm
+        orig_shape = input_fp8.shape
+        input_fp8_reshaped = input_fp8.reshape(-1, orig_shape[-1])
+        res_bits = torch.mm(input_fp8_reshaped, weight_fp8_t)
+        res_bits = res_bits.reshape(*orig_shape[:-1], res_bits.shape[-1])
+        return res_bits
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_hp, weight_hp_t = ctx.saved_tensors
+
+        # TODO scaling
+
+        # the reshapes are needed in order to make the shapes compatible with
+        # torch.mm
+        grad_output_orig_shape = grad_output.shape
+        grad_output_reshaped = grad_output.reshape(
+            -1, grad_output_orig_shape[-1]
+        )
+
+        #
+        # calculate grad_input
+        #
+
+        grad_output_reshaped_fp8_dim0 = hp_tensor_to_float8_dynamic(
+            grad_output_reshaped,
+            e5m2_dtype,
+            ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.GRAD_OUTPUT,
+            scaling_granularity=ctx.grad_output_scaling_granularity,
+            axiswise_dim=-1,
+        )
+        weight_t_fp8_dim0 = hp_tensor_to_float8_dynamic(
+            weight_hp_t,
+            e4m3_dtype,
+            ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.WEIGHT,
+            scaling_granularity=ctx.weight_scaling_granularity,
+            axiswise_dim=1,  # will be transposed
+        )
+
+        grad_input = torch.mm(
+            grad_output_reshaped_fp8_dim0,
+            weight_t_fp8_dim0.t(),
+        )
+        grad_input = grad_input.reshape(
+            *grad_output_orig_shape[:-1], grad_input.shape[-1]
+        )
+
+        input_hp_orig_shape = input_hp.shape
+        input_hp_reshaped = input_hp.reshape(-1, input_hp_orig_shape[-1])
+
+        #
+        # calculate grad_weight
+        #
+
+        grad_output_reshaped_fp8_dim1 = hp_tensor_to_float8_dynamic(
+            grad_output_reshaped,
+            e5m2_dtype,
+            ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.GRAD_OUTPUT,
+            scaling_granularity=ctx.grad_output_scaling_granularity,
+            axiswise_dim=0,  # will be transposed
+        )
+        input_reshaped_fp8_dim1 = hp_tensor_to_float8_dynamic(
+            input_hp_reshaped,
+            e4m3_dtype,
+            ctx.linear_mm_config,
+            gemm_input_role=GemmInputRole.INPUT,
+            scaling_granularity=ctx.input_scaling_granularity,
+            axiswise_dim=0,
+        )
+
+        grad_weight = torch.mm(
+            grad_output_reshaped_fp8_dim1.t(),
+            input_reshaped_fp8_dim1,
+        )
+
+        return grad_input, grad_weight.t(), None, None, None, None
 
 
 class Float8Linear(torch.nn.Linear):
@@ -289,7 +422,10 @@ class Float8Linear(torch.nn.Linear):
             )
         elif self.scaling_type_input is ScalingType.DYNAMIC:
             input_fp8 = hp_tensor_to_float8_dynamic(
-                input, e4m3_dtype, self.linear_mm_config
+                input, 
+                e4m3_dtype, 
+                self.linear_mm_config,
+                gemm_input_role=GemmInputRole.INPUT,
             )
         else:
             assert self.scaling_type_input is ScalingType.STATIC
@@ -395,13 +531,33 @@ class Float8Linear(torch.nn.Linear):
         if self.has_any_delayed_scaling:
             self.float8_pre_forward(input)
 
-        input_fp8 = self.cast_input_to_float8(input, self.is_amax_initialized)
-        weight_fp8 = self.cast_weight_to_float8(self.weight, self.is_amax_initialized)
+        # TODO(this PR): reuse with config, make a property
+        has_all_axiswise_scaling = (
+            self.config.cast_config_input.scaling_granularity is ScalingGranularity.AXISWISE and
+            self.config.cast_config_weight.scaling_granularity is ScalingGranularity.AXISWISE and
+            self.config.cast_config_grad_output.scaling_granularity is ScalingGranularity.AXISWISE
+        )
 
-        output = manual_float8_matmul.apply(input_fp8, weight_fp8.t())
+        if not has_all_axiswise_scaling:
+            input_fp8 = self.cast_input_to_float8(input, self.is_amax_initialized)
+            weight_fp8 = self.cast_weight_to_float8(self.weight, self.is_amax_initialized)
 
-        # Cast grad_output to float8_e5m2 during backward
-        output = self.cast_output_to_float8_in_bw(output)
+            output = manual_float8_matmul_with_args_in_float8.apply(input_fp8, weight_fp8.t())
+
+            # Cast grad_output to float8_e5m2 during backward
+            output = self.cast_output_to_float8_in_bw(output)
+
+        else:
+            # for now, axiswise path is separate
+            # TODO(future PR): unify to support mix and match
+            output = manual_float8_matmul_with_args_in_hp.apply(
+                input, 
+                self.weight.t(),
+                self.linear_mm_config,
+                self.config.cast_config_input.scaling_granularity,
+                self.config.cast_config_weight.scaling_granularity,
+                self.config.cast_config_grad_output.scaling_granularity,
+            )
 
         if self.bias is not None:
             output = output + self.bias.to(output.dtype)
@@ -410,13 +566,21 @@ class Float8Linear(torch.nn.Linear):
             self.float8_post_forward()
         return output
 
-    def scaling_repr(self):
-        # add scaling settings without using too many characters
+    def scaling_type_repr(self):
+        # add scaling type settings without using too many characters
         # example: "i:del,w:del,go:dyn"
         return f"i:{self.scaling_type_input.short_str()},w:{self.scaling_type_weight.short_str()},go:{self.scaling_type_grad_output.short_str()}"
 
+    def scaling_granularity_repr(self):
+        # add scaling granularity settings without using too many characters
+        # example: "i:ten,w:ten,g:ten" or "i:axs,w:axs,g:axs"
+        gi = self.config.cast_config_input.scaling_granularity.short_str()
+        gw = self.config.cast_config_weight.scaling_granularity.short_str()
+        ggo = self.config.cast_config_grad_output.scaling_granularity.short_str()
+        return f"i:{gi},w:{gw},go:{ggo}"
+
     def extra_repr(self):
-        s = f'{super().extra_repr()}, scaling="{self.scaling_repr()}"'
+        s = f'{super().extra_repr()}, scaling_type="{self.scaling_type_repr()}", scaling_granularity="{self.scaling_granularity_repr()}"'
         return s
 
     @classmethod

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -43,12 +43,9 @@ def implements(aten_ops):
     [
         aten.view.default,
         aten._unsafe_view.default,
-        aten.t.default,
         aten.as_strided.default,
         aten.clone.default,
-        aten.detach.default,
         aten.slice.Tensor,
-        aten.transpose.int,
         aten.fill_.Scalar,
         aten.reshape.default,
     ]
@@ -67,11 +64,28 @@ def float8_desugar_op(aten_op, args, kwargs=None):
 
 @implements(
     [
+        aten.detach.default,
+    ]
+)
+def float8_desugar_data_and_scale_op(aten_op, args, kwargs=None):
+    new_data = aten_op(args[0]._data, *args[1:], **kwargs)
+    new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
+    return Float8Tensor(
+        new_data,
+        new_scale,
+        args[0]._orig_dtype,
+        args[0]._linear_mm_config,
+        args[0]._gemm_input_role,
+    )
+
+
+@implements(
+    [
         aten.t.default,
         aten.transpose.int,
     ]
 )
-def float8_desugar_data_and_scale(aten_op, args, kwargs=None):
+def float8_transpose(aten_op, args, kwargs=None):
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
     new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
 


### PR DESCRIPTION
Summary:

This PR: support scaling of all arguments of all gemms to be axiswise,
and ensure that training with axiswise scaling works e2e.

Future PR: support more granular configurability and optimize
performance, add docs

Test Plan:

```
// tests pass
./test/float8/test_everything.sh

// sanity check on torchtitan with LLaMa 3 8B on 4 H100s with float8:
// 1. verify performance does not regress with tensorwise scaling
// 2. smoke test that axiswise scaling works and numerics are sane, performance isn't there though
// logs: https://gist.github.com/vkuzo/70fa5eb3c23375f307d11e7bae48682f
```

Reviewers:

Subscribers:

Tasks:

Tags: