### PR TITLE
Implement more efficient pack and unpack uint5

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/bitpacking/uint5.h
+++ b/torchao/experimental/kernels/cpu/aarch64/bitpacking/uint5.h
@@ -22,63 +22,45 @@ namespace internal {
 TORCHAO_ALWAYS_INLINE inline void pack_8_uint5_values(
     uint8_t* packed,
     const uint8_t* unpacked) {
-  // Given 8 unpacked uint5 values: 0abcd, 1efgh, 2ijkl, 3mnop, 4qrst, 5uvwx,
-  // 6yzAB, 7CDEF, this function packs them as:
-  //    b4: 7|6|5|4|3|2|1|0 (upper bits for all values)
-  //    b3210_0: efgh|abcd (lower 4 bits for first 2 values)
-  //    b3210_1: mnop|ijkl (lower 4 bits for second 2 values)
-  //    b3210_2: qrst|uvwx (lower 4 bits for third 2 values)
-  //    b3210_3: yzAB|CDEF (lower 4 bits for fourth 2 values)
+  // Given 8 unpacked uint5 values u0, u1, u2, u3, u4, u5, u6, u7,
+  // pack them into 5 uint8 values.
+  // All 5 bits of u0, u2, ... are stored into the lower parts of p0-p3.
+  // The lower 3 bits of u1, u3, ... are stored in the upper parts of p0-p3.
+  // The upper 2 bits of u1, u3, ... are stored in p4.
 
-  // These are stored in packed as: b2, b3210_0, b3210_1, b3210_2, b3210_3
-  //
-  // Input is 8 bytes
-  // Output is 5 * 8 bits = 5 bytes
-
-  // b4
-  packed[0] = ((unpacked[0] & 16) >> 4) | ((unpacked[1] & 16) >> 3) |
-      ((unpacked[2] & 16) >> 2) | ((unpacked[3] & 16) >> 1) |
-      ((unpacked[4] & 16)) | ((unpacked[5] & 16) << 1) |
-      ((unpacked[6] & 16) << 2) | ((unpacked[7] & 16) << 3);
-
-  // b3210_0
-  packed[1] = (unpacked[0] & 15) | ((unpacked[1] & 15) << 4);
-
-  // b3210_1
-  packed[2] = (unpacked[2] & 15) | ((unpacked[3] & 15) << 4);
-
-  // b3210_2
-  packed[3] = (unpacked[4] & 15) | ((unpacked[5] & 15) << 4);
-
-  // b3210_3
-  packed[4] = (unpacked[6] & 15) | ((unpacked[7] & 15) << 4);
+  packed[0] = unpacked[0] | (unpacked[1] << 5);
+  packed[1] = unpacked[2] | (unpacked[3] << 5);
+  packed[2] = unpacked[4] | (unpacked[5] << 5);
+  packed[3] = unpacked[6] | (unpacked[7] << 5);
+  packed[4] = (unpacked[1] >> 3) | ((unpacked[3] >> 3) << 2) |
+      ((unpacked[5] >> 3) << 4) | ((unpacked[7] >> 3) << 6);
 }
 
 TORCHAO_ALWAYS_INLINE inline void unpack_8_uint5_values(
     uint8_t* unpacked,
     const uint8_t* packed) {
-  // Unpacks data packed by pack_8_uint5_values
-  //
-  // Input is 40 bits = 5 bytes
-  // Output is 8 bytes
+  // Given 5 packed uint8 values p0, p1, p2, p3, p4, packed by
+  // pack_8_uint5_values, unpack them into 8 unpacked uint5 values u0, u1,
+  // u2, u3, u4, u5, u6, u7.
+  // All 5 bits of u0, u2, ... can be restored by extracting the lower 5 bits of
+  // p0-p3. The lower 3 bits of u1, u3, ... can be restored by extracting the
+  // upper 3 bits of p0-p3. The upper 2 bits of u1, u3, ... can be extracted
+  // from p4.
 
-  uint8_t b4 = packed[0];
-  uint8_t b3210_0 = packed[1];
-  uint8_t b3210_1 = packed[2];
-  uint8_t b3210_2 = packed[3];
-  uint8_t b3210_3 = packed[4];
+  uint8_t p0 = packed[0];
+  uint8_t p1 = packed[1];
+  uint8_t p2 = packed[2];
+  uint8_t p3 = packed[3];
+  uint8_t p4 = packed[4];
 
-  unpacked[0] = ((b4 & 1) << 4) | (b3210_0 & 15);
-  unpacked[1] = ((b4 & 2) << 3) | (b3210_0 >> 4);
-
-  unpacked[2] = ((b4 & 4) << 2) | (b3210_1 & 15);
-  unpacked[3] = ((b4 & 8) << 1) | (b3210_1 >> 4);
-
-  unpacked[4] = (b4 & 16) | (b3210_2 & 15);
-  unpacked[5] = ((b4 & 32) >> 1) | (b3210_2 >> 4);
-
-  unpacked[6] = ((b4 & 64) >> 2) | (b3210_3 & 15);
-  unpacked[7] = ((b4 & 128) >> 3) | (b3210_3 >> 4);
+  unpacked[0] = p0 & 0b11111;
+  unpacked[1] = p0 >> 5 | ((p4 & 0b00000011) << 3);
+  unpacked[2] = p1 & 0b11111;
+  unpacked[3] = p1 >> 5 | ((p4 & 0b00001100) << 1);
+  unpacked[4] = p2 & 0b11111;
+  unpacked[5] = p2 >> 5 | ((p4 & 0b00110000) >> 1);
+  unpacked[6] = p3 & 0b11111;
+  unpacked[7] = p3 >> 5 | ((p4 & 0b11000000) >> 3);
 }
 
 TORCHAO_ALWAYS_INLINE inline void vec_pack_64_uint5_values(
@@ -87,63 +69,28 @@ TORCHAO_ALWAYS_INLINE inline void vec_pack_64_uint5_values(
     const uint8x16_t& unpacked1,
     const uint8x16_t& unpacked2,
     const uint8x16_t& unpacked3) {
-  // This function is a vectorized version of pack_8_uint5_values
-  // To understand it, please see pack_8_uint5_values first.
-  // Before each code section, there is a comment indicating the
-  // code in pack_8_uint5_values that is being vectorized
-  //
-  // Input is 64 bytes
-  // Output is 5*64= 320 bits = 40 bytes
+  // This function is an optimized version of pack_8_uint5_values,
+  // for 64 uint5 values.
 
-  uint8x8_t b4;
-  uint8x8_t mask;
+  // The first 2 * 128 bits are packed in the following way:
+  // p0 = unpacked0 | (unpacked1 << 5)
+  // p1 = unpacked2 | (unpacked3 << 5)
+  // The remaining 64 bits are packed in the following way:
+  // p2 = (unpacked1_0 >> 3) | ((unpacked1_1 >> 3) << 2) |
+  //      ((unpacke3_0 >> 3) << 4) | ((unpacked3_1 >> 3) << 6)
+  // where _0, _1 suffixes denote the low and high 64 bits, respectively.
 
-  // b4
-  //  packed[0] = ((unpacked[0] & 16) >> 4) | ((unpacked[1] & 16) >> 3) |
-  //       ((unpacked[2] & 16) >> 2) | ((unpacked[3] & 16) >> 1) |
-  //       ((unpacked[4] & 16)) | ((unpacked[5] & 16) << 1) |
-  //       ((unpacked[6] & 16) << 2) | ((unpacked[7] & 16) << 3);
-  mask = vdup_n_u8(16);
-  b4 = vshr_n_u8(vand_u8(vget_low_u8(unpacked0), mask), 4);
-  b4 = vorr_u8(b4, vshr_n_u8(vand_u8(vget_high_u8(unpacked0), mask), 3));
+  uint8x16_t p0 = vorrq_u8(unpacked0, vshlq_n_u8(unpacked1, 5));
+  uint8x16_t p1 = vorrq_u8(unpacked2, vshlq_n_u8(unpacked3, 5));
 
-  b4 = vorr_u8(b4, vshr_n_u8(vand_u8(vget_low_u8(unpacked1), mask), 2));
-  b4 = vorr_u8(b4, vshr_n_u8(vand_u8(vget_high_u8(unpacked1), mask), 1));
+  uint8x8_t p2 = vshr_n_u8(vget_low_u8(unpacked1), 3);
+  p2 = vorr_u8(p2, vshl_n_u8(vshr_n_u8(vget_high_u8(unpacked1), 3), 2));
+  p2 = vorr_u8(p2, vshl_n_u8(vshr_n_u8(vget_low_u8(unpacked3), 3), 4));
+  p2 = vorr_u8(p2, vshl_n_u8(vshr_n_u8(vget_high_u8(unpacked3), 3), 6));
 
-  b4 = vorr_u8(b4, vand_u8(vget_low_u8(unpacked2), mask));
-  b4 = vorr_u8(b4, vshl_n_u8(vand_u8(vget_high_u8(unpacked2), mask), 1));
-
-  b4 = vorr_u8(b4, vshl_n_u8(vand_u8(vget_low_u8(unpacked3), mask), 2));
-  b4 = vorr_u8(b4, vshl_n_u8(vand_u8(vget_high_u8(unpacked3), mask), 3));
-
-  vst1_u8(packed, b4);
-
-  mask = vdup_n_u8(15);
-  uint8x8_t b3210;
-
-  // b3210_0
-  // packed[1] = (unpacked[0] & 15) | ((unpacked[1] & 15) << 4);
-  b3210 = vand_u8(vget_low_u8(unpacked0), mask);
-  b3210 = vorr_u8(b3210, vshl_n_u8(vand_u8(vget_high_u8(unpacked0), mask), 4));
-  vst1_u8(packed + 8, b3210);
-
-  // b3210_1
-  // packed[2] = (unpacked[2] & 15) | ((unpacked[3] & 15) << 4);
-  b3210 = vand_u8(vget_low_u8(unpacked1), mask);
-  b3210 = vorr_u8(b3210, vshl_n_u8(vand_u8(vget_high_u8(unpacked1), mask), 4));
-  vst1_u8(packed + 16, b3210);
-
-  // b3210_2
-  // packed[3] = (unpacked[4] & 15) | ((unpacked[5] & 15) << 4);
-  b3210 = vand_u8(vget_low_u8(unpacked2), mask);
-  b3210 = vorr_u8(b3210, vshl_n_u8(vand_u8(vget_high_u8(unpacked2), mask), 4));
-  vst1_u8(packed + 24, b3210);
-
-  // b3210_3
-  //  packed[4] = (unpacked[6] & 15) | ((unpacked[7] & 15) << 4);
-  b3210 = vand_u8(vget_low_u8(unpacked3), mask);
-  b3210 = vorr_u8(b3210, vshl_n_u8(vand_u8(vget_high_u8(unpacked3), mask), 4));
-  vst1_u8(packed + 32, b3210);
+  vst1q_u8(packed, p0);
+  vst1q_u8(packed + 16, p1);
+  vst1_u8(packed + 32, p2);
 }
 
 TORCHAO_ALWAYS_INLINE inline void vec_unpack_64_uint5_values(
@@ -152,70 +99,30 @@ TORCHAO_ALWAYS_INLINE inline void vec_unpack_64_uint5_values(
     uint8x16_t& unpacked2,
     uint8x16_t& unpacked3,
     const uint8_t* packed) {
-  // Unpacks data packed by pack_64_uint5_values
-  //
-  // This function vectorizes vec_unpack_8_uint5_values
-  // To understand it, please see vec_unpack_8_uint5_values first.
-  // Before each code section, there is a comment indicating the
-  // code in vec_unpack_8_uint5_values that is being vectorized
+  // Unpacks data packed by vec_pack_64_uint5_values
 
-  // Input is 5*64 = 320 bits = 40 bytes
-  // Output is 64 bytes
+  // unpacked0 = p0 & 0b11111
+  // unpacked1_0 = p0 >> 5 | ((p2 & 0b00000011) << 3)
+  // unpacked1_1 = p0 >> 5 | ((p2 & 0b00001100) << 1)
+  // unpacked2 = p1 & 0b11111
+  // unpacked3_0 = p1 >> 5 | ((p2 & 0b00110000) >> 1)
+  // unpacked3_1 = p1 >> 5 | ((p2 & 0b11000000) >> 3)
+  // where _0, _1 suffixes denote the low and high 64 bits, respectively.
 
-  uint8x8_t b4 = vld1_u8(packed);
-  uint8x8_t b3210;
-  uint8x8_t unpacked_tmp0;
-  uint8x8_t unpacked_tmp1;
+  uint8x16_t p0 = vld1q_u8(packed);
+  uint8x16_t p1 = vld1q_u8(packed + 16);
+  uint8x8_t p2 = vld1_u8(packed + 32);
 
-  // unpacked[0] = ((b4 & 1) << 4) | (b3210_0 & 15);
-  // unpacked[1] = ((b4 & 2) << 3) | (b3210_0 >> 4);
-  b3210 = vld1_u8(packed + 8);
-
-  unpacked_tmp0 = vshl_n_u8(vand_u8(b4, vdup_n_u8(1)), 4);
-  unpacked_tmp0 = vorr_u8(unpacked_tmp0, vand_u8(b3210, vdup_n_u8(15)));
-
-  unpacked_tmp1 = vshl_n_u8(vand_u8(b4, vdup_n_u8(2)), 3);
-  unpacked_tmp1 = vorr_u8(unpacked_tmp1, vshr_n_u8(b3210, 4));
-
-  unpacked0 = vcombine_u8(unpacked_tmp0, unpacked_tmp1);
-
-  // unpacked[2] = ((b4 & 4) << 2) | (b3210_1 & 15);
-  // unpacked[3] = ((b4 & 8) << 1) | (b3210_1 >> 4);
-  b3210 = vld1_u8(packed + 16);
-
-  unpacked_tmp0 = vshl_n_u8(vand_u8(b4, vdup_n_u8(4)), 2);
-  unpacked_tmp0 = vorr_u8(unpacked_tmp0, vand_u8(b3210, vdup_n_u8(15)));
-
-  unpacked_tmp1 = vshl_n_u8(vand_u8(b4, vdup_n_u8(8)), 1);
-  unpacked_tmp1 = vorr_u8(unpacked_tmp1, vshr_n_u8(b3210, 4));
-
-  unpacked1 = vcombine_u8(unpacked_tmp0, unpacked_tmp1);
-
-  // unpacked[4] = (b4 & 16) | (b3210_2 & 15);
-  // unpacked[5] = ((b4 & 32) >> 1) | (b3210_2 >> 4);
-
-  b3210 = vld1_u8(packed + 24);
-
-  unpacked_tmp0 = vand_u8(b4, vdup_n_u8(16));
-  unpacked_tmp0 = vorr_u8(unpacked_tmp0, vand_u8(b3210, vdup_n_u8(15)));
-
-  unpacked_tmp1 = vshr_n_u8(vand_u8(b4, vdup_n_u8(32)), 1);
-  unpacked_tmp1 = vorr_u8(unpacked_tmp1, vshr_n_u8(b3210, 4));
-
-  unpacked2 = vcombine_u8(unpacked_tmp0, unpacked_tmp1);
-
-  // unpacked[6] = ((b4 & 64) >> 2) | (b3210_3 & 15);
-  // unpacked[7] = ((b4 & 128) >> 3) | (b3210_3 >> 4);
-
-  b3210 = vld1_u8(packed + 32);
-
-  unpacked_tmp0 = vshr_n_u8(vand_u8(b4, vdup_n_u8(64)), 2);
-  unpacked_tmp0 = vorr_u8(unpacked_tmp0, vand_u8(b3210, vdup_n_u8(15)));
-
-  unpacked_tmp1 = vshr_n_u8(vand_u8(b4, vdup_n_u8(128)), 3);
-  unpacked_tmp1 = vorr_u8(unpacked_tmp1, vshr_n_u8(b3210, 4));
-
-  unpacked3 = vcombine_u8(unpacked_tmp0, unpacked_tmp1);
+  unpacked0 = vandq_u8(p0, vdupq_n_u8(0b11111));
+  unpacked1 = vcombine_u8(
+      vshl_n_u8(vand_u8(p2, vdup_n_u8(0b00000011)), 3),
+      vshl_n_u8(vand_u8(p2, vdup_n_u8(0b00001100)), 1));
+  unpacked1 = vorrq_u8(unpacked1, vshrq_n_u8(p0, 5));
+  unpacked2 = vandq_u8(p1, vdupq_n_u8(0b11111));
+  unpacked3 = vcombine_u8(
+      vshr_n_u8(vand_u8(p2, vdup_n_u8(0b00110000)), 1),
+      vshr_n_u8(vand_u8(p2, vdup_n_u8(0b11000000)), 3));
+  unpacked3 = vorrq_u8(unpacked3, vshrq_n_u8(p1, 5));
 }
 
 TORCHAO_ALWAYS_INLINE inline void vec_pack_128_uint5_values(
@@ -228,63 +135,33 @@ TORCHAO_ALWAYS_INLINE inline void vec_pack_128_uint5_values(
     const uint8x16_t& unpacked5,
     const uint8x16_t& unpacked6,
     const uint8x16_t& unpacked7) {
-  // This function is a vectorized version of pack_8_uint5_values
-  // To understand it, please see pack_8_uint5_values first.
-  // Before each code section, there is a comment indicating the
-  // code in pack_8_uint5_values that is being vectorized
-  //
-  // Input is 128 bytes
-  // Output is 5*128= 640 bits = 80 bytes
+  // This function is a vectorized version of pack_8_uint5_values,
+  // for 128 uint5 values.
 
-  uint8x16_t b4;
-  uint8x16_t mask;
+  // The first 4 * 128 bits are packed in the following way:
+  // p0 = unpacked0 | (unpacked1 << 5)
+  // p1 = unpacked2 | (unpacked3 << 5)
+  // p2 = unpacked4 | (unpacked5 << 5)
+  // p3 = unpacked6 | (unpacked7 << 5)
+  // The remaining 128 bits are packed in the following way:
+  // p4 = (unpacked1 >> 3) | ((unpacked3 >> 3) << 2) |
+  //      ((unpacked5 >> 3) << 4) | ((unpacked7 >> 3) << 6)
 
-  // b4
-  //  packed[0] = ((unpacked[0] & 16) >> 4) | ((unpacked[1] & 16) >> 3) |
-  //       ((unpacked[2] & 16) >> 2) | ((unpacked[3] & 16) >> 1) |
-  //       ((unpacked[4] & 16)) | ((unpacked[5] & 16) << 1) |
-  //       ((unpacked[6] & 16) << 2) | ((unpacked[7] & 16) << 3);
-  mask = vdupq_n_u8(16);
-  b4 = vshrq_n_u8(vandq_u8(unpacked0, mask), 4);
-  b4 = vorrq_u8(b4, vshrq_n_u8(vandq_u8(unpacked1, mask), 3));
+  uint8x16_t p0 = vorrq_u8(unpacked0, vshlq_n_u8(unpacked1, 5));
+  uint8x16_t p1 = vorrq_u8(unpacked2, vshlq_n_u8(unpacked3, 5));
+  uint8x16_t p2 = vorrq_u8(unpacked4, vshlq_n_u8(unpacked5, 5));
+  uint8x16_t p3 = vorrq_u8(unpacked6, vshlq_n_u8(unpacked7, 5));
 
-  b4 = vorrq_u8(b4, vshrq_n_u8(vandq_u8(unpacked2, mask), 2));
-  b4 = vorrq_u8(b4, vshrq_n_u8(vandq_u8(unpacked3, mask), 1));
+  uint8x16_t p4 = vshrq_n_u8(unpacked1, 3);
+  p4 = vorrq_u8(p4, vshlq_n_u8(vshrq_n_u8(unpacked3, 3), 2));
+  p4 = vorrq_u8(p4, vshlq_n_u8(vshrq_n_u8(unpacked5, 3), 4));
+  p4 = vorrq_u8(p4, vshlq_n_u8(vshrq_n_u8(unpacked7, 3), 6));
 
-  b4 = vorrq_u8(b4, vandq_u8(unpacked4, mask));
-  b4 = vorrq_u8(b4, vshlq_n_u8(vandq_u8(unpacked5, mask), 1));
-
-  b4 = vorrq_u8(b4, vshlq_n_u8(vandq_u8(unpacked6, mask), 2));
-  b4 = vorrq_u8(b4, vshlq_n_u8(vandq_u8(unpacked7, mask), 3));
-
-  vst1q_u8(packed, b4);
-
-  mask = vdupq_n_u8(15);
-  uint8x16_t b3210;
-
-  // b3210_0
-  // packed[1] = (unpacked[0] & 15) | ((unpacked[1] & 15) << 4);
-  b3210 = vandq_u8(unpacked0, mask);
-  b3210 = vorrq_u8(b3210, vshlq_n_u8(vandq_u8(unpacked1, mask), 4));
-  vst1q_u8(packed + 16, b3210);
-
-  // b3210_1
-  // packed[2] = (unpacked[2] & 15) | ((unpacked[3] & 15) << 4);
-  b3210 = vandq_u8(unpacked2, mask);
-  b3210 = vorrq_u8(b3210, vshlq_n_u8(vandq_u8(unpacked3, mask), 4));
-  vst1q_u8(packed + 32, b3210);
-
-  // b3210_2
-  // packed[3] = (unpacked[4] & 15) | ((unpacked[5] & 15) << 4);
-  b3210 = vandq_u8(unpacked4, mask);
-  b3210 = vorrq_u8(b3210, vshlq_n_u8(vandq_u8(unpacked5, mask), 4));
-  vst1q_u8(packed + 48, b3210);
-
-  // b3210_3
-  //  packed[4] = (unpacked[6] & 15) | ((unpacked[7] & 15) << 4);
-  b3210 = vandq_u8(unpacked6, mask);
-  b3210 = vorrq_u8(b3210, vshlq_n_u8(vandq_u8(unpacked7, mask), 4));
-  vst1q_u8(packed + 64, b3210);
+  vst1q_u8(packed, p0);
+  vst1q_u8(packed + 16, p1);
+  vst1q_u8(packed + 32, p2);
+  vst1q_u8(packed + 48, p3);
+  vst1q_u8(packed + 64, p4);
 }
 
 TORCHAO_ALWAYS_INLINE inline void vec_unpack_128_uint5_values(
@@ -297,60 +174,35 @@ TORCHAO_ALWAYS_INLINE inline void vec_unpack_128_uint5_values(
     uint8x16_t& unpacked6,
     uint8x16_t& unpacked7,
     const uint8_t* packed) {
-  // Unpacks data packed by pack_128_uint5_values
-  //
-  // This function vectorizes vec_unpack_8_uint5_values
-  // To understand it, please see vec_unpack_8_uint5_values first.
-  // Before each code section, there is a comment indicating the
-  // code in vec_unpack_8_uint5_values that is being vectorized
+  // Unpacks data packed by vec_pack_128_uint5_values
 
-  // Input is 5*128 = 640 bits = 80 bytes
-  // Output is 128 bytes
+  // unpacked0 = p0 & 0b11111
+  // unpacked1 = p0 >> 5 | ((p4 & 0b00000011) << 3)
+  // unpacked2 = p1 & 0b11111
+  // unpacked3 = p1 >> 5 | ((p4 & 0b00001100) << 1)
+  // unpacked4 = p2 & 0b11111
+  // unpacked5 = p2 >> 5 | ((p4 & 0b00110000) >> 1)
+  // unpacked6 = p3 & 0b11111
+  // unpacked7 = p3 >> 5 | ((p4 & 0b11000000) >> 3)
 
-  uint8x16_t b4 = vld1q_u8(packed);
-  uint8x16_t b3210;
+  uint8x16_t p0 = vld1q_u8(packed);
+  uint8x16_t p1 = vld1q_u8(packed + 16);
+  uint8x16_t p2 = vld1q_u8(packed + 32);
+  uint8x16_t p3 = vld1q_u8(packed + 48);
+  uint8x16_t p4 = vld1q_u8(packed + 64);
 
-  // unpacked[0] = ((b4 & 1) << 4) | (b3210_0 & 15);
-  // unpacked[1] = ((b4 & 2) << 3) | (b3210_0 >> 4);
-  b3210 = vld1q_u8(packed + 16);
-
-  unpacked0 = vshlq_n_u8(vandq_u8(b4, vdupq_n_u8(1)), 4);
-  unpacked0 = vorrq_u8(unpacked0, vandq_u8(b3210, vdupq_n_u8(15)));
-
-  unpacked1 = vshlq_n_u8(vandq_u8(b4, vdupq_n_u8(2)), 3);
-  unpacked1 = vorrq_u8(unpacked1, vshrq_n_u8(b3210, 4));
-
-  // unpacked[2] = ((b4 & 4) << 2) | (b3210_1 & 15);
-  // unpacked[3] = ((b4 & 8) << 1) | (b3210_1 >> 4);
-  b3210 = vld1q_u8(packed + 32);
-
-  unpacked2 = vshlq_n_u8(vandq_u8(b4, vdupq_n_u8(4)), 2);
-  unpacked2 = vorrq_u8(unpacked2, vandq_u8(b3210, vdupq_n_u8(15)));
-
-  unpacked3 = vshlq_n_u8(vandq_u8(b4, vdupq_n_u8(8)), 1);
-  unpacked3 = vorrq_u8(unpacked3, vshrq_n_u8(b3210, 4));
-
-  // unpacked[4] = (b4 & 16) | (b3210_2 & 15);
-  // unpacked[5] = ((b4 & 32) >> 1) | (b3210_2 >> 4);
-
-  b3210 = vld1q_u8(packed + 48);
-
-  unpacked4 = vandq_u8(b4, vdupq_n_u8(16));
-  unpacked4 = vorrq_u8(unpacked4, vandq_u8(b3210, vdupq_n_u8(15)));
-
-  unpacked5 = vshrq_n_u8(vandq_u8(b4, vdupq_n_u8(32)), 1);
-  unpacked5 = vorrq_u8(unpacked5, vshrq_n_u8(b3210, 4));
-
-  // unpacked[6] = ((b4 & 64) >> 2) | (b3210_3 & 15);
-  // unpacked[7] = ((b4 & 128) >> 3) | (b3210_3 >> 4);
-
-  b3210 = vld1q_u8(packed + 64);
-
-  unpacked6 = vshrq_n_u8(vandq_u8(b4, vdupq_n_u8(64)), 2);
-  unpacked6 = vorrq_u8(unpacked6, vandq_u8(b3210, vdupq_n_u8(15)));
-
-  unpacked7 = vshrq_n_u8(vandq_u8(b4, vdupq_n_u8(128)), 3);
-  unpacked7 = vorrq_u8(unpacked7, vshrq_n_u8(b3210, 4));
+  unpacked0 = vandq_u8(p0, vdupq_n_u8(0b11111));
+  unpacked1 = vorrq_u8(
+      vshrq_n_u8(p0, 5), vshlq_n_u8(vandq_u8(p4, vdupq_n_u8(0b00000011)), 3));
+  unpacked2 = vandq_u8(p1, vdupq_n_u8(0b11111));
+  unpacked3 = vorrq_u8(
+      vshrq_n_u8(p1, 5), vshlq_n_u8(vandq_u8(p4, vdupq_n_u8(0b00001100)), 1));
+  unpacked4 = vandq_u8(p2, vdupq_n_u8(0b11111));
+  unpacked5 = vorrq_u8(
+      vshrq_n_u8(p2, 5), vshrq_n_u8(vandq_u8(p4, vdupq_n_u8(0b00110000)), 1));
+  unpacked6 = vandq_u8(p3, vdupq_n_u8(0b11111));
+  unpacked7 = vorrq_u8(
+      vshrq_n_u8(p3, 5), vshrq_n_u8(vandq_u8(p4, vdupq_n_u8(0b11000000)), 3));
 }
 
 } // namespace internal


### PR DESCRIPTION
Summary:
Implemented more efficient 5-bit packing and unpacking algorithm, for 8/64/128 values.
The algorithm is commented in code, but you may also refer to T204077841 for discussion.

## Before
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
benchmark_pack_uint_values<1>/128/8           17.3 ns         17.2 ns     40530134
...
benchmark_pack_uint_values<5>/128/8           36.8 ns         36.5 ns     18974458
benchmark_pack_uint_values<5>/128/64          5.47 ns         5.43 ns    128341462
benchmark_pack_uint_values<5>/128/128         2.91 ns         2.70 ns    261633340
benchmark_unpack_uint_values<5>/128/8         28.8 ns         28.6 ns     24475696
benchmark_unpack_uint_values<5>/128/64        6.14 ns         5.65 ns    124953143
benchmark_unpack_uint_values<5>/128/128       2.90 ns         2.88 ns    242818639
```

## After
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
benchmark_pack_uint_values<1>/128/8           17.9 ns         17.5 ns     40221794
...
benchmark_pack_uint_values<5>/128/8           24.9 ns         24.8 ns     28330676
benchmark_pack_uint_values<5>/128/64          2.63 ns         2.61 ns    267856460
benchmark_pack_uint_values<5>/128/128         2.04 ns         2.03 ns    344166380
benchmark_unpack_uint_values<5>/128/8         22.1 ns         22.0 ns     31850032
benchmark_unpack_uint_values<5>/128/64        2.92 ns         2.89 ns    242508228
benchmark_unpack_uint_values<5>/128/128       2.33 ns         2.25 ns    310688575
```

Reviewed By: metascroy

Differential Revision: D64703548


