### PR TITLE
Pin pt nightly CPU version

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -61,7 +61,7 @@ jobs:
             gpu-arch-version: ""
           - name: CPU Nightly
             runs-on: linux.4xlarge
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cpu'
+            torch-spec: '--pre torch==2.6.0.dev20241010+cpu --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
 


### PR DESCRIPTION
This just makes https://github.com/pytorch/ao/actions/runs/11293700323/job/31428383947?pr=962 green instead

There's dozens of these failures but the main one with a repro is 


```
  f = <built-in function create_dynamic>
  args = (ModuleSpec(name='czbwqbrpps7k557gwtx5ach55zcy5nlo4hkgesymkc7ywznzhsf5.kernel', loader=<_frozen_importlib_external.Ext...ject at 0x7f2ec81a6d90>, origin='/tmp/torchinductor_root/zb/czbwqbrpps7k557gwtx5ach55zcy5nlo4hkgesymkc7ywznzhsf5.so'),)
  kwds = {}
  
  >   ???
  E   torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
  E   ImportError: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /tmp/torchinductor_root/zb/czbwqbrpps7k557gwtx5ach55zcy5nlo4hkgesymkc7ywznzhsf5.so)
  E   
  E   Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
  E   
  E   
  E   You can suppress this exception and fall back to eager by setting:
  E       import torch._dynamo
  E       torch._dynamo.config.suppress_errors = True
  E   
  E   
  E   To execute this test, run the following from the base repo dir:
  E       python test/prototype/test_low_bit_optim.py TestOptim.test_optim_smoke_optim_name_AdamWFp8_bfloat16_device_cpu
```