### PR TITLE
Add min_sqnr to torchao/_models

### DIFF
--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -1,45 +1,37 @@
-import itertools
-import requests
-import uvicorn
-import fire
-import tempfile
-import logging
-import sys
-import time
+import asyncio
 import json
+import logging
+import time
+from contextlib import asynccontextmanager
+from io import BytesIO
 from pathlib import Path
-from typing import List, Optional
 
+import cv2
+import fire
+import matplotlib.pyplot as plt
+import numpy as np
+import requests
 import torch
 import torch._dynamo.config
 import torch._inductor.config
-from fastapi.responses import Response
+import uvicorn
+from compile_export_utils import (
+    export_model,
+    load_exported_model,
+    set_fast,
+    set_furious,
+)
 from fastapi import FastAPI, File, UploadFile
-from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
-from io import BytesIO
-import shutil
-from pydantic import BaseModel
-import cv2
+from fastapi.responses import StreamingResponse
+from torch._inductor import config as inductorconfig
 
-import matplotlib.pyplot as plt
-import numpy as np
-
-import asyncio
-from contextlib import asynccontextmanager
-import contextlib
 from torchao._models.utils import (
     get_arch_name,
-    write_json_result_ossci,
     write_json_result_local,
+    write_json_result_ossci,
 )
 
-from compile_export_utils import set_fast
-from compile_export_utils import set_furious
-from compile_export_utils import load_exported_model
-from compile_export_utils import export_model
-
-from torch._inductor import config as inductorconfig
 inductorconfig.triton.unique_kernel_names = True
 inductorconfig.coordinate_descent_tuning = True
 inductorconfig.coordinate_descent_check_all_directions = True
@@ -48,12 +40,13 @@ inductorconfig.allow_buffer_reuse = False
 # torch._dynamo.config.capture_dynamic_output_shape_ops = True
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
+
 def download_file(url, download_dir):
     # Create the directory if it doesn't exist
     download_dir = Path(download_dir)
     download_dir.mkdir(parents=True, exist_ok=True)
     # Extract the file name from the URL
-    file_name = url.split('/')[-1]
+    file_name = url.split("/")[-1]
     # Define the full path for the downloaded file
     file_path = download_dir / file_name
     # Download the file
@@ -61,110 +54,123 @@ def download_file(url, download_dir):
     response.raise_for_status()  # Raise an error for bad responses
     # Write the file to the specified directory
     print(f"Downloading '{file_name}' to '{download_dir}'")
-    with open(file_path, 'wb') as file:
+    with open(file_path, "wb") as file:
         for chunk in response.iter_content(chunk_size=8192):
             file.write(chunk)
     print(f"Downloaded '{file_name}' to '{download_dir}'")
 
+
 def example_shapes():
-    return [(848, 480, 3),
-            (720, 1280, 3),
-            (848, 480, 3),
-            (1280, 720, 3),
-            (480, 848, 3),
-            (1080, 1920, 3),
-            (1280, 720, 3),
-            (1280, 720, 3),
-            (720, 1280, 3),
-            (848, 480, 3),
-            (480, 848, 3),
-            (864, 480, 3),
-            (1920, 1080, 3),
-            (1920, 1080, 3),
-            (1280, 720, 3),
-            (1232, 672, 3),
-            (848, 480, 3),
-            (848, 480, 3),
-            (1920, 1080, 3),
-            (1080, 1920, 3),
-            (480, 848, 3),
-            (848, 480, 3),
-            (480, 848, 3),
-            (480, 848, 3),
-            (720, 1280, 3),
-            (720, 1280, 3),
-            (900, 720, 3),
-            (848, 480, 3),
-            (864, 480, 3),
-            (360, 640, 3),
-            (360, 640, 3),
-            (864, 480, 3)]
+    return [
+        (848, 480, 3),
+        (720, 1280, 3),
+        (848, 480, 3),
+        (1280, 720, 3),
+        (480, 848, 3),
+        (1080, 1920, 3),
+        (1280, 720, 3),
+        (1280, 720, 3),
+        (720, 1280, 3),
+        (848, 480, 3),
+        (480, 848, 3),
+        (864, 480, 3),
+        (1920, 1080, 3),
+        (1920, 1080, 3),
+        (1280, 720, 3),
+        (1232, 672, 3),
+        (848, 480, 3),
+        (848, 480, 3),
+        (1920, 1080, 3),
+        (1080, 1920, 3),
+        (480, 848, 3),
+        (848, 480, 3),
+        (480, 848, 3),
+        (480, 848, 3),
+        (720, 1280, 3),
+        (720, 1280, 3),
+        (900, 720, 3),
+        (848, 480, 3),
+        (864, 480, 3),
+        (360, 640, 3),
+        (360, 640, 3),
+        (864, 480, 3),
+    ]
 
 
 def example_shapes_2():
-    return [(1080, 1920, 3),
-            (1920, 1080, 3),
-            (1920, 1080, 3),
-            (1080, 1920, 3),
-            (848, 480, 3),
-            (864, 480, 3),
-            (720, 1280, 3),
-            (864, 480, 3),
-            (848, 480, 3),
-            (848, 480, 3),
-            (848, 480, 3),
-            (848, 480, 3),
-            (720, 1280, 3),
-            (864, 480, 3),
-            (480, 848, 3),
-            (1280, 720, 3),
-            (720, 1280, 3),
-            (1080, 1920, 3),
-            (1080, 1920, 3),
-            (1280, 720, 3),
-            (1080, 1920, 3),
-            (1080, 1920, 3),
-            (720, 1280, 3),
-            (720, 1280, 3),
-            (1280, 720, 3),
-            (360, 640, 3),
-            (864, 480, 3),
-            (1920, 1080, 3),
-            (1080, 1920, 3),
-            (1920, 1080, 3),
-            (1920, 1080, 3),
-            (1080, 1920, 3)]
+    return [
+        (1080, 1920, 3),
+        (1920, 1080, 3),
+        (1920, 1080, 3),
+        (1080, 1920, 3),
+        (848, 480, 3),
+        (864, 480, 3),
+        (720, 1280, 3),
+        (864, 480, 3),
+        (848, 480, 3),
+        (848, 480, 3),
+        (848, 480, 3),
+        (848, 480, 3),
+        (720, 1280, 3),
+        (864, 480, 3),
+        (480, 848, 3),
+        (1280, 720, 3),
+        (720, 1280, 3),
+        (1080, 1920, 3),
+        (1080, 1920, 3),
+        (1280, 720, 3),
+        (1080, 1920, 3),
+        (1080, 1920, 3),
+        (720, 1280, 3),
+        (720, 1280, 3),
+        (1280, 720, 3),
+        (360, 640, 3),
+        (864, 480, 3),
+        (1920, 1080, 3),
+        (1080, 1920, 3),
+        (1920, 1080, 3),
+        (1920, 1080, 3),
+        (1080, 1920, 3),
+    ]
+
 
 # torch.set_float32_matmul_precision('high')
+
 
 def iou(mask1, mask2):
     assert mask1.dim() == 2
     assert mask2.dim() == 2
     intersection = torch.logical_and(mask1, mask2)
     union = torch.logical_or(mask1, mask2)
-    return (intersection.sum(dim=(-1, -2)) / union.sum(dim=(-1, -2)))
+    return intersection.sum(dim=(-1, -2)) / union.sum(dim=(-1, -2))
 
 
 def show_anns(anns, rle_to_mask, sort_by_area=True, seed=None):
     if len(anns) == 0:
         return
     if sort_by_area:
-        sorted_anns = sorted(anns, key=(lambda x: x['area']), reverse=True)
+        sorted_anns = sorted(anns, key=(lambda x: x["area"]), reverse=True)
     else:
         sorted_anns = anns
     ax = plt.gca()
     ax.set_autoscale_on(False)
 
     for ann in sorted_anns:
-        ann['segmentation'] = rle_to_mask(ann['segmentation'])
+        ann["segmentation"] = rle_to_mask(ann["segmentation"])
 
-    img = np.ones((sorted_anns[0]['segmentation'].shape[0], sorted_anns[0]['segmentation'].shape[1], 4))
-    img[:,:,3] = 0
+    img = np.ones(
+        (
+            sorted_anns[0]["segmentation"].shape[0],
+            sorted_anns[0]["segmentation"].shape[1],
+            4,
+        )
+    )
+    img[:, :, 3] = 0
 
     np.random.seed(seed)
     ms = []
     for ann in sorted_anns:
-        m = ann['segmentation']
+        m = ann["segmentation"]
         ms.append(torch.as_tensor(m))
         color_mask = np.concatenate([np.random.random(3), [0.35]])
         img[m] = color_mask
@@ -174,9 +180,12 @@ def show_anns(anns, rle_to_mask, sort_by_area=True, seed=None):
 
 def profiler_runner(path, fn, *args, **kwargs):
     with torch.profiler.profile(
-            activities=[torch.profiler.ProfilerActivity.CPU,
-                        torch.profiler.ProfilerActivity.CUDA],
-            record_shapes=True) as prof:
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
+        record_shapes=True,
+    ) as prof:
         result = fn(*args, **kwargs)
     prof.export_chrome_trace(path)
     return result
@@ -186,16 +195,15 @@ def memory_runner(path, fn, *args, **kwargs):
     print("Start memory recording")
     torch.cuda.synchronize()
     torch.cuda.memory._record_memory_history(
-        True,
-        trace_alloc_max_entries=100000,
-        trace_alloc_record_context=True
+        True, trace_alloc_max_entries=100000, trace_alloc_record_context=True
     )
     result = fn(*args, **kwargs)
     torch.cuda.synchronize()
     snapshot = torch.cuda.memory._snapshot()
     print("Finish memory recording")
     import pickle
-    with open(path, 'wb') as f:
+
+    with open(path, "wb") as f:
         pickle.dump(snapshot, f)
     # Use to convert pickle file into html
     # python torch/cuda/_memory_viz.py trace_plot <snapshot>.pickle -o <snapshot>.html
@@ -218,9 +226,11 @@ def file_bytes_to_image_tensor(file_bytes, output_format="numpy"):
     if output_format == "numpy":
         return example_image
     if output_format not in ["torch"]:
-        raise ValueError("Expected output_format to be numpy or torch,"
-                         f" but got {output_format}")
+        raise ValueError(
+            "Expected output_format to be numpy or torch," f" but got {output_format}"
+        )
     from torchvision.transforms import ToTensor
+
     return ToTensor()(example_image)
 
 
@@ -257,7 +267,6 @@ async def batch_worker(mask_generator, batch_size, *, pad_batch=True, furious=Fa
             batch.append(await request_queue.get())
 
         if batch:
-
             padded_batch = batch
             if pad_batch:
                 padded_batch = batch + ([batch[-1]] * (batch_size - len(batch)))
@@ -274,7 +283,9 @@ async def lifespan(app: FastAPI):
     mask_generator = app.state.mask_generator
     batch_size = app.state.batch_size
     furious = app.state.furious
-    task = asyncio.create_task(batch_worker(mask_generator, batch_size, furious=furious))
+    task = asyncio.create_task(
+        batch_worker(mask_generator, batch_size, furious=furious)
+    )
     yield
     # Shutdown logic (if needed)
     task.cancel()
@@ -290,7 +301,7 @@ def benchmark_fn(func, inp, mask_generator, warmup=3, runs=10):
     t = time.time()
     for _ in range(runs):
         func(inp, mask_generator)
-    avg_time_per_run = (time.time() - t)/runs
+    avg_time_per_run = (time.time() - t) / runs
     print(f"Benchmark took {avg_time_per_run}s per iteration.")
     max_memory_allocated_bytes, max_memory_allocated_percentage = max_memory_allocated()
     return avg_time_per_run, max_memory_allocated_bytes, max_memory_allocated_percentage
@@ -299,9 +310,13 @@ def benchmark_fn(func, inp, mask_generator, warmup=3, runs=10):
 def max_memory_allocated_stats():
     max_memory_allocated_bytes = torch.cuda.max_memory_allocated()
     _, total_memory = torch.cuda.mem_get_info()
-    max_memory_allocated_percentage = int(100 * (max_memory_allocated_bytes / total_memory))
-    return {"bytes": max_memory_allocated_bytes,
-            "percentage": max_memory_allocated_percentage}
+    max_memory_allocated_percentage = int(
+        100 * (max_memory_allocated_bytes / total_memory)
+    )
+    return {
+        "bytes": max_memory_allocated_bytes,
+        "percentage": max_memory_allocated_percentage,
+    }
 
 
 def max_memory_allocated():
@@ -309,11 +324,15 @@ def max_memory_allocated():
     mib = stats["bytes"] >> 20
     print(f"max_memory_allocated_bytes: {mib}MiB")
     print(f"max_memory_allocated_percentage: {stats['percentage']}%")
+    return mib, stats["percentage"]
 
 
 def unittest_fn(masks, ref_masks, order_by_area=False, verbose=False):
     from compare_rle_lists import compare_masks
-    miou, equal_count = compare_masks(masks, ref_masks, order_by_area=order_by_area, verbose=verbose)
+
+    miou, equal_count = compare_masks(
+        masks, ref_masks, order_by_area=order_by_area, verbose=verbose
+    )
     if equal_count == len(masks):
         print("Masks exactly match reference.")
     else:
@@ -321,26 +340,26 @@ def unittest_fn(masks, ref_masks, order_by_area=False, verbose=False):
 
 
 MODEL_TYPES_TO_CONFIG = {
-        "tiny": "sam2.1_hiera_t.yaml",
-        "small": "sam2.1_hiera_s.yaml",
-        "plus": "sam2.1_hiera_b+.yaml",
-        "large": "sam2.1_hiera_l.yaml",
-        }
+    "tiny": "sam2.1_hiera_t.yaml",
+    "small": "sam2.1_hiera_s.yaml",
+    "plus": "sam2.1_hiera_b+.yaml",
+    "large": "sam2.1_hiera_l.yaml",
+}
 
 MODEL_TYPES_TO_MODEL = {
-        "tiny": "sam2.1_hiera_tiny.pt",
-        "small": "sam2.1_hiera_small.pt",
-        "plus": "sam2.1_hiera_base_plus.pt",
-        "large": "sam2.1_hiera_large.pt",
-        }
+    "tiny": "sam2.1_hiera_tiny.pt",
+    "small": "sam2.1_hiera_small.pt",
+    "plus": "sam2.1_hiera_base_plus.pt",
+    "large": "sam2.1_hiera_large.pt",
+}
 
 
 MODEL_TYPES_TO_URL = {
-        "tiny": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt",
-        "small": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt",
-        "plus": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt",
-        "large": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt",
-        }
+    "tiny": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt",
+    "small": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_small.pt",
+    "plus": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt",
+    "large": "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_large.pt",
+}
 
 
 def main_docstring():
@@ -353,107 +372,150 @@ def main_docstring():
 
 def model_type_to_paths(checkpoint_path, model_type):
     if model_type not in MODEL_TYPES_TO_CONFIG.keys():
-        raise ValueError(f"Expected model_type to be one of {', '.join(MODEL_TYPES_TO_MODEL.keys())} but got {model_type}")
+        raise ValueError(
+            f"Expected model_type to be one of {', '.join(MODEL_TYPES_TO_MODEL.keys())} but got {model_type}"
+        )
     sam2_checkpoint = Path(checkpoint_path) / Path(MODEL_TYPES_TO_MODEL[model_type])
     if not sam2_checkpoint.exists():
-        print(f"Can't find checkpoint {sam2_checkpoint} in folder {checkpoint_path}. Downloading.")
+        print(
+            f"Can't find checkpoint {sam2_checkpoint} in folder {checkpoint_path}. Downloading."
+        )
         download_file(MODEL_TYPES_TO_URL[model_type], checkpoint_path)
     assert sam2_checkpoint.exists(), "Can't find downloaded file. Please open an issue."
     model_cfg = f"configs/sam2.1/{MODEL_TYPES_TO_CONFIG[model_type]}"
     return sam2_checkpoint, model_cfg
 
 
-def set_autoquant(mask_generator):
+def set_autoquant(mask_generator, autoquant_type, min_sqnr):
     import torchao
     from torchao import autoquant
+
     # NOTE: Not baseline feature
-    mask_generator.predictor.model.image_encoder = autoquant(mask_generator.predictor.model.image_encoder, qtensor_class_list=torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST, min_sqnr=40)
+    if autoquant_type == "autoquant":
+        mask_generator.predictor.model.image_encoder = autoquant(
+            mask_generator.predictor.model.image_encoder, min_sqnr=min_sqnr
+        )
+    elif autoquant_type == "autoquant-fp":
+        mask_generator.predictor.model.image_encoder = autoquant(
+            mask_generator.predictor.model.image_encoder,
+            qtensor_class_list=torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
+            min_sqnr=min_sqnr,
+        )
+    elif autoquant_type == "autoquant-all":
+        mask_generator.predictor.model.image_encoder = autoquant(
+            mask_generator.predictor.model.image_encoder,
+            qtensor_class_list=torchao.quantization.ALL_AUTOQUANT_CLASS_LIST,
+            min_sqnr=min_sqnr,
+        )
+    else:
+        raise ValueError(f"Unexpected autoquant type: {autoquant_type}")
+
     mask_generator.predictor._transforms_device = mask_generator.predictor.device
-    torch.set_float32_matmul_precision('high')
+    torch.set_float32_matmul_precision("high")
     # NOTE: this fails when we run
     # python server.py ~/checkpoints/sam2 large --port 8000 --host localhost --fast --use_autoquant --unittest
     # https://gist.github.com/jerryzh168/d337cb5de0a1dec306069fe48ac8225e
     # mask_generator.predictor.model.sam_mask_decoder = autoquant(mask_generator.predictor.model.sam_mask_decoder, qtensor_class_list=DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST, min_sqnr=40)
 
 
-def main(checkpoint_path,
-         model_type,
-         baseline=False,
-         fast=False,
-         furious=False,
-         use_autoquant=False,
-         unittest=False,
-         benchmark=False,
-         profile=None,
-         memory_profile=None,
-         verbose=False,
-         points_per_batch=64,
-         port=5000,
-         host="127.0.0.1",
-         dry=False,
-         batch_size=1,
-         load_fast="",
-         save_fast="",
-         output_json_path=None,
-         output_json_local=False):
+def main(
+    checkpoint_path,
+    model_type,
+    baseline=False,
+    fast=False,
+    furious=False,
+    autoquant_type=None,
+    min_sqnr=None,
+    unittest=False,
+    benchmark=False,
+    profile=None,
+    memory_profile=None,
+    verbose=False,
+    points_per_batch=64,
+    port=5000,
+    host="127.0.0.1",
+    dry=False,
+    batch_size=1,
+    load_fast="",
+    save_fast="",
+    output_json_path=None,
+    output_json_local=False,
+):
     if verbose:
-        logging.basicConfig(level=logging.INFO,
-                            format='%(asctime)s - %(levelname)s - %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S')
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
     logging.info(f"Running with fast set to {fast} and furious set to {furious}")
     logging.info(f"Running with port {port} and host {host}")
     logging.info(f"Running with batch size {batch_size}")
 
     if baseline:
         assert batch_size == 1, "baseline only supports batch size 1."
-        logging.info(f"Importing sam2 from outside of torchao. If this errors, install https://github.com/facebookresearch/sam2")
-        from sam2.build_sam import build_sam2
+        logging.info(
+            "Importing sam2 from outside of torchao. If this errors, install https://github.com/facebookresearch/sam2"
+        )
         from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+        from sam2.build_sam import build_sam2
         from sam2.utils.amg import rle_to_mask
     else:
+        from torchao._models.sam2.automatic_mask_generator import (
+            SAM2AutomaticMaskGenerator,
+        )
         from torchao._models.sam2.build_sam import build_sam2
-        from torchao._models.sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
         from torchao._models.sam2.utils.amg import rle_to_mask
 
     device = "cuda"
     sam2_checkpoint, model_cfg = model_type_to_paths(checkpoint_path, model_type)
 
     logging.info(f"Loading model {sam2_checkpoint} with config {model_cfg}")
-    sam2 = build_sam2(model_cfg, sam2_checkpoint, device=device, apply_postprocessing=False)
+    sam2 = build_sam2(
+        model_cfg, sam2_checkpoint, device=device, apply_postprocessing=False
+    )
 
     logging.info(f"Using {points_per_batch} points_per_batch")
-    mask_generator = SAM2AutomaticMaskGenerator(sam2, points_per_batch=points_per_batch, output_mode="uncompressed_rle")
+    mask_generator = SAM2AutomaticMaskGenerator(
+        sam2, points_per_batch=points_per_batch, output_mode="uncompressed_rle"
+    )
 
     if load_fast != "":
-        load_exported_model(mask_generator, load_fast, "amg", furious, batch_size, points_per_batch)
+        load_exported_model(
+            mask_generator, load_fast, "amg", furious, batch_size, points_per_batch
+        )
 
     if furious:
         set_furious(mask_generator)
 
     if save_fast != "":
-        assert load_fast == "", "Can't save compiled models while loading them with --load-fast."
+        assert (
+            load_fast == ""
+        ), "Can't save compiled models while loading them with --load-fast."
         assert not baseline, "--fast cannot be combined with baseline. code to be torch.compile(fullgraph=True) compatible."
         print(f"Saving compiled models under directory {save_fast}")
-        export_model(mask_generator,
-                     save_fast,
-                     "amg",
-                     furious=furious,
-                     batch_size=batch_size,
-                     points_per_batch=points_per_batch)
+        export_model(
+            mask_generator,
+            save_fast,
+            "amg",
+            furious=furious,
+            batch_size=batch_size,
+            points_per_batch=points_per_batch,
+        )
 
     if fast:
         assert not baseline, "--fast cannot be combined with baseline. code to be torch.compile(fullgraph=True) compatible."
         set_fast(mask_generator, load_fast)
 
     # since autoquant is replicating what furious mode is doing, don't use these two together
-    if use_autoquant:
+    if autoquant_type is not None:
         assert not furious, "use autoquant can't be used together with furious"
-        set_autoquant(mask_generator)
+        set_autoquant(mask_generator, autoquant_type, min_sqnr)
 
-    with open('dog.jpg', 'rb') as f:
+    with open("dog.jpg", "rb") as f:
         output_format = "numpy" if baseline else "torch"
-        image_tensor = file_bytes_to_image_tensor(bytearray(f.read()),
-                                                  output_format=output_format)
+        image_tensor = file_bytes_to_image_tensor(
+            bytearray(f.read()), output_format=output_format
+        )
 
     # from torchvision import io as tio
     # img_bytes_tensor = tio.read_file('dog.jpg')
@@ -469,7 +531,9 @@ def main(checkpoint_path,
         else:
             # TODO: Transpose dog image to create diversity in input image shape
             logging.info(f"batch size {batch_size} unittest")
-            all_masks = image_tensors_to_masks([image_tensor] * batch_size, mask_generator)
+            all_masks = image_tensors_to_masks(
+                [image_tensor] * batch_size, mask_generator
+            )
             all_masks = [masks_to_rle_dict(masks) for masks in all_masks]
             ref_masks = json.loads(open("dog_rle.json").read())
             for masks in all_masks:
@@ -480,17 +544,24 @@ def main(checkpoint_path,
         if batch_size == 1:
             result = benchmark_fn(image_tensor_to_masks, image_tensor, mask_generator)
         else:
-            result = benchmark_fn(image_tensors_to_masks, [image_tensor] * batch_size, mask_generator)
+            result = benchmark_fn(
+                image_tensors_to_masks, [image_tensor] * batch_size, mask_generator
+            )
 
         for i, shapes in enumerate([example_shapes(), example_shapes_2()]):
             print(f"batch size {batch_size} example shapes {i} benchmark")
-            random_images = [np.random.randint(0, 256, size=size, dtype=np.uint8) for size in shapes]
+            random_images = [
+                np.random.randint(0, 256, size=size, dtype=np.uint8) for size in shapes
+            ]
             if batch_size > len(random_images):
                 num_repeat = (len(random_images) + batch_size) // batch_size
                 random_images = num_repeat * random_images
 
             if batch_size == 1:
-                [benchmark_fn(image_tensor_to_masks, r, mask_generator) for r in random_images]
+                [
+                    benchmark_fn(image_tensor_to_masks, r, mask_generator)
+                    for r in random_images
+                ]
             else:
                 random_images = random_images[:batch_size]
                 print("len(random_images): ", len(random_images))
@@ -500,12 +571,44 @@ def main(checkpoint_path,
             headers = ["name", "dtype", "device", "arch", "metric", "actual", "target"]
             name = "sam2-" + model_type
             arch = get_arch_name()
-            dtype = "autoquant" if use_autoquant else "noquant"
-            avg_time_per_run, max_memory_allocated_bytes, max_memory_allocated_percentage = result
-            memory_result = [name, dtype, device, arch, "memory(MiB)", max_memory_allocated_bytes, None]
-            memory_percent_result = [name, dtype, device, arch, "memory(%)", max_memory_allocated_percentage, None]
-            performance_result = [name, dtype, device, arch, "time_s(avg)", avg_time_per_run, None]
-            write_json_result = write_json_result_local if output_json_local else write_json_result_ossci
+            dtype = autoquant_type or "noquant"
+            (
+                avg_time_per_run,
+                max_memory_allocated_bytes,
+                max_memory_allocated_percentage,
+            ) = result
+            memory_result = [
+                name,
+                dtype,
+                device,
+                arch,
+                "memory(MiB)",
+                max_memory_allocated_bytes,
+                None,
+            ]
+            memory_percent_result = [
+                name,
+                dtype,
+                device,
+                arch,
+                "memory(%)",
+                max_memory_allocated_percentage,
+                None,
+            ]
+            performance_result = [
+                name,
+                dtype,
+                device,
+                arch,
+                "time_s(avg)",
+                avg_time_per_run,
+                None,
+            ]
+            write_json_result = (
+                write_json_result_local
+                if output_json_local
+                else write_json_result_ossci
+            )
             write_json_result(output_json_path, headers, memory_result)
             write_json_result(output_json_path, headers, memory_percent_result)
             write_json_result(output_json_path, headers, performance_result)
@@ -513,16 +616,30 @@ def main(checkpoint_path,
     if profile is not None:
         print(f"Saving profile under {profile}")
         if batch_size == 1:
-            profiler_runner(profile, image_tensor_to_masks, image_tensor, mask_generator)
+            profiler_runner(
+                profile, image_tensor_to_masks, image_tensor, mask_generator
+            )
         else:
-            profiler_runner(profile, image_tensors_to_masks, [image_tensor] * batch_size, mask_generator)
+            profiler_runner(
+                profile,
+                image_tensors_to_masks,
+                [image_tensor] * batch_size,
+                mask_generator,
+            )
 
     if memory_profile is not None:
         print(f"Saving memory profile under {memory_profile}")
         if batch_size == 1:
-            memory_runner(memory_profile, image_tensor_to_masks, image_tensor, mask_generator)
+            memory_runner(
+                memory_profile, image_tensor_to_masks, image_tensor, mask_generator
+            )
         else:
-            memory_runner(memory_profile, image_tensors_to_masks, [image_tensor] * batch_size, mask_generator)
+            memory_runner(
+                memory_profile,
+                image_tensors_to_masks,
+                [image_tensor] * batch_size,
+                mask_generator,
+            )
 
     if dry:
         return
@@ -555,23 +672,24 @@ def main(checkpoint_path,
         response_future = asyncio.Future()
         await request_queue.put((image_tensor, response_future))
         masks = await response_future
-        
+
         # Create figure and ensure it's closed after generating response
         fig = plt.figure(figsize=(image_tensor.shape[1]/100., image_tensor.shape[0]/100.), dpi=100)
         plt.imshow(image_tensor)
         show_anns(masks, rle_to_mask)
-        plt.axis('off')
+        plt.axis("off")
         plt.tight_layout()
-            
+
         buf = BytesIO()
-        plt.savefig(buf, format='png')
+        plt.savefig(buf, format="png")
         buf.seek(0)
         plt.close(fig)  # Close figure after we're done with it
-            
+
         return StreamingResponse(buf, media_type="image/png")
 
     # uvicorn.run(app, host=host, port=port, log_level="info")
     uvicorn.run(app, host=host, port=port)
+
 
 main.__doc__ = main_docstring()
 if __name__ == "__main__":

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -1024,12 +1024,30 @@ def main(
         f.close()
 
     if output_json_path:
-        headers = ["name", "dtype", "device", "arch", "metric", "actual", "target"]
+        headers = [
+            "name",
+            "dtype",
+            "min_sqnr",
+            "device",
+            "arch",
+            "metric",
+            "actual",
+            "target",
+        ]
         name = checkpoint_path.parent.name
         arch = get_arch_name()
         dtype = quantization or "noquant"
-        memory_result = [name, dtype, device, arch, "mem/s", bandwidth, None]
-        performance_result = [name, dtype, device, arch, "tok/s", tokpersec, None]
+        memory_result = [name, dtype, min_sqnr, device, arch, "mem/s", bandwidth, None]
+        performance_result = [
+            name,
+            dtype,
+            min_sqnr,
+            device,
+            arch,
+            "tok/s",
+            tokpersec,
+            None,
+        ]
         write_json_result = (
             write_json_result_local if output_json_local else write_json_result_ossci
         )

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -266,6 +266,7 @@ def main(
         "checkpoints/meta-Transformer/Transformer-2-7b-chat-hf/model.pth"
     ),
     quantization: Optional[str] = None,
+    min_sqnr: Optional[float] = None,
     sparsity: Optional[str] = None,
     kv_cache_quantization: bool = False,
     cache_size: Optional[int] = None,
@@ -706,6 +707,7 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.DEFAULT_INT4_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             elif "autoquant-float8" == quantization:
                 model = autoquant(
@@ -713,6 +715,7 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.OTHER_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             elif "autoquant-fp" == quantization:
                 model = autoquant(
@@ -720,6 +723,7 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             elif "autoquant-sparse" == quantization:
                 model = autoquant(
@@ -727,6 +731,7 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.DEFAULT_SPARSE_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             elif "autoquant-gemlite-int4" == quantization:
                 import os
@@ -742,6 +747,7 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.GEMLITE_INT4_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             elif "autoquant-all" == quantization:
                 try:
@@ -761,9 +767,12 @@ def main(
                     manual=True,
                     qtensor_class_list=torchao.quantization.ALL_AUTOQUANT_CLASS_LIST,
                     example_input=inputs,
+                    min_sqnr=min_sqnr,
                 )
             else:
-                model = autoquant(model, manual=True, example_input=inputs)
+                model = autoquant(
+                    model, manual=True, example_input=inputs, min_sqnr=min_sqnr
+                )
 
             generate(
                 model,
@@ -1074,6 +1083,14 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--min_sqnr",
+        type=float,
+        default=None,
+        help=(
+            "min sqnr for quantizing v.s. not quantizing a layer, used in autoquant options",
+        ),
+    )
+    parser.add_argument(
         "-s",
         "--sparsity",
         type=str,
@@ -1148,6 +1165,7 @@ if __name__ == "__main__":
         args.temperature,
         args.checkpoint_path,
         args.quantization,
+        args.min_sqnr,
         args.sparsity,
         args.kv_cache_quantization,
         args.cache_size,

--- a/torchao/_models/sam/eval_combo.py
+++ b/torchao/_models/sam/eval_combo.py
@@ -638,20 +638,39 @@ def run(
         f.write(vals + "\n")
 
     if output_json_path:
-        headers = ["name", "dtype", "device", "arch", "metric", "actual", "target"]
+        headers = [
+            "name",
+            "dtype",
+            "min_sqnr",
+            "device",
+            "arch",
+            "metric",
+            "actual",
+            "target",
+        ]
         name = sam_model_type
         arch = get_arch_name()
         dtype = compress or "noquant"
         memory_result = [
             name,
             dtype,
+            min_sqnr,
             device,
             arch,
             "memory(MiB)",
             max_memory_allocated_bytes,
             None,
         ]
-        performance_result = [name, dtype, device, arch, "img_s(avg)", img_s, None]
+        performance_result = [
+            name,
+            dtype,
+            min_sqnr,
+            device,
+            arch,
+            "img_s(avg)",
+            img_s,
+            None,
+        ]
         write_json_result = (
             write_json_result_local if output_json_local else write_json_result_ossci
         )

--- a/torchao/_models/sam/eval_combo.py
+++ b/torchao/_models/sam/eval_combo.py
@@ -284,6 +284,7 @@ def run(
     use_compile="False",
     use_compile_decoder=False,
     compress=None,
+    min_sqnr=None,
     num_workers=0,
     use_rel_pos=True,
     pad_input_image_batch=True,
@@ -457,6 +458,7 @@ def run(
                 example_input=example_input,
                 manual=True,
                 qtensor_class_list=torchao.quantization.DEFAULT_INT4_AUTOQUANT_CLASS_LIST,
+                min_sqnr=min_sqnr,
             )
         elif "autoquant-float8" == compress:
             autoquant(
@@ -464,6 +466,7 @@ def run(
                 example_input=example_input,
                 manual=True,
                 qtensor_class_list=torchao.quantization.OTHER_AUTOQUANT_CLASS_LIST,
+                min_sqnr=min_sqnr,
             )
         elif "autoquant-sparse" == compress:
             autoquant(
@@ -471,6 +474,7 @@ def run(
                 example_input=example_input,
                 manual=True,
                 qtensor_class_list=torchao.quantization.DEFAULT_SPARSE_AUTOQUANT_CLASS_LIST,
+                min_sqnr=min_sqnr,
             )
         elif "autoquant-all" == compress:
             autoquant(
@@ -478,10 +482,14 @@ def run(
                 example_input=example_input,
                 manual=True,
                 qtensor_class_list=torchao.quantization.ALL_AUTOQUANT_CLASS_LIST,
+                min_sqnr=min_sqnr,
             )
         else:
             autoquant(
-                predictor.model.image_encoder, example_input=example_input, manual=True
+                predictor.model.image_encoder,
+                example_input=example_input,
+                manual=True,
+                min_sqnr=min_sqnr,
             )
         predictor.model.image_encoder(example_input)
         predictor.model.image_encoder.finalize_autoquant()

--- a/torchao/_models/utils.py
+++ b/torchao/_models/utils.py
@@ -38,7 +38,7 @@ def write_json_result_ossci(output_json_path, headers, row):
         "model": {
             "name": mapping_headers["name"],
             "type": "model",
-            "origins": ["torchao/_models"],
+            "origins": ["torchao"],
         },
         "metric": {
             "name": mapping_headers["metric"],
@@ -87,7 +87,7 @@ def write_json_result_local(output_json_path, headers, row):
         "model": {
             "name": mapping_headers["name"],
             "type": "model",
-            "origins": ["torchao/_models"],
+            "origins": ["torchao"],
         },
         "metric": {
             "name": mapping_headers["metric"],

--- a/torchao/_models/utils.py
+++ b/torchao/_models/utils.py
@@ -30,6 +30,7 @@ def write_json_result_ossci(output_json_path, headers, row):
             "name": "TorchAO benchmark",
             "mode": "inference",
             "dtype": mapping_headers["dtype"],
+            "min_sqnr": mapping_headers["min_sqnr"],
             "extra_info": {
                 "device": mapping_headers["device"],
                 "arch": mapping_headers["arch"],
@@ -79,6 +80,7 @@ def write_json_result_local(output_json_path, headers, row):
             "name": "TorchAO benchmark",
             "mode": "inference",
             "dtype": mapping_headers["dtype"],
+            "min_sqnr": mapping_headers["min_sqnr"],
             "extra_info": {
                 "device": mapping_headers["device"],
                 "arch": mapping_headers["arch"],

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -420,7 +420,7 @@ class AQInt8DynamicallyQuantizedLinearWeight(AQMixin, LinearActivationQuantizedT
 
         # TODO test if this is valid
         # in_features = weight.shape[1]
-        # # int8 dynamic quantization only has benefit when in_feature > 16
+        # int8 dynamic quantization only has benefit when in_feature > 16
         # if in_features <= 16:
         #     return weight
 
@@ -627,11 +627,14 @@ class AQInt4G32WeightOnlyQuantizedLinearWeight(AffineQuantizedTensor, AQMixin):
         if weight.shape[-1] % group_size != 0:
             return weight
 
-        # if isinstance(_layout, TensorCoreTiledLayout) and weight.dtype != torch.bfloat16:
-        #     return weight
+        if (
+            isinstance(_layout, TensorCoreTiledLayout)
+            and weight.dtype != torch.bfloat16
+        ):
+            return weight
 
-        # if isinstance(_layout, MarlinSparseLayout) and weight.dtype != torch.float16:
-        #     return weight
+        if isinstance(_layout, MarlinSparseLayout) and weight.dtype != torch.float16:
+            return weight
 
         use_hqq = True
         mapping_type = MappingType.ASYMMETRIC
@@ -1062,7 +1065,6 @@ if not is_sm_at_least_89():
 
 # deduplicate
 ALL_AUTOQUANT_CLASS_LIST = list(set(ALL_AUTOQUANT_CLASS_LIST))
-# print(ALL_AUTOQUANT_CLASS_LIST)
 
 
 def _change_linears_to_autoquantizable(model, **kwargs):

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -415,14 +415,14 @@ class AQInt8DynamicallyQuantizedLinearWeight(AQMixin, LinearActivationQuantizedT
 
     @classmethod
     def from_float(cls, weight):
-        # TODO test if this is valid
-        # in_features = weight.shape[1]
-        # int8 dynamic quantization only has benefit when in_feature > 16
-        # if in_features <= 16:
-        # return weight
-
         if weight.dim() != 2:
             return weight
+
+        # TODO test if this is valid
+        # in_features = weight.shape[1]
+        # # int8 dynamic quantization only has benefit when in_feature > 16
+        # if in_features <= 16:
+        #     return weight
 
         # avoid circular dep
         from torchao.dtypes import to_affine_quantized_intx
@@ -522,7 +522,7 @@ class AQInt8DynamicallyQuantizedLinearWeight(AQMixin, LinearActivationQuantizedT
 class AQInt8DynamicallyQuantizedSemiSparseLinearWeight(
     AQInt8DynamicallyQuantizedLinearWeight
 ):
-    layout: Layout = SemiSparseLayout()
+    aq_layout: Layout = SemiSparseLayout()
 
     @classmethod
     def _autoquant_test(cls, act_mat, weight, bias, best_time, mode=["relu", None]):
@@ -627,6 +627,12 @@ class AQInt4G32WeightOnlyQuantizedLinearWeight(AffineQuantizedTensor, AQMixin):
         if weight.shape[-1] % group_size != 0:
             return weight
 
+        # if isinstance(_layout, TensorCoreTiledLayout) and weight.dtype != torch.bfloat16:
+        #     return weight
+
+        # if isinstance(_layout, MarlinSparseLayout) and weight.dtype != torch.float16:
+        #     return weight
+
         use_hqq = True
         mapping_type = MappingType.ASYMMETRIC
         block_size = (1, group_size)
@@ -690,6 +696,9 @@ class AQGemliteInt4G32WeightOnlyQuantizedLinearWeight(AffineQuantizedTensor, AQM
 
     @classmethod
     def from_float(cls, weight):
+        if weight.dtype != torch.float16:
+            return weight
+
         from torchao.dtypes.uintx.gemlite_layout import get_gemlite_aqt_kwargs
 
         bit_width = 4
@@ -1022,7 +1031,9 @@ OTHER_AUTOQUANT_CLASS_LIST = [
 
 DEFAULT_SPARSE_AUTOQUANT_CLASS_LIST = [
     AQDefaultLinearWeight,
+    # TODO: investigate why there are some problems when adding sparse kernels for sam2
     AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
+    # some errors when calling cusparse kernels when running on sam2
     AQInt8DynamicallyQuantizedSemiSparseLinearWeight,
 ]
 
@@ -1051,6 +1062,7 @@ if not is_sm_at_least_89():
 
 # deduplicate
 ALL_AUTOQUANT_CLASS_LIST = list(set(ALL_AUTOQUANT_CLASS_LIST))
+# print(ALL_AUTOQUANT_CLASS_LIST)
 
 
 def _change_linears_to_autoquantizable(model, **kwargs):


### PR DESCRIPTION
Summary:
att, this allows us to run benchmarks with different min_sqnr to control the accuracy loss of the model

Test Plan:
```
export CHECKPOINT_PATH=checkpoints
export MODEL_REPO=meta-llama/Meta-Llama-3.1-8B
python torchao/_models/llama/generate.py --checkpoint_path "${CHECKPOINT_PATH}/${MODEL_REPO}/model.pth" --compile --compile_prefill --quantization autoquant-all --output_json_path benchmark-results.json --outpu\t_json_local --min_sqnr 40

python torchao/_models/sam/eval_combo.py --coco_root_dir datasets/coco2017 --coco_slice_name val2017 --sam_checkpoint_base_path checkpoints --sam_model_type vit_h --point_sampling_cache_dir tmp/sam_coco_mask_ce\nter_cache --mask_debug_out_dir tmp/sam_eval_masks_out --batch_size 32 --num_workers 8 --use_compile max-autotune --use_half bfloat16 --device cuda --compress autoquant-all --output_json_path benchmark-results.json\ --output_json_local --min_sqnr 40

cd examples/sam2_amg_server
python server.py ../../${CHECKPOINT_PATH}/sam2 large --port 4000 --host localhost --fast --use_autoquant --benchmark --dry --output_json_path ../../benchmark-results.json --output_json_local --min_sqnr 40
```

Reviewers:

Subscribers:

Tasks:

Tags: