### PR TITLE
migrate to linux_job_v2 and manylinux 2_28

### DIFF
--- a/.github/workflows/float8_test.yml
+++ b/.github/workflows/float8_test.yml
@@ -29,7 +29,7 @@ jobs:
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
 
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 60
       runner: ${{ matrix.runs-on }}

--- a/.github/workflows/float8_test.yml
+++ b/.github/workflows/float8_test.yml
@@ -38,8 +38,6 @@ jobs:
       script: |
         conda create -n venv python=3.9 -y
         conda activate venv
-        echo "::group::Install newer objcopy that supports --set-section-alignment"
-        yum install -y  devtoolset-10-binutils
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}

--- a/.github/workflows/nightly_smoke_test.yml
+++ b/.github/workflows/nightly_smoke_test.yml
@@ -26,7 +26,7 @@ jobs:
             gpu-arch-version: "12.1"
 
 
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -70,12 +70,6 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
-          - name: CUDA Nightly
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: '--pre torch==2.6.0.dev20241101 --index-url https://download.pytorch.org/whl/nightly/cu121'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
-
           - name: CPU 2.3
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu'
@@ -89,11 +83,6 @@ jobs:
           - name: CPU 2.5.1
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
-          - name: CPU Nightly
-            runs-on: linux.4xlarge
-            torch-spec: '--pre torch==2.6.0.dev20241101 --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
 

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -18,6 +18,38 @@ env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
 jobs:
+  test-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: CUDA Nightly
+            runs-on: linux.g5.12xlarge.nvidia.gpu
+            torch-spec: '--pre torch==2.6.0.dev20241101 --index-url https://download.pytorch.org/whl/nightly/cu121'
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.1"
+          - name: CPU Nightly
+            runs-on: linux.4xlarge
+            torch-spec: '--pre torch==2.6.0.dev20241101 --index-url https://download.pytorch.org/whl/nightly/cpu'
+            gpu-arch-type: "cpu"
+            gpu-arch-version: ""
+
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 120
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      script: |
+        conda create -n venv python=3.9 -y
+        conda activate venv
+        python -m pip install --upgrade pip
+        pip install ${{ matrix.torch-spec }}
+        pip install -r dev-requirements.txt
+        pip install .
+        export CONDA=$(dirname $(dirname $(which conda)))
+        export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
+        pytest test --verbose -s
   test:
     strategy:
       fail-fast: false

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -13,7 +13,7 @@ if [[ "$CU_VERSION" == cu* ]]; then
     WHEEL_NAME=$(ls dist/)
 
     pushd dist
-    manylinux_plat=manylinux2014_x86_64
+    manylinux_plat=manylinux2_28_x86_64
     auditwheel repair --plat "$manylinux_plat" -w . \
     --exclude libtorch.so \
     --exclude libtorch_python.so \

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -13,7 +13,7 @@ if [[ "$CU_VERSION" == cu* ]]; then
     WHEEL_NAME=$(ls dist/)
 
     pushd dist
-    manylinux_plat=manylinux2_28_x86_64
+    manylinux_plat=manylinux_2_28_x86_64
     auditwheel repair --plat "$manylinux_plat" -w . \
     --exclude libtorch.so \
     --exclude libtorch_python.so \


### PR DESCRIPTION
this is to handle the migration of dev-infra from manylinux_2_26 to 2_28: https://github.com/pytorch/pytorch/issues/123649

this required us update to linux_job_v2 for everything using nightly pytorch.
float8 tests: change to linux_job_v2 and remove binutils (they don't seem to be needed anymore)
nightly smoke tests: change to linux_job_v2
regression tests: only the nightlies need to use the new linux_job_v2, the rest needs to remain unchanged. We are currentlly pinning the pytorch version due to the bad_alloc tests but when that gets unpinned in https://github.com/pytorch/ao/pull/1283 the same changes for float8 test will need to be made to the nightly regression tests

these changes are working if CI is passing here

wheel builds: we update the manylinux version to 2_28, this was tested with https://github.com/pytorch/ao/actions/runs/11901019589 where all the cpu/cuda jobs pass, though we are still seeing failures with rocm jobs, that is a larger issue, unrelated to this PR, fixes for that are ongoing in https://github.com/pytorch/pytorch/issues/140631
