### PR TITLE
More SAM2-fast server improvements

### DIFF
--- a/examples/sam2_amg_server/README.md
+++ b/examples/sam2_amg_server/README.md
@@ -24,7 +24,7 @@ Experiments run on H100 and with batch size 1
 | mode            | mIoU               | mask count mismatch | avg. ms per request | max. memory (MiB (%)) | batch size | points per batch |
 | --------------  | -----------------  | ------------------- | ------------------- | --------------------- | ---------- | ---------------- |
 |        baseline | 1.0                |   0                 | 863                 |  4013MiB (4%)         |  1         |   64             |
-|              ao | 1.0                |   0                 | 840                 |  4350MiB (4%)         |  1         |   64             |
+|              ao | 0.9999980926513672 |   6                 | 586                 |                       |  1         |   64             |
 |            fast | 0.9937329888343811 | 191                 | 333                 |                       |  1         | 1024             |
 |            fast | 0.9937219619750977 | 192                 | 324                 |                       | 16         | 1024             |
 |  fast + furious | 0.9804400205612183 | 292                 | 131                 |                       |  1         | 1024             |
@@ -34,7 +34,7 @@ mask count mismatch counts the number of requests where the number of masks diff
 For example, the baseline may have chosen to segment an image into 18 masks, but the fast variant produces 17 or 19.
 We exclude these examples from the mIoU calculation.
 
-The 'ao' mode is a copy of the baseline with modifications to make the code compile-able and improve the performance of fast.
+The 'ao' mode is a copy of the baseline with modifications to make the code more compile-able and speed up run length encoding
 
 ### 0. Download checkpoints and install requirements
 

--- a/examples/sam2_amg_server/README.md
+++ b/examples/sam2_amg_server/README.md
@@ -25,10 +25,10 @@ Experiments run on H100 and with batch size 1
 | --------------  | -----------------  | ------------------- | ------------------- | --------------------- | ---------- | ---------------- |
 |        baseline | 1.0                |   0                 | 863                 |  4013MiB (4%)         |  1         |   64             |
 |              ao | 1.0                |   0                 | 840                 |  4350MiB (4%)         |  1         |   64             |
-|            fast | 0.9897813200950623 | 191                 | 661                 |  3916MiB (4%)         |  1         |   64             |
-|            fast | 0.9897371530532837 | 192                 | 388                 | 50787MiB (52%)        | 16         | 1024             |
-|  fast + furious | 0.974319338798523  | 209                 | 461                 |  3453MiB (3%)         |  1         |   64             |
-|  fast + furious | 0.9702069759368896 | 196                 | 195                 | 48298MiB (49%)        | 16         | 1024             |
+|            fast | 0.9937329888343811 | 191                 | 333                 |                       |  1         | 1024             |
+|            fast | 0.9937219619750977 | 192                 | 324                 |                       | 16         | 1024             |
+|  fast + furious | 0.9804400205612183 | 292                 | 131                 |                       |  1         | 1024             |
+|  fast + furious | 0.9806423187255859 | 282                 | 130                 |                       | 16         | 1024             |
 
 mask count mismatch counts the number of requests where the number of masks differ from the baseline.
 For example, the baseline may have chosen to segment an image into 18 masks, but the fast variant produces 17 or 19.

--- a/examples/sam2_amg_server/README.md
+++ b/examples/sam2_amg_server/README.md
@@ -33,6 +33,8 @@ Experiments run on H100 and with batch size 1
 mask count mismatch counts the number of requests where the number of masks differ from the baseline.
 For example, the baseline may have chosen to segment an image into 18 masks, but the fast variant produces 17 or 19.
 We exclude these examples from the mIoU calculation.
+Difference in mask count seem to stem from even only slight reorderings in compute. For example preprocessing on GPU instead of CPU.
+A more relaxed way of measuring mIoU might be useful here to take into account slight differences in the number of masks, which may be caused by additional or missing sub-divisions.
 
 The 'ao' mode is a copy of the baseline with modifications to make the code more compile-able and speed up run length encoding
 

--- a/examples/sam2_amg_server/compare_rle_lists.py
+++ b/examples/sam2_amg_server/compare_rle_lists.py
@@ -16,8 +16,8 @@ def iou(mask1, mask2):
     union = torch.logical_or(mask1, mask2)
     return (intersection.sum(dim=(-1, -2)) / union.sum(dim=(-1, -2)))
 
+
 def compare_masks(masks, ref_masks, order_by_area=False, verbose=False):
-    from torchao._models.sam2.utils.amg import rle_to_mask
     v0_areas = []
     v1_areas = []
     v0_masks = []
@@ -40,17 +40,20 @@ def compare_masks(masks, ref_masks, order_by_area=False, verbose=False):
         v0_masks = sorted(v0_masks, key=(lambda x: x[1]), reverse=True)
         v1_masks = sorted(v1_masks, key=(lambda x: x[1]), reverse=True)
     miou_sum = 0.0
-    miou_count = 0
+    miou_count = 0.0
+    equal_count = 0
     for ((v0_mask, _), (v1_mask, _)) in zip(v0_masks, v1_masks):
         miou_sum += iou(v0_mask, v1_mask)
         miou_count += 1
+        equal_count += torch.equal(v0_mask, v1_mask)
         if verbose:
             print(f"Masks don't match for key {k0}. IoU is {iou(v0_mask, v1_mask)}")
 
-    return miou_sum, miou_count
+    return miou_sum / miou_count, equal_count
 
 
-def main(path0, path1):
+def main(path0, path1, strict=False):
+    # path0 are candidates and path1 the ground truth
     fail_count = 0
     miou_sum = 0.0
     miou_count = 0
@@ -59,11 +62,13 @@ def main(path0, path1):
             masks0 = json.loads(line0)
             masks1 = json.loads(line1)
             if masks0.keys() != masks1.keys():
-                fail_count += 1
-                continue
-            s, c = compare_masks(masks0, masks1, order_by_area=True)
-            miou_sum += s
-            miou_count += c
+                if strict:
+                    fail_count += 1
+                    continue
+
+            m, e = compare_masks(masks0, masks1, order_by_area=True)
+            miou_sum += m
+            miou_count += 1
 
     print(f"fail_count: {fail_count} mIoU: {miou_sum / miou_count}")
 

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -325,12 +325,6 @@ def main(checkpoint_path,
         #     dynamic=True,
         # )
 
-        # mask_generator._process_batch_fullgraph_masks = torch.compile(
-        #     mask_generator._process_batch_fullgraph_masks,
-        #     fullgraph=True,
-        #     dynamic=True,
-        # )
-
     if furious:
         mask_generator.predictor.model.image_encoder = mask_generator.predictor.model.image_encoder.to(torch.float16)
         # NOTE: Not baseline feature

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -223,14 +223,14 @@ async def lifespan(app: FastAPI):
 def benchmark_fn(func, inp, mask_generator):
     torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
-    logging.info("Running 3 warumup iterations.")
-    for _ in range(3):
+    logging.info("Running 30 warumup iterations.")
+    for _ in range(30):
         func(inp, mask_generator)
-    logging.info("Running 10 benchmark iterations.")
+    logging.info("Running 100 benchmark iterations.")
     t = time.time()
-    for _ in range(10):
+    for _ in range(100):
         func(inp, mask_generator)
-    print(f"Benchmark took {(time.time() - t)/10.0}s per iteration.")
+    print(f"Benchmark took {(time.time() - t)/100.0}s per iteration.")
     max_memory_allocated()
 
 

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -173,7 +173,7 @@ def masks_to_rle_dict(masks):
 
 # Queue to hold incoming requests
 request_queue = asyncio.Queue()
-batch_interval = 0.1  # Time interval to wait before processing a batch
+batch_interval = 0.01  # Time interval to wait before processing a batch
 
 
 def process_batch(batch, mask_generator):
@@ -186,7 +186,7 @@ def process_batch(batch, mask_generator):
         print(f"Processing batch of len {len(batch)} using generate_batch")
         masks = mask_generator.generate_batch(image_tensors)
     print(f"Took avg. {(time.time() - t) / len(batch)}s per batch entry")
-    max_memory_allocated()
+    # max_memory_allocated()
     return masks
 
 
@@ -409,7 +409,8 @@ def main(checkpoint_path,
         return StreamingResponse(buf, media_type="image/png")
     
 
-    uvicorn.run(app, host=host, port=port, log_level="info")
+    # uvicorn.run(app, host=host, port=port, log_level="info")
+    uvicorn.run(app, host=host, port=port)
 
 if __name__ == "__main__":
     fire.Fire(main)

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -297,22 +297,42 @@ def main(checkpoint_path,
     if fast:
         assert not baseline, "--fast cannot be combined with baseline. code to be torch.compile(fullgraph=True) compatible."
         # TODO: Using CUDA graphs can cause numerical differences?
-        mask_generator.predictor.model.forward_image = torch.compile(
-            mask_generator.predictor.model.forward_image,
-            # mode="max-autotune-no-cudagraphs",
+        mask_generator.predictor.model.image_encoder = torch.compile(
+            mask_generator.predictor.model.image_encoder,
             mode="max-autotune",
             fullgraph=True,
             dynamic=False,
         )
 
-        # mask_generator.predictor.model.sam_mask_decoder = torch.compile(
-        #     mask_generator.predictor.model.sam_mask_decoder,
-        #     fullgraph=True,
-        #     dynamic=True,
-        # )
+        mask_generator.predictor.model.sam_prompt_encoder = torch.compile(
+            mask_generator.predictor.model.sam_prompt_encoder,
+            mode="max-autotune-no-cudagraphs",
+            fullgraph=True,
+            dynamic=False,
+        )
 
-        mask_generator._process_batch_fullgraph = torch.compile(
-            mask_generator._process_batch_fullgraph,
+        mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe = torch.compile(
+            mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe,
+            mode="max-autotune",
+            fullgraph=True,
+            dynamic=False,
+        )
+
+        mask_generator.predictor.model.sam_mask_decoder = torch.compile(
+            mask_generator.predictor.model.sam_mask_decoder,
+            mode="max-autotune-no-cudagraphs",
+            fullgraph=True,
+            dynamic=False,
+        )
+
+        mask_generator.predictor._transforms.postprocess_masks = torch.compile(
+            mask_generator._process_batch_fullgraph_masks,
+            fullgraph=True,
+            dynamic=True,
+        )
+
+        mask_generator._process_batch_fullgraph_masks = torch.compile(
+            mask_generator._process_batch_fullgraph_masks,
             fullgraph=True,
             dynamic=True,
         )

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -318,12 +318,12 @@ def main(checkpoint_path,
         #     dynamic=False,
         # )
 
-        # mask_generator.predictor.model.sam_mask_decoder = torch.compile(
-        #     mask_generator.predictor.model.sam_mask_decoder,
-        #     mode="max-autotune-no-cudagraphs",
-        #     fullgraph=True,
-        #     dynamic=False,
-        # )
+        mask_generator.predictor.model.sam_mask_decoder = torch.compile(
+            mask_generator.predictor.model.sam_mask_decoder,
+            mode="max-autotune",
+            fullgraph=True,
+            dynamic=False,
+        )
 
         mask_generator.predictor._transforms.postprocess_masks = torch.compile(
             mask_generator.predictor._transforms.postprocess_masks,

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -34,7 +34,7 @@ inductorconfig.coordinate_descent_tuning = True
 inductorconfig.coordinate_descent_check_all_directions = True
 inductorconfig.allow_buffer_reuse = False
 
-torch._dynamo.config.capture_dynamic_output_shape_ops = True
+# torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
 
 def example_shapes():
@@ -304,6 +304,12 @@ def main(checkpoint_path,
             fullgraph=True,
             dynamic=False,
         )
+
+        # mask_generator.predictor.model.sam_mask_decoder = torch.compile(
+        #     mask_generator.predictor.model.sam_mask_decoder,
+        #     fullgraph=True,
+        #     dynamic=True,
+        # )
 
         mask_generator._process_batch_fullgraph = torch.compile(
             mask_generator._process_batch_fullgraph,

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -306,27 +306,27 @@ def main(checkpoint_path,
 
         mask_generator.predictor.model.sam_prompt_encoder = torch.compile(
             mask_generator.predictor.model.sam_prompt_encoder,
-            mode="max-autotune-no-cudagraphs",
-            fullgraph=True,
-            dynamic=False,
-        )
-
-        mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe = torch.compile(
-            mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe,
             mode="max-autotune",
             fullgraph=True,
             dynamic=False,
         )
 
-        mask_generator.predictor.model.sam_mask_decoder = torch.compile(
-            mask_generator.predictor.model.sam_mask_decoder,
-            mode="max-autotune-no-cudagraphs",
-            fullgraph=True,
-            dynamic=False,
-        )
+        # mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe = torch.compile(
+        #     mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe,
+        #     mode="max-autotune",
+        #     fullgraph=True,
+        #     dynamic=False,
+        # )
+
+        # mask_generator.predictor.model.sam_mask_decoder = torch.compile(
+        #     mask_generator.predictor.model.sam_mask_decoder,
+        #     mode="max-autotune-no-cudagraphs",
+        #     fullgraph=True,
+        #     dynamic=False,
+        # )
 
         mask_generator.predictor._transforms.postprocess_masks = torch.compile(
-            mask_generator._process_batch_fullgraph_masks,
+            mask_generator.predictor._transforms.postprocess_masks,
             fullgraph=True,
             dynamic=True,
         )

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -35,6 +35,7 @@ inductorconfig.coordinate_descent_check_all_directions = True
 inductorconfig.allow_buffer_reuse = False
 
 # torch._dynamo.config.capture_dynamic_output_shape_ops = True
+torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
 
 def example_shapes():
@@ -318,11 +319,11 @@ def main(checkpoint_path,
             dynamic=False,
         )
 
-        mask_generator.predictor._predict_masks_postprocess = torch.compile(
-            mask_generator.predictor._predict_masks_postprocess,
-            fullgraph=True,
-            dynamic=True,
-        )
+        # mask_generator.predictor._predict_masks_postprocess = torch.compile(
+        #     mask_generator.predictor._predict_masks_postprocess,
+        #     fullgraph=True,
+        #     dynamic=True,
+        # )
 
         mask_generator._process_batch_fullgraph_masks = torch.compile(
             mask_generator._process_batch_fullgraph_masks,

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -370,7 +370,7 @@ def main(checkpoint_path,
             random_images = [np.random.randint(0, 256, size=size, dtype=np.uint8) for size in shapes]
 
             if batch_size == 1:
-                [benchmark_fn(image_tensor_to_masks, r, mask_generator, warmup=1, runs=1) for r in random_images]
+                [benchmark_fn(image_tensor_to_masks, r, mask_generator) for r in random_images]
             else:
                 random_images = random_images[:batch_size]
                 benchmark_fn(image_tensors_to_masks, random_images, mask_generator)

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -360,7 +360,10 @@ def main(checkpoint_path,
 
     if profile is not None:
         print(f"Saving profile under {profile}")
-        profiler_runner(profile, image_tensors_to_masks, [image_tensor] * batch_size, mask_generator)
+        if batch_size == 1:
+            profiler_runner(profile, image_tensor_to_masks, image_tensor, mask_generator)
+        else:
+            profiler_runner(profile, image_tensors_to_masks, [image_tensor] * batch_size, mask_generator)
 
     if dry:
         return

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -297,8 +297,8 @@ def main(checkpoint_path,
     if fast:
         assert not baseline, "--fast cannot be combined with baseline. code to be torch.compile(fullgraph=True) compatible."
         # TODO: Using CUDA graphs can cause numerical differences?
-        mask_generator.predictor.model.image_encoder = torch.compile(
-            mask_generator.predictor.model.image_encoder,
+        mask_generator.predictor.model.forward_image = torch.compile(
+            mask_generator.predictor.model.forward_image,
             # mode="max-autotune-no-cudagraphs",
             mode="max-autotune",
             fullgraph=True,

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -304,8 +304,8 @@ def main(checkpoint_path,
             dynamic=False,
         )
 
-        mask_generator.predictor.model.sam_prompt_encoder = torch.compile(
-            mask_generator.predictor.model.sam_prompt_encoder,
+        mask_generator.predictor.model.sam_prompt_encoder.forward = torch.compile(
+            mask_generator.predictor.model.sam_prompt_encoder.forward,
             mode="max-autotune",
             fullgraph=True,
             dynamic=False,

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -311,22 +311,15 @@ def main(checkpoint_path,
             dynamic=False,
         )
 
-        # mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe = torch.compile(
-        #     mask_generator.predictor.model.sam_prompt_encoder.get_dense_pe,
-        #     mode="max-autotune",
-        #     fullgraph=True,
-        #     dynamic=False,
-        # )
-
-        mask_generator.predictor.model.sam_mask_decoder = torch.compile(
-            mask_generator.predictor.model.sam_mask_decoder,
+        mask_generator.predictor._predict_masks = torch.compile(
+            mask_generator.predictor._predict_masks,
             mode="max-autotune",
             fullgraph=True,
             dynamic=False,
         )
 
-        mask_generator.predictor._transforms.postprocess_masks = torch.compile(
-            mask_generator.predictor._transforms.postprocess_masks,
+        mask_generator.predictor._predict_masks_postprocess = torch.compile(
+            mask_generator.predictor._predict_masks_postprocess,
             fullgraph=True,
             dynamic=True,
         )

--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -245,11 +245,11 @@ def max_memory_allocated():
 
 def unittest_fn(masks, ref_masks, order_by_area=False, verbose=False):
     from compare_rle_lists import compare_masks
-    miou_sum, miou_count = compare_masks(masks, ref_masks, order_by_area=order_by_area, verbose=verbose)
-    if miou_count == 0:
+    miou, equal_count = compare_masks(masks, ref_masks, order_by_area=order_by_area, verbose=verbose)
+    if equal_count == len(masks):
         print("Masks exactly match reference.")
     else:
-        print(f"mIoU is {miou_sum / miou_count}")
+        print(f"mIoU is {miou} with equal count {equal_count} out of {len(masks)}")
 
 
 def main(checkpoint_path,
@@ -291,7 +291,7 @@ def main(checkpoint_path,
     
     logging.info(f"Loading model {sam2_checkpoint} with config {model_cfg}")
     sam2 = build_sam2(model_cfg, sam2_checkpoint, device=device, apply_postprocessing=False)
-
+ 
     logging.info(f"Using {points_per_batch} points_per_batch")
     mask_generator = SAM2AutomaticMaskGenerator(sam2, points_per_batch=points_per_batch, output_mode="uncompressed_rle")
 
@@ -325,11 +325,11 @@ def main(checkpoint_path,
         #     dynamic=True,
         # )
 
-        mask_generator._process_batch_fullgraph_masks = torch.compile(
-            mask_generator._process_batch_fullgraph_masks,
-            fullgraph=True,
-            dynamic=True,
-        )
+        # mask_generator._process_batch_fullgraph_masks = torch.compile(
+        #     mask_generator._process_batch_fullgraph_masks,
+        #     fullgraph=True,
+        #     dynamic=True,
+        # )
 
     if furious:
         mask_generator.predictor.model.image_encoder = mask_generator.predictor.model.image_encoder.to(torch.float16)

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -539,7 +539,8 @@ class SAM2AutomaticMaskGenerator:
             with torch.autograd.profiler.record_function("stability_score_thresh"):
                 if self.stability_score_thresh > 0.0:
                     keep_mask = data["stability_score"] >= self.stability_score_thresh
-                    data.filter(keep_mask)
+                    keep_index = keep_mask.nonzero(as_tuple=True)[0]
+                    data.filter(keep_index)
         else:
             # One step refinement using previous mask predictions
             in_points = self.predictor._transforms.transform_coords(
@@ -577,8 +578,8 @@ class SAM2AutomaticMaskGenerator:
             )
 
         with torch.autograd.profiler.record_function("filter(keep_mask)"):
-            # if not torch.all(keep_mask):
-            data.filter(keep_mask)
+            keep_index = keep_mask.nonzero(as_tuple=True)[0]
+            data.filter(keep_index)
 
         return data
 

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -451,6 +451,8 @@ class SAM2AutomaticMaskGenerator:
                     rles_nt, rles_nt_counts_init = mask_to_rle_pytorch_2_nt(data["masks"])
                     data["rles_nt"] = rles_nt
                     data["rles_nt_counts_init"] = rles_nt_counts_init
+                    b, h, w = data["masks"].size()
+                    data["rles_sizes"] = [{"size": [h, w]}] * b
                     del data["masks"]
 
                     batch_data = data

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -524,6 +524,8 @@ class SAM2AutomaticMaskGenerator:
         keep_mask = None
 
         if not self.use_m2m:
+            # NOTE: This is left just for reference. We filter earlier for this case to save
+            # on compute within the expensive _predict_masks_postprocess
             # with torch.autograd.profiler.record_function("thresh and filter"):
             #     # Filter by predicted IoU
             #     if self.pred_iou_thresh > 0.0:

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -501,10 +501,11 @@ class SAM2AutomaticMaskGenerator:
                 # Filter by predicted IoU
                 if self.pred_iou_thresh > 0.0:
                     keep_mask = iou_preds.flatten(0, 1) > self.pred_iou_thresh
+                    keep_index = keep_mask.nonzero(as_tuple=True)[0]
                     low_res_masks = low_res_masks.flatten(0, 1).unsqueeze(1)
-                    low_res_masks = low_res_masks[keep_mask]
-                    iou_preds = iou_preds.flatten(0, 1).unsqueeze(1)[keep_mask]
-                    points = points[keep_mask]
+                    low_res_masks = low_res_masks[keep_index]
+                    iou_preds = iou_preds.flatten(0, 1).unsqueeze(1)[keep_index]
+                    points = points[keep_index]
         if masks is None:
             masks, low_res_mask = self.predictor._predict_masks_postprocess(low_res_masks, -1, True, channel_1=low_res_masks.size(1) == 1)
 

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -579,17 +579,13 @@ class SAM2AutomaticMaskGenerator:
 
         with torch.autograd.profiler.record_function("is_box_near_crop_edge"):
             # Filter boxes that touch crop boundaries
-            keep_mask_crop = ~is_box_near_crop_edge_torch(
+            keep_mask = ~is_box_near_crop_edge_torch(
                 data["boxes"], crop_box, crop_box_torch, orig_box_torch, is_box_near_crop_edge_torch_offset,
             )
-            if keep_mask is None:
-                keep_mask = keep_mask_crop
-            else:
-                keep_mask = torch.logical_and(keep_mask, keep_mask_crop)
 
-        # with torch.autograd.profiler.record_function("filter(keep_mask)"):
-        #     # if not torch.all(keep_mask):
-        data.filter(keep_mask)
+        with torch.autograd.profiler.record_function("filter(keep_mask)"):
+            # if not torch.all(keep_mask):
+            data.filter(keep_mask)
 
         # return data, keep_mask
         return data, None

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -494,25 +494,29 @@ class SAM2AutomaticMaskGenerator:
                 multimask_output=self.multimask_output,
                 return_logits=True,
             )
+            # TODO: Turn this off and replace with below
+            masks, low_res_mask = self.predictor._predict_masks_postprocess(low_res_masks, -1, True, channel_1=False)
 
 
         x0, y0, _, _ = crop_box
         is_box_near_crop_edge_torch_offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory().to(device=in_points.device, non_blocking=True)
         points = points.repeat_interleave(3 if masks is None else masks.shape[1], dim=0)
-        if not self.use_m2m:
-            with torch.autograd.profiler.record_function("thresh and filter"):
-                # Filter by predicted IoU
-                if self.pred_iou_thresh > 0.0:
-                    keep_mask = iou_preds.flatten(0, 1) > self.pred_iou_thresh
-                    low_res_masks = low_res_masks.flatten(0, 1).unsqueeze(1)
-                    low_res_masks = low_res_masks[keep_mask]
-                    masks, low_res_mask = self.predictor._predict_masks_postprocess(low_res_masks, -1, True, channel_1=True)
-                    iou_preds = iou_preds.flatten(0, 1).unsqueeze(1)[keep_mask]
-                    points = points[keep_mask]
-                    # import pdb; pdb.set_trace()
-                    # print("SDJKFL")
-                    # TODO: Might need this for correctness due to calculate_stability_score IoU?
-                    # data.filter(keep_mask)
+
+        # TODO: Turn this off and replace with above
+        # if not self.use_m2m:
+        #     with torch.autograd.profiler.record_function("thresh and filter"):
+        #         # Filter by predicted IoU
+        #         if self.pred_iou_thresh > 0.0:
+        #             keep_mask = iou_preds.flatten(0, 1) > self.pred_iou_thresh
+        #             low_res_masks = low_res_masks.flatten(0, 1).unsqueeze(1)
+        #             low_res_masks = low_res_masks[keep_mask]
+        #             masks, low_res_mask = self.predictor._predict_masks_postprocess(low_res_masks, -1, True, channel_1=True)
+        #             iou_preds = iou_preds.flatten(0, 1).unsqueeze(1)[keep_mask]
+        #             points = points[keep_mask]
+        #             # import pdb; pdb.set_trace()
+        #             # print("SDJKFL")
+        #             # TODO: Might need this for correctness due to calculate_stability_score IoU?
+        #             # data.filter(keep_mask)
 
         # Serialize predictions and store in MaskData
         with torch.autograd.profiler.record_function("MaskData"):
@@ -528,12 +532,12 @@ class SAM2AutomaticMaskGenerator:
         keep_mask = None
 
         if not self.use_m2m:
-            # with torch.autograd.profiler.record_function("thresh and filter"):
-            #     # Filter by predicted IoU
-            #     if self.pred_iou_thresh > 0.0:
-            #         keep_mask = data["iou_preds"] > self.pred_iou_thresh
-            #         # TODO: Might need this for correctness due to calculate_stability_score IoU?
-            #         # data.filter(keep_mask)
+            with torch.autograd.profiler.record_function("thresh and filter"):
+                # Filter by predicted IoU
+                if self.pred_iou_thresh > 0.0:
+                    keep_mask = data["iou_preds"] > self.pred_iou_thresh
+                    # TODO: Might need this for correctness due to calculate_stability_score IoU?
+                    data.filter(keep_mask)
 
             with torch.autograd.profiler.record_function("calculate_stability_score"):
                 # Calculate and filter by stability score

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -261,7 +261,7 @@ class SAM2AutomaticMaskGenerator:
                 iou_threshold=self.crop_nms_thresh,
             )
             data.filter(keep_by_nms)
-        # data.to_numpy()
+        data.to_numpy()
         return data
 
     def _generate_masks_batch(self, images: List[np.ndarray]) -> List[MaskData]:

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -251,10 +251,13 @@ class SAM2AutomaticMaskGenerator:
         )
 
         # Iterate over image crops
-        data = MaskData()
+        data = None
         for crop_box, layer_idx in zip(crop_boxes, layer_idxs):
             crop_data = self._process_crop(image, crop_box, layer_idx, orig_size)
-            data.cat(crop_data)
+            if data is None:
+                data = crop_data
+            else:
+                data.cat(crop_data)
 
         return self._deduplicate_masks(crop_boxes, data)
 
@@ -348,11 +351,11 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("filter"):
             data.filter(keep_by_nms)
 
-        with torch.autograd.profiler.record_function("uncrop_boxes_xyxy"):
-            # Return to the original image frame
-            data["boxes"] = uncrop_boxes_xyxy(data["boxes"], crop_box)
-        with torch.autograd.profiler.record_function("uncrop_points"):
-            data["points"] = uncrop_points(data["points"], crop_box)
+        # with torch.autograd.profiler.record_function("uncrop_boxes_xyxy"):
+        #     # Return to the original image frame
+        #     data["boxes"] = uncrop_boxes_xyxy(data["boxes"], crop_box)
+        # with torch.autograd.profiler.record_function("uncrop_points"):
+        #     data["points"] = uncrop_points(data["points"], crop_box)
         with torch.autograd.profiler.record_function("crop_boxes"):
             # data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
             data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles_nt"]))])

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -499,7 +499,6 @@ class SAM2AutomaticMaskGenerator:
 
 
         x0, y0, _, _ = crop_box
-        is_box_near_crop_edge_torch_offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory().to(device=in_points.device, non_blocking=True)
         points = points.repeat_interleave(3 if masks is None else masks.shape[1], dim=0)
 
         # TODO: Turn this off and replace with above
@@ -581,7 +580,7 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("is_box_near_crop_edge"):
             # Filter boxes that touch crop boundaries
             keep_mask = ~is_box_near_crop_edge_torch(
-                data["boxes"], crop_box, crop_box_torch, orig_box_torch, is_box_near_crop_edge_torch_offset,
+                data["boxes"], crop_box, crop_box_torch, orig_box_torch
             )
 
         with torch.autograd.profiler.record_function("filter(keep_mask)"):

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -545,12 +545,8 @@ class SAM2AutomaticMaskGenerator:
                 )
             with torch.autograd.profiler.record_function("stability_score_thresh"):
                 if self.stability_score_thresh > 0.0:
-                    keep_mask_stability = data["stability_score"] >= self.stability_score_thresh
-                    # if keep_mask is None:
-                    #     keep_mask = keep_mask_stability
-                    # else:
-                    #     keep_mask = torch.logical_and(keep_mask, keep_mask_stability)
-                    data.filter(keep_mask_stability)
+                    keep_mask = data["stability_score"] >= self.stability_score_thresh
+                    data.filter(keep_mask)
         else:
             # One step refinement using previous mask predictions
             in_points = self.predictor._transforms.transform_coords(

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -521,12 +521,12 @@ class SAM2AutomaticMaskGenerator:
         keep_mask = None
 
         if not self.use_m2m:
-            with torch.autograd.profiler.record_function("thresh and filter"):
-                # Filter by predicted IoU
-                if self.pred_iou_thresh > 0.0:
-                    keep_mask = data["iou_preds"] > self.pred_iou_thresh
-                    # TODO: Might need this for correctness due to calculate_stability_score IoU?
-                    data.filter(keep_mask)
+            # with torch.autograd.profiler.record_function("thresh and filter"):
+            #     # Filter by predicted IoU
+            #     if self.pred_iou_thresh > 0.0:
+            #         keep_mask = data["iou_preds"] > self.pred_iou_thresh
+            #         # TODO: Might need this for correctness due to calculate_stability_score IoU?
+            #         data.filter(keep_mask)
 
             with torch.autograd.profiler.record_function("calculate_stability_score"):
                 # Calculate and filter by stability score

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -498,9 +498,6 @@ class SAM2AutomaticMaskGenerator:
 
         x0, y0, _, _ = crop_box
         is_box_near_crop_edge_torch_offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory().to(device=in_points.device, non_blocking=True)
-        return self._process_batch_fullgraph_masks(masks, iou_preds, low_res_masks, points, normalize, im_size, crop_box, crop_box_torch, orig_box_torch, is_box_near_crop_edge_torch_offset)
-
-    def _process_batch_fullgraph_masks(self, masks, iou_preds, low_res_masks, points, normalize, im_size, crop_box, crop_box_torch, orig_box_torch, is_box_near_crop_edge_torch_offset):
         points = points.repeat_interleave(3 if masks is None else masks.shape[1], dim=0)
         if not self.use_m2m:
             with torch.autograd.profiler.record_function("thresh and filter"):

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -26,6 +26,7 @@ from torchao._models.sam2.utils.amg import (
     is_box_near_crop_edge_torch,
     mask_to_rle_pytorch,
     mask_to_rle_pytorch_2,
+    mask_to_rle_pytorch_2_nt,
     MaskData,
     remove_small_regions,
     rle_to_mask,
@@ -208,6 +209,15 @@ class SAM2AutomaticMaskGenerator:
         elif self.output_mode == "binary_mask":
             mask_data["segmentations"] = [rle_to_mask(rle) for rle in mask_data["rles"]]
         else:
+            # import pdb; pdb.set_trace()
+            rles = []
+            for (mask_i, d) in zip(mask_data["rles_nt"].unbind(), mask_data["rles_sizes"]):
+                h, w = d["size"]
+                if mask_i.size() == 0:
+                    rles.append({"size": [h, w], "counts": []})
+                else:
+                    rles.append({"size": [h, w], "counts": [0] + (mask_i.tolist()[:-1])})
+            mask_data["rles"] = rles
             mask_data["segmentations"] = mask_data["rles"]
 
         # Write mask records
@@ -258,7 +268,7 @@ class SAM2AutomaticMaskGenerator:
                 iou_threshold=self.crop_nms_thresh,
             )
             data.filter(keep_by_nms)
-        data.to_numpy()
+        # data.to_numpy()
         return data
 
     def _generate_masks_batch(self, images: List[np.ndarray]) -> List[MaskData]:
@@ -338,7 +348,8 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_points"):
             data["points"] = uncrop_points(data["points"], crop_box)
         with torch.autograd.profiler.record_function("crop_boxes"):
-            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
+            # data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
+            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles_nt"]))])
 
         return data
 
@@ -432,7 +443,8 @@ class SAM2AutomaticMaskGenerator:
                     # TODO: Capture all these masks in a single NT for mask_to_rle_pytorch_2
                     # or at a minimum create a mask_to_rle_pytorch_2_list and use loops
                     # to cause a single DtoH sync
-                    data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+                    # data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+                    data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
                     del data["masks"]
 
                     batch_data = data
@@ -575,7 +587,10 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_masks"):
             # Compress to RLE
             data["masks"] = uncrop_masks(data["masks"], crop_box, orig_h, orig_w)
-            data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+            # data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+            data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
+            b, h, w = data["masks"].size()
+            data["rles_sizes"] = [{"size": [h, w]}] * b
             del data["masks"]
 
         return data

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -210,17 +210,16 @@ class SAM2AutomaticMaskGenerator:
             elif self.output_mode == "binary_mask":
                 mask_data["segmentations"] = [rle_to_mask(rle) for rle in mask_data["rles"]]
             else:
-                # import pdb; pdb.set_trace()
-                rles = []
-                # TODO: Using .cpu() directly plus unbind seems to cause weakref error.
-                rles_nt_cpu = torch.nested.nested_tensor_from_jagged(mask_data["rles_nt"].values().cpu(), mask_data["rles_nt"].offsets().cpu())
-                for (mask_i, d) in zip(rles_nt_cpu.unbind(), mask_data["rles_sizes"]):
-                    h, w = d["size"]
-                    if mask_i.size() == 0:
-                        rles.append({"size": [h, w], "counts": []})
-                    else:
-                        rles.append({"size": [h, w], "counts": [0] + (mask_i.tolist()[:-1])})
-                mask_data["rles"] = rles
+                # rles = []
+                # # TODO: Using .cpu() directly plus unbind seems to cause weakref error.
+                # rles_nt_cpu = torch.nested.nested_tensor_from_jagged(mask_data["rles_nt"].values().cpu(), mask_data["rles_nt"].offsets().cpu())
+                # for (mask_i, d) in zip(rles_nt_cpu.unbind(), mask_data["rles_sizes"]):
+                #     h, w = d["size"]
+                #     if mask_i.size() == 0:
+                #         rles.append({"size": [h, w], "counts": []})
+                #     else:
+                #         rles.append({"size": [h, w], "counts": [0] + (mask_i.tolist()[:-1])})
+                # mask_data["rles"] = rles
                 mask_data["segmentations"] = mask_data["rles"]
 
         with torch.autograd.profiler.record_function("_encode_masks: Write mask records"):
@@ -352,8 +351,8 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_points"):
             data["points"] = uncrop_points(data["points"], crop_box)
         with torch.autograd.profiler.record_function("crop_boxes"):
-            # data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
-            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles_nt"]))])
+            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
+            # data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles_nt"]))])
 
         return data
 
@@ -447,8 +446,8 @@ class SAM2AutomaticMaskGenerator:
                     # TODO: Capture all these masks in a single NT for mask_to_rle_pytorch_2
                     # or at a minimum create a mask_to_rle_pytorch_2_list and use loops
                     # to cause a single DtoH sync
-                    # data["rles"] = mask_to_rle_pytorch_2(data["masks"])
-                    data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
+                    data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+                    # data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
                     del data["masks"]
 
                     batch_data = data
@@ -591,10 +590,10 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_masks"):
             # Compress to RLE
             data["masks"] = uncrop_masks(data["masks"], crop_box, orig_h, orig_w)
-            # data["rles"] = mask_to_rle_pytorch_2(data["masks"])
-            data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
-            b, h, w = data["masks"].size()
-            data["rles_sizes"] = [{"size": [h, w]}] * b
+            data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+            # data["rles_nt"] = mask_to_rle_pytorch_2_nt(data["masks"])
+            # b, h, w = data["masks"].size()
+            # data["rles_sizes"] = [{"size": [h, w]}] * b
             del data["masks"]
 
         return data

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -212,7 +212,8 @@ class SAM2AutomaticMaskGenerator:
             else:
                 rles = []
                 # TODO: Using .cpu() directly plus unbind seems to cause weakref error.
-                rles_nt_cpu = torch.nested.nested_tensor_from_jagged(mask_data["rles_nt"].values().cpu(), mask_data["rles_nt"].offsets().cpu())
+                rles_nt_cpu = mask_data["rles_nt"].cpu()
+                del mask_data["rles_nt"]
                 counts_init = mask_data["rles_nt_counts_init"]
                 for (mask_i, d, ci) in zip(rles_nt_cpu.unbind(), mask_data["rles_sizes"], counts_init):
                     h, w = d["size"]

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -420,9 +420,7 @@ class SAM2AutomaticMaskGenerator:
                     orig_box = [0, 0, orig_w, orig_h]
                     orig_box_torch = torch.as_tensor(orig_box, dtype=torch.float, device=self.predictor.device)
                     crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float, device=self.predictor.device)
-                    data, keep_mask = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
-                    if keep_mask is not None:
-                        data.filter(keep_mask)
+                    data = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
                     all_batch_iterator_data.append(data)
                 self.predictor.reset_predictor()
             all_all_batch_iterator_data.append(all_batch_iterator_data)
@@ -587,8 +585,7 @@ class SAM2AutomaticMaskGenerator:
             # if not torch.all(keep_mask):
             data.filter(keep_mask)
 
-        # return data, keep_mask
-        return data, None
+        return data
 
     def _process_batch(
         self,
@@ -607,10 +604,7 @@ class SAM2AutomaticMaskGenerator:
         crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float)
         crop_box_torch = crop_box_torch.pin_memory()
         crop_box_torch = crop_box_torch.to(device=self.predictor.device, non_blocking=True)
-        data, keep_mask = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
-        if keep_mask is not None:
-            keep_index = keep_mask.nonzero(as_tuple=True)[0]
-            data.filter_by_index(keep_index)
+        data = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
 
         with torch.autograd.profiler.record_function("uncrop_masks"):
             # Compress to RLE

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -343,7 +343,7 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_points"):
             data["points"] = uncrop_points(data["points"], crop_box)
         with torch.autograd.profiler.record_function("crop_boxes"):
-            data["crop_boxes"] = torch.tensor([crop_box for _ in range(data["rles"].b)])
+            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
 
         return data
 
@@ -486,6 +486,8 @@ class SAM2AutomaticMaskGenerator:
             in_points.shape[0], dtype=torch.int, device=in_points.device
         )
         with torch.autograd.profiler.record_function("_predict"):
+            # NOTE: Just leaving this for reference. predict was split to
+            # allow earlier filtering by predicted iou
             # masks, iou_preds, low_res_masks = self.predictor._predict(
             masks = None
             low_res_masks, iou_preds = self.predictor._predict_masks(
@@ -599,9 +601,11 @@ class SAM2AutomaticMaskGenerator:
         orig_box_torch = torch.as_tensor(orig_box, dtype=torch.float)
         orig_box_torch = orig_box_torch.pin_memory()
         orig_box_torch = orig_box_torch.to(device=self.predictor.device, non_blocking=True)
+
         crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float)
         crop_box_torch = crop_box_torch.pin_memory()
         crop_box_torch = crop_box_torch.to(device=self.predictor.device, non_blocking=True)
+
         data = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
 
         with torch.autograd.profiler.record_function("uncrop_masks"):

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -601,14 +601,14 @@ class SAM2AutomaticMaskGenerator:
         orig_h, orig_w = orig_size
 
         orig_box = [0, 0, orig_w, orig_h]
-        orig_box_torch = torch.as_tensor(orig_box, dtype=torch.float).pin_memory().to(device=self.predictor.device, non_blocking=True)
-        crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float).pin_memory().to(device=self.predictor.device, non_blocking=True)
-        with torch.autograd.profiler.record_function("_process_batch: _process_batch_fullgraph"):
-            data, keep_mask = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
-        with torch.autograd.profiler.record_function("_process_batch: filter"):
-            if keep_mask is not None:
-                keep_index = keep_mask.nonzero(as_tuple=True)[0]
-                data.filter_by_index(keep_index)
+        orig_box_torch = torch.as_tensor(orig_box, dtype=torch.float)
+        orig_box_torch = orig_box_torch.pin_memory().to(device=self.predictor.device, non_blocking=True)
+        crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float)
+        crop_box_torch = crop_box_torch.pin_memory().to(device=self.predictor.device, non_blocking=True)
+        data, keep_mask = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
+        if keep_mask is not None:
+            keep_index = keep_mask.nonzero(as_tuple=True)[0]
+            data.filter_by_index(keep_index)
 
         with torch.autograd.profiler.record_function("uncrop_masks"):
             # Compress to RLE

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -509,6 +509,9 @@ class SAM2AutomaticMaskGenerator:
                 return_logits=True,
             )
 
+        return self._process_batch_fullgraph_masks(masks, iou_preds, low_res_masks, points, normalize, im_size, crop_box, crop_box_torch, orig_box_torch)
+
+    def _process_batch_fullgraph_masks(self, masks, iou_preds, low_res_masks, points, normalize, im_size, crop_box, crop_box_torch, orig_box_torch):
         # Serialize predictions and store in MaskData
         with torch.autograd.profiler.record_function("MaskData"):
             data = MaskData(

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -578,7 +578,7 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("is_box_near_crop_edge"):
             # Filter boxes that touch crop boundaries
             keep_mask = ~is_box_near_crop_edge_torch(
-                data["boxes"], crop_box, crop_box_torch, orig_box_torch
+                data["boxes"], crop_box, crop_box_torch, orig_box_torch,
             )
 
         with torch.autograd.profiler.record_function("filter(keep_mask)"):

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -25,7 +25,8 @@ from torchao._models.sam2.utils.amg import (
     is_box_near_crop_edge,
     is_box_near_crop_edge_torch,
     mask_to_rle_pytorch,
-    mask_to_rle_pytorch_2,
+    _mask_to_rle_pytorch_2_0,
+    _mask_to_rle_pytorch_2_1,
     MaskData,
     remove_small_regions,
     rle_to_mask,
@@ -200,6 +201,7 @@ class SAM2AutomaticMaskGenerator:
         return self._encode_masks(mask_data)
 
     def _encode_masks(self, mask_data):
+        mask_data["rles"] = _mask_to_rle_pytorch_2_1(mask_data["rles"])
         # Encode masks
         if self.output_mode == "coco_rle":
             mask_data["segmentations"] = [
@@ -341,7 +343,7 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_points"):
             data["points"] = uncrop_points(data["points"], crop_box)
         with torch.autograd.profiler.record_function("crop_boxes"):
-            data["crop_boxes"] = torch.tensor([crop_box for _ in range(len(data["rles"]))])
+            data["crop_boxes"] = torch.tensor([crop_box for _ in range(data["rles"].b)])
 
         return data
 
@@ -435,7 +437,7 @@ class SAM2AutomaticMaskGenerator:
                     # TODO: Capture all these masks in a single NT for mask_to_rle_pytorch_2
                     # or at a minimum create a mask_to_rle_pytorch_2_list and use loops
                     # to cause a single DtoH sync
-                    data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+                    data["rles"] = _mask_to_rle_pytorch_2_0(data["masks"])
                     del data["masks"]
 
                     batch_data = data
@@ -602,7 +604,7 @@ class SAM2AutomaticMaskGenerator:
         with torch.autograd.profiler.record_function("uncrop_masks"):
             # Compress to RLE
             data["masks"] = uncrop_masks(data["masks"], crop_box, orig_h, orig_w)
-            data["rles"] = mask_to_rle_pytorch_2(data["masks"])
+            data["rles"] = _mask_to_rle_pytorch_2_0(data["masks"])
             del data["masks"]
 
         return data

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -602,9 +602,11 @@ class SAM2AutomaticMaskGenerator:
 
         orig_box = [0, 0, orig_w, orig_h]
         orig_box_torch = torch.as_tensor(orig_box, dtype=torch.float)
-        orig_box_torch = orig_box_torch.pin_memory().to(device=self.predictor.device, non_blocking=True)
+        orig_box_torch = orig_box_torch.pin_memory()
+        orig_box_torch = orig_box_torch.to(device=self.predictor.device, non_blocking=True)
         crop_box_torch = torch.as_tensor(crop_box, dtype=torch.float)
-        crop_box_torch = crop_box_torch.pin_memory().to(device=self.predictor.device, non_blocking=True)
+        crop_box_torch = crop_box_torch.pin_memory()
+        crop_box_torch = crop_box_torch.to(device=self.predictor.device, non_blocking=True)
         data, keep_mask = self._process_batch_fullgraph(points, im_size, crop_box, crop_box_torch, orig_size, normalize, orig_box_torch)
         if keep_mask is not None:
             keep_index = keep_mask.nonzero(as_tuple=True)[0]

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -534,6 +534,7 @@ class SAM2AutomaticMaskGenerator:
                 # Filter by predicted IoU
                 if self.pred_iou_thresh > 0.0:
                     keep_mask = data["iou_preds"] > self.pred_iou_thresh
+                    # TODO: Might need this for correctness due to calculate_stability_score IoU?
                     # data.filter(keep_mask)
 
             with torch.autograd.profiler.record_function("calculate_stability_score"):

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -115,14 +115,15 @@ class TwoWayTransformer(nn.Module):
         queries = point_embedding
         keys = image_embedding
 
-        # Apply transformer blocks and final layernorm
-        for layer in self.layers:
-            queries, keys = layer(
-                queries=queries,
-                keys=keys,
-                query_pe=point_embedding,
-                key_pe=image_pe,
-            )
+        with torch.autograd.profiler.record_function("TwoWayTransformer: layers"):
+            # Apply transformer blocks and final layernorm
+            for layer in self.layers:
+                queries, keys = layer(
+                    queries=queries,
+                    keys=keys,
+                    query_pe=point_embedding,
+                    key_pe=image_pe,
+                )
 
         # Apply the final attention layer from the points to the image
         q = queries + point_embedding

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -389,6 +389,10 @@ class SAM2ImagePredictor:
                 "An image must be set with .set_image(...) before mask prediction."
             )
 
+        low_res_masks, iou_predictions = self._predict_masks(point_coords, point_labels, boxes, mask_input, multimask_output, return_logits, img_idx)
+        return self._predict_masks_postprocess(low_res_masks, img_idx, iou_predictions, return_logits)
+
+    def _predict_masks(self, point_coords, point_labels, boxes, mask_input, multimask_output, return_logits, img_idx):
         if point_coords is not None:
             concat_points = (point_coords, point_labels)
         else:
@@ -434,6 +438,9 @@ class SAM2ImagePredictor:
                 high_res_features=high_res_features,
             )
 
+        return low_res_masks, iou_predictions
+
+    def _predict_masks_postprocess(self, low_res_masks, img_idx, iou_predictions, return_logits):
         with torch.autograd.profiler.record_function("self._transforms.postprocess_masks"):
             # Upscale the masks to the original image resolution
             masks = self._transforms.postprocess_masks(

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -109,10 +109,13 @@ class SAM2ImagePredictor:
         else:
             raise NotImplementedError("Image format not supported")
 
-        image_torch = self._transforms.to_tensor(image)
-        image_torch = image_torch.to(device=self.device)
-        image_torch = self._transforms.transforms(image_torch)
-        input_image = image_torch[None, ...].to(dtype=self._image_dtype)
+        input_image = self._transforms.to_tensor(image)
+        # TODO: Doing these transforms on the GPU changes the numerics
+        input_image = self._transforms.transforms(input_image)
+        input_image = input_image.to(device=self.device)
+        # TODO: Doing this here instead causes masks to not match reference exactly
+        # input_image = self._transforms.transforms(input_image)
+        input_image = input_image[None, ...].to(dtype=self._image_dtype)
 
         assert (
             len(input_image.shape) == 4 and input_image.shape[1] == 3

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -110,8 +110,7 @@ class SAM2ImagePredictor:
             raise NotImplementedError("Image format not supported")
 
         input_image = self._transforms(image)
-        input_image = input_image[None, ...].to(self.device)
-        input_image = input_image.to(self._image_dtype)
+        input_image = input_image[None, ...].to(device=self.device, dtype=self._image_dtype)
 
         assert (
             len(input_image.shape) == 4 and input_image.shape[1] == 3

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -110,13 +110,9 @@ class SAM2ImagePredictor:
             raise NotImplementedError("Image format not supported")
 
         image_torch = self._transforms.to_tensor(image)
-        # image_torch = image_torch.pin_memory().to(device=self.device, non_blocking=True)
         image_torch = image_torch.to(device=self.device)
-        with torch.autograd.profiler.record_function("self._transforms.transforms"):
-            image_torch = self._transforms.transforms(image_torch)
-        # input_image = self._transforms(image)
+        image_torch = self._transforms.transforms(image_torch)
         input_image = image_torch[None, ...].to(dtype=self._image_dtype)
-        # input_image = input_image[None, ...].to(device=self.device, dtype=self._image_dtype)
 
         assert (
             len(input_image.shape) == 4 and input_image.shape[1] == 3

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -389,8 +389,10 @@ class SAM2ImagePredictor:
                 "An image must be set with .set_image(...) before mask prediction."
             )
 
-        low_res_masks, iou_predictions = self._predict_masks(point_coords, point_labels, boxes, mask_input, multimask_output, return_logits, img_idx)
-        return self._predict_masks_postprocess(low_res_masks, img_idx, iou_predictions, return_logits)
+        with torch.autograd.profiler.record_function("_predict_masks"):
+            low_res_masks, iou_predictions = self._predict_masks(point_coords, point_labels, boxes, mask_input, multimask_output, return_logits, img_idx)
+        with torch.autograd.profiler.record_function("_predict_masks_postprocess"):
+            return self._predict_masks_postprocess(low_res_masks, img_idx, iou_predictions, return_logits)
 
     def _predict_masks(self, point_coords, point_labels, boxes, mask_input, multimask_output, return_logits, img_idx):
         if point_coords is not None:

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -109,8 +109,14 @@ class SAM2ImagePredictor:
         else:
             raise NotImplementedError("Image format not supported")
 
-        input_image = self._transforms(image)
-        input_image = input_image[None, ...].to(device=self.device, dtype=self._image_dtype)
+        image_torch = self._transforms.to_tensor(image)
+        # image_torch = image_torch.pin_memory().to(device=self.device, non_blocking=True)
+        image_torch = image_torch.to(device=self.device)
+        with torch.autograd.profiler.record_function("self._transforms.transforms"):
+            image_torch = self._transforms.transforms(image_torch)
+        # input_image = self._transforms(image)
+        input_image = image_torch[None, ...].to(dtype=self._image_dtype)
+        # input_image = input_image[None, ...].to(device=self.device, dtype=self._image_dtype)
 
         assert (
             len(input_image.shape) == 4 and input_image.shape[1] == 3

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -449,6 +449,7 @@ class SAM2ImagePredictor:
         return low_res_masks, iou_predictions
 
     def _predict_masks_postprocess(self, low_res_masks, img_idx, iou_predictions, return_logits):
+        # TODO: Might want to defer this until after data["iou_preds"] > self.pred_iou_thresh
         with torch.autograd.profiler.record_function("self._transforms.postprocess_masks"):
             # Upscale the masks to the original image resolution
             masks = self._transforms.postprocess_masks(

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -420,15 +420,15 @@ class SAM2ImagePredictor:
             concat_points is not None and concat_points[0].shape[0] > 1
         )  # multi object prediction
         high_res_features = [
-            feat_level[img_idx].unsqueeze(0)
+            feat_level[img_idx].unsqueeze(0).clone()
             for feat_level in self._features["high_res_feats"]
         ]
         with torch.autograd.profiler.record_function("self.model.sam_mask_decoder"):
             low_res_masks, iou_predictions, _, _ = self.model.sam_mask_decoder(
-                image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0),
-                image_pe=self.model.sam_prompt_encoder.get_dense_pe(),
-                sparse_prompt_embeddings=sparse_embeddings,
-                dense_prompt_embeddings=dense_embeddings,
+                image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0).clone(),
+                image_pe=self.model.sam_prompt_encoder.get_dense_pe().clone(),
+                sparse_prompt_embeddings=sparse_embeddings.clone(),
+                dense_prompt_embeddings=dense_embeddings.clone(),
                 multimask_output=multimask_output,
                 repeat_image=batched_mode,
                 high_res_features=high_res_features,

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -11,10 +11,43 @@ from typing import Any, Dict, Generator, ItemsView, List, Tuple
 
 import numpy as np
 import torch
+from dataclasses import dataclass, astuple
+
+
+@dataclass
+class RLEData:
+    alt_lens_nt: torch.Tensor
+    counts_init: torch.Tensor
+    b: int
+    h: int
+    w: int
+
+
+def nt_index_select_dim_0(nt, index):
+    values = nt.values()
+    offsets = nt.offsets()
+    lengths = offsets.diff()
+    offsets_index = offsets[index].cpu()
+    lengths_index = lengths[index].cpu()
+    indices = [o + torch.arange(l) for (o, l) in zip(offsets_index, lengths_index)]
+    indices = torch.cat(indices).to(values.device)
+    values_index = torch.index_select(values, 0, indices)
+    lengths_index = lengths_index.to(values.device)
+    return torch.nested.nested_tensor_from_jagged(values_index, lengths=lengths_index)
+
+
+def nt_cat_dim_0(nts: List[torch.Tensor]):
+    all_values = []
+    all_lengths = []
+    for nt in nts:
+        all_values.append(nt.values())
+        all_lengths.append(nt.offsets().diff())
+    new_values = torch.cat(all_values)
+    new_lengths = torch.cat(all_lengths)
+    return torch.nested.nested_tensor_from_jagged(new_values, lengths=new_lengths)
+
 
 # Very lightly adapted from https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/utils/amg.py
-
-
 class MaskData:
     """
     A structure for storing masks and their related data in batched format.
@@ -24,13 +57,13 @@ class MaskData:
     def __init__(self, **kwargs) -> None:
         for v in kwargs.values():
             assert isinstance(
-                v, (list, np.ndarray, torch.Tensor)
+                v, (list, np.ndarray, torch.Tensor, RLEData)
             ), "MaskData only supports list, numpy arrays, and torch tensors."
         self._stats = dict(**kwargs)
 
     def __setitem__(self, key: str, item: Any) -> None:
         assert isinstance(
-            item, (list, np.ndarray, torch.Tensor)
+            item, (list, np.ndarray, torch.Tensor, RLEData)
         ), "MaskData only supports list, numpy arrays, and torch tensors."
         self._stats[key] = item
 
@@ -56,6 +89,14 @@ class MaskData:
                 self._stats[k] = [a for i, a in enumerate(v) if keep[i]]
             elif isinstance(v, list):
                 self._stats[k] = [v[i] for i in keep]
+            elif isinstance(v, RLEData):
+                new_alt_lens_nt = nt_index_select_dim_0(v.alt_lens_nt, keep)
+                self._stats[k] = RLEData(
+                        alt_lens_nt=new_alt_lens_nt,
+                        counts_init=v.counts_init[keep],
+                        b=new_alt_lens_nt.size(0),
+                        h=v.h,
+                        w=v.w)
             else:
                 raise TypeError(f"MaskData key {k} has an unsupported type {type(v)}.")
 
@@ -69,6 +110,15 @@ class MaskData:
                 self._stats[k] = np.concatenate([self._stats[k], v], axis=0)
             elif isinstance(v, list):
                 self._stats[k] = self._stats[k] + deepcopy(v)
+            elif isinstance(v, RLEData):
+                assert self._stats[k].h == v.h
+                assert self._stats[k].w == v.w
+                self._stats[k] = RLEData(
+                        alt_lens_nt=nt_cat_dim_0([self._stats[k].alt_lens_nt, v.alt_lens_nt]),
+                        counts_init=torch.cat([self._stats[k].counts_init, v.counts_init]),
+                        b=self._stats[k].b + v.b,
+                        h=v.h,
+                        w=v.w)
             else:
                 raise TypeError(f"MaskData key {k} has an unsupported type {type(v)}.")
 
@@ -162,7 +212,7 @@ def rle_to_mask(rle: Dict[str, Any]) -> np.ndarray:
     return mask.transpose()  # Put in C order
 
 
-def mask_to_rle_pytorch_2(tensor: torch.Tensor) -> List[Dict[str, Any]]:
+def _mask_to_rle_pytorch_2_0(tensor: torch.Tensor) -> (torch.Tensor, torch.Tensor, torch.Tensor):
     """
     Encodes masks to an uncompressed RLE, in the format expected by
     pycoco tools.
@@ -187,25 +237,43 @@ def mask_to_rle_pytorch_2(tensor: torch.Tensor) -> List[Dict[str, Any]]:
             change_indices = diff.nonzero()
 
     with torch.autograd.profiler.record_function("mask_to_rle_pytorch_2: all_btw_idx"):
-        alt_lens = diff.sum(dim=1).tolist()
+        alt_lens = diff.sum(dim=1)
 
         all_cur_idx = change_indices[:, 1]
         all_btw_idx = torch.cat([all_cur_idx[1:], all_cur_idx[:1]]) - all_cur_idx
-        all_btw_idx = all_btw_idx.tolist()
 
     with torch.autograd.profiler.record_function("mask_to_rle_pytorch_2: Encode run length"):
+        alt_lens_nt = torch.nested.nested_tensor_from_jagged(all_btw_idx, lengths=alt_lens)
         # Encode run length
+        counts_init = (tensor[:, 0] == 0)
+        return RLEData(alt_lens_nt=alt_lens_nt,
+                       counts_init=counts_init,
+                       b=b,
+                       h=h,
+                       w=w)
+
+
+def _mask_to_rle_pytorch_2_1(rle_data: RLEData):
+    with torch.autograd.profiler.record_function("mask_to_rle_pytorch_2: Encode run length"):
         out = []
-        counts_init = (tensor[:, 0] == 0).tolist()
+        alt_lens = rle_data.alt_lens_nt.offsets().diff()
+        all_btw_idx = rle_data.alt_lens_nt.values()
+        alt_lens = alt_lens.tolist()
+        all_btw_idx = all_btw_idx.tolist()
+        counts_init = rle_data.counts_init.tolist()
         offset = 0
-        for i, ci in zip(range(b), counts_init):
+        for i, ci in zip(range(rle_data.b), counts_init):
             btw_idxs = all_btw_idx[offset:offset + alt_lens[i]][:-1]
             offset += alt_lens[i]
             counts = [] if ci else [0]
             counts.extend(btw_idxs)
-            out.append({"size": [h, w], "counts": counts})
+            out.append({"size": [rle_data.h, rle_data.w], "counts": counts})
 
     return out
+
+
+def mask_to_rle_pytorch_2(tensor: torch.Tensor) -> List[Dict[str, Any]]:
+    return _mask_to_rle_pytorch_2_1(_mask_to_rle_pytorch_2_0(tensor))
 
 
 def area_from_rle(rle: Dict[str, Any]) -> int:

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -22,6 +22,9 @@ class RLEData:
     h: int
     w: int
 
+    def __len__(self):
+        return self.b
+
 
 def nt_index_select_dim_0(nt, index):
     values = nt.values()

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -127,11 +127,10 @@ def is_box_near_crop_edge_torch(
     crop_box: List[int],
     crop_box_torch: torch.Tensor,
     orig_box_torch: torch.Tensor,
-    is_box_near_crop_edge_torch_offset: torch.Tensor,
     atol: float = 20.0,
 ) -> torch.Tensor:
     """Filter masks at the edge of a crop, but not at the edge of the original image."""
-    boxes = uncrop_boxes_xyxy_torch(boxes, crop_box, is_box_near_crop_edge_torch_offset).float()
+    boxes = uncrop_boxes_xyxy(boxes, crop_box).float()
     near_crop_edge = torch.isclose(boxes, crop_box_torch[None, :], atol=atol, rtol=0)
     near_image_edge = torch.isclose(boxes, orig_box_torch[None, :], atol=atol, rtol=0)
     near_crop_edge = torch.logical_and(near_crop_edge, ~near_image_edge)
@@ -361,15 +360,6 @@ def generate_crop_boxes(
 def uncrop_boxes_xyxy(boxes: torch.Tensor, crop_box: List[int]) -> torch.Tensor:
     x0, y0, _, _ = crop_box
     offset = torch.tensor([[x0, y0, x0, y0]], device=boxes.device)
-    # Check if boxes has a channel dimension
-    if len(boxes.shape) == 3:
-        offset = offset.unsqueeze(1)
-    return boxes + offset
-
-def uncrop_boxes_xyxy_torch(boxes: torch.Tensor, crop_box: List[int], offset) -> torch.Tensor:
-    x0, y0, _, _ = crop_box
-    # Had to move construction of offset with pin_memory outside this function because of compile
-    # offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory().to(device=boxes.device, non_blocking=True)
     # Check if boxes has a channel dimension
     if len(boxes.shape) == 3:
         offset = offset.unsqueeze(1)

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -206,7 +206,9 @@ def _mask_to_rle_pytorch_2_chunk_values_lengths(tensor: torch.Tensor) -> List[Di
 
     return alt_lens, all_btw_idx
 
-def _mask_to_rle_pytorch_2_chunk_to_dict(alt_lens: torch.Tensor, all_btw_idx: torch.Tensor):
+def _mask_to_rle_pytorch_2_chunk_to_dict(tensor: torch.Tensor, alt_lens: torch.Tensor, all_btw_idx: torch.Tensor):
+    b, h, w = tensor.shape
+    tensor = tensor.permute(0, 2, 1).flatten(1)
 
     with torch.autograd.profiler.record_function("mask_to_rle_pytorch_2: tolist"):
         alt_lens = alt_lens.tolist()
@@ -235,7 +237,7 @@ def mask_to_rle_pytorch_2(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     rles = []
     for mask_chunk in tensor.chunk(4):
         alt_lens, all_btw_idx = _mask_to_rle_pytorch_2_chunk_values_lengths(mask_chunk)
-        rles.extend(_mask_to_rle_pytorch_2_chunk_to_dict(alt_lens, all_btw_idx))
+        rles.extend(_mask_to_rle_pytorch_2_chunk_to_dict(mask_chunk, alt_lens, all_btw_idx))
     return rles
 
 

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -364,7 +364,8 @@ def generate_crop_boxes(
 
 def uncrop_boxes_xyxy(boxes: torch.Tensor, crop_box: List[int]) -> torch.Tensor:
     x0, y0, _, _ = crop_box
-    offset = torch.tensor([[x0, y0, x0, y0]], device=boxes.device)
+    offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory()
+    offset = offset.to(device=boxes.device, non_blocking=True)
     # Check if boxes has a channel dimension
     if len(boxes.shape) == 3:
         offset = offset.unsqueeze(1)
@@ -428,6 +429,7 @@ def coco_encode_rle(uncompressed_rle: Dict[str, Any]) -> Dict[str, Any]:
     return rle
 
 
+@torch.compile(fullgraph=True, dynamic=True)
 def batched_mask_to_box(masks: torch.Tensor) -> torch.Tensor:
     """
     Calculates boxes in XYXY format around masks. Return [0,0,0,0] for

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -212,6 +212,7 @@ def area_from_rle(rle: Dict[str, Any]) -> int:
     return sum(rle["counts"][1::2])
 
 
+@torch.compile(fullgraph=True, dynamic=True)
 def calculate_stability_score(
     masks: torch.Tensor, mask_threshold: float, threshold_offset: float
 ) -> torch.Tensor:

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -253,7 +253,12 @@ def mask_to_rle_pytorch_2_nt(tensor: torch.Tensor) -> (torch.Tensor, torch.Tenso
         rles.append((alt_lens, all_btw_idx))
     all_btw_idx = torch.cat([r[1] for r in rles])
     alt_lens = torch.cat([r[0] for r in rles])
-    return torch.nested.nested_tensor_from_jagged(all_btw_idx, lengths=alt_lens)
+    ret_nt = torch.nested.nested_tensor_from_jagged(all_btw_idx, lengths=alt_lens)
+
+    b, h, w = tensor.shape
+    tensor = tensor.permute(0, 2, 1).flatten(1)
+    counts_init = (tensor[:, 0] == 0).tolist()
+    return ret_nt, counts_init
 
 
 def area_from_rle(rle: Dict[str, Any]) -> int:

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -188,10 +188,12 @@ def _mask_to_rle_pytorch_2_chunk_values_lengths(tensor: torch.Tensor) -> List[Di
     with torch.autograd.profiler.record_function("mask_to_rle_pytorch_2: change indices"):
         # Compute change indices
         diff = tensor[:, 1:] ^ tensor[:, :-1]
-        a = torch.tensor([[True]])
-        if diff.is_cuda:
-            a = a.pin_memory().cuda()
-            # a = a.to(diff.device)
+        # a = torch.tensor([[True]], device=diff.device)
+        a = torch.ones((1, 1), dtype=torch.bool, device=diff.device)
+        # import pdb; pdb.set_trace()
+        # if diff.is_cuda:
+        #     a = a.pin_memory().cuda()
+        #     # a = a.to(diff.device)
         a = a.expand_as(diff.narrow(1, 0, 1))
         diff = torch.cat([a, diff, a], dim=1)
         change_indices = diff.nonzero()

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -374,7 +374,8 @@ def uncrop_boxes_xyxy(boxes: torch.Tensor, crop_box: List[int]) -> torch.Tensor:
 
 def uncrop_points(points: torch.Tensor, crop_box: List[int]) -> torch.Tensor:
     x0, y0, _, _ = crop_box
-    offset = torch.tensor([[x0, y0]], device=points.device)
+    offset = torch.tensor([[x0, y0]]).pin_memory()
+    offset = offset.to(device=points.device, non_blocking=True)
     # Check if points has a channel dimension
     if len(points.shape) == 3:
         offset = offset.unsqueeze(1)

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -74,6 +74,26 @@ class MaskData:
             else:
                 raise TypeError(f"MaskData key {k} has an unsupported type {type(v)}.")
 
+    def filter_by_index(self, keep: torch.Tensor) -> None:
+        keep_list = keep.tolist()
+        for k, v in self._stats.items():
+            if v is None:
+                self._stats[k] = None
+            elif isinstance(v, torch.Tensor):
+                # self._stats[k] = v[torch.as_tensor(keep, device=v.device)]
+                if v.is_nested:
+                    self._stats[k] = nt_index_select_dim_0(v, keep)
+                else:
+                    self._stats[k] = v[keep]
+            elif isinstance(v, np.ndarray):
+                self._stats[k] = v[keep.detach().cpu().numpy()]
+            elif isinstance(v, list) and keep.dtype == torch.bool:
+                self._stats[k] = [a for i, a in enumerate(v) if keep_list[i]]
+            elif isinstance(v, list):
+                self._stats[k] = [v[i] for i in keep]
+            else:
+                raise TypeError(f"MaskData key {k} has an unsupported type {type(v)}.")
+
     def cat(self, new_stats: "MaskData") -> None:
         for k, v in new_stats.items():
             if k not in self._stats or self._stats[k] is None:
@@ -98,10 +118,11 @@ def is_box_near_crop_edge_torch(
     crop_box: List[int],
     crop_box_torch: torch.Tensor,
     orig_box_torch: torch.Tensor,
+    is_box_near_crop_edge_torch_offset: torch.Tensor,
     atol: float = 20.0,
 ) -> torch.Tensor:
     """Filter masks at the edge of a crop, but not at the edge of the original image."""
-    boxes = uncrop_boxes_xyxy(boxes, crop_box).float()
+    boxes = uncrop_boxes_xyxy_torch(boxes, crop_box, is_box_near_crop_edge_torch_offset).float()
     near_crop_edge = torch.isclose(boxes, crop_box_torch[None, :], atol=atol, rtol=0)
     near_image_edge = torch.isclose(boxes, orig_box_torch[None, :], atol=atol, rtol=0)
     near_crop_edge = torch.logical_and(near_crop_edge, ~near_image_edge)
@@ -354,6 +375,15 @@ def generate_crop_boxes(
 def uncrop_boxes_xyxy(boxes: torch.Tensor, crop_box: List[int]) -> torch.Tensor:
     x0, y0, _, _ = crop_box
     offset = torch.tensor([[x0, y0, x0, y0]], device=boxes.device)
+    # Check if boxes has a channel dimension
+    if len(boxes.shape) == 3:
+        offset = offset.unsqueeze(1)
+    return boxes + offset
+
+def uncrop_boxes_xyxy_torch(boxes: torch.Tensor, crop_box: List[int], offset) -> torch.Tensor:
+    x0, y0, _, _ = crop_box
+    # Had to move construction of offset with pin_memory outside this function because of compile
+    # offset = torch.tensor([[x0, y0, x0, y0]]).pin_memory().to(device=boxes.device, non_blocking=True)
     # Check if boxes has a channel dimension
     if len(boxes.shape) == 3:
         offset = offset.unsqueeze(1)

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -99,7 +99,16 @@ class MaskData:
             if k not in self._stats or self._stats[k] is None:
                 self._stats[k] = deepcopy(v)
             elif isinstance(v, torch.Tensor):
-                self._stats[k] = torch.cat([self._stats[k], v], dim=0)
+                if v.is_nested:
+                    values0 = self._stats[k].values()
+                    lengths0 = self._stats[k].offsets().diff()
+                    values1 = v.values()
+                    lengths1 = v.offsets().diff()
+                    new_values = torch.cat([values0, values1])
+                    new_lengths = torch.cat([lengths0, lengths1])
+                    self._stats[k] = torch.nested.nested_tensor_from_jagged(new_values, lengths=new_lengths)
+                else:
+                    self._stats[k] = torch.cat([self._stats[k], v], dim=0)
             elif isinstance(v, np.ndarray):
                 self._stats[k] = np.concatenate([self._stats[k], v], axis=0)
             elif isinstance(v, list):

--- a/torchao/_models/sam2/utils/amg.py
+++ b/torchao/_models/sam2/utils/amg.py
@@ -206,6 +206,7 @@ def _mask_to_rle_pytorch_2_chunk_values_lengths(tensor: torch.Tensor) -> List[Di
 
     return alt_lens, all_btw_idx
 
+
 def _mask_to_rle_pytorch_2_chunk_to_dict(tensor: torch.Tensor, alt_lens: torch.Tensor, all_btw_idx: torch.Tensor):
     b, h, w = tensor.shape
     tensor = tensor.permute(0, 2, 1).flatten(1)

--- a/torchao/_models/sam2/utils/transforms.py
+++ b/torchao/_models/sam2/utils/transforms.py
@@ -118,3 +118,50 @@ class SAM2Transforms(nn.Module):
 
         masks = F.interpolate(masks, orig_hw, mode="bilinear", align_corners=False)
         return masks
+
+    def postprocess_masks_1_channel(self, masks: torch.Tensor, orig_hw) -> torch.Tensor:
+        """
+        Perform PostProcessing on output masks.
+        """
+        from torchao._models.sam2.utils.misc import get_connected_components
+
+        assert masks.dim() == 4
+        assert masks.size(1) == 1
+        masks = masks.float()
+        input_masks = masks
+        # mask_flat = masks.flatten(0, 1).unsqueeze(1)  # flatten as 1-channel image
+        mask_flat = masks
+        try:
+            if self.max_hole_area > 0:
+                # Holes are those connected components in background with area <= self.fill_hole_area
+                # (background regions are those with mask scores <= self.mask_threshold)
+                labels, areas = get_connected_components(
+                    mask_flat <= self.mask_threshold
+                )
+                is_hole = (labels > 0) & (areas <= self.max_hole_area)
+                # is_hole = is_hole.reshape_as(masks)
+                # We fill holes with a small positive mask score (10.0) to change them to foreground.
+                masks = torch.where(is_hole, self.mask_threshold + 10.0, masks)
+
+            if self.max_sprinkle_area > 0:
+                labels, areas = get_connected_components(
+                    mask_flat > self.mask_threshold
+                )
+                is_hole = (labels > 0) & (areas <= self.max_sprinkle_area)
+                # is_hole = is_hole.reshape_as(masks)
+                # We fill holes with negative mask score (-10.0) to change them to background.
+                masks = torch.where(is_hole, self.mask_threshold - 10.0, masks)
+        except Exception as e:
+            # Skip the post-processing step if the CUDA kernel fails
+            warnings.warn(
+                f"{e}\n\nSkipping the post-processing step due to the error above. You can "
+                "still use SAM 2 and it's OK to ignore the error above, although some post-processing "
+                "functionality may be limited (which doesn't affect the results in most cases; see "
+                "https://github.com/facebookresearch/sam2/blob/main/INSTALL.md).",
+                category=UserWarning,
+                stacklevel=2,
+            )
+            masks = input_masks
+
+        masks = F.interpolate(masks, orig_hw, mode="bilinear", align_corners=False)
+        return masks

--- a/torchao/_models/sam2/utils/transforms.py
+++ b/torchao/_models/sam2/utils/transforms.py
@@ -27,12 +27,14 @@ class SAM2Transforms(nn.Module):
         self.mean = [0.485, 0.456, 0.406]
         self.std = [0.229, 0.224, 0.225]
         self.to_tensor = ToTensor()
-        self.transforms = torch.jit.script(
+        # self.transforms = torch.jit.script(
+        self.transforms = (
             nn.Sequential(
                 Resize((self.resolution, self.resolution)),
                 Normalize(self.mean, self.std),
             )
         )
+        self.transforms = torch.compile(self.transforms, fullgraph=True, dynamic=True)
 
     def __call__(self, x):
         x = self.to_tensor(x)

--- a/torchao/_models/sam2/utils/transforms.py
+++ b/torchao/_models/sam2/utils/transforms.py
@@ -27,14 +27,12 @@ class SAM2Transforms(nn.Module):
         self.mean = [0.485, 0.456, 0.406]
         self.std = [0.229, 0.224, 0.225]
         self.to_tensor = ToTensor()
-        # self.transforms = torch.jit.script(
-        self.transforms = (
+        self.transforms = torch.jit.script(
             nn.Sequential(
                 Resize((self.resolution, self.resolution)),
                 Normalize(self.mean, self.std),
             )
         )
-        self.transforms = torch.compile(self.transforms, fullgraph=True, dynamic=True)
 
     def __call__(self, x):
         x = self.to_tensor(x)


### PR DESCRIPTION
RLEData, some reorder of filtering, more compile-able regions. Causes slight numerical differences across all test images, but passes unit tests bit perfectly. Improves perf from ~190ms to ~130ms in the furious case with an increase in number of mismatched mask count. Improves perf from ~390ms to ~320ms without changing the mismatched mask count.