### PR TITLE
Print args/kwargs types for utils and examples

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -386,7 +386,9 @@ def _dispatch__torch_dispatch__(cls, func, types, args, kwargs):
        func in cls._ATEN_OP_OR_TORCH_FN_TABLE:
         return cls._ATEN_OP_OR_TORCH_FN_TABLE[func](func, types, args, kwargs)
 
-    raise NotImplementedError(f"{cls.__name__} dispatch: attempting to run unimplemented operator/function: {func}")
+    arg_types = tuple(type(arg) for arg in args)
+    kwarg_types = {k: type(arg) for k, arg in kwargs}
+    raise NotImplementedError(f"{cls.__name__} dispatch: attempting to run unimplemented operator/function: {func=}, {types=}, {arg_types=}, {kwarg_types=}")
 
 def _register_layout_cls(cls: Callable, layout_type_class: Callable):
     """Helper function for layout registrations, this is used to implement


### PR DESCRIPTION
Summary:
printing arg types are useful for understanding how the op should be implemented

Test Plan:
python tutorials/developer_api_guide/print_op_and_shapes.py

Examples putput:
```
TORCH_FUNC func=<function dropout at 0x7f7bfa006440>, types=(<class 'torch.Tensor'>,), args[0] shape: torch.Size([1, 197, 768])
TORCH_FUNC func=<method 'dim' of 'torch._C.TensorBase' objects>, types=(<class 'torch.Tensor'>,), args[0] shape: torch.Size([1, 197, 768])
TORCH_FUNC func=<method-wrapper '__get__' of getset_descriptor object at 0x7f7c6b1ba6c0>, types=(<class 'torch.Tensor'>,), args[0] shape: torch.Size([1, 197, 768])
TORCH_FUNC func=<function _assert at 0x7f7c2c3c6c20>, types=(), args[0] shape: None
TORCH_FUNC func=<function layer_norm at 0x7f7bfa007a30>, types=(<class 'torch.Tensor'>,), args[0] shape: torch.Size([1, 197, 768])
TORCH_FUNC func=<method 'dim' of 'torch._C.TensorBase' objects>, types=(<class 'torch.Tensor'>,), args[0] shape: torch.Size([1, 197, 768])
...
all linear shapes (M, K, N): [(197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (197, 768, 3072), (197, 3072, 768), (1, 768, 1000)]
```




python test/test_utils.py

   raise NotImplementedError(f"{cls.__name__} dispatch: attempting to run unimplemented operator/function: {func=}, {types=}, {arg_types=}, {kwarg_types=}")
NotImplementedError: MyTensor dispatch: attempting to run unimplemented operator/function: func=<OpOverload(op='aten.detach', overload='default')>, types=(<class '__main__.TestTorchAOBaseTensor.test_print_arg_types
.<locals>.MyTensor'>,), arg_types=(<class '__main__.TestTorchAOBaseTensor.test_print_arg_types.<locals>.MyTensor'>,), kwarg_types={}


Reviewers:

Subscribers:

Tasks:

Tags: