### PR TITLE
Move MarlinQQQTensor out of AQT

### DIFF
--- a/torchao/dtypes/README.md
+++ b/torchao/dtypes/README.md
@@ -1,0 +1,19 @@
+# README
+
+## File Structure of the `dtypes` Folder
+
+The `dtypes` folder contains several important files and subfolders that are organized as follows:
+
+- **affine_quantized_tensor.py**: This is the main file, from which the subfolders `uintx` and `floatx` inherit. It contains the base tensor subclass `AffineQuantizedTensor` and code for layout and tensorImpl registration.
+
+- **affine_quantized_tensor_ops.py**: This file defines all the overriden aten ops and different dispatch kernels related to affine quantized tensors.
+
+- **utils.py**: A utility file that provides helper functions and common utilities used across different files in the `dtypes` folder.
+
+- **nf4tensor.py**: This file is specific to the NF4 tensor implementation, and layouts.
+
+### Subfolders
+
+- **uintx**: A subfolder that contains layouts and tensor subclasses inheriting from `affine_quantized_tensor.py`. It is specialized for handling unsigned integer quantized tensors.
+
+- **floatx**: Similar to `uintx`, this subfolder contains layouts and tensor subclasses that inherit from `affine_quantized_tensor.py`, but it is focused on floating-point quantized tensors.

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -1,14 +1,12 @@
 from . import affine_quantized_tensor_ops
 from .affine_quantized_tensor import (
     AffineQuantizedTensor,
-    MarlinQQQTensor,
     to_affine_quantized_floatx,
     to_affine_quantized_floatx_static,
     # experimental, will be merged into floatx in the future
     to_affine_quantized_fpx,
     to_affine_quantized_intx,
     to_affine_quantized_intx_static,
-    to_marlinqqq_quantized_intx,
 )
 from .floatx import (
     Float8Layout,
@@ -18,10 +16,12 @@ from .uintx import (
     BlockSparseLayout,
     Int4CPULayout,
     MarlinQQQLayout,
+    MarlinQQQTensor,
     MarlinSparseLayout,
     SemiSparseLayout,
     TensorCoreTiledLayout,
     UintxLayout,
+    to_marlinqqq_quantized_intx,
 )
 from .utils import (
     Layout,

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -16,10 +16,8 @@ from torchao.quantization.quant_primitives import (
     choose_qparams_affine,
     choose_qparams_affine_floatx,
     choose_qparams_and_quantize_affine_hqq,
-    choose_qparams_and_quantize_affine_qqq,
     dequantize_affine,
     dequantize_affine_floatx,
-    dequantize_affine_qqq,
     quantize_affine,
     quantize_affine_floatx,
 )

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -20,7 +20,7 @@ from torchao.dtypes.uintx.block_sparse_layout import (
     _linear_int8_act_int8_weight_block_sparse_check,
     _linear_int8_act_int8_weight_block_sparse_impl,
 )
-from torchao.dtypes.uintx.marlin_qqq_layout import (
+from torchao.dtypes.uintx.marlin_qqq_tensor import (
     _linear_int8_act_int4_weight_marlin_qqq_check,
     _linear_int8_act_int4_weight_marlin_qqq_impl,
 )

--- a/torchao/dtypes/uintx/__init__.py
+++ b/torchao/dtypes/uintx/__init__.py
@@ -1,8 +1,10 @@
 from .block_sparse_layout import (
     BlockSparseLayout,
 )
-from .marlin_qqq_layout import (
+from .marlin_qqq_tensor import (
     MarlinQQQLayout,
+    MarlinQQQTensor,
+    to_marlinqqq_quantized_intx,
 )
 from .marlin_sparse_layout import (
     MarlinSparseLayout,
@@ -26,4 +28,6 @@ __all__ = [
     "TensorCoreTiledLayout",
     "Int4CPULayout",
     "MarlinQQQLayout",
+    "MarlinQQQTensor",
+    "to_marlinqqq_quantized_intx",
 ]

--- a/torchao/dtypes/uintx/marlin_qqq_tensor.py
+++ b/torchao/dtypes/uintx/marlin_qqq_tensor.py
@@ -1,5 +1,7 @@
 import logging
+import math
 from dataclasses import dataclass
+from typing import Optional, Tuple
 
 import torch
 from torch.utils._python_dispatch import (
@@ -8,12 +10,18 @@ from torch.utils._python_dispatch import (
 
 from torchao.dtypes.affine_quantized_tensor import (
     AffineQuantizedTensor,
+    get_tensor_impl_constructor,
     register_layout,
 )
 from torchao.dtypes.uintx.plain_layout import (
     _aqt_is_int8_reduced_range,
 )
 from torchao.dtypes.utils import AQTTensorImpl, Layout
+from torchao.quantization.quant_primitives import (
+    ZeroPointDomain,
+    choose_qparams_and_quantize_affine_qqq,
+    dequantize_affine_qqq,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Reorganization of AQT: Move MarlinQQQTensor to marlin_qqq_tensor file, with layouts and kernels. 