### PR TITLE
Fix Marlin QQQ ops test with unittest

### DIFF
--- a/test/quantization/test_marlin_qqq.py
+++ b/test/quantization/test_marlin_qqq.py
@@ -21,10 +21,7 @@ from torchao.quantization.quant_primitives import (
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5, is_fbcode
 import unittest
 
-if is_fbcode():
-    unittest.skip("Skipping the test in fbcode since we don't have TARGET file for kernels")
-
-
+@unittest.skipIf(is_fbcode(), "Skipping the test in fbcode since we don't have TARGET file for kernels")
 class TestMarlinQQQ(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Summary: Skipping test_marlin_qqq in fbcode

Reviewed By: jerryzh168

Differential Revision: D66031641
