### PR TITLE
Apply lint to contributor PR on demand

### DIFF
--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -79,7 +79,7 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         
         # Apply fixes
-        ruff check --fix .
+        ruff check --select F,I --fix
         ruff format .
         
         # Commit and push if there are changes

--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -1,6 +1,12 @@
 name: Code Analysis with Ruff
 
 on:
+  workflow_dispatch:
+    inputs:
+      fix:
+        description: 'Apply fixes automatically'
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -13,30 +19,58 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
     strategy:
       matrix:
         python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install ruff==0.6.8
-    - name: Analyzing the code with ruff
+        
+    - name: Check or fix code with Ruff
+      if: ${{ !inputs.fix }}
       run: |
         ruff check .
-    - name: Check *all* Python files for F821, F823, and W191
-      run: |
         # --isolated is used to skip the allowlist at all so this applies to all files
         # please be careful when using this large changes means everyone needs to rebase
         ruff check --isolated --select F821,F823,W191
-    - name: Check the allow-listed files for F,I
-      run: |
         ruff check --select F,I
-    - name: Check the allow-listed files for well formatted code
-      run: |
         ruff format --check
+
+    - name: Apply Ruff fixes
+      if: ${{ inputs.fix }}
+      run: |
+        # Fix general issues
+        ruff check --fix .
+        # Fix formatting
+        ruff format .
+        
+    - name: Create Pull Request with fixes
+      if: ${{ inputs.fix }}
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'Auto-fix: Apply Ruff formatting and fixes'
+        title: 'Auto-fix: Apply Ruff formatting and fixes'
+        body: |
+          This PR applies automatic fixes using Ruff linter and formatter.
+          
+          Changes were made automatically by the Ruff workflow.
+        branch: ruff-fixes-${{ github.event.pull_request.number }}
+        base: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -3,10 +3,10 @@ name: Code Analysis with Ruff
 on:
   workflow_dispatch:
     inputs:
-      fix:
-        description: 'Apply fixes automatically'
-        type: boolean
-        default: false
+      pr_url:
+        description: 'URL of the PR to fix'
+        required: true
+        type: string
   push:
     branches:
       - main
@@ -27,10 +27,17 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
+    - name: Extract PR info
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        PR_URL=${{ github.event.inputs.pr_url }}
+        PR_NUMBER=$(echo $PR_URL | grep -oE '[0-9]+$')
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        fetch-depth: 0
+        ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', env.PR_NUMBER) || '' }}
         token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Set up Python ${{ matrix.python-version }}
@@ -43,8 +50,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install ruff==0.6.8
         
-    - name: Check or fix code with Ruff
-      if: ${{ !inputs.fix }}
+    - name: Regular lint check
+      if: github.event_name != 'workflow_dispatch'
       run: |
         ruff check .
         # --isolated is used to skip the allowlist at all so this applies to all files
@@ -53,24 +60,21 @@ jobs:
         ruff check --select F,I
         ruff format --check
 
-    - name: Apply Ruff fixes
-      if: ${{ inputs.fix }}
+    - name: Apply fixes to PR
+      if: github.event_name == 'workflow_dispatch'
       run: |
-        # Fix general issues
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        
+        # Apply fixes
         ruff check --fix .
-        # Fix formatting
         ruff format .
         
-    - name: Create Pull Request with fixes
-      if: ${{ inputs.fix }}
-      uses: peter-evans/create-pull-request@v5
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: 'Auto-fix: Apply Ruff formatting and fixes'
-        title: 'Auto-fix: Apply Ruff formatting and fixes'
-        body: |
-          This PR applies automatic fixes using Ruff linter and formatter.
-          
-          Changes were made automatically by the Ruff workflow.
-        branch: ruff-fixes-${{ github.event.pull_request.number }}
-        base: ${{ github.event.pull_request.head.ref }}
+        # Commit and push if there are changes
+        if [[ -n "$(git status --porcelain)" ]]; then
+          git add .
+          git commit -m "Apply automatic Ruff fixes"
+          git push
+        else
+          echo "No fixes needed!"
+        fi

--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -35,10 +35,22 @@ jobs:
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
         
     - uses: actions/checkout@v3
+      if: github.event_name == 'workflow_dispatch'
       with:
         fetch-depth: 0
-        ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', env.PR_NUMBER) || '' }}
         token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Checkout PR branch
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        gh pr checkout ${{ env.PR_NUMBER }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - uses: actions/checkout@v3
+      if: github.event_name != 'workflow_dispatch'
+      with:
+        fetch-depth: 0
         
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3


### PR DESCRIPTION
Some of my least favorite interactions with OSS users is asking them to lint their code, it causes huge delays in merging code for something that feels quite silly. See this PR as an example https://github.com/pytorch/ao/pull/1113

So instead when we feel like a contributor PR is close to getting merged, we can trigger a github action to push lint fixes to their branch directly

Main issue is this probably won't work for forks

And I got this working on my fork of ao https://github.com/msaroufim/ao

To test this I made a PR that ruins the lint on a specific file 
![Screenshot 2024-11-13 at 1 22 39 PM](https://github.com/user-attachments/assets/c1d16e18-84ea-4aa5-94a8-0759bbb6bad2)

You can see how the bot added changes to my PR

![Screenshot 2024-11-13 at 1 19 22 PM](https://github.com/user-attachments/assets/6c627ef7-3477-40bc-8c77-0539a09fb4f6)

And this is how I trigger a lint job by passing in a link to the PR

![Screenshot 2024-11-13 at 1 19 43 PM](https://github.com/user-attachments/assets/b231c734-d00d-4e3a-b9db-cbc434cd57bd)


