### PR TITLE
Add missing QAT linear classes in BC path

### DIFF
--- a/torchao/quantization/prototype/qat/_module_swap_api.py
+++ b/torchao/quantization/prototype/qat/_module_swap_api.py
@@ -2,7 +2,9 @@
 # These will be removed in the future
 
 from .linear import (
+    Int8DynActInt4WeightQATLinear,
     Int8DynActInt4WeightQATQuantizer as Int8DynActInt4WeightQATQuantizerModuleSwap,
+    Int4WeightOnlyQATLinear,
     Int4WeightOnlyQATQuantizer as Int4WeightOnlyQATQuantizerModuleSwap,
     enable_8da4w_fake_quant as enable_8da4w_fake_quant_module_swap,
     disable_8da4w_fake_quant as disable_8da4w_fake_quant_module_swap,


### PR DESCRIPTION
https://github.com/pytorch/ao/pull/1037 moved the module API and attempted to maintain BC, but it seems it missed the linear classes. This unintentionally broke some workflows. This commit adds the missing linear classes back until we are ready to fully remove this path.