### PR TITLE
[float8nocompile] Add unit tests validating model outputs, weight gradients, input gradients match expected values

### DIFF
--- a/torchao/prototype/float8nocompile/float8nocompile_linear.py
+++ b/torchao/prototype/float8nocompile/float8nocompile_linear.py
@@ -15,12 +15,7 @@ from torchao.float8.config import Float8LinearConfig, ScalingGranularity, Scalin
 from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
 from torchao.float8.float8_linear import manual_float8_matmul_with_args_in_float8
 from torchao.float8.float8_scaling_utils import NoopFwToFloat8BwDynamic
-from torchao.float8.float8_tensor import (
-    GemmInputRole,
-    hp_tensor_and_scale_to_float8,
-    LinearMMConfig,
-    ScaledMMConfig,
-)
+from torchao.float8.float8_tensor import GemmInputRole, LinearMMConfig, ScaledMMConfig
 from torchao.float8.float8_utils import tensor_to_scale
 
 from torchao.prototype.float8nocompile.float8nocompile_scaling_utils import (

--- a/torchao/prototype/float8nocompile/test/test.py
+++ b/torchao/prototype/float8nocompile/test/test.py
@@ -3,11 +3,9 @@ import torch
 import torch.nn as nn
 
 from torchao.float8.float8_linear_utils import convert_to_float8_training
-
 from torchao.prototype.float8nocompile.float8nocompile_linear_utils import (
     convert_to_float8_nocompile_training,
 )
-
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
@@ -46,14 +44,19 @@ def test_model_weights_and_gradients(model1, model2):
     model2 = model2.to(torch.bfloat16).to(device)
 
     # compare production float8 linear conversion with no-compile version
-    convert_to_float8_nocompile_training(model1)
     convert_to_float8_training(model2)
+    convert_to_float8_nocompile_training(model1)
 
-    input_data = torch.randn(16, 32, dtype=torch.bfloat16).to(device)
+    input_tensor = torch.randn(
+        16, 32, requires_grad=True, dtype=torch.bfloat16, device=device
+    )
+    input_copy1 = input_tensor.clone().detach().requires_grad_(True)
+    input_copy2 = input_tensor.clone().detach().requires_grad_(True)
+
     loss_fn = nn.MSELoss()
 
-    output1 = model1(input_data)
-    output2 = model2(input_data)
+    output1 = model1(input_copy1)
+    output2 = model2(input_copy2)
 
     loss1 = loss_fn(output1, torch.zeros_like(output1))
     loss2 = loss_fn(output2, torch.zeros_like(output2))
@@ -61,7 +64,8 @@ def test_model_weights_and_gradients(model1, model2):
     loss1.backward()
     loss2.backward()
 
-    # compare the weights and gradients of both models
+    # compare the outputs, weight gradients, and input gradients
+    assert torch.allclose(output1, output2, atol=0, rtol=0)
+    assert torch.allclose(input_copy1.grad, input_copy2.grad, atol=0, rtol=0)
     for param1, param2 in zip(model1.parameters(), model2.parameters()):
-        assert torch.allclose(param1.data, param2.data, atol=0, rtol=0)
         assert torch.allclose(param1.grad, param2.grad, atol=0, rtol=0)

--- a/torchao/prototype/float8nocompile/test/test.py
+++ b/torchao/prototype/float8nocompile/test/test.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from torchao.float8.float8_linear_utils import convert_to_float8_training
+from torchao.prototype.float8nocompile.float8nocompile_linear_utils import (
+    convert_to_float8_nocompile_training,
+)
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
+
+if not TORCH_VERSION_AT_LEAST_2_5:
+    raise AssertionError("torchao.float8 requires PyTorch version 2.5 or greater")
+
+
+class TestModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(32, 64, bias=False),
+            nn.Linear(64, 32, bias=False),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+@pytest.fixture
+def model1():
+    torch.manual_seed(0)
+    return TestModel()
+
+
+@pytest.fixture
+def model2():
+    torch.manual_seed(0)
+    return TestModel()
+
+
+def test_model_weights_and_gradients(model1, model2):
+    assert torch.cuda.is_available()
+    device = torch.device("cuda")
+
+    model1.to(torch.bfloat16).to(device)
+    model2.to(torch.bfloat16).to(device)
+
+    # swap nn.Linear layers with Float8LinearNoCompile layers in model1 only
+    convert_to_float8_nocompile_training(model1)
+
+    input_data = torch.randn(16, 32, dtype=torch.bfloat16).to(device)
+    optim1 = torch.optim.SGD(model1.parameters(), lr=0.01)
+    optim2 = torch.optim.SGD(model2.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+
+    for i in range(1):
+        print(f"step {i}")
+        optim1.zero_grad()
+        optim2.zero_grad()
+
+        output1 = model1(input_data)
+        output2 = model2(input_data)
+
+        loss1 = loss_fn(output1, torch.zeros_like(output1))
+        loss2 = loss_fn(output2, torch.zeros_like(output2))
+
+        loss1.backward()
+        loss2.backward()
+
+        optim1.step()
+        optim2.step()
+
+        # compare the weights and gradients of both models
+        for param1, param2 in zip(model1.parameters(), model2.parameters()):
+            assert torch.allclose(param1.data, param2.data, atol=1e-3, rtol=1e-3)
+            assert torch.allclose(param1.grad, param2.grad, atol=1e-3, rtol=1e-3)

--- a/torchao/prototype/float8nocompile/test/test.py
+++ b/torchao/prototype/float8nocompile/test/test.py
@@ -2,10 +2,10 @@ import pytest
 import torch
 import torch.nn as nn
 
-from torchao.float8.float8_linear_utils import convert_to_float8_training
 from torchao.prototype.float8nocompile.float8nocompile_linear_utils import (
     convert_to_float8_nocompile_training,
 )
+
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if not TORCH_VERSION_AT_LEAST_2_5:
@@ -40,35 +40,25 @@ def test_model_weights_and_gradients(model1, model2):
     assert torch.cuda.is_available()
     device = torch.device("cuda")
 
-    model1.to(torch.bfloat16).to(device)
-    model2.to(torch.bfloat16).to(device)
+    model1 = model1.to(torch.bfloat16).to(device)
+    model2 = model2.to(torch.bfloat16).to(device)
 
     # swap nn.Linear layers with Float8LinearNoCompile layers in model1 only
     convert_to_float8_nocompile_training(model1)
 
     input_data = torch.randn(16, 32, dtype=torch.bfloat16).to(device)
-    optim1 = torch.optim.SGD(model1.parameters(), lr=0.01)
-    optim2 = torch.optim.SGD(model2.parameters(), lr=0.01)
     loss_fn = nn.MSELoss()
 
-    for i in range(1):
-        print(f"step {i}")
-        optim1.zero_grad()
-        optim2.zero_grad()
+    output1 = model1(input_data)
+    output2 = model2(input_data)
 
-        output1 = model1(input_data)
-        output2 = model2(input_data)
+    loss1 = loss_fn(output1, torch.zeros_like(output1))
+    loss2 = loss_fn(output2, torch.zeros_like(output2))
 
-        loss1 = loss_fn(output1, torch.zeros_like(output1))
-        loss2 = loss_fn(output2, torch.zeros_like(output2))
+    loss1.backward()
+    loss2.backward()
 
-        loss1.backward()
-        loss2.backward()
-
-        optim1.step()
-        optim2.step()
-
-        # compare the weights and gradients of both models
-        for param1, param2 in zip(model1.parameters(), model2.parameters()):
-            assert torch.allclose(param1.data, param2.data, atol=1e-3, rtol=1e-3)
-            assert torch.allclose(param1.grad, param2.grad, atol=1e-3, rtol=1e-3)
+    # compare the weights and gradients of both models
+    for param1, param2 in zip(model1.parameters(), model2.parameters()):
+        assert torch.allclose(param1.data, param2.data, atol=0, rtol=0)
+        assert torch.allclose(param1.grad, param2.grad, atol=1e-3, rtol=1e-3)

--- a/torchao/prototype/float8nocompile/test/test.py
+++ b/torchao/prototype/float8nocompile/test/test.py
@@ -2,6 +2,8 @@ import pytest
 import torch
 import torch.nn as nn
 
+from torchao.float8.float8_linear_utils import convert_to_float8_training
+
 from torchao.prototype.float8nocompile.float8nocompile_linear_utils import (
     convert_to_float8_nocompile_training,
 )
@@ -43,8 +45,9 @@ def test_model_weights_and_gradients(model1, model2):
     model1 = model1.to(torch.bfloat16).to(device)
     model2 = model2.to(torch.bfloat16).to(device)
 
-    # swap nn.Linear layers with Float8LinearNoCompile layers in model1 only
+    # compare production float8 linear conversion with no-compile version
     convert_to_float8_nocompile_training(model1)
+    convert_to_float8_training(model2)
 
     input_data = torch.randn(16, 32, dtype=torch.bfloat16).to(device)
     loss_fn = nn.MSELoss()
@@ -61,4 +64,4 @@ def test_model_weights_and_gradients(model1, model2):
     # compare the weights and gradients of both models
     for param1, param2 in zip(model1.parameters(), model2.parameters()):
         assert torch.allclose(param1.data, param2.data, atol=0, rtol=0)
-        assert torch.allclose(param1.grad, param2.grad, atol=1e-3, rtol=1e-3)
+        assert torch.allclose(param1.grad, param2.grad, atol=0, rtol=0)


### PR DESCRIPTION
**Summary**

The purpose of this change is to add a unit test validating weights and gradients are equal for the production float8 conversion path and the new float8nocompile path.

Note: this is different than the example in `examples/example.py` which is just a simple runnable e2e example documenting the UX.

**Test plan**:

Test is passing.

```
[danvm@devgpu006.vll6 ~/local/ao/torchao/prototype/float8nocompile/test (test)]$ pytest test.py
========================================================= test session starts =========================================================
platform linux -- Python 3.13.1, pytest-7.4.0, pluggy-1.5.0
rootdir: /data/users/danvm/ao
plugins: hypothesis-6.122.3
collected 1 item                                                                                                                      

test.py .                                                                                                                       [100%]

========================================================== warnings summary ===========================================================
test.py:15
  /data/users/danvm/ao/torchao/prototype/float8nocompile/test/test.py:15: PytestCollectionWarning: cannot collect test class 'TestModel' because it has a __init__ constructor (from: torchao/prototype/float8nocompile/test/test.py)
    class TestModel(nn.Module):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 1 passed, 1 warning in 2.52s =====================================================
[danvm@devgpu006.vll6 ~/local/ao/torchao/prototype/float8nocompile/test (test)]$ 
```