### PR TITLE
Enable float8 attention support (q/k/v)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,6 @@ pandas
 fire  # QOL for commandline scripts
 tabulate  # QOL for printing tables to stdout
 
-
 # Custom CUDA Extensions
 ninja
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,8 @@ matplotlib
 pandas
 fire  # QOL for commandline scripts
 tabulate  # QOL for printing tables to stdout
+einops  # for testing flash attention 3
+
 
 # Custom CUDA Extensions
 ninja

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,6 @@ matplotlib
 pandas
 fire  # QOL for commandline scripts
 tabulate  # QOL for printing tables to stdout
-einops  # for testing flash attention 3
 
 
 # Custom CUDA Extensions

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -288,7 +288,149 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
 
 
+# need to install einops
+import math
+
+from einops import rearrange, repeat
+
+
+# copied from https://github.com/Dao-AILab/flash-attention/blob/1feb711f46563960fc10a8e659c93c300619504b/tests/test_util.py#L185
+def attention_ref(
+    q,
+    k,
+    v,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    attn_bias=None,
+    dropout_p=0.0,
+    dropout_mask=None,
+    causal=False,
+    window_size=(-1, -1),  # -1 means infinite window size
+    softcap=0.0,
+    upcast=True,
+    reorder_ops=False,
+    key_leftpad=None,
+):
+    """
+    Arguments:
+        q: (batch_size, seqlen_q, nheads, head_dim)
+        k: (batch_size, seqlen_k, nheads_k, head_dim)
+        v: (batch_size, seqlen_k, nheads_k, head_dim)
+        query_padding_mask: (batch_size, seqlen_q)
+        key_padding_mask: (batch_size, seqlen_k)
+        attn_bias: broadcastable to (batch_size, nheads, seqlen_q, seqlen_k)
+        dropout_p: float
+        dropout_mask: (batch_size, nheads, seqlen_q, seqlen_k)
+        causal: whether to apply causal masking
+        window_size: (int, int), left and right window size
+        upcast: whether to cast all inputs to fp32, do all computation in fp32, then cast
+            output back to fp16/bf16.
+        reorder_ops: whether to change the order of operations (scaling k instead of scaling q, etc.)
+            without changing the math. This is to estimate the numerical error from operation
+            reordering.
+    Output:
+        output: (batch_size, seqlen_q, nheads, head_dim)
+        attention: (batch_size, nheads, seqlen_q, seqlen_k), softmax after dropout
+    """
+    if causal:
+        window_size = (window_size[0], 0)
+    dtype_og = q.dtype
+    if upcast:
+        q, k, v = q.float(), k.float(), v.float()
+    seqlen_q, seqlen_k = q.shape[1], k.shape[1]
+    k = repeat(k, "b s h d -> b s (h g) d", g=q.shape[2] // k.shape[2])
+    v = repeat(v, "b s h d -> b s (h g) d", g=q.shape[2] // v.shape[2])
+    d = q.shape[-1]
+    if not reorder_ops:
+        scores = torch.einsum("bthd,bshd->bhts", q / math.sqrt(d), k)
+    else:
+        scores = torch.einsum("bthd,bshd->bhts", q, k / math.sqrt(d))
+    if softcap > 0:
+        scores /= softcap
+        scores = scores.tanh()
+        scores *= softcap
+    if key_padding_mask is not None:
+        scores.masked_fill_(
+            rearrange(~key_padding_mask, "b s -> b 1 1 s"), float("-inf")
+        )
+    if window_size[0] >= 0 or window_size[1] >= 0:
+        local_mask = construct_local_mask(
+            seqlen_q,
+            seqlen_k,
+            window_size,
+            query_padding_mask,
+            key_padding_mask,
+            q.device,
+            key_leftpad=key_leftpad,
+        )
+        scores.masked_fill_(local_mask, float("-inf"))
+    if attn_bias is not None:
+        scores = scores + attn_bias
+    attention = torch.softmax(scores, dim=-1).to(v.dtype)
+    # Some rows might be completely masked out so we fill them with zero instead of NaN
+    if window_size[0] >= 0 or window_size[1] >= 0:
+        attention = attention.masked_fill(
+            torch.all(local_mask, dim=-1, keepdim=True), 0.0
+        )
+    # We want to mask here so that the attention matrix doesn't have any NaNs
+    # Otherwise we'll get NaN in dV
+    if query_padding_mask is not None:
+        attention = attention.masked_fill(
+            rearrange(~query_padding_mask, "b s -> b 1 s 1"), 0.0
+        )
+    dropout_scaling = 1.0 / (1 - dropout_p)
+    # attention_drop = attention.masked_fill(~dropout_mask, 0.0) * dropout_scaling
+    # output = torch.einsum('bhts,bshd->bthd', attention_drop , v)
+    if dropout_mask is not None:
+        attention_drop = attention.masked_fill(~dropout_mask, 0.0)
+    else:
+        attention_drop = attention
+    output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
+    if query_padding_mask is not None:
+        output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
+    if key_padding_mask is not None:
+        output.masked_fill_(
+            rearrange(
+                torch.logical_not(torch.any(key_padding_mask, 1)), "b -> b 1 1 1"
+            ),
+            0.0,
+        )
+    return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
+
+
+class TestAffineQuantizedFloat8Attention(common_utils.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_float8_attention(self):
+        import torch.nn.functional as F
+
+        from torchao.quantization.quant_api import _float8_symmetric_per_tensor_quant
+
+        class MyModel(torch.nn.Module):
+            def forward(self, q, k, v, float8_quantize=False):
+                if float8_quantize:
+                    q = _float8_symmetric_per_tensor_quant(q)
+                    k = _float8_symmetric_per_tensor_quant(k)
+                    v = _float8_symmetric_per_tensor_quant(v)
+                return F.scaled_dot_product_attention(q, k, v)
+
+        # note: last headdim must be 64, 128, 256
+        q = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+        k = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+        v = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+
+        m = MyModel().eval()
+        # it differs a lot from the non-quantized implementation
+        # sqnr = -2.5
+        # ref = m(q, k, v)
+
+        # but matches the custom attention implementation in flash attention repo
+        ref = attention_ref(q, k, v)[0]
+        quantized = m(q, k, v, True)
+        assert compute_error(ref, quantized) > 25.0
+
+
 common_utils.instantiate_parametrized_tests(TestAffineQuantizedFloat8Compile)
 
 if __name__ == "__main__":
     pytest.main([__file__])
+    common_utils.run_tests()

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -288,6 +288,8 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
 
 
+@unittest.skip("Only running locally so we don't need to add installation of fa3 "
+               "hopper kernels to CI, we'll probably copy paste kernel in the future")
 class TestAffineQuantizedFloat8Attention(common_utils.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_float8_attention(self):

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -9,6 +9,7 @@ if not TORCH_VERSION_AT_LEAST_2_5:
 
 import copy
 import io
+import math
 import random
 import unittest
 from contextlib import nullcontext
@@ -17,6 +18,7 @@ from typing import Tuple
 
 import pytest
 import torch
+from einops import rearrange, repeat
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch.testing._internal import common_utils
 
@@ -288,13 +290,46 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
 
 
-# need to install einops
-import math
-
-from einops import rearrange, repeat
-
-
 # copied from https://github.com/Dao-AILab/flash-attention/blob/1feb711f46563960fc10a8e659c93c300619504b/tests/test_util.py#L185
+
+
+def construct_local_mask(
+    seqlen_q,
+    seqlen_k,
+    window_size=(-1, -1),  # -1 means infinite window size
+    query_padding_mask=None,
+    key_padding_mask=None,
+    device=None,
+    key_leftpad=None,
+):
+    row_idx = rearrange(
+        torch.arange(seqlen_q, device=device, dtype=torch.long), "s -> s 1"
+    )
+    col_idx = torch.arange(seqlen_k, device=device, dtype=torch.long)
+    if key_leftpad is not None:
+        key_leftpad = rearrange(key_leftpad, "b -> b 1 1 1")
+        col_idx = repeat(col_idx, "s -> b 1 1 s", b=key_leftpad.shape[0])
+        col_idx = torch.where(col_idx >= key_leftpad, col_idx - key_leftpad, 2**32)
+    sk = (
+        seqlen_k
+        if key_padding_mask is None
+        else rearrange(key_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    sq = (
+        seqlen_q
+        if query_padding_mask is None
+        else rearrange(query_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    if window_size[0] < 0:
+        return col_idx > row_idx + sk - sq + window_size[1]
+    else:
+        sk = torch.full_like(col_idx, seqlen_k) if key_padding_mask is None else sk
+        return torch.logical_or(
+            col_idx > torch.minimum(row_idx + sk - sq + window_size[1], sk),
+            col_idx < row_idx + sk - sq - window_size[0],
+        )
+
+
 def attention_ref(
     q,
     k,

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -288,8 +288,10 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
 
 
-@unittest.skip("Only running locally so we don't need to add installation of fa3 "
-               "hopper kernels to CI, we'll probably copy paste kernel in the future")
+@unittest.skip(
+    "Only running locally so we don't need to add installation of fa3 "
+    "hopper kernels to CI, we'll probably copy paste kernel in the future"
+)
 class TestAffineQuantizedFloat8Attention(common_utils.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_float8_attention(self):

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -329,5 +329,5 @@ class TestAffineQuantizedFloat8Attention(common_utils.TestCase):
 common_utils.instantiate_parametrized_tests(TestAffineQuantizedFloat8Compile)
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
+    pytest.main([__file__])
     common_utils.run_tests()

--- a/torchao/_models/llama/model.py
+++ b/torchao/_models/llama/model.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from torch.nn import functional as F
 from torchao.utils import find_multiple
 
-_QUANTIZE_ATTN = True
+_QUANTIZE_ATTN = False
 
 # TODO remove suplerfluous arg
 def prepare_inputs_for_model(inps, max_new_tokens=1):

--- a/torchao/_models/llama/model.py
+++ b/torchao/_models/llama/model.py
@@ -13,6 +13,8 @@ from torch import Tensor
 from torch.nn import functional as F
 from torchao.utils import find_multiple
 
+_QUANTIZE_ATTN = True
+
 # TODO remove suplerfluous arg
 def prepare_inputs_for_model(inps, max_new_tokens=1):
     # this is because input from lm-eval is 2d
@@ -85,7 +87,7 @@ transformer_configs = {
     ),
 }
 
-# this is a model specific variable that controls whether index_put is used for the kv_cache update, 
+# this is a model specific variable that controls whether index_put is used for the kv_cache update,
 # it is needed for GPTQ but otherwise attenuates perf so the default is to not use it
 use_index_put_for_kv_cache = False
 
@@ -124,7 +126,7 @@ class AffineQuantizedKVCache(nn.Module):
         self.register_buffer('v_cache', torch.zeros(cache_shape, dtype=torch.int8))
         self.register_buffer('k_cache_scale', torch.ones(scale_shape, dtype=scale_dtype))
         self.register_buffer('v_cache_scale', torch.ones(scale_shape, dtype=scale_dtype))
-    
+
     def update(self, input_pos, k_val, v_val):
         # quantize current k_val and store it in the cache
         q_k_val, k_scale = quantize_activation_per_token_absmax(k_val)
@@ -138,7 +140,7 @@ class AffineQuantizedKVCache(nn.Module):
         self.v_cache_scale[:, :, input_pos] = v_scale.unsqueeze(-1)
         v_out = self.v_cache*self.v_cache_scale
         v_out[:, :, input_pos] = v_val
-        
+
         return k_out, v_out
 
     @classmethod
@@ -194,16 +196,16 @@ class Transformer(nn.Module):
                 else:
                     b.attention.kv_cache = KVCache(max_batch_size, max_seq_length, self.config.n_local_heads, head_dim, dtype)
         self.freqs_cis = precompute_freqs_cis(
-            self.config.block_size, 
-            self.config.dim // self.config.n_head, 
-            self.config.rope_base, 
-            dtype, 
+            self.config.block_size,
+            self.config.dim // self.config.n_head,
+            self.config.rope_base,
+            dtype,
             use_scaled=self.config.use_scaled_rope
         )
 
     def reset_caches(self):
         """Reset caches.
-        
+
         The caches used by training stage and inference stage may be different, reset them before switching.
         """
         self.max_batch_size = -1
@@ -215,7 +217,7 @@ class Transformer(nn.Module):
         """Forward pass of the model.
 
         Args:
-            idx  (`torch.LongTensor` of shape `(batch_size, seq_length)`): 
+            idx  (`torch.LongTensor` of shape `(batch_size, seq_length)`):
                 Indices of input sequence tokens in the vocabulary.
             input_pos (`torch.LongTensor` of shape `(batch_size, seq_length)`, *optional*):
                 Indices of positions of each input sequence tokens in the position embeddings.
@@ -227,7 +229,7 @@ class Transformer(nn.Module):
         """
         assert self.freqs_cis is not None, "Caches must be initialized first"
 
-        if input_pos is None: 
+        if input_pos is None:
             mask = None
             freqs_cis = self.freqs_cis[:idx.shape[1]]
         else:
@@ -311,10 +313,24 @@ class Attention(nn.Module):
 
         k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
         v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+
+        # quantize q/k/v with per tensor float8 quantization
+        padded = False
+        if _QUANTIZE_ATTN:
+            from torchao.quantization.quant_api import _float8_symmetric_per_tensor_quant
+            original_dtype = v.dtype
+            if q.shape[-1] in [64, 128, 256]:
+                q = _float8_symmetric_per_tensor_quant(q)
+                k = _float8_symmetric_per_tensor_quant(k)
+                v = _float8_symmetric_per_tensor_quant(v)
+
         if mask is not None:
             y = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0)
         else:
             y = F.scaled_dot_product_attention(q, k, v, dropout_p=0.0, is_causal=True)
+
+        if _QUANTIZE_ATTN:
+            y = y.to(original_dtype)
 
         y = y.transpose(1, 2).contiguous().view(bsz, seqlen, self.dim)
 
@@ -371,8 +387,8 @@ def apply_scaling(freqs: torch.Tensor):
     return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
 
 def precompute_freqs_cis(
-    seq_len: int, 
-    n_elem: int, 
+    seq_len: int,
+    n_elem: int,
     base: int = 10000,
     dtype: torch.dtype = torch.bfloat16,
     use_scaled: bool=False

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -17,6 +17,7 @@ from torch import nn, Tensor
 from torchao._models.sam2.modeling.position_encoding import apply_rotary_enc, compute_axial_cis
 from torchao._models.sam2.modeling.sam2_utils import MLP
 from torchao._models.sam2.utils.misc import get_sdpa_settings
+from torchao.quantization.quant_api import _float8_symmetric_per_token_quant
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 # Check whether Flash Attention is available (and use it by default)
@@ -263,6 +264,11 @@ class Attention(nn.Module):
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
 
+        # quantize q/k/v
+        q = _float8_symmetric_per_token_quant(q)
+        k = _float8_symmetric_per_token_quant(k)
+        v = _float8_symmetric_per_token_quant(v)
+
         dropout_p = self.dropout_p if self.training else 0.0
         # # Attention
         # try:
@@ -322,6 +328,11 @@ class RoPEAttention(Attention):
         q = self._separate_heads(q, self.num_heads)
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
+
+        # quantize q/k/v
+        q = _float8_symmetric_per_token_quant(q)
+        k = _float8_symmetric_per_token_quant(k)
+        v = _float8_symmetric_per_token_quant(v)
 
         # Apply rotary position encoding
         w = h = math.sqrt(q.shape[-2])

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -281,6 +281,9 @@ class Attention(nn.Module):
                 padded = True
 
             if q.shape[-1] in [64, 128, 256]:
+                q = q.transpose(1, 2)
+                k = k.transpose(1, 2)
+                v = v.transpose(1, 2)
                 q = _float8_symmetric_per_tensor_quant(q)
                 k = _float8_symmetric_per_tensor_quant(k)
                 v = _float8_symmetric_per_tensor_quant(v)

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -267,6 +267,7 @@ class Attention(nn.Module):
         v = self._separate_heads(v, self.num_heads)
 
         # quantize q/k/v
+        padded = False
         if _QUANTIZE_ATTN:
             from torchao.quantization.quant_api import _float8_symmetric_per_tensor_quant
             original_head_dim = list(q.shape)[-1]
@@ -345,11 +346,6 @@ class RoPEAttention(Attention):
         q = self._separate_heads(q, self.num_heads)
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
-
-        # quantize q/k/v
-        q = _float8_symmetric_per_token_quant(q)
-        k = _float8_symmetric_per_token_quant(k)
-        v = _float8_symmetric_per_token_quant(v)
 
         # Apply rotary position encoding
         w = h = math.sqrt(q.shape[-2])

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -266,11 +266,12 @@ class Attention(nn.Module):
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
 
-        # quantize q/k/v
+        # quantize q/k/v with per tensor float8 quantization
         padded = False
         if _QUANTIZE_ATTN:
             from torchao.quantization.quant_api import _float8_symmetric_per_tensor_quant
             original_head_dim = list(q.shape)[-1]
+            original_dtype = v.dtype
             padded = False
             # padding:
             if q.shape[-1] == 32:

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -510,9 +510,9 @@ class MarlinQQQTensor(AffineQuantizedTensor):
         )
 
 
-######################################################
+###############################################
 # Layout and TensorImpl Subclass Registration #
-######################################################
+###############################################
 register_layout = AffineQuantizedTensor.register_layout
 get_tensor_impl_constructor = AffineQuantizedTensor.get_tensor_impl_constructor
 

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -282,7 +282,7 @@ def _(func, types, args, kwargs):
 @implements(torch.nn.functional.scaled_dot_product_attention)
 def _(func, types, args, kwargs):
     q, k, v = args[:3]
-    if not _sdpa_float8_check(q, k, v):
+    if not _sdpa_float8_check(q, k, v, kwargs):
         # dequantize and call original op
         if hasattr(q, "dequantize"):
             q = q.dequantize()
@@ -294,6 +294,7 @@ def _(func, types, args, kwargs):
             q, k, v, *args[3:], **kwargs
         )
     else:
+        print("calling float8 impl")
         return _sdpa_float8_impl(k, q, v, kwargs)
 
 

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -282,7 +282,7 @@ def _(func, types, args, kwargs):
 @implements(torch.nn.functional.scaled_dot_product_attention)
 def _(func, types, args, kwargs):
     q, k, v = args[:3]
-    if not _sdpa_float8_check(q, k, v, kwargs):
+    if not _sdpa_float8_check(q, k, v, args, kwargs):
         # dequantize and call original op
         if hasattr(q, "dequantize"):
             q = q.dequantize()
@@ -294,8 +294,7 @@ def _(func, types, args, kwargs):
             q, k, v, *args[3:], **kwargs
         )
     else:
-        print("calling float8 impl")
-        return _sdpa_float8_impl(k, q, v, kwargs)
+        return _sdpa_float8_impl(k, q, v, args, kwargs)
 
 
 @implements(aten.detach.default)

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -177,45 +177,6 @@ def _(func, types, args, kwargs):
         return torch.nn.functional.linear(input_tensor, weight_tensor, bias)
 
 
-@implements(torch.nn.functional.embedding)
-def _(func, types, args, kwargs):
-    # new_arg1 = args[1].dequantize()
-    # return torch.nn.embedding(args[0], new_arg1, *args[2:], **kwargs)
-    assert isinstance(
-        args[1].tensor_impl, PlainAQTTensorImpl
-    ), f"embedding only works with PlainAQTTensorImpl but got {type(args[1].tensor_impl)}"
-    assert (
-        kwargs["padding_idx"] is None
-        and kwargs["max_norm"] is None
-        and not kwargs["scale_grad_by_freq"]
-        and not kwargs["sparse"]
-        and kwargs["norm_type"] == 2.0
-    )
-    idx = args[0]
-    int_data, scale, zero_point = args[1].tensor_impl.get_plain()
-
-    sliced_data, sliced_scale, sliced_zero_point = (
-        int_data[idx],
-        scale[idx],
-        zero_point[idx],
-    )
-    # Block size is expecting 2 dimensions [1, group size] but
-    # batchsize or other dims gets added to sliced_data, sliced_scale and sliced_zero_point so
-    # we need to increase block size to correct dim
-    new_blocks = idx.dim() - 1
-    return dequantize_affine(
-        sliced_data,
-        new_blocks * [1] + list(args[1].block_size),
-        sliced_scale,
-        sliced_zero_point,
-        sliced_data.dtype,
-        args[1].quant_min,
-        args[1].quant_max,
-        args[1].zero_point_domain,
-        output_dtype=sliced_scale.dtype,
-    )
-
-
 @implements(aten.addmm.default)
 def _(func, types, args, kwargs):
     input_tensor, weight_tensor, bias = (
@@ -275,6 +236,74 @@ def _(func, types, args, kwargs):
         if isinstance(weight_tensor, AffineQuantizedTensor):
             weight_tensor = weight_tensor.dequantize()
         return func(input_tensor, weight_tensor)
+
+
+@implements(torch.nn.functional.embedding)
+def _(func, types, args, kwargs):
+    # new_arg1 = args[1].dequantize()
+    # return torch.nn.embedding(args[0], new_arg1, *args[2:], **kwargs)
+    assert isinstance(
+        args[1].tensor_impl, PlainAQTTensorImpl
+    ), f"embedding only works with PlainAQTTensorImpl but got {type(args[1].tensor_impl)}"
+    assert (
+        kwargs["padding_idx"] is None
+        and kwargs["max_norm"] is None
+        and not kwargs["scale_grad_by_freq"]
+        and not kwargs["sparse"]
+        and kwargs["norm_type"] == 2.0
+    )
+    idx = args[0]
+    int_data, scale, zero_point = args[1].tensor_impl.get_plain()
+
+    sliced_data, sliced_scale, sliced_zero_point = (
+        int_data[idx],
+        scale[idx],
+        zero_point[idx],
+    )
+    # Block size is expecting 2 dimensions [1, group size] but
+    # batchsize or other dims gets added to sliced_data, sliced_scale and sliced_zero_point so
+    # we need to increase block size to correct dim
+    new_blocks = idx.dim() - 1
+    return dequantize_affine(
+        sliced_data,
+        new_blocks * [1] + list(args[1].block_size),
+        sliced_scale,
+        sliced_zero_point,
+        sliced_data.dtype,
+        args[1].quant_min,
+        args[1].quant_max,
+        args[1].zero_point_domain,
+        output_dtype=sliced_scale.dtype,
+    )
+
+
+@implements([torch.nn.functional.scaled_dot_product_attention])
+def _(func, types, args, kwargs):
+    # for libc10.so
+    import torch
+    from hopper.flash_attn_interface import flash_attn_func
+    q, k, v = args[:3]
+    q_tensor_impl = q.tensor_impl
+    assert not q_tensor_impl.transposed
+    q_float8_data = q_tensor_impl.float8_data
+    q_scale = q.scale
+
+    k_tensor_impl = k.tensor_impl
+    assert not k_tensor_impl.transposed
+    k_float8_data = k_tensor_impl.float8_data
+    k_scale = k.scale
+
+    v_tensor_impl = v.tensor_impl
+    assert not v_tensor_impl.transposed
+    v_float8_data = v_tensor_impl.float8_data
+    v_scale = v.scale
+
+    softmax_scale = kwargs.get("scale", None)
+    dropout_p = kwargs.get("dropout_p", None)
+    assert dropout_p is None or dropout_p == 0.0, "dropout_p should be set to 0.0 during inference"
+
+    breakpoint()
+    return flash_attn_func(q_float8_data, k_float8_data, v_float8_data, softmax_scale=softmax_scale, descale_q=q_scale, descale_k=k_scale, descale_v=v_scale)
 
 
 @implements(aten.detach.default)

--- a/torchao/dtypes/floatx/float8_layout.py
+++ b/torchao/dtypes/floatx/float8_layout.py
@@ -371,7 +371,6 @@ def _sdpa_float8_impl(
     ), "dropout_p should be set to 0.0 during inference"
     causal = kwargs.get("causal", False)
 
-    gqa_parallel = False
     out = flash_attn_func(
         q_float8_data,
         k_float8_data,

--- a/torchao/dtypes/floatx/float8_layout.py
+++ b/torchao/dtypes/floatx/float8_layout.py
@@ -319,25 +319,24 @@ def _sdpa_float8_check(
     v: Union[torch.Tensor, "AffineQuantizedTensor"],
     kwargs,
 ) -> bool:
-
     def is_compatible_per_tensor_float8_aqt(t):
         # tensor is float8 quantized affine quantized tensor
         return (
             isinstance(t, AffineQuantizedTensor)
             and isinstance(t._layout, Float8Layout)
             and t.tensor_impl.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]
-            and (t.shape == t.block_size) and
-            t.shape[-1] in [64, 128, 256]
+            and (t.shape == t.block_size)
+            and t.shape[-1] in [64, 128, 256]
         )
 
     dropout_p = kwargs.get("dropout_p", 0.0)
 
     return (
-        is_compatible_per_tensor_float8_aqt(q) and
-        is_compatible_per_tensor_float8_aqt(k) and
-        is_compatible_per_tensor_float8_aqt(v) and
-        "attn_mask" not in kwargs and
-        dropout_p == 0.0
+        is_compatible_per_tensor_float8_aqt(q)
+        and is_compatible_per_tensor_float8_aqt(k)
+        and is_compatible_per_tensor_float8_aqt(v)
+        and "attn_mask" not in kwargs
+        and dropout_p == 0.0
     )
 
 

--- a/torchao/dtypes/uintx/semi_sparse_layout.py
+++ b/torchao/dtypes/uintx/semi_sparse_layout.py
@@ -44,6 +44,7 @@ def _linear_int8_act_int8_weight_semi_structured_sparse_impl(
     # must pad
     row, col = tmp.shape
     from torch.sparse import SparseSemiStructuredTensorCUSPARSELT
+
     tmp_padded = SparseSemiStructuredTensorCUSPARSELT._pad_dense_input(tmp)
     # we fuse one of the scalar matrix multiplications (w_scales) into the sparse mm
     y_dot_bf16_w_scales_fused = torch._cslt_sparse_mm(
@@ -51,7 +52,7 @@ def _linear_int8_act_int8_weight_semi_structured_sparse_impl(
         tmp_padded.t(),
         alpha=w_scales.to(torch.float32),
         out_dtype=torch.bfloat16,
-        ).t()[:row, :]
+    ).t()[:row, :]
     y = (y_dot_bf16_w_scales_fused * x_scales.reshape(-1, 1)).reshape(
         *x_vals_int8.shape[:-1], y_dot_bf16_w_scales_fused.shape[-1]
     )

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -305,7 +305,9 @@ Note that the workaround will not be needed after https://github.com/pytorch/pyt
 
 Note that the workaround is also required for `torch.compile` with `freezing` (`torch._inductor.config.freezing=True`) until https://github.com/pytorch/pytorch/pull/136265 is fixed.
 
-## Other Available Quantization Techniques
+## [Prototype Features] Other Available Quantization Techniques
+
+Note: APIs in this section are prototype and subject to change.
 
 ### KV Cache Quantization
 We've added kv cache quantization and other features in order to enable long context length (and necessarily memory efficient) inference.

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -360,6 +360,36 @@ We have kernels that do 8-bit dynamic quantization of activations and uintx grou
 
 You try can out these apis with the `quantize_` api as above alongside the constructor `int8_dynamic_activation_intx_weight`.  An example can be found in `torchao/_models/llama/generate.py`.
 
+### Float8 `scaled_dot_product_attention` Support
+We also have initial support for per tensor float8 `scaled_dot_product_attention`, using flash attention 3 (optimized for H100 GPUs). To use the feature:
+
+1. Install from source:
+https://github.com/Dao-AILab/flash-attention/tree/main?tab=readme-ov-file#flashattention-3-beta-release
+
+2. Modify the model to quantize q/k/v to per tensor float8 tensors
+```
+from torchao.quantization.quant_api import _float8_symmetric_per_tensor_quant
+import torch.nn.functional as F
+
+class MyModel(torch.nn.Module):
+    def forward(self, q, k, v, float8_quantize=False):
+        if float8_quantize:
+            q = _float8_symmetric_per_tensor_quant(q)
+            k = _float8_symmetric_per_tensor_quant(k)
+            v = _float8_symmetric_per_tensor_quant(v)
+        return F.scaled_dot_product_attention(q, k, v)
+
+# note: (last dimension) headdim must be 64, 128, 256
+q = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+k = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+v = torch.randn([64, 8, 8, 64], dtype=torch.bfloat16, device="cuda")
+```
+See `test_float8_attention` in `test/dtypes/test_affine_quantized_float.py` on the full test.
+
+Note that right now the float8 attention implementation differs a lot from the original unquantized version, but matches more closely with their reference attention implementation in [flash attention repo](https://github.com/Dao-AILab/flash-attention/blob/1feb711f46563960fc10a8e659c93c300619504b/tests/test_util.py#L185) we still need to invetigate why.
+
+We might be adding new variations of attention implementation in the future (per row, per column, per block scaling etc.).
+
 ### Automatic Inductor Configuration
 The `quantize_` and `autoquant` apis now automatically use our recommended inductor configuration setings. You can mimic the same configuration settings for your own experiments by using the `torchao.quantization.utils.recommended_inductor_config_setter` to replicate our recommended configuration settings. Alternatively if you wish to disable these recommended settings, you can use the key word argument `set_inductor_config` and set it to false in the `quantize_` or `autoquant` apis to prevent assignment of those configuration settings. You can also overwrite these configuration settings after they are assigned if you so desire, as long as they are overwritten before passing any inputs to the torch.compiled model. This means that previous flows which referenced a variety of inductor configurations that needed to be set are now outdated, though continuing to manually set those same inductor configurations is unlikely to cause any issues.
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -803,7 +803,9 @@ def int8_dynamic_activation_int8_semi_sparse_weight():
     return int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
 
 
-def _float8_symmetric_per_token_quant(x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn):
+def _float8_symmetric_per_token_quant(
+    x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn
+):
     from torchao.dtypes import to_affine_quantized_floatx
 
     return to_affine_quantized_floatx(
@@ -813,6 +815,23 @@ def _float8_symmetric_per_token_quant(x: torch.Tensor, dtype: torch.dtype = torc
         scale_dtype=None,
         _layout=Float8Layout(mm_config=None),
     )
+
+
+def _float8_symmetric_per_tensor_quant(
+    x: torch.Tensor,
+    dtype: torch.dtype = torch.float8_e4m3fn,
+    mm_config: Optional[Float8MMConfig] = None,
+):
+    from torchao.dtypes import to_affine_quantized_floatx
+
+    return to_affine_quantized_floatx(
+        input_float=x,
+        block_size=tuple(x.shape),
+        target_dtype=dtype,
+        scale_dtype=torch.float32,
+        _layout=Float8Layout(mm_config=mm_config),
+    )
+
 
 def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
     """
@@ -825,6 +844,7 @@ def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
         The actual matmul will be computed in original precision of the weight tensor.
 
     """
+
     def apply_float8wo_quant(weight):
         return _float8_symmetric_per_token_quant(weight, weight_dtype)
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -803,6 +803,17 @@ def int8_dynamic_activation_int8_semi_sparse_weight():
     return int8_dynamic_activation_int8_weight(layout=SemiSparseLayout())
 
 
+def _float8_symmetric_per_token_quant(x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn):
+    from torchao.dtypes import to_affine_quantized_floatx
+
+    return to_affine_quantized_floatx(
+        input_float=x,
+        block_size=_get_per_token_block_size(x),
+        target_dtype=dtype,
+        scale_dtype=None,
+        _layout=Float8Layout(mm_config=None),
+    )
+
 def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
     """
     Applies float8 weight-only symmetric per-channel quantization to linear layers.
@@ -814,17 +825,8 @@ def float8_weight_only(weight_dtype: torch.dtype = torch.float8_e4m3fn):
         The actual matmul will be computed in original precision of the weight tensor.
 
     """
-    from torchao.dtypes import to_affine_quantized_floatx
-
     def apply_float8wo_quant(weight):
-        block_size = (1, weight.shape[1])
-        return to_affine_quantized_floatx(
-            input_float=weight,
-            block_size=block_size,
-            target_dtype=weight_dtype,
-            scale_dtype=None,
-            _layout=Float8Layout(mm_config=None),
-        )
+        return _float8_symmetric_per_token_quant(weight, weight_dtype)
 
     return _get_linear_subclass_inserter(apply_float8wo_quant)
 
@@ -1172,5 +1174,6 @@ if TORCH_VERSION_AT_LEAST_2_5:
             _int8_asymm_per_token_quant,
             _int8_symm_per_token_reduced_range_quant,
             _input_activation_quant_func_fp8,
+            _float8_symmetric_per_token_quant,
         ]
     )


### PR DESCRIPTION
Summary:
This PR integrates flashattention 3 kernel: https://github.com/Dao-AILab/flash-attention/blob/1feb711f46563960fc10a8e659c93c300619504b/flash_attn/flash_attn_interface.py#L1102 to float8 affine quantized tensor.

To use the kernel, right now we need to manually add quantize call for q/k/v before sdpa op, but we can explore other APIs in the future

@sijiac is working on adding new variations of attention implementation in the future (per row, per column, per block scaling etc.).

Test Plan:
python test/dtypes/test_affine_quantized_float.py -k test_float8_attention

### SAM2
tested on sam2 and seems to be a bit slower than before, this is reasonable because sam2 is using 16 and 32 head dimension, but fa3 requires 64 being the minimum size, we need to do some padding to make this work (pad 32 to 64) which is expected to increase runtime significantly.

### llama2
llama2 without fallback: doesn't work because `attn_mask` is not supported.

### llama2 numerics only
(just for testing, code is not checked in) tested on llama2 (with fallback to test numerics):

since `attn_mask` is not supported in flashattention 3 kernel, it's using the fallback path: https://github.com/pytorch/ao/pull/1382/files#diff-3019e8f38b0919dbaba5aa1329a697e89fc98749e35a7bdc274c71a0d3738ec2R285
```
no quantize attn:

wikitext: {'alias': 'wikitext', 'word_perplexity,none': 12.2451228989592, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.5975503222785694, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.675861376279183, 'bits_per_byte_stderr,none': 'N/A'}

quantize attn:

wikitext: {'alias': 'wikitext', 'word_perplexity,none': 12.294668124182962, 'word_perplexity_stderr,none': 'N/A', 'byte_perplexity,none': 1.5987571166545238, 'byte_perplexity_stderr,none': 'N/A', 'bits_per_byte,none': 0.6769507810861697, 'bits_per_byte_stderr,none': 'N/A'}
```
Reviewers:

Subscribers:

Tasks:

Tags: