### PR TITLE
Enable ciflow/benchmark

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,1 +1,3 @@
 mergebot: True
+ciflow_push_tags:
+- ciflow/benchmark

--- a/.github/workflows/dashboard_perf_test.yml
+++ b/.github/workflows/dashboard_perf_test.yml
@@ -1,6 +1,9 @@
 name: A100-perf-nightly
 
 on:
+  push:
+    tags:
+      - ciflow/benchmark/*
   workflow_dispatch:
   schedule:
     - cron: 0 7 * * 0-6


### PR DESCRIPTION
This label can then be added to PR to trigger benchmark jobs.  The label can only be used after this lands though, so it's not possible to test it out in this PR.

Alternatively, people can run the benchmark manually using https://github.com/pytorch/ao/actions/workflows/dashboard_perf_test.yml, which is useful if there are parameters to customize.