### PR TITLE
[Low-bit optim] Support for `dcp.save()` and `dcp.load()`

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -399,7 +399,7 @@ class TestFSDP2(FSDPTest):
         # this will change model weights due to weight decay, but since we don't use the model anymore, it's fine.
         resumed_fsdp_optim.step()
 
-        # NOTE: should dcp.load() has a flag for weights_only=False?
+        # NOTE: should dcp.load() have a flag for weights_only=False?
         subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
         with torch.serialization.safe_globals(subclasses):
             dcp.load(resumed_fsdp_optim.state_dict(), checkpoint_id=checkpoint_id)

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -5,12 +5,17 @@ from pathlib import Path
 
 import pytest
 import torch
+from packaging.version import Version
 from torch import nn
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
-from torch.testing._internal.common_utils import TestCase, instantiate_parametrized_tests, parametrize, run_tests
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 
-from packaging.version import Version
 from torchao.prototype import low_bit_optim
 from torchao.prototype.low_bit_optim.quant_utils import (
     _fp32_to_bf16_sr,

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -446,12 +446,11 @@ class TestFSDP2(FSDPTest):
         # this will change model weights due to weight decay, but since we don't use the model anymore, it's fine.
         resumed_fsdp_optim.step()
 
-        # NOTE: should dcp.load() have a flag for weights_only=False?
-        subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
-        with torch.serialization.safe_globals(subclasses):
-            dcp.load(resumed_fsdp_optim.state_dict(), checkpoint_id=checkpoint_id)
+        dcp.load(resumed_fsdp_optim.state_dict(), checkpoint_id=checkpoint_id)
         if dist.get_rank() == 0:
             shutil.rmtree(checkpoint_id)
+
+        subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
 
         for v1, v2 in zip(pytree.tree_iter(resumed_fsdp_optim.state_dict()), pytree.tree_iter(fsdp_optim.state_dict())):
             assert v1.__class__ == v2.__class__, (v1.__class__, v2.__class__)

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -150,11 +150,11 @@ class TestOptim(TestCase):
     @parametrize("device", _DEVICES)
     def test_subclass_slice(self, subclass, shape, device):
         if subclass == OptimStateFp8:
-            if len(shape) > 1 and device == "cpu" and not TORCH_VERSION_AT_LEAST_2_5:
+            if device == "cpu" and len(shape) > 1 and not TORCH_VERSION_AT_LEAST_2_5:
                 pytest.skip("fill_cpu not implemented for Float8_e4m3fn for torch<2.5")
-            if not TORCH_VERSION_AT_LEAST_2_4:
+            if device == "cuda" and not TORCH_VERSION_AT_LEAST_2_4:
                 pytest.skip("FP8 CUDA requires PyTorch >= 2.4")
-            if torch.cuda.get_device_capability() < (8, 9):
+            if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
         tensor = subclass.zeros(shape, device=device)

--- a/torchao/prototype/low_bit_optim/subclass_4bit.py
+++ b/torchao/prototype/low_bit_optim/subclass_4bit.py
@@ -161,12 +161,14 @@ def _(func, types, args, kwargs):
     raise ValueError(f"{x.__class__.__name__} only supports .view() with same shape or shape=[-1]")
 
 
-# this is needed for DTensor.full_tensor()
 @OptimState4bit.implements([
+    # required by DTensor.full_tensor()
     c10d_functional.all_gather_into_tensor.default,
     _c10d_functional.all_gather_into_tensor.default,
     c10d_functional.wait_tensor.default,
     _c10d_functional.wait_tensor.default,
+    # required by torch.distributed.checkpoint.save
+    aten.detach.default,
 ])
 def _(func, types, args, kwargs):
     x = args[0]
@@ -181,3 +183,11 @@ def _(func, types, args, kwargs):
 
     # assume tensors from all ranks have the same signedness
     return OptimState4bit(codes, scale, x.qmap.clone(), x.signed, shape)
+
+
+# required by torch.distributed.checkpoint.save
+# note that we don't actually implement pin memory for this tensor subclass
+# (pin_memory argument is ignored in aten._to_copy)
+@OptimState4bit.implements(aten.is_pinned.default)
+def _(func, types, args, kwargs):
+    return args[0].codes.is_pinned() and args[0].scale.is_pinned() and args[0].qmap.is_pinned()

--- a/torchao/prototype/low_bit_optim/subclass_4bit.py
+++ b/torchao/prototype/low_bit_optim/subclass_4bit.py
@@ -120,7 +120,11 @@ def _(func, types, args, kwargs):
     src = args[1]
 
     if isinstance(dst, OptimState4bit) and isinstance(src, OptimState4bit):
-        assert dst.signed == src.signed and dst.block_size == src.block_size and dst._shape == src._shape
+        assert (
+            dst.signed == src.signed
+            and dst.block_size == src.block_size
+            and dst._shape == src._shape
+        )
         dst.codes.copy_(src.codes)
         dst.scale.copy_(src.scale)
         # qmap should be the same, don't need to copy
@@ -204,7 +208,11 @@ def _(func, types, args, kwargs):
 # (pin_memory argument is ignored in aten._to_copy)
 @OptimState4bit.implements(aten.is_pinned.default)
 def _(func, types, args, kwargs):
-    return args[0].codes.is_pinned() and args[0].scale.is_pinned() and args[0].qmap.is_pinned()
+    return (
+        args[0].codes.is_pinned()
+        and args[0].scale.is_pinned()
+        and args[0].qmap.is_pinned()
+    )
 
 
 # required by torch.distributed.checkpoint.load when world size changes i.e. re-sharding
@@ -215,9 +223,9 @@ def _(func, types, args, kwargs):
 
     # input validation
     if dim != 0:
-        raise ValueError(f"Only support aten.slice along the first dim")
+        raise ValueError("Only support aten.slice along the first dim")
     if step != 1:
-        raise ValueError(f"Only support aten.slice with step=1")
+        raise ValueError("Only support aten.slice with step=1")
 
     block_size = x.block_size
     stride = math.prod(x.shape[1:])

--- a/torchao/prototype/low_bit_optim/subclass_8bit.py
+++ b/torchao/prototype/low_bit_optim/subclass_8bit.py
@@ -181,7 +181,11 @@ def _(func, types, args, kwargs):
 # (pin_memory argument is ignored in aten._to_copy)
 @OptimState8bit.implements(aten.is_pinned.default)
 def _(func, types, args, kwargs):
-    return args[0].codes.is_pinned() and args[0].scale.is_pinned() and args[0].qmap.is_pinned()
+    return (
+        args[0].codes.is_pinned()
+        and args[0].scale.is_pinned()
+        and args[0].qmap.is_pinned()
+    )
 
 
 # required by torch.distributed.checkpoint.load when world size changes i.e. re-sharding
@@ -192,9 +196,9 @@ def _(func, types, args, kwargs):
 
     # input validation
     if dim != 0:
-        raise ValueError(f"Only support aten.slice along the first dim")
+        raise ValueError("Only support aten.slice along the first dim")
     if step != 1:
-        raise ValueError(f"Only support aten.slice with step=1")
+        raise ValueError("Only support aten.slice with step=1")
 
     block_size = x.block_size
     stride = math.prod(x.shape[1:])

--- a/torchao/prototype/low_bit_optim/subclass_fp8.py
+++ b/torchao/prototype/low_bit_optim/subclass_fp8.py
@@ -165,9 +165,9 @@ def _(func, types, args, kwargs):
 
     # input validation
     if dim != 0:
-        raise ValueError(f"Only support aten.slice along the first dim")
+        raise ValueError("Only support aten.slice along the first dim")
     if step != 1:
-        raise ValueError(f"Only support aten.slice with step=1")
+        raise ValueError("Only support aten.slice with step=1")
 
     block_size = x.block_size
     stride = math.prod(x.shape[1:])


### PR DESCRIPTION
Fixes #1189

- To support `dcp.save()`, `aten.detach` and `aten.is_pinned` are required
- To support `dcp.load()`
  - When world size does not change, no addition ops are needed
  - When world size changes, `aten.slice` is required

Thus this PR adds implementations for the above 3 ops for all low-bit optim state subclasses in torchao, as well as appropriate tests. Also did some minor housekeeping (e.g. format code, remove torch>=2.3 guard since we only test against torch>=2.3 now...).

Note: Low-bit optims are still not compatible with `dcp.state_dict.get_optimizer_state_dict()` due to pytorch/pytorch#139575