### PR TITLE
refactor: move delayed and static scaling to StatefulFloat8Linear

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -55,9 +55,11 @@ from torchao.float8.float8_tensor import (
 from torchao.float8.float8_utils import (
     FP8_TYPES,
     compute_error,
+    config_has_stateful_scaling,
     fp8_tensor_statistics,
     tensor_to_scale,
 )
+from torchao.float8.stateful_float8_linear import StatefulFloat8Linear
 from torchao.testing.float8.test_utils import get_test_float8_linear_config
 
 random.seed(0)
@@ -279,10 +281,17 @@ class TestFloat8Linear:
         config: Float8LinearConfig,
         use_ac: bool = False,
     ):
-        m_fp8 = Float8Linear.from_float(
-            copy.deepcopy(m_ref),
-            config,
-        )
+        if config_has_stateful_scaling(config):
+            m_fp8 = StatefulFloat8Linear.from_float(
+                copy.deepcopy(m_ref),
+                config,
+            )
+        else:
+            m_fp8 = Float8Linear.from_float(
+                copy.deepcopy(m_ref),
+                config,
+            )
+
         for _ in range(2):
             if use_ac:
                 y_fp8 = torch.utils.checkpoint.checkpoint(m_fp8, x, use_reentrant=False)

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -48,6 +48,8 @@ from torchao.float8.float8_tensor import (
     LinearMMConfig,
     ScaledMMConfig,
 )
+from torchao.float8.float8_utils import config_has_stateful_scaling
+from torchao.float8.stateful_float8_linear import StatefulFloat8Linear
 from torchao.testing.float8.test_utils import get_test_float8_linear_config
 
 
@@ -66,10 +68,16 @@ def _test_compile_base(
     x_ref = copy.deepcopy(x)
     m_ref = nn.Linear(16, 32, bias=True, device="cuda", dtype=linear_dtype)
 
-    m_fp8 = Float8Linear.from_float(
-        copy.deepcopy(m_ref),
-        config,
-    )
+    if config_has_stateful_scaling(config):
+        m_fp8 = StatefulFloat8Linear.from_float(
+            copy.deepcopy(m_ref),
+            config,
+        )
+    else:
+        m_fp8 = Float8Linear.from_float(
+            copy.deepcopy(m_ref),
+            config,
+        )
 
     m_fp8 = torch.compile(m_fp8, backend=backend, fullgraph=fullgraph)
     m_ref = torch.compile(m_ref, backend=backend, fullgraph=fullgraph)

--- a/torchao/float8/__init__.py
+++ b/torchao/float8/__init__.py
@@ -11,7 +11,6 @@ from torchao.float8.config import (
     Float8LinearConfig,
     ScalingType,
 )
-from torchao.float8.float8_linear import WeightWithDelayedFloat8CastTensor
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
     linear_requires_sync,
@@ -25,6 +24,7 @@ from torchao.float8.float8_tensor import (
 )
 from torchao.float8.fsdp_utils import precompute_float8_dynamic_scale_for_fsdp
 from torchao.float8.inference import Float8MMConfig
+from torchao.float8.stateful_float8_linear import WeightWithDelayedFloat8CastTensor
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_5
 
 if TORCH_VERSION_AT_LEAST_2_5:

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -15,14 +15,9 @@ import torch.utils.checkpoint as checkpoint
 from torchao.float8.config import Float8LinearConfig, ScalingGranularity, ScalingType
 from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
 from torchao.float8.float8_scaling_utils import (
-    NoopFwToFloat8BwDelayed,
     NoopFwToFloat8BwDynamic,
-    NoopFwToFloat8BwStatic,
-    _maybe_initialize_amaxes_scales_for_float8_cast,
     get_maybe_axiswise_dim,
-    hp_tensor_to_float8_delayed,
     hp_tensor_to_float8_dynamic,
-    hp_tensor_to_float8_static,
 )
 from torchao.float8.float8_tensor import (
     Float8Tensor,
@@ -31,15 +26,8 @@ from torchao.float8.float8_tensor import (
     ScaledMMConfig,
     hp_tensor_and_scale_to_float8,
 )
-from torchao.float8.float8_utils import (
-    tensor_to_amax,
-    tensor_to_scale,
-)
-from torchao.float8.fsdp_utils import (
-    WeightWithDelayedFloat8CastTensor,
-    WeightWithDynamicFloat8CastTensor,
-    WeightWithStaticFloat8CastTensor,
-)
+from torchao.float8.float8_utils import tensor_to_scale
+from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 
 
 @torch._dynamo.allow_in_graph
@@ -283,143 +271,40 @@ class Float8Linear(torch.nn.Linear):
         * `config`: Float8LinearConfig
         """
 
-        # Amax scales should always be kept as float32.
-        self.always_float32_buffers = set()
         config = kwargs.pop("config")
-        emulate = config.emulate
         super().__init__(*args, **kwargs)
 
         # Defines the scaling behavior of input, weight, grad_output
         self.scaling_type_input = config.cast_config_input.scaling_type
         self.scaling_type_weight = config.cast_config_weight.scaling_type
         self.scaling_type_grad_output = config.cast_config_grad_output.scaling_type
-        # Convenience flag to skip code related to delayed scaling
-        self.has_any_delayed_scaling = (
-            self.scaling_type_input is ScalingType.DELAYED
-            or self.scaling_type_weight is ScalingType.DELAYED
-            or self.scaling_type_grad_output is ScalingType.DELAYED
-        )
-
         self.config = config
-
-        self.create_buffers()
 
         self.linear_mm_config = LinearMMConfig(
             # output
             ScaledMMConfig(
-                emulate,
+                config.emulate,
                 self.config.gemm_config_output.use_fast_accum,
                 False,
                 self.config.pad_inner_dim,
             ),
             # grad_input
             ScaledMMConfig(
-                emulate,
+                config.emulate,
                 self.config.gemm_config_grad_input.use_fast_accum,
                 False,
                 self.config.pad_inner_dim,
             ),
             # grad_weight
             ScaledMMConfig(
-                emulate,
+                config.emulate,
                 self.config.gemm_config_grad_weight.use_fast_accum,
                 False,
                 self.config.pad_inner_dim,
             ),
         )
 
-        # Note: is_amax_initialized is not a buffer to avoid data dependent
-        # control flow visible to dynamo
-        # TODO(future PR): add serialization for this flag
-        self.is_amax_initialized = not self.config.enable_amax_init
-
-        # pre_forward and post_forward are currently broken with FSDP
-        # and torch.compile, this option can disable them
-        # Note that when using `self.config.enable_pre_and_post_forward = False`,
-        # it's recommended to also set `self.config.enable_amax_init = False`.
-        # Otherwise, the amax buffer would never be marked as initialized and
-        # would be initialized in every iteration.
-        self.enable_pre_and_post_forward = self.config.enable_pre_and_post_forward
-
-    def create_buffers(self):
-        # Default values for history buffers, see above TODO
-        history_len = self.config.delayed_scaling_config.history_len
-        device = self.weight.device
-        default_input = torch.finfo(self.config.cast_config_input.target_dtype).max
-        default_weight = torch.finfo(self.config.cast_config_weight.target_dtype).max
-        default_grad_output = torch.finfo(
-            self.config.cast_config_grad_output.target_dtype
-        ).max
-
-        # Note: for now, create all the buffers if any are needed, to postpone
-        # the work to make the scale and amax syncing and history calculation
-        # handle a heterogeneous setup. We can do that work later if benchmarks
-        # show it is worth doing.
-        if self.has_any_delayed_scaling:
-            self.register_always_float32_buffer(
-                "fp8_amax_input", torch.tensor([default_input], device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_amax_history_input", torch.zeros(history_len, device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_scale_input", torch.tensor([1.0], device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_amax_weight", torch.tensor([default_weight], device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_amax_history_weight", torch.zeros(history_len, device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_scale_weight", torch.tensor([1.0], device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_amax_grad_output",
-                torch.tensor([default_grad_output], device=device),
-            )
-            self.register_always_float32_buffer(
-                "fp8_amax_history_grad_output", torch.zeros(history_len, device=device)
-            )
-            self.register_always_float32_buffer(
-                "fp8_scale_grad_output", torch.tensor([1.0], device=device)
-            )
-
-        if self.config.cast_config_input.static_scale is not None:
-            self.register_always_float32_buffer(
-                "fp8_static_scale_input",
-                self.config.cast_config_input.static_scale.to(device),
-            )
-        if self.config.cast_config_weight.static_scale is not None:
-            self.register_always_float32_buffer(
-                "fp8_static_scale_weight",
-                self.config.cast_config_weight.static_scale.to(device),
-            )
-        if self.config.cast_config_grad_output.static_scale is not None:
-            self.register_always_float32_buffer(
-                "fp8_static_scale_grad_output",
-                self.config.cast_config_grad_output.static_scale.to(device),
-            )
-
-    def register_always_float32_buffer(
-        self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True
-    ) -> None:
-        self.register_buffer(name=name, tensor=tensor, persistent=persistent)
-        self.always_float32_buffers.add(name)
-
-    def _apply(self, fn, recurse=True):
-        ret = super()._apply(fn, recurse)
-        self.convert_amax_buffer_to_float32()
-        return ret
-
-    def convert_amax_buffer_to_float32(self):
-        for key in self.always_float32_buffers:
-            if self._buffers[key] is not None:
-                self._buffers[key] = self._buffers[key].to(torch.float32)
-
-    def cast_input_to_float8(
-        self, input: torch.Tensor, is_amax_initialized: bool
-    ) -> torch.Tensor:
+    def cast_input_to_float8(self, input: torch.Tensor) -> torch.Tensor:
         # Duplicate the autocast logic for F.linear, so that the output
         # of our module has the right original precision
         if torch.is_autocast_enabled():
@@ -428,71 +313,24 @@ class Float8Linear(torch.nn.Linear):
             autocast_dtype = torch.get_autocast_gpu_dtype()
             input = input.to(autocast_dtype)
 
-        if self.scaling_type_input is ScalingType.DELAYED:
-            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
-            _maybe_initialize_amaxes_scales_for_float8_cast(
-                input,
-                self.fp8_amax_input,
-                self.fp8_amax_history_input,
-                self.fp8_scale_input,
-                scale_fn_name,
-                self.config.cast_config_input.target_dtype,
-                is_amax_initialized,
-                reduce_amax=True,
-            )
-            input_fp8 = hp_tensor_to_float8_delayed(
-                input,
-                self.fp8_scale_input,
-                self.config.cast_config_input.target_dtype,
-                self.fp8_amax_input,
-                linear_mm_config=self.linear_mm_config,
-                gemm_input_role=GemmInputRole.INPUT,
-            )
-        elif self.scaling_type_input is ScalingType.DYNAMIC:
-            input_fp8 = hp_tensor_to_float8_dynamic(
-                input,
-                self.config.cast_config_input.target_dtype,
-                self.linear_mm_config,
-                gemm_input_role=GemmInputRole.INPUT,
-            )
-        else:
-            assert self.scaling_type_input is ScalingType.STATIC
-            input_fp8 = hp_tensor_to_float8_static(
-                input,
-                self.fp8_static_scale_input,
-                self.config.cast_config_input.target_dtype,
-                self.linear_mm_config,
-            )
-
+        assert self.scaling_type_input is ScalingType.DYNAMIC
+        input_fp8 = hp_tensor_to_float8_dynamic(
+            input,
+            self.config.cast_config_input.target_dtype,
+            self.linear_mm_config,
+            gemm_input_role=GemmInputRole.INPUT,
+        )
         return input_fp8
 
     def get_weight_scale(self, weight: torch.Tensor) -> Optional[torch.Tensor]:
         if tensor_already_casted_to_fp8(weight):
             return None
-        if self.scaling_type_weight is ScalingType.DELAYED:
-            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
-            _maybe_initialize_amaxes_scales_for_float8_cast(
-                weight,
-                self.fp8_amax_weight,
-                self.fp8_amax_history_weight,
-                self.fp8_scale_weight,
-                scale_fn_name,
-                self.config.cast_config_weight.target_dtype,
-                self.is_amax_initialized,
-                reduce_amax=True,
-            )
-            self.fp8_amax_weight.fill_(tensor_to_amax(weight))
-            return self.fp8_scale_weight
-        elif self.scaling_type_weight is ScalingType.DYNAMIC:
-            return tensor_to_scale(weight, self.config.cast_config_weight.target_dtype)
-        else:
-            assert self.scaling_type_weight is ScalingType.STATIC
-            return self.fp8_static_scale_weight
+        assert self.scaling_type_weight is ScalingType.DYNAMIC
+        return tensor_to_scale(weight, self.config.cast_config_weight.target_dtype)
 
     def cast_weight_to_float8_t(
         self,
         weight: torch.Tensor,
-        is_amax_initialized: bool,
         weight_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if tensor_already_casted_to_fp8(weight):
@@ -513,45 +351,13 @@ class Float8Linear(torch.nn.Linear):
             return weight.t()
 
     def cast_output_to_float8_in_bw(self, output: torch.Tensor) -> torch.Tensor:
-        if self.scaling_type_grad_output is ScalingType.DELAYED:
-            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
-            output = NoopFwToFloat8BwDelayed.apply(
-                output,
-                self.fp8_amax_grad_output,
-                self.fp8_amax_history_grad_output,
-                self.fp8_scale_grad_output,
-                scale_fn_name,
-                self.is_amax_initialized,
-                self.linear_mm_config,
-                self.config.cast_config_grad_output.target_dtype,
-            )
-        elif self.scaling_type_grad_output is ScalingType.DYNAMIC:
-            output = NoopFwToFloat8BwDynamic.apply(
-                output,
-                self.linear_mm_config,
-                self.config.cast_config_grad_output.target_dtype,
-            )
-        else:
-            assert self.scaling_type_grad_output is ScalingType.STATIC
-            output = NoopFwToFloat8BwStatic.apply(
-                output,
-                self.fp8_static_scale_grad_output,
-                self.linear_mm_config,
-                self.config.cast_config_grad_output.target_dtype,
-            )
+        assert self.scaling_type_grad_output is ScalingType.DYNAMIC
+        output = NoopFwToFloat8BwDynamic.apply(
+            output,
+            self.linear_mm_config,
+            self.config.cast_config_grad_output.target_dtype,
+        )
         return output
-
-    def float8_pre_forward(self, input):
-        # TODO(future PR): deprecate these functions and the corresponding
-        # config setting
-        if not self.enable_pre_and_post_forward:
-            return
-
-    def float8_post_forward(self):
-        # TODO(future PR): deprecate these functions and the corresponding
-        # config setting
-        if not self.enable_pre_and_post_forward:
-            return
 
     def forward_fp8_matmul(self, input: torch.Tensor) -> torch.Tensor:
         has_any_axiswise_scaling = any(
@@ -567,7 +373,7 @@ class Float8Linear(torch.nn.Linear):
         )
 
         if not has_any_axiswise_scaling:
-            input_fp8 = self.cast_input_to_float8(input, self.is_amax_initialized)
+            input_fp8 = self.cast_input_to_float8(input)
             # If force_recompute_fp8_weight_in_bwd, we only recompute the fp8 weight,
             # weight_scale should be saved.
             weight_scale = self.get_weight_scale(self.weight)
@@ -576,13 +382,10 @@ class Float8Linear(torch.nn.Linear):
                 weight_fp8_t = checkpoint.checkpoint(
                     self.cast_weight_to_float8_t,
                     self.weight,
-                    self.is_amax_initialized,
                     weight_scale,
                 )
             else:
-                weight_fp8_t = self.cast_weight_to_float8_t(
-                    self.weight, self.is_amax_initialized, weight_scale
-                )
+                weight_fp8_t = self.cast_weight_to_float8_t(self.weight, weight_scale)
 
             output = manual_float8_matmul_with_args_in_float8.apply(
                 input_fp8, weight_fp8_t
@@ -614,9 +417,6 @@ class Float8Linear(torch.nn.Linear):
         return output
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        if self.has_any_delayed_scaling:
-            self.float8_pre_forward(input)
-
         if self.config.use_fp8_all_gather_only:
             output = self.forward_original_precision_matmul(input)
         else:
@@ -624,9 +424,6 @@ class Float8Linear(torch.nn.Linear):
 
         if self.bias is not None:
             output = output + self.bias.to(output.dtype)
-
-        if self.has_any_delayed_scaling:
-            self.float8_post_forward()
         return output
 
     def extra_repr(self):
@@ -671,9 +468,6 @@ class Float8Linear(torch.nn.Linear):
             )
         new_mod.weight = mod.weight
         new_mod.bias = mod.bias
-        # need to create buffers again when moving from meta device to
-        # real device
-        new_mod.create_buffers()
 
         # If FSDP float8 all-gather is on, wrap the weight in a float8-aware
         # tensor subclass. This must happen last because:
@@ -681,35 +475,13 @@ class Float8Linear(torch.nn.Linear):
         # 2. buffers need to be already created for the delayed scaling version
         #    of the weight wrapper to be initialized
         if config.enable_fsdp_float8_all_gather:
-            if config.cast_config_weight.scaling_type is ScalingType.DYNAMIC:
-                new_mod.weight = torch.nn.Parameter(
-                    WeightWithDynamicFloat8CastTensor(
-                        new_mod.weight,
-                        new_mod.linear_mm_config,
-                        new_mod.config.cast_config_weight.target_dtype,
-                    )
+            assert config.cast_config_weight.scaling_type is ScalingType.DYNAMIC
+            new_mod.weight = torch.nn.Parameter(
+                WeightWithDynamicFloat8CastTensor(
+                    new_mod.weight,
+                    new_mod.linear_mm_config,
+                    new_mod.config.cast_config_weight.target_dtype,
                 )
-            elif config.cast_config_weight.scaling_type is ScalingType.DELAYED:
-                new_mod.weight = torch.nn.Parameter(
-                    WeightWithDelayedFloat8CastTensor(
-                        new_mod.weight,
-                        new_mod.fp8_amax_weight,
-                        new_mod.fp8_amax_history_weight,
-                        new_mod.fp8_scale_weight,
-                        new_mod.linear_mm_config,
-                        new_mod.config.cast_config_weight.target_dtype,
-                        new_mod.is_amax_initialized,
-                    )
-                )
-            else:
-                assert config.cast_config_weight.scaling_type is ScalingType.STATIC
-                new_mod.weight = torch.nn.Parameter(
-                    WeightWithStaticFloat8CastTensor(
-                        new_mod.weight,
-                        new_mod.fp8_static_scale_weight,
-                        new_mod.linear_mm_config,
-                        new_mod.config.cast_config_weight.target_dtype,
-                    )
-                )
+            )
 
         return new_mod

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -10,7 +10,11 @@ import torch
 import torch.distributed as dist
 from torch.distributed._functional_collectives import AsyncCollectiveTensor, all_reduce
 
-from torchao.float8.config import ScalingGranularity
+from torchao.float8.config import (
+    Float8LinearConfig,
+    ScalingGranularity,
+    ScalingType,
+)
 
 # Helpful visualizer for debugging (only supports fp32):
 # https://www.h-schmidt.net/FloatConverter/IEEE754.html
@@ -251,3 +255,14 @@ def pad_tensor_for_matmul(
     pad_dim2 = dim2_aligned - dim2
 
     return torch.nn.functional.pad(tensor, (0, pad_dim2, 0, pad_dim1))
+
+
+def config_has_stateful_scaling(config: Float8LinearConfig) -> bool:
+    """
+    Returns True if `config` has any delayed or static scaling, and False otherwise.
+    """
+    return (
+        config.cast_config_input.scaling_type != ScalingType.DYNAMIC
+        or config.cast_config_weight.scaling_type != ScalingType.DYNAMIC
+        or config.cast_config_grad_output.scaling_type != ScalingType.DYNAMIC
+    )

--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -13,6 +13,7 @@ import torch.utils._pytree as pytree
 from torch._prims_common import suggest_memory_format
 
 from torchao.float8.float8_scaling_utils import (
+    _maybe_initialize_amaxes_scales_for_float8_cast,
     hp_tensor_to_float8_delayed,
     hp_tensor_to_float8_dynamic,
 )
@@ -420,10 +421,6 @@ class WeightWithDelayedFloat8CastTensor(torch.Tensor):
         # initialize if needed
         # TODO(before land): ensure settings are consistent between Float8Linear and here
         if not self.is_amax_initialized:
-            from torchao.float8.float8_linear import (
-                _maybe_initialize_amaxes_scales_for_float8_cast,
-            )
-
             _maybe_initialize_amaxes_scales_for_float8_cast(
                 self._tensor,
                 self._amax_buffer,

--- a/torchao/float8/stateful_float8_linear.py
+++ b/torchao/float8/stateful_float8_linear.py
@@ -1,0 +1,331 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Stateful version of Float8Linear, created to keep Float8Linear simple and
+only require code readers to read the stateful code if they care about delayed
+or static scaling.
+"""
+
+from typing import Optional
+
+import torch
+
+from torchao.float8.config import Float8LinearConfig, ScalingType
+from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
+from torchao.float8.float8_linear import Float8Linear
+from torchao.float8.float8_scaling_utils import (
+    NoopFwToFloat8BwDelayed,
+    NoopFwToFloat8BwDynamic,
+    NoopFwToFloat8BwStatic,
+    _maybe_initialize_amaxes_scales_for_float8_cast,
+    hp_tensor_to_float8_delayed,
+    hp_tensor_to_float8_dynamic,
+    hp_tensor_to_float8_static,
+)
+from torchao.float8.float8_tensor import GemmInputRole
+from torchao.float8.float8_utils import (
+    tensor_to_amax,
+    tensor_to_scale,
+)
+from torchao.float8.fsdp_utils import (
+    WeightWithDelayedFloat8CastTensor,
+    WeightWithDynamicFloat8CastTensor,
+    WeightWithStaticFloat8CastTensor,
+)
+
+
+class StatefulFloat8Linear(Float8Linear):
+    def __init__(self, *args, **kwargs):
+        # Amax scales should always be kept as float32.
+        self.always_float32_buffers = set()
+
+        super().__init__(*args, **kwargs)
+
+        # Convenience flag to skip code related to delayed scaling
+        self.has_any_delayed_scaling = (
+            self.scaling_type_input is ScalingType.DELAYED
+            or self.scaling_type_weight is ScalingType.DELAYED
+            or self.scaling_type_grad_output is ScalingType.DELAYED
+        )
+
+        self.create_buffers()
+
+        # Note: is_amax_initialized is not a buffer to avoid data dependent
+        # control flow visible to dynamo
+        # TODO(future PR): add serialization for this flag
+        self.is_amax_initialized = not self.config.enable_amax_init
+
+        # pre_forward and post_forward are currently broken with FSDP
+        # and torch.compile, this option can disable them
+        # Note that when using `self.config.enable_pre_and_post_forward = False`,
+        # it's recommended to also set `self.config.enable_amax_init = False`.
+        # Otherwise, the amax buffer would never be marked as initialized and
+        # would be initialized in every iteration.
+        self.enable_pre_and_post_forward = self.config.enable_pre_and_post_forward
+
+    def create_buffers(self):
+        # Default values for history buffers, see above TODO
+        history_len = self.config.delayed_scaling_config.history_len
+        device = self.weight.device
+        default_input = torch.finfo(self.config.cast_config_input.target_dtype).max
+        default_weight = torch.finfo(self.config.cast_config_weight.target_dtype).max
+        default_grad_output = torch.finfo(
+            self.config.cast_config_grad_output.target_dtype
+        ).max
+
+        # Note: for now, create all the buffers if any are needed, to postpone
+        # the work to make the scale and amax syncing and history calculation
+        # handle a heterogeneous setup. We can do that work later if benchmarks
+        # show it is worth doing.
+        if self.has_any_delayed_scaling:
+            self.register_always_float32_buffer(
+                "fp8_amax_input", torch.tensor([default_input], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_input", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_input", torch.tensor([1.0], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_weight", torch.tensor([default_weight], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_weight", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_weight", torch.tensor([1.0], device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_grad_output",
+                torch.tensor([default_grad_output], device=device),
+            )
+            self.register_always_float32_buffer(
+                "fp8_amax_history_grad_output", torch.zeros(history_len, device=device)
+            )
+            self.register_always_float32_buffer(
+                "fp8_scale_grad_output", torch.tensor([1.0], device=device)
+            )
+
+        if self.config.cast_config_input.static_scale is not None:
+            self.register_always_float32_buffer(
+                "fp8_static_scale_input",
+                self.config.cast_config_input.static_scale.to(device),
+            )
+        if self.config.cast_config_weight.static_scale is not None:
+            self.register_always_float32_buffer(
+                "fp8_static_scale_weight",
+                self.config.cast_config_weight.static_scale.to(device),
+            )
+        if self.config.cast_config_grad_output.static_scale is not None:
+            self.register_always_float32_buffer(
+                "fp8_static_scale_grad_output",
+                self.config.cast_config_grad_output.static_scale.to(device),
+            )
+
+    def register_always_float32_buffer(
+        self, name: str, tensor: Optional[torch.Tensor], persistent: bool = True
+    ) -> None:
+        self.register_buffer(name=name, tensor=tensor, persistent=persistent)
+        self.always_float32_buffers.add(name)
+
+    def _apply(self, fn, recurse=True):
+        ret = super()._apply(fn, recurse)
+        self.convert_amax_buffer_to_float32()
+        return ret
+
+    def convert_amax_buffer_to_float32(self):
+        for key in self.always_float32_buffers:
+            if self._buffers[key] is not None:
+                self._buffers[key] = self._buffers[key].to(torch.float32)
+
+    def cast_input_to_float8(self, input: torch.Tensor) -> torch.Tensor:
+        is_amax_initialized = self.is_amax_initialized
+        # Duplicate the autocast logic for F.linear, so that the output
+        # of our module has the right original precision
+        if torch.is_autocast_enabled():
+            # For now, hardcode to GPU's autocast dtype
+            # if we need CPU support in the future, we can add it
+            autocast_dtype = torch.get_autocast_gpu_dtype()
+            input = input.to(autocast_dtype)
+
+        if self.scaling_type_input is ScalingType.DELAYED:
+            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
+            _maybe_initialize_amaxes_scales_for_float8_cast(
+                input,
+                self.fp8_amax_input,
+                self.fp8_amax_history_input,
+                self.fp8_scale_input,
+                scale_fn_name,
+                self.config.cast_config_input.target_dtype,
+                is_amax_initialized,
+                reduce_amax=True,
+            )
+            input_fp8 = hp_tensor_to_float8_delayed(
+                input,
+                self.fp8_scale_input,
+                self.config.cast_config_input.target_dtype,
+                self.fp8_amax_input,
+                linear_mm_config=self.linear_mm_config,
+                gemm_input_role=GemmInputRole.INPUT,
+            )
+        elif self.scaling_type_input is ScalingType.DYNAMIC:
+            input_fp8 = hp_tensor_to_float8_dynamic(
+                input,
+                self.config.cast_config_input.target_dtype,
+                self.linear_mm_config,
+                gemm_input_role=GemmInputRole.INPUT,
+            )
+        else:
+            assert self.scaling_type_input is ScalingType.STATIC
+            input_fp8 = hp_tensor_to_float8_static(
+                input,
+                self.fp8_static_scale_input,
+                self.config.cast_config_input.target_dtype,
+                self.linear_mm_config,
+            )
+
+        return input_fp8
+
+    def get_weight_scale(self, weight: torch.Tensor) -> Optional[torch.Tensor]:
+        if tensor_already_casted_to_fp8(weight):
+            return None
+        if self.scaling_type_weight is ScalingType.DELAYED:
+            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
+            _maybe_initialize_amaxes_scales_for_float8_cast(
+                weight,
+                self.fp8_amax_weight,
+                self.fp8_amax_history_weight,
+                self.fp8_scale_weight,
+                scale_fn_name,
+                self.config.cast_config_weight.target_dtype,
+                self.is_amax_initialized,
+                reduce_amax=True,
+            )
+            self.fp8_amax_weight.fill_(tensor_to_amax(weight))
+            return self.fp8_scale_weight
+        elif self.scaling_type_weight is ScalingType.DYNAMIC:
+            return tensor_to_scale(weight, self.config.cast_config_weight.target_dtype)
+        else:
+            assert self.scaling_type_weight is ScalingType.STATIC
+            return self.fp8_static_scale_weight
+
+    def cast_output_to_float8_in_bw(self, output: torch.Tensor) -> torch.Tensor:
+        if self.scaling_type_grad_output is ScalingType.DELAYED:
+            scale_fn_name = self.config.delayed_scaling_config.scale_fn_name
+            output = NoopFwToFloat8BwDelayed.apply(
+                output,
+                self.fp8_amax_grad_output,
+                self.fp8_amax_history_grad_output,
+                self.fp8_scale_grad_output,
+                scale_fn_name,
+                self.is_amax_initialized,
+                self.linear_mm_config,
+                self.config.cast_config_grad_output.target_dtype,
+            )
+        elif self.scaling_type_grad_output is ScalingType.DYNAMIC:
+            output = NoopFwToFloat8BwDynamic.apply(
+                output,
+                self.linear_mm_config,
+                self.config.cast_config_grad_output.target_dtype,
+            )
+        else:
+            assert self.scaling_type_grad_output is ScalingType.STATIC
+            output = NoopFwToFloat8BwStatic.apply(
+                output,
+                self.fp8_static_scale_grad_output,
+                self.linear_mm_config,
+                self.config.cast_config_grad_output.target_dtype,
+            )
+        return output
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.has_any_delayed_scaling:
+            self.float8_pre_forward(input)
+        output = super().forward(input)
+        if self.has_any_delayed_scaling:
+            self.float8_post_forward()
+        return output
+
+    def float8_pre_forward(self, input):
+        # TODO(future PR): deprecate these functions and the corresponding
+        # config setting
+        if not self.enable_pre_and_post_forward:
+            return
+
+    def float8_post_forward(self):
+        # TODO(future PR): deprecate these functions and the corresponding
+        # config setting
+        if not self.enable_pre_and_post_forward:
+            return
+
+    @classmethod
+    def from_float(
+        cls,
+        mod,
+        config: Optional[Float8LinearConfig] = None,
+    ):
+        """
+        Create an nn.Linear with fp8 compute from a regular nn.Linear
+
+        Args:
+            mod (torch.nn.Linear): nn.Linear to convert
+            config (Optional[Float8LinearConfig]): configuration for conversion to float8
+        """
+        if config is None:
+            config = Float8LinearConfig()
+        with torch.device("meta"):
+            new_mod = cls(
+                mod.in_features,
+                mod.out_features,
+                bias=False,
+                config=config,
+            )
+        new_mod.weight = mod.weight
+        new_mod.bias = mod.bias
+        # need to create buffers again when moving from meta device to
+        # real device
+        new_mod.create_buffers()
+
+        # If FSDP float8 all-gather is on, wrap the weight in a float8-aware
+        # tensor subclass. This must happen last because:
+        # 1. weight needs to be on the correct device to create the buffers
+        # 2. buffers need to be already created for the delayed scaling version
+        #    of the weight wrapper to be initialized
+        if config.enable_fsdp_float8_all_gather:
+            if config.cast_config_weight.scaling_type is ScalingType.DYNAMIC:
+                new_mod.weight = torch.nn.Parameter(
+                    WeightWithDynamicFloat8CastTensor(
+                        new_mod.weight,
+                        new_mod.linear_mm_config,
+                        new_mod.config.cast_config_weight.target_dtype,
+                    )
+                )
+            elif config.cast_config_weight.scaling_type is ScalingType.DELAYED:
+                new_mod.weight = torch.nn.Parameter(
+                    WeightWithDelayedFloat8CastTensor(
+                        new_mod.weight,
+                        new_mod.fp8_amax_weight,
+                        new_mod.fp8_amax_history_weight,
+                        new_mod.fp8_scale_weight,
+                        new_mod.linear_mm_config,
+                        new_mod.config.cast_config_weight.target_dtype,
+                        new_mod.is_amax_initialized,
+                    )
+                )
+            else:
+                assert config.cast_config_weight.scaling_type is ScalingType.STATIC
+                new_mod.weight = torch.nn.Parameter(
+                    WeightWithStaticFloat8CastTensor(
+                        new_mod.weight,
+                        new_mod.fp8_static_scale_weight,
+                        new_mod.linear_mm_config,
+                        new_mod.config.cast_config_weight.target_dtype,
+                    )
+                )
+
+        return new_mod


### PR DESCRIPTION
Summary:

This PR splits `Float8Linear` into 
(a) `Float8Linear`, which now supports only dynamic scaling
(b) `StatefulFloat8Linear`, which supports dynamic, delayed, static scaling.  `StatefulFloat8Linear` inherits from `Float8Linear` and overrides methods as needed.

The `convert_to_float8_training` function looks at `Float8LinearConfig` and uses `Float8Linear` if only dynamic scaling is configured, and `StatefulFloat8Linear` otherwise.

Motivation: simplify the most common path, and contain the complexity from stateful scaling in a place where most people won't need to look at it.  Note that there are other refactors in various scaling and utility functions we can do to move even further in this direction - saving that for future PRs.

Note that this is not BC-breaking.

Test Plan:

```
./test/float8/test_everything.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: