### PR TITLE
update test-infra to release version

### DIFF
--- a/.github/workflows/build-wheels_m1.yml
+++ b/.github/workflows/build-wheels_m1.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@torchao-release0.7
     with:
       package-type: wheel
       os: macos-arm64
@@ -30,7 +30,7 @@ jobs:
     needs: generate-matrix
     if: github.repository_owner == 'pytorch'
     name: pytorch/ao
-    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@torchao-release0.7
     with:
       repository: pytorch/ao
       ref: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -22,12 +22,12 @@ on:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@torchao-release0.7
     with:
       package-type: wheel
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: torchao-release0.7
       with-cuda: disable
 
   build:
@@ -35,7 +35,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@torchao-release0.7
     with:
       # Set the ref to an empty string instead of the default nightly because
       # torchao doesn't have nightly branch setup yet, instead the build is

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -24,6 +24,7 @@ jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@torchao-release0.7
     with:
+      test-infra-ref: torchao-release0.7
       package-type: wheel
       os: linux
       with-cpu: enable

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@torchao-release0.7
     with:
       package-type: wheel
       os: linux
@@ -36,7 +36,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@torchao-release0.7
     with:
       # Set the ref to an empty string instead of the default nightly because
       # torchao doesn't have nightly branch setup yet, instead the build is
@@ -44,7 +44,7 @@ jobs:
       repository: pytorch/ao
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: torchao-release0.7
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-var-script: packaging/env_var_script_linux.sh
       pre-script: packaging/pre_build_script.sh

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -25,12 +25,12 @@ permissions:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@torchao-release0.7
     with:
       package-type: wheel
       os: windows
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: torchao-release0.7
       with-xpu: enable
       with-cuda: disable
 
@@ -47,12 +47,12 @@ jobs:
             smoke-test-script: packaging/smoke_test.py
             package-name: torchao
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@torchao-release0.7
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: torchao-release0.7
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}


### PR DESCRIPTION
Summary:

https://github.com/pytorch/test-infra/pull/6016 landed recently which is breaking our ROCm builds

We point to a special branch of test-infra created just before this PR to unblock the v0.7.0 release.

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags: