### PR TITLE
Fix a bug in LinearActivationQuantizedTensor

### DIFF
--- a/test/dtypes/test_affine_quantized_tensor_parallel.py
+++ b/test/dtypes/test_affine_quantized_tensor_parallel.py
@@ -182,6 +182,9 @@ if torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0):
             return self._test_tp(dtype)
 
     common_utils.instantiate_parametrized_tests(
+        TestFloat8woAffineQuantizedTensorParallel
+    )
+    common_utils.instantiate_parametrized_tests(
         TestFloat8dqTensorAffineQuantizedTensorParallel
     )
     common_utils.instantiate_parametrized_tests(

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -203,7 +203,9 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         LinearActivationQuantizedTensor(
-            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func, args[0].quant_kwargs
+            func(args[0].original_weight_tensor, *args[1:]),
+            args[0].input_quant_func,
+            args[0].quant_kwargs,
         ),
     )
 
@@ -216,7 +218,9 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         LinearActivationQuantizedTensor(
-            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func, args[0].quant_kwargs
+            func(args[0].original_weight_tensor, *args[1:]),
+            args[0].input_quant_func,
+            args[0].quant_kwargs,
         ),
     )
 

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -147,8 +147,8 @@ def _(func, types, args, kwargs):
         )
         input_quant_func = weight_tensor.input_quant_func
         original_weight_tensor = weight_tensor.original_weight_tensor
-        aqt = input_quant_func(input_tensor)
-        return func(bias, aqt, original_weight_tensor)
+        qtensor = input_quant_func(input_tensor, **weight_tensor.quant_kwargs)
+        return func(bias, qtensor, original_weight_tensor)
     else:
         # aten.mm.default
         assert args[0].shape[-1] == args[1].shape[0], (
@@ -161,8 +161,8 @@ def _(func, types, args, kwargs):
         )
         input_quant_func = weight_tensor.input_quant_func
         original_weight_tensor = weight_tensor.original_weight_tensor
-        aqt = input_quant_func(input_tensor)
-        return func(aqt, original_weight_tensor)
+        qtensor = input_quant_func(input_tensor, **weight_tensor.quant_kwargs)
+        return func(qtensor, original_weight_tensor)
 
 
 @implements(aten.detach.default)
@@ -203,7 +203,7 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         LinearActivationQuantizedTensor(
-            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func
+            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func, args[0].quant_kwargs
         ),
     )
 
@@ -216,7 +216,7 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         LinearActivationQuantizedTensor(
-            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func
+            func(args[0].original_weight_tensor, *args[1:]), args[0].input_quant_func, args[0].quant_kwargs
         ),
     )
 


### PR DESCRIPTION
Summary:
quant_kwargs is not populated in some places, that results in some errors when using DTensor.from_float, this PR fixes it.

Previous error:
```
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/test/dtypes/test_affine_quantized_tensor_parallel.py", line 102, in _test_tp
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     up_dist = self.colwise_shard(up_quant, mesh)
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/test/dtypes/test_affine_quantized_tensor_parallel.py", line 41, in colwise_shard
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     dtensor = DTensor.from_local(local_shard, mesh, [Shard(0)])
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/home/jerryzh/.conda/envs/ao/lib/python3.10/site-packages/torch/distributed/tensor/_api.py", line 425, in from_
local
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     return _FromTorchTensor.apply(  # pyre-ignore[16]: autograd func
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/home/jerryzh/.conda/envs/ao/lib/python3.10/site-packages/torch/autograd/function.py", line 575, in apply
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     return super().apply(*args, **kwargs)  # type: ignore[misc]
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/home/jerryzh/.conda/envs/ao/lib/python3.10/site-packages/torch/distributed/tensor/_api.py", line 179, in forwa
rd
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     input.view_as(input),
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/torchao/utils.py", line 434, in _dispatch__torch_function__
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     return func(*args, **kwargs)
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/torchao/utils.py", line 449, in _dispatch__torch_dispatch__
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     return cls._ATEN_OP_OR_TORCH_FN_TABLE[func](func, types, args, kwargs)
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/torchao/utils.py", line 410, in wrapper
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     return func(f, types, args, kwargs)
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]   File "/data/users/jerryzh/ao/torchao/quantization/linear_activation_quantized_tensor.py", line 218, in _
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]     LinearActivationQuantizedTensor(
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733] TypeError: LinearActivationQuantizedTensor.__new__() missing 1 required positional argument: 'quant_kwargs'
E1211 13:23:28.887412 1248070 site-packages/torch/testing/_internal/common_distributed.py:733]
```
Test Plan:
```
# in local H100 machine only, CI does not support H100 right now
python test/dtypes/test_affine_quantized_tensor_parallel.py
```

Reviewers:

Subscribers:

Tasks:

Tags: