### PR TITLE
Move Int4CPULayout to int4_cpu_layout.py

### DIFF
--- a/torchao/dtypes/uintx/__init__.py
+++ b/torchao/dtypes/uintx/__init__.py
@@ -13,8 +13,10 @@ from .semi_sparse_layout import (
     SemiSparseLayout,
 )
 from .tensor_core_tiled_layout import (
-    Int4CPULayout,
     TensorCoreTiledLayout,
+)
+from .int4_cpu_layout import (
+    Int4CPULayout,
 )
 from .uintx_layout import (
     UintxLayout,

--- a/torchao/dtypes/uintx/__init__.py
+++ b/torchao/dtypes/uintx/__init__.py
@@ -1,6 +1,9 @@
 from .block_sparse_layout import (
     BlockSparseLayout,
 )
+from .int4_cpu_layout import (
+    Int4CPULayout,
+)
 from .marlin_qqq_tensor import (
     MarlinQQQLayout,
     MarlinQQQTensor,
@@ -14,9 +17,6 @@ from .semi_sparse_layout import (
 )
 from .tensor_core_tiled_layout import (
     TensorCoreTiledLayout,
-)
-from .int4_cpu_layout import (
-    Int4CPULayout,
 )
 from .uintx_layout import (
     UintxLayout,

--- a/torchao/dtypes/uintx/int4_cpu_layout.py
+++ b/torchao/dtypes/uintx/int4_cpu_layout.py
@@ -2,178 +2,40 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
-from torch.utils._python_dispatch import (
-    is_traceable_wrapper_subclass,
-    return_and_correct_aliasing,
-)
+from torch.utils._python_dispatch import return_and_correct_aliasing
 
-from torchao.dtypes.affine_quantized_tensor import (
-    AffineQuantizedTensor,
-    register_layout,
-)
+from torchao.dtypes.affine_quantized_tensor import register_layout
 from torchao.dtypes.utils import AQTTensorImpl, Layout, is_device
-from torchao.quantization.quant_primitives import ZeroPointDomain, _get_reduction_params
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
     TORCH_VERSION_AT_LEAST_2_6,
     fill_defaults,
-    find_multiple,
 )
 
 aten = torch.ops.aten
 
-
-def _aqt_is_tensor_core_tile_uint4(aqt):
-    """Check if an AffineQuantizedTensor is uint4 quantized Tensor"""
-    # TODO: use torch.uint4
-    return (
-        aqt.tensor_impl.dtype == torch.int32
-        and aqt.quant_min == 0
-        and aqt.quant_max == 15
-    )
-
-
-def _linear_bf16_act_uint4_weight_check(input_tensor, weight_tensor, bias):
-    return (
-        # input is native bfloat16 tensor
-        not is_traceable_wrapper_subclass(input_tensor)
-        and input_tensor.dtype == torch.bfloat16
-        and
-        # weight is uint4, group quantized tensor_core_tiled tensor impl affine quantized tensor
-        isinstance(weight_tensor, AffineQuantizedTensor)
-        and _aqt_is_tensor_core_tile_uint4(weight_tensor)
-        and weight_tensor.dtype == torch.bfloat16
-        and len(weight_tensor.shape) == 2
-        and weight_tensor.zero_point_domain == ZeroPointDomain.FLOAT
-        and isinstance(weight_tensor._layout, TensorCoreTiledLayout)
-    )
-
-
-def _linear_bf16_act_uint4_weight_impl(input_tensor, weight_tensor, bias):
-    assert (
-        weight_tensor.block_size[0] == 1
-    ), f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
-    assert input_tensor.shape[-1] == weight_tensor.shape[1], (
-        f"need input_tensor shape: {input_tensor.shape} final"
-        f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
-    )
-
-    # TODO: check groupsize quantization
-    # avoid circular dep, TODO: move this to a common util.py
-    act_mat = input_tensor
-    # weight is packed from padded (out_features, in_features) weight tensor
-    # (same dimension requirement as F.linear weight)
-    packed_weight = weight_tensor.tensor_impl.packed_weight
-    scale_and_zero = weight_tensor.tensor_impl.scale_and_zero
-
-    orig_act_size = act_mat.size()
-    orig_dtype = act_mat.dtype
-
-    # reshape and pad activation
-    act_mat = act_mat.reshape(-1, act_mat.shape[-1]).to(torch.bfloat16)
-    pad_size = find_multiple(act_mat.shape[-1], 1024)
-    act_mat = torch.nn.functional.pad(act_mat, (0, pad_size - act_mat.shape[-1]))
-
-    # groupwise int4 quantization
-    groupsize = weight_tensor.block_size[1]
-    if is_device(input_tensor.device.type, "cpu") and TORCH_VERSION_AT_LEAST_2_6:
-        y = torch.ops.aten._weight_int4pack_mm_for_cpu(
-            act_mat.contiguous(), packed_weight, groupsize, scale_and_zero
-        )
-    else:
-        y = torch.ops.aten._weight_int4pack_mm(
-            act_mat.contiguous(), packed_weight, groupsize, scale_and_zero
-        )
-
-    # remove out_feature padding
-    orig_out_features = weight_tensor.shape[-2]
-    y = y[:, :orig_out_features]
-    y = y.reshape(*orig_act_size[:-1], orig_out_features)
-
-    if bias is not None:
-        y += bias
-    return y.to(orig_dtype)
-
-
 @dataclass(frozen=True)
-class TensorCoreTiledLayout(Layout):
+class Int4CPULayout(Layout):
+    """Only for PyTorch version at least 2.6"""
+
+    pass
+
+
+@register_layout(Int4CPULayout)
+class Int4CPUAQTTensorImpl(AQTTensorImpl):
     """
-    inner_k_tiles is an internal argument for packing function of tensor core tiled layout
-    that can affect the performance of the matmul kernel
-    """
-
-    inner_k_tiles: int = 8
-
-    def pre_process(self, input: torch.Tensor) -> torch.Tensor:
-        orig_out_features, orig_in_features = input.shape
-        in_features = find_multiple(orig_in_features, 1024)
-        out_features = find_multiple(orig_out_features, 8)
-        input = torch.nn.functional.pad(
-            input,
-            (0, in_features - orig_in_features, 0, out_features - orig_out_features),
-        )
-        return input
-
-    def pre_process_static(
-        self,
-        input: torch.Tensor,
-        scale: torch.Tensor,
-        zero_point: torch.Tensor,
-        block_size: Tuple[int, ...],
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        input = self.pre_process(input)
-        orig_qparam_shape = scale.shape
-        new_qparam_shape, reduction_dims = _get_reduction_params(
-            block_size, input.size()
-        )
-        for dim in reduction_dims:
-            new_qparam_shape.pop(dim)
-        change_in_qparam_shape = [
-            new_dim_size - orig_dim_size
-            for new_dim_size, orig_dim_size in zip(new_qparam_shape, orig_qparam_shape)
-        ]
-        padding_changes = []
-        for dim_change in change_in_qparam_shape:
-            padding_changes = [0, dim_change] + padding_changes
-        scale = torch.nn.functional.pad(scale, padding_changes)
-        zero_point = torch.nn.functional.pad(zero_point, padding_changes)
-        return input, scale, zero_point
-
-    def post_process(self, input: torch.Tensor) -> torch.Tensor:
-        orig_out_features, orig_in_features = input.shape
-        in_features = find_multiple(orig_in_features, 1024)
-        out_features = find_multiple(orig_out_features, 8)
-        input = torch.nn.functional.pad(
-            input,
-            (0, in_features - orig_in_features, 0, out_features - orig_out_features),
-        )
-        return input
-
-    def extra_repr(self):
-        return f"inner_k_tiles={self.inner_k_tiles}"
-
-
-@register_layout(TensorCoreTiledLayout)
-class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
-    """
-    TensorImpl for tensor_core_tiled layout for affine quantized tensor, this is for int4 only,
-    used by tinygemm kernels `_weight_int4pack_mm`
-
-    It stores the original tensor of dimension [n][k] (int32 dtype) as packed weight of 4-d tensor of
-    dimension: [n / 8][k / (inner_k_tiles * 16)][32][inner_k_tiles / 2]
+    TensorImpl for int4 CPU layout for affine quantized tensor, this is for int4 only,
+    used by tinygemm kernels `_weight_int4pack_mm_for_cpu`
+    It stores the original tensor of dimension [n][k] (int32 dtype) as packed weight of 2-d tensor of
+    dimension: [n][k / 2] (uint8 dtype)
     (unpacked Tensor shape is n * k)
-    where inner_k_tiles is an internal argument for packing function of tensor core tiled layout
-    that can affect the performance of the matmul kernel (defaults to 8)
-
     Note: we also pack scale and zero point together here for tinygemm kernel
-
-    Note: technically tensor core tiled layout should be the layout for the underlying packed weight
+    Note: technically Int4 CPU layout should be the layout for the underlying packed weight
     (int Tensor) but since the scale and zero_point are also packed into the same tensor here which is not used
     in plain layout, we just created a layout for AQT right now, this could be improved if we split out
     int4 aqt into a separate tensor subclass
-
     fields:
-      packed_weight (torch.Tensor): the 4-d packed tensor in a tensor_core_tiled layout
+      packed_weight (torch.Tensor): the 2-d packed tensor in a Int4 CPU layout
       scale_and_zero (torch.Tensor): the combined scale Tensor used to map between floating point tensor to quantized tensor and zero_point Tensor
     """
 
@@ -233,20 +95,32 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         zero_point: Optional[torch.Tensor],
         _layout: Layout,
     ):
-        assert isinstance(_layout, TensorCoreTiledLayout)
+        assert isinstance(_layout, Int4CPULayout)
 
-        if TORCH_VERSION_AT_LEAST_2_5:
+        if TORCH_VERSION_AT_LEAST_2_6:
+            assert (
+                int_data.dtype == torch.int32
+            ), "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"
+            packed_weight = torch.ops.aten._convert_weight_to_int4pack_for_cpu(
+                int_data,
+                1,  # TODO:remove
+            )
+        elif TORCH_VERSION_AT_LEAST_2_5:
             int_data = (int_data[::, ::2] << 4 | int_data[::, 1::2]).to(torch.uint8)
             assert (
                 int_data.dtype == torch.uint8
             ), "torch.ops.aten._convert_weight_to_int4pack in torch 2.5 expects `uint8` dtype"
+            packed_weight = torch.ops.aten._convert_weight_to_int4pack(
+                int_data, _layout.inner_k_tiles
+            )
         else:
             assert (
                 int_data.dtype == torch.int32
             ), "torch.ops.aten._convert_weight_to_int4pack in torch 2.4 expects `int32` dtype"
-        packed_weight = torch.ops.aten._convert_weight_to_int4pack(
-            int_data, _layout.inner_k_tiles
-        )
+            packed_weight = torch.ops.aten._convert_weight_to_int4pack(
+                int_data, _layout.inner_k_tiles
+            )
+
         scale = scale.reshape(int_data.shape[0], -1)
         zero_point = zero_point.reshape(int_data.shape[0], -1)
         from torchao.quantization.utils import pack_tinygemm_scales_and_zeros
@@ -257,12 +131,9 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
     def to(self, *args, **kwargs):
         kwargs = self._get_to_kwargs(*args, **kwargs)
         device = kwargs["device"]
-        # tensor core tiled layout supports both cpu and cuda but does not support the conversion
-        # between these two devices, in the future we should not use the same layout for
-        # cpu and cuda device: https://github.com/pytorch/ao/issues/1117
         if not is_device(torch.device(self.device).type, device):
             raise ValueError(
-                f"TensorCoreTiledAQTTensorImpl does not support conversion from {self.device} to {device}"
+                f"Int4CPUAQTTensorImpl does not support conversion from {self.device} to {device}"
             )
         return self.__class__(
             self.packed_weight.to(device),
@@ -272,9 +143,6 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         )
 
     def _apply_fn_to_data(self, fn):
-        # self.packed_weight = fn(self.packed_weight)
-        # self.scale_and_zero = fn(self.scale_and_zero)
-        # return self
         return self.__class__(
             fn(self.packed_weight),
             fn(self.scale_and_zero),
@@ -300,7 +168,7 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
             """we don't need to repack the weight and just rely on external
             shape being changed and record the status of transpose/no-transpose
             """
-            transposed = TensorCoreTiledAQTTensorImpl(
+            transposed = Int4CPUAQTTensorImpl(
                 args[0].packed_weight,
                 args[0].scale_and_zero,
                 not args[0].transposed,
@@ -337,11 +205,11 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
                 return sliced
             else:
                 raise NotImplementedError(
-                    f"TensorCoreTiledAQTTensorImpl dispatch: attempting to run {func}, with dim={dim}, that is not supported"
+                    f"Int4CPUAQTTensorImpl dispatch: attempting to run {func}, with dim={dim}, that is not supported"
                 )
 
         raise NotImplementedError(
-            f"TensorCoreTiledAQTTensorImpl dispatch: attempting to run {func}, this is not supported"
+            f"Int4CPUAQTTensorImpl dispatch: attempting to run {func}, this is not supported"
         )
 
     __torch_function__ = torch._C._disabled_torch_function_impl
@@ -356,9 +224,8 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         scale, zero = unpack_tinygemm_scales_and_zeros(self.scale_and_zero)
 
         cur_shape = self.shape
-        assert len(cur_shape) == 4
-        inner_k_tiles = cur_shape[-1] * 2
-        original_shape = (cur_shape[0] * 8, cur_shape[1] * (inner_k_tiles * 16))
+        assert len(cur_shape) == 2
+        original_shape = (cur_shape[0], cur_shape[1] * 2)
         eye_shape = original_shape[1]
         groupsize = int(original_shape[1] / scale.shape[-2])
         block_size = (1, groupsize)
@@ -369,7 +236,7 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         quant_max = 15
         zero_point_domain = ZeroPointDomain.FLOAT
         assert len(block_size) == 2 and block_size[0] == 1
-        dequantized = torch.ops.aten._weight_int4pack_mm(
+        dequantized = torch.ops.aten._weight_int4pack_mm_for_cpu(
             torch.eye(eye_shape, device=device, dtype=original_dtype),
             self.packed_weight,
             groupsize,

--- a/torchao/dtypes/uintx/int4_cpu_layout.py
+++ b/torchao/dtypes/uintx/int4_cpu_layout.py
@@ -14,6 +14,7 @@ from torchao.utils import (
 
 aten = torch.ops.aten
 
+
 @dataclass(frozen=True)
 class Int4CPULayout(Layout):
     """Only for PyTorch version at least 2.6"""


### PR DESCRIPTION
This PR is to move Int4CPULayout to int4_cpu_layout.py, which is required in https://github.com/pytorch/ao/pull/1278#discussion_r1884352308.