### PR TITLE
Update gpu_sparsity kernel benchmarking script

### DIFF
--- a/torchao/sparsity/utils.py
+++ b/torchao/sparsity/utils.py
@@ -30,12 +30,12 @@ def create_semi_structured_tensor(
     mask_entries = [random.choice(choices) for i in range(r * c // 2)]
 
     mask = (
-        torch.tensor(mask_entries, dtype=dtype)
+        torch.tensor(mask_entries, dtype=torch.int32)
         .reshape(r, c)
         .contiguous()
     ).cuda()
-    sparse_weight = torch.rand(r, c).to(dtype).cuda() * mask
-    return sparse_weight
+    sparse_weight = torch.rand(r, c).cuda() * mask
+    return sparse_weight.to(dtype)
 
 # Observers
 class PerChannelNormObserver(UniformQuantizationObserverBase):


### PR DESCRIPTION
Summary:
Updates the benchmarking GPU script to work with float8 dtypes and torch.compile for cuSPARSELt autotuning

<img width="641" alt="Screenshot 2024-10-17 at 2 10 38 PM" src="https://github.com/user-attachments/assets/8621daeb-f4a8-4423-a108-995d76ce3e32">

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: