### PR TITLE
Some improvement to make autoquant v2 work with Mixtral-8x7B-v0.1

### DIFF
--- a/torchao/prototype/quantization/autoquant_v2.py
+++ b/torchao/prototype/quantization/autoquant_v2.py
@@ -1192,7 +1192,6 @@ def autoquant_v2(
 
     fqn_to_submodule = {}
 
-    print("extraction idxs:", extraction_idxs)
     for extraction_idx in extraction_idxs:
         summary_filename = os.path.join(target_folder, f"summary_{extraction_idx}.csv")
         summary_rows = []


### PR DESCRIPTION
Summary:
Tested locally running autoquant v2 with llama2-7b and Mixtral-8x7B-v0.1 in https://github.com/pytorch/pytorch/blob/main/benchmarks/gpt_fast/benchmark.py

Llama-2-7b-chat-hf:
Compilation time: 81.71 seconds
Average tokens/sec: 131.12 tokens/sec
Average bandwidth achieved: 1732.77 GB/s
Memory used: 27.71 GB

Mixtral-8x7B-v0.1:
Compilation time: 108.89 seconds
Average tokens/sec: 79.59 tokens/sec
Average bandwidth achieved: 1025.14 GB/s
Memory used: 61.62 GB

more result can be found in https://github.com/pytorch/pytorch/pull/140627

Test Plan:
local test with pytorch/benchmarks/gpt_fast/benchmark.py

Reviewers:

Subscribers:

Tasks:

Tags: