### PR TITLE
clarify torchao.float8 PyTorch version support

### DIFF
--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -25,6 +25,10 @@ This is the most accurate recipe as every tensor is scaled dynamically.
 import torch
 import torch.nn as nn
 from torchao.float8 import convert_to_float8_training
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
+
+if not TORCH_VERSION_AT_LEAST_2_5:
+    raise AssertionError("torchao.float8 requires PyTorch version 2.5 or greater")
 
 # create model and sample input
 m = nn.Sequential(
@@ -73,6 +77,10 @@ from torchao.float8 import (
     ScalingType,
     CastConfig,
 )
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
+
+if not TORCH_VERSION_AT_LEAST_2_5:
+    raise AssertionError("torchao.float8 requires PyTorch version 2.5 or greater")
 
 # create model and sample input
 m = nn.Sequential(


### PR DESCRIPTION
We currently only support PyTorch version 2.5 and up.  

For historical context:
* we haven't supported 2.4 and below since the float8_experimental repository moved into torchao
* the error when we run the float8 README.md demo on PyTorch 2.4: https://gist.github.com/vkuzo/e8c06fd27429da0a6a079dcd46cc234f

In a future PR we can see what it would take to enable 2.4.1 support, but for now let's at least clarify the currently supported version.