### PR TITLE
is_linear fix for MHA

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1296,6 +1296,32 @@ class TestAutoQuant(unittest.TestCase):
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "autoquant requires 2.5+.")
+    def test_autoquant_mha(self, device, dtype):
+        class MHAModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mha = torch.nn.MultiheadAttention(4096, 32)
+                self.lin = torch.nn.Linear(4096, 4096)
+
+            def forward(self, x):
+                y = self.mha(x, x, x)[0]
+                return self.lin(y)
+
+        mod = MHAModel()
+        input = torch.randn(1,1,4096)
+        out=mod(*input)
+
+        torchao.autoquant(mod, set_inductor_config=False)
+        assert not isinstance(mod.mha.out_proj.weight, AutoQuantizableLinearWeight)
+        assert isinstance(mod.lin.weight, AutoQuantizableLinearWeight)
+        mod(*input)
+        from torchao.quantization.autoquant import AUTOQUANT_CACHE
+        assert len(AUTOQUANT_CACHE)>0
+
+
+
+    @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "autoquant requires 2.5+.")
     def test_autoquant_manual(self, device, dtype):
         undo_recommended_configs()
         if device != "cuda" or not torch.cuda.is_available():

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1297,6 +1297,8 @@ class TestAutoQuant(unittest.TestCase):
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "autoquant requires 2.5+.")
     def test_autoquant_mha(self, device, dtype):
+        if device != "cuda" or not torch.cuda.is_available():
+            self.skipTest(f"autoquant currently does not support {device}")
         class MHAModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1307,8 +1307,8 @@ class TestAutoQuant(unittest.TestCase):
                 y = self.mha(x, x, x)[0]
                 return self.lin(y)
 
-        mod = MHAModel()
-        input = torch.randn(1,1,4096)
+        mod = MHAModel().to(device).to(dtype)
+        input = torch.randn(1,1,4096).to(device).to(dtype)
         out=mod(*input)
 
         torchao.autoquant(mod, set_inductor_config=False)

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -186,7 +186,6 @@ def _replace_with_custom_fn_if_matches_filter(
     replacement_fn,
     filter_fn,
     cur_fqn="",
-    type_list=[],
     device=None,
 ) -> None:
     """
@@ -198,20 +197,12 @@ def _replace_with_custom_fn_if_matches_filter(
         replacement_fn (Callable[[torch.nn.Module], torch.nn.Module]): The function to replace matching modules.
         filter_fn (Callable[[torch.nn.Module], bool]): The filter function to determine which modules to replace.
         cur_fqn (str, optional): The current fully qualified name of the module being processed. Defaults to "".
-        type_list (list, optional): The list of types corresponding to the modules in the cur_fqn. Defaults to [].
         device (device, optional): Device to move the model to before applying `filter_fn`. Defaults to None.
 
     Returns:
         None
-    """    
-    
-    filter_accept = False
-    try:
-        filter_accept = filter_fn(model, cur_fqn[:-1], type_list+type(model))
-    except TypeError: # we used to not have type_list
-        filter_accept = filter_fn(model, cur_fqn[:-1])
-
-    if filter_accept:
+    """
+    if filter_fn(model, cur_fqn[:-1]):
         if device is not None:
             model.to(device=device)  # move to device before quantization
         model = replacement_fn(model)
@@ -219,7 +210,7 @@ def _replace_with_custom_fn_if_matches_filter(
     else:
         for name, child in model.named_children():
             new_child = _replace_with_custom_fn_if_matches_filter(
-                child, replacement_fn, filter_fn, f"{cur_fqn}{name}.", type_list+type(model), device
+                child, replacement_fn, filter_fn, f"{cur_fqn}{name}.", device
             )
             if new_child is not child:
                 setattr(model, name, new_child)
@@ -233,11 +224,10 @@ def _is_linear(mod, *args):
     from torchao.quantization.qat.affine_fake_quantized_tensor import (
         AffineFakeQuantizedTensor,
     )
-    if len(args)>=2:
-        not_in_mha = torch.nn.MultiheadAttention not in args[2]
+
     # adding weight tensor subclass isinstance check to make sure the weight is only quantized once
     # when it is shared by multiple linear modules
-    return not_in_mha and (
+    return (
         isinstance(mod, torch.nn.Linear)
         and hasattr(mod, "weight")
         and not isinstance(mod.weight, QuantizedLinearWeightBase)
@@ -245,6 +235,7 @@ def _is_linear(mod, *args):
         and not isinstance(mod.weight, AffineQuantizedTensor)
         and not isinstance(mod.weight, LinearActivationQuantizedTensor)
         and not isinstance(mod.weight, AffineFakeQuantizedTensor)
+        and not isinstance(mod, nn.modules.linear.NonDynamicallyQuantizableLinear)
     )
 
 import torch.nn.utils.parametrize as parametrize


### PR DESCRIPTION
Summary: filter fn may need access to parent types of module as in the case with mha

Test Plan: python /home/cdhernandez/local/ao/test/integration/test_integration.py -k "test_autoquant_mha"

Reviewers:

Subscribers:

Tasks:

Tags: