### PR TITLE
Enable CPU Offload for Intel GPU

### DIFF
--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -305,9 +305,6 @@ if __name__ == "__main__":
             print(f"Epoch {epoch_idx + 1}/{args.n_epochs}: val_acc={val_acc.item() * 100:.2f}")
             logger.log(dict(val_acc=val_acc), step=step)
 
-    if args.device == "cuda":
-        peak_mem = torch.cuda.max_memory_allocated() / 1e9
-    elif args.device == "xpu":
-        peak_mem = torch.xpu.max_memory_allocated() / 1e9
+    peak_mem = getattr(torch, args.device).max_memory_allocated() / 1e9
     print(f"Max memory used: {peak_mem:.02f} GB")
     logger.log(dict(max_memory_allocated=peak_mem))

--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -250,13 +250,7 @@ if __name__ == "__main__":
         pbar = tqdm(dloader, dynamic_ncols=True, desc=f"Epoch {epoch_idx + 1}/{args.n_epochs}")
 
         if args.profile:
-            activities = [torch.profiler.ProfilerActivity.CPU]
-            if args.device == "cuda":
-                activities.append(torch.profiler.ProfilerActivity.CUDA)
-            elif args.device == "xpu":
-                activities.append(torch.profiler.ProfilerActivity.XPU)
-
-            prof = torch.profiler.profile(activities=activities)
+            prof = torch.profiler.profile(activities=torch.profiler.supported_activities())
         else:
             prof = nullcontext()
 

--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -38,7 +38,7 @@ from tqdm import tqdm
 from torchao.prototype import low_bit_optim
 
 _DEVICE = get_available_devices()[-1]
-assert ("cuda" in _DEVICE or "xpu" in _DEVICE), "Benchmark currently only supports CUDA & XPU(BF16)"
+assert _DEVICE in ["cuda", "xpu"], "Benchmark currently only supports CUDA & XPU(BF16)"
 
 OPTIM_MAP = dict(
     AdamW=partial(torch.optim.AdamW, fused=True),

--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -252,12 +252,7 @@ if __name__ == "__main__":
         model.train()
         pbar = tqdm(dloader, dynamic_ncols=True, desc=f"Epoch {epoch_idx + 1}/{args.n_epochs}")
 
-        if args.profile:
-            prof = torch.profiler.profile(activities=torch.profiler.supported_activities())
-        else:
-            prof = nullcontext()
-
-        with prof:
+        with torch.profiler.profile() if args.profile else nullcontext() as prof:
             for batch in pbar:
                 if args.full_bf16:
                     batch["image"] = batch["image"].bfloat16()

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -95,7 +95,9 @@ class TestQuantize(TestCase):
         x = torch.rand(32, device=device) * 100
         x_rep = x.view(-1, 1).repeat(1, 100_000)
 
-        func = torch.compile(_fp32_to_bf16_sr, fullgraph=True, dynamic=False, disable=not compile)
+        func = torch.compile(
+            _fp32_to_bf16_sr, fullgraph=True, dynamic=False, disable=not compile
+        )
         x_rep_bf16 = func(x_rep)
         assert x_rep_bf16.dtype is torch.bfloat16
 
@@ -170,8 +172,13 @@ class TestOptim(TestCase):
         tensor = subclass.zeros(shape, device=device)
         offset = shape[0] // 2
 
-        torch.testing.assert_close(tensor.dequantize()[:offset], tensor[:offset].dequantize())
-        torch.testing.assert_close(tensor.dequantize()[offset:offset*2], tensor[offset:offset*2].dequantize())
+        torch.testing.assert_close(
+            tensor.dequantize()[:offset], tensor[:offset].dequantize()
+        )
+        torch.testing.assert_close(
+            tensor.dequantize()[offset : offset * 2],
+            tensor[offset : offset * 2].dequantize(),
+        )
 
     @pytest.mark.skipif(bnb is None, reason="bitsandbytes is not available")
     @pytest.mark.skipif(
@@ -189,7 +196,9 @@ class TestOptim(TestCase):
         block_size = 256 if Version(bnb.__version__) >= Version("0.44.0") else 2048
 
         optim1 = getattr(bnb.optim, optim_name)(model1.parameters())
-        optim2 = getattr(low_bit_optim, optim_name)(model2.parameters(), block_size=block_size)
+        optim2 = getattr(low_bit_optim, optim_name)(
+            model2.parameters(), block_size=block_size
+        )
 
         for _ in range(2):
             x = torch.randn(4, 32, device=device)
@@ -246,7 +255,7 @@ class TestOptim(TestCase):
 
     @pytest.mark.skipif(
         not torch.cuda.is_available() and not torch.xpu.is_available(),
-        reason="optim CPU offload requires CUDA or XPU"
+        reason="optim CPU offload requires CUDA or XPU",
     )
     @parametrize("offload_grad,grad_accum", [(False, 1), (False, 2), (True, 1)])
     def test_optim_cpu_offload_correctness(self, offload_grad, grad_accum):
@@ -282,13 +291,15 @@ class TestOptim(TestCase):
 
     @pytest.mark.skipif(
         not torch.cuda.is_available() and not torch.xpu.is_available(),
-        reason="optim CPU offload requires CUDA or XPU"
+        reason="optim CPU offload requires CUDA or XPU",
     )
     def test_optim_cpu_offload_save_load(self):
         device = _DEVICES[-1]
         model1 = nn.Sequential(nn.Linear(32, 1024), nn.ReLU(), nn.Linear(1024, 128))
         model1.to(device)
-        optim1 = low_bit_optim.CPUOffloadOptimizer(model1.parameters(), torch.optim.AdamW)
+        optim1 = low_bit_optim.CPUOffloadOptimizer(
+            model1.parameters(), torch.optim.AdamW
+        )
 
         for _ in range(2):
             x = torch.randn(4, 32, device=device)
@@ -303,7 +314,9 @@ class TestOptim(TestCase):
 
         # resume training
         model2 = copy.deepcopy(model1)
-        optim2 = low_bit_optim.CPUOffloadOptimizer(model2.parameters(), torch.optim.AdamW)
+        optim2 = low_bit_optim.CPUOffloadOptimizer(
+            model2.parameters(), torch.optim.AdamW
+        )
         optim2.load_state_dict(state_dict)
 
         for _ in range(2):
@@ -387,7 +400,11 @@ class TestFSDP2(FSDPTest):
         import torch.utils._pytree as pytree
         from torch.distributed._composable.fsdp import fully_shard
         from torch.distributed.tensor import DTensor
-        from torch.testing._internal.distributed._tensor.common_dtensor import ModelArgs, Transformer, TransformerBlock
+        from torch.testing._internal.distributed._tensor.common_dtensor import (
+            ModelArgs,
+            Transformer,
+            TransformerBlock,
+        )
 
         batch_size = 3
         vocab_size = 1024
@@ -460,7 +477,10 @@ class TestFSDP2(FSDPTest):
 
         subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
 
-        for v1, v2 in zip(pytree.tree_iter(resumed_fsdp_optim.state_dict()), pytree.tree_iter(fsdp_optim.state_dict())):
+        for v1, v2 in zip(
+            pytree.tree_iter(resumed_fsdp_optim.state_dict()),
+            pytree.tree_iter(fsdp_optim.state_dict()),
+        ):
             assert v1.__class__ == v2.__class__, (v1.__class__, v2.__class__)
             if isinstance(v1, DTensor):
                 v1 = v1.to_local()

--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -26,6 +26,7 @@ from torchao.prototype.low_bit_optim.subclass_4bit import OptimState4bit
 from torchao.prototype.low_bit_optim.subclass_8bit import OptimState8bit
 from torchao.prototype.low_bit_optim.subclass_fp8 import OptimStateFp8
 from torchao.utils import (
+    get_available_devices,
     TORCH_VERSION_AT_LEAST_2_4,
     TORCH_VERSION_AT_LEAST_2_5,
     TORCH_VERSION_AT_LEAST_2_6,
@@ -42,12 +43,7 @@ except ImportError:
     lpmm = None
 
 
-if torch.cuda.is_available():
-    _DEVICES = ["cpu", "cuda"]
-elif torch.xpu.is_available():
-    _DEVICES = ["cpu", "xpu"]
-else:
-    _DEVICES = ["cpu"]
+_DEVICES = get_available_devices()
 
 
 class TestQuantize(TestCase):
@@ -267,7 +263,6 @@ class TestOptim(TestCase):
             model2.parameters(),
             torch.optim.AdamW,
             offload_gradients=offload_grad,
-            device=device,
         )
 
         for _ in range(2):

--- a/torchao/prototype/low_bit_optim/README.md
+++ b/torchao/prototype/low_bit_optim/README.md
@@ -80,7 +80,7 @@ All of our low-bit optimizers mentioned above also support `bf16_stochastic_roun
 
 ## Optimizer CPU offload
 
-This folder also implements optimizer CPU offload (i.e. ZeRO-Offload) for single GPU training. Only CUDA is supported. For multi-GPU training, you can use FSDP's built-in CPU offload.
+This folder also implements optimizer CPU offload (i.e. ZeRO-Offload) for single GPU training. Only CUDA and XPU is supported. For multi-GPU training, you can use FSDP's built-in CPU offload.
 
 ```python
 import torch
@@ -97,7 +97,7 @@ optim = CPUOffloadOptimizer(model.parameters(), torch.optim.AdamW, offload_gradi
 
 This will reduce GPU memory usage by optimizer state size, and additionally gradient size if `offload_gradients=True`. `CPUOffloadOptimizer` can wrap any base optimizer.
 
-For saving and loading `CPUOffloadOptimizer`, it is important that you load model's weights BEFORE creating the optimizer, since we create a CPU copy of the parameters inside `CPUOffloadOptimizer.__init__()`. (TODO: we might want to have a method to synchronize CUDA and CPU params in either direction CPU->CUDA and CUDA->CPU, in case they are out of sync.)
+For saving and loading `CPUOffloadOptimizer`, it is important that you load model's weights BEFORE creating the optimizer, since we create a CPU copy of the parameters inside `CPUOffloadOptimizer.__init__()`. (TODO: we might want to have a method to synchronize GPU and CPU params in either direction CPU->GPU and GPU->CPU, in case they are out of sync.)
 
 ```python
 ckpt = torch.load("checkpoint.pth")

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -13,6 +13,7 @@ class CPUOffloadOptimizer:
         optimizer_class: Type[Optimizer] = torch.optim.AdamW,
         *,
         offload_gradients: bool = False,
+        device: str = "cuda",
         **kwargs,
     ) -> None:
         """Offload optimizer to CPU for single-GPU training. This will reduce GPU memory by the size of optimizer state.
@@ -22,6 +23,7 @@ class CPUOffloadOptimizer:
             params: a list of parameters or parameter groups.
             optimizer_class: constructor of the base optimizer. Defaults to :class:`torch.optim.AdamW`.
             offload_gradients: free GPU gradients once they are moved to CPU. Not compatible with gradient accumulation.
+            device: device type for GPU. Choose from "cuda" and "xpu". Defaults to "cuda".
             kwargs: other keyword arguments to be passed to the base optimizer e.g. `lr`, `weight_decay`.
         """
         # default to fused CPU AdamW
@@ -38,51 +40,57 @@ class CPUOffloadOptimizer:
         if not isinstance(param_groups[0], dict):
             param_groups = [{"params": param_groups}]
 
-        self.param_cuda2cpu_map = dict()
+        self.param_d2h_map = dict()
         self.optim_dict = dict()
-        self.stream = torch.cuda.Stream()
+        self.device = device
+        self.stream = torch.Stream(device=self.device)
 
         # the queue maintains the order which param we should do optim step on first.
         self.queue = dict()
 
-        def backward_hook(p_cuda):
-            if p_cuda.grad is not None:
-                p_cpu = self.param_cuda2cpu_map[p_cuda]
+        def backward_hook(p_device):
+            if p_device.grad is not None:
+                p_host = self.param_d2h_map[p_device]
 
                 # make sure backward for this param finishes
-                self.stream.wait_stream(torch.cuda.current_stream())
-                with torch.cuda.stream(self.stream):
-                    p_cpu.grad.copy_(p_cuda.grad, non_blocking=True)
+                if self.device == "cuda":
+                    self.stream.wait_stream(torch.cuda.current_stream())
+                    with torch.cuda.stream(self.stream):
+                        p_host.grad.copy_(p_device.grad, non_blocking=True)
+                elif self.device == "xpu":
+                    self.stream.wait_stream(torch.xpu.current_stream())
+                    with torch.xpu.stream(self.stream):
+                        p_host.grad.copy_(p_device.grad, non_blocking=True)
 
                 # we rely on CPython implementation of dictionary, which preserves insertion order.
                 # if a param is added again (e.g. due to gradient accumulation), it is moved to the
                 # end of the queue by removing and inserting it again.
-                if p_cuda in self.queue:
-                    del self.queue[p_cuda]
-                self.queue[p_cuda] = self.stream.record_event()
+                if p_device in self.queue:
+                    del self.queue[p_device]
+                self.queue[p_device] = self.stream.record_event()
 
-                # deallocate CUDA gradients once D2H transfer finishes.
+                # deallocate DEVICE gradients once D2H transfer finishes.
                 if offload_gradients:
-                    p_cuda.grad.record_stream(self.stream)
-                    p_cuda.grad = None
+                    p_device.grad.record_stream(self.stream)
+                    p_device.grad = None
 
         for param_group in param_groups:
             params = param_group.pop("params")
 
-            for p_cuda in params:
-                if not p_cuda.requires_grad:
+            for p_device in params:
+                if not p_device.requires_grad:
                     continue
 
                 # pre-allocate CPU params and grads
-                p_cpu = torch.empty_like(p_cuda, device="cpu", pin_memory=True)
-                p_cpu.grad = torch.empty_like(p_cpu, pin_memory=True)
+                p_host = torch.empty_like(p_device, device="cpu", pin_memory=True)
+                p_host.grad = torch.empty_like(p_host, pin_memory=True)
 
-                p_cpu.copy_(p_cuda.detach(), non_blocking=True)
-                self.param_cuda2cpu_map[p_cuda] = p_cpu
+                p_host.copy_(p_device.detach(), non_blocking=True)
+                self.param_d2h_map[p_device] = p_host
 
-                p_cuda.register_post_accumulate_grad_hook(backward_hook)
-                self.optim_dict[p_cuda] = optimizer_class(
-                    [{"params": p_cpu, **param_group}], **kwargs
+                p_device.register_post_accumulate_grad_hook(backward_hook)
+                self.optim_dict[p_device] = optimizer_class(
+                    [{"params": p_host, **param_group}], **kwargs
                 )
 
     @torch.no_grad()
@@ -91,16 +99,20 @@ class CPUOffloadOptimizer:
         if closure is not None:
             loss = closure()
 
-        for p_cuda, grad_d2h_event in self.queue.items():
+        for p_device, grad_d2h_event in self.queue.items():
             grad_d2h_event.synchronize()
-            self.optim_dict[p_cuda].step()
+            self.optim_dict[p_device].step()
 
             # submit more job to self.stream. it guarantees that we only start
             # moving param H2D once all backwards finish, since self.stream
             # will wait for current_stream when moving grad D2H.
-            p_cpu = self.param_cuda2cpu_map[p_cuda]
-            with torch.cuda.stream(self.stream):
-                p_cuda.copy_(p_cpu, non_blocking=True)
+            p_host = self.param_d2h_map[p_device]
+            if self.device == "cuda":
+                with torch.cuda.stream(self.stream):
+                    p_device.copy_(p_host, non_blocking=True)
+            elif self.device == "xpu":
+                with torch.xpu.stream(self.stream):
+                    p_device.copy_(p_host, non_blocking=True)
 
         self.queue.clear()
         return loss
@@ -108,9 +120,9 @@ class CPUOffloadOptimizer:
     def zero_grad(self, set_to_none=True):
         assert set_to_none
 
-        # only clear CUDA grad. CPU grad will always be overwritten by CUDA grad.
-        for p_cuda in self.param_cuda2cpu_map.keys():
-            p_cuda.grad = None
+        # only clear DEVICE grad. CPU grad will always be overwritten by DEVICE grad.
+        for p_device in self.param_d2h_map.keys():
+            p_device.grad = None
 
     @property
     def param_groups(self):

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -41,7 +41,7 @@ class CPUOffloadOptimizer:
         self.param_d2h_map = dict()
         self.optim_dict = dict()
         self.device = get_available_devices()[-1]
-        assert ("cuda" in self.device or "xpu" in self.device), "CPU Offload currently only supports CUDA & XPU"
+        assert self.device in ["cuda", "xpu"], "CPU Offload currently only supports CUDA & XPU"
         self.stream = getattr(torch, self.device).Stream()
 
         # the queue maintains the order which param we should do optim step on first.

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -3,7 +3,7 @@ from typing import Type
 import torch
 from torch.optim.optimizer import Optimizer, ParamsT
 
-from torchao.utils import get_available_devices, TORCH_VERSION_AT_LEAST_2_4
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_4, get_available_devices
 
 
 class CPUOffloadOptimizer:

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -41,7 +41,10 @@ class CPUOffloadOptimizer:
         self.param_d2h_map = dict()
         self.optim_dict = dict()
         self.device = get_available_devices()[-1]
-        assert self.device in ["cuda", "xpu"], "CPU Offload currently only supports CUDA & XPU"
+        assert self.device in [
+            "cuda",
+            "xpu",
+        ], "CPU Offload currently only supports CUDA & XPU"
         self.stream = getattr(torch, self.device).Stream()
 
         # the queue maintains the order which param we should do optim step on first.

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -131,8 +131,9 @@ def get_available_devices():
         devices.append("cuda")
     elif torch.xpu.is_available():
         devices.append("xpu")
-    elif torch.mps.is_available():
-        devices.append("mps")
+    if TORCH_VERSION_AT_LEAST_2_5:
+        if torch.mps.is_available():
+            devices.append("mps")
     return devices
 
 

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -13,6 +13,7 @@ import torch.nn.utils.parametrize as parametrize
 __all__ = [
     "benchmark_model",
     "profiler_runner",
+    "get_available_devices",
     "get_compute_capability",
     "skip_if_compute_capability_less_than",
     "benchmark_torch_function_in_microseconds",
@@ -122,6 +123,17 @@ def profiler_runner(path, fn, *args, **kwargs):
         result = fn(*args, **kwargs)
     prof.export_chrome_trace(path)
     return result
+
+
+def get_available_devices():
+    devices = ["cpu"]
+    if torch.cuda.is_available():
+        devices.append("cuda")
+    elif torch.xpu.is_available():
+        devices.append("xpu")
+    elif torch.mps.is_available():
+        devices.append("mps")
+    return devices
 
 
 def get_compute_capability():


### PR DESCRIPTION
# Background
Current CPU Offload in torchao only supports CUDA backend. We would like to add support for Intel GPU with the device option "xpu". 

# Details
- add "device" attribute to CPUOffloadOptimizer, default setting to "cuda"
- enhance and verify UT test_optim_cpu_offload_correctness & test_optim_cpu_offload_save_load pass on Intel GPU
- add "device" argument to benchmark_low_bit_adam.py. Users can use "--device xpu" to benchmark CPU Offload on Intel GPU. Currently it supports both full BF16 and BF16 AMP training w/ eager and compiled mode. Verified workloads on Intel GPU achieve memory saving and interleaving as expected as the description in reference PR:[ao#584](https://github.com/pytorch/ao/pull/584)