### PR TITLE
add fp8 conversion kernel that writes both row and column major outputs

### DIFF
--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
@@ -255,6 +255,55 @@ def to_fp8_col_major_t(
     tl.store(out_ptr + out_offs, fp8_vals, mask=out_mask)
 
 
+@triton.autotune(
+    configs=kernel_configs_2D,
+    key=["num_elements"],
+)
+@triton.jit
+def _to_fp8_row_and_col_major(
+    input_ptr,
+    row_major_out_ptr,
+    col_major_out_ptr,
+    scale_ptr,
+    num_elements: int,
+    fp8_dtype_min: float,
+    fp8_dtype_max: float,
+    num_rows: int,
+    num_cols: int,
+    input_dtype: tl.constexpr,
+    output_dtype: tl.constexpr,
+    BLOCK_SIZE_ROWS: tl.constexpr,
+    BLOCK_SIZE_COLS: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    block_row_id = tl.program_id(axis=0)
+    block_col_id = tl.program_id(axis=1)
+
+    # load scaling factor
+    scale = tl.load(scale_ptr).to(tl.float32)
+
+    # load block of input tensor
+    block_row_start = block_row_id * BLOCK_SIZE_ROWS
+    block_col_start = block_col_id * BLOCK_SIZE_COLS
+    block_row_offs = block_row_start + tl.arange(0, BLOCK_SIZE_ROWS)
+    block_col_offs = block_col_start + tl.arange(0, BLOCK_SIZE_COLS)
+    block_offs = block_row_offs[:, None] * num_cols + block_col_offs[None, :]
+    mask = (block_row_offs[:, None] < num_rows) & (block_col_offs[None, :] < num_cols)
+    vals = tl.load(input_ptr + block_offs, mask=mask).to(input_dtype)
+
+    # perform conversion
+    vals = vals * scale
+    fp8_vals = tl.clamp(vals, min=fp8_dtype_min, max=fp8_dtype_max).to(output_dtype)
+
+    # write row major output
+    row_major_offs = block_row_offs[:, None] * num_cols + block_col_offs[None, :]
+    tl.store(row_major_out_ptr + row_major_offs, fp8_vals, mask=mask)
+
+    # write column major output
+    col_major_offs = block_col_offs[None, :] * num_rows + block_row_offs[:, None]
+    tl.store(col_major_out_ptr + col_major_offs, fp8_vals, mask=mask)
+
+
 @triton.autotune(configs=kernel_configs_1D, key=["num_elements"])
 @triton.jit
 def _amax_atomic(
@@ -571,6 +620,86 @@ def hp_to_fp8_col_major_t(
         gemm_input_role=gemm_input_role,
     )
     return fp8_tensor_col_major_t
+
+
+def hp_to_fp8_row_and_col_major(
+    hp_tensor: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    linear_mm_config: LinearMMConfig,
+    gemm_input_role: GemmInputRole = GemmInputRole.INPUT,
+    algo: KernelAlgorithm = KernelAlgorithm.ATOMIC_MAX,
+) -> Float8Tensor:
+    assert hp_tensor.is_contiguous(), "input tensor must be contiguous"
+
+    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+    tl_output_dtype = FP8_DTYPE_MAP[fp8_dtype]
+
+    fp8_dtype_min = torch.finfo(fp8_dtype).min
+    fp8_dtype_max = torch.finfo(fp8_dtype).max
+
+    # compute scaling factor for tensor
+    scale = _hp_tensor_to_scale(
+        hp_tensor,
+        tl_input_dtype,
+        fp8_dtype_max,
+        algo,
+    )
+
+    # perform fp8 conversion
+    orig_shape = hp_tensor.shape
+    num_elements = hp_tensor.numel()
+
+    # preallocate necessary output tensors
+    fp8_output_row_major = torch.empty(
+        orig_shape, dtype=fp8_dtype, device=hp_tensor.device
+    )
+    fp8_output_col_major = torch.empty(
+        orig_shape, dtype=fp8_dtype, device=hp_tensor.device
+    )
+
+    # launch triton kernel to perform conversion
+    num_rows, num_cols = orig_shape
+    grid = lambda meta: (
+        triton.cdiv(num_rows, meta["BLOCK_SIZE_ROWS"]),
+        triton.cdiv(num_cols, meta["BLOCK_SIZE_COLS"]),
+    )
+    _to_fp8_row_and_col_major[grid](
+        hp_tensor,
+        fp8_output_row_major,
+        fp8_output_col_major,
+        scale,
+        num_elements,
+        fp8_dtype_min,
+        fp8_dtype_max,
+        num_rows,
+        num_cols,
+        input_dtype=tl_input_dtype,
+        output_dtype=tl_output_dtype,
+        EPS=EPS,
+    )
+
+    # for col major we need to update the strides to reflect the new memory layout
+    col_major_strides = (1, num_rows)
+    fp8_output_col_major = fp8_output_col_major.as_strided(
+        fp8_output_col_major.size(), col_major_strides
+    )
+
+    # wrap outputs in Float8Tensors
+    fp8_tensor_row_major = Float8Tensor(
+        fp8_output_row_major,
+        scale,
+        orig_dtype=hp_tensor.dtype,
+        linear_mm_config=linear_mm_config,
+        gemm_input_role=gemm_input_role,
+    )
+    fp8_tensor_col_major = Float8Tensor(
+        fp8_output_col_major,
+        scale,
+        orig_dtype=hp_tensor.dtype,
+        linear_mm_config=linear_mm_config,
+        gemm_input_role=gemm_input_role,
+    )
+    return fp8_tensor_row_major, fp8_tensor_col_major
 
 
 def _hp_tensor_to_scale(

--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
@@ -6,6 +6,7 @@ from torchao.float8.float8_utils import is_row_major
 from torchao.prototype.float8nocompile.kernels.fp8_dynamic_tensorwise import (
     hp_to_fp8_col_major,
     hp_to_fp8_col_major_t,
+    hp_to_fp8_row_and_col_major,
     hp_to_fp8_row_major,
     hp_to_fp8_row_major_t,
     KernelAlgorithm,
@@ -271,6 +272,88 @@ def test_fp8_hp_to_fp8_col_major_t(input_shape: tuple[int, int], algo: KernelAlg
     # assert that error is raised when input tensor is not contiguous
     with pytest.raises(AssertionError, match="tensor must be contiguous"):
         hp_to_fp8_col_major(
+            y_bf16.t(),  # transpose so tensor memory layout is no longer contiguous
+            torch.float8_e4m3fn,
+            LinearMMConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    "algo",
+    [KernelAlgorithm.REDUCTION, KernelAlgorithm.ATOMIC_MAX],
+)
+@pytest.mark.parametrize(
+    "input_shape",
+    [(2, 4), (32, 16), (512, 512)],
+)
+def test_fp8_hp_to_fp8_row_and_col_major(
+    input_shape: tuple[int, int], algo: KernelAlgorithm
+):
+    assert torch.cuda.is_available()
+    device = "cuda"
+    input_bf16 = torch.randn(input_shape, dtype=torch.bfloat16, device=device)
+    x_bf16 = input_bf16.clone().detach().to(device)
+    y_bf16 = input_bf16.clone().detach().to(device)
+
+    # production implementation
+    x_fp8_row_major = hp_tensor_to_float8_dynamic(
+        x_bf16,
+        torch.float8_e4m3fn,
+        LinearMMConfig(),
+    )
+    x_fp8_col_major = x_fp8_row_major.t().contiguous().t()
+
+    # float8nocompile triton implementation
+    y_fp8_row_major, y_fp8_col_major = hp_to_fp8_row_and_col_major(
+        y_bf16,
+        torch.float8_e4m3fn,
+        LinearMMConfig(),
+        algo=algo,
+    )
+
+    # check scales
+    assert torch.allclose(
+        x_fp8_row_major._scale, y_fp8_row_major._scale, atol=1e-3, rtol=1e-3
+    )
+    assert torch.allclose(
+        x_fp8_col_major._scale, y_fp8_col_major._scale, atol=1e-3, rtol=1e-3
+    )
+
+    # check data
+    assert allclose_fp8(
+        x_fp8_row_major._data, y_fp8_row_major._data, atol=1e-3, rtol=1e-3
+    )
+    assert allclose_fp8(
+        x_fp8_col_major._data, y_fp8_col_major._data, atol=1e-3, rtol=1e-3
+    )
+
+    # check shapes
+    assert x_fp8_row_major.shape == y_fp8_row_major.shape
+    assert x_fp8_col_major.shape == y_fp8_col_major.shape
+
+    # check strides
+    assert x_fp8_row_major.stride() == y_fp8_row_major.stride()
+    assert x_fp8_col_major.stride() == y_fp8_col_major.stride()
+
+    # check memory layout
+    assert is_row_major(x_fp8_row_major.stride())
+    assert is_row_major(y_fp8_row_major.stride())
+    assert not is_row_major(x_fp8_col_major.stride())
+    assert not is_row_major(y_fp8_col_major.stride())
+
+    # check underlying memory layout
+    assert (
+        x_fp8_row_major._data.storage().tolist()
+        == y_fp8_row_major._data.storage().tolist()
+    )
+    assert (
+        x_fp8_col_major._data.storage().tolist()
+        == y_fp8_col_major._data.storage().tolist()
+    )
+
+    # assert that error is raised when input tensor is not contiguous
+    with pytest.raises(AssertionError, match="tensor must be contiguous"):
+        hp_to_fp8_row_and_col_major(
             y_bf16.t(),  # transpose so tensor memory layout is no longer contiguous
             torch.float8_e4m3fn,
             LinearMMConfig(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #1488
* #1475
* #1474
* __->__ #1473
* #1472
* #1471

**Test Plan**
`pytest kernels/`

