### PR TITLE
Refactor `tiktoken` import bare except

### DIFF
--- a/torchao/_models/llama/tokenizer.py
+++ b/torchao/_models/llama/tokenizer.py
@@ -1,14 +1,8 @@
 # copied from https://github.com/pytorch-labs/gpt-fast/blob/main/tokenizer.py
+from __future__ import annotations
 
 import os
-import sentencepiece as spm
-try:
-    import tiktoken
-    from tiktoken.load import load_tiktoken_bpe
-except:
-    pass
 from pathlib import Path
-from typing import Dict
 
 class TokenizerInterface:
     def __init__(self, model_path):
@@ -28,6 +22,8 @@ class TokenizerInterface:
 
 class SentencePieceWrapper(TokenizerInterface):
     def __init__(self, model_path):
+        import sentencepiece as spm
+
         super().__init__(model_path)
         self.processor = spm.SentencePieceProcessor(str(model_path))
         self.bos_token_id = self.bos_id()
@@ -50,16 +46,19 @@ class TiktokenWrapper(TokenizerInterface):
     Tokenizing and encoding/decoding text using the Tiktoken tokenizer.
     """
 
-    special_tokens: Dict[str, int]
+    special_tokens: dict[str, int]
 
     num_reserved_special_tokens = 256
 
     pat_str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"  # noqa: E501
 
     def __init__(self, model_path):
+        import tiktoken
+        import tiktoken.load
+
         super().__init__(model_path)
         assert os.path.isfile(model_path), str(model_path)
-        mergeable_ranks = load_tiktoken_bpe(str(model_path))
+        mergeable_ranks = tiktoken.load.load_tiktoken_bpe(str(model_path))
         num_base_tokens = len(mergeable_ranks)
         special_tokens = [
             "<|begin_of_text|>",

--- a/torchao/_models/llama/tokenizer.py
+++ b/torchao/_models/llama/tokenizer.py
@@ -1,5 +1,4 @@
 # copied from https://github.com/pytorch-labs/gpt-fast/blob/main/tokenizer.py
-from __future__ import annotations
 
 import os
 from pathlib import Path


### PR DESCRIPTION
We shouldn't suppress the import error if `tiktoken` is not installed. Also do the same thing for `sentencepiece`.

Instead of importing them at the top of the file, we can import them inside the only functions that use them; we can consider a different import structure if we end up needing to access them elsewhere.

This lazy importing should also decrease the load time of these modules.

cc: @msaroufim 
