### PR TITLE
Fix Bias APIs, re-enable kleidi tests for arm64

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/aarch64/CMakeLists.txt
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-option(TORCHAO_BUILD_KLEIDIAI "Download, build, and link against Arm KleidiAI library" OFF)
-
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   add_library(
     torchao_kernels_aarch64

--- a/torchao/experimental/kernels/cpu/aarch64/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/aarch64/CMakeLists.txt
@@ -26,7 +26,6 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     # Temporarily exposing this to the parent scope until we wire
     # this up properly from the top level
     set(TORCHAO_ENABLE_KLEIDI ON PARENT_SCOPE)
-    message(STATUS "Building with Kleidi")
     target_link_libraries(torchao_kernels_aarch64 PUBLIC kleidiai)
   endif()
 endif()

--- a/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod.h
+++ b/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod.h
@@ -69,7 +69,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros) {
+    const int8_t* weight_zeros,
+    const float* bias) {
   kai_matmul_clamp_f32_qai8dxp_qsi4c32p::prepare_weight_data(
       get_ukernel(),
       weight_data,
@@ -78,7 +79,8 @@ void prepare_weight_data(
       group_size,
       weight_qvals,
       weight_scales,
-      weight_zeros);
+      weight_zeros,
+      bias);
 }
 
 void kernel(
@@ -90,10 +92,8 @@ void kernel(
     int group_size,
     const void* weight_data,
     const void* activation_data,
-    const float* bias,
     float clamp_min,
     float clamp_max) {
-  (void)bias; // TODO(T203756650) - unused - needs API fixing
   assert(output_m_stride == n);
   if (clamp_min == 0 && clamp_max == 0) {
     clamp_min = std::numeric_limits<float>::lowest();

--- a/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod.h
+++ b/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod.h
@@ -70,7 +70,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros) {
+    const int8_t* weight_zeros,
+    const float* bias) {
   kai_matmul_clamp_f32_qai8dxp_qsi4c32p::prepare_weight_data(
       get_ukernel(),
       weight_data,
@@ -79,7 +80,8 @@ void prepare_weight_data(
       group_size,
       weight_qvals,
       weight_scales,
-      weight_zeros);
+      weight_zeros,
+      bias);
 }
 
 void kernel(
@@ -91,10 +93,8 @@ void kernel(
     int group_size,
     const void* weight_data,
     const void* activation_data,
-    const float* bias,
     float clamp_min,
     float clamp_max) {
-    (void) bias; // TODO(T203756650) - unused - needs API fixing
     assert(output_m_stride == n);
     if (clamp_min == 0 && clamp_max == 0) {
       clamp_min = std::numeric_limits<float>::lowest();

--- a/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp_qsi4c32p.h
+++ b/torchao/experimental/kernels/cpu/aarch64/kleidi/kai_matmul_clamp_f32_qai8dxp_qsi4c32p.h
@@ -89,7 +89,8 @@ void prepare_weight_data(
     int group_size,
     const int8_t* weight_qvals,
     const float* weight_scales,
-    const int8_t* weight_zeros) {
+    const int8_t* weight_zeros,
+    const float* bias) {
   // TODO(T204312268) - remove this constraint and pad when possible
   assert(n % 2 == 0);
 
@@ -139,7 +140,7 @@ void prepare_weight_data(
       group_size,
       /*rhs=*/reinterpret_cast<const uint8_t*>(packed_weight_qvals.data()),
       /*rhs_stride=*/roundup(k, 2) / 2,
-      /*bias=*/nullptr, // TODO(T203756650) fix APIs to move bias here
+      /*bias=*/bias,
       /*scale=*/reinterpret_cast<const uint16_t*>(weight_scales_bf16.data()),
       /*scale_stride=*/sizeof(uint16_t) * (roundup(k, group_size) / group_size),
       /*rhs_packed=*/weight_data,

--- a/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
@@ -36,7 +36,6 @@ endif()
 add_subdirectory(${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64 ${CMAKE_CURRENT_BINARY_DIR}/torchao_kernels_aarch64)
 
 # The TORCHAO_ENABLE_KLEIDI cmake variable should be set by `torchao_kernels_aarch64"
-# This is a temporary work around.
 if(TORCHAO_ENABLE_KLEIDI)
   add_compile_definitions(TORCHAO_ENABLE_KLEIDI)
 endif()

--- a/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
@@ -10,9 +10,15 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
 export CMAKE_OUT=/tmp/cmake-out/torch_ao/tests
 
+IS_ARM64=0
+hash arch; retval=$?
+if [[ ${retval} -eq 0 && $(arch) == "arm64" ]]; then
+    IS_ARM64=1
+fi
+
 cmake -DCMAKE_BUILD_TYPE=Debug \
     -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
-    -DTORCHAO_BUILD_KLEIDIAI=ON \
+    -DTORCHAO_BUILD_KLEIDIAI=${IS_ARM64} \
     -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/tests \
     -B ${CMAKE_OUT}
 

--- a/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
@@ -9,7 +9,12 @@ set -eu
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 export TORCHAO_LIBRARIES=${SCRIPT_DIR}/../../../../../..
 export CMAKE_OUT=/tmp/cmake-out/torch_ao/tests
-cmake -DCMAKE_BUILD_TYPE=Debug -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/tests -B ${CMAKE_OUT}
+
+cmake -DCMAKE_BUILD_TYPE=Debug \
+    -DTORCHAO_LIBRARIES=${TORCHAO_LIBRARIES} \
+    -DTORCHAO_BUILD_KLEIDIAI=ON \
+    -S ${TORCHAO_LIBRARIES}/torchao/experimental/kernels/cpu/aarch64/tests \
+    -B ${CMAKE_OUT}
 
 cmake --build ${CMAKE_OUT}
 

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
@@ -399,7 +399,8 @@ void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod(
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      /*weight_zeros=*/test_case.weight_zeros.data());
+      /*weight_zeros=*/test_case.weight_zeros.data(),
+      /*bias=*/test_case.bias.data());
 
   std::vector<float> output(m * n);
   kernel(
@@ -411,7 +412,6 @@ void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p4x8_1x4x32_neon_dotprod(
       group_size,
       weight_data.data(),
       activation_data.data(),
-      /*bias=*/test_case.bias.data(),
       /*clamp_min=*/test_case.clamp_min,
       /*clamp_max=*/test_case.clamp_max);
 
@@ -513,7 +513,8 @@ void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod(
       group_size,
       test_case.weight_qvals.data(),
       test_case.weight_scales.data(),
-      /*weight_zeros=*/test_case.weight_zeros.data());
+      /*weight_zeros=*/test_case.weight_zeros.data(),
+      /*bias=*/test_case.bias.data());
 
   std::vector<float> output(m * n);
   kernel(
@@ -525,7 +526,6 @@ void test_kai_matmul_clamp_f32_qai8dxp1x8_qsi4c32p8x8_1x8x32_neon_dotprod(
       group_size,
       weight_data.data(),
       activation_data.data(),
-      /*bias=*/test_case.bias.data(),
       /*clamp_min=*/test_case.clamp_min,
       /*clamp_max=*/test_case.clamp_max);
 


### PR DESCRIPTION
This will be later guarded with ISA features once we add newer kernels
which doesn't work on M1 and older older Arm CPUs.