### PR TITLE
[WIP] Use `int_scaled_matmul` with `int8_dynamic_activation_int8_weight(act_mapping_type=MappingType.ASYMMETRIC)`

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -872,7 +872,7 @@ class TestSubclass(unittest.TestCase):
         test_device,
         min_sqnr=35,
         test_dtype=torch.bfloat16,
-        test_shape=(32, 4096, 14336)
+        test_shape=(32, 64, 32)
     ):
         m, k, n = test_shape
         x = torch.randn(m, k, device=test_device, dtype=test_dtype)

--- a/test/quantization/test_observer.py
+++ b/test/quantization/test_observer.py
@@ -21,6 +21,7 @@ from torchao.quantization.quant_api import (
 )
 from torchao.quantization.quant_primitives import (
     MappingType,
+    ZeroPointDomain,
 )
 
 
@@ -74,7 +75,7 @@ class TestQuantFlow(TestCase):
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
-            zero_point_domain=None,
+            zero_point_domain=ZeroPointDomain.NONE,
         )
         example_inputs = [
             torch.randn(10, 2048),
@@ -93,7 +94,7 @@ class TestQuantFlow(TestCase):
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
-            zero_point_domain=None,
+            zero_point_domain=ZeroPointDomain.NONE,
         )
         for example_input in example_inputs:
             obs(example_input)
@@ -108,7 +109,7 @@ class TestQuantFlow(TestCase):
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
-            zero_point_domain=None,
+            zero_point_domain=ZeroPointDomain.NONE,
         )
         example_inputs = [
             torch.randn(10, 2048),
@@ -127,7 +128,7 @@ class TestQuantFlow(TestCase):
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
-            zero_point_domain=None,
+            zero_point_domain=ZeroPointDomain.NONE,
         )
         example_inputs = [
             torch.randn(10, 2048),
@@ -155,7 +156,7 @@ class TestLinearObserver(TestCase):
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
-            zero_point_domain=None,
+            zero_point_domain=ZeroPointDomain.NONE,
         )
         if observe_weight:
             weight_observer = AffineQuantizedMinMaxObserver(
@@ -165,7 +166,7 @@ class TestLinearObserver(TestCase):
                 eps=torch.finfo(torch.float32).eps,
                 scale_dtype=torch.float,
                 zero_point_dtype=torch.int,
-                zero_point_domain=None,
+                zero_point_domain=ZeroPointDomain.NONE,
             )
         else:
             weight_observer = None
@@ -199,7 +200,6 @@ class TestLinearObserver(TestCase):
             input_scale.item(),
             max_val / max_fp8,
         )
-        self.assertIsNotNone(input_zero_point)
 
         if observe_weight:
             weight_observer = linear.weight.weight_observer
@@ -210,7 +210,6 @@ class TestLinearObserver(TestCase):
                 atol=5e-5,
                 rtol=0.0,
             )
-            self.assertIsNotNone(weight_zero_point)
         else:
             self.assertIsNone(linear.weight.weight_observer)
 

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -799,6 +799,32 @@ class TestQuantPrimitives(unittest.TestCase):
         torch.testing.assert_close(dequantized, fake_quantized)
         torch.testing.assert_close(expected_mask, mask)
 
+    # ZeroPointDomain.NONE should work
+    def test_none_zero_point_domain(self):
+        input = torch.randn(10, 256)
+        n_bit = 8
+        mapping_type = MappingType.SYMMETRIC
+        dtype = torch.int8
+        block_size = (1, 128)
+        quant_min = None
+        quant_max = None
+        eps = 1e-6
+        scale_dtype = torch.float32
+        zero_point_dtype = torch.int64
+        _, zero_point = choose_qparams_affine(
+            input,
+            mapping_type,
+            block_size,
+            dtype,
+            quant_min,
+            quant_max,
+            eps,
+            scale_dtype=scale_dtype,
+            zero_point_dtype=zero_point_dtype,
+            preserve_zero=True,
+            zero_point_domain=ZeroPointDomain.NONE,
+        )
+        self.assertTrue(torch.equal(zero_point, torch.zeros_like(zero_point)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -824,7 +824,7 @@ class TestQuantPrimitives(unittest.TestCase):
             preserve_zero=True,
             zero_point_domain=ZeroPointDomain.NONE,
         )
-        self.assertTrue(torch.equal(zero_point, torch.zeros_like(zero_point)))
+        self.assertTrue(zero_point is None)
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -251,7 +251,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
                 zero_point_domain,
             )
             # choose_qparams_affine is a custom op that does support returning optional Tensors. We thus set the zero_point to None if its domain is None
-            if zero_point_domain == ZeroPointDomain.NONE:
+            if zero_point_domain == ZeroPointDomain.NONE or zero_point_domain is None:
                 zero_point = None
             data = quantize_affine(
                 input_float,

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -251,7 +251,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
                 zero_point_domain,
             )
             # choose_qparams_affine is a custom op that does support returning optional Tensors. We thus set the zero_point to None if its domain is None
-            if zero_point_domain is None:
+            if zero_point_domain == ZeroPointDomain.NONE:
                 zero_point = None
             data = quantize_affine(
                 input_float,

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -349,7 +349,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
                 scale_dtype=scale_dtype,
                 zero_point_dtype=None,
                 preserve_zero=True,
-                zero_point_domain=None,
+                zero_point_domain=ZeroPointDomain.NONE,
                 _layout=_layout,
                 use_hqq=False,
             )
@@ -376,7 +376,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
                 target_dtype=target_dtype,
                 quant_min=math.ceil(torch.finfo(target_dtype).min),
                 quant_max=math.ceil(torch.finfo(target_dtype).max),
-                zero_point_domain=None,
+                zero_point_domain=ZeroPointDomain.NONE,
                 _layout=_layout,
             )
         else:

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -32,8 +32,10 @@ from torchao.dtypes.uintx.plain_layout import (
     PlainAQTTensorImpl,
     _linear_fp_act_int8_weight_check,
     _linear_fp_act_int8_weight_impl,
-    _linear_int8_act_int8_weight_check,
-    _linear_int8_act_int8_weight_impl,
+    _linear_sym_int8_act_sym_int8_weight_check,
+    _linear_sym_int8_act_sym_int8_weight_impl,
+    _linear_asym_int8_act_sym_int8_weight_check,
+    _linear_asym_int8_act_sym_int8_weight_impl
 )
 from torchao.dtypes.uintx.semi_sparse_layout import (
     _linear_int8_act_int8_weight_semi_structured_sparse_check,
@@ -110,7 +112,14 @@ AffineQuantizedTensor._quantized_linear_op = _quantized_linear_op
 # so that these can be shared by F.linear, aten.mm, aten.addmm dispatches
 def _register_aqt_quantized_linear_dispatches():
     for dispatch_condition, impl in [
-        (_linear_int8_act_int8_weight_check, _linear_int8_act_int8_weight_impl),
+        (
+            _linear_sym_int8_act_sym_int8_weight_check,
+            _linear_sym_int8_act_sym_int8_weight_impl
+        ),
+        (
+            _linear_asym_int8_act_sym_int8_weight_check,
+            _linear_asym_int8_act_sym_int8_weight_impl
+        ),
         (
             _linear_int8_act_int8_weight_semi_structured_sparse_check,
             _linear_int8_act_int8_weight_semi_structured_sparse_impl,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -739,7 +739,9 @@ def _int8_symm_per_token_reduced_range_quant(x: torch.Tensor) -> torch.Tensor:
 
 
 def int8_dynamic_activation_int8_weight(
-    layout=PlainLayout(), act_mapping_type=MappingType.SYMMETRIC
+    layout=PlainLayout(),
+    act_mapping_type=MappingType.SYMMETRIC,
+    weight_zp_domain=ZeroPointDomain.INT
 ):
     """
     Applies int8 dynamic symmetric per-token activation and int8 per-channel weight
@@ -781,6 +783,7 @@ def int8_dynamic_activation_int8_weight(
             eps=eps,
             zero_point_dtype=zero_point_dtype,
             _layout=layout,
+            zero_point_domain=weight_zp_domain
         )
         weight = to_linear_activation_quantized(weight, input_quant_func)
         return weight

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -533,16 +533,6 @@ def _dequantize_affine_no_dtype_check(
         ), "zero_point should be None when zero_point_domain is NONE"
         dequant = input.to(output_dtype)
         dequant = dequant * scale
-    elif zero_point_domain is None:
-        # This case handles dequantization for float8 we expect no zero point and no zero point domain
-        assert (
-            zero_point is None
-        ), "zero_point should be None when zero_point_domain is None"
-        assert _is_float8_type(
-            input.dtype
-        ), f"dequantiztion with no zero point domain is only supported with FP8 types, got {input.dtype}"
-        dequant = input.to(output_dtype)
-        dequant = dequant * scale
     else:
         assert (
             zero_point_domain == ZeroPointDomain.FLOAT.name
@@ -889,7 +879,6 @@ def _choose_qparams_affine(
             )
         if (
             zero_point_domain != ZeroPointDomain.NONE.name
-            and zero_point_domain != None
             and zero_point_domain != ZeroPointDomain.INT.name
         ):
             raise ValueError(

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -888,11 +888,11 @@ def _choose_qparams_affine(
                 "preserve_zero == False is not supported for symmetric quantization"
             )
         if (
-            zero_point_domain is not None
+            zero_point_domain != ZeroPointDomain.NONE.name
             and zero_point_domain != ZeroPointDomain.INT.name
         ):
             raise ValueError(
-                "zero_point_domain != ZeroPointDomain.INT is not supported for symmetric quantization"
+                "Only ZeroPointDomain.NONE and ZeroPointDomain.INT are supported for symmetric quantization"
             )
         scale = torch.clamp(scale, min=eps)
         zero_point = torch.full_like(scale, int((quant_max + quant_min + 1) / 2))

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -889,13 +889,18 @@ def _choose_qparams_affine(
             )
         if (
             zero_point_domain != ZeroPointDomain.NONE.name
+            and zero_point_domain != None
             and zero_point_domain != ZeroPointDomain.INT.name
         ):
             raise ValueError(
-                "Only ZeroPointDomain.NONE and ZeroPointDomain.INT are supported for symmetric quantization"
+                "Except a None value for zero_point_domain, Only ZeroPointDomain.NONE and ZeroPointDomain.INT"
+                " are supported for symmetric quantization."
             )
+        if zero_point_domain == ZeroPointDomain.NONE.name:
+            zero_point = None
+        else:
+            zero_point = torch.full_like(scale, int((quant_max + quant_min + 1) / 2))
         scale = torch.clamp(scale, min=eps)
-        zero_point = torch.full_like(scale, int((quant_max + quant_min + 1) / 2))
     else:
         assert mapping_type == MappingType.ASYMMETRIC.name
         scale = (max_val_pos - min_val_neg) / float(quant_max - quant_min)


### PR DESCRIPTION
## Feature

Use `int_scaled_matmul` with asymmetrically int8 quantized activation & symmetrically int8 quantized weight by applying compensation for zero point of activation.

### Motivation
Currently, optimizing GEMMs by using asymmetrically int8 quantized activation & symmetrically quantized weight with the `int8_dynamic_activation_int8_weight` API poses a problem - torchao currently does not use `torch._int_mm` for this case, so in case of frozen weights (inference, and Inductor freezing config enabled), the frozen int8 weights are folded into FP32 weights (as `aten.mm`'s second argument) during Inductor's constant-folding passes (during freezing).

With `sym act, sym wgt` case, `torch._int_mm` is being used, and that makes it easier to leverage frozen int8 weights with Inductor pattern-matching & use Inductor max-autotune mode.

This PR does something similar for `asym act, sym wgt` case by using `torch._int_mm` with int8 activation & weights, and applying compensation corresponding to the activation's zero points.

This change makes it possible to leverage this GEMM's pattern with Inductor pattern-matching & using Inductor max-autotune to fuse the whole GEMM (I'd add its support in a PyTorch PR).

### TODO

 - [ ] Report if there's any eager mode slowdown with this approach
 - [ ] Create PyTorch PR & report inference speedup
