### PR TITLE
[float8] all-reduce amax on dp mesh instead of global pg

### DIFF
--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -312,7 +312,7 @@ class Test2DParallelMultiThread(FSDPTestMultiThread, TestFloat8Common):
 
         if self.rank in [0, 1]:
             # rank 0 and 1 are the 1st stage in the pipeline
-            # rank 2 and 4 are doing thing but waiting for the 1st stage
+            # rank 2 and 4 are doing nothing but waiting for the 1st stage
             float8_tensor = hp_tensor_to_float8_dynamic(
                 hp_tensor,
                 torch.float8_e4m3fn,

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -17,10 +17,12 @@ import torch.distributed as dist
 import torch.nn as nn
 from torchao.float8.config import CastConfig, Float8LinearConfig, ScalingType
 from torchao.float8.float8_linear_utils import convert_to_float8_training
+from torchao.float8.float8_scaling_utils import hp_tensor_to_float8_dynamic
 from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 from fsdp2_common import check_parity_bf16_mp, check_parity_no_mp
 from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
-from torch.distributed._tensor import DTensor
+from torch.distributed._tensor import DTensor, init_device_mesh
+from torchao.float8.float8_tensor import GemmInputRole
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
@@ -292,6 +294,35 @@ class TestFloat8MultiProcess(FSDPTest, TestFloat8Common):
         mem_stats = torch.cuda.memory_stats()
         return round(mem_stats["active_bytes.all.current"] / 1e6)
 
+
+class Test2DParallelMultiThread(FSDPTestMultiThread, TestFloat8Common):
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_amax_allreduce_device_mesh(self):
+        dp_size = 2
+        pp_size = self.world_size // dp_size
+        global_mesh = init_device_mesh("cuda", (pp_size, dp_size), mesh_dim_names=("pp", "dp"))
+        dp_mesh  = global_mesh["dp"]
+        pp_mesh = global_mesh["pp"]
+
+        torch.manual_seed(42 + self.rank)
+        hp_tensor = torch.randn(768, 32, device="cuda")
+
+        if self.rank in [0, 1]:
+            # rank 0 and 1 are the 1st stage in the pipeline
+            # rank 2 and 4 are doing thing but waiting for the 1st stage
+            float8_tensor = hp_tensor_to_float8_dynamic(
+                hp_tensor,
+                torch.float8_e4m3fn,
+                Float8LinearConfig(
+                    cast_config_weight=CastConfig(scaling_type=ScalingType.DYNAMIC),
+                ),
+                gemm_input_role=GemmInputRole.WEIGHT,
+                reduce_amax=True,
+                device_mesh=dp_mesh
+            )
 
 class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
     @property

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -307,12 +307,11 @@ class Test2DParallelMultiThread(FSDPTestMultiThread, TestFloat8Common):
         dp_mesh  = global_mesh["dp"]
         pp_mesh = global_mesh["pp"]
 
-        torch.manual_seed(42 + self.rank)
-        hp_tensor = torch.randn(768, 32, device="cuda")
-
         if self.rank in [0, 1]:
             # rank 0 and 1 are the 1st stage in the pipeline
             # rank 2 and 4 are doing nothing but waiting for the 1st stage
+            torch.manual_seed(42 + self.rank)
+            hp_tensor = torch.randn(768, 32, device="cuda")
             float8_tensor = hp_tensor_to_float8_dynamic(
                 hp_tensor,
                 torch.float8_e4m3fn,

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -36,6 +36,7 @@ def hp_tensor_to_float8_dynamic(
     linear_mm_config: LinearMMConfig,
     reduce_amax: bool = False,
     gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
+    device_mesh: "DeviceMesh" = None,
 ) -> Float8Tensor:
     """
     Given a high precision tensor `hp_tensor`,
@@ -52,7 +53,7 @@ def hp_tensor_to_float8_dynamic(
     """
     if tensor_already_casted_to_fp8(hp_tensor):
         return hp_tensor
-    scale = tensor_to_scale(hp_tensor, float8_dtype, reduce_amax)
+    scale = tensor_to_scale(hp_tensor, float8_dtype, reduce_amax, device_mesh)
     return hp_tensor_and_scale_to_float8(
         hp_tensor,
         scale,

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -36,7 +36,7 @@ def hp_tensor_to_float8_dynamic(
     linear_mm_config: LinearMMConfig,
     reduce_amax: bool = False,
     gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
-    device_mesh: "torch.distributed.DeviceMesh" = None,
+    device_mesh = None,
 ) -> Float8Tensor:
     """
     Given a high precision tensor `hp_tensor`,

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -36,7 +36,7 @@ def hp_tensor_to_float8_dynamic(
     linear_mm_config: LinearMMConfig,
     reduce_amax: bool = False,
     gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
-    device_mesh: "DeviceMesh" = None,
+    device_mesh: "torch.distributed.DeviceMesh" = None,
 ) -> Float8Tensor:
     """
     Given a high precision tensor `hp_tensor`,

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -99,7 +99,7 @@ def amax_history_to_scale_stack(
 
 @torch.no_grad()
 def tensor_to_amax(
-    x: torch.Tensor, reduce_amax: bool = False, device_mesh = None
+    x: torch.Tensor, reduce_amax: bool = False, device_mesh=None
 ) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
@@ -118,7 +118,7 @@ def tensor_to_scale(
     x: torch.Tensor,
     float8_dtype: torch.dtype,
     reduce_amax: bool = False,
-    device_mesh = None,
+    device_mesh=None,
 ) -> torch.Tensor:
     amax = tensor_to_amax(x, reduce_amax=reduce_amax, device_mesh=device_mesh)
     return amax_to_scale(amax, float8_dtype, x.dtype)

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -98,23 +98,27 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False) -> torch.Tensor:
+def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False, device_mesh: "DeviceMesh" = None) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.
     # If the user did not ask for it, assume that it will
     # happen elsewhere.
     if reduce_amax and dist.is_initialized():
-        dist.all_reduce(amax, op=dist.ReduceOp.MAX)
+        pg = device_mesh.get_group() if device_mesh is not None else None
+        dist.all_reduce(amax, op=dist.ReduceOp.MAX, group=pg)
 
     return amax
 
 
 @torch.no_grad()
 def tensor_to_scale(
-    x: torch.Tensor, float8_dtype: torch.dtype, reduce_amax: bool = False
+    x: torch.Tensor,
+    float8_dtype: torch.dtype,
+    reduce_amax: bool = False,
+    device_mesh: "DeviceMesh" = None,
 ) -> torch.Tensor:
-    amax = tensor_to_amax(x, reduce_amax=reduce_amax)
+    amax = tensor_to_amax(x, reduce_amax=reduce_amax, device_mesh=device_mesh)
     return amax_to_scale(amax, float8_dtype, x.dtype)
 
 

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -99,7 +99,7 @@ def amax_history_to_scale_stack(
 
 @torch.no_grad()
 def tensor_to_amax(
-    x: torch.Tensor, reduce_amax: bool = False, device_mesh: dist.DeviceMesh = None
+    x: torch.Tensor, reduce_amax: bool = False, device_mesh = None
 ) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
@@ -118,7 +118,7 @@ def tensor_to_scale(
     x: torch.Tensor,
     float8_dtype: torch.dtype,
     reduce_amax: bool = False,
-    device_mesh: dist.DeviceMesh = None,
+    device_mesh = None,
 ) -> torch.Tensor:
     amax = tensor_to_amax(x, reduce_amax=reduce_amax, device_mesh=device_mesh)
     return amax_to_scale(amax, float8_dtype, x.dtype)

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -98,7 +98,7 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False, device_mesh: "DeviceMesh" = None) -> torch.Tensor:
+def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False, device_mesh: dist.DeviceMesh = None) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.
@@ -116,7 +116,7 @@ def tensor_to_scale(
     x: torch.Tensor,
     float8_dtype: torch.dtype,
     reduce_amax: bool = False,
-    device_mesh: "DeviceMesh" = None,
+    device_mesh: dist.DeviceMesh = None,
 ) -> torch.Tensor:
     amax = tensor_to_amax(x, reduce_amax=reduce_amax, device_mesh=device_mesh)
     return amax_to_scale(amax, float8_dtype, x.dtype)

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -98,7 +98,9 @@ def amax_history_to_scale_stack(
 
 
 @torch.no_grad()
-def tensor_to_amax(x: torch.Tensor, reduce_amax: bool = False, device_mesh: dist.DeviceMesh = None) -> torch.Tensor:
+def tensor_to_amax(
+    x: torch.Tensor, reduce_amax: bool = False, device_mesh: dist.DeviceMesh = None
+) -> torch.Tensor:
     amax = torch.max(torch.abs(x))
 
     # If the user asked for distributed reduction, do it.

--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -216,6 +216,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
                 self._linear_mm_config,
                 reduce_amax=True,
                 gemm_input_role=GemmInputRole.WEIGHT,
+                device_mesh=mesh,
             )
         return (float8_tensor._data,), (float8_tensor._scale,)
 


### PR DESCRIPTION
this PR makes sure FSDP2 + pipeline parallel work. For amax all-reduce, we should do allreduce on dp mesh, instead of global pg. otherwise it causes NCCL hanging