### PR TITLE
Expose zero_point_domain as arguments

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -24,7 +24,9 @@ from torchao.utils import (
 )
 
 
-def get_quantization_functions(do_sparse: bool, do_int4: bool, device: str = "cuda", int4_zp_int: bool = False):
+def get_quantization_functions(
+    do_sparse: bool, do_int4: bool, device: str = "cuda", int4_zp_int: bool = False
+):
     base_functions = [
         int8_weight_only(),
         int8_dynamic_activation_int4_weight(),
@@ -38,7 +40,11 @@ def get_quantization_functions(do_sparse: bool, do_int4: bool, device: str = "cu
             )
             if int4_zp_int:
                 base_functions.append(
-                    int4_weight_only(group_size=32, layout=Int4CPULayout(), zero_point_domain=ZeroPointDomain.INT)
+                    int4_weight_only(
+                        group_size=32,
+                        layout=Int4CPULayout(),
+                        zero_point_domain=ZeroPointDomain.INT,
+                    )
                 )
         else:
             base_functions.append(int4_weight_only(group_size=32))
@@ -75,7 +81,9 @@ class TestAffineQuantized(TestCase):
             self.assertEqual(aqt_shape, shape)
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    @common_utils.parametrize("apply_quant", get_quantization_functions(True, True, "cuda", True))
+    @common_utils.parametrize(
+        "apply_quant", get_quantization_functions(True, True, "cuda", True)
+    )
     def test_weights_only(self, apply_quant):
         linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
         ql = apply_quant(linear)

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -42,8 +42,6 @@ def get_quantization_functions(do_sparse: bool, do_int4: bool, device: str = "cu
                 )
         else:
             base_functions.append(int4_weight_only(group_size=32))
-            if int4_zp_int:
-                base_functions.append(int4_weight_only(group_size=32, zero_point_domain=ZeroPointDomain.INT))
 
     if do_sparse:
         base_functions.append(

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -108,7 +108,6 @@ def _groupwise_affine_quantize_tensor_from_qparams(
     zeros = zeros.reshape(-1, 1)
     max_int = 2**n_bit - 1
     min_int = 0
-    # import pdb; pdb.set_trace()
     if zero_point_domain == ZeroPointDomain.FLOAT:
         min_val = zeros - scales * (2 ** (n_bit - 1))
         w_int4x8 = (

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -57,7 +57,7 @@ def check_idempotent(self, fn, *args, **kwargs):
 
 
 # Legacy tinygemm ops
-def _get_groupwise_affine_qparams(w, n_bit=4, groupsize=128, dtype=torch.bfloat16):
+def _get_groupwise_affine_qparams(w, n_bit=4, groupsize=128, dtype=torch.bfloat16, zero_point_domain=ZeroPointDomain.FLOAT):
     if groupsize > w.shape[-1]:
         groupsize = w.shape[-1]
     assert groupsize > 1
@@ -70,11 +70,18 @@ def _get_groupwise_affine_qparams(w, n_bit=4, groupsize=128, dtype=torch.bfloat1
     max_val = to_quant.amax(dim=1, keepdim=True)
     min_val = to_quant.amin(dim=1, keepdim=True)
     max_int = 2**n_bit - 1
+    quant_min = 0
+    quant_max = max_int
     scales = (max_val - min_val).clamp(min=1e-6) / max_int
-    zeros = min_val + scales * (2 ** (n_bit - 1))
-    return scales.to(dtype=dtype).reshape(w.shape[0], -1), zeros.to(
-        dtype=dtype
-    ).reshape(w.shape[0], -1)
+    if (zero_point_domain == ZeroPointDomain.FLOAT):
+        zeros = min_val + scales * (2 ** (n_bit - 1))
+        zeros = zeros.to(dtype=dtype).reshape(w.shape[0], -1)
+    else:
+        zeros = quant_min - torch.round(min_val / scales)
+        zeros = torch.clamp(zeros, quant_min, quant_max)
+        zeros = zeros.to(dtype=dtype).reshape(w.shape[0], -1)
+    scales = scales.to(dtype=dtype).reshape(w.shape[0], -1)
+    return scales, zeros
 
 
 def _groupwise_affine_quantize_tensor_from_qparams(
@@ -83,8 +90,10 @@ def _groupwise_affine_quantize_tensor_from_qparams(
     zeros,
     n_bit=4,
     groupsize=128,
+    zero_point_domain=ZeroPointDomain.FLOAT
 ):
     assert groupsize > 1
+    assert n_bit == 4
     # needed for GPTQ single column quantize
     if groupsize > w.shape[-1] and scales.shape[-1] == 1:
         groupsize = w.shape[-1]
@@ -97,17 +106,29 @@ def _groupwise_affine_quantize_tensor_from_qparams(
 
     scales = scales.reshape(-1, 1)
     zeros = zeros.reshape(-1, 1)
-    min_val = zeros - scales * (2 ** (n_bit - 1))
     max_int = 2**n_bit - 1
     min_int = 0
-    w_int4x8 = (
-        to_quant.sub(min_val)
-        .div(scales)
-        .round()
-        .clamp_(min_int, max_int)
-        .to(torch.int32)
-        .reshape_as(w)
-    )
+    # import pdb; pdb.set_trace()
+    if zero_point_domain == ZeroPointDomain.FLOAT:
+        min_val = zeros - scales * (2 ** (n_bit - 1))
+        w_int4x8 = (
+            to_quant.sub(min_val)
+            .div(scales)
+            .round()
+            .clamp_(min_int, max_int)
+            .to(torch.int32)
+            .reshape_as(w)
+        )
+    else:
+        w_int4x8 = (
+            to_quant.div(scales)
+            .round()
+            .add(zeros)
+            .clamp_(min_int, max_int)
+            .to(torch.int32)
+            .reshape_as(w)
+        )
+
     if TORCH_VERSION_AT_LEAST_2_5:
         if not (is_device(w.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6):
             w_int4x8 = (w_int4x8[::, ::2] << 4 | w_int4x8[::, 1::2]).to(torch.uint8)
@@ -121,6 +142,7 @@ def _groupwise_affine_dequantize_tensor_from_qparams(
     zeros,
     n_bit=4,
     groupsize=128,
+    zero_point_domain=ZeroPointDomain.FLOAT
 ):
     assert groupsize > 1
     # needed for GPTQ single column dequantize
@@ -133,12 +155,19 @@ def _groupwise_affine_dequantize_tensor_from_qparams(
     scales = scales.reshape(-1, 1)
     zeros = zeros.reshape(-1, 1)
 
-    w_dq = (
-        w_int4x8_grouped.sub(2 ** (n_bit - 1))
-        .mul(scales)
-        .add(zeros)
-        .reshape_as(w_int4x8)
-    )
+    if zero_point_domain == ZeroPointDomain.FLOAT:
+        w_dq = (
+            w_int4x8_grouped.sub(2 ** (n_bit - 1))
+            .mul(scales)
+            .add(zeros)
+            .reshape_as(w_int4x8)
+        )
+    else:
+        w_dq = (
+            w_int4x8_grouped.sub(zeros)
+            .mul(scales)
+            .reshape_as(w_int4x8)
+        )
     return w_dq
 
 
@@ -650,10 +679,8 @@ class TestQuantPrimitives(unittest.TestCase):
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)
         n_bit = 4
-        scale_ref, zero_point_ref = _get_groupwise_affine_qparams(
-            input, n_bit=n_bit, groupsize=128, dtype=torch.bfloat16
-        )
 
+        zero_point_domains = [ZeroPointDomain.FLOAT, ZeroPointDomain.INT]
         mapping_type = MappingType.ASYMMETRIC
         dtype = torch.int8
         block_size = (1, 128)
@@ -662,19 +689,24 @@ class TestQuantPrimitives(unittest.TestCase):
         eps = 1e-6
         scale_dtype = torch.bfloat16
         zero_point_dtype = torch.bfloat16
-        scale, zero_point = choose_qparams_affine(
-            input,
-            mapping_type,
-            block_size,
-            dtype,
-            quant_min,
-            quant_max,
-            eps,
-            scale_dtype=scale_dtype,
-            zero_point_dtype=zero_point_dtype,
-            preserve_zero=False,
-            zero_point_domain=ZeroPointDomain.FLOAT,
-        )
+        for zero_point_domain in zero_point_domains:
+            scale_ref, zero_point_ref = _get_groupwise_affine_qparams(
+                    input, n_bit=n_bit, groupsize=128, dtype=torch.bfloat16,
+                    zero_point_domain=zero_point_domain
+                )
+            scale, zero_point = choose_qparams_affine(
+                input,
+                mapping_type,
+                block_size,
+                dtype,
+                quant_min,
+                quant_max,
+                eps,
+                scale_dtype=scale_dtype,
+                zero_point_dtype=zero_point_dtype,
+                preserve_zero=zero_point_domain == ZeroPointDomain.INT,
+                zero_point_domain=zero_point_domain,
+            )
 
         self.assertTrue(torch.equal(scale, scale_ref))
         self.assertTrue(torch.equal(zero_point, zero_point_ref))
@@ -686,14 +718,15 @@ class TestQuantPrimitives(unittest.TestCase):
         n_bit = 4
         groupsize = 128
 
-        w_int4x8 = groupwise_affine_quantize_tensor_from_qparams(
-            input, scales, zeros, n_bit, groupsize
-        )
-        w_int4x8_ref = _groupwise_affine_quantize_tensor_from_qparams(
-            input, scales, zeros, n_bit, groupsize
-        )
+        for zero_point_domain in [ZeroPointDomain.FLOAT, ZeroPointDomain.INT]:
+            w_int4x8 = groupwise_affine_quantize_tensor_from_qparams(
+                input, scales, zeros, n_bit, groupsize, zero_point_domain
+            )
+            w_int4x8_ref = _groupwise_affine_quantize_tensor_from_qparams(
+                input, scales, zeros, n_bit, groupsize, zero_point_domain
+            )
 
-        self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
+            self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
 
     def test_groupwise_affine_dequantize_tensor_from_qparams(self):
         input = torch.randint(0, 15, (10, 256), dtype=torch.int32)
@@ -702,20 +735,25 @@ class TestQuantPrimitives(unittest.TestCase):
         n_bit = 4
         groupsize = 128
 
-        if TORCH_VERSION_AT_LEAST_2_5:
-            input_tmp = input
-            if not (is_device(input.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6):
-                input_tmp = (input[::, ::2] << 4 | input[::, 1::2]).to(torch.uint8)
-            w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
-                input_tmp, scales, zeros, n_bit, groupsize
+        for zero_point_domain in [ZeroPointDomain.FLOAT, ZeroPointDomain.INT]:
+            if zero_point_domain == ZeroPointDomain.INT:
+                zeros = torch.randint(0, 15, (10, 2), dtype=torch.int32)
+            if TORCH_VERSION_AT_LEAST_2_5:
+                input_tmp = input
+                if not (is_device(input.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6):
+                    input_tmp = (input[::, ::2] << 4 | input[::, 1::2]).to(torch.uint8)
+                w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
+                    input_tmp, scales, zeros, n_bit, groupsize, zero_point_domain
+                )
+            else:
+                if zero_point_domain == ZeroPointDomain.INT:
+                    continue
+                w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
+                    input, scales, zeros, n_bit, groupsize
+                )
+            w_bf16_ref = _groupwise_affine_dequantize_tensor_from_qparams(
+                input, scales, zeros, n_bit, groupsize, zero_point_domain
             )
-        else:
-            w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
-                input, scales, zeros, n_bit, groupsize
-            )
-        w_bf16_ref = _groupwise_affine_dequantize_tensor_from_qparams(
-            input, scales, zeros, n_bit, groupsize
-        )
 
         self.assertTrue(torch.equal(w_bf16, w_bf16_ref))
 

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -203,7 +203,7 @@ We also have a unified quantized tensor subclass that implements how to get a qu
 We extended the `layout` concept to represent different packing formats for a tensor. `AffineQuantizedTensor` supports `plain` and `tensor_core_tiled` layout. `plain` layout is used for `int8_weight_only` and `int8_dynamic_activation_int8_weight` and also as a default layout. `tensor_core_tiled` layout is used for `int4_weight_only` quantization and is packing the weights in a format that is compatible with tinygemm [int4mm](https://github.com/pytorch/pytorch/blob/39357ba06f48cda7d293a4995aa5eba2a46598b5/aten/src/ATen/native/native_functions.yaml#L4138) kernels.
 
 ### Zero Point Domains
-```ZeroPointDomain``` is used to control the data types of zero points. ```None``` represents symmetric quantization, while ```ZeroPointDomain.FLOAT``` and ```ZeroPointDomain.INT``` indicate asymmetric quantization. For detailed implementation of different zero point data types, refer to [the reference implementation]((../../test/quantization/test_quant_primitives.py)).
+```ZeroPointDomain``` is used to control the data types of zero points. ```ZeroPointDomain.None``` means zero_point is None, ```ZeroPointDomain.FLOAT``` means zero_point is in the floating point domain and ```ZeroPointDomain.INT``` means integer domain. For detailed implementation of different zero point data types, refer to [the reference implementation](../../test/quantization/test_quant_primitives.py).
 The following support matrix illustrates the relationship between layouts and zero point domains, which may be updated with backend changes:
 
 |Layout|None(Symmetric)|Float|Int|

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -202,6 +202,17 @@ We also have a unified quantized tensor subclass that implements how to get a qu
 #### Layouts
 We extended the `layout` concept to represent different packing formats for a tensor. `AffineQuantizedTensor` supports `plain` and `tensor_core_tiled` layout. `plain` layout is used for `int8_weight_only` and `int8_dynamic_activation_int8_weight` and also as a default layout. `tensor_core_tiled` layout is used for `int4_weight_only` quantization and is packing the weights in a format that is compatible with tinygemm [int4mm](https://github.com/pytorch/pytorch/blob/39357ba06f48cda7d293a4995aa5eba2a46598b5/aten/src/ATen/native/native_functions.yaml#L4138) kernels.
 
+### Zero Point Domains
+```ZeroPointDomain``` is used to control the data types of zero points. ```None``` represents symmetric quantization, while ```ZeroPointDomain.FLOAT``` and ```ZeroPointDomain.INT``` indicate asymmetric quantization. For detailed implementation of different zero point data types, refer to [the reference implementation]((../../test/quantization/test_quant_primitives.py)).
+The following support matrix illustrates the relationship between layouts and zero point domains, which may be updated with backend changes:
+
+|Layout|None(Symmetric)|Float|Int|
+|------|---------------|-----|---|
+|TensorCoreTiledLayout| Yes | Yes(Default) | No|
+|Int4CPULayout | Yes | Yes(Default) | No |
+|MarlinSparseLayout | No | No | Yes(Default) |
+
+
 ### Full Affine Quantization Flow Example
 Let's use int4 weight only quantization that's targeting tinygemm int4 weight only quantized matmul
 as an example:
@@ -239,6 +250,8 @@ m_bf16 = torch.compile(m_bf16, mode='max-autotune')
 group_size = 32
 # only works for torch 2.4+
 quantize_(m, int4_weight_only(group_size=group_size))
+## If different zero_point_domain needed
+# quantize_(m, int4_weight_only(group_size=group_size), zero_point_domain=ZeroPointDomain.FLOAT)
 
 # temporary workaround for tensor subclass + torch.compile
 # NOTE: this is only need for torch version < 2.5+

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -682,7 +682,7 @@ def int4_weight_only(
         zero_point_dtype = torch.bfloat16
 
         nonlocal zero_point_domain
-        assert any(isinstance(layout, support_layout) for support_layout in LAYOUT_TO_ZERO_POINT_DOMAIN.keys()), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
+        assert type(layout) in LAYOUT_TO_ZERO_POINT_DOMAIN.keys(), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
         if zero_point_domain is None:
             # the first value is the default one
             zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)][0]

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -112,13 +112,13 @@ __all__ = [
 ]
 
 # update according to the support matrix
-layout_to_zero_point_domain = {
+LAYOUT_TO_ZERO_POINT_DOMAIN = {
     TensorCoreTiledLayout: [ZeroPointDomain.FLOAT],
     MarlinSparseLayout: [ZeroPointDomain.INT],
     Int4CPULayout: [ZeroPointDomain.FLOAT]
 }
 
-layout_to_preserve_zeros = {
+LAYOUT_TO_PRESERVE_ZEROS = {
     TensorCoreTiledLayout: False,
     MarlinSparseLayout: True,
     Int4CPULayout: False
@@ -681,13 +681,13 @@ def int4_weight_only(
         eps = 1e-6
         zero_point_dtype = torch.bfloat16
 
-        assert layout in layout_to_zero_point_domain.keys(), f"Only support layout: {layout_to_zero_point_domain.keys()}"
+        assert layout in LAYOUT_TO_ZERO_POINT_DOMAIN.keys(), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
         if zero_point_domain is None:
             # the first value is the default one
-            zero_point_domain = layout_to_zero_point_domain[layout][0]
-            preserve_zero = layout_to_preserve_zeros[layout]
+            zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[layout][0]
+            preserve_zero = LAYOUT_TO_PRESERVE_ZEROS[layout]
         else:
-            assert zero_point_domain  in layout_to_zero_point_domain[layout], f"Layout only support {layout_to_zero_point_domain[layout]}"
+            assert zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[layout], f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
 
         # Sparse Marlin only supports symmetric quantization.
         # NOTE: If we start having lots of layouts that require different configurations,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -631,7 +631,7 @@ def int8_dynamic_activation_int4_weight(
 
 def int4_weight_only(
     group_size=128, layout=TensorCoreTiledLayout(inner_k_tiles=8), use_hqq=False,
-    zero_point_domain=ZeroPointDomain.FLOAT
+    zero_point_domain=None
 ):
     """
     Applies uint4 weight-only asymmetric per-group quantization to linear layers, using
@@ -670,8 +670,11 @@ def int4_weight_only(
         zero_point_dtype = torch.bfloat16
 
         if isinstance(layout, TensorCoreTiledLayout):
-                assert(zero_point_domain != ZeroPointDomain.INT
+            assert(zero_point_domain != ZeroPointDomain.INT
             ), f"TensorCoreTiledLayout, doesn't support integer zero points\n"
+            if zero_point_domain is None:
+                # TinyGEMM only supports floating zero points now
+                zero_point_domain = ZeroPointDomain.FLOAT
 
         # Sparse Marlin only supports symmetric quantization.
         # NOTE: If we start having lots of layouts that require different configurations,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -664,6 +664,7 @@ def int4_weight_only(
          size is more fine grained, choices are [256, 128, 64, 32]
         `layout`: layout type for quantized tensor, default is `TensorCoreTiledLayout(inner_k_tiles=8)`
         `use_hqq`: whether to use hqq or default quantization mode, default is False
+        `zero_point_domain`: data type of zeros points, choices are [None(default), ZeroPointDomain.FLOAT, ZeroPointDomain.INT, ZeroPointDomain.NONE]
     """
 
     def apply_int4_weight_only_quant(weight):
@@ -679,6 +680,7 @@ def int4_weight_only(
         quant_min = 0
         quant_max = 15
         eps = 1e-6
+        preserve_zero = LAYOUT_TO_PRESERVE_ZEROS[type(layout)]
         zero_point_dtype = torch.bfloat16
 
         nonlocal zero_point_domain
@@ -686,7 +688,6 @@ def int4_weight_only(
         if zero_point_domain is None:
             # the first value is the default one
             zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)][0]
-            preserve_zero = LAYOUT_TO_PRESERVE_ZEROS[type(layout)]
         else:
             assert zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)], f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -664,7 +664,7 @@ def int4_weight_only(
          size is more fine grained, choices are [256, 128, 64, 32]
         `layout`: layout type for quantized tensor, default is `TensorCoreTiledLayout(inner_k_tiles=8)`
         `use_hqq`: whether to use hqq or default quantization mode, default is False
-        `zero_point_domain`: data type of zeros points, choices are [None(default), ZeroPointDomain.FLOAT, ZeroPointDomain.INT, ZeroPointDomain.NONE]
+        `zero_point_domain`: data type of zeros points, choices are [None(then the value is determined by the layout), ZeroPointDomain.FLOAT, ZeroPointDomain.INT, ZeroPointDomain.NONE]
     """
 
     def apply_int4_weight_only_quant(weight):

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -669,6 +669,10 @@ def int4_weight_only(
         preserve_zero = zero_point_domain == ZeroPointDomain.INT
         zero_point_dtype = torch.bfloat16
 
+        if isinstance(layout, TensorCoreTiledLayout):
+                assert(zero_point_domain != ZeroPointDomain.INT
+            ), f"TensorCoreTiledLayout, doesn't support integer zero points\n"
+
         # Sparse Marlin only supports symmetric quantization.
         # NOTE: If we start having lots of layouts that require different configurations,
         # we should consider moving this logic somewhere else.

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -681,13 +681,14 @@ def int4_weight_only(
         eps = 1e-6
         zero_point_dtype = torch.bfloat16
 
-        assert layout in LAYOUT_TO_ZERO_POINT_DOMAIN.keys(), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
+        nonlocal zero_point_domain
+        assert any(isinstance(layout, support_layout) for support_layout in LAYOUT_TO_ZERO_POINT_DOMAIN.keys()), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
         if zero_point_domain is None:
             # the first value is the default one
-            zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[layout][0]
-            preserve_zero = LAYOUT_TO_PRESERVE_ZEROS[layout]
+            zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)][0]
+            preserve_zero = LAYOUT_TO_PRESERVE_ZEROS[type(layout)]
         else:
-            assert zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[layout], f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
+            assert zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)], f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
 
         # Sparse Marlin only supports symmetric quantization.
         # NOTE: If we start having lots of layouts that require different configurations,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -630,7 +630,8 @@ def int8_dynamic_activation_int4_weight(
 
 
 def int4_weight_only(
-    group_size=128, layout=TensorCoreTiledLayout(inner_k_tiles=8), use_hqq=False
+    group_size=128, layout=TensorCoreTiledLayout(inner_k_tiles=8), use_hqq=False,
+    zero_point_domain=ZeroPointDomain.FLOAT
 ):
     """
     Applies uint4 weight-only asymmetric per-group quantization to linear layers, using
@@ -665,9 +666,8 @@ def int4_weight_only(
         quant_min = 0
         quant_max = 15
         eps = 1e-6
-        preserve_zero = False
+        preserve_zero = zero_point_domain == ZeroPointDomain.INT
         zero_point_dtype = torch.bfloat16
-        zero_point_domain = ZeroPointDomain.FLOAT
 
         # Sparse Marlin only supports symmetric quantization.
         # NOTE: If we start having lots of layouts that require different configurations,

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -373,12 +373,7 @@ def unpack_tinygemm_scales_and_zeros(scales_and_zeros):
 
 
 def groupwise_affine_quantize_tensor_from_qparams(
-    w,
-    scales,
-    zeros,
-    n_bit=4,
-    groupsize=128,
-    zero_point_domain=ZeroPointDomain.FLOAT
+    w, scales, zeros, n_bit=4, groupsize=128, zero_point_domain=ZeroPointDomain.FLOAT
 ):
     assert groupsize > 1
     # needed for GPTQ single column quantize
@@ -401,7 +396,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
         output_dtype,
         quant_min,
         quant_max,
-        zero_point_domain=zero_point_domain
+        zero_point_domain=zero_point_domain,
     )
     if TORCH_VERSION_AT_LEAST_2_5 and w.shape[-1] > 1:
         if not (is_device(int_data.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6):
@@ -415,7 +410,7 @@ def groupwise_affine_dequantize_tensor_from_qparams(
     zeros,
     n_bit=4,
     groupsize=128,
-    zero_point_domain=ZeroPointDomain.FLOAT
+    zero_point_domain=ZeroPointDomain.FLOAT,
 ):
     assert groupsize > 1
     assert w_int4x8.dim() == 2

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -378,6 +378,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
     zeros,
     n_bit=4,
     groupsize=128,
+    zero_point_domain=ZeroPointDomain.FLOAT
 ):
     assert groupsize > 1
     # needed for GPTQ single column quantize
@@ -400,7 +401,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
         output_dtype,
         quant_min,
         quant_max,
-        zero_point_domain=ZeroPointDomain.FLOAT,
+        zero_point_domain=zero_point_domain
     )
     if TORCH_VERSION_AT_LEAST_2_5 and w.shape[-1] > 1:
         if not (is_device(int_data.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6):
@@ -414,6 +415,7 @@ def groupwise_affine_dequantize_tensor_from_qparams(
     zeros,
     n_bit=4,
     groupsize=128,
+    zero_point_domain=ZeroPointDomain.FLOAT
 ):
     assert groupsize > 1
     assert w_int4x8.dim() == 2
@@ -452,7 +454,7 @@ def groupwise_affine_dequantize_tensor_from_qparams(
         input_dtype,
         quant_min,
         quant_max,
-        zero_point_domain=ZeroPointDomain.FLOAT,
+        zero_point_domain=zero_point_domain,
         output_dtype=scales.dtype,
     )
 


### PR DESCRIPTION
As discussed in https://github.com/pytorch/ao/issues/1264, expose zero_point_domain to the users.

```
from torchao.quantization.quant_primitives import ZeroPointDomain
from torchao.quantization.quant_api import (
    quantize_,
    int4_weight_only,
)
quantize_(m, int4_weight_only(zero_point_domain=...))
```

However, to run the model E2E with integer zero points, we need to separate scales and zero points tensors. The first PR to enable this is https://github.com/pytorch/pytorch/pull/137566

@jgong5 @mingfeima @leslie-fang-intel @liangan1