### PR TITLE
float8 delayed scaling: remove need to use workaround for AC

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -261,6 +261,7 @@ class TestFloat8Linear:
         x,
         m_ref,
         config: Float8LinearConfig,
+        use_ac: bool = False,
     ):
         m_fp8 = Float8Linear.from_float(
             copy.deepcopy(m_ref),
@@ -269,9 +270,15 @@ class TestFloat8Linear:
         for _ in range(2):
             if linear_requires_sync(config):
                 sync_float8_amax_and_scale_history(m_fp8)
-            y_fp8 = m_fp8(x)
+            if use_ac:
+                y_fp8 = torch.utils.checkpoint.checkpoint(m_fp8, x, use_reentrant=False)
+            else:
+                y_fp8 = m_fp8(x)
             y_fp8.sum().backward()
-            y_ref = m_ref(x)
+            if use_ac:
+                y_ref = torch.utils.checkpoint.checkpoint(m_ref, x, use_reentrant=False)
+            else:
+                y_ref = m_ref(x)
             y_ref.sum().backward()
 
         assert y_ref.shape == y_fp8.shape
@@ -344,6 +351,7 @@ class TestFloat8Linear:
     )
     @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
     @pytest.mark.parametrize("linear_bias", [False, True])
+    @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_linear_from_config_params(
         self,
@@ -354,6 +362,7 @@ class TestFloat8Linear:
         scaling_type_grad_output: ScalingType,
         linear_dtype: torch.dtype,
         linear_bias: bool,
+        use_ac: bool,
     ):
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)
@@ -369,6 +378,7 @@ class TestFloat8Linear:
             x,
             m_ref,
             config,
+            use_ac,
         )
 
     # Note: there are now too many config combinations to test all of


### PR DESCRIPTION
Summary:

The logic to check if the user has called
`sync_float8_amax_and_scale_history`, while nice, hasn't been that useful in practice.  Removing this logic in order to simplify the integration with manual activation checkpointing - now it "just works" without the need to work around with a non-standard config.

Test Plan:

```
pytest test/float8/test_base.py -s -x
```

Reviewers:

Subscribers:

Tasks:

Tags: