### PR TITLE
[float8nocompile] Initial commit of float8nocompile prototype

### DIFF
--- a/torchao/prototype/float8nocompile/.gitignore
+++ b/torchao/prototype/float8nocompile/.gitignore
@@ -1,0 +1,2 @@
+examples/
+kernels/

--- a/torchao/prototype/float8nocompile/README.md
+++ b/torchao/prototype/float8nocompile/README.md
@@ -1,0 +1,3 @@
+# Work in progress
+
+A prototype version of Float8Linear which is performant without `torch.compile`.

--- a/torchao/prototype/float8nocompile/float8nocompile_linear.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+A simple module swap UX for a float8 version of `torch.nn.Linear` which
+does not require `torch.compile` to be performant..
+"""
+
+import torch
+
+
+class Float8LinearNoCompile(torch.nn.Linear):
+    """
+    Float8LinearNoCompile is a version of Float8Linear that does not require
+    the use of torch.compile to be performant.
+
+    Note: this is **prototype** and not suitable for production use.
+    """
+
+    pass

--- a/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import logging
+from typing import Callable, Optional
+
+import torch
+import torch.nn as nn
+
+from torchao.float8.config import Float8LinearConfig
+from torchao.float8.float8_linear_utils import swap_linear_layers
+
+from torchao.prototype.float8nocompile.float8_linear import Float8LinearNoCompile
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+def convert_to_float8_nocompile_training(
+    module: nn.Module,
+    *,
+    module_filter_fn: Optional[Callable[[nn.Module, str], bool]] = None,
+    config: Float8LinearConfig = None,
+) -> nn.Module:
+    """
+    Swaps `torch.nn.Linear` in `module` with `Float8LinearNoCompile`.
+
+    Args:
+        module: Module to modify.
+        module_filter_fn: If specified, only the `torch.nn.Linear` subclasses that
+            that pass the filter function will be swapped. The inputs to the
+            filter function are the module instance and the FQN.
+        config (Float8LinearConfig): configuration for conversion to float8
+
+    Returns:
+     nn.Module: The modified module with swapped linear layers.
+    """
+    if config is None:
+        config = Float8LinearConfig()
+    from_float = lambda m: Float8LinearNoCompile.from_float(
+        m,
+        config=config,
+    )
+    return swap_linear_layers(
+        module,
+        from_float,
+        module_filter_fn=module_filter_fn,
+    )


### PR DESCRIPTION
This PR is the initial commit for the float8nocompile prototype.

Changes:
- Create the float8nocompile prototype directory
- Define the entry point conversion function `convert_to_float8_nocompile_training()` 
- Define empty `Float8LinearNoCompile` class which will be fleshed out in subsequent PRs.
- Add temporary .gitignore file ignoring WIP test files and Triton kernels, to avoid accidentally including them prematurely