### PR TITLE
[AFQ] Optimize tensor_flatten for runtime

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -232,7 +232,11 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         raise QuantizedLinearNotImplementedError("No specialized dispatch found for quantized linear op")
 
     def __tensor_flatten__(self):
-        return ["tensor_impl"], [self.block_size, self.shape, self.quant_min, self.quant_max, self.zero_point_domain, self.dtype]
+        # This is used in rumtime to unwrap AffineQuantizedTensor activations.
+        # AffineQuantizedTensor has __torch_function__ override:
+        # Each getattr will go through it, which is up to 10x slower than default attribute access.
+        with torch._C.DisableTorchFunctionSubclass():
+            return ["tensor_impl"], [self.block_size, self.shape, self.quant_min, self.quant_max, self.zero_point_domain, self.dtype]
 
     @classmethod
     def __tensor_unflatten__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1114


__tensor_flatten__ is called at runtime when inputs are subclasses e.g. AffineQuantizedTensor

In case of using `float8_dynamic_activation_float8_weight` quantization, the activations will also be AQT.

There was external complain, that unwrap_tensor_subclasses sometimes exceeds in duration that compiled region execution.

Profiling shows that tensor_flatten attribute access will go through torch_function handling (AQT has it).
If to remove this torch_function dispatch for each getattr at runtime - tensor_flatten becomes (in my measurements x9 faster)

<img width="1608" alt="Screenshot 2024-10-18 at 14 31 33" src="https://github.com/user-attachments/assets/c6e1ac40-b1b1-4f1e-b083-3645eaeb8c08">



