### PR TITLE
`fast_flush` kwarg of `do_bench` is removed

### DIFF
--- a/benchmarks/quantized_training/benchmark_int8mm.py
+++ b/benchmarks/quantized_training/benchmark_int8mm.py
@@ -6,7 +6,7 @@ from torchao.prototype.quantized_training.int8_mm import int8_mm_dequant
 
 
 def bench_f(f, *args):
-    return do_bench(lambda: f(*args), fast_flush=False, return_mode="median")
+    return do_bench(lambda: f(*args), return_mode="median")
 
 
 shapes = [(sz, sz, sz) for sz in [1024, 2048, 4096]]


### PR DESCRIPTION
Summary: We just always use the fast path now; there's no reason to do anything different.

Reviewed By: minjang

Differential Revision: D65444506


