### PR TITLE
Fixes observer attachment to model based on config for wanda sparsifier

### DIFF
--- a/torchao/sparsity/wanda.py
+++ b/torchao/sparsity/wanda.py
@@ -65,7 +65,8 @@ class WandaSparsifier(BaseSparsifier):
                 # Apply the qconfig directly to the module if it exists
                 if module is not None:
                     module.qconfig = QConfig(
-                        activation=PerChannelNormObserver, weight=default_placeholder_observer
+                        activation=PerChannelNormObserver,
+                        weight=default_placeholder_observer,
                     )  # type: ignore[assignment]
         torch.ao.quantization.prepare(model, inplace=True)
 


### PR DESCRIPTION
This PR fixes the issue [ https://github.com/pytorch/ao/issues/1133]( https://github.com/pytorch/ao/issues/1133) by only attaching the observers to the layers passed in the sparse config. 
Earlier irrespective of the layers being defined in sparse config, the observer was being attached to the entire model, leading to runtime errors as mentioned in the issue. 

cc: @jcaip @HDCharles @msaroufim 