### PR TITLE
Update build_wheels_linux.yml - Pass test-infra input params

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -43,6 +43,8 @@ jobs:
       # triggered daily from main with a schedule
       repository: pytorch/ao
       ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-var-script: packaging/env_var_script_linux.sh
       pre-script: packaging/pre_build_script.sh


### PR DESCRIPTION
Same as vision: https://github.com/pytorch/vision/blob/main/.github/workflows/build-wheels-linux.yml
Resolve rocm failures: https://github.com/pytorch/ao/actions/runs/12001002536/job/33450903389