### PR TITLE
[2/2] Switch ao to use py_limited_api 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ def get_extensions():
         extension(
             "torchao._C",
             sources,
+            py_limited_api=True,
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,
         )
@@ -139,4 +140,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch-labs/ao",
     cmdclass={"build_ext": BuildExtension},
+    options={"bdist_wheel": {
+        "py_limited_api": "cp39"
+    }},
 )


### PR DESCRIPTION
This PR enables torchao to build 1 python wheel across multiple python versions. How? Our previous PR #1276 replaced reliance on the torch_python/PYBIND11 API in favor of using torch.library to register custom ops. This means that ao's custom extensions are Python free now!

As a result, we can now safely make use of Python/setuptools `py_limited_api` flags to build a Python agnostic wheel by passing the right arguments into Extension and bdist_wheel. Though the core PR has landed: https://github.com/pytorch/pytorch/pull/138088, torchao wheels are built on the stable release (2.5.1 for now) so torch_python.so will still be linked. I have tested locally that linking torch_python.so does not affect the wheel's python agnosticism, because torchao cuda extensions are python free and do not use anything from torch_python.

This will have repercussions on built + released wheels and will change their names to, for example, `torchao-0.8.0-cp39-abi3-linux_x86_64.whl` and should be installable on linux_x86_64 across multiple Python versions.

Why was this a draft?

I needed to figure out a plan to safely land this (aka test well) and now I'm confident we should land this. How did I test?
1) build pytorch without my new change (so torchpython is unfortunately still linked)
2) build the ao wheel with old pytorch
3) install the wheel in the env (say 3.11)
4) run test_ops.py and make sure everything passes
5) NOW. SWITCH TO 3.9
6) pip uninstall torch torchao
7) python setup.py clean && python setup.py develop in pytorch to reinstall torch for 3.9 (and not 3.11)
8) pip install the ao wheel built on 3.11 but here we are on 3.9
9) run the tests, make sure they pass

The above shows that the torchao wheel built with this change is python agnostic.
