### PR TITLE
🐛 Fix: Memory leak in image processing endpoint

### DIFF
--- a/examples/sam2_amg_server/server.py
+++ b/examples/sam2_amg_server/server.py
@@ -557,8 +557,9 @@ def main(checkpoint_path,
         await request_queue.put((image_tensor, response_future))
         masks = await response_future
         
-        # Use context manager to handle figure lifecycle and ensure cleanup
-        with plt.figure(figsize=(image_tensor.shape[1]/100., image_tensor.shape[0]/100.), dpi=100) as fig:
+        # Create figure and ensure it's closed after use
+        fig = plt.figure(figsize=(image_tensor.shape[1]/100., image_tensor.shape[0]/100.), dpi=100)
+        try:
             # Display the original image
             plt.imshow(image_tensor)
             # Overlay annotations (masks) on the image
@@ -575,11 +576,11 @@ def main(checkpoint_path,
             # Reset buffer position to start
             buf.seek(0)
             
-            # Explicitly close the figure to prevent memory leaks
+            return StreamingResponse(buf, media_type="image/png")
+        finally:
+            # Ensure figure is closed even if an error occurs
             plt.close(fig)
-            
-        # Return the image as a streaming response
-            return StreamingResponse(buf, media_type="image/png")       
+
     # uvicorn.run(app, host=host, port=port, log_level="info")
     uvicorn.run(app, host=host, port=port)
 


### PR DESCRIPTION
@cpuhrsch 

# 🐛 Fix: Memory leak causing process termination under high load

## Issue Description
When processing large batches of images through the `/upload` endpoint in production, we encountered two critical issues:

1. Memory Leak Warning:

RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory.


2. Process Termination:
Under high load with multiple concurrent requests, the server process would eventually terminate due to memory exhaustion caused by unclosed matplotlib figures accumulating in memory.

## Root Cause
The `/upload` endpoint creates new matplotlib figures for each request but doesn't properly clean them up, leading to:
- Memory leaks as figures accumulate
- Resource exhaustion under high concurrency
- Eventual process termination in production environments

## Changes Made
- Added proper figure cleanup using try/finally block
- Fixed the incorrect usage of context manager with plt.figure()
- Ensures matplotlib figures are properly closed after generating the image response, even when exceptions occur

## Before
```python
@app.post("/upload")
async def upload_image(image: UploadFile = File(...)):
    # ... other code ...
    plt.figure(figsize=(image_tensor.shape[1]/100., image_tensor.shape[0]/100.), dpi=100)
    plt.imshow(image_tensor)
    # ... figure generation ...
    return StreamingResponse(buf, media_type="image/png")
```

## After
```python
@app.post("/upload")
async def upload_image(image: UploadFile = File(...)):
    # Convert uploaded file to image tensor
    image_tensor = file_bytes_to_image_tensor(bytearray(await image.read()))
    response_future = asyncio.Future()
    await request_queue.put((image_tensor, response_future))
    masks = await response_future
    
    # Create figure and ensure it's closed after use
    fig = plt.figure(figsize=(image_tensor.shape[1]/100., image_tensor.shape[0]/100.), dpi=100)
    try:
        # Display the original image
        plt.imshow(image_tensor)
        # Overlay annotations (masks) on the image
        show_anns(masks, rle_to_mask)
        # Remove axis for cleaner visualization
        plt.axis('off')
        # Adjust layout to remove padding
        plt.tight_layout()
        
        # Create a buffer to store the image
        buf = BytesIO()
        # Save the figure to buffer in PNG format
        plt.savefig(buf, format='png')
        # Reset buffer position to start
        buf.seek(0)
        
        return StreamingResponse(buf, media_type="image/png")
    finally:
        # Ensure figure is closed even if an error occurs
        plt.close(fig)
```

## Testing Done
- Fixed the `AttributeError: __enter__` error when using `with` statement
- Verified that the endpoint still returns correct image responses
- Confirmed that the memory leak warning no longer appears
- Load tested with high concurrency (100+ requests/minute) to verify:
  - No memory leaks under sustained load
  - Process remains stable
  - All figures are properly cleaned up

## Production Impact
This fix addresses a critical stability issue where image processing services would terminate under load due to memory exhaustion, requiring manual restarts and potentially causing service interruptions.

Let me know if you'd like me to make any adjustments to this PR or if you need additional testing information.
```