### PR TITLE
Skipping nvcc compilation for sm equal or lower than 80

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ def get_extensions():
             "nvcc": [
                 "-O3" if not debug_mode else "-O0",
                 "-t=0",
+                "-gencode=arch=compute_86,code=sm_86",
             ]
         }
 


### PR DESCRIPTION
sm_80 or lower does not have bfloat16 which causes the compilation to fail, e.g. https://github.com/pytorch/pytorch/actions/runs/11960091588/job/33347870789