### PR TITLE
Add BF16 stochastic rounding option for optimizers

### DIFF
--- a/benchmarks/quantized_training/pretrain_llama2.py
+++ b/benchmarks/quantized_training/pretrain_llama2.py
@@ -11,6 +11,7 @@ import os
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 import argparse
+import json
 import time
 from functools import partial
 from pathlib import Path
@@ -108,6 +109,7 @@ if __name__ == "__main__":
     parser.add_argument("--optim", default="AdamW")
     parser.add_argument("--lr", type=float, default=3e-4)
     parser.add_argument("--weight_decay", type=float, default=1e-2)
+    parser.add_argument("--optim_kwargs", type=json.loads, default=dict())
 
     parser.add_argument("--project", default="quantized_training")
     parser.add_argument("--run_name")
@@ -171,7 +173,12 @@ if __name__ == "__main__":
     # only use optimizers from torchao.prototype.low_bit_optim to support quantized training
     if args.optim == "AdamW":
         args.optim = "_AdamW"
-    optim = getattr(low_bit_optim, args.optim)(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    optim = getattr(low_bit_optim, args.optim)(
+        model.parameters(),
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        **args.optim_kwargs,
+    )
 
     data = get_tinystories().cuda()
     args.torch_version = torch.__version__

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -14,8 +14,12 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torchao.prototype import low_bit_optim
-from torchao.prototype.low_bit_optim.quant_utils import quantize_8bit_with_qmap, quantize_4bit_with_qmap
-from torchao.utils import TORCH_VERSION_AT_LEAST_2_3, TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_5
+from torchao.prototype.low_bit_optim.quant_utils import (
+    quantize_8bit_with_qmap,
+    quantize_4bit_with_qmap,
+    _fp32_to_bf16_sr,
+)
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_3, TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_6
 
 try:
     import bitsandbytes as bnb
@@ -73,6 +77,22 @@ class TestQuantize(TestCase):
         expected = quantize_4bit_with_qmap(x, qmap)
 
         torch.testing.assert_close(actual, expected)
+
+    @parametrize("device", _DEVICES)
+    @parametrize("compile", [False, True])
+    def test_bf16_stochastic_round(self, device, compile):
+        x = torch.rand(32, device=device) * 100
+        x_rep = x.view(-1, 1).repeat(1, 100_000)
+
+        if compile:
+            x_rep_bf16 = torch.compile(_fp32_to_bf16_sr, fullgraph=True, dynamic=False)(x_rep)
+        else:
+            x_rep_bf16 = _fp32_to_bf16_sr(x_rep)
+
+        assert x_rep_bf16.dtype is torch.bfloat16
+
+        # must cast BF16 tensor back to FP32 so that .mean() is accurate
+        torch.testing.assert_close(x_rep_bf16.float().mean(1), x, atol=3e-5, rtol=3e-5)
 
 
 class TestOptim(TestCase):
@@ -249,13 +269,44 @@ class TestOptim(TestCase):
         for p1, p2 in zip(model1.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1)
 
+    def test_optim_bf16_stochastic_round_correctness(self):
+        device = "cuda"
+        torch.manual_seed(2024)
+        model1 = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
+        model2 = copy.deepcopy(model1).bfloat16()
+
+        # small LR so that weight update is small
+        # when bf16_stochastic_round=False, the test will fail after 1 iteration
+        optim1 = torch.optim.AdamW(model1.parameters(), lr=1e-5, fused=True)
+        optim2 = low_bit_optim._AdamW(model2.parameters(), lr=1e-5, bf16_stochastic_round=True)
+
+        # overfit on this sample
+        x = torch.randn(4, 32, device=device)
+
+        for idx in range(5):
+            # mixed-precision training
+            with torch.autocast(device, dtype=torch.bfloat16):
+                loss1 = model1(x)
+            loss1 = loss1.sum()  # under autocast context, bf16.sum() will return fp32
+            loss1.backward()
+            optim1.step()
+            optim1.zero_grad()
+
+            # full BF16 training with stochastic round weight update
+            loss2 = model2(x.bfloat16()).sum()
+            loss2.backward()
+            optim2.step()
+            optim2.zero_grad()
+
+            torch.testing.assert_close(loss1, loss2, msg=lambda msg: f"Iteration {idx}. {msg}")
+
 
 class TestFSDP2(FSDPTest):
     @property
     def world_size(self) -> int:
         return 2
 
-    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="OptimState8bit dispatch: attempting to run unimplemented operator/function: aten.as_strided.default")
+    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_6, reason="PyTorch>=2.6 is required.")
     @skip_if_lt_x_gpu(2)
     def test_fsdp2(self):
         optim_classes = [low_bit_optim.AdamW8bit, low_bit_optim.AdamW4bit]

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -277,7 +277,7 @@ class TestOptim(TestCase):
 
         # small LR so that weight update is small
         # when bf16_stochastic_round=False, the test will fail after 1 iteration
-        optim1 = torch.optim.AdamW(model1.parameters(), lr=1e-5, fused=True)
+        optim1 = torch.optim.AdamW(model1.parameters(), lr=1e-5)
         optim2 = low_bit_optim._AdamW(model2.parameters(), lr=1e-5, bf16_stochastic_round=True)
 
         # overfit on this sample

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -270,7 +270,7 @@ class TestOptim(TestCase):
             torch.testing.assert_close(p2, p1)
 
     def test_optim_bf16_stochastic_round_correctness(self):
-        device = "cuda"
+        device = "cuda" if torch.cuda.is_available() else "cpu"
         torch.manual_seed(2024)
         model1 = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128)).to(device)
         model2 = copy.deepcopy(model1).bfloat16()

--- a/torchao/prototype/low_bit_optim/README.md
+++ b/torchao/prototype/low_bit_optim/README.md
@@ -65,7 +65,7 @@ Note that our optimizer step calculations are always done in FP32 to ensure accu
 - In stochastic rounding, we will round up with the probability of `(x - round_down(x)) / (round_up(x) - round_down(x))`, and round down otherwise.
 - It follows that successive weight update with stochastic rounding will correctly approximate high-precision weight update.
 - Since BF16 is simply a truncation of FP32, there is an efficient implementation for FP32->BF16 stochastic rounding (the same is not true for FP32->FP16).
-- More detailed discussion can be found at https://arxiv.org/abs/2010.06192. [llm.c](https://github.com/karpathy/llm.c/blob/master/llmc/adamw.cuh#L43) also implements this approach.
+- More detailed discussion can be found at https://arxiv.org/abs/2010.06192. [llm.c](https://github.com/karpathy/llm.c/blob/7ecd8906afe6ed7a2b2cdb731c042f26d525b820/llmc/adamw.cuh#L43) also implements this approach.
 
 ```python
 # a clone of torch.optim.AdamW with extra features

--- a/torchao/prototype/low_bit_optim/README.md
+++ b/torchao/prototype/low_bit_optim/README.md
@@ -5,6 +5,7 @@ This folder implements:
 - 8-bit optimizers as outlined in https://arxiv.org/abs/2110.02861
 - 4-bit optimizers as outlined in https://arxiv.org/abs/2309.01507
 - FP8 optimizers using the native `torch.float8_e4m3fn` dtype (experimental)
+- Stochastic rounding for BF16 weight (https://arxiv.org/abs/2010.06192, experimental)
 
 The implementation is fully done in Python (with tensor subclass) and relies on `torch.compile()` to generate efficient fused kernel. Thus, your platform must support `torch.compile()` to use these optimizers. We only test on CPU and CUDA, so there might be bugs or errors on other platforms.
 
@@ -55,6 +56,27 @@ ao 8-bit         | 39.1                       | 2900   | 41.50
 ao 4-bit         | 33.2                       | 2900   | 42.27
 
 NOTE: lpmm's 4-bit AdamW does not support BF16 weights.
+
+## Stochastic rounding for BF16 weight
+
+BF16 only has around 3 decimal precision. This means that if weight update is smaller than 1e-3 of the weight magnitude, there will be no change to the weight (using nearest rounding). This is highly problematic for full BF16 training, where we don't keep an FP32 copy of model weights.
+
+Note that our optimizer step calculations are always done in FP32 to ensure accurate results. The "underflow" only happens when we copy the new weight value (in FP32) to the existing BF16 weight. To combat this problem, one way is to perform **stochastic rounding** when casting FP32->BF16.
+- In stochastic rounding, we will round up with the probability of `(x - round_down(x)) / (round_up(x) - round_down(x))`, and round down otherwise.
+- It follows that successive weight update with stochastic rounding will correctly approximate high-precision weight update.
+- Since BF16 is simply a truncation of FP32, there is an efficient implementation for FP32->BF16 stochastic rounding (the same is not true for FP32->FP16).
+- More detailed discussion can be found at https://arxiv.org/abs/2010.06192. [llm.c](https://github.com/karpathy/llm.c/blob/master/llmc/adamw.cuh#L43) also implements this approach.
+
+```python
+# a clone of torch.optim.AdamW with extra features
+from torchao.prototype.low_bit_optim import _AdamW
+
+model = ...
+model_bf16 = model.bfloat16()
+optim = _AdamW(model_bf16.parameters(), bf16_stochastic_round=True)
+```
+
+All of our low-bit optimizers mentioned above also support `bf16_stochastic_round` flag. Note that this flag only applies to BF16 weight.
 
 ## Optimizer CPU offload
 

--- a/torchao/prototype/low_bit_optim/adam.py
+++ b/torchao/prototype/low_bit_optim/adam.py
@@ -8,10 +8,13 @@ from torch.distributed._tensor import DTensor
 from .subclass_8bit import OptimState8bit
 from .subclass_4bit import OptimState4bit
 from .subclass_fp8 import OptimStateFp8
+from .quant_utils import _fp32_to_bf16_sr
 
 
 class _AdamBase(Optimizer):
-    def __init__(self, params, lr, betas, eps, weight_decay, amsgrad, *, block_size, is_adamw) -> None:
+    def __init__(
+        self, params, lr, betas, eps, weight_decay, amsgrad, *, block_size, bf16_stochastic_round, is_adamw
+    ) -> None:
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
@@ -23,6 +26,7 @@ class _AdamBase(Optimizer):
         defaults = dict(lr=torch.tensor(lr), betas=betas, eps=eps, weight_decay=weight_decay, amsgrad=amsgrad)
         super().__init__(params, defaults)
         self.block_size = block_size
+        self.bf16_stochastic_round = bf16_stochastic_round
         self.is_adamw = is_adamw
 
     def __setstate__(self, state):
@@ -102,6 +106,7 @@ class _AdamBase(Optimizer):
                         group["weight_decay"],
                         group["eps"],
                         self.is_adamw,
+                        self.bf16_stochastic_round and p.dtype is torch.bfloat16,
                     )
 
         return loss
@@ -121,14 +126,17 @@ def single_param_adam(
     beta2: float,
     weight_decay: float,
     eps: float,
-    is_adamw: bool,
+    IS_ADAMW: bool,
+    BF16_STOCHASTIC_ROUND: bool,
 ):
     # compute in FP32 for accurate calculations
     p_f32 = p.float()
     grad_f32 = grad.float()
 
-    if not is_adamw:
-        grad_f32 = grad_f32.add(p_f32, alpha=weight_decay)
+    if IS_ADAMW:
+        p_f32 = p_f32 - lr * weight_decay * p_f32
+    else:
+        grad_f32 = grad_f32 + weight_decay * p_f32
 
     bias_correction1 = 1 - beta1**step
     bias_correction2 = 1 - beta2**step
@@ -143,16 +151,16 @@ def single_param_adam(
     if max_exp_avg_sq is not None:
         max_exp_avg_sq_f32 = torch.maximum(max_exp_avg_sq.float(), exp_avg_sq_f32)
         max_exp_avg_sq.copy_(max_exp_avg_sq_f32)
-        denom = (max_exp_avg_sq_f32.sqrt() / bias_correction2.sqrt()).add_(eps)
+        denom = (max_exp_avg_sq_f32.sqrt() / bias_correction2.sqrt()) + eps
     else:
-        denom = (exp_avg_sq_f32.sqrt() / bias_correction2.sqrt()).add_(eps)
+        denom = (exp_avg_sq_f32.sqrt() / bias_correction2.sqrt()) + eps
 
-    step_size = lr / bias_correction1
-    if is_adamw:
-        # merge weight decay and param update in a single .add_() to make this work with quantized param
-        p.add_(-lr * weight_decay * p_f32 - step_size * exp_avg_f32 / denom)
+    p_f32 = p_f32 - lr * (exp_avg_f32 / bias_correction1) / denom
+
+    if BF16_STOCHASTIC_ROUND:
+        p.copy_(_fp32_to_bf16_sr(p_f32))
     else:
-        p.addcdiv_(exp_avg_f32, denom, value=-step_size)
+        p.copy_(p_f32)
 
 
 class Adam8bit(_AdamBase):
@@ -166,8 +174,19 @@ class Adam8bit(_AdamBase):
         amsgrad=False,
         *,
         block_size=256,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=False)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=False,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -185,8 +204,19 @@ class Adam4bit(_AdamBase):
         amsgrad=False,
         *,
         block_size=128,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=False)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=False,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -204,8 +234,19 @@ class AdamFp8(_AdamBase):
         amsgrad=False,
         *,
         block_size=256,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=False)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=False,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -223,8 +264,19 @@ class AdamW8bit(_AdamBase):
         amsgrad=False,
         *,
         block_size=256,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=True)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -242,8 +294,19 @@ class AdamW4bit(_AdamBase):
         amsgrad=False,
         *,
         block_size=128,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=True)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -261,8 +324,19 @@ class AdamWFp8(_AdamBase):
         amsgrad=False,
         *,
         block_size=256,
+        bf16_stochastic_round=False,
     ) -> None:
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=block_size, is_adamw=True)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
 
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
@@ -278,7 +352,19 @@ class _AdamW(_AdamBase):
         eps=1e-8,
         weight_decay=1e-2,
         amsgrad=False,
+        *,
+        bf16_stochastic_round=False,
     ) -> None:
         """AdamW optimizer that supports quantized training (parameter is quantized). This optimizer should
         only be used with torchao's quantized training."""
-        super().__init__(params, lr, betas, eps, weight_decay, amsgrad, block_size=float("inf"), is_adamw=True)
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=float("inf"),
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )


### PR DESCRIPTION
## Stochastic rounding for BF16 weight

BF16 only has around 3 decimal precision. This means that if weight update is smaller than 1e-3 of the weight magnitude, there will be no change to the weight (using nearest rounding). This is highly problematic for full BF16 training, where we don't keep an FP32 copy of model weights.

Note that our optimizer step calculations are always done in FP32 to ensure accurate results. The "underflow" only happens when we copy the new weight value (in FP32) to the existing BF16 weight. To combat this problem, one way is to perform **stochastic rounding** when casting FP32->BF16.
- In stochastic rounding, we will round up with the probability of `(x - round_down(x)) / (round_up(x) - round_down(x))`, and round down otherwise.
- It follows that successive weight update with stochastic rounding will correctly approximate high-precision weight update.
- Since BF16 is simply a truncation of FP32, there is an efficient implementation for FP32->BF16 stochastic rounding (the same is not true for FP32->FP16).
- More detailed discussion can be found at https://arxiv.org/abs/2010.06192. [llm.c](https://github.com/karpathy/llm.c/blob/master/llmc/adamw.cuh#L43) also implements this approach.

```python
# a clone of torch.optim.AdamW with extra features
from torchao.prototype.low_bit_optim import _AdamW

model = ...
model_bf16 = model.bfloat16()
optim = _AdamW(model_bf16.parameters(), bf16_stochastic_round=True)
```

All of our low-bit optimizers mentioned above also support `bf16_stochastic_round` flag. Note that this flag only applies to BF16 weight.

## Experimental results

I purposely use small LR (1e-5) to exaggerate the problem.

```bash
python benchmarks/quantized_training/pretrain_llama2.py --seed 2024 --bf16_model --compile --lr 1e-5 # full BF16
python benchmarks/quantized_training/pretrain_llama2.py --seed 2024 --bf16_model --compile --lr 1e-5 --optim_kwargs {"bf16_stochastic_round":true} # with stochastic rounding
python benchmarks/quantized_training/pretrain_llama2.py --seed 2024 --bf16_amp --compile --lr 1e-5 # BF16 AMP (FP32 weight)
```

![image](https://github.com/user-attachments/assets/1a4c7213-7b4d-4115-b458-5d23c6815e7d)

BF16 stochastic round matches BF16 amp loss curve, while having the same memory footprint and speed as full BF16 (BF16 amp is slower due to amp overhead).