### PR TITLE
Fix QAT module swap BC

### DIFF
--- a/torchao/quantization/prototype/qat/_module_swap_api.py
+++ b/torchao/quantization/prototype/qat/_module_swap_api.py
@@ -2,6 +2,7 @@
 # These will be removed in the future
 
 from .linear import (
+    Int8DynActInt4WeightQATLinear,
     Int8DynActInt4WeightQATQuantizer as Int8DynActInt4WeightQATQuantizerModuleSwap,
     Int4WeightOnlyQATQuantizer as Int4WeightOnlyQATQuantizerModuleSwap,
     enable_8da4w_fake_quant as enable_8da4w_fake_quant_module_swap,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1058

Add back _module_swap_api.Int8DynActInt4WeightQATLinear.

Differential Revision: [D64252460](https://our.internmc.facebook.com/intern/diff/D64252460)