### PR TITLE
[WIP] Enable float8 attention support (q/k/v)

### DIFF
--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -17,6 +17,7 @@ from torch import nn, Tensor
 from torchao._models.sam2.modeling.position_encoding import apply_rotary_enc, compute_axial_cis
 from torchao._models.sam2.modeling.sam2_utils import MLP
 from torchao._models.sam2.utils.misc import get_sdpa_settings
+from torchao.quantization.quant_api import _float8_symmetric_per_token_quant
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 # Check whether Flash Attention is available (and use it by default)
@@ -263,6 +264,11 @@ class Attention(nn.Module):
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
 
+        # quantize q/k/v
+        q = _float8_symmetric_per_token_quant(q)
+        k = _float8_symmetric_per_token_quant(k)
+        v = _float8_symmetric_per_token_quant(v)
+
         dropout_p = self.dropout_p if self.training else 0.0
         # # Attention
         # try:
@@ -322,6 +328,11 @@ class RoPEAttention(Attention):
         q = self._separate_heads(q, self.num_heads)
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
+
+        # quantize q/k/v
+        q = _float8_symmetric_per_token_quant(q)
+        k = _float8_symmetric_per_token_quant(k)
+        v = _float8_symmetric_per_token_quant(v)
 
         # Apply rotary position encoding
         w = h = math.sqrt(q.shape[-2])

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -510,9 +510,9 @@ class MarlinQQQTensor(AffineQuantizedTensor):
         )
 
 
-######################################################
+###############################################
 # Layout and TensorImpl Subclass Registration #
-######################################################
+###############################################
 register_layout = AffineQuantizedTensor.register_layout
 get_tensor_impl_constructor = AffineQuantizedTensor.get_tensor_impl_constructor
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -803,6 +803,17 @@ def int8_dynamic_activation_int8_semi_sparse_weight():
     return int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
 
 
+def _float8_symmetric_per_token_quant(x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn):
+    from torchao.dtypes import to_affine_quantized_floatx
+
+    return to_affine_quantized_floatx(
+        input_float=x,
+        block_size=_get_per_token_block_size(x),
+        target_dtype=dtype,
+        scale_dtype=None,
+        _layout=Float8Layout(mm_config=None),
+    )
+
 def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
     """
     Applies float8 weight-only symmetric per-channel quantization to linear layers.
@@ -814,17 +825,8 @@ def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
         The actual matmul will be computed in original precision of the weight tensor.
 
     """
-    from torchao.dtypes import to_affine_quantized_floatx
-
     def apply_float8wo_quant(weight):
-        block_size = (1, weight.shape[1])
-        return to_affine_quantized_floatx(
-            input_float=weight,
-            block_size=block_size,
-            target_dtype=weight_dtype,
-            scale_dtype=None,
-            _layout=Float8Layout(mm_config=None),
-        )
+        return _float8_symmetric_per_token_quant(weight, weight_dtype)
 
     return _get_linear_subclass_inserter(apply_float8wo_quant)
 
@@ -1172,5 +1174,6 @@ if TORCH_VERSION_AT_LEAST_2_5:
             _int8_asymm_per_token_quant,
             _int8_symm_per_token_reduced_range_quant,
             _input_activation_quant_func_fp8,
+            _float8_symmetric_per_token_quant,
         ]
     )


### PR DESCRIPTION
Summary:
att, right now we need to manually add quantize call for q/k/v before sdpa op, but we can explore other APIs in the future

Test Plan:
TBD

Reviewers:

Subscribers:

Tasks:

Tags: