### PR TITLE
Fix gcc warning

### DIFF
--- a/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu
+++ b/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu
@@ -401,10 +401,13 @@ __global__ void Marlin_24(
         meta_ptr[i] += m_gl_rd_delta_o;
       }
       // Only fetch scales if this tile starts a new group
-      if (group_blocks != -1 && pipe % (group_blocks / thread_k_blocks) == 0) {
-        int4* sh_s_stage = sh_s + s_sh_stage * pipe;
-        if (s_sh_wr_pred) cp_async4(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
-        s_gl_rd += s_gl_rd_delta;
+      if constexpr (group_blocks != -1) {
+        if (pipe % (group_blocks / thread_k_blocks) == 0) {
+          int4 *sh_s_stage = sh_s + s_sh_stage * pipe;
+          if (s_sh_wr_pred)
+            cp_async4(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
+          s_gl_rd += s_gl_rd_delta;
+        }
       }
     }
     // Insert a fence even when we are winding down the pipeline to ensure that
@@ -429,7 +432,7 @@ __global__ void Marlin_24(
     // however, this does not seem to be a significant bottleneck, while some
     // theoretically better attempts have lead to bad instruction ordering by
     // the compiler and correspondingly a noticeable drop in performance.
-    if (group_blocks != -1) {
+    if constexpr (group_blocks != -1) {
       int4* sh_s_stage =
           sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) *
                                (pipe / (group_blocks / thread_k_blocks)));


### PR DESCRIPTION
Stacked PRs:
 * __->__#1527


--- --- ---

Fix gcc warning

Fixes warning:
```
[1/1] /usr/local/cuda-12.4/bin/nvcc --generate-dependencies-with-compile --dependency-output /home/drisspg/meta/ao/build/temp.linux-x86_64-cpython-311/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.o.d -I/home/drisspg/.conda/envs/nightly/lib/python3.11/site-packages/torch/include -I/home/drisspg/.conda/envs/nightly/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -I/home/drisspg/.conda/envs/nightly/lib/python3.11/site-packages/torch/include/TH -I/home/drisspg/.conda/envs/nightly/lib/python3.11/site-packages/torch/include/THC -I/usr/local/cuda-12.4/include -I/home/drisspg/.conda/envs/nightly/include/python3.11 -c -c /home/drisspg/meta/ao/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu -o /home/drisspg/meta/ao/build/temp.linux-x86_64-cpython-311/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -O3 -t=0 -DTORCHAO_USE_CUTLASS -I/home/drisspg/meta/ao/third_party/cutlass/include -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=1 -gencode=arch=compute_90a,code=sm_90a -std=c++17
/home/drisspg/meta/ao/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu(404): warning #179-D: right operand of "%" is zero
        if (group_blocks > 0 && pipe % (group_blocks / thread_k_blocks) == 0) {
                                       ^
          detected during instantiation of "void torchao::Marlin_24<num_bits,threads,thread_m_blocks,thread_n_blocks,thread_k_blocks,stages,group_blocks>(const int4 *, const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *) [with num_bits=4, threads=256, thread_m_blocks=1, thread_n_blocks=8, thread_k_blocks=4, stages=4, group_blocks=-1]" at line 956

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/home/drisspg/meta/ao/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu(437): warning #39-D: division by zero
                                 (pipe / (group_blocks / thread_k_blocks)));
                                 
```