### PR TITLE
Fixing eval.py to use GPTQ_MT for gptq

### DIFF
--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -104,13 +104,13 @@ def run_evaluation(
             quantize_(model, int4_weight_only(layout=MarlinSparseLayout()))
         if "int4wo" in quantization and "gptq" in quantization:
             # avoid circular imports
-            from torchao._models._eval import InputRecorder
-            from torchao.quantization.GPTQ import Int4WeightOnlyGPTQQuantizer
+            from torchao._models._eval import MultiTensorInputRecorder
+            from torchao.quantization.GPTQ_MT import Int4WeightOnlyGPTQQuantizer
             groupsize=int(quantization.split("-")[-2])
             assert groupsize in [32,64,128,256], f"int4wo groupsize needs to be one of [32,64,128,256] but got {groupsize}"
             assert precision==torch.bfloat16, f"{quantization} requires precision or bfloat16 but got {precision}"
             assert "cuda" in device, "int4 gptq quantization only works on cuda"
-            inputs = InputRecorder(
+            inputs = MultiTensorInputRecorder(
                 tokenizer,
                 calibration_seq_length,
                 prepare_inputs_for_model,
@@ -122,7 +122,7 @@ def run_evaluation(
                 calibration_limit,
             ).get_inputs()
 
-            quantizer = Int4WeightOnlyGPTQQuantizer(groupsize=groupsize, device=device)
+            quantizer = Int4WeightOnlyGPTQQuantizer(group_size=groupsize, device=device)
             model.setup_caches(max_batch_size=1, max_seq_length=calibration_seq_length)
             model = quantizer.quantize(model, inputs).to(device)
         else:

--- a/torchao/quantization/GPTQ_MT.py
+++ b/torchao/quantization/GPTQ_MT.py
@@ -269,7 +269,7 @@ class MultiTensor(torch.Tensor):
                         #if detected_difference and not isinstance(NON_IN_PLACE_OPS[func], bool):
                             #print("THIS OP IS IN PLACE", func)
                             #NON_IN_PLACE_OPS[func] = False
-                        if detected_difference:
+                        if detected_difference and not NON_IN_PLACE_OPS[func]:
                             NON_IN_PLACE_OPS[func]['is_in_place'] = True
                             print(f"Function {func} is in-place")
 
@@ -297,7 +297,6 @@ class MultiTensor(torch.Tensor):
                 
                 # Run the function again with updated weights and skip_gptq=True
                 out = cls.__torch_function__(func, types, (args[0], DQ.cpu(), *args[2:]), kwargs, skip_gptq=True)
-                print(args[0].debug)
                 if args[0].debug:
                     act = args[0].values[0].to("cuda")
                     bias = args[2].values[0].to("cuda") if args[2] is not None else args[2]


### PR DESCRIPTION
Summary: small fix so we can assess gptq accuracy

Test Plan: python eval.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --quantization int4wo-64-gptq --calibration_limit 1 --limit 1

Reviewers:

Subscribers:

Tasks:

Tags: