### PR TITLE
Gemlite fixes

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -962,6 +962,14 @@ class TestSubclass(unittest.TestCase):
                             test_shape=test_shape,
                             test_dtype=dtype,
                         )
+        # test that shapes with non divisible by 128 shapes aren't causing errors
+        self._test_lin_weight_subclass_api_impl(
+            lambda mod: quantize_(mod, gemlite_uintx_weight_only(None, 4, 32)),
+            device,
+            15, 
+            test_shape=[1, 1025, 513],
+            test_dtype=dtype,
+        )
 
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)

--- a/torchao/dtypes/uintx/gemlite_layout.py
+++ b/torchao/dtypes/uintx/gemlite_layout.py
@@ -15,6 +15,7 @@ from torchao.dtypes.uintx.tensor_core_tiled_layout import TensorCoreTiledAQTTens
 from torchao.dtypes.utils import Layout, is_device
 from torchao.quantization.quant_primitives import quantize_affine
 from torchao.utils import fill_defaults
+import warnings
 
 aten = torch.ops.aten
 
@@ -75,6 +76,14 @@ def apply_gemlite_quant(
 
     out_features, in_features = weight.shape
     group_size = in_features if group_size is None else group_size
+
+    if in_features % 128 != 0 and out_features % 128 != 0:
+        warnings.simplefilter("once", UserWarning)
+        warnings.warn(
+            "Gemlite only works for layers with in_features or out_features divisible by 128, "
+            + "some layers have been skipped", UserWarning
+        )
+        return weight
 
     quant_kwargs = get_gemlite_quant_kwargs(bit_width, group_size)
 
@@ -173,6 +182,10 @@ class GemliteAQTTensorImpl(TensorCoreTiledAQTTensorImpl):
             exhaustive=False,
             use_cuda_graph=False,
         )
+        if _layout.group_size == None and _layout.bit_width == 4:
+                from gemlite.core import GEMLITE_ACC_DTYPE
+                from gemlite.dtypes import DType
+                GEMLITE_ACC_DTYPE[DType.FP16] = DType.FP32
 
         out_features, in_features = int_data.shape
         input_dtype, output_dtype = DType.FP16, DType.FP16


### PR DESCRIPTION
Summary:

shapes need to be divisible by 128 or they will not work with gemlite need fp32 accumulation for groupsize None on int4

Test Plan:

python test_integration.py -k "test_gemlite" (new test for non divisible shape)a

python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --compile --precision float16 --quantization gemlite-8-4-None  --write_result benchmark_results.txt python generate.py --checkpoint_path
$CHECKPOINT_PATH/$MODEL_REPO/model.pth --compile --precision float16 --quantization gemlite-32-4-None  --write_result benchmark_results.txta

(previously these gave nonsense responses)

Reviewers:

Subscribers:

Tasks:

Tags: