### PR TITLE
swapping pytest for unittest

### DIFF
--- a/test/dora/test_dora_fusion.py
+++ b/test/dora/test_dora_fusion.py
@@ -5,7 +5,7 @@ import unittest
 from torch.testing._internal.common_utils import parametrize
 
 if sys.version_info < (3, 11):
-    pytest.skip("requires Python >= 3.11", allow_module_level=True)
+    unittest.skip("requires Python >= 3.11", allow_module_level=True)
 
 triton = pytest.importorskip("triton", reason="requires triton")
 
@@ -74,7 +74,7 @@ def test_dora_column_norm(
     shape, store_acc, epilogue_norm, add_source, magnitude_vector, dtype
 ):
     if not (store_acc or epilogue_norm):
-        pytest.skip("Either store_acc or epilogue_norm must be True")
+        unittest.skip("Either store_acc or epilogue_norm must be True")
 
     M, N, K = shape
     A = torch.randn(M, K, device="cuda", dtype=dtype)

--- a/test/dora/test_dora_fusion.py
+++ b/test/dora/test_dora_fusion.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 if sys.version_info < (3, 11):
     pytest.skip("requires Python >= 3.11", allow_module_level=True)
@@ -64,7 +65,7 @@ def check(expected, actual, dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
-@pytest.mark.parametrize(
+@parametrize(
     "shape, store_acc, epilogue_norm, add_source, magnitude_vector, dtype",
     FUSED_DORA_TEST_CONFIGS,
     ids=_arg_to_id,
@@ -142,7 +143,7 @@ FUSED_MATMUL_TEST_CONFIGS = list(
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
-@pytest.mark.parametrize(
+@parametrize(
     "shape, dtype, epilogue_add, epilogue_scale",
     FUSED_MATMUL_TEST_CONFIGS,
     ids=_arg_to_id,
@@ -167,8 +168,8 @@ def test_dora_matmul(shape, dtype, epilogue_add, epilogue_scale):
 MODES = ["default"]
 
 
-@pytest.mark.skip("TODO: torch.compile does not work with custom kernel")
-@pytest.mark.parametrize(
+@unittest.skip("TODO: torch.compile does not work with custom kernel")
+@parametrize(
     "shape, dtype, epilogue_add, epilogue_scale, mode",
     [[*cfg, mode] for cfg in FUSED_MATMUL_TEST_CONFIGS for mode in MODES][:1],
     ids=_arg_to_id,

--- a/test/dora/test_dora_fusion.py
+++ b/test/dora/test_dora_fusion.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+import unittest
 
 if sys.version_info < (3, 11):
     pytest.skip("requires Python >= 3.11", allow_module_level=True)
@@ -62,7 +63,7 @@ def check(expected, actual, dtype):
     return diff
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize(
     "shape, store_acc, epilogue_norm, add_source, magnitude_vector, dtype",
     FUSED_DORA_TEST_CONFIGS,
@@ -140,7 +141,7 @@ FUSED_MATMUL_TEST_CONFIGS = list(
 )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize(
     "shape, dtype, epilogue_add, epilogue_scale",
     FUSED_MATMUL_TEST_CONFIGS,

--- a/test/dora/test_dora_layer.py
+++ b/test/dora/test_dora_layer.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 if sys.version_info < (3, 11):
     pytest.skip("requires Python >= 3.11", allow_module_level=True)
@@ -61,7 +62,7 @@ TEST_CONFIGS = list(
 )
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "bs, seqlen, in_features, out_features, lora_rank, dtype, model_type",
     TEST_CONFIGS,
     ids=_arg_to_id,

--- a/test/dora/test_dora_layer.py
+++ b/test/dora/test_dora_layer.py
@@ -1,10 +1,11 @@
 import sys
 
 import pytest
+import unittest
 from torch.testing._internal.common_utils import parametrize
 
 if sys.version_info < (3, 11):
-    pytest.skip("requires Python >= 3.11", allow_module_level=True)
+    unittest.skip("requires Python >= 3.11", allow_module_level=True)
 
 bnbnn = pytest.importorskip("bitsandbytes.nn", reason="requires bitsandbytes")
 hqq_core = pytest.importorskip("hqq.core.quantize", reason="requires hqq")

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -1,5 +1,6 @@
-import pytest
 import unittest
+
+import pytest
 
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -1,11 +1,12 @@
 import pytest
+import unittest
 
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
 )
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import copy
 import io
@@ -15,7 +16,6 @@ from contextlib import nullcontext
 from functools import partial
 from typing import Tuple
 
-import pytest
 import torch
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch.testing._internal import common_utils

--- a/test/dtypes/test_bitnet.py
+++ b/test/dtypes/test_bitnet.py
@@ -1,5 +1,6 @@
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 import torch
 import torch.nn as nn
 from torchao.prototype.dtypes import BitnetTensor
@@ -42,7 +43,7 @@ def test_multiply(bitnet_tensor):
     w = BitnetTensor.from_unpacked(w_t)
     y = torch.addmm(torch.Tensor([1]), bitnet_tensor, w)
 
-@pytest.mark.parametrize("dtype", [torch.float, torch.float16, torch.bfloat16, torch.int16, torch.int32, torch.int64])
+@parametrize("dtype", [torch.float, torch.float16, torch.bfloat16, torch.int16, torch.int32, torch.int64])
 def test_conversion(bitnet_tensor, dtype):
     converted_tensor = bitnet_tensor.to(dtype)
     expected_tensor = unpack_uint2(bitnet_tensor.elem).to(dtype)
@@ -60,7 +61,7 @@ def _apply_weight_only_uint2_quant(model):
     )
 
 @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="Regression introdued in nightlies")
-@pytest.mark.parametrize("input_shape", [[2, 4], [5, 5, 5, 4], [1, 4, 4]])
+@parametrize("input_shape", [[2, 4], [5, 5, 5, 4], [1, 4, 4]])
 def test_uint2_quant(input_shape):
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     x = torch.randn(*input_shape).to(device)

--- a/test/dtypes/test_bitnet.py
+++ b/test/dtypes/test_bitnet.py
@@ -9,7 +9,7 @@ from torchao.quantization.quant_api import _replace_with_custom_fn_if_matches_fi
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_4:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():

--- a/test/dtypes/test_bitnet.py
+++ b/test/dtypes/test_bitnet.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 import torch
 import torch.nn as nn
 from torchao.prototype.dtypes import BitnetTensor
@@ -58,7 +59,7 @@ def _apply_weight_only_uint2_quant(model):
         lambda mod, fqn: isinstance(mod, torch.nn.Linear),
     )
 
-@pytest.mark.skipif(TORCH_VERSION_AT_LEAST_2_5, reason="Regression introdued in nightlies")
+@unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="Regression introdued in nightlies")
 @pytest.mark.parametrize("input_shape", [[2, 4], [5, 5, 5, 4], [1, 4, 4]])
 def test_uint2_quant(input_shape):
     device = 'cuda' if torch.cuda.is_available() else 'cpu'

--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -1,6 +1,7 @@
 import torch
 from torchao.dtypes.uintx.bitpacking import pack, unpack, pack_cpu, unpack_cpu
 import pytest
+import unittest
 from torch.utils._triton import has_triton
 
 bit_widths = (1,2,3,4,5,6,7)
@@ -20,7 +21,7 @@ def test_CPU(bit_width, dim):
     assert(unpacked.allclose(test_tensor))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("bit_width", bit_widths)
 @pytest.mark.parametrize("dim", dimensions)
 def test_GPU(bit_width, dim):
@@ -30,8 +31,8 @@ def test_GPU(bit_width, dim):
     assert(unpacked.allclose(test_tensor))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not has_triton(), reason="unsupported without triton")
 @pytest.mark.parametrize("bit_width", bit_widths)
 @pytest.mark.parametrize("dim", dimensions)
 def test_compile(bit_width, dim):
@@ -44,7 +45,7 @@ def test_compile(bit_width, dim):
     assert(unpacked.allclose(test_tensor))
 
 # these test cases are for the example pack walk through in the bitpacking.py file
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 def test_pack_example():
     test_tensor = torch.tensor([0x30,0x29,0x17,0x5,0x20,0x16,0x9,0x22], dtype=torch.uint8).cuda()
     shard_4,shard_2  = pack(test_tensor, 6)

--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -2,6 +2,7 @@ import torch
 from torchao.dtypes.uintx.bitpacking import pack, unpack, pack_cpu, unpack_cpu
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 from torch.utils._triton import has_triton
 
 bit_widths = (1,2,3,4,5,6,7)
@@ -12,8 +13,8 @@ def run_before_and_after_tests():
     yield
     torch._dynamo.reset() # reset cache between tests
 
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
+@parametrize("bit_width", bit_widths)
+@parametrize("dim", dimensions)
 def test_CPU(bit_width, dim):
     test_tensor = torch.randint(0, 2**bit_width, (32,32,32), dtype=torch.uint8, device='cpu')
     packed = pack_cpu(test_tensor, bit_width, dim = dim)
@@ -22,8 +23,8 @@ def test_CPU(bit_width, dim):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
+@parametrize("bit_width", bit_widths)
+@parametrize("dim", dimensions)
 def test_GPU(bit_width, dim):
     test_tensor = torch.randint(0, 2**bit_width, (32,32,32), dtype=torch.uint8).cuda()
     packed = pack(test_tensor, bit_width, dim = dim)
@@ -33,8 +34,8 @@ def test_GPU(bit_width, dim):
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @unittest.skipIf(not has_triton(), reason="unsupported without triton")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
+@parametrize("bit_width", bit_widths)
+@parametrize("dim", dimensions)
 def test_compile(bit_width, dim):
     torch._dynamo.config.specialize_int = True
     pack_compile = torch.compile(pack, fullgraph=True)

--- a/test/dtypes/test_floatx.py
+++ b/test/dtypes/test_floatx.py
@@ -1,6 +1,7 @@
 import copy
 
 import pytest
+import unittest
 import torch
 from torch.testing._internal.common_utils import (
     TestCase,
@@ -70,7 +71,7 @@ class TestFloatxTensorCoreAQTTensorImpl(TestCase):
         actual = torch.compile(from_scaled_tc_floatx, fullgraph=True)(x, ebits, mbits, scale)
         torch.testing.assert_close(actual, expected)
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
     @parametrize("ebits,mbits", _Floatx_DTYPES)
     def test_to_copy_device(self, ebits, mbits):
         from torchao.quantization.quant_primitives import (
@@ -87,12 +88,12 @@ class TestFloatxTensorCoreAQTTensorImpl(TestCase):
         floatx_tensor_impl = floatx_tensor_impl.cpu()
         assert floatx_tensor_impl.device.type == "cpu"
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="quantization only works with torch.compile for 2.5+")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="quantization only works with torch.compile for 2.5+")
     @parametrize("ebits,mbits", _Floatx_DTYPES)
     @parametrize("bias", [False, True])
     @parametrize("dtype", [torch.half, torch.bfloat16])
-    @pytest.mark.skipif(is_fbcode(), reason="broken in fbcode")
+    @unittest.skipIf(is_fbcode(), reason="broken in fbcode")
     def test_fpx_weight_only(self, ebits, mbits, bias, dtype):
         N, OC, IC = 4, 256, 64
         device = "cuda"

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -574,7 +574,7 @@ class TestQLoRA(FSDPTest):
     def world_size(self) -> int:
         return 2
 
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         version.parse(torch.__version__).base_version < "2.4.0",
         reason="torch >= 2.4 required",
     )

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -6,7 +6,6 @@ import unittest
 from collections import OrderedDict
 from typing import Tuple, Union
 
-import pytest
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/test/dtypes/test_uint2.py
+++ b/test/dtypes/test_uint2.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 from torch.testing._internal.common_utils import parametrize
 import torch
 import torch.nn as nn
@@ -7,7 +8,7 @@ from torchao.prototype.dtypes.uint2 import unpack_uint2
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_4
 
 if not TORCH_VERSION_AT_LEAST_2_4:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 @pytest.fixture
 def uint2_tensor():

--- a/test/dtypes/test_uint2.py
+++ b/test/dtypes/test_uint2.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 import torch
 import torch.nn as nn
 from torchao.prototype.dtypes import UInt2Tensor
@@ -22,7 +23,7 @@ def test_transpose(uint2_tensor):
     expected_tensor = unpack_uint2(uint2_tensor.elem).t()
     assert torch.equal(unpack_uint2(transposed_tensor.elem), expected_tensor)
 
-@pytest.mark.parametrize("dtype", [torch.float, torch.float16, torch.bfloat16, torch.int16, torch.int32, torch.int64])
+@parametrize("dtype", [torch.float, torch.float16, torch.bfloat16, torch.int16, torch.int32, torch.int64])
 def test_conversion(uint2_tensor, dtype):
     converted_tensor = uint2_tensor.to(dtype)
     expected_tensor = unpack_uint2(uint2_tensor.elem).to(dtype)

--- a/test/dtypes/test_uintx.py
+++ b/test/dtypes/test_uintx.py
@@ -1,6 +1,7 @@
 from math import log
 from copy import deepcopy
 import pytest
+import unittest
 
 import torch
 
@@ -46,8 +47,8 @@ class Linear16(torch.nn.Module):
 
 @pytest.mark.parametrize("dtype", dtypes)
 @pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_quant_on_cpu_then_move_to_cuda(dtype, group_size):
     scale = 512
     fp16_mod_on_cpu = Linear16(scale, "cpu")
@@ -62,8 +63,8 @@ def test_uintx_quant_on_cpu_then_move_to_cuda(dtype, group_size):
 @pytest.mark.parametrize("dtype", dtypes)
 @pytest.mark.parametrize("group_size", group_sizes)
 @pytest.mark.parametrize("device", devices)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_weight_only_model_quant(dtype, group_size, device):
     scale = 512
     fp16 = Linear16(scale, device)
@@ -76,8 +77,8 @@ def test_uintx_weight_only_model_quant(dtype, group_size, device):
 @pytest.mark.parametrize("dtype", dtypes)
 @pytest.mark.parametrize("group_size", group_sizes)
 @pytest.mark.parametrize("device", devices)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_weight_only_quant(dtype, group_size, device):
     input_float = torch.randn((1, 256), dtype=torch.float16, device = device)
     mapping_type = MappingType.SYMMETRIC
@@ -110,8 +111,8 @@ def test_uintx_weight_only_quant(dtype, group_size, device):
 
 
 @pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
+@unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
 def test_uintx_target_dtype(dtype):
     from torchao.quantization.quant_api import uintx_weight_only
     l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
@@ -120,8 +121,8 @@ def test_uintx_target_dtype(dtype):
     l(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
 
 @pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="torch.compile without unwrap_tensor_subclass requires torch 2.5+")
+@unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="torch.compile without unwrap_tensor_subclass requires torch 2.5+")
 def test_uintx_target_dtype_compile(dtype):
     from torchao.quantization.quant_api import uintx_weight_only
     l = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
@@ -132,8 +133,8 @@ def test_uintx_target_dtype_compile(dtype):
 
 
 @pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
+@unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
 def test_uintx_model_size(dtype):
     from torchao.quantization.quant_api import uintx_weight_only
     from torchao.utils import get_model_size_in_bytes

--- a/test/dtypes/test_uintx.py
+++ b/test/dtypes/test_uintx.py
@@ -2,6 +2,7 @@ from math import log
 from copy import deepcopy
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 import torch
 
@@ -45,8 +46,8 @@ class Linear16(torch.nn.Module):
     def forward(self, x):
         return self.net(x)
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
+@parametrize("dtype", dtypes)
+@parametrize("group_size", group_sizes)
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_quant_on_cpu_then_move_to_cuda(dtype, group_size):
@@ -60,9 +61,9 @@ def test_uintx_quant_on_cpu_then_move_to_cuda(dtype, group_size):
     output_on_cuda = fp16_mod_on_cuda(test_input_on_cuda)
     assert torch.allclose(output_on_cpu, output_on_cuda.cpu(), atol=1.0e-3), "The output of the model on CPU and CUDA should be close"
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.parametrize("device", devices)
+@parametrize("dtype", dtypes)
+@parametrize("group_size", group_sizes)
+@parametrize("device", devices)
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_weight_only_model_quant(dtype, group_size, device):
@@ -74,9 +75,9 @@ def test_uintx_weight_only_model_quant(dtype, group_size, device):
     output = uintx.forward(test_input)
     assert output != None, "model quantization failed"
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.parametrize("device", devices)
+@parametrize("dtype", dtypes)
+@parametrize("group_size", group_sizes)
+@parametrize("device", devices)
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build")
 def test_uintx_weight_only_quant(dtype, group_size, device):
@@ -110,7 +111,7 @@ def test_uintx_weight_only_quant(dtype, group_size, device):
     assert deqaunt != None, "deqauntization failed"
 
 
-@pytest.mark.parametrize("dtype", dtypes)
+@parametrize("dtype", dtypes)
 @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
 def test_uintx_target_dtype(dtype):
@@ -120,7 +121,7 @@ def test_uintx_target_dtype(dtype):
     uintx_weight_only(dtype)(l)
     l(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
 
-@pytest.mark.parametrize("dtype", dtypes)
+@parametrize("dtype", dtypes)
 @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="torch.compile without unwrap_tensor_subclass requires torch 2.5+")
 def test_uintx_target_dtype_compile(dtype):
@@ -132,7 +133,7 @@ def test_uintx_target_dtype_compile(dtype):
     l(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
 
 
-@pytest.mark.parametrize("dtype", dtypes)
+@parametrize("dtype", dtypes)
 @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+")
 def test_uintx_model_size(dtype):

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -13,6 +13,7 @@ import warnings
 from typing import List, Tuple
 
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 import torch
 import torch.nn as nn
@@ -144,8 +145,8 @@ class TestFloat8Tensor:
         fp8_b.copy_(fp8_a)
         torch.testing.assert_close(fp8_a._data, fp8_b._data)
 
-    @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
-    @pytest.mark.parametrize("axiswise_dim", [0, -1])
+    @parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
+    @parametrize("axiswise_dim", [0, -1])
     def test_axiswise_dynamic_cast(self, shape, axiswise_dim):
         a = torch.randn(*shape, dtype=torch.bfloat16)
         linear_mm_config = LinearMMConfig()
@@ -212,8 +213,8 @@ class TestFloat8Tensor:
         with pytest.raises(RuntimeError):
             a_fp8_d2_r2 = a_fp8_d2.reshape(3, -1)
 
-    @pytest.mark.parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
-    @pytest.mark.parametrize(
+    @parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
+    @parametrize(
         "a_granularity,b_granularity",
         [
             (ScalingGranularity.AXISWISE, ScalingGranularity.AXISWISE),
@@ -328,22 +329,22 @@ class TestFloat8Linear:
             # verify initialization flags got updated
             assert m_fp8.is_amax_initialized, "Amax was not properly initialized"
 
-    @pytest.mark.parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
-    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @pytest.mark.parametrize(
+    @parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
+    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @parametrize(
         "scaling_type_input",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_weight",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_grad_output",
         [ScalingType.DELAYED, ScalingType.DYNAMIC],
     )
-    @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
-    @pytest.mark.parametrize("linear_bias", [False, True])
+    @parametrize("linear_dtype", [torch.bfloat16, torch.float32])
+    @parametrize("linear_bias", [False, True])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_linear_from_config_params(
         self,
@@ -375,15 +376,15 @@ class TestFloat8Linear:
     # them, so this function factors out some of the recipes which are annoying
     # to combine with the main testing function.
     # TODO(future PR): make this cleaner.
-    @pytest.mark.parametrize(
+    @parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.ALL_AXISWISE,
             Float8LinearRecipeName.LW_AXISWISE_WITH_GW_HP,
         ],
     )
-    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @pytest.mark.parametrize("linear_bias", [True, False])
+    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @parametrize("linear_bias", [True, False])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_linear_from_recipe(
         self,
@@ -407,8 +408,8 @@ class TestFloat8Linear:
             config,
         )
 
-    @pytest.mark.parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
-    @pytest.mark.parametrize(
+    @parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
+    @parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
@@ -448,10 +449,10 @@ class TestFloat8Linear:
             y.dtype == torch.bfloat16
         ), f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
-    @pytest.mark.parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
+    @parametrize("emulate", [True, False] if is_cuda_8_9 else [True])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_type_cast(self, linear_dtype: torch.dtype, emulate: bool):
         m = nn.Linear(32, 16, device="cuda", dtype=linear_dtype)
@@ -526,10 +527,10 @@ class TestScaledMM:
         not is_cuda_8_9,
         "CUDA not available",
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
-    @pytest.mark.parametrize("use_fast_accum", [True, False])
+    @parametrize("use_fast_accum", [True, False])
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -607,10 +608,10 @@ class TestScaledMM:
         not is_cuda_8_9,
         "CUDA not available",
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
-    @pytest.mark.parametrize("use_fast_accum", [True, False])
+    @parametrize("use_fast_accum", [True, False])
     def test_pad_inner_dim(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -690,7 +691,7 @@ class TestScaledMM:
 
 
 class TestNumerics:
-    @pytest.mark.parametrize(
+    @parametrize(
         "float8_dtype",
         [
             torch.float8_e4m3fn,

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 
 from torchao.float8.config import (
@@ -396,7 +396,7 @@ class TestFloat8Linear:
             warnings.warn(
                 f"CUDA capability {torch.cuda.get_device_capability()} < (9.0)"
             )
-            pytest.skip()
+            unittest.skip()
 
         linear_dtype = torch.bfloat16
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -13,7 +13,7 @@ import warnings
 from typing import List, Tuple
 
 import pytest
-from torch.testing._internal.common_utils import parametrize
+from torch.testing._internal.common_utils import parametrize, run_tests
 
 import torch
 import torch.nn as nn
@@ -852,4 +852,4 @@ class TestFloat8LinearUtils(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    run_tests()

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -87,18 +87,18 @@ def _test_compile_base(
     torch.testing.assert_close(x.grad, x_ref.grad, atol=8e-2, rtol=8e-2)
 
 
-@pytest.mark.parametrize("fullgraph", [True])
-@pytest.mark.parametrize(
+@parametrize("fullgraph", [True])
+@parametrize(
     "scaling_type_input", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_weight", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize("emulate", [False, True] if is_cuda_8_9 else [True])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@parametrize("emulate", [False, True] if is_cuda_8_9 else [True])
+@parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
 def test_eager_only(
     fullgraph,
@@ -123,18 +123,18 @@ def test_eager_only(
     )
 
 
-@pytest.mark.parametrize("fullgraph", [True])
-@pytest.mark.parametrize("emulate", [False, True] if is_cuda_8_9 else [True])
-@pytest.mark.parametrize(
+@parametrize("fullgraph", [True])
+@parametrize("emulate", [False, True] if is_cuda_8_9 else [True])
+@parametrize(
     "scaling_type_input", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_weight", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
 def test_aot_eager(
     fullgraph,
@@ -159,19 +159,19 @@ def test_aot_eager(
     )
 
 
-@pytest.mark.parametrize("fullgraph", [True])
-@pytest.mark.parametrize("emulate", [False])
-@pytest.mark.parametrize(
+@parametrize("fullgraph", [True])
+@parametrize("emulate", [False])
+@parametrize(
     "scaling_type_input", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_weight", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "scaling_type_grad_output", [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC]
 )
 @unittest.skipIf(not torch.cuda.is_available() or not is_cuda_8_9, "CUDA with float8 support not available")
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -198,7 +198,7 @@ def test_inductor_from_config_params(
 # them, so this function factors out some of the recipes which are annoying
 # to combine with the main testing function.
 # TODO(future PR): make this cleaner.
-@pytest.mark.parametrize(
+@parametrize(
     "recipe_name",
     [Float8LinearRecipeName.ALL_AXISWISE, Float8LinearRecipeName.LW_AXISWISE_WITH_GW_HP],
 )
@@ -371,7 +371,7 @@ def test_sync_amax_func_cuda_graph_success():
         not is_cuda_8_9,
         "CUDA not available",
     )
-@pytest.mark.parametrize(
+@parametrize(
     "dtype",
     [
         torch.float32,

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_utils import parametrize
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import torch
 import torch.nn as nn

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -11,6 +11,7 @@ import unittest
 from io import StringIO
 
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 

--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -18,11 +18,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import pytest
+import unittest
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 from torchao.float8 import Float8LinearConfig
 from torchao.float8.float8_linear_utils import convert_to_float8_training

--- a/test/float8/test_fsdp.py
+++ b/test/float8/test_fsdp.py
@@ -14,6 +14,7 @@ Test numerics of bf16 versus float8 with FSDP on. At a high level:
 import copy
 import os
 import pytest
+import unittest
 import warnings
 
 import fire
@@ -21,7 +22,7 @@ import fire
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import torch
 import torch.distributed as dist

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 
 import torch
@@ -40,7 +40,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 is_cuda_8_9 = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)
 if not is_cuda_8_9:
-    pytest.skip("Unsupported CUDA device capability version", allow_module_level=True)
+    unittest.skip("Unsupported CUDA device capability version", allow_module_level=True)
 
 class TestFloat8Common:
     def broadcast_module(self, module: nn.Module) -> None:

--- a/test/float8/test_fsdp2/test_fsdp2_fp8_comm_only.py
+++ b/test/float8/test_fsdp2/test_fsdp2_fp8_comm_only.py
@@ -1,11 +1,13 @@
 import copy
 import pytest
+import unittest
+import unittest
 from typing import Optional
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import torch
 import torch._dynamo.testing
@@ -39,7 +41,7 @@ from torchao.testing.float8.fsdp2_utils import check_parity_fp8_comm_only
 
 is_cuda_8_9 = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)
 if not is_cuda_8_9:
-    pytest.skip("Unsupported CUDA device capability version", allow_module_level=True)
+    unittest.skip("Unsupported CUDA device capability version", allow_module_level=True)
 
 
 class Float8CommTestLinear(torch.nn.Linear):

--- a/test/float8/test_fsdp_compile.py
+++ b/test/float8/test_fsdp_compile.py
@@ -14,11 +14,12 @@ import warnings
 import fire
 
 import pytest
+import unittest
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import torch
 import torch.distributed as dist

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -167,15 +167,15 @@ class TestFloat8NumericsIntegrationTest:
             sqnr = compute_error(ref_grad, cur_grad)
             assert sqnr > grad_sqnr_threshold
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_input", 
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_weight", 
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_grad_output",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
@@ -195,7 +195,7 @@ class TestFloat8NumericsIntegrationTest:
         )
         self._test_impl(config)
 
-    @pytest.mark.parametrize(
+    @parametrize(
         "recipe_name",
         [Float8LinearRecipeName.ALL_AXISWISE, Float8LinearRecipeName.LW_AXISWISE_WITH_GW_HP],
     )

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -10,6 +10,7 @@ import copy
 from typing import Optional
 
 import pytest
+import unittest
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
@@ -178,8 +179,8 @@ class TestFloat8NumericsIntegrationTest:
         "scaling_type_grad_output",
         [ScalingType.DELAYED, ScalingType.DYNAMIC, ScalingType.STATIC],
     )
-    @pytest.mark.skipif(not is_cuda_8_9, reason="requires SM89 compatible machine")
-    @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
+    @unittest.skipIf(not is_cuda_8_9, reason="requires SM89 compatible machine")
+    @unittest.skipIf(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
@@ -198,8 +199,8 @@ class TestFloat8NumericsIntegrationTest:
         "recipe_name",
         [Float8LinearRecipeName.ALL_AXISWISE, Float8LinearRecipeName.LW_AXISWISE_WITH_GW_HP],
     )
-    @pytest.mark.skipif(not is_cuda_9_0, reason="requires SM90 compatible machine")
-    @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
+    @unittest.skipIf(not is_cuda_9_0, reason="requires SM90 compatible machine")
+    @unittest.skipIf(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -16,7 +16,7 @@ from torch.testing._internal.common_utils import parametrize
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 import torch
 import torch.nn as nn

--- a/test/hqq/test_triton_mm.py
+++ b/test/hqq/test_triton_mm.py
@@ -1,5 +1,6 @@
 # Skip entire test if following module not available, otherwise CI failure
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 triton = pytest.importorskip(
     "triton", minversion="3.0.0", reason="Triton > 3.0.0 required to run this test"

--- a/test/hqq/test_triton_mm.py
+++ b/test/hqq/test_triton_mm.py
@@ -71,7 +71,7 @@ def _arg_to_id(arg):
     return str(arg)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "shape, group_size, axis, dtype, transposed, kernel_type",
     TEST_CONFIGS,
     ids=_arg_to_id,

--- a/test/hqq/test_triton_qkv_fused.py
+++ b/test/hqq/test_triton_qkv_fused.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 triton = pytest.importorskip(
     "triton", minversion="3.0.0", reason="Triton > 3.0.0 required to run this test"
@@ -102,7 +103,7 @@ def ref_proj(x, packed_w, scale, zero, group_size, kernel_type, transposed=False
     )
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "q_shape, kv_shape, group_size, axis, dtype, transposed, kernel_type",
     TEST_CONFIGS,
     ids=_arg_to_id,

--- a/test/kernel/test_fused_kernels.py
+++ b/test/kernel/test_fused_kernels.py
@@ -2,6 +2,7 @@ import itertools
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:
@@ -104,7 +105,7 @@ TEST_CONFIGS = list(
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
-@pytest.mark.parametrize("kernel, dtype, M, N, rank, allow_tf32", TEST_CONFIGS)
+@parametrize("kernel, dtype, M, N, rank, allow_tf32", TEST_CONFIGS)
 def test_galore_fused_kernels(kernel, dtype, M, N, rank, allow_tf32):
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32
 

--- a/test/kernel/test_fused_kernels.py
+++ b/test/kernel/test_fused_kernels.py
@@ -1,6 +1,7 @@
 import itertools
 
 import pytest
+import unittest
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:
@@ -102,7 +103,7 @@ TEST_CONFIGS = list(
 # TEST_CONFIGS = TEST_CONFIGS[0:1]
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize("kernel, dtype, M, N, rank, allow_tf32", TEST_CONFIGS)
 def test_galore_fused_kernels(kernel, dtype, M, N, rank, allow_tf32):
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32

--- a/test/kernel/test_fused_kernels.py
+++ b/test/kernel/test_fused_kernels.py
@@ -8,7 +8,7 @@ from torch.testing._internal.common_utils import parametrize
 try:
     import triton
 except ImportError:
-    pytest.skip("triton is not installed", allow_module_level=True)
+    unittest.skip("triton is not installed", allow_module_level=True)
 
 import torch
 from galore_test_utils import get_kernel, make_copy, make_data

--- a/test/kernel/test_galore_downproj.py
+++ b/test/kernel/test_galore_downproj.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:
@@ -28,7 +29,7 @@ TEST_CONFIGS = [
 ]
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+@unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
 @pytest.mark.parametrize("M, N, rank, allow_tf32, fp8_fast_accum, dtype", TEST_CONFIGS)
 def test_galore_downproj(M, N, rank, allow_tf32, fp8_fast_accum, dtype):
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32

--- a/test/kernel/test_galore_downproj.py
+++ b/test/kernel/test_galore_downproj.py
@@ -1,5 +1,6 @@
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:
@@ -30,7 +31,7 @@ TEST_CONFIGS = [
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="requires GPU")
-@pytest.mark.parametrize("M, N, rank, allow_tf32, fp8_fast_accum, dtype", TEST_CONFIGS)
+@parametrize("M, N, rank, allow_tf32, fp8_fast_accum, dtype", TEST_CONFIGS)
 def test_galore_downproj(M, N, rank, allow_tf32, fp8_fast_accum, dtype):
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32
     MAX_DIFF = MAX_DIFF_tf32 if allow_tf32 else MAX_DIFF_no_tf32

--- a/test/kernel/test_galore_downproj.py
+++ b/test/kernel/test_galore_downproj.py
@@ -6,7 +6,7 @@ from torch.testing._internal.common_utils import parametrize
 try:
     import triton
 except ImportError:
-    pytest.skip("triton is not installed", allow_module_level=True)
+    unittest.skip("triton is not installed", allow_module_level=True)
 
 import torch
 from galore_test_utils import make_data

--- a/test/profiler/test_device_spec.py
+++ b/test/profiler/test_device_spec.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 cuda_driver = pytest.importorskip(
     "triton.runtime.driver", reason="requires triton cuda driver module"
@@ -21,7 +22,7 @@ USE_TENSORCORES = [True, False]
 DEVICE_CONFIGS = itertools.product(DEVICE_NAMES, DTYPES, USE_TENSORCORES)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "device_name, dtype, use_tensorcores", DEVICE_CONFIGS, ids=lambda x: str(x)
 )
 def test_device_spec(device_name, dtype, use_tensorcores):

--- a/test/profiler/test_performance_counter.py
+++ b/test/profiler/test_performance_counter.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 
 # Skip if transformers is not installed
 transformers = pytest.importorskip("transformers")
@@ -226,7 +227,7 @@ PERFSTATS_TEST_CONFIGS = [
 ]
 
 
-@pytest.mark.parametrize("cfg", PERFSTATS_TEST_CONFIGS, ids=lambda cfg: cfg.label)
+@parametrize("cfg", PERFSTATS_TEST_CONFIGS, ids=lambda cfg: cfg.label)
 def test_performance_stats(cfg: PerfStatsTestConfig):
     stats = PerformanceStats(**asdict(cfg))
     num_tokens = cfg.num_tokens

--- a/test/prototype/mx_formats/test_custom_cast.py
+++ b/test/prototype/mx_formats/test_custom_cast.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
+import unittest
 
 import torch
 
@@ -318,9 +319,9 @@ def test_fp4_pack_unpack():
     assert torch.all(orig_vals_dq == orig_vals)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_4, reason="requires PyTorch >= 2.4")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not has_triton(), reason="unsupported without triton")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_4, reason="requires PyTorch >= 2.4")
 def test_fp4_triton_unscaled_cast():
     packed_vals = torch.arange(0, 255, dtype=torch.uint8, device="cuda")
     f32_ref = f4_unpacked_to_f32(unpack_uint4(packed_vals))
@@ -328,9 +329,9 @@ def test_fp4_triton_unscaled_cast():
     assert torch.all(torch.eq(f32_ref, f32_triton))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_4, reason="requires PyTorch >= 2.4")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not has_triton(), reason="unsupported without triton")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_4, reason="requires PyTorch >= 2.4")
 def test_fp4_triton_scaled_cast():
     size = (256,)
     orig_vals = torch.randn(size, dtype=torch.float, device="cuda") * 100
@@ -392,7 +393,7 @@ def test_fp6_values(dtype_name):
     "device",
     [
         "cpu",
-        pytest.param("cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")),
+        pytest.param("cuda", marks=unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")),
     ]
 )
 @pytest.mark.parametrize(

--- a/test/prototype/mx_formats/test_custom_cast.py
+++ b/test/prototype/mx_formats/test_custom_cast.py
@@ -6,6 +6,7 @@
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 import torch
 
@@ -51,7 +52,7 @@ from torchao.utils import TORCH_VERSION_AT_LEAST_2_4
 torch.manual_seed(0)
 
 
-@pytest.mark.skip(
+@unittest.skipIf(
     reason="TODO debug CI failure, low pri since this is not used in the MX code"  # noqa: E501
 )
 def test_fp32():
@@ -61,7 +62,7 @@ def test_fp32():
         _assert_equals(fp_ref, s_enc_ref, e_enc_ref, m_enc_ref, dtype)
 
 
-@pytest.mark.skip(
+@unittest.skipIf(
     reason="TODO debug CI failure, low pri since this is not used in the MX code"  # noqa: E501
 )
 def test_bf16():
@@ -344,7 +345,7 @@ def test_fp4_triton_scaled_cast():
     assert torch.all(torch.eq(f32_ref, f32_triton))
 
 
-@pytest.mark.parametrize("dtype_name", (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2))
+@parametrize("dtype_name", (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2))
 def test_fp6_values(dtype_name):
     """
     The fp6 dtypes have 2**6 = 64 unique values each. The test
@@ -389,14 +390,14 @@ def test_fp6_values(dtype_name):
         torch.testing.assert_close(f32, f32_ref, rtol=0, atol=0)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "device",
     [
         "cpu",
         pytest.param("cuda", marks=unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")),
     ]
 )
-@pytest.mark.parametrize(
+@parametrize(
     "f32_val,f6_e3m2_enc",
     [
         (29.0,   0b011111),  # normal round down

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -8,6 +8,7 @@ import copy
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 import torch
 import torch.nn as nn
@@ -34,9 +35,9 @@ if not TORCH_VERSION_AT_LEAST_2_4:
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("bias", [True, False])
+@parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
 def test_linear_eager(elem_dtype, bias, input_shape):
     """
     Smoke test for training linear module with mx weight
@@ -96,8 +97,8 @@ def test_activation_checkpointing():
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("bias", [False, True])
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("bias", [False, True])
 def test_linear_compile(elem_dtype, bias):
     """
     Verify that compile does not change numerics of MX linear fw + bw
@@ -144,9 +145,9 @@ def test_linear_compile(elem_dtype, bias):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("bias", [True, False])
-@pytest.mark.parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("bias", [True, False])
+@parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
 def test_inference_linear(elem_dtype, bias, input_shape):
     """
     Smoke test for inference linear module with mx weight
@@ -168,7 +169,7 @@ def test_inference_linear(elem_dtype, bias, input_shape):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_inference_compile_simple(elem_dtype):
     """
     Smoke test for inference compile

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -31,7 +31,7 @@ IS_CUDA_GE_89 = __has_cuda and torch.cuda.get_device_capability() >= (8, 9)
 torch.manual_seed(2)
 
 if not TORCH_VERSION_AT_LEAST_2_4:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
@@ -105,7 +105,7 @@ def test_linear_compile(elem_dtype, bias):
     """
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         if not IS_CUDA_GE_89:
-            pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
+            unittest.skip("CUDA capability >= 8.9 required for float8 in triton")
     input_shape = (2, 4)
     grad_shape = (2, 6)
     m_mx = nn.Sequential(
@@ -176,7 +176,7 @@ def test_inference_compile_simple(elem_dtype):
     """
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         if not IS_CUDA_GE_89:
-            pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
+            unittest.skip("CUDA capability >= 8.9 required for float8 in triton")
     m = nn.Sequential(nn.Linear(4, 6, bias=False, dtype=torch.bfloat16))
     m = m.cuda()
     m_mx = copy.deepcopy(m)

--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -7,6 +7,7 @@
 import copy
 
 import pytest
+import unittest
 
 import torch
 import torch.nn as nn
@@ -32,7 +33,7 @@ if not TORCH_VERSION_AT_LEAST_2_4:
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
@@ -75,7 +76,7 @@ def test_linear_eager(elem_dtype, bias, input_shape):
 
 
 # TODO(future): enable compile support
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 def test_activation_checkpointing():
     input_shape = (2, 4)
     grad_shape = (2, 6)
@@ -94,7 +95,7 @@ def test_activation_checkpointing():
     y.backward(g)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("bias", [False, True])
 def test_linear_compile(elem_dtype, bias):
@@ -142,7 +143,7 @@ def test_linear_compile(elem_dtype, bias):
     torch.testing.assert_close(x_g_ref, x_g, atol=0.02, rtol=0.02)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("input_shape", [(2, 4), (1, 2, 4), (1, 1, 2, 4)])
@@ -166,7 +167,7 @@ def test_inference_linear(elem_dtype, bias, input_shape):
         assert sqnr >= 11.0
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_inference_compile_simple(elem_dtype):
     """

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
+import unittest
 
 import torch
 from torchao.prototype.mx_formats import config
@@ -69,7 +70,7 @@ def _test_mx(data_hp, elem_dtype, block_size):
         assert_sqnr_gt_threshold(data_hp, data_mx_dq, 14.0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
     data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
@@ -77,7 +78,7 @@ def test_hello_world(elem_dtype):
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
     data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
@@ -85,7 +86,7 @@ def test_all_zeros(elem_dtype):
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
     data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
@@ -95,7 +96,7 @@ def test_some_zeros(elem_dtype):
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
@@ -111,7 +112,7 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(tensor_mx._scale_e8m0[1:] == E8M0_EXPONENT_NAN_VAL)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
     """
@@ -144,7 +145,7 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp[2:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
     """
@@ -157,7 +158,7 @@ def test_ranks(elem_dtype):
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_block_sizes(elem_dtype):
     """
@@ -170,7 +171,7 @@ def test_block_sizes(elem_dtype):
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("fp4_triton", [False, True])
 def test_transpose(elem_dtype, fp4_triton):
@@ -196,7 +197,7 @@ def test_transpose(elem_dtype, fp4_triton):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_cast_autograd(elem_dtype):
     x = torch.arange(8, device="cuda").bfloat16().requires_grad_()
@@ -216,7 +217,7 @@ def test_view(elem_dtype):
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -6,6 +6,7 @@
 
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 
 import torch
 from torchao.prototype.mx_formats import config
@@ -71,7 +72,7 @@ def _test_mx(data_hp, elem_dtype, block_size):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
     data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
     block_size = 2
@@ -79,7 +80,7 @@ def test_hello_world(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
     data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
     block_size = 2
@@ -87,7 +88,7 @@ def test_all_zeros(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
     data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
     data[0, :] = 0.0
@@ -97,7 +98,7 @@ def test_some_zeros(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
     If high precision block values has a NaN, the exponent block
@@ -113,7 +114,7 @@ def test_exponent_nan_in(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
@@ -146,7 +147,7 @@ def test_exponent_nan_out(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
@@ -159,7 +160,7 @@ def test_ranks(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_block_sizes(elem_dtype):
     """
     Smoke test for various block sizes
@@ -172,8 +173,8 @@ def test_block_sizes(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("fp4_triton", [False, True])
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("fp4_triton", [False, True])
 def test_transpose(elem_dtype, fp4_triton):
     """
     Verify that transposing an MX tensor works
@@ -198,7 +199,7 @@ def test_transpose(elem_dtype, fp4_triton):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_cast_autograd(elem_dtype):
     x = torch.arange(8, device="cuda").bfloat16().requires_grad_()
     grad = torch.arange(8, device="cuda").bfloat16() * 0.5
@@ -209,7 +210,7 @@ def test_cast_autograd(elem_dtype):
     torch.testing.assert_close(grad, x.grad, atol=0, rtol=0)
 
 
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
     x = torch.randn(1, 2, 4)
     block_size = 2
@@ -218,9 +219,9 @@ def test_view(elem_dtype):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.parametrize("all_zeros", [False, True])
+@parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@parametrize("hp_dtype", [torch.float32, torch.bfloat16])
+@parametrize("all_zeros", [False, True])
 def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -35,7 +35,7 @@ IS_CUDA_GE_89 = __has_cuda and torch.cuda.get_device_capability() >= (8, 9)
 torch.manual_seed(2)
 
 if not TORCH_VERSION_AT_LEAST_2_4:
-    pytest.skip("Unsupported PyTorch version", allow_module_level=True)
+    unittest.skip("Unsupported PyTorch version", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)
@@ -167,7 +167,7 @@ def test_block_sizes(elem_dtype):
     """
     for B in (1, 2, 32):
         if B == 1 and elem_dtype == DTYPE_FP4:
-            pytest.skip("unsupported configuration")
+            unittest.skip("unsupported configuration")
         tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
         _test_mx(tensor_hp, elem_dtype, B)
 
@@ -180,7 +180,7 @@ def test_transpose(elem_dtype, fp4_triton):
     Verify that transposing an MX tensor works
     """
     if elem_dtype != DTYPE_FP4 and fp4_triton:
-        pytest.skip("unsupported configuration")
+        unittest.skip("unsupported configuration")
 
     tensor_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
     block_size = 32
@@ -229,7 +229,7 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         if not IS_CUDA_GE_89:
             # separate ifs because flake8 is outsmarting me
-            pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
+            unittest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:

--- a/test/prototype/test_autoround.py
+++ b/test/prototype/test_autoround.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 from torchao.prototype.autoround.utils import is_auto_round_available
 
 if not is_auto_round_available():
@@ -86,7 +87,7 @@ def _check_params_and_buffers_type(module, check_fun):
 
 class TestAutoRound(TestCase):
 
-    @pytest.mark.skip(not TORCH_VERSION_AT_LEAST_2_5, "Requires torch 2.5 or later")
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "Requires torch 2.5 or later")
     @parametrize("device", _AVAILABLE_DEVICES)
     @torch.no_grad()
     def test_auto_round(self, device: str):
@@ -127,7 +128,7 @@ class TestAutoRound(TestCase):
         after_quant = m(*example_inputs)
         assert after_quant is not None, "Quantized model forward pass failed"
 
-    @pytest.mark.skip(not TORCH_VERSION_AT_LEAST_2_5, "Requires torch 2.5 or later")
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "Requires torch 2.5 or later")
     @parametrize("device", _AVAILABLE_DEVICES)
     @torch.no_grad()
     def test_wrap_model_with_multi_tensor(self, device: str):

--- a/test/prototype/test_autoround.py
+++ b/test/prototype/test_autoround.py
@@ -3,7 +3,7 @@ import unittest
 from torchao.prototype.autoround.utils import is_auto_round_available
 
 if not is_auto_round_available():
-    pytest.skip("AutoRound is not available", allow_module_level=True)
+    unittest.skip("AutoRound is not available", allow_module_level=True)
 
 import torch
 from torch.testing._internal.common_utils import (

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import os
 import pytest
+import unittest
 import torch
 from torchao.quantization import quantize_
 
@@ -38,8 +39,8 @@ def run_before_and_after_tests():
     
 @pytest.mark.parametrize("device", devices)   
 @pytest.mark.parametrize("qdtype", qdtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
 def test_awq_loading(device, qdtype):
     if qdtype == torch.uint4 and device == "cpu":
         pytest.skip("uint4 not supported on cpu")
@@ -84,8 +85,8 @@ def test_awq_loading(device, qdtype):
     assert awq_save_load_out is not None
     assert torch.allclose(awq_out, awq_save_load_out, atol = 1e-2)
 
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 def test_save_weights_only():
     dataset_size = 100
     l1,l2,l3 = 512,256,128

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -44,7 +44,7 @@ def run_before_and_after_tests():
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
 def test_awq_loading(device, qdtype):
     if qdtype == torch.uint4 and device == "cpu":
-        pytest.skip("uint4 not supported on cpu")
+        unittest.skip("uint4 not supported on cpu")
         
     dataset_size = 100
     l1,l2,l3 = 512,256,128

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import os
 import pytest
 import unittest
+from torch.testing._internal.common_utils import parametrize
 import torch
 from torchao.quantization import quantize_
 
@@ -37,8 +38,8 @@ def run_before_and_after_tests():
     yield
     torch._dynamo.reset() # reset cache between tests
     
-@pytest.mark.parametrize("device", devices)   
-@pytest.mark.parametrize("qdtype", qdtypes)
+@parametrize("device", devices)   
+@parametrize("qdtype", qdtypes)
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5,reason="requires nightly pytorch")
 def test_awq_loading(device, qdtype):

--- a/test/prototype/test_bitpacking_gen.py
+++ b/test/prototype/test_bitpacking_gen.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 import torch
 
 from torchao.prototype.dtypes.uintgen import (
@@ -6,7 +7,7 @@ from torchao.prototype.dtypes.uintgen import (
     pack_uint5, unpack_uint5, pack_uint6, unpack_uint6, pack_uint7, unpack_uint7
 )
 
-@pytest.mark.parametrize("pack_fn, unpack_fn, bit_count", [
+@parametrize("pack_fn, unpack_fn, bit_count", [
     (pack_uint2, unpack_uint2, 2),
     (pack_uint3, unpack_uint3, 3),
     (pack_uint4, unpack_uint4, 4),

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -2,6 +2,7 @@ import copy
 import tempfile
 
 import pytest
+import unittest
 import torch
 from packaging.version import Version
 from torch import nn
@@ -102,7 +103,7 @@ class TestQuantize(TestCase):
 
 
 class TestOptim(TestCase):
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_3, reason="requires PyTorch >= 2.3"
     )
     @parametrize(
@@ -151,12 +152,12 @@ class TestOptim(TestCase):
         for p1, p2 in zip(model.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1)
 
-    @pytest.mark.skipif(bnb is None, reason="bitsandbytes is not available")
-    @pytest.mark.skipif(
+    @unittest.skipIf(bnb is None, reason="bitsandbytes is not available")
+    @unittest.skipIf(
         not torch.cuda.is_available(),
         reason="bitsandbytes 8-bit Adam only works for CUDA",
     )
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_3, reason="requires PyTorch >= 2.3"
     )
     @parametrize("optim_name", ["Adam8bit", "AdamW8bit"])
@@ -192,11 +193,11 @@ class TestOptim(TestCase):
             torch.testing.assert_close(p2, p1, rtol=1e-5, atol=1e-5)
 
     # this will not run in CI because we can't install lpmm
-    @pytest.mark.skipif(lpmm is None, reason="lpmm is not available")
-    @pytest.mark.skipif(
+    @unittest.skipIf(lpmm is None, reason="lpmm is not available")
+    @unittest.skipIf(
         not torch.cuda.is_available(), reason="lpmm 4-bit Adam only works for CUDA"
     )
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_3, reason="requires PyTorch >= 2.3"
     )
     @parametrize("optim_name", ["Adam4bit", "AdamW4bit"])
@@ -232,7 +233,7 @@ class TestOptim(TestCase):
         for p1, p2 in zip(model1.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1, rtol=1e-5, atol=1e-5)
 
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not torch.cuda.is_available(), reason="optim CPU offload requires CUDA"
     )
     @parametrize("offload_grad,grad_accum", [(False, 1), (False, 2), (True, 1)])
@@ -268,7 +269,7 @@ class TestOptim(TestCase):
         for p1, p2 in zip(model1.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1)
 
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not torch.cuda.is_available(), reason="optim CPU offload requires CUDA"
     )
     def test_optim_cpu_offload_save_load(self):
@@ -355,7 +356,7 @@ class TestFSDP2(FSDPTest):
     def world_size(self) -> int:
         return 2
 
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_6, reason="PyTorch>=2.6 is required."
     )
     @skip_if_lt_x_gpu(2)

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -115,9 +115,9 @@ class TestOptim(TestCase):
     def test_optim_smoke(self, optim_name, dtype, device):
         if optim_name.endswith("Fp8") and device == "cuda":
             if not TORCH_VERSION_AT_LEAST_2_4:
-                pytest.skip("FP8 CUDA requires PyTorch >= 2.4")
+                unittest.skip("FP8 CUDA requires PyTorch >= 2.4")
             if torch.cuda.get_device_capability() < (8, 9):
-                pytest.skip("FP8 CUDA requires compute capability >= 8.9")
+                unittest.skip("FP8 CUDA requires compute capability >= 8.9")
 
         model = nn.Sequential(nn.Linear(32, 256), nn.ReLU(), nn.Linear(256, 32))
         model.to(device=device, dtype=dtype)

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -1,4 +1,5 @@
 import pytest
+import unittest
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_6
 
@@ -160,7 +161,7 @@ class TestQuantizedTraining(TestCase):
         ],
     )
     @parametrize("module_swap", [False, True])
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
     def test_int8_mixed_precision_training(self, compile, config, module_swap):
         _reset()
         bsize = 64
@@ -192,7 +193,7 @@ class TestQuantizedTraining(TestCase):
 
     @pytest.mark.skip('Flaky on CI')
     @parametrize("compile", [False, True])
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
     def test_bitnet_training(self, compile):
         # reference implementation
         # https://github.com/microsoft/unilm/blob/master/bitnet/The-Era-of-1-bit-LLMs__Training_Tips_Code_FAQ.pdf

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -4,7 +4,7 @@ import unittest
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_4, TORCH_VERSION_AT_LEAST_2_6
 
 if not TORCH_VERSION_AT_LEAST_2_4:
-    pytest.skip("Requires torch>=2.4", allow_module_level=True)
+    unittest.skip("Requires torch>=2.4", allow_module_level=True)
 
 import copy
 

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -191,7 +191,7 @@ class TestQuantizedTraining(TestCase):
         assert snr(inputs_ref.grad, inputs_int8mp.grad) > 20
         assert snr(linear.weight.grad, linear_int8mp.weight.grad) > 20
 
-    @pytest.mark.skip('Flaky on CI')
+    @unittest.skipIf('Flaky on CI')
     @parametrize("compile", [False, True])
     @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
     def test_bitnet_training(self, compile):

--- a/test/prototype/test_smoothquant.py
+++ b/test/prototype/test_smoothquant.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import pytest
+from torch.testing._internal.common_utils import parametrize
 import torch
 import tempfile
 from torchao.quantization import quantize_
@@ -49,11 +50,11 @@ if TORCH_VERSION_AT_LEAST_2_5:
     # This test case will trigger recompilation many times, so set a large cache_size_limit here
     torch._dynamo.config.cache_size_limit = 128
 
-@pytest.mark.parametrize("bias", bias_list)
-@pytest.mark.parametrize("alpha", alpha_list)
-@pytest.mark.parametrize("quant_mode", quant_mode_list)
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.parametrize("idtype", idtypes)
+@parametrize("bias", bias_list)
+@parametrize("alpha", alpha_list)
+@parametrize("quant_mode", quant_mode_list)
+@parametrize("device", devices)
+@parametrize("idtype", idtypes)
 def test_compute(bias, alpha, quant_mode, device, idtype):
     class Linear(torch.nn.Module):
         def __init__(self, bias: bool):
@@ -118,10 +119,10 @@ def test_compute(bias, alpha, quant_mode, device, idtype):
         assert torch.allclose(out, out_ref.to(idtype), atol=atol)
 
 
-@pytest.mark.parametrize("alpha", alpha_list)
-@pytest.mark.parametrize("quant_mode", quant_mode_list)
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.parametrize("idtype", idtypes)
+@parametrize("alpha", alpha_list)
+@parametrize("quant_mode", quant_mode_list)
+@parametrize("device", devices)
+@parametrize("idtype", idtypes)
 def test_save_load_recipe(alpha, quant_mode, device, idtype):
     dataset_size = 20
     l1, l2, l3 = 512, 256, 128

--- a/test/prototype/test_spinquant.py
+++ b/test/prototype/test_spinquant.py
@@ -1,4 +1,5 @@
 import pytest
+from torch.testing._internal.common_utils import parametrize
 import torch
 from torchao._models.llama.model import Transformer
 from torchao.prototype.spinquant import apply_spinquant
@@ -13,7 +14,7 @@ def _init_model(name="7B", device="cpu", precision=torch.bfloat16):
 _AVAILABLE_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
-@pytest.mark.parametrize("device", _AVAILABLE_DEVICES)
+@parametrize("device", _AVAILABLE_DEVICES)
 def test_spinquant_no_quantization(device):
     model = _init_model(device=device)
     seq_len = 16

--- a/test/quantization/test_galore_quant.py
+++ b/test/quantization/test_galore_quant.py
@@ -1,6 +1,8 @@
 import itertools
 
 import pytest
+import unittest
+from torch.testing._internal.common_utils import parametrize
 
 # Skip entire test if triton is not available, otherwise CI failure
 try:
@@ -28,8 +30,8 @@ BLOCKSIZE = [2048]
 TEST_CONFIGS = list(itertools.product(DIM1, DIM2, DTYPES, SIGNS, BLOCKSIZE))
 
 
-@pytest.mark.skip("skipping for now, see comments below")
-@pytest.mark.parametrize(
+@unittest.skipIf("skipping for now, see comments below")
+@parametrize(
     "dim1,dim2,dtype,signed,blocksize",
     TEST_CONFIGS,
 )
@@ -75,7 +77,7 @@ def test_galore_quantize_blockwise(dim1, dim2, dtype, signed, blocksize):
     assert tt_check or (not tt_check and dist_sum < 1e-4)
 
 
-@pytest.mark.parametrize(
+@parametrize(
     "dim1,dim2,dtype,signed,blocksize",
     TEST_CONFIGS,
 )

--- a/test/quantization/test_galore_quant.py
+++ b/test/quantization/test_galore_quant.py
@@ -8,7 +8,7 @@ from torch.testing._internal.common_utils import parametrize
 try:
     import triton
 except ImportError:
-    pytest.skip("triton is not installed", allow_module_level=True)
+    unittest.skip("triton is not installed", allow_module_level=True)
 
 import bitsandbytes.functional as F
 import torch

--- a/test/sparsity/test_marlin.py
+++ b/test/sparsity/test_marlin.py
@@ -1,6 +1,7 @@
 import torch
 import copy
 import pytest
+import unittest
 
 from torch import nn
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -40,7 +41,7 @@ class SparseMarlin24(TestCase):
             .cuda()
         )
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_quant_sparse_marlin_layout_eager(self):
         apply_fake_sparsity(self.model)
         model_copy = copy.deepcopy(self.model)
@@ -55,8 +56,8 @@ class SparseMarlin24(TestCase):
 
         assert torch.allclose(dense_result, sparse_result, atol=3e-1), "Results are not close"
 
-    @pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="Needs PyTorch 2.5+")
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, reason="Needs PyTorch 2.5+")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_quant_sparse_marlin_layout_compile(self):
         apply_fake_sparsity(self.model)
         model_copy = copy.deepcopy(self.model)
@@ -73,7 +74,7 @@ class SparseMarlin24(TestCase):
 
         assert torch.allclose(dense_result, sparse_result, atol=3e-1), "Results are not close"
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_pack_unpack_equivalence(self):
         num_bits = 4
         group_size = 128

--- a/test/test_ao_models.py
+++ b/test/test_ao_models.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 import torch
 from torchao._models.llama.model import Transformer
 
@@ -11,9 +11,9 @@ def init_model(name="stories15M", device="cpu", precision=torch.bfloat16):
     return model.eval()
 
 
-@pytest.mark.parametrize("device", _AVAILABLE_DEVICES)
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("is_training", [True, False])
+@unittest.parametrize("device", _AVAILABLE_DEVICES)
+@unittest.parametrize("batch_size", [1, 4])
+@unittest.parametrize("is_training", [True, False])
 def test_ao_llama_model_inference_mode(device, batch_size, is_training):
     random_model = init_model(device=device)
     seq_len = 16

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -101,7 +101,7 @@ TEST_CONFIGS_DEQUANT = list(itertools.product(SHAPES, INNERKTILES, QGROUP_SIZES)
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 # @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="weight packing is updated in 2.5+")
-@pytest.mark.parametrize("shape, inner_k_tiles", TEST_CONFIGS_UNPACK, ids=str)
+@parametrize("shape, inner_k_tiles", TEST_CONFIGS_UNPACK, ids=str)
 def test_unpack_tensor_core_tiled_layout_correctness(shape, inner_k_tiles):
     N, K = shape
     assert K % (inner_k_tiles * kTileSizeK) == 0 and N % kTileSizeN == 0
@@ -118,7 +118,7 @@ def test_unpack_tensor_core_tiled_layout_correctness(shape, inner_k_tiles):
 # TODO: Fix "test_aot_dispatch_dynamic" test failure
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 # @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="weight packing is updated in 2.5+")
-@pytest.mark.parametrize("shape, inner_k_tiles", TEST_CONFIGS_UNPACK , ids=str)
+@parametrize("shape, inner_k_tiles", TEST_CONFIGS_UNPACK , ids=str)
 def test_unpack_tensor_core_tiled_layout_op(shape, inner_k_tiles):
     test_utils = [
         "test_schema",
@@ -163,7 +163,7 @@ def dequant_ref(q, scales, zeros, group_size, nbits=4, dtype=torch.bfloat16):
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 # @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="weight packing is updated in 2.5+")
-@pytest.mark.parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
+@parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
 def test_dequantize_tensor_core_tiled_layout_correctness_quant_dequant(shape, inner_k_tiles, group_size):
     n, k = shape
     dtype = torch.bfloat16
@@ -222,7 +222,7 @@ def test_dequantize_tensor_core_tiled_layout_correctness_quant_dequant(shape, in
 # This test differs from one above in that it uses `unpack_tensor_core_tiled_layout` to unpack then dequantize
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 # @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="weight packing is updated in 2.5+")
-@pytest.mark.parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
+@parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
 def test_dequantize_tensor_core_tiled_layout_correctness_unpack_and_dequant(shape, inner_k_tiles, group_size):
     n, k = shape
     dtype = torch.bfloat16
@@ -279,7 +279,7 @@ def test_dequantize_tensor_core_tiled_layout_correctness_unpack_and_dequant(shap
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
 # @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_5, reason="weight packing is updated in 2.5+")
-@pytest.mark.parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
+@parametrize("shape, inner_k_tiles, group_size", TEST_CONFIGS_DEQUANT, ids=str)
 def test_dequantize_tensor_core_tiled_layout_op(shape, inner_k_tiles, group_size):
     n, k = shape
     device = "cuda"
@@ -379,7 +379,7 @@ def _symmetric_quantize_with_ref(w: torch.Tensor, num_bits: int, group_size: int
     )
 
 @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("batch_size, k_chunk, n_chunk, num_bits, group_size, mnk_factors", MARLIN_TEST_PARAMS, ids=str)
+@parametrize("batch_size, k_chunk, n_chunk, num_bits, group_size, mnk_factors", MARLIN_TEST_PARAMS, ids=str)
 def test_marlin_24(batch_size, k_chunk, n_chunk, num_bits, group_size, mnk_factors):
     m_factor, n_factor, k_factor = mnk_factors
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -17,12 +17,12 @@ import pytest
 import unittest
 
 if is_fbcode():
-    pytest.skip("Skipping the test in fbcode since we don't have TARGET file for kernels")
+    unittest.skip("Skipping the test in fbcode since we don't have TARGET file for kernels")
 
 try:
     import torchao.ops
 except RuntimeError:
-    pytest.skip("torchao.ops not available")
+    unittest.skip("torchao.ops not available")
 
 from torchao.quantization.utils import (
     get_groupwise_affine_qparams,

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -1097,7 +1097,7 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
     def get_plain(self):
         from torchao.sparsity.marlin import (
             unpack_from_marlin_24,
-        )  # avoid circular import
+        )
 
         int_data_expanded, scales_expanded = unpack_from_marlin_24(
             self.int_data,
@@ -1122,7 +1122,7 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
         from torchao.sparsity.marlin import (
             const,
             pack_to_marlin_24,
-        )  # avoid circular import
+        )
 
         assert isinstance(_layout, MarlinSparseLayout)
 


### PR DESCRIPTION
Summary: pytest is flaky in fbcode, this PR replaces pytest.mark.skip and pytest.mark.skipif for unittest.skipIf and replace pytest.mark.parametrize for torch's parametrize

Test Plan: see CI, the real test will be fbcode CI