### PR TITLE
[NF4] Add `quantize_()` API support for NF4

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -954,6 +954,15 @@ def to_nf4(tensor, block_size: int = 64, scaler_block_size: int = 256):
     return NF4Tensor.from_tensor(tensor, block_size, scaler_block_size)
 
 
+def nf4_weight_only(block_size: int = 64, scaler_block_size: int = 256):
+    from torchao.quantization.quant_api import _get_linear_subclass_inserter
+
+    def _to_nf4(tensor: torch.Tensor):
+        return NF4Tensor.from_tensor(tensor, block_size, scaler_block_size)
+
+    return _get_linear_subclass_inserter(_to_nf4)
+
+
 NF4_TORCH_FUNCTIONS = {}
 
 
@@ -998,6 +1007,17 @@ def function_cpu(*args, **kwargs):
     updated_attrs = call_from_inner_tensors(nf4tensor, "cpu", args[1:], kwargs)
     updated_attrs["device"] = "cpu"
     return NF4Tensor(*construct_nf4_args(nf4tensor, updated_attrs))
+
+
+@implements_torch_function(F.linear)
+def _(*args, **kwargs):
+    input = args[0]
+    weight = args[1]
+    bias = args[2] if len(args) > 2 else None
+    out = LinearNF4.apply(input, weight)
+    if bias is not None:
+        out = out + bias
+    return out
 
 
 @torch._dynamo.allow_in_graph


### PR DESCRIPTION
## Background

When I was working on INT8 training stuff a while back, I realized there was no issue to make NF4 training work with `quantize_()` API (i.e. swap plain tensor with tensor subclass). This is because autograd+compile still works correctly for `__torch_function__` (might not be the case in the past when NF4 was implemented) -> eliminate the need for custom `nn.Module` for downstream users as well as need for explicitly call to `linear_nf4()`.

## Usage

```python
from torchao import quantize_
from torchao.dtypes.nf4 import nf4_weight_only

model = ...
quantize_(model, nf4_weight_only())  # works for both training and inference. NF4 weight is non-trainable
```

This would also compose nicely with LoRA, making QLoRA implementation more seamless. e.g.

```python
from torch import nn
import torch.nn.functional as F

class LoRALinear(nn.Module):
    ...
    def forward(self, x):
        out = F.linear(x, self.weight)  # self.weight can be NF4Tensor
        out = out + self.lora_b(self.lora_a(x)) * (self.alpha / self.rank)
        return out

lora_layer = LoRALinear(...)
quantize_(
    lora_layer,
    nf4_weight_only(),
    filter_fn=lambda module, name: isinstance(module, LoRALinear),
)  # now this becomes QLoRA
```