### PR TITLE
float8 training: fix bug with AC + compile

### DIFF
--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -334,10 +334,6 @@ class Float8Linear(torch.nn.Linear):
         # TODO(future PR): add serialization for this flag
         self.is_amax_initialized = not self.config.enable_amax_init
 
-        # This is needed to properly handle autocast in the amax/scale
-        # update function for torch.float16
-        self.last_seen_output_dtype = None
-
         # pre_forward and post_forward are currently broken with FSDP
         # and torch.compile, this option can disable them
         # Note that when using `self.config.enable_pre_and_post_forward = False`,
@@ -627,7 +623,6 @@ class Float8Linear(torch.nn.Linear):
 
         if self.has_any_delayed_scaling:
             self.float8_post_forward()
-        self.last_seen_output_dtype = output.dtype
         return output
 
     def extra_repr(self):

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -177,9 +177,7 @@ def _maybe_initialize_amaxes_scales_for_float8_cast(
         new_amax = tensor_to_amax(x, reduce_amax=reduce_amax)
         cur_amax.fill_(new_amax)
         amax_history[0] = new_amax
-        new_scale = amax_history_to_scale(
-            amax_history, float8_dtype, x.dtype, scale_fn_name
-        )
+        new_scale = amax_history_to_scale(amax_history, float8_dtype, scale_fn_name)
         scale.copy_(new_scale)
 
 


### PR DESCRIPTION
Summary:

In https://github.com/pytorch/ao/pull/1306 I accidentally broke torchtitan + float8 + AC + compile.

I don't have a non-torchtitan repro now, putting up the fix first to ensure torchtitan still works, and we should follow-up later with adding test coverage to torchao to prevent similar breakages in the future.

What broke:
* in the forward of `Float8Linear`, we were setting an attribute on the module
* ^ is not supported with compile + something how torchtitan specifically calls AC

The fix: remove this attribute setting altogether. Unfortunately this breaks an edge case feature for ensuring scales are reprensentable in `float16`.  Since `float16` training is not commonly used with `float8` and this feature was added during very early testing, removing this for now is fine.

If we need to add this feature back in the future, I'd advocate for doing it via explicit configuration such as `config.set_scale_upper_bound` and avoiding the stateful hacks, which are usually not compiler friendly.

Test Plan:

```
// this repo
./test/float8/test_everything.sh

// torchtitan - broken before this PR, works after this PR
with-proxy CONFIG_FILE="./train_configs/llama3_8b.toml" ./run_llama_train.sh --float8.enable_float8_linear --training.compile
```

Reviewers:

Subscribers:

Tasks:

Tags: