### PR TITLE
torchao setup.py with cmake

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -32,6 +32,18 @@ if not _IS_FBCODE:
         assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
         torch.ops.load_library(so_files[0])
         from . import ops
+
+        # The following library contains CPU kernels from torchao/experimental
+        # They are built automatically by ao/setup.py if on an ARM machine.
+        # They can also be built outside of the torchao install process by
+        # running the script `torchao/experimental/build_torchao_ops.sh <aten|executorch>`
+        # For more information, see https://github.com/pytorch/ao/blob/main/torchao/experimental/docs/readme.md
+        experimental_lib = list(Path(__file__).parent.glob("libtorchao_ops_aten.*"))
+        if len(experimental_lib) > 0:
+            assert (
+                len(experimental_lib) == 1
+            ), f"Expected at most one libtorchao_ops_aten.* file, found {len(experimental_lib)}"
+            torch.ops.load_library(experimental_lib[0])
     except:
         logging.debug("Skipping import of cpp extensions")
 


### PR DESCRIPTION
Summary:
Initial draft of using cmake in torchao's build process.

Install torchao with:

```
USE_CPP=1 pip install .
```

If on an arm64 machine, it builds the dynamic library for torchao at site-packages/torchao/libtorchao_ops_aten.dylib.  On import of torchao, if this library is found it is loaded.

Differential Revision: D67777662


