### PR TITLE
Enable ROCM in CI

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -46,7 +46,6 @@ jobs:
     with:
       timeout: 120
       no-sudo: ${{ matrix.gpu-arch-type == 'rocm' }}
-      test-infra-ref: main
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -42,12 +42,11 @@ jobs:
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
             gpu-arch-type: "rocm"
             gpu-arch-version: "6.3"
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@rocm_experiment
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120
       no-sudo: ${{ matrix.gpu-arch-type == 'rocm' }}
-      continue-on-error: ${{ matrix.gpu-arch-type == 'rocm' }}
-      test-infra-ref: rocm_experiment
+      test-infra-ref: main
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -17,6 +17,10 @@ concurrency:
 env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test-nightly:
     strategy:
@@ -33,10 +37,17 @@ jobs:
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
-
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+          - name: ROCM Nightly
+            runs-on: linux.rocm.gpu
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
+            gpu-arch-type: "rocm"
+            gpu-arch-version: "6.3"
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@rocm_experiment
     with:
       timeout: 120
+      no-sudo: ${{ matrix.gpu-arch-type == 'rocm' }}
+      continue-on-error: ${{ matrix.gpu-arch-type == 'rocm' }}
+      test-infra-ref: rocm_experiment
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
@@ -71,7 +82,6 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
-
           - name: CPU 2.3
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu'
@@ -99,8 +109,6 @@ jobs:
         conda create -n venv python=3.9 -y
         conda activate venv
         echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
-        export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -38,10 +38,11 @@ jobs:
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
           - name: ROCM Nightly
-            runs-on: linux.rocm.gpu
+            runs-on: linux.rocm.gpu.2
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
             gpu-arch-type: "rocm"
             gpu-arch-version: "6.3"
+
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -607,7 +607,7 @@ def _torch_version_at_least(min_version):
 def is_MI300():
     if torch.cuda.is_available() and torch.version.hip:
         mxArchName = ["gfx940", "gfx941", "gfx942"]
-        archName = torch.cuda.get_device_properties().gcnArchName
+        archName = torch.cuda.get_device_properties(0).gcnArchName
         for arch in mxArchName:
             if arch in archName:
                 return True


### PR DESCRIPTION
Salient points:
* Add ROCm nightly wheels to test matrix
* https://github.com/pytorch/pytorch/pull/140157
The above PR shows that we've migrated to almalinux-builder due to the EOL CENTOS 7. Changes to regression_test.yml to not install devtoolset-10 have been made in accordance with this switch.
* Fix bug in `torchao/utils.py` in invocation of `torch.cuda.get_device_properties()`

Needs changes in https://github.com/pytorch/test-infra/pull/6104