### PR TITLE
ROCM binary upload

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -28,7 +28,7 @@ jobs:
       os: linux
       with-cpu: enable
       with-cuda: enable
-      with-rocm: disable
+      with-rocm: enable
 
   build:
     needs: generate-matrix


### PR DESCRIPTION
This is a job purely to test ROCM binary upload and not the ROCM test suite. For the test suite we're still waiting on NOVA workflow integration

This seems to just work and you can confirm a dry run push here https://github.com/pytorch/ao/actions/runs/11376979295/job/31650746802?pr=1099 and the for real test will be when this gets kicked off on main as a nightly job

CPU regression test is a flake