### PR TITLE
Reduce startup time for SAM2 AMG by using torch.export

### DIFF
--- a/examples/sam2_amg_server/cli.py
+++ b/examples/sam2_amg_server/cli.py
@@ -6,6 +6,8 @@ from server import show_anns
 from server import model_type_to_paths
 from server import MODEL_TYPES_TO_MODEL
 from server import set_fast
+from server import set_aot_fast
+from server import load_aot_fast
 from server import set_furious
 from torchao._models.sam2.build_sam import build_sam2
 from torchao._models.sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
@@ -22,17 +24,25 @@ def main_docstring():
     """
 
 
-def main_headless(checkpoint_path, model_type, input_bytes, points_per_batch=1024, output_format='png', verbose=False, fast=False, furious=False):
+def main_headless(checkpoint_path, model_type, input_bytes, points_per_batch=1024, output_format='png', verbose=False, fast=False, furious=False, load_fast=False):
     device = "cuda"
     sam2_checkpoint, model_cfg = model_type_to_paths(checkpoint_path, model_type)
     if verbose:
         print(f"Loading model {sam2_checkpoint} with config {model_cfg}")
     sam2 = build_sam2(model_cfg, sam2_checkpoint, device=device, apply_postprocessing=False)
     mask_generator = SAM2AutomaticMaskGenerator(sam2, points_per_batch=points_per_batch, output_mode="uncompressed_rle")
-    if fast:
-        set_fast(mask_generator)
     if furious:
         set_furious(mask_generator)
+    if fast:
+        set_aot_fast(mask_generator)
+        import sys; sys.exit(1)
+        set_fast(mask_generator)
+    print("load_fast: ", load_fast)
+    if load_fast:
+        print("Start load.")
+        load_aot_fast(mask_generator)
+        print("End load.")
+
     image_tensor = file_bytes_to_image_tensor(input_bytes)
     if verbose:
         print(f"Loaded image of size {tuple(image_tensor.shape)} and generating mask.")
@@ -50,7 +60,7 @@ def main_headless(checkpoint_path, model_type, input_bytes, points_per_batch=102
     buf.seek(0)
     return buf.getvalue()
 
-def main(checkpoint_path, model_type, input_path, output_path, points_per_batch=1024, output_format='png', verbose=False, fast=False, furious=False):
+def main(checkpoint_path, model_type, input_path, output_path, points_per_batch=1024, output_format='png', verbose=False, fast=False, furious=False, load_fast=False):
     input_bytes = bytearray(open(input_path, 'rb').read())
     output_bytes = main_headless(checkpoint_path,
                                  model_type,
@@ -59,7 +69,8 @@ def main(checkpoint_path, model_type, input_path, output_path, points_per_batch=
                                  output_format=output_format,
                                  verbose=verbose,
                                  fast=fast,
-                                 furious=furious)
+                                 furious=furious,
+                                 load_fast=load_fast)
     with open(output_path, "wb") as file:
         file.write(output_bytes)
 

--- a/examples/sam2_amg_server/cli.py
+++ b/examples/sam2_amg_server/cli.py
@@ -33,15 +33,17 @@ def main_headless(checkpoint_path, model_type, input_bytes, points_per_batch=102
     mask_generator = SAM2AutomaticMaskGenerator(sam2, points_per_batch=points_per_batch, output_mode="uncompressed_rle")
     if furious:
         set_furious(mask_generator)
+    print("load_fast: ", load_fast)
+    if load_fast:
+        import time
+        t0 = time.time()
+        print(f"Start load. {t0}")
+        load_aot_fast(mask_generator)
+        print(f"End load. {time.time() - t0}")
     if fast:
         set_aot_fast(mask_generator)
         import sys; sys.exit(1)
         set_fast(mask_generator)
-    print("load_fast: ", load_fast)
-    if load_fast:
-        print("Start load.")
-        load_aot_fast(mask_generator)
-        print("End load.")
 
     image_tensor = file_bytes_to_image_tensor(input_bytes)
     if verbose:

--- a/torchao/_models/sam2/automatic_mask_generator.py
+++ b/torchao/_models/sam2/automatic_mask_generator.py
@@ -36,7 +36,7 @@ from torchao._models.sam2.utils.amg import (
 )
 
 
-class SAM2AutomaticMaskGenerator:
+class SAM2AutomaticMaskGenerator(torch.nn.Module):
     def __init__(
         self,
         model: SAM2Base,
@@ -105,7 +105,7 @@ class SAM2AutomaticMaskGenerator:
           use_m2m (bool): Whether to add a one step refinement using previous mask predictions.
           multimask_output (bool): Whether to output multimask at each point of the grid.
         """
-
+        super().__init__()
         assert (points_per_side is None) != (
             point_grids is None
         ), "Exactly one of points_per_side or point_grid must be provided."

--- a/torchao/_models/sam2/modeling/sam2_base.py
+++ b/torchao/_models/sam2/modeling/sam2_base.py
@@ -466,6 +466,7 @@ class SAM2Base(torch.nn.Module):
 
     def forward_image(self, img_batch: torch.Tensor):
         """Get the image feature on the input batch."""
+        print("img_batch.size(): ", img_batch.size())
         backbone_out = self.image_encoder(img_batch)
         if self.use_high_res_features_in_sam:
             # precompute projected level 0 and level 1 features in SAM decoder

--- a/torchao/_models/sam2/modeling/sam2_base.py
+++ b/torchao/_models/sam2/modeling/sam2_base.py
@@ -466,7 +466,6 @@ class SAM2Base(torch.nn.Module):
 
     def forward_image(self, img_batch: torch.Tensor):
         """Get the image feature on the input batch."""
-        print("img_batch.size(): ", img_batch.size())
         backbone_out = self.image_encoder(img_batch)
         if self.use_high_res_features_in_sam:
             # precompute projected level 0 and level 1 features in SAM decoder

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -17,7 +17,7 @@ from torchao._models.sam2.modeling.sam2_base import SAM2Base
 from torchao._models.sam2.utils.transforms import SAM2Transforms
 
 
-class SAM2ImagePredictor:
+class SAM2ImagePredictor(torch.nn.Module):
     def __init__(
         self,
         sam_model: SAM2Base,

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -169,6 +169,7 @@ class SAM2ImagePredictor:
         ), f"img_batch must be of size Bx3xHxW, got {img_batch.shape}"
         logging.info("Computing image embeddings for the provided images...")
         with torch.autograd.profiler.record_function("forward_image"):
+            print("img_batch.size(): ", img_batch.size())
             backbone_out = self.model.forward_image(img_batch)
         with torch.autograd.profiler.record_function("_prepare_backbone_features"):
             _, vision_feats, _, _ = self.model._prepare_backbone_features(backbone_out)

--- a/torchao/_models/sam2/sam2_image_predictor.py
+++ b/torchao/_models/sam2/sam2_image_predictor.py
@@ -169,7 +169,6 @@ class SAM2ImagePredictor(torch.nn.Module):
         ), f"img_batch must be of size Bx3xHxW, got {img_batch.shape}"
         logging.info("Computing image embeddings for the provided images...")
         with torch.autograd.profiler.record_function("forward_image"):
-            print("img_batch.size(): ", img_batch.size())
             backbone_out = self.model.forward_image(img_batch)
         with torch.autograd.profiler.record_function("_prepare_backbone_features"):
             _, vision_feats, _, _ = self.model._prepare_backbone_features(backbone_out)


### PR DESCRIPTION
Save the compiled model via torch.export and load it back up.

So far this only works for the image encoder.