### PR TITLE
SM75 (Turing) support for FP6 kernel

### DIFF
--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -7,7 +7,7 @@ from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
 
 
-def benchmark(m: int, k: int, n: int):
+def benchmark(m: int, n: int, k: int):
     float_data = torch.randn(n, k, dtype=torch.half, device="cuda")
     fp6_weight = to_affine_quantized_fpx(float_data, FloatxTensorCoreLayoutType(3, 2))
     fp16_weight = fp6_weight.dequantize(torch.half)

--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -7,7 +7,7 @@ from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
 
 
-def benchmark(m: int, n: int, k: int):
+def benchmark(m: int, k: int, n: int):
     float_data = torch.randn(n, k, dtype=torch.half, device="cuda")
     fp6_weight = to_affine_quantized_fpx(float_data, FloatxTensorCoreLayoutType(3, 2))
     fp16_weight = fp6_weight.dequantize(torch.half)
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
     for m in tqdm([1 << i for i in range(10)]):
         for n, k in zip(n_vals, k_vals):
-            results.append(benchmark(m, n, k))
+            results.append(benchmark(m, k, n))
 
     df = pd.DataFrame(results)
     df.to_csv("fp6_llm_benchmark_results.csv", index=False)

--- a/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
+++ b/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
@@ -14,7 +14,7 @@
 // 
 // This file is adapted from https://github.com/usyd-fsalab/fp6_llm/blob/5df6737cca32f604e957e3f63f03ccc2e4d1df0d/fp6_llm/csrc/fp6_linear.cu
 
-#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800  // at least Ampere
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 750  // at least Turing
 
 #include "kernel_matmul.cuh"
 #include "kernel_reduction.cuh"

--- a/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
+++ b/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
@@ -22,6 +22,22 @@
 #include <stdio.h>
 #include <assert.h>
 
+inline bool isSM75GPU() {
+    int device;
+    cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) {
+        return false;
+    }
+
+    cudaDeviceProp props;
+    err = cudaGetDeviceProperties(&props, device);
+    if (err != cudaSuccess) {
+        return false;
+    }
+
+    return (props.major == 7) && (props.minor == 5);
+}
+
 template<typename TilingConfig, typename OutputDataType, int EXPONENT, int MANTISSA>
 static void Kernel_Ex(cudaStream_t    stream,
                       const uint4     *Weight,
@@ -80,38 +96,51 @@ cudaError_t fpx_linear_kernel(cudaStream_t    stream,
     if(N_Global>64 && N_Global<=128)    N_PowerOf2 = 128;
     if(N_Global>128)                    N_PowerOf2 = ((N_Global-1)/128+1) * 128;
 
-    if (Split_K == 1) {
-        switch (N_PowerOf2) {
-            case 8:     Kernel_Ex<TilingConfig<4, 1, 1>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
-            case 16:    Kernel_Ex<TilingConfig<4, 1, 2>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
-            case 32:    Kernel_Ex<TilingConfig<4, 1, 4>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
-            case 64:    Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
-            case 128:   Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
-            default:    if (N_PowerOf2 % 128 != 0) {
-                            printf("FP6LLM_API Error: Unsupported N dimension %d!\n", N_PowerOf2);
-                            return cudaErrorUnknown;
-                        }
-                        Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+    if (isSM75GPU() && (N_PowerOf2 == 64 || N_PowerOf2 == 128 || N_PowerOf2 % 128 == 0)) {
+        // For SM75 and N >= 64, we use a different TilingConfig to deal with smaller shared memory.
+        if (Split_K == 1) {
+            Kernel_Ex<TilingConfig<4, 1, 4>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);
+        } else {
+            Kernel_Ex<TilingConfig<4, 1, 4>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);
+        }
+    } else {
+        if (Split_K == 1) {
+            switch (N_PowerOf2) {
+                case 8:     Kernel_Ex<TilingConfig<4, 1, 1>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+                case 16:    Kernel_Ex<TilingConfig<4, 1, 2>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+                case 32:    Kernel_Ex<TilingConfig<4, 1, 4>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+                case 64:    Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+                case 128:   Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+                default:    if (N_PowerOf2 % 128 != 0) {
+                                printf("FP6LLM_API Error: Unsupported N dimension %d!\n", N_PowerOf2);
+                                return cudaErrorUnknown;
+                            }
+                            Kernel_Ex<TilingConfig<4, 1, 8>, half, EXPONENT, MANTISSA>(stream, Weight, Scales, B, C, M_Global, N_Global, K_Global, Split_K);  break;
+            }
+        }
+        else {
+            switch (N_PowerOf2) {
+                case 8:     Kernel_Ex<TilingConfig<4, 1, 1>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+                case 16:    Kernel_Ex<TilingConfig<4, 1, 2>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+                case 32:    Kernel_Ex<TilingConfig<4, 1, 4>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+                case 64:    Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+                case 128:   Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+                default:    if (N_PowerOf2 % 128 != 0) {
+                                printf("FP6LLM_API Error: Unsupported N dimension %d!\n", N_PowerOf2);
+                                return cudaErrorUnknown;
+                            }
+                            Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
+            }
         }
     }
-    else {
-        switch (N_PowerOf2) {
-            case 8:     Kernel_Ex<TilingConfig<4, 1, 1>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-            case 16:    Kernel_Ex<TilingConfig<4, 1, 2>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-            case 32:    Kernel_Ex<TilingConfig<4, 1, 4>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-            case 64:    Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-            case 128:   Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-            default:    if (N_PowerOf2 % 128 != 0) {
-                            printf("FP6LLM_API Error: Unsupported N dimension %d!\n", N_PowerOf2);
-                            return cudaErrorUnknown;
-                        }
-                        Kernel_Ex<TilingConfig<4, 1, 8>, float, EXPONENT, MANTISSA>(stream, Weight, Scales, B, Reduction_Workspace, M_Global, N_Global, K_Global, Split_K);  break;
-        }
+
+    if (Split_K != 1) {
         // Reduction for SplitK
         dim3 GridDim((M_Global * N_Global) / REDUCTION_ELEMENT_PER_THREADBLOCK, 1, 1);
         dim3 BlockDim(WARP_SIZE, 1, 1);
         SplitK_Reduction<<<GridDim, BlockDim, 0, stream>>>(C, Reduction_Workspace, M_Global, N_Global, Split_K);
     }
+
     return cudaGetLastError();
 }
 

--- a/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
+++ b/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
@@ -13,6 +13,10 @@
 //    limitations under the License.
 // 
 // This file is adapted from https://github.com/usyd-fsalab/fp6_llm/blob/5df6737cca32f604e957e3f63f03ccc2e4d1df0d/fp6_llm/csrc/fp6_linear.cu
+//
+// MODIFICATION NOTE (2024-09-25): added SM75 support (https://github.com/pytorch/ao/pull/942):
+// - Modified the TilingConfig parameters for SM75 to deal with smaller shared memory
+//
 
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 750  // at least Turing
 

--- a/torchao/csrc/cuda/fp6_llm/kernel_matmul.cuh
+++ b/torchao/csrc/cuda/fp6_llm/kernel_matmul.cuh
@@ -13,6 +13,10 @@
 //    limitations under the License.
 // 
 // This file is modified from https://github.com/usyd-fsalab/fp6_llm/blob/5df6737cca32f604e957e3f63f03ccc2e4d1df0d/fp6_llm/csrc/include/kernel_matmul.cuh
+//
+// MODIFICATION NOTE (2024-09-25): added SM75 support (https://github.com/pytorch/ao/pull/942):
+// - Added __CUDA_ARCH__ guards such that async operations are only executed for SM80 and up
+//
 
 #include "configs.h"
 #include "utils_gmem.cuh"

--- a/torchao/csrc/cuda/fp6_llm/ptx_mma.cuh
+++ b/torchao/csrc/cuda/fp6_llm/ptx_mma.cuh
@@ -13,6 +13,10 @@
 //    limitations under the License.
 // 
 // This file is modified from https://github.com/usyd-fsalab/fp6_llm/blob/5df6737cca32f604e957e3f63f03ccc2e4d1df0d/fp6_llm/csrc/include/ptx_mma.cuh
+//
+// MODIFICATION NOTE (2024-09-25): added SM75 support (https://github.com/pytorch/ao/pull/942):
+// - Replaced m16n8k16 Tensor core operation with two m16n8k8 operations
+// - Accounted for a difference in expected parameters for the ldmatrix operation
 
 /***************************************************************************
  * Copyright 2023 The FLash-LLM Authors. All rights reserved.

--- a/torchao/csrc/cuda/fp6_llm/utils_gmem.cuh
+++ b/torchao/csrc/cuda/fp6_llm/utils_gmem.cuh
@@ -13,6 +13,10 @@
 //    limitations under the License.
 // 
 // This file is modified from https://github.com/usyd-fsalab/fp6_llm/blob/ce76774bcfc26b325c1b558abcf1935026d9abbc/fp6_llm/csrc/include/utils_gmem.cuh
+//
+// MODIFICATION NOTE (2024-09-25): added SM75 support (https://github.com/pytorch/ao/pull/942):
+// - Replaced asynchronous copy operations with vectorized loads
+//
 
 #ifndef UTILS_GMEM_CUH
 #define UTILS_GMEM_CUH

--- a/torchao/dtypes/floatx/README.md
+++ b/torchao/dtypes/floatx/README.md
@@ -43,6 +43,7 @@ outputs = quant_llm_linear(ebits, mbits, fp16_act, fp6_weight, scales)  # shape 
 - Since this kernel's computation dtype is FP16, it is recommended to convert the model to FP16 (instead of BF16) before applying quantization and use FP16 for activations.
 - Only FP6 E3M2 and FP5 E2M2 are tested and enabled in the official repo. We additionally enable support for FP6 E2M3 and FP5 E3M1.
 - On most hardware, this kernel is faster than FP16 linear for batch size from 1 to 128, and slower for batch size larger than or equal to 256. See https://github.com/usyd-fsalab/fp6_llm/issues/8 for a detailed discussion. See https://github.com/pytorch/ao/pull/223 for some microbenchmark results.
+- FP6 is supported for >=SM80 (Ampere generation) as well as SM75 (Turing generation) GPUs. However, SM75 support requires manual compilation of the C++/CUDA extensions (see the installation instructions in the [README](https://github.com/pytorch/ao/blob/main/README.md#installation) for details).
 
 ## End-to-End benchmarks
 


### PR DESCRIPTION
The [FP6 CUDA kernel](https://github.com/pytorch/ao/tree/main/torchao/csrc/cuda/fp6_llm) is currently limited to >=SM80, i.e. at least Ampere generation NVIDIA GPUs. However, as mentioned in [this issue](https://github.com/pytorch/ao/issues/208), the FP6 kernel could theoretically work for any card with uint8_t and fp16 support.

This PR adds FP6 support for SM75 (Turing generation) GPUs. Given the modest support for SM75 GPUs (e.g. the NVIDIA T4) in `torchao`, I'm hoping this can be a step towards improving that.

Most important changes:
- Replace asynchronous copy operations with vectorized loads ([diff](https://github.com/pytorch/ao/compare/main...tobiasvanderwerff:ao:fp6-sm75#diff-1ff6c927363707476562ee05743bdcdbcc90aa7e8d420b045f231310fd663806R42))
- Replace `m16n8k16` Tensor core operation with two `m16n8k8` operations ([diff](https://github.com/pytorch/ao/compare/main...tobiasvanderwerff:ao:fp6-sm75#diff-d095cc529407429f6f9c6736383cdc658d0b4e870fe9d27f64a36e2b79c72177R91))
- Account for a difference in expected parameters for the `ldmatrix` operation ([diff](https://github.com/pytorch/ao/compare/main...tobiasvanderwerff:ao:fp6-sm75#diff-d095cc529407429f6f9c6736383cdc658d0b4e870fe9d27f64a36e2b79c72177R58))

Before this, FP6 failed to run on SM75 (specifically, it would error out with "RuntimeError: operator torchao::quant_llm_linear does not exist").

Below are the benchmark and correctness test results (using `ao/benchmarks/benchmark_fp6.py`). Compared to the [initial FP6 results](https://github.com/pytorch/ao/pull/223) done by @gau-nernst, we still see a speedup of at least 2x compared to FP16 in most cases.

Testing specs:
- NVIDIA T4 GPU (SM75 generation)
- Torch version: 2.6.0.dev20240917

|   m |     k |     n |   fp6_latency (ms) |   fp16_latency (ms) |   speedup (d/s) |   correct |
|----:|------:|------:|-------------------:|--------------------:|----------------:|----------:|
|   1 |  8192 |  8192 |           223.05   |             517.205 |         2.31878 |         1 |
|   1 |  8192 | 10240 |           267.519  |             644.85  |         2.41048 |         1 |
|   1 |  8192 | 57344 |          1409.66   |            3618.91  |         2.56722 |         1 |
|   1 | 28672 |  8192 |           760.036  |            1800.83  |         2.3694  |         1 |
|   2 |  8192 |  8192 |           226.652  |             550.078 |         2.42697 |         1 |
|   2 |  8192 | 10240 |           271.363  |             687.359 |         2.53299 |         1 |
|   2 |  8192 | 57344 |          1442.43   |            3795.44  |         2.63128 |         1 |
|   2 | 28672 |  8192 |           768.993  |            1945.42  |         2.52982 |         1 |
|   4 |  8192 |  8192 |           229.543  |             567.315 |         2.4715  |         1 |
|   4 |  8192 | 10240 |           276.362  |             690.747 |         2.49943 |         1 |
|   4 |  8192 | 57344 |          1457.8    |            3805.93  |         2.61074 |         1 |
|   4 | 28672 |  8192 |           776.344  |            1965.42  |         2.53163 |         1 |
|   8 |  8192 |  8192 |           237.398  |             573     |         2.41367 |         1 |
|   8 |  8192 | 10240 |           284.349  |             810.79  |         2.85139 |         1 |
|   8 |  8192 | 57344 |          1521.18   |            3823.49  |         2.51349 |         1 |
|   8 | 28672 |  8192 |           783.763  |            1988.13  |         2.53665 |         1 |
|  16 |  8192 |  8192 |           273.57   |             582.142 |         2.12795 |         1 |
|  16 |  8192 | 10240 |           334.392  |             815.086 |         2.43751 |         1 |
|  16 |  8192 | 57344 |          1908.2    |            3857.97  |         2.02178 |         1 |
|  16 | 28672 |  8192 |           896.452  |            2002.43  |         2.23373 |         1 |
|  32 |  8192 |  8192 |           449.671  |             659.112 |         1.46576 |         1 |
|  32 |  8192 | 10240 |           548.003  |             821.81  |         1.49965 |         1 |
|  32 |  8192 | 57344 |          3255.59   |            4543.11  |         1.39548 |         1 |
|  32 | 28672 |  8192 |          1531.63   |            2403.52  |         1.56925 |         1 |
|  64 |  8192 |  8192 |            58.3608 |             672.911 |        11.5302  |         0 |
|  64 |  8192 | 10240 |            60.6918 |             887.669 |        14.6258  |         0 |
|  64 |  8192 | 57344 |           433.124  |            4812.82  |        11.1119  |         0 |
|  64 | 28672 |  8192 |            58.4863 |            2505.37  |        42.8369  |         0 |
| 128 |  8192 |  8192 |            58.2865 |            1096.99  |        18.8206  |         0 |
| 128 |  8192 | 10240 |           121.688  |            1202.46  |         9.88147 |         0 |
| 128 |  8192 | 57344 |           767.995  |            6741.57  |         8.77814 |         0 |
| 128 | 28672 |  8192 |            58.5768 |            3579.83  |        61.1134  |         0 |
| 256 |  8192 |  8192 |           194.799  |            1731.37  |         8.888   |         0 |
| 256 |  8192 | 10240 |           212.755  |            2273.48  |        10.6859  |         0 |
| 256 |  8192 | 57344 |          1186.61   |           11964.1   |        10.0825  |         0 |
| 256 | 28672 |  8192 |           195.011  |            5868.9   |        30.0953  |         0 |
| 512 |  8192 |  8192 |           388.129  |            3043.3   |         7.84093 |         0 |
| 512 |  8192 | 10240 |           199.79   |            3544.64  |        17.7418  |         0 |
| 512 |  8192 | 57344 |            51.1464 |           19975.7   |       390.559   |         0 |
| 512 | 28672 |  8192 |           388.241  |           10728.5   |        27.6335  |         0 |

As you can see, the kernel produces correct results for `m < 64` but incorrect results for `m >= 64`. So in that sense this kernel is currently not functional for `m >= 64`. Note also that the latency is drastically reduced for `m >= 64`, indicating that the kernel is exiting early for some reason. I did some digging and documented my findings below.

### Why does `m >= 64` produce incorrect results?

After looking into this, I think the problem is allocation of too much shared memory. The A100 has quite a lot more shared memory (164 KB per SM) than the T4, so some assumptions made about shared memory may not hold for the T4.

First, I ran the following script to query the device properties of my T4 GPU:

```cpp
#include <cuda_runtime.h>
#include <iostream>

int main() {
    cudaDeviceProp prop;
    cudaGetDeviceProperties(&prop, 0);
    std::cout << "Compute Capability: " << prop.major << "." << prop.minor << std::endl;
    std::cout << "Shared memory per block: " << prop.sharedMemPerBlock << " bytes" << std::endl;
    std::cout << "Shared memory per multiprocessor: " << prop.sharedMemPerMultiprocessor << " bytes" << std::endl;
    return 0;
}

```

Which outputs the following:

```
Compute Capability: 7.5
Shared memory per block: 49152 bytes
Shared memory per multiprocessor: 65536 bytes
```

So the available shared memory is indeed highly reduced compared to the A100. At the threshold of `m>=64`, the kernel gets called with a `TilingConfig` where `WARP_COL_MMA_TENSORS` is set to 8, instead of 4:

https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/fp6_linear.cu#L101-L103

This leads to an increased size of `TILE_N`:

https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/configs.h#L56

Which in turn leads to an increased shared memory allocation:

https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/configs.h#L62-L63

Printing `TilingConfig::SMEM_SIZE_C_TILE` during runtime shows that when `m` goes from 32 to 64, `TilingConfig::SMEM_SIZE_C_TILE` goes from 38912 to 69362. Since 69362 bytes is more shared memory than the T4 has per block and per SM, it seems likely that this is causing problems. (But somehow, this does not throw any kind of error.) Setting `WARP_COL_MMA_TENSORS` to a maximum of 4, i.e. setting `TilingConfig<4, 1, 4>` here:

https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/fp6_linear.cu#L88-L94

and here:

https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/fp6_linear.cu#L102-L108

leads to correct results for all benchmarks:

|   m |     k |     n |   fp6_latency (ms) |   fp16_latency (ms) |   speedup (d/s) |   correct |
|----:|------:|------:|-------------------:|--------------------:|----------------:|----------:|
|   1 |  8192 |  8192 |            223.036 |             516.966 |        2.31786  |         1 |
|   1 |  8192 | 10240 |            269.426 |             644.646 |        2.39266  |         1 |
|   1 |  8192 | 57344 |           1410.92  |            3648.77  |        2.58609  |         1 |
|   1 | 28672 |  8192 |            759.226 |            1804.14  |        2.37629  |         1 |
|   2 |  8192 |  8192 |            225.865 |             549.892 |        2.4346   |         1 |
|   2 |  8192 | 10240 |            271.288 |             687.137 |        2.53287  |         1 |
|   2 |  8192 | 57344 |           1441.76  |            3795.4   |        2.63247  |         1 |
|   2 | 28672 |  8192 |            765.302 |            1945.28  |        2.54185  |         1 |
|   4 |  8192 |  8192 |            230.63  |             567.303 |        2.45979  |         1 |
|   4 |  8192 | 10240 |            276.171 |             690.602 |        2.50063  |         1 |
|   4 |  8192 | 57344 |           1456.33  |            3805.46  |        2.61305  |         1 |
|   4 | 28672 |  8192 |            774.708 |            1965.41  |        2.53696  |         1 |
|   8 |  8192 |  8192 |            237.608 |             573.233 |        2.41252  |         1 |
|   8 |  8192 | 10240 |            284.422 |             811.645 |        2.85367  |         1 |
|   8 |  8192 | 57344 |           1521.34  |            3823.1   |        2.51298  |         1 |
|   8 | 28672 |  8192 |            786.987 |            1986.32  |        2.52395  |         1 |
|  16 |  8192 |  8192 |            272.092 |             581.971 |        2.13888  |         1 |
|  16 |  8192 | 10240 |            334.622 |             816.67  |        2.44058  |         1 |
|  16 |  8192 | 57344 |           1909.48  |            3857.44  |        2.02015  |         1 |
|  16 | 28672 |  8192 |            890.995 |            1978.75  |        2.22083  |         1 |
|  32 |  8192 |  8192 |            450.208 |             659.402 |        1.46466  |         1 |
|  32 |  8192 | 10240 |            547.148 |             825.829 |        1.50933  |         1 |
|  32 |  8192 | 57344 |           3261.63  |            4540.91  |        1.39222  |         1 |
|  32 | 28672 |  8192 |           1532.26  |            2396.69  |        1.56416  |         1 |
|  64 |  8192 |  8192 |            739.317 |             671.094 |        0.907721 |         1 |
|  64 |  8192 | 10240 |            886.388 |             839.778 |        0.947416 |         1 |
|  64 |  8192 | 57344 |           5192.64  |            4846.74  |        0.933387 |         1 |
|  64 | 28672 |  8192 |           2360.6   |            2637.51  |        1.1173   |         1 |
| 128 |  8192 |  8192 |           1243.43  |            1049.64  |        0.844148 |         1 |
| 128 |  8192 | 10240 |           1598.47  |            1226.33  |        0.767191 |         1 |
| 128 |  8192 | 57344 |           9111.21  |            6696.32  |        0.734954 |         1 |
| 128 | 28672 |  8192 |           4154.84  |            3649.96  |        0.878483 |         1 |
| 256 |  8192 |  8192 |           2493.73  |            1603.46  |        0.642994 |         1 |
| 256 |  8192 | 10240 |           3069.87  |            2045.3   |        0.666251 |         1 |
| 256 |  8192 | 57344 |          17182.4   |           11757.5   |        0.68428  |         1 |
| 256 | 28672 |  8192 |           8275.68  |            5849.96  |        0.706886 |         1 |
| 512 |  8192 |  8192 |           5030.14  |            3091.38  |        0.614572 |         1 |
| 512 |  8192 | 10240 |           5893.7   |            3557.85  |        0.603671 |         1 |
| 512 |  8192 | 57344 |          31538.6   |           19964.7   |        0.633024 |         1 |
| 512 | 28672 |  8192 |          16674     |           11045.6   |        0.662444 |         1 |

But as you can see, performance becomes quite slow now for `m>=64` (slower than FP16). I might look into the details to see if there's any optimizations that can be made for the T4 in this particular case.

I tried creating a guard that checks for sm_75 and `m>=64`, but this is causing problems. Specifically, I tried to check for `__CUDA_ARCH__` in `fp6_linear.cu` (as done [here](https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/csrc/cuda/fp6_llm/fp6_linear.cu#L17)), but this does not seem to work for some reason  (best reason I can think of is that `__CUDA_ARCH__` is not defined because it is not device code, but that doesn't explain why the guard does work at the beginning of the file). However, if I instead try to put the directive inside the device code, it seems that functions like `assert` don't have any effect (I'm not really sure why). 

So currently, the `m>=64` case is not handled well (it will lead to incorrect results) and I'd be happy to hear suggestions about how to deal with this case.

## Final thoughts
- I noticed the `splitK` paramater for the FP6 kernel is set based on a [dictionary](https://github.com/pytorch/ao/blob/2dea31543635ad747e52047f5091fe0b490c3807/torchao/dtypes/affine_quantized_tensor.py#L1347) that is optimized for the A100 GPU. It might not be optimal for the T4, but I don't have any insights into how much it matters.

Any feedback is very welcome!