### PR TITLE
Remove lm_eval warning

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -28,7 +28,7 @@ if not _IS_FBCODE:
         torch.ops.load_library(so_files[0])
         from . import ops
     except:
-        logging.info("Skipping import of cpp extensions")
+        logging.debug("Skipping import of cpp extensions")
 
 from torchao.quantization import (
     autoquant,

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -25,7 +25,6 @@ from torchao.utils import (
 from .quant_primitives import MappingType
 from .unified import Quantizer
 from .utils import (
-    _lm_eval_available,
     _MultiInput,
     get_group_qparams_symmetric,
     get_groupwise_affine_qparams,
@@ -38,10 +37,6 @@ from .utils import (
 )
 
 aten = torch.ops.aten
-
-
-if not _lm_eval_available:
-    logging.info("lm_eval is not installed, GPTQ may not be usable")
 
 add_ons = []
 


### PR DESCRIPTION
I was running torchtitan now with fp8 and this warning popped up

```
6, multiple_of=1024, ffn_dim_multiplier=1.3, norm_eps=1e-05, rope_theta=500000, max_seq_len=8192, depth_init=True, norm_type='rmsnorm')
[rank0]:2024-11-25 17:29:38,310 - root - INFO - Skipping import of cpp extensions
[rank0]:2024-11-25 17:29:38,391 - root - INFO - lm_eval is not installed, GPTQ may not be usable
[rank0]:2024-11-25 17:29:38,393 - root - INFO - Float8 training active
[rank0]:2024-11-25 17:29:38,414 - root - INFO - Swapped to Float8Linear layers with enable_fsdp_float8_all_gather=False
[rank0]:2024-11-25 17:29:38,415 - root - INFO - Model llama3 8B size: 8,030,261,248 total parameters
[rank0]:2024-11-25 17:29:38,416 - root - INFO - Applied selective activation checkpointing to the model
[rank0]:2024-11-25 17:29:38,480 - root - INFO - Applied FSDP to the model
```

There is no reason this warning needs to pop up, as if someone is using GPTQ without the necessary requirements it should fail. lm_eval is also unused in this specific file

Also practically speaking most of our custom kernels are inference only and warning people they're not imported in a training codebase seems off so also downgrading a message to debug instead of info so we don't see it