### PR TITLE
Fix error message in float8 FSDP utils

### DIFF
--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -45,7 +45,7 @@ def precompute_float8_dynamic_scale_for_fsdp(module: nn.Module) -> None:
         isinstance(m, Float8Linear) and m.scaling_type_weight is ScalingType.DELAYED
         for m in module.modules()
     ):
-        raise NotImplementedError("Only supports delayed scaling")
+        raise NotImplementedError("Only supports dynamic scaling")
     float8_linears: List[Float8Linear] = [
         m
         for m in module.modules()


### PR DESCRIPTION
Fixes #1108 

Error message should say `"Only supports dynamic scaling"`.