### PR TITLE
[WIP] Create build_wheels_windows.yml

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -1,0 +1,54 @@
+name: Build Windows Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: windows
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-xpu: enable
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/ao
+            pre-script: packaging/pre_build_script.sh
+            env-script: packaging/vc_env_helper.bat
+            # post-script: "python packaging/wheel/relocate.py"
+            smoke-test-script: packaging/smoke_test.py
+            package-name: torchao
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      env-script: ${{ matrix.env-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -32,6 +32,8 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       with-xpu: enable
+      with-cuda: disable
+
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - build/packaging/**
-      - .github/workflows/build_wheels_aarch64_linux.yml
+      - .github/workflows/build_wheels_windows.yml
       - setup.py
   push:
     branches:

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -2,6 +2,10 @@ name: Build Windows Wheels
 
 on:
   pull_request:
+    paths:
+      - build/packaging/**
+      - .github/workflows/build_wheels_aarch64_linux.yml
+      - setup.py
   push:
     branches:
       - nightly
@@ -11,6 +15,8 @@ on:
         # NOTE: Binary build pipelines should only get triggered on release candidate builds
         # Release candidate tags look like: v1.11.0-rc1
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  schedule:
+    - cron: '0 0 * * *'  # Runs at midnight UTC every day
   workflow_dispatch:
 
 permissions:

--- a/packaging/vc_env_helper.bat
+++ b/packaging/vc_env_helper.bat
@@ -1,0 +1,49 @@
+@echo on
+
+set VC_VERSION_LOWER=17
+set VC_VERSION_UPPER=18
+if "%VC_YEAR%" == "2019" (
+    set VC_VERSION_LOWER=16
+    set VC_VERSION_UPPER=17
+)
+if "%VC_YEAR%" == "2017" (
+    set VC_VERSION_LOWER=15
+    set VC_VERSION_UPPER=16
+)
+
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -legacy -products * -version [%VC_VERSION_LOWER%^,%VC_VERSION_UPPER%^) -property installationPath`) do (
+    if exist "%%i" if exist "%%i\VC\Auxiliary\Build\vcvarsall.bat" (
+        set "VS15INSTALLDIR=%%i"
+        set "VS15VCVARSALL=%%i\VC\Auxiliary\Build\vcvarsall.bat"
+        goto vswhere
+    )
+)
+
+:vswhere
+if "%VSDEVCMD_ARGS%" == "" (
+    call "%VS15VCVARSALL%" x64 || exit /b 1
+) else (
+    call "%VS15VCVARSALL%" x64 %VSDEVCMD_ARGS% || exit /b 1
+)
+
+@echo on
+
+if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+
+set DISTUTILS_USE_SDK=1
+
+set args=%1
+shift
+:start
+if [%1] == [] goto done
+set args=%args% %1
+shift
+goto start
+
+:done
+if "%args%" == "" (
+    echo Usage: vc_env_helper.bat [command] [args]
+    echo e.g. vc_env_helper.bat cl /c test.cpp
+)
+
+%args% || exit /b 1

--- a/packaging/vc_env_helper.bat
+++ b/packaging/vc_env_helper.bat
@@ -24,6 +24,12 @@ if "%VSDEVCMD_ARGS%" == "" (
 
 if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
+REM Check CUDA version and skip build if it's 11.8
+if "%CUDA_VERSION%" == "11.8" (
+    echo Skipping build for CUDA 11.8
+    exit /b 0
+)
+
 REM Set TORCH_CUDA_ARCH_LIST
 set TORCH_CUDA_ARCH_LIST=8.0;8.6
 if "%CU_VERSION%" == "cu124" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;9.0

--- a/packaging/vc_env_helper.bat
+++ b/packaging/vc_env_helper.bat
@@ -2,14 +2,8 @@
 
 set VC_VERSION_LOWER=17
 set VC_VERSION_UPPER=18
-if "%VC_YEAR%" == "2019" (
-    set VC_VERSION_LOWER=16
-    set VC_VERSION_UPPER=17
-)
-if "%VC_YEAR%" == "2017" (
-    set VC_VERSION_LOWER=15
-    set VC_VERSION_UPPER=16
-)
+if "%VC_YEAR%" == "2019" ( set VC_VERSION_LOWER=16 set VC_VERSION_UPPER=17)
+if "%VC_YEAR%" == "2017" ( set VC_VERSION_LOWER=15 set VC_VERSION_UPPER=16)
 
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -legacy -products * -version [%VC_VERSION_LOWER%^,%VC_VERSION_UPPER%^) -property installationPath`) do (
     if exist "%%i" if exist "%%i\VC\Auxiliary\Build\vcvarsall.bat" (
@@ -29,6 +23,10 @@ if "%VSDEVCMD_ARGS%" == "" (
 @echo on
 
 if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+
+REM Set TORCH_CUDA_ARCH_LIST
+set TORCH_CUDA_ARCH_LIST=8.0;8.6
+if "%CU_VERSION%" == "cu124" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;9.0
 
 set DISTUTILS_USE_SDK=1
 

--- a/packaging/vc_env_helper.bat
+++ b/packaging/vc_env_helper.bat
@@ -24,16 +24,6 @@ if "%VSDEVCMD_ARGS%" == "" (
 
 if "%CU_VERSION%" == "xpu" call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 
-REM Check CUDA version and skip build if it's 11.8
-if "%CUDA_VERSION%" == "11.8" (
-    echo Skipping build for CUDA 11.8
-    exit /b 0
-)
-
-REM Set TORCH_CUDA_ARCH_LIST
-set TORCH_CUDA_ARCH_LIST=8.0;8.6
-if "%CU_VERSION%" == "cu124" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;9.0
-
 set DISTUTILS_USE_SDK=1
 
 set args=%1


### PR DESCRIPTION
Mostly copied from the torchvision workflows, upload working fine, need to test for real and will validate on my PC

Seems like it's working fine although I'm having issues building custom cuda extensions on Windows for cuda 11.8 only
* FAILED: C:/actions-runner/_work/ao/ao/pytorch/ao/build/temp.win-amd64-cpython-39/Release/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.obj 
* FAILED: C:/actions-runner/_work/ao/ao/pytorch/ao/build/temp.win-amd64-cpython-39/Release/torchao/csrc/cuda/tensor_core_tiled_layout/tensor_core_tiled_layout.obj 
* FAILED: C:/actions-runner/_work/ao/ao/pytorch/ao/build/temp.win-amd64-cpython-39/Release/torchao/csrc/cuda/fp6_llm/fp6_linear.obj 

So I tried to instead skip cuda 11.8 builds by adding the below, unfortunately the nova builds don't allow me to configure a specific cuda version but i suspect the below will just make build success but upload fail 

```bat
REM Check CUDA version and skip build if it's 11.8
if "%CUDA_VERSION%" == "11.8" (
    echo Skipping build for CUDA 11.8
    exit /b 0
)

REM Set TORCH_CUDA_ARCH_LIST
set TORCH_CUDA_ARCH_LIST=8.0;8.6
if "%CU_VERSION%" == "cu124" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;9.0
````

EDIT: Well considering cuda extensions arent build anywhere on windows and triton windows support is still experimental it seems fine as a stop gap to only publish windows cpu binaries for now