### PR TITLE
Move bias from kernel to packed_weights

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/benchmarks/benchmark_linear.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/benchmarks/benchmark_linear.cpp
@@ -43,15 +43,17 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot(
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      test_case.weight_zeros.data());
+      test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * k);
   for (auto _ : state) {
@@ -64,7 +66,6 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot(
         group_size,
         weight_data.data(),
         activation_data.data(),
-        test_case.bias.data(),
         test_case.clamp_min,
         test_case.clamp_max);
   }
@@ -103,15 +104,17 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot(
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      test_case.weight_zeros.data());
+      test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * k);
   for (auto _ : state) {
@@ -124,7 +127,6 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot(
         group_size,
         weight_data.data(),
         activation_data.data(),
-        test_case.bias.data(),
         test_case.clamp_min,
         test_case.clamp_max);
   }
@@ -163,15 +165,17 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot(
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      test_case.weight_zeros.data());
+      test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * k);
   for (auto _ : state) {
@@ -184,7 +188,6 @@ channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot(
         group_size,
         weight_data.data(),
         activation_data.data(),
-        test_case.bias.data(),
         test_case.clamp_min,
         test_case.clamp_max);
   }

--- a/torchao/experimental/kernels/cpu/aarch64/linear/linear.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/linear.h
@@ -28,10 +28,10 @@ void prepare_activation_data(
     int group_size,
     const float* activations);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 size_t weight_data_size(int n, int k, int group_size);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 void prepare_weight_data(
     void* weight_data,
     // Inputs
@@ -40,7 +40,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros);
+    const int8_t* weight_zeros,
+    const float* bias);
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
 void kernel(
@@ -54,8 +55,6 @@ void kernel(
     int group_size,
     const void* weight_data,
     const void* activation_data,
-    // Not applied if nullptr
-    const float* bias,
     // Ignored if has_clamp = false
     float clamp_min,
     float clamp_max);
@@ -78,10 +77,10 @@ void prepare_activation_data(
     int group_size,
     const float* activations);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 size_t weight_data_size(int n, int k, int group_size);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 void prepare_weight_data(
     void* weight_data,
     // Inputs
@@ -90,7 +89,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros);
+    const int8_t* weight_zeros,
+    const float* bias);
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
 void kernel(
@@ -104,8 +104,6 @@ void kernel(
     int group_size,
     const void* weight_data,
     const void* activation_data,
-    // Not applied if nullptr
-    const float* bias,
     // Ignored if has_clamp = false
     float clamp_min,
     float clamp_max);
@@ -128,10 +126,10 @@ void prepare_activation_data(
     int group_size,
     const float* activations);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 size_t weight_data_size(int n, int k, int group_size);
 
-template <int weight_nbit, bool has_weight_zeros>
+template <int weight_nbit, bool has_weight_zeros, bool has_bias>
 void prepare_weight_data(
     void* weight_data,
     // Inputs
@@ -140,7 +138,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros);
+    const int8_t* weight_zeros,
+    const float* bias);
 
 template <int weight_nbit, bool has_weight_zeros, bool has_bias, bool has_clamp>
 void kernel(
@@ -154,8 +153,6 @@ void kernel(
     int group_size,
     const void* weight_data,
     const void* activation_data,
-    // Not applied if nullptr
-    const float* bias,
     // Ignored if has_clamp = false
     float clamp_min,
     float clamp_max);

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
@@ -51,15 +51,17 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      /*weight_zeros=*/test_case.weight_zeros.data());
+      /*weight_zeros=*/test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
@@ -71,7 +73,6 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x1x32_f32_neondot
       group_size,
       weight_data.data(),
       activation_data.data(),
-      /*bias=*/test_case.bias.data(),
       /*clamp_min=*/test_case.clamp_min,
       /*clamp_max=*/test_case.clamp_max);
 
@@ -154,15 +155,17 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      /*weight_zeros=*/test_case.weight_zeros.data());
+      /*weight_zeros=*/test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
@@ -174,7 +177,6 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot
       group_size,
       weight_data.data(),
       activation_data.data(),
-      /*bias=*/test_case.bias.data(),
       /*clamp_min=*/test_case.clamp_min,
       /*clamp_max=*/test_case.clamp_max);
 
@@ -270,15 +272,17 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot
       test_case.activations.data());
 
   std::vector<char> weight_data(
-      weight_data_size<weight_nbit, has_weight_zeros>(n, k, group_size));
-  prepare_weight_data<weight_nbit, has_weight_zeros>(
+      weight_data_size<weight_nbit, has_weight_zeros, has_bias>(
+          n, k, group_size));
+  prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>(
       (void*)weight_data.data(),
       n,
       k,
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      /*weight_zeros=*/test_case.weight_zeros.data());
+      /*weight_zeros=*/test_case.weight_zeros.data(),
+      test_case.bias.data());
 
   std::vector<float> output(m * n);
   kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>(
@@ -290,7 +294,6 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot
       group_size,
       weight_data.data(),
       activation_data.data(),
-      /*bias=*/test_case.bias.data(),
       /*clamp_min=*/test_case.clamp_min,
       /*clamp_max=*/test_case.clamp_max);
 
@@ -370,7 +373,7 @@ void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod(
           n,
           group_size,
           /*weight_nbit=*/4,
-          /*has_weight_zeros*/false,
+          /*has_weight_zeros*/ false,
           has_bias,
           has_clamp,
           /*weight_scale_bf16_round_trip=*/true);
@@ -470,7 +473,6 @@ TEST(
       true /*has_clamp*/>(
       /*m=*/11, /*k=*/128, /*n=*/182, /*group_size=*/128);
 }
-
 
 template <bool has_bias, bool has_clamp>
 void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod(

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h
@@ -161,7 +161,7 @@ struct channelwise_8bit_activation_groupwise_lowbit_weight_test_case {
     assert(weight_qvals.size() == n * k);
     assert((weight_group_size * weight_scales.size()) == (n * k));
     assert((weight_group_size * weight_zeros.size()) == (n * k));
-    assert(bias.size() == m);
+    assert(bias.size() == n);
 
     if (has_clamp) {
       assert(clamp_min < clamp_max);
@@ -258,9 +258,9 @@ struct channelwise_8bit_activation_groupwise_lowbit_weight_test_case {
           qmax);
     }
 
-    std::vector<float> bias(m, 0.0);
+    std::vector<float> bias(n, 0.0);
     if (has_bias) {
-      bias = get_random_vector(m, -1.0, 1.0);
+      bias = get_random_vector(n, -1.0, 1.0);
     }
 
     float clamp_min = 0.0;
@@ -289,7 +289,7 @@ struct channelwise_8bit_activation_groupwise_lowbit_weight_test_case {
 
           res += activation_dequant * weight_dequant;
         }
-        res += bias[m_idx];
+        res += bias[n_idx];
         if (has_clamp) {
           res = std::min(std::max(res, clamp_min), clamp_max);
         }

--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
@@ -5,8 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <stdint.h>
-#include <torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h>
 #include <torchao/experimental/ops/library.h>
+#include <torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h>
 #include <torchao/experimental/ops/parallel.h>
 #include <algorithm>
 #include <cassert>
@@ -50,7 +50,8 @@ void pack_weight_data_operator(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros) {
+    const int8_t* weight_zeros,
+    const float* bias) {
   TORCHAO_CHECK(group_size % 16 == 0, "group_size must be a multiple of 16");
   TORCHAO_CHECK(k % group_size == 0, "group_size must divide k");
 
@@ -67,6 +68,7 @@ void pack_weight_data_operator(
         (n_idx / nr) * ukernel_config.weight_data_size_fn(nr, k, group_size);
     int weight_qvals_offset = n_idx * k;
     int weight_scales_and_zeros_offset = (n_idx * k / group_size);
+    int bias_offset = n_idx;
 
     ukernel_config.prepare_weight_data_fn(
         (char*)weight_data + weight_data_offset,
@@ -75,7 +77,8 @@ void pack_weight_data_operator(
         group_size,
         weight_qvals + weight_qvals_offset,
         weight_scales + weight_scales_and_zeros_offset,
-        weight_zeros + weight_scales_and_zeros_offset);
+        weight_zeros + weight_scales_and_zeros_offset,
+        bias + bias_offset);
   });
 }
 
@@ -151,9 +154,6 @@ inline void linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
     int group_size,
     const void* weight_data,
     const float* activations,
-    // const void* activation_data,
-    // Not applied if nullptr
-    const float* bias,
     // Ignored if has_clamp = false
     float clamp_min,
     float clamp_max) {
@@ -162,7 +162,8 @@ inline void linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
   int nc = std::min(n, tiling_params.nc_by_nr * ukernel_config.nr);
   int num_mc_panels = (m + mc - 1) / mc;
   int num_nc_panels = (n + nc - 1) / nc;
-  size_t weight_data_size = ukernel_config.weight_data_size_fn(nr, k, group_size);
+  size_t weight_data_size =
+      ukernel_config.weight_data_size_fn(nr, k, group_size);
 
   for (int mc_tile_idx = 0; mc_tile_idx < num_mc_panels; mc_tile_idx++) {
     int m_idx = mc_tile_idx * mc;
@@ -182,7 +183,6 @@ inline void linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
 
       int output_offset = m_idx * n + n_idx;
       int weight_data_offset = (n_idx / nr) * weight_data_size;
-      int bias_offset = m_idx;
 
       ukernel_config.kernel_fn(
           output + output_offset,
@@ -193,7 +193,6 @@ inline void linear_operator_with_tile_schedule_policy_single_mc_parallel_nc(
           group_size,
           /*weight_data=*/(char*)weight_data + weight_data_offset,
           /*activation_data=*/activation_data_buffer,
-          /*bias=*/bias + bias_offset,
           clamp_min,
           clamp_max);
     });
@@ -213,7 +212,6 @@ inline void linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
     int group_size,
     const void* weight_data,
     const float* activations,
-    const float* bias,
     float clamp_min,
     float clamp_max) {
   int mr = ukernel_config.mr;
@@ -223,7 +221,8 @@ inline void linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
   int num_mc_panels = (m + mc - 1) / mc;
   int num_nc_panels = (n + nc - 1) / nc;
 
-  size_t weight_data_size = ukernel_config.weight_data_size_fn(nr, k, group_size);
+  size_t weight_data_size =
+      ukernel_config.weight_data_size_fn(nr, k, group_size);
   size_t activation_data_size =
       ukernel_config.activation_data_size_fn(mr, k, group_size);
 
@@ -254,7 +253,6 @@ inline void linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
     int activation_data_offset = (m_idx / mr) * activation_data_size;
     int output_offset = m_idx * n + n_idx;
     int weight_data_offset = (n_idx / nr) * weight_data_size;
-    int bias_offset = m_idx;
 
     ukernel_config.kernel_fn(
         output + output_offset,
@@ -265,7 +263,6 @@ inline void linear_operator_with_tile_schedule_policy_parallel_mc_parallel_nc(
         group_size,
         /*weight_data=*/(char*)weight_data + weight_data_offset,
         /*activation_data=*/activation_data_buffer + activation_data_offset,
-        /*bias=*/bias + bias_offset,
         clamp_min,
         clamp_max);
   });
@@ -286,8 +283,6 @@ void linear_operator(
     int group_size,
     const void* weight_data,
     const float* activations,
-    // Not applied if nullptr
-    const float* bias,
     // Ignored if has_clamp = false
     float clamp_min,
     float clamp_max) {
@@ -306,7 +301,6 @@ void linear_operator(
           group_size,
           weight_data,
           activations,
-          bias,
           clamp_min,
           clamp_max);
       break;
@@ -323,7 +317,6 @@ void linear_operator(
               group_size,
               weight_data,
               activations,
-              bias,
               clamp_min,
               clamp_max);
       break;

--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
@@ -27,7 +27,8 @@ struct UKernelConfig {
       int group_size,
       const int8_t* weight_qvals,
       const float* weight_scales,
-      const int8_t* weight_zeros);
+      const int8_t* weight_zeros,
+      const float* bias);
   using kernel_fn_type = void (*)(
       float* output,
       int output_m_stride,
@@ -37,7 +38,6 @@ struct UKernelConfig {
       int group_size,
       const void* weight_data,
       const void* activation_data,
-      const float* bias,
       float clamp_min,
       float clamp_max);
 
@@ -98,7 +98,8 @@ void pack_weight_data_operator(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros);
+    const int8_t* weight_zeros,
+    const float* bias);
 
 // Linear functions
 struct LinearTilingParams {
@@ -144,7 +145,6 @@ void linear_operator(
     int group_size,
     const void* weight_data,
     const float* activations,
-    const float* bias,
     float clamp_min,
     float clamp_max);
 

--- a/torchao/experimental/ops/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/experimental/ops/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -30,10 +30,10 @@ UKernelConfig get_ukernel_config() {
   config.prepare_activation_data_fn =
       &ukernel::prepare_activation_data<has_weight_zeros>;
   config.weight_data_size_fn =
-      &ukernel::weight_data_size<weight_nbit, has_weight_zeros>;
+      &ukernel::weight_data_size<weight_nbit, has_weight_zeros, has_bias>;
   config.preferred_weight_data_alignment = 16; // size of neon register
   config.prepare_weight_data_fn =
-      &ukernel::prepare_weight_data<weight_nbit, has_weight_zeros>;
+      &ukernel::prepare_weight_data<weight_nbit, has_weight_zeros, has_bias>;
   config.kernel_fn =
       &ukernel::kernel<weight_nbit, has_weight_zeros, has_bias, has_clamp>;
 
@@ -84,7 +84,8 @@ void test_linear_8bit_act_xbit_weight(int m, int n, int k, int group_size) {
           group_size,
           test_case.weight_qvals.data(),
           test_case.weight_scales.data(),
-          test_case.weight_zeros.data());
+          test_case.weight_zeros.data(),
+          test_case.bias.data());
 
       // Allocate activation buffer
       auto linear_tiling_params =
@@ -115,7 +116,6 @@ void test_linear_8bit_act_xbit_weight(int m, int n, int k, int group_size) {
           group_size,
           packed_weight_data.get(),
           test_case.activations.data(),
-          test_case.bias.data(),
           test_case.clamp_min,
           test_case.clamp_max);
 
@@ -195,7 +195,8 @@ TEST(test_linear_8bit_act_xbit_weight, KNotDivisibleByGroupSize) {
             group_size,
             /*weight_qvals=*/nullptr,
             /*weight_scales=*/nullptr,
-            /*weight_zeros=*/nullptr);
+            /*weight_zeros=*/nullptr,
+            /*bias=*/nullptr);
       },
       std::runtime_error);
 }
@@ -224,7 +225,8 @@ TEST(test_linear_8bit_act_xbit_weight, GroupSizeNotDivisibleBy16) {
             group_size,
             /*weight_qvals=*/nullptr,
             /*weight_scales=*/nullptr,
-            /*weight_zeros=*/nullptr);
+            /*weight_zeros=*/nullptr,
+            /*bias=*/nullptr);
       },
       std::runtime_error);
 }


### PR DESCRIPTION
Summary: Moves bias term from kernel to prepare_weight_data.  This better aligns with KleidiAI.  (Note, the currently registered ops do not use bias, but the kernels do support bias).

Reviewed By: digantdesai

Differential Revision: D64499096


