### PR TITLE
make float 8 error message test BC

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -632,7 +632,7 @@ class TestScaledMM:
         with pytest.raises(
             RuntimeError,
             match=re.escape(
-                "Expected trailing dimension of mat1 to be divisible by 16 but got mat1 shape: (16x41)."
+                "Expected trailing dimension of mat1 to be divisible by 16 but got mat1 shape: (16x41"
             ),
         ):
             a_fp8 @ b_fp8


### PR DESCRIPTION
this test is going to fail on older versions of pytorch, i.e. https://github.com/pytorch/ao/actions/runs/11827805971/job/32956667984?pr=1282 we can make this handle both old/current by being slightly less specific with the error check