### PR TITLE
Fix failing FP6 benchmark

### DIFF
--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -1,7 +1,7 @@
 import torch
 import pandas as pd
 import torch.nn.functional as F
-from torchao.dtypes import to_affine_quantized_floatx
+from torchao.dtypes import to_affine_quantized_fpx
 from torchao.dtypes.floatx import FloatxTensorCoreAQTLayout, FloatxTensorCoreLayoutType
 from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 def benchmark(m: int, k: int, n: int):
     float_data = torch.randn(n, k, dtype=torch.half, device="cuda")
-    fp6_weight = to_affine_quantized_floatx(float_data, FloatxTensorCoreLayoutType(3, 2))
+    fp6_weight = to_affine_quantized_fpx(float_data, FloatxTensorCoreLayoutType(3, 2))
     fp16_weight = fp6_weight.dequantize(torch.half)
 
     fp16_act = torch.randn(m, k, dtype=torch.half, device="cuda")


### PR DESCRIPTION
The FP6 benchmark script `benchmarks/benchmark_fp6.py` is broken because of [this renaming PR](https://github.com/pytorch/ao/commit/8236a874479a9a9168e584c81dda8707f4c41006). The current PR fixes this by using the correct call to `to_affine_quantized_fpx` instead of `to_affine_quantized_floatx`.

https://github.com/pytorch/ao/blob/858205a44fa6c10d84fa6084bfd8c526f1b85914/benchmarks/benchmark_fp6.py#L12

Originally discussed [here](https://github.com/pytorch/ao/pull/928)

@jerryzh168 