### PR TITLE
fixed `weights_only=True` load for `float8_dynamic_activation_float8_weight` in quant_api

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -196,10 +196,6 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
 
         # Load the state dict from the buffer
         weights_only_load = True
-        if mode == "dynamic":
-            # TODO will fix in followup
-            weights_only_load = False
-
         loaded_state_dict = torch.load(buffer, weights_only=weights_only_load)
 
         # Create a new model and load the state dict

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -26,6 +26,8 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         on top of it
       `input_quant_func` (Callable[[torch.Tensor], torch.Tensor]): a function that takes a high precision floating point tensor and returns
         a quantized tensor, this is used to quantize input
+      `quant_kwargs` (Dict[str, Any]): Additional keyword arguments for the quantization function.
+        Restriction: Must not contain tensor values.
     """
     quant_kwargs: Dict[str, Any]
     

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Optional
 from torch.utils._python_dispatch import return_and_correct_aliasing
 from torchao.utils import (
     TorchAOBaseTensor,
@@ -72,7 +72,7 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         )
 
     @staticmethod
-    def _quantized_linear_op(input_tensor, weight_tensor, bias):
+    def _quantized_linear_op(input_tensor: torch.Tensor, weight_tensor: torch.Tensor, bias: torch.Tensor):
         input_quant_func = weight_tensor.input_quant_func
         original_weight_tensor = weight_tensor.original_weight_tensor
         quant_kwargs = weight_tensor.quant_kwargs
@@ -80,7 +80,10 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         return torch.nn.functional.linear(aqt, original_weight_tensor, bias)
 
     @classmethod
-    def from_float(cls, input_float, input_quant_func, quant_kwargs):
+    def from_float(cls, 
+                   input_float: torch.Tensor, 
+                   input_quant_func: Callable, 
+                   quant_kwargs: Optional[Dict[str, Any]] = None):
         if quant_kwargs is None:
             quant_kwargs = {}
         return cls(input_float, input_quant_func, quant_kwargs)

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Callable
+from typing import Callable, Dict, Any
 from torch.utils._python_dispatch import return_and_correct_aliasing
 from torchao.utils import (
     TorchAOBaseTensor,
@@ -27,10 +27,13 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
       `input_quant_func` (Callable[[torch.Tensor], torch.Tensor]): a function that takes a high precision floating point tensor and returns
         a quantized tensor, this is used to quantize input
     """
+    quant_kwargs: Dict[str, Any]
+    
     def __new__(
         cls,
         original_weight_tensor: torch.Tensor,
         input_quant_func: Callable,
+        quant_kwargs: Dict[str, Any]
     ):
         kwargs = {}
         dtype = original_weight_tensor.dtype
@@ -44,42 +47,49 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         self,
         original_weight_tensor: torch.Tensor,
         input_quant_func: Callable[[torch.Tensor], torch.Tensor],
+        quant_kwargs: Dict[str, Any],
     ):
         self.original_weight_tensor = original_weight_tensor
         self.input_quant_func = input_quant_func
+        self.quant_kwargs = quant_kwargs
 
     def __repr__(self):
-        return f"LinearActivationQuantizedTensor({self.original_weight_tensor}, {self.input_quant_func})"
+        return f"LinearActivationQuantizedTensor({self.original_weight_tensor}, {self.input_quant_func}, quant_kwargs={self.quant_kwargs}))"
 
     def __tensor_flatten__(self):
-        return ["original_weight_tensor"], [self.input_quant_func]
+        return ["original_weight_tensor"], [self.input_quant_func, self.quant_kwargs]
 
     @classmethod
     def __tensor_unflatten__(
         cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
     ):
         original_weight_tensor = tensor_data_dict["original_weight_tensor"]
-        input_quant_func, = tensor_attributes
+        input_quant_func, quant_kwargs = tensor_attributes
         return cls(
             original_weight_tensor,
             input_quant_func,
+            quant_kwargs
         )
 
     @staticmethod
     def _quantized_linear_op(input_tensor, weight_tensor, bias):
         input_quant_func = weight_tensor.input_quant_func
         original_weight_tensor = weight_tensor.original_weight_tensor
-        aqt = input_quant_func(input_tensor)
+        quant_kwargs = weight_tensor.quant_kwargs
+        aqt = input_quant_func(input_tensor, **quant_kwargs)
         return torch.nn.functional.linear(aqt, original_weight_tensor, bias)
 
     @classmethod
-    def from_float(cls, input_float, input_quant_func):
-        return cls(input_float, input_quant_func)
+    def from_float(cls, input_float, input_quant_func, quant_kwargs):
+        if quant_kwargs is None:
+            quant_kwargs = {}
+        return cls(input_float, input_quant_func, quant_kwargs)
 
     def _apply_fn_to_data(self, fn):
         return self.__class__(
             fn(self.original_weight_tensor),
             self.input_quant_func,
+            self.quant_kwargs,
         )
 
     def to(self, *args, **kwargs):
@@ -87,6 +97,7 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         return self.__class__(
             self.original_weight_tensor.to(**kwargs),
             self.input_quant_func,
+            self.quant_kwargs,
         )
 
 implements = LinearActivationQuantizedTensor.implements

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -768,14 +768,16 @@ def float8_dynamic_activation_float8_weight(
             _layout=Float8Layout(mm_config=mm_config),
         )
 
-        input_quant_func = partial(
-            _input_activation_quant_func_fp8,
-            activation_granularity=activation_granularity,
-            activation_dtype=activation_dtype,
-        )
+        input_quant_func = _input_activation_quant_func_fp8
+        input_quant_kwargs = {
+            "activation_granularity": activation_granularity,
+            "activation_dtype": activation_dtype,
+        }
 
         quantized_weight = to_linear_activation_quantized(
-            quantized_weight, input_quant_func
+            quantized_weight, 
+            input_quant_func,
+            quant_kwargs=input_quant_kwargs
         )
         return quantized_weight
 


### PR DESCRIPTION
Fixes #1118
Changes made:
1. Modified the `float8_dynamic_activation_float8_weight` function to have a flow like `float8_static_activation_float8_weight` inside the `quant_api.py` as suggested by @drisspg.
2. Added `quant_kwargs` in `linear_activation_quantized_tensor.py` so that they can be serialized using `torch.save` instead of unsafe serialization of partially initialized `input_quant_func`.