### PR TITLE
support exlusion of params when using low bit optim

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -19,6 +19,7 @@ from torchao.prototype.low_bit_optim.quant_utils import (
     quantize_4bit_with_qmap,
     _fp32_to_bf16_sr,
 )
+
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_3, TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_6
 
 try:
@@ -300,7 +301,72 @@ class TestOptim(TestCase):
             optim2.zero_grad()
 
             torch.testing.assert_close(loss1, loss2, msg=lambda msg: f"Iteration {idx}. {msg}")
+            
 
+    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_3, reason="requires PyTorch >= 2.3")
+    @parametrize("optim_name", ["Adam8bit", "AdamW8bit", "Adam4bit", "AdamW4bit", "AdamFp8", "AdamWFp8"])
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    @parametrize("device", _DEVICES)
+    def test_optim_exclude_low_bit_params(self, optim_name, dtype, device):
+        # Skip FP8 tests on devices that don't support it
+        if optim_name.endswith("Fp8") and device == "cuda":
+            if not TORCH_VERSION_AT_LEAST_2_4:
+                pytest.skip("FP8 CUDA requires PyTorch >= 2.4")
+            if torch.cuda.get_device_capability() < (8, 9):
+                pytest.skip("FP8 CUDA requires compute capability >= 8.9")
+                
+        model = nn.Sequential(
+            nn.Linear(32, 256),
+            nn.ReLU(),
+            nn.Linear(256, 32)
+        )
+        model.to(device=device, dtype=dtype)
+
+        params_to_exclude = [model[0].weight]
+
+        optim = getattr(low_bit_optim, optim_name)(
+            model.parameters(),
+            exclude_low_bit_optim_params=params_to_exclude
+        )
+
+        x = torch.randn(4, 32, device=device, dtype=dtype)
+        loss = model(x).sum()
+        loss.backward()
+        optim.step()
+        optim.zero_grad()
+        state = optim.state
+        excluded_param = params_to_exclude[0]
+        excluded_state = state[excluded_param]
+        exp_avg = excluded_state['exp_avg']
+        exp_avg_sq = excluded_state['exp_avg_sq']
+
+        if optim_name.endswith("8bit"):
+            quantized_state_types = (low_bit_optim.OptimState8bit,)
+        elif optim_name.endswith("4bit"):
+            quantized_state_types = (low_bit_optim.OptimState4bit,)
+        elif optim_name.endswith("Fp8"):
+            quantized_state_types = (low_bit_optim.OptimStateFp8,)
+        else:
+            quantized_state_types = ()
+
+        # Assert that the state tensors for the excluded parameter are not quantized
+        self.assertNotIsInstance(exp_avg, quantized_state_types)
+        self.assertNotIsInstance(exp_avg_sq, quantized_state_types)
+
+        for param in model.parameters():
+            if param is not excluded_param:
+                param_state = state[param]
+                exp_avg = param_state['exp_avg']
+                exp_avg_sq = param_state['exp_avg_sq']
+                self.assertIsInstance(exp_avg, quantized_state_types)
+                self.assertIsInstance(exp_avg_sq, quantized_state_types)
+
+        # Since the excluded parameter is not quantized, its data type should remain the same
+        self.assertEqual(excluded_param.dtype, dtype)
+
+        # Ensure that other parameters are still being updated correctly
+        for param in model.parameters():
+            self.assertIsNotNone(param.grad)
 
 class TestFSDP2(FSDPTest):
     @property

--- a/torchao/prototype/low_bit_optim/adam.py
+++ b/torchao/prototype/low_bit_optim/adam.py
@@ -13,7 +13,7 @@ from .quant_utils import _fp32_to_bf16_sr
 
 class _AdamBase(Optimizer):
     def __init__(
-        self, params, lr, betas, eps, weight_decay, amsgrad, *, block_size, bf16_stochastic_round, is_adamw
+        self, params, lr, betas, eps, weight_decay, amsgrad, *, block_size, bf16_stochastic_round, is_adamw,exclude_low_bit_optim_params=None
     ) -> None:
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
@@ -28,6 +28,10 @@ class _AdamBase(Optimizer):
         self.block_size = block_size
         self.bf16_stochastic_round = bf16_stochastic_round
         self.is_adamw = is_adamw
+        # Store the IDs of parameters to exclude
+        self.exclude_low_bit_optim_params_ids = set(
+            id(p) for p in exclude_low_bit_optim_params
+        ) if exclude_low_bit_optim_params else set()
 
     def __setstate__(self, state):
         super().__setstate__(state)
@@ -42,7 +46,7 @@ class _AdamBase(Optimizer):
     # follow bitsandbytes, only quantize tensors >= 4096 values
     # also wrap subclass in DTensor when needed
     def _new_buffer(self, p: Tensor, signed: bool):
-        if p.numel() >= 4096 and p.numel() % self.block_size == 0:
+        if p.numel() >= 4096 and p.numel() % self.block_size == 0 and id(p) not in self.exclude_low_bit_optim_params_ids :
             if isinstance(p, DTensor):
                 out = DTensor.from_local(
                     local_tensor=self._subclass_zeros(p.to_local(), signed, self.block_size),
@@ -175,6 +179,7 @@ class Adam8bit(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None,
     ) -> None:
         super().__init__(
             params,
@@ -186,6 +191,7 @@ class Adam8bit(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=False,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )
 
     @staticmethod
@@ -205,6 +211,7 @@ class Adam4bit(_AdamBase):
         *,
         block_size=128,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None,
     ) -> None:
         super().__init__(
             params,
@@ -216,6 +223,7 @@ class Adam4bit(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=False,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params,
         )
 
     @staticmethod
@@ -235,6 +243,7 @@ class AdamFp8(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None
     ) -> None:
         super().__init__(
             params,
@@ -246,6 +255,7 @@ class AdamFp8(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=False,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )
 
     @staticmethod
@@ -265,6 +275,7 @@ class AdamW8bit(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None
     ) -> None:
         super().__init__(
             params,
@@ -276,6 +287,7 @@ class AdamW8bit(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=True,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )
 
     @staticmethod
@@ -295,6 +307,7 @@ class AdamW4bit(_AdamBase):
         *,
         block_size=128,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None
     ) -> None:
         super().__init__(
             params,
@@ -306,6 +319,7 @@ class AdamW4bit(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=True,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )
 
     @staticmethod
@@ -325,6 +339,7 @@ class AdamWFp8(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None
     ) -> None:
         super().__init__(
             params,
@@ -336,6 +351,7 @@ class AdamWFp8(_AdamBase):
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=True,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )
 
     @staticmethod
@@ -354,6 +370,7 @@ class _AdamW(_AdamBase):
         amsgrad=False,
         *,
         bf16_stochastic_round=False,
+        exclude_low_bit_optim_params=None
     ) -> None:
         """AdamW optimizer that supports quantized training (parameter is quantized). This optimizer should
         only be used with torchao's quantized training."""
@@ -367,4 +384,5 @@ class _AdamW(_AdamBase):
             block_size=float("inf"),
             bf16_stochastic_round=bf16_stochastic_round,
             is_adamw=True,
+            exclude_low_bit_optim_params=exclude_low_bit_optim_params
         )


### PR DESCRIPTION
This PR allows, exclusion and inclusion of params layerwise when using low bit optimizers. this will allow for improving stability by running certain layers with 32 bit adam. https://huggingface.co/docs/bitsandbytes/main/en/optimizers