### PR TITLE
check `scale.ndim` before applying `t`/`transpose`

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -141,6 +141,25 @@ class TestFloat8Tensor:
         fp8_b.copy_(fp8_a)
         torch.testing.assert_close(fp8_a._data, fp8_b._data)
 
+    def test_transpose(self):
+        a = torch.rand((16, 16), dtype=torch.bfloat16)
+        for axiswise_dim in (None, 0, -1):
+            scale_a = tensor_to_scale(a, e4m3_dtype)
+            fp8_a = hp_tensor_and_scale_to_float8(
+                a, scale_a, e4m3_dtype, axiswise_dim=axiswise_dim
+            )
+            fp8_b = hp_tensor_and_scale_to_float8(
+                a, scale_a, e4m3_dtype, axiswise_dim=axiswise_dim
+            )
+
+            fp8_a_transposed = fp8_a.transpose(0, 1)
+            fp8_b_t = fp8_b.t()
+
+            torch.testing.assert_close(
+                (fp8_a_transposed._data, fp8_a_transposed._scale),
+                (fp8_b_t._data, fp8_b_t._scale),
+            )
+
     @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
     @pytest.mark.parametrize("axiswise_dim", [0, -1])
     def test_axiswise_dynamic_cast(self, shape, axiswise_dim):

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -85,7 +85,7 @@ def float8_desugar_data_and_scale_op(aten_op, args, kwargs=None):
 )
 def float8_transpose(aten_op, args, kwargs=None):
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
-    if args[0]._scale.ndim == 2:
+    if args[0]._scale.ndim > 1:
         new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
     else:
         new_scale = args[0]._scale

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -85,7 +85,10 @@ def float8_desugar_data_and_scale_op(aten_op, args, kwargs=None):
 )
 def float8_transpose(aten_op, args, kwargs=None):
     new_data = aten_op(args[0]._data, *args[1:], **kwargs)
-    new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
+    if args[0]._scale.ndim == 2:
+        new_scale = aten_op(args[0]._scale, *args[1:], **kwargs)
+    else:
+        new_scale = args[0]._scale
 
     if aten_op == aten.transpose.int:
         _assert_tensorwise_scale(aten_op, args[0]._scale)


### PR DESCRIPTION
This check is for `torch.ops.aten.transpose.int`.

This is because (a) `scale` could be 0D/1D and (b) the args and kwargs of `torch.ops.aten.transpose.int` would supply `dim0` and `dim1`, which is not appropriate for <2D tensor and dim canonicalization would fail like [`torch._prims_common.canonicalize_dims`](https://github.com/pytorch/pytorch/blob/07906f2/torch/_prims_common/__init__.py#L704)