### PR TITLE
[1/2] Wean off of PYBIND in favor of torch.ops.load_library

### DIFF
--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -7,15 +7,14 @@
 
 set -eux
 
-WHEEL_NAME=$(ls dist/)
+# Prepare manywheel, only for CUDA.
+# The wheel is a pure python wheel for other platforms.
+if [[ "$CU_VERSION" == cu* ]]; then
+    WHEEL_NAME=$(ls dist/)
 
-pushd dist
-# Prepare manywheel
-manylinux_plat=manylinux2014_x86_64
-if [[ "$CU_VERSION" == "xpu" ]]; then
-    manylinux_plat=manylinux_2_28_x86_64
-fi
-auditwheel repair --plat "$manylinux_plat" -w . \
+    pushd dist
+    manylinux_plat=manylinux2014_x86_64
+    auditwheel repair --plat "$manylinux_plat" -w . \
     --exclude libtorch.so \
     --exclude libtorch_python.so \
     --exclude libtorch_cuda.so \
@@ -26,10 +25,11 @@ auditwheel repair --plat "$manylinux_plat" -w . \
     --exclude libcudart.so.11.0 \
     "${WHEEL_NAME}"
 
-ls -lah .
-# Clean up the linux_x86_64 wheel
-rm "${WHEEL_NAME}"
-popd
+    ls -lah .
+    # Clean up the linux_x86_64 wheel
+    rm "${WHEEL_NAME}"
+    popd
+fi
 
 MANYWHEEL_NAME=$(ls dist/)
 # Try to install the new wheel

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,9 @@ def get_extensions():
     if use_cuda:
         sources += cuda_sources
 
+    if len(sources) == 0:
+        return None
+
     ext_modules = [
         extension(
             "torchao._C",

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -22,10 +22,12 @@ _IS_FBCODE = (
 )
 if not _IS_FBCODE:
     try:
-        from . import _C
+        from pathlib import Path
+        so_files = list(Path(__file__).parent.glob("_C*.so"))
+        assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
+        torch.ops.load_library(so_files[0])
         from . import ops
     except:
-        _C = None
         logging.info("Skipping import of cpp extensions")
 
 from torchao.quantization import (

--- a/torchao/csrc/init.cpp
+++ b/torchao/csrc/init.cpp
@@ -1,3 +1,0 @@
-#include <torch/extension.h>
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}


### PR DESCRIPTION
The no ghstack version of https://github.com/pytorch/ao/pull/1275 to see if the mac tests pass (they do).

Pave the path for python agnostic ao by removing depending on PYBIND (which is not python agnostic).

Concretely, what happened this PR?
- no more PYBIND, so no more init.cpp
- for all non-CUDA platforms, ao no longer has custom cpp extensions, and thus ao is a pure python lib
- so we skip auditwheel (which is used for when the platform is linux) for all non-cuda wheel builds. (This does also mean we now needlessly build the same python wheel for every other platform rocm, cpu, xpu...)
- no more PYBIND also means no more torchao._C, which we're replacing with a load_library call

This PR should have no failures. The next PR will be targeting the wheel process to only output one wheel for every python version. If you're curious, the next PR looks like https://github.com/pytorch/ao/pull/1277