### PR TITLE
Unskip `test_int8_dynamic_quant_subclass_api` in `test_integration.py`

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -885,7 +885,6 @@ class TestSubclass(unittest.TestCase):
 
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
-    @unittest.skipIf(TORCH_VERSION_AT_LEAST_2_4, "skip because there is some bug in inductor codegen")
     def test_int8_dynamic_quant_subclass_api(self, device, dtype):
         self._test_lin_weight_subclass_api_impl(
             _int8da_int8w_api, device, 35, test_dtype=dtype


### PR DESCRIPTION
This UT was being skipped for PyTorch versions above 2.4 but it now passes for both CPU & CUDA.