### PR TITLE
[low-bit optim] Upcast everything to FP32 for internal calculations

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -67,7 +67,7 @@ jobs:
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
-      timeout: 60
+      timeout: 120
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}


### PR DESCRIPTION
Fixes #1067.

Previously, it seems like torch.compile will not check for dtype mismatch when tensor subclass is used (e.g. `tensor_subclass_fp32.lerp(plain_tensor_bf16, weight)`). Now it does, raising the error. To fix it, I simply cast everything to FP32.

The dtype mismatch comes from the fact that my tensor subclasses for optim state have always used FP32 appearance dtype, even if param is BF16. This results in FP32 calculations, which is correct, though not originally intentional. Now I have made it explicit and intentional. This also means that BF16 param + BF16 optim state combination is now more accurate.

If I have time, I will re-run some some of the benchmarks to make sure things are alright.