### PR TITLE
Consolidate formatting check and fix script to one

### DIFF
--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -65,15 +65,7 @@ jobs:
     - name: Regular lint check
       if: github.event_name != 'workflow_dispatch'
       run: |
-        ruff check .
-        # --isolated is used to skip the allowlist at all so this applies to all files
-        # please be careful when using this large changes means everyone needs to rebase
-        ruff check --isolated --select F821,F823,W191
-        ruff check --select F,I
-        ruff format --check || {
-          echo "Ruff check failed, please try again after running 'ruff format'."
-          exit 1
-        }
+        sh scripts/run_ruff.sh --check
 
     - name: Apply fixes to PR
       if: github.event_name == 'workflow_dispatch'
@@ -82,8 +74,7 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         
         # Apply fixes
-        ruff check --select F,I --fix
-        ruff format .
+        sh scripts/run_ruff.sh
         
         # Commit and push if there are changes
         if [[ -n "$(git status --porcelain)" ]]; then

--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -65,15 +65,7 @@ jobs:
     - name: Regular lint check
       if: github.event_name != 'workflow_dispatch'
       run: |
-        ruff check .
-        # --isolated is used to skip the allowlist at all so this applies to all files
-        # please be careful when using this large changes means everyone needs to rebase
-        ruff check --isolated --select F821,F823,W191
-        ruff check --select F,I
-        ruff format --check || {
-          echo "Ruff check failed, please try again after running 'ruff format'."
-          exit 1
-        }
+        sh scripts/run_ruff.sh --check
 
     - name: Apply fixes to PR
       if: github.event_name == 'workflow_dispatch'
@@ -82,8 +74,7 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         
         # Apply fixes
-        ruff check --select F,I --fix
-        ruff format .
+        sh scripts/run_ruff.sh        
         
         # Commit and push if there are changes
         if [[ -n "$(git status --porcelain)" ]]; then

--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -65,7 +65,15 @@ jobs:
     - name: Regular lint check
       if: github.event_name != 'workflow_dispatch'
       run: |
-        sh scripts/run_ruff.sh --check
+        ruff check .
+        # --isolated is used to skip the allowlist at all so this applies to all files
+        # please be careful when using this large changes means everyone needs to rebase
+        ruff check --isolated --select F821,F823,W191
+        ruff check --select F,I
+        ruff format --check || {
+          echo "Ruff check failed, please try again after running 'ruff format'."
+          exit 1
+        }
 
     - name: Apply fixes to PR
       if: github.event_name == 'workflow_dispatch'
@@ -74,7 +82,8 @@ jobs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         
         # Apply fixes
-        sh scripts/run_ruff.sh
+        ruff check --select F,I --fix
+        ruff format .
         
         # Commit and push if there are changes
         if [[ -n "$(git status --porcelain)" ]]; then

--- a/scripts/run_ruff.sh
+++ b/scripts/run_ruff.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --fix      Fix format (default)"
+  echo "  --check    Check for formatting issues"
+  exit 1
+}
+
+# Parse the command-line options
+# TEMP=$(getopt -o '' --long fix,check -- "$@")
+# eval set -- "$TEMP"
+FIX=true
+case "$1" in
+    --fix)
+        FIX=true
+        break
+        ;;
+    --check)
+        FIX=false
+        break
+        ;;
+    "")
+        FIX=true
+        break
+        ;;
+    *)
+        usage
+        break
+        ;;
+esac
+
+# Execute the desired action based on the value of FIX_ISSUES
+if $FIX; then
+    ruff check . --fix
+    # --isolated is used to skip the allowlist at all so this applies to all files
+    # please be careful when using this large changes means everyone needs to rebase
+    ruff check --isolated --select F821,F823,W191 --fix
+    ruff check --select F,I --fix
+    ruff format .
+else
+    ruff check .
+    # --isolated is used to skip the allowlist at all so this applies to all files
+    # please be careful when using this large changes means everyone needs to rebase
+    ruff check --isolated --select F821,F823,W191
+    ruff check --select F,I
+    ruff format --check || {
+        echo "Ruff check failed, please try again after running scripts/run_ruff.sh"
+        exit 1
+    }
+fi

--- a/scripts/run_ruff_fix.sh
+++ b/scripts/run_ruff_fix.sh
@@ -1,6 +1,0 @@
-ruff check . --fix
-# --isolated is used to skip the allowlist at all so this applies to all files
-# please be careful when using this large changes means everyone needs to rebase
-ruff check --isolated --select F821,F823,W191 --fix
-ruff check --select F,I --fix
-ruff format .

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -15,25 +15,25 @@ from pathlib import Path
 import torch
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torch.ao.quantization.quantizer.xnnpack_quantizer import (
-    get_symmetric_quantization_config,
     XNNPACKQuantizer,
+    get_symmetric_quantization_config,
 )
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import TestCase
 
 from torchao import quantize_
-from torchao._models.llama.model import prepare_inputs_for_model, Transformer
+from torchao._models.llama.model import Transformer, prepare_inputs_for_model
 from torchao._models.llama.tokenizer import get_tokenizer
 from torchao.dtypes import AffineQuantizedTensor
 from torchao.quantization import LinearActivationQuantizedTensor
 from torchao.quantization.quant_api import (
+    Quantizer,
+    TwoStepQuantizer,
     _replace_with_custom_fn_if_matches_filter,
     int4_weight_only,
     int8_dynamic_activation_int4_weight,
     int8_dynamic_activation_int8_weight,
     int8_weight_only,
-    Quantizer,
-    TwoStepQuantizer,
 )
 from torchao.quantization.quant_primitives import MappingType
 from torchao.quantization.subclass import (


### PR DESCRIPTION
Summary:
To reduce discrepandcies of ruff format checking and fixing, we want to use the same script to do both

The script can be used in both CI and locally.

```
sh scripts/run_ruff.sh
sh scripts/run_ruff.sh --fix
sh scripts/run_ruff.sh --check
```

Test Plan:
1. fix sh scripts/run_ruff.sh
sh scripts/run_ruff.sh --fix

All checks passed!
All checks passed!
All checks passed!
142 files left unchanged

2. check

sh scripts/run_ruff.sh --check
All checks passed!
All checks passed!
All checks passed!
142 files already formatted

3. unknown sh scripts/run_ruff.sh --unknown

Usage: scripts/run_ruff.sh [options]
Options:
  --fix      Fix format (default)
  --check    Check for formatting issues
Reviewers:

Subscribers:

Tasks:

Tags: