### PR TITLE
Skip marlin QQQ ops test in fbcode

### DIFF
--- a/test/quantization/test_marlin_qqq.py
+++ b/test/quantization/test_marlin_qqq.py
@@ -18,10 +18,14 @@ from torchao.quantization.quant_primitives import (
     MappingType,
     choose_qparams_and_quantize_affine_qqq,
 )
-from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5, is_fbcode
+import unittest
+
+if is_fbcode():
+    unittest.skip("Skipping the test in fbcode since we don't have TARGET file for kernels")
 
 
-class MarlinQQQ(TestCase):
+class TestMarlinQQQ(TestCase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(0)


### PR DESCRIPTION
fbcode doesn't support tests for kernels as we don't have TARGET file