### PR TITLE
avoid .to() followed by inplace mutation to appease export

### DIFF
--- a/torchao/dtypes/uintx/plain_layout.py
+++ b/torchao/dtypes/uintx/plain_layout.py
@@ -264,5 +264,5 @@ def _linear_int8_act_int8_weight_impl(input_tensor, weight_tensor, bias):
     output_dtype = input_tensor.dtype
     y = y.to(output_dtype)
     if bias is not None:
-        y += bias
+        y = y + bias
     return y


### PR DESCRIPTION
Export currently has a restriction, where inplace mutations on the output of a call to `aten.to()` results in an error.

We should really lift this restriction, but in the meantime, this PR avoids hitting that problem in the quantization logic.

I tested by adding the following lines to the bottom of https://github.com/hustvl/ViTMatte/blob/main/modeling%2Fbackbone%2Fvit.py and confirming that export did not error:

```
quantize_(m, int8_dynamic_activation_int8_weight())
m = unwrap_tensor_subclass(m)

x = torch.randn(4, 3, 128, 128)
m = torch.export.export(m, (x,))
m2 = m.run_decompositions()
print(m2)
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1387

