### PR TITLE
[not for land] hardcoded two-stage reduction for max(abs(tensor))

### DIFF
--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -110,7 +110,8 @@ def tensor_to_amax(
     axiswise_dim: Optional[int] = None,
 ) -> torch.Tensor:
     if scaling_granularity is ScalingGranularity.TENSORWISE:
-        amax = torch.max(torch.abs(x))
+        # amax = torch.max(torch.abs(x))
+        amax = torch.max(torch.max(torch.abs(x), dim=-1).values)
     else:
         assert scaling_granularity is ScalingGranularity.AXISWISE, "unsupported"
         assert axiswise_dim is not None, "unsupported"


### PR DESCRIPTION
Summary:

Based on investigations around
https://github.com/pytorch/pytorch/issues/128063, changing the user code to do the tensorwise max in two steps helps the compiler find better fusion opportunities.

TBD on if we want to land this or have torch.compile do this automatically, but for now putting up a PR to make this easier to explore/benchmark.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: