### PR TITLE
Aqt rename#1 Layout -> TensorImpl

### DIFF
--- a/benchmarks/benchmark_fp6.py
+++ b/benchmarks/benchmark_fp6.py
@@ -2,7 +2,7 @@ import torch
 import pandas as pd
 import torch.nn.functional as F
 from torchao.dtypes import to_affine_quantized_fpx
-from torchao.dtypes.floatx import FloatxTensorCoreAQTLayout, FloatxTensorCoreLayoutType
+from torchao.dtypes.floatx import FloatxTensorCoreAQTTensorImpl, FloatxTensorCoreLayoutType
 from torchao.utils import benchmark_torch_function_in_microseconds
 from tqdm import tqdm
 

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -210,18 +210,18 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
 
             # Compare weights
             if mode == "weight-only":
-                original_weight = original_layer.weight.layout_tensor.float8_data.to(
+                original_weight = original_layer.weight.tensor_impl.float8_data.to(
                     torch.float32
                 )
-                new_weight = new_layer.weight.layout_tensor.float8_data.to(
-                    torch.float32
-                )
+                new_weight = new_layer.weight.tensor_impl.float8_data.to(torch.float32)
             else:
-                original_weight = original_layer.weight.original_weight_tensor.layout_tensor.float8_data.to(
+                original_weight = original_layer.weight.original_weight_tensor.tensor_impl.float8_data.to(
                     torch.float32
                 )
-                new_weight = new_layer.weight.original_weight_tensor.layout_tensor.float8_data.to(
-                    torch.float32
+                new_weight = (
+                    new_layer.weight.original_weight_tensor.tensor_impl.float8_data.to(
+                        torch.float32
+                    )
                 )
 
             assert torch.allclose(

--- a/test/dtypes/test_floatx.py
+++ b/test/dtypes/test_floatx.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 from torchao.dtypes.floatx import (
-    FloatxTensorCoreAQTLayout,
+    FloatxTensorCoreAQTTensorImpl,
     FloatxTensorCoreLayoutType,
     to_scaled_tc_floatx,
     from_scaled_tc_floatx,
@@ -28,7 +28,7 @@ _DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 _Floatx_DTYPES = [(3, 2), (2, 2)]
 
 
-class TestFloatxTensorCoreAQTLayout(TestCase):
+class TestFloatxTensorCoreAQTTensorImpl(TestCase):
     @parametrize("device", _DEVICES)
     def test_pack_tc_fp6_correctness(self, device):
         x = torch.randint(256, size=(256, 64), dtype=torch.uint8, device=device)
@@ -82,10 +82,10 @@ class TestFloatxTensorCoreAQTLayout(TestCase):
         scale = choose_qparams_affine_floatx(x, ebits, mbits)
         x = quantize_affine_floatx(x, scale, ebits, mbits)
         layout_type = FloatxTensorCoreLayoutType(ebits, mbits)
-        floatx_layout_tensor = FloatxTensorCoreAQTLayout.from_plain(x, scale, None, layout_type).cuda()
-        assert floatx_layout_tensor.device.type == "cuda"
-        floatx_layout_tensor = floatx_layout_tensor.cpu()
-        assert floatx_layout_tensor.device.type == "cpu"
+        floatx_tensor_impl = FloatxTensorCoreAQTTensorImpl.from_plain(x, scale, None, layout_type).cuda()
+        assert floatx_tensor_impl.device.type == "cuda"
+        floatx_tensor_impl = floatx_tensor_impl.cpu()
+        assert floatx_tensor_impl.device.type == "cpu"
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="quantization only works with torch.compile for 2.5+")
@@ -106,7 +106,7 @@ class TestFloatxTensorCoreAQTLayout(TestCase):
         torch.testing.assert_close(actual, expected)
 
 
-instantiate_parametrized_tests(TestFloatxTensorCoreAQTLayout)
+instantiate_parametrized_tests(TestFloatxTensorCoreAQTTensorImpl)
 
 
 if __name__ == "__main__":

--- a/test/hqq/test_hqq_affine.py
+++ b/test/hqq/test_hqq_affine.py
@@ -3,9 +3,9 @@ import torch
 from torchao.dtypes.affine_quantized_tensor import (
     to_affine_quantized_intx,
     ZeroPointDomain,
-    PlainAQTLayout,
+    PlainAQTTensorImpl,
     PlainLayoutType,
-    TensorCoreTiledAQTLayout,
+    TensorCoreTiledAQTTensorImpl,
     TensorCoreTiledLayoutType,
     MappingType,
 )

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1051,7 +1051,7 @@ class TestSaveLoadMeta(unittest.TestCase):
         self.assertTrue(torch.equal(ref_q, test))
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
-    @unittest.skipIf(is_fbcode(), "'PlainAQTLayout' object has no attribute 'int_data'")
+    @unittest.skipIf(is_fbcode(), "'PlainAQTTensorImpl' object has no attribute 'int_data'")
     @torch.no_grad()
     def test_save_load_dqtensors(self, device, dtype):
         if device == "cpu":

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -14,7 +14,7 @@ from .affine_quantized_tensor import (
     SemiSparseLayoutType,
     TensorCoreTiledLayoutType,
     Float8LayoutType,
-    Float8AQTLayout,
+    Float8AQTTensorImpl,
     MarlinSparseLayoutType,
 )
 
@@ -33,6 +33,6 @@ __all__ = [
     "SemiSparseLayoutType",
     "TensorCoreTiledLayoutType",
     "Float8LayoutType",
-    "Float8AQTLayout",
+    "Float8AQTTensorImpl",
     "MarlinSparseLayoutType",
 ]

--- a/torchao/dtypes/floatx/__init__.py
+++ b/torchao/dtypes/floatx/__init__.py
@@ -1,1 +1,1 @@
-from .floatx import FloatxTensorCoreLayoutType, FloatxTensorCoreAQTLayout, to_scaled_tc_floatx, from_scaled_tc_floatx, _SPLIT_K_MAP
+from .floatx import FloatxTensorCoreLayoutType, FloatxTensorCoreAQTTensorImpl, to_scaled_tc_floatx, from_scaled_tc_floatx, _SPLIT_K_MAP

--- a/torchao/dtypes/floatx/floatx.py
+++ b/torchao/dtypes/floatx/floatx.py
@@ -10,7 +10,7 @@ from torchao.dtypes.utils import (
 )
 from torchao.quantization.quant_api import _get_linear_subclass_inserter
 from dataclasses import dataclass
-from torchao.dtypes.affine_quantized_tensor import AQTLayout, register_layout_cls
+from torchao.dtypes.affine_quantized_tensor import AQTTensorImpl, register_layout
 
 
 aten = torch.ops.aten
@@ -354,14 +354,14 @@ _SPLIT_K_MAP = [
 
 @dataclass(frozen=True)
 class FloatxTensorCoreLayoutType(LayoutType):
-    """Layout type for FloatxTensorCoreAQTLayout
+    """Layout type for FloatxTensorCoreAQTTensorImpl
     """
     ebits: int
     mbits: int
 
-@register_layout_cls(FloatxTensorCoreLayoutType)
-class FloatxTensorCoreAQTLayout(AQTLayout):
-    """FloatxTensorCoreAQTLayout represents a Tensor with dtype floatx(ebits=a, mbits=b),
+@register_layout(FloatxTensorCoreLayoutType)
+class FloatxTensorCoreAQTTensorImpl(AQTTensorImpl):
+    """FloatxTensorCoreAQTTensorImpl represents a Tensor with dtype floatx(ebits=a, mbits=b),
     it has a internal tensor field of "packed_floatx_data", which is packed from the
     uint8 unpacked data (the output of `quantize_affine_floatx` operator)
 
@@ -377,10 +377,10 @@ class FloatxTensorCoreAQTLayout(AQTLayout):
     If original Tensor shape is (M, N), and the data is in nbit, the shape of the packed data will be
     (M, N // 8 * nbit)
 
-    FloatxTensorCoreAQTLayout.from_plain takes an unpacked uint8 floatx Tensor of shape (M, N), with format of
+    FloatxTensorCoreAQTTensorImpl.from_plain takes an unpacked uint8 floatx Tensor of shape (M, N), with format of
     (zero padding bits + sign bit + exponent bits + mantissa bits), e.g. 00SEEEMM for fp6_e3_m2
-    it will then pack the weight and instantiate the FloatxTensorCoreAQTLayout tensor
-    FloatxTensorCoreAQTLayout.__init__() takes a packed floatx Tensor of shape (M, N // 8 * nbit)
+    it will then pack the weight and instantiate the FloatxTensorCoreAQTTensorImpl tensor
+    FloatxTensorCoreAQTTensorImpl.__init__() takes a packed floatx Tensor of shape (M, N // 8 * nbit)
     """
     def __new__(
         cls,
@@ -483,7 +483,7 @@ class FloatxTensorCoreAQTLayout(AQTLayout):
             )
 
         raise NotImplementedError(
-            f"FloatxTensorCoreAQTLayout dispatch: attempting to run {func}, this is not supported"
+            f"FloatxTensorCoreAQTTensorImpl dispatch: attempting to run {func}, this is not supported"
         )
 
     __torch_function__ = torch._C._disabled_torch_function_impl

--- a/torchao/dtypes/uintx/__init__.py
+++ b/torchao/dtypes/uintx/__init__.py
@@ -1,1 +1,1 @@
-from .uintx import UintxTensor, UintxLayoutType, UintxAQTLayout, to_uintx, _DTYPE_TO_BIT_WIDTH
+from .uintx import UintxTensor, UintxLayoutType, UintxAQTTensorImpl, to_uintx, _DTYPE_TO_BIT_WIDTH

--- a/torchao/dtypes/uintx/uintx.py
+++ b/torchao/dtypes/uintx/uintx.py
@@ -8,7 +8,7 @@ from torchao.dtypes.utils import (
     LayoutType,
 )
 from torchao.utils import TorchAOBaseTensor
-from torchao.dtypes.affine_quantized_tensor import PlainAQTLayout, register_layout_cls
+from torchao.dtypes.affine_quantized_tensor import PlainAQTTensorImpl, register_layout
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_3
 
 aten = torch.ops.aten
@@ -194,8 +194,8 @@ class UintxLayoutType(LayoutType):
     def post_process(self, input: torch.Tensor) -> torch.Tensor:
         return to_uintx(input, self.dtype, self.pack_dim)
 
-@register_layout_cls(UintxLayoutType)
-class UintxAQTLayout(PlainAQTLayout):
+@register_layout(UintxLayoutType)
+class UintxAQTTensorImpl(PlainAQTTensorImpl):
 
     def get_plain(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return self.int_data.get_plain(), self.scale, self.zero_point

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 
 """
 Base class for different LayoutType, should not be instantiated directly
-used to allow users to pass around configurations for the layout tensor, e.g. inner_k_tiles
-for int4 tensor core tiled layout
+used to allow users to pass around configurations for the tensor impl, e.g. inner_k_tiles
+for int4 tensor core tiled tensor impl
 
-Note: layout is an abstraction not only for custom data representation, it is also used for how the
-layout interacts with different operators, e.g. the same data representation can have different
+Note: TensorImpl is an abstraction not only for custom data representation, it is also used for how the
+tensorImpl interacts with different operators, e.g. the same data representation can have different
 behaviors when running the same operator, e.g. transpose, quantized_linear.
 """
 @dataclass(frozen=True)

--- a/torchao/prototype/hqq/example.py
+++ b/torchao/prototype/hqq/example.py
@@ -3,9 +3,9 @@ from torchao.prototype.hqq.core import HQQQuantizer
 from torchao.dtypes.affine_quantized_tensor import (
     to_affine_quantized_intx,
     ZeroPointDomain,
-    PlainAQTLayout,
+    PlainAQTTensorImpl,
     PlainLayoutType,
-    TensorCoreTiledAQTLayout,
+    TensorCoreTiledAQTTensorImpl,
     TensorCoreTiledLayoutType,
     MappingType,
 )

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -348,7 +348,7 @@ class AQInt8DynamicallyQuantizedLinearWeight(AQMixin, LinearActivationQuantizedT
         )
         q_c_matmul=torch.compile(quantized_matmul, mode="max-autotune-no-cudagraphs")
         with torch.no_grad():
-            w_vals_int8 = w_qtensor.original_weight_tensor.layout_tensor.int_data.contiguous().t()
+            w_vals_int8 = w_qtensor.original_weight_tensor.tensor_impl.int_data.contiguous().t()
             res_matmul = do_autoquant_bench(q_c_matmul, x_vals_int8, x_scales.reshape(-1,1), w_vals_int8)
         print(f">>time: {res_matmul:0.3f}ms for {cls} matmul, to_beat: {best_time:0.3f}ms")
 
@@ -399,8 +399,8 @@ class AQInt8WeightOnlyQuantizedLinearWeight2(AQInt8WeightOnlyQuantizedLinearWeig
         orig_dtype = act_mat.dtype
         orig_shape = act_mat.shape
         act_mat = act_mat.reshape(-1, act_mat.shape[-1], 1)
-        y = (act_mat*w_qtensor.layout_tensor.int_data.t().unsqueeze(0)).sum(dim=-2)
-        y = y.reshape(*orig_shape[:-1], y.shape[-1]) * w_qtensor.layout_tensor.scale
+        y = (act_mat*w_qtensor.tensor_impl.int_data.t().unsqueeze(0)).sum(dim=-2)
+        y = y.reshape(*orig_shape[:-1], y.shape[-1]) * w_qtensor.tensor_impl.scale
         if bias is not None:
             y += bias
         return y.to(orig_dtype)
@@ -420,7 +420,7 @@ class AQInt8WeightOnlyQuantizedLinearWeight3(AQInt8WeightOnlyQuantizedLinearWeig
     @staticmethod
     def _quantized_linear_op(act_mat, w_qtensor, bias):
         orig_shape = act_mat.shape
-        y = torch.mm(act_mat.reshape(-1, orig_shape[-1]), w_qtensor.layout_tensor.int_data.t()*w_qtensor.layout_tensor.scale)
+        y = torch.mm(act_mat.reshape(-1, orig_shape[-1]), w_qtensor.tensor_impl.int_data.t()*w_qtensor.tensor_impl.scale)
         y=y.reshape(*orig_shape[:-1], y.shape[-1])
         if bias is not None:
             y += bias

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -886,7 +886,7 @@ def fpx_weight_only(ebits: int, mbits: int):
     e.g. fp6_e3_m2, fp6_e2_m3, ...
     The packing format and kernels are from the fp6-llm paper: https://arxiv.org/abs/2401.14112
     github repo: https://github.com/usyd-fsalab/fp6_llm, now renamed to quant-llm
-    For more details for packing please see: :class:`~torchao.dtypes.fpx.FpxTensorCoreAQTLayout`
+    For more details for packing please see: :class:`~torchao.dtypes.fpx.FpxTensorCoreAQTTensorImpl`
 
     This is experimental, will be merged with `to_affine_quantized_floatx`
     in the future

--- a/torchao/sparsity/marlin/utils.py
+++ b/torchao/sparsity/marlin/utils.py
@@ -9,7 +9,7 @@ class Marlin24Constants:
     MIN_THREAD_N: int = 128
     MAX_PARALLEL: int = 64
 
-    # NOTE: Cuda kernel supports fp8, but not implemented yet in SparseMarlinAQTLayout
+    # NOTE: Cuda kernel supports fp8, but not implemented yet in SparseMarlinAQTTensorImpl
     SUPPORTED_NUM_BITS: List[int] = field(default_factory=lambda: [4, 8])
     SUPPORTED_GROUP_SIZES: List[int] = field(default_factory=lambda: [-1, 32, 64, 128])
 const = Marlin24Constants()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -392,34 +392,34 @@ def _dispatch__torch_dispatch__(cls, func, types, args, kwargs):
     kwarg_types = {k: type(arg) for k, arg in kwargs}
     raise NotImplementedError(f"{cls.__name__} dispatch: attempting to run unimplemented operator/function: {func=}, {types=}, {arg_types=}, {kwarg_types=}")
 
-def _register_layout_cls(cls: Callable, layout_type_class: Callable):
+def _register_layout(cls: Callable, layout_type_class: Callable):
     """Helper function for layout registrations, this is used to implement
-    register_layout_cls decorator for each tensor subclass, see aqt.py for example usage
+    register_layout decorator for each tensor subclass, see aqt.py for example usage
 
     Args:
         cls: Tensor subclass type
         layout_type_class: the class type of subclass of `LayoutType`, e.g. `PlainLayoutType`
 
     Returns:
-        a decorator that registers the layout tensor constructor in the table
+        a decorator that registers the tensor impl constructor in the table
     """
 
     # cls._LAYOUT_CONSTRUCTOR_TABLE is a map from layout_type_class like TensorCoreTiledLayout
-    # to layout class constructor like TensorCoreTiledAQTLayout.from_plain that can construct a layout_tensor
+    # to tensor_impl class constructor like TensorCoreTiledAQTTensorImpl.from_plain that can construct a tensor_impl
     # from plain data like (quantized, unpacked) `data`, `scale`, `zero_point`
     if not hasattr(cls, "_LAYOUT_CONSTRUCTOR_TABLE"):
         cls._LAYOUT_CONSTRUCTOR_TABLE = {}
 
-    def decorator(layout_class):
-        cls._LAYOUT_CONSTRUCTOR_TABLE[layout_type_class] = layout_class.from_plain
+    def decorator(tensor_impl_class):
+        cls._LAYOUT_CONSTRUCTOR_TABLE[layout_type_class] = tensor_impl_class.from_plain
         if TORCH_VERSION_AT_LEAST_2_5:
-            # Allow serialization to work for models uses this layout tensor subclass
-            torch.serialization.add_safe_globals([layout_type_class, layout_class])
-        return layout_class
+            # Allow serialization to work for models uses this tensor impl subclass
+            torch.serialization.add_safe_globals([layout_type_class, tensor_impl_class])
+        return tensor_impl_class
     return decorator
 
-def _get_layout_tensor_constructor(cls: Callable, layout_type_class: Callable) -> Callable:
-    """Get Layout class constructor (LayoutClass.from_plain) for `cls` based on `layout_type_class`
+def _get_tensor_impl_constructor(cls: Callable, layout_type_class: Callable) -> Callable:
+    """Get TensorImpl class constructor (TensorImplClass.from_plain) for `cls` based on `layout_type_class`
     `layout_type_class` means the class type of subclass of `LayoutType`, e.g. `PlainLayoutType`
 
     Args:
@@ -427,10 +427,10 @@ def _get_layout_tensor_constructor(cls: Callable, layout_type_class: Callable) -
         layout_type_class: the class type of subclass of `LayoutType`, e.g. `PlainLayoutType`
 
     Returns:
-        layout tensor subclass constructor for the layout_type_class
+        tensor impl subclass constructor for the layout_type_class
     """
     if not hasattr(cls, "_LAYOUT_CONSTRUCTOR_TABLE"):
-        raise ValueError(f"no registered layout class constructor for: {cls}")
+        raise ValueError(f"no registered tensor_impl class constructor for: {cls}")
     if layout_type_class not in cls._LAYOUT_CONSTRUCTOR_TABLE:
         raise ValueError(f"layout_name: {layout_type_class} is not supported yet for {cls}")
 
@@ -457,25 +457,25 @@ class TorchAOBaseTensor(torch.Tensor):
             def _(func, types, args, kwargs):
                 ...
 
-        `register_layout_cls`:
-            register_layout_cls = MyTensor.register_layout_cls
+        `register_layout`:
+            register_layout = MyTensor.register_layout
 
-            @register_layout_cls(PlainLayoutType)
-            class PlainAQTLayout(...):
+            @register_layout(PlainLayoutType)
+            class PlainAQTTensorImpl(...):
                 ...
 
-         `get_layout_tensor_constructor`:
-            get_layout_tensor_constructor = MyTensor.get_layout_tensor_constructor
+         `get_tensor_impl_constructor`:
+            get_tensor_impl_constructor = MyTensor.get_tensor_impl_constructor
             # in constructor of MyTensor:
-            layout_tensor_ctr = get_layout_tensor_constructor(type(layout_type))
-            layout_tensor = layout_tensor_ctr(data, scale, zero_point, layout_type)
+            tensor_impl_ctr = get_tensor_impl_constructor(type(layout_type))
+            tensor_impl = tensor_impl_ctr(data, scale, zero_point, layout_type)
 
     """
     implements = classmethod(_implements)
     __torch_dispatch__ = classmethod(_dispatch__torch_dispatch__)
     __torch_function__ = classmethod(_dispatch__torch_function__)
-    register_layout_cls = classmethod(_register_layout_cls)
-    get_layout_tensor_constructor = classmethod(_get_layout_tensor_constructor)
+    register_layout = classmethod(_register_layout)
+    get_tensor_impl_constructor = classmethod(_get_tensor_impl_constructor)
 
     def _get_to_kwargs(self, *args, **kwargs):
         # `torch._C._nn._parse_to` can't handle `layout` argument

--- a/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_dtype_tensor_subclass.py
@@ -33,11 +33,11 @@ from torchao.utils import (
 aten = torch.ops.aten
 
 ###############################
-# Base Layout Tensor Subclass #
+# Base Tensor Impl Subclass #
 ###############################
-class MyDTypeLayout(torch.Tensor):
+class MyDTypeTensorImpl(torch.Tensor):
     """
-    Base class for the layout tensor for `MyDTypeTensor`
+    Base class for the tensor impl for `MyDTypeTensor`
     """
     # get the original unpacked Tensors
     def get_plain(self) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -53,7 +53,7 @@ class MyDTypeLayout(torch.Tensor):
         scale: torch.Tensor,
         layout_type: LayoutType,
     ):
-        """Construct a layout tensor from plain tensors and a layout_type, which main contain
+        """Construct a tensor impl from plain tensors and a layout_type, which main contain
         extra metadata for packing etc.
         """
         pass
@@ -82,17 +82,17 @@ class MyDTypeTensor(TorchAOBaseTensor):
     @staticmethod
     def __new__(
         cls,
-        layout_tensor: MyDTypeLayout,
+        tensor_impl: MyDTypeTensorImpl,
         shape: torch.Size,
         dtype: Optional[torch.dtype] = None,
         requires_grad: bool = False,
     ):
         kwargs = {}
-        kwargs["device"] = layout_tensor.device
+        kwargs["device"] = tensor_impl.device
         kwargs["layout"] = (
             kwargs.get("layout")
             if kwargs.get("layout", False)
-            else layout_tensor.layout
+            else tensor_impl.layout
         )
         kwargs["dtype"] = dtype
         kwargs["requires_grad"] = requires_grad
@@ -100,12 +100,12 @@ class MyDTypeTensor(TorchAOBaseTensor):
 
     def __init__(
         self,
-        layout_tensor: MyDTypeLayout,
+        tensor_impl: MyDTypeTensorImpl,
         shape: torch.Size,
         dtype: Optional[torch.dtype] = None,
         requires_grad: bool = False,
     ):
-        self.layout_tensor = layout_tensor
+        self.tensor_impl = tensor_impl
 
     """__tensor_flatten__ and __tensor_unflatten__ are used to desugar the tensor into native Tensors/attributes and
     reconstruct the tensor subclass instance from the desugared tensor and attributes, these are required to define
@@ -118,7 +118,7 @@ class MyDTypeTensor(TorchAOBaseTensor):
         The first one contains any tensor fields such as int_data and scale as keys to a dictionary
         The second one contains all other non tensor type fields as values of a list
         """
-        return ["layout_tensor"], [self.shape, self.dtype, self.requires_grad]
+        return ["tensor_impl"], [self.shape, self.dtype, self.requires_grad]
 
     @classmethod
     def __tensor_unflatten__(
@@ -129,10 +129,10 @@ class MyDTypeTensor(TorchAOBaseTensor):
         tensor_data_dict contains the tensor fields of the class as a dictionary
         tensor_attributes contains all other non tensor type fields
         """
-        layout_tensor = tensor_data_dict["layout_tensor"]
+        tensor_impl = tensor_data_dict["tensor_impl"]
         shape, dtype, requires_grad = tensor_attributes
         return cls(
-            layout_tensor,
+            tensor_impl,
             shape if outer_size is None else outer_size,
             dtype=dtype,
             requires_grad=requires_grad,
@@ -152,25 +152,25 @@ class MyDTypeTensor(TorchAOBaseTensor):
         dtype = torch.int16
         scale, zero_point = choose_qparams_affine(input_float, mapping_type, block_size, dtype)
         int_data = quantize_affine(input_float, block_size, scale, zero_point, dtype)
-        layout_tensor_ctr = get_layout_tensor_constructor(type(layout_type))
-        layout_tensor = layout_tensor_ctr(int_data, scale, layout_type)
-        return cls(layout_tensor, input_float.shape)
+        tensor_impl_ctr = get_tensor_impl_constructor(type(layout_type))
+        tensor_impl = tensor_impl_ctr(int_data, scale, layout_type)
+        return cls(tensor_impl, input_float.shape)
 
     """[Optional] We can overwrite layout property of the Tensor to represent different packing formats
     """
 
     @property
     def layout_type(self) -> LayoutType:
-        return self.layout_tensor.layout_type
+        return self.tensor_impl.layout_type
 
     def dequantize(self, output_dtype=None):
         """We can define a dequantize method to convert the quantized tensor to a floating point tensor"""
         if output_dtype is None:
             output_dtype = torch.get_default_dtype()
-        int_data, scale = self.layout_tensor.get_plain()
+        int_data, scale = self.tensor_impl.get_plain()
         transposed = False
         block_size = (1, int_data.shape[-1])
-        if hasattr(self.layout_tensor, "transposed") and self.layout_tensor.transposed:
+        if hasattr(self.tensor_impl, "transposed") and self.tensor_impl.transposed:
             transposed = True
         res = dequantize_affine(int_data, block_size, scale, None, int_data.dtype, output_dtype=output_dtype)
         if transposed:
@@ -186,10 +186,10 @@ class MyDTypeTensor(TorchAOBaseTensor):
     def _apply_fn_to_data(self, fn):
         """
         Used for implementing aten ops by applying them only to the relevant tensor atributes
-        In this case we only want to call things like to() or view() on the layout tensor
+        In this case we only want to call things like to() or view() on the tensor impl
         """
         return self.__class__(
-            fn(self.layout_tensor),
+            fn(self.tensor_impl),
             self.shape,
             self.dtype,
         )
@@ -206,14 +206,14 @@ class MyDTypeTensor(TorchAOBaseTensor):
     """
 
 ######################################################
-# LayoutType and Layout Tensor Subclass Registration #
+# LayoutType and TensorImpl Subclass Registration #
 ######################################################
 
-register_layout_cls = MyDTypeTensor.register_layout_cls
-get_layout_tensor_constructor = MyDTypeTensor.get_layout_tensor_constructor
+register_layout = MyDTypeTensor.register_layout
+get_tensor_impl_constructor = MyDTypeTensor.get_tensor_impl_constructor
 
-@register_layout_cls(PlainLayoutType)
-class PlainMyDTypeLayout(MyDTypeLayout):
+@register_layout(PlainLayoutType)
+class PlainMyDTypeTensorImpl(MyDTypeTensorImpl):
     def __new__(
         cls,
         int_data: torch.Tensor,
@@ -261,7 +261,7 @@ class PlainMyDTypeLayout(MyDTypeLayout):
         scale: torch.Tensor,
         layout_type: LayoutType,
     ):
-        """Construct a layout tensor from plain tensors and a layout_type, which main contain
+        """Construct a tensor impl from plain tensors and a layout_type, which main contain
         extra metadata for packing etc.
         """
         assert isinstance(layout_type, PlainLayoutType)
@@ -292,11 +292,11 @@ class PlainMyDTypeLayout(MyDTypeLayout):
         elif func is aten.split.Tensor:
             int_data_list = func(args[0].int_data, *args[1:], **kwargs)
             scale_list = func(args[0].scale, *args[1:], **kwargs)
-            out = [PlainMyDTypeLayout(int_data, scale, args[0].transposed, args[0].layout_type) for int_data, scale in zip(int_data_list, scale_list)]
+            out = [PlainMyDTypeTensorImpl(int_data, scale, args[0].transposed, args[0].layout_type) for int_data, scale in zip(int_data_list, scale_list)]
             return out
         elif func is aten.empty_like.default:
             int_data_empty_like = func(args[0].int_data, *args[1:], **kwargs)
-            return PlainMyDTypeLayout(int_data_empty_like, args[0].scale, args[0].transposed, args[0].layout_type)
+            return PlainMyDTypeTensorImpl(int_data_empty_like, args[0].scale, args[0].transposed, args[0].layout_type)
         elif func is aten.slice.Tensor:
             self, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
             if dim == 0:
@@ -304,16 +304,16 @@ class PlainMyDTypeLayout(MyDTypeLayout):
                     func, args, kwargs, args[0]._apply_fn_to_data(lambda x: aten.slice.Tensor(x, dim, start, end, step))
                 )
             elif dim == 1:
-                return PlainMyDTypeLayout(aten.slice.Tensor(self.int_data, dim, start, end, step), self.scale.view(-1), self.transposed, self.layout_type)
+                return PlainMyDTypeTensorImpl(aten.slice.Tensor(self.int_data, dim, start, end, step), self.scale.view(-1), self.transposed, self.layout_type)
             else:
-                raise NotImplementedError(f"PlainMyDTypeLayout dispatch: attempting to run {func}, with dim={dim}, that is not supported")
+                raise NotImplementedError(f"PlainMyDTypeTensorImpl dispatch: attempting to run {func}, with dim={dim}, that is not supported")
         elif func is aten.t.default:
-            return return_and_correct_aliasing(func, args, kwargs, PlainMyDTypeLayout(args[0].int_data, args[0].scale, not args[0].transposed, args[0].layout_type))
+            return return_and_correct_aliasing(func, args, kwargs, PlainMyDTypeTensorImpl(args[0].int_data, args[0].scale, not args[0].transposed, args[0].layout_type))
 
         # Tensor parallel support END
 
         raise NotImplementedError(
-            f"PlainMyDTypeLayout dispatch: attempting to run {func}, this is not supported"
+            f"PlainMyDTypeTensorImpl dispatch: attempting to run {func}, this is not supported"
         )
 
 #####################################################

--- a/tutorials/developer_api_guide/my_trainable_tensor_subclass.py
+++ b/tutorials/developer_api_guide/my_trainable_tensor_subclass.py
@@ -43,8 +43,8 @@ class MyTrainableDTypeTensor(MyDTypeTensor):
         dtype = torch.int16
         scale, _ = choose_qparams_affine(input_float, mapping_type, block_size, dtype)
         int_data = (input_float / scale).to(torch.int8)
-        layout_tensor_ctr = cls.get_layout_tensor_constructor(type(layout_type))
-        return layout_tensor_ctr(int_data, scale, layout_type)
+        tensor_impl_ctr = cls.get_tensor_impl_constructor(type(layout_type))
+        return tensor_impl_ctr(int_data, scale, layout_type)
 
     @classmethod
     def from_float(
@@ -71,9 +71,9 @@ class _ToMyTrainableDTypeTensor(torch.autograd.Function):
         input_float: torch.Tensor,
         layout_type: LayoutType,
     ) -> "MyTrainableDTypeTensor":
-        layout_tensor = MyTrainableDTypeTensor._quantize(input_float, layout_type)
+        tensor_impl = MyTrainableDTypeTensor._quantize(input_float, layout_type)
         return MyTrainableDTypeTensor(
-            layout_tensor,
+            tensor_impl,
             input_float.shape,
             requires_grad=True,
         )
@@ -137,15 +137,15 @@ def _(func, types, args, kwargs):
     """
     assert len(args) == 2
     assert isinstance(args[0], MyTrainableDTypeTensor)
-    assert args[0].layout_tensor.int_data.dtype == torch.int8
+    assert args[0].tensor_impl.int_data.dtype == torch.int8
     float0 = args[0].dequantize()
     float1 = args[1].dequantize() if isinstance(args[1], MyTrainableDTypeTensor) else args[1]
     new_value = torch.add(float0, float1, **kwargs)
-    new_layout_tensor = MyTrainableDTypeTensor._quantize(
+    new_tensor_impl = MyTrainableDTypeTensor._quantize(
         new_value,
-        args[0].layout_tensor.get_layout_type(),
+        args[0].tensor_impl.get_layout_type(),
     )
-    args[0].layout_tensor = new_layout_tensor
+    args[0].tensor_impl = new_tensor_impl
     return return_and_correct_aliasing(func, args, kwargs, args[0])
 
 @implements(aten.add.Tensor)
@@ -190,7 +190,7 @@ def main():
         loss = loss_fn(output, target)
         loss.backward()
         if VERBOSE:
-            weight = m.linear.weight.layout_tensor.int_data.flatten()[:3]
+            weight = m.linear.weight.tensor_impl.int_data.flatten()[:3]
             weight_grad = m.linear.weight.grad.flatten()[:3]
             print(" * step %s: weight grad = %s, weight value = %s" % (i, weight_grad, weight))
         optimizer.step()


### PR DESCRIPTION
Current Layout/Layout type confusing and not corresponding to pytorch layout

- Current Layout class and aqt.layout_tensor corresponds to TensorImpl in pytorch
- Rename
- “Layout” class to “TensorImpl” (following the naming for https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/SparseTensorImpl.h) and
- “aqt.layout_tensor” to “aqt.tensor_impl”