### PR TITLE
[WIP] Remove python version specific usage within extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,4 +137,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch-labs/ao",
     cmdclass={"build_ext": BuildExtension},
+    options={"bdist_wheel": {
+        "py_limited_api": "cp38"
+    }},
 )

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ def get_extensions():
         extension(
             "torchao._C",
             sources,
+            py_limited_api=True,
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,
         )

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -22,10 +22,14 @@ _IS_FBCODE = (
 )
 if not _IS_FBCODE:
     try:
-        from . import _C
+        from importlib.util import find_spec
+        from pathlib import Path
+        spec = find_spec("torchao")
+        assert spec is not None, "torchao python module spec is unexpectedly None"
+        SO_PATH = Path(spec.origin).parent / "_C.abi3.so"
+        torch.ops.load_library(SO_PATH)
         from . import ops
     except:
-        _C = None
         logging.info("Skipping import of cpp extensions")
 
 from torchao.quantization import (

--- a/torchao/csrc/init.cpp
+++ b/torchao/csrc/init.cpp
@@ -1,3 +1,0 @@
-#include <torch/extension.h>
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}


### PR DESCRIPTION
This PR will be landed in two stages in 
#1276 
#1277
____

Replace PYBIND usage with torch.ops.load_library in order to allow ao to build 1 wheel for multiple python versions.
This requires https://github.com/pytorch/pytorch/pull/138088

## Why is this cool?
You no longer have to build an ao wheel for every python version, saving time, resources, and pypi package space (though this last one might not be a concern).

This proves that there is a way to use torch CPP extensions without dragging an unnecessary python dependency, which was not the case before.

## One disclaimer:
This _does_ mean that there will be no more torchao._C python module, which may be BC breaking. There are ways to not BC break (by creating a _C.py and re-exposing all the functions) so I'm not too concerned about that. Though some reviewer should let me know if this is crucial.

## Test Plan
Yes, it looks like there is still much CI to fix for ao, but I wanted to be confident that the core change worked before sinking the time into this. How did I gain confidence in this change? Locally, I built ao for python 3.10 using

```
pip wheel -e .
```

This produced `torchao-0.7.0+gitac340bb4-cp38-abi3-linux_x86_64.whl`

Then, I installed this wheel within other conda environments (with fresh torch) for python 3.9 through python 3.12 using `pip install torchao-0.7.0+gitac340bb4-cp38-abi3-linux_x86_64.whl` To verify this wheel was good, I ran `python test/test_ops.py` to check that all the tests passed, which they do.

I also made sure that the python setup.py develop path was not broken. How? I ran `pip install -e .` on the code in this PR and ensured that `python test/test_ops.py` passed in both 3.9 and 3.10.

## What do I want review on?
a. Is it okay that there is no longer a python module for torchao._C? A quick GH search shows 0 uses https://github.com/search?q=torchao._C&type=code in public code.
b. Are there other ways to install ao (other than pip install and pip wheel) that I need to test? Or other uses of the custom ops outside of test/test_ops.py that I need to verify?
c. Do we still want the old behavior to exist? Is there any reason we'd still want to build wheels per python?
d. I assumed py38 was the lowest version supported by ao, but I later learned that pytorch has moved to 3.9 so that should probably be 3.9 now. Does ao follow pytorch in terms of python support?

Based on the answers to the above qs, I will clean up this PR accordingly.