### PR TITLE
[float8nocompile] Simplified Float8Linear implementation which only supports dynamic tensorwise scaling

### DIFF
--- a/torchao/prototype/float8nocompile/.gitignore
+++ b/torchao/prototype/float8nocompile/.gitignore
@@ -1,2 +1,1 @@
-examples/
 kernels/

--- a/torchao/prototype/float8nocompile/examples/example.py
+++ b/torchao/prototype/float8nocompile/examples/example.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+
+from torchao.prototype.float8nocompile.float8nocompile_linear_utils import (
+    convert_to_float8_nocompile_training,
+)
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
+
+if not TORCH_VERSION_AT_LEAST_2_5:
+    raise AssertionError("torchao.float8 requires PyTorch version 2.5 or greater")
+
+# create model and sample input
+m = (
+    nn.Sequential(
+        nn.Linear(32, 32),
+    )
+    .bfloat16()
+    .cuda()
+)
+x = torch.randn(32, 32, device="cuda", dtype=torch.bfloat16)
+optimizer = torch.optim.SGD(m.parameters(), lr=0.1)
+
+# convert specified `torch.nn.Linear` modules to `Float8Linear`
+print("calling convert_to_float8_nocompile_training")
+convert_to_float8_nocompile_training(m)
+print("finished convert_to_float8_nocompile_training")
+
+for i in range(10):
+    print(f"step {i}")
+    optimizer.zero_grad()
+    y = m(x)
+    y.sum().backward()
+    optimizer.step()

--- a/torchao/prototype/float8nocompile/float8nocompile_linear.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear.py
@@ -5,10 +5,27 @@
 # LICENSE file in the root directory of this source tree.
 """
 A simple module swap UX for a float8 version of `torch.nn.Linear` which
-does not require `torch.compile` to be performant..
+does not require `torch.compile` to be performant.
 """
+from typing import Optional
 
 import torch
+
+from torchao.float8.config import Float8LinearConfig, ScalingGranularity, ScalingType
+from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
+from torchao.float8.float8_linear import manual_float8_matmul_with_args_in_float8
+from torchao.float8.float8_scaling_utils import NoopFwToFloat8BwDynamic
+from torchao.float8.float8_tensor import (
+    GemmInputRole,
+    hp_tensor_and_scale_to_float8,
+    LinearMMConfig,
+    ScaledMMConfig,
+)
+from torchao.float8.float8_utils import tensor_to_scale
+
+from torchao.prototype.float8nocompile.float8nocompile_scaling_utils import (
+    hp_tensor_to_float8nocompile_dynamic,
+)
 
 
 class Float8LinearNoCompile(torch.nn.Linear):
@@ -19,4 +36,149 @@ class Float8LinearNoCompile(torch.nn.Linear):
     Note: this is **prototype** and not suitable for production use.
     """
 
-    pass
+    def __init__(self, *args, **kwargs):
+        """
+        Additional arguments on top of `torch.nn.Linear`'s arguments:
+        * `config`: Float8LinearConfig
+        """
+
+        # Amax scales should always be kept as float32.
+        self.always_float32_buffers = set()
+        config = kwargs.pop("config")
+        emulate = config.emulate
+        super().__init__(*args, **kwargs)
+
+        # Defines the scaling behavior of input, weight, grad_output
+        self.scaling_type_input = config.cast_config_input.scaling_type
+        self.scaling_type_weight = config.cast_config_weight.scaling_type
+        self.scaling_type_grad_output = config.cast_config_grad_output.scaling_type
+
+        self.config = config
+        self.is_amax_initialized = not self.config.enable_amax_init
+
+        self.linear_mm_config = LinearMMConfig(
+            # output
+            ScaledMMConfig(
+                emulate,
+                self.config.gemm_config_output.use_fast_accum,
+                False,
+                self.config.pad_inner_dim,
+            ),
+            # grad_input
+            ScaledMMConfig(
+                emulate,
+                self.config.gemm_config_grad_input.use_fast_accum,
+                False,
+                self.config.pad_inner_dim,
+            ),
+            # grad_weight
+            ScaledMMConfig(
+                emulate,
+                self.config.gemm_config_grad_weight.use_fast_accum,
+                False,
+                self.config.pad_inner_dim,
+            ),
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        # TODO(danielvegamyhre): modify to support for FSDP once dependencies are implemented
+        output = self.forward_fp8_matmul(input)
+        if self.bias is not None:
+            output = output + self.bias.to(output.dtype)
+        return output
+
+    def forward_fp8_matmul(self, input: torch.Tensor) -> torch.Tensor:
+        # perform hp to fp8 conversions
+        # TODO(danielvegamyhre): replace conversion with triton kernels
+        input_fp8 = self.cast_input_to_float8(input, self.is_amax_initialized)
+        weight_scale = self.get_weight_scale(self.weight)
+        weight_fp8_t = self.cast_weight_to_float8_t(
+            self.weight, self.is_amax_initialized, weight_scale
+        )
+
+        # compute fp8 matmul
+        output = manual_float8_matmul_with_args_in_float8.apply(input_fp8, weight_fp8_t)
+
+        # cast grad_output to float8_e5m2 during backward
+        # TODO(danielvegamyhre): replace with triton kernel
+        return self.cast_output_to_float8_in_bw(output)
+
+    def cast_input_to_float8(
+        self, input: torch.Tensor, is_amax_initialized: bool
+    ) -> torch.Tensor:
+        # Duplicate the autocast logic for F.linear, so that the output
+        # of our module has the right original precision
+        if torch.is_autocast_enabled():
+            # For now, hardcode to GPU's autocast dtype
+            # if we need CPU support in the future, we can add it
+            autocast_dtype = torch.get_autocast_gpu_dtype()
+            input = input.to(autocast_dtype)
+
+        # TODO(danielvegamyhre): implement this fn in scaling_utils with call to triton kernel
+        return hp_tensor_to_float8nocompile_dynamic(
+            input,
+            self.config.cast_config_input.target_dtype,
+            self.linear_mm_config,
+            gemm_input_role=GemmInputRole.INPUT,
+        )
+
+    def get_weight_scale(self, weight: torch.Tensor) -> Optional[torch.Tensor]:
+        # TODO(danielvegamyhre): replace scale calculation with triton kernel
+        if tensor_already_casted_to_fp8(weight):
+            return None
+        return tensor_to_scale(weight, self.config.cast_config_weight.target_dtype)
+
+    def cast_weight_to_float8_t(
+        self,
+        weight: torch.Tensor,
+        is_amax_initialized: bool,
+        weight_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if tensor_already_casted_to_fp8(weight):
+            return weight.t()
+
+        # TODO(danielvegamyhre): replace conversion with triton kernel
+        weight_fp8 = hp_tensor_and_scale_to_float8(
+            weight,
+            weight_scale,
+            self.config.cast_config_weight.target_dtype,
+            self.linear_mm_config,
+            gemm_input_role=GemmInputRole.WEIGHT,
+        )
+        return weight_fp8.t()
+
+    def cast_output_to_float8_in_bw(self, output: torch.Tensor) -> torch.Tensor:
+        # TODO(danielvegamyhre): replace conversion with triton kernel
+        return NoopFwToFloat8BwDynamic.apply(
+            output,
+            self.linear_mm_config,
+            self.config.cast_config_grad_output.target_dtype,
+        )
+
+    @classmethod
+    def from_float(
+        cls,
+        mod,
+        config: Optional[Float8LinearConfig] = None,
+    ):
+        """
+        Create an nn.Linear with fp8 compute from a regular nn.Linear
+
+        Args:
+            mod (torch.nn.Linear): nn.Linear to convert
+            config (Optional[Float8LinearConfig]): configuration for conversion to float8
+        """
+        if config is None:
+            config = Float8LinearConfig()
+        with torch.device("meta"):
+            new_mod = cls(
+                mod.in_features,
+                mod.out_features,
+                bias=False,
+                config=config,
+            )
+        new_mod.weight = mod.weight
+        new_mod.bias = mod.bias
+
+        # TODO(danielvegamyhre): support for FSDP once dependencies are implemented
+        return new_mod

--- a/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
@@ -12,7 +12,9 @@ import torch.nn as nn
 from torchao.float8.config import Float8LinearConfig
 from torchao.float8.float8_linear_utils import swap_linear_layers
 
-from torchao.prototype.float8nocompile.float8_linear import Float8LinearNoCompile
+from torchao.prototype.float8nocompile.float8nocompile_linear import (
+    Float8LinearNoCompile,
+)
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear_utils.py
@@ -24,7 +24,6 @@ def convert_to_float8_nocompile_training(
     module: nn.Module,
     *,
     module_filter_fn: Optional[Callable[[nn.Module, str], bool]] = None,
-    config: Float8LinearConfig = None,
 ) -> nn.Module:
     """
     Swaps `torch.nn.Linear` in `module` with `Float8LinearNoCompile`.
@@ -39,12 +38,7 @@ def convert_to_float8_nocompile_training(
     Returns:
      nn.Module: The modified module with swapped linear layers.
     """
-    if config is None:
-        config = Float8LinearConfig()
-    from_float = lambda m: Float8LinearNoCompile.from_float(
-        m,
-        config=config,
-    )
+    from_float = lambda m: Float8LinearNoCompile.from_float(m)
     return swap_linear_layers(
         module,
         from_float,

--- a/torchao/prototype/float8nocompile/float8nocompile_scaling_utils.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_scaling_utils.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utilities for scaling high precision tensors to float8.
+"""
+
+from typing import Optional
+
+import torch
+
+from torchao.float8.config import ScalingGranularity
+from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
+from torchao.float8.float8_tensor import (
+    Float8Tensor,
+    GemmInputRole,
+    hp_tensor_and_scale_to_float8,
+    LinearMMConfig,
+)
+from torchao.float8.float8_utils import tensor_to_scale
+
+
+def hp_tensor_to_float8nocompile_dynamic(
+    hp_tensor: torch.Tensor,
+    float8_dtype: torch.dtype,
+    linear_mm_config: LinearMMConfig,
+    reduce_amax: bool = False,
+    gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
+    device_mesh=None,
+    scaling_granularity: ScalingGranularity = ScalingGranularity.TENSORWISE,
+    axiswise_dim: Optional[int] = None,
+) -> Float8Tensor:
+    """
+    Given a high precision tensor `hp_tensor`,
+    scales `hp_tensor` dynamically and returns a `Float8Tensor` of the result.
+
+    Args:
+        hp_tensor: the tensor to convert
+        float8_dtype: the float8 dtype to use
+        linear_mm_config: Defines the configuration for the scaled_mm for
+          the 3 fwd/bwd gemms of linear
+        reduce_amax: whether to reduce the max(abs(hp_tensor)) value across distributed ranks
+        gemm_input_role: Defines the role of this tensor (input, weight or grad_output) in
+          the 3 fwd/bwd gemms of linear
+        scaling_granularity: Defines the scaling granularity
+        axiswise_dim: if axiswise granularity is used, defines the dim to scale across
+    """
+    # TODO(danielvegamyhre): replace this torch implementation with custom triton kernel
+    if tensor_already_casted_to_fp8(hp_tensor):
+        return hp_tensor
+    scale = tensor_to_scale(
+        hp_tensor,
+        float8_dtype,
+        reduce_amax,
+        device_mesh,
+        scaling_granularity,
+        axiswise_dim,
+    )
+    return hp_tensor_and_scale_to_float8(
+        hp_tensor,
+        scale,
+        float8_dtype,
+        linear_mm_config,
+        gemm_input_role,
+        axiswise_dim,
+    )


### PR DESCRIPTION
Summary:

This PR adds a simplified implementation of Float8Linear dubbed `Float8LinearNoCompile` which only supports dynamic tensorwise scaling. I've used TODOs to mark the places where I need to replace the torch based logic with custom triton kernels, in order to improve eager mode performance. Once those kernels have been implemented, I'll benchmark the performance and do some profiling to identify bottlenecks and find additional optimization opportunities. 

The purpose of starting with  this is to start with a simple implementation which works e2e for float8 training (as shown in the test plan section below), so that as I start replacing torch logic with new triton kernels, I can use the e2e training example as a basic test to validate it's still working.

Test plan:
- Validated this simplified implementation works e2e by running a simple example in `examples/example.py`:

```
[danvm@devgpu006.vll6 /data/users/danvm/ao/torchao/prototype/float8nocompile/examples (linear1)]$ python3 example.py 
calling convert_to_float8_nocompile_training
finished convert_to_float8_nocompile_training
step 0
step 1
step 2
step 3
step 4
step 5
step 6
step 7
step 8
step 9
```