### PR TITLE
int8wo Embedding Quant

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -943,6 +943,20 @@ class TestWeightOnlyInt8Quant(unittest.TestCase):
             sqnr = compute_error(y_ref, y_wo)
             self.assertGreater(sqnr, 45.0)
 
+    def test_weight_only_groupwise_embedding_quant(self):
+        group_size = 64
+        m = nn.Embedding(4096, 128)
+        input = torch.randint(0, 4096, (1, 6))
+        
+        quantize_(m, int8_weight_only(group_size=group_size), filter_fn=lambda x, *args: isinstance(x, nn.Embedding))
+        y_q = m(input)
+        y_ref = m.weight.dequantize()[input]
+        
+        sqnr = compute_error(y_ref, y_q)
+
+        self.assertGreater(sqnr, 45.0)
+
+
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @torch.no_grad()
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -237,6 +237,8 @@ def main(
             quantize_(model, int4_weight_only(layout=MarlinSparseLayout()))
         if "fp6" in quantization:
             quantize_(model, fpx_weight_only(3, 2))
+        if "embed-int8wo" in quantization:
+            quantize_(model, int8_weight_only(group_size=64), filter_fn=lambda x, *args: isinstance(x, torch.nn.Embedding))
         if quantization.startswith("awq"):
             from torchao._models._eval import TransformerEvalWrapper
             from torchao.utils import TORCH_VERSION_AT_LEAST_2_3
@@ -463,7 +465,7 @@ if __name__ == '__main__':
     parser.add_argument('-q', '--quantization', type=str, 
         help=(
             'Which quantization techniques to apply: int8dq, int8wo, fp6, int4wo-<groupsize>, int4wo-<groupsize>-hqq, autoquant, '
-            +'autoquant-int4, autoquant-float8, uintx-<nbits>-<groupsize>, uintx-<nbits>-<groupsize>-hqq, sparse-marlin, spinquant'
+            +'autoquant-int4, autoquant-float8, uintx-<nbits>-<groupsize>, uintx-<nbits>-<groupsize>-hqq, sparse-marlin, spinquant, embed-int8wo'
         )
     )
     parser.add_argument("--calibration_limit", type=int, default=10, help="Number of calibration examples")


### PR DESCRIPTION
    Summary: Added int8 embedding quant to torchAO, speeds up inference on
    our llama benchmark from 107.8 -> 108.5 tok/s on A100
    
    expected api is
    
    quantize_(model, int8_weight_only(group_size=64), filter_fn=lambda x,
    *args: isinstance(x, torch.nn.Embedding))
    
    Test Plan:
    
    python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --quantization embed-int8wo --compile
    python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --compile
    python test_integration.py -k
    "test_weight_only_groupwise_embedding_quant"
    
    Reviewers:
    
    Subscribers:
    
    Tasks:
    
    Tags: