### PR TITLE
notify when CI job fails

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -72,7 +72,7 @@ jobs:
           to: cdhernandez@meta.com
           subject: Scheduled CI Failure for TorchAO
           body: |
-            Workflow failed: ${{ name }}.
+            Workflow failed: Build Linux Wheels.
             The error is: ${{ env.WORKFLOW_CONCLUSION }}.
             see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             ${{ github.event_name }} and ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: dawidd6/action-send-mail@v4
         with:
           server_address: smtp.gmail.com
-          server_port: 587
+          server_port: 465
           username: torchao.notify
           password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}
           from: torchao.notify@gmail.com

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -56,26 +56,11 @@ jobs:
       upload-to-pypi: cu121
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  
-  capture-error:
-    runs-on: ubuntu-latest
-    if: failure()
-    needs: [build, generate-matrix]
-    outputs:
-      error-message: ${{ steps.get-error.outputs.error }}
-    steps:
-      - id: get-error
-        run: |
-          ERROR=$(gh run view ${{ github.run_id }} --json jobs -q '.jobs[] | select(.conclusion == "failure") | .steps[] | select(.conclusion == "failure") | .name + ": " + .conclusion')
-          echo "error=$ERROR" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
   notify:
     runs-on: ubuntu-latest
     name: Email notification
     needs: [generate-matrix, build]
-    if: failure() && github.event_name == 'pull_request'
+    if: failure() && github.event_name == 'pull_request' # SHOULD BE schedule
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:
@@ -101,7 +86,8 @@ jobs:
             You can view the full run details here:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            Error Details:
-            ${{ needs.capture-error.outputs.error-message }}
+            Error Information:
+            ${{ needs.generate-matrix.result == 'failure' && 'Matrix generation failed' || '' }}
+            ${{ needs.build.result == 'failure' && 'Build job failed' || '' }}
             
             This is an automated notification. Please check the GitHub Actions page for more details about the failure.

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Email notification
     needs: [generate-matrix, build]
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event_name == 'pull_request'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:
@@ -69,8 +69,8 @@ jobs:
           username: torchao.notify
           password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}
           from: torchao.notify@gmail.com
-          to: cdhernandez@meta.com
-          subject: Scheduled Build Failure for TorchAO
+          to: ${{ secrets.TORCHAO_NOTIFY_RECIPIENT }}
+          subject: breakbutterflyScheduled Build Failure for TorchAO
           body: |
             Build Failure Notification for TorchAO
 

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,9 +65,10 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          from: torchao.notify@gmail.com
-          to_address: cdhernandez@meta.com
-          subject: Scheduled CI Failure for TorchAO
-          body: "Workflow failed: Build Linux Wheels\ngetlink"
           username: torchao.notify
           password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}
+          from: torchao.notify@gmail.com
+          to: cdhernandez@meta.com
+          subject: Scheduled CI Failure for TorchAO
+          body: "Workflow failed: Build Linux Wheels\ngetlink"
+

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -56,11 +56,26 @@ jobs:
       upload-to-pypi: cu121
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  
+  capture-error:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs: [build, generate-matrix]
+    outputs:
+      error-message: ${{ steps.get-error.outputs.error }}
+    steps:
+      - id: get-error
+        run: |
+          ERROR=$(gh run view ${{ github.run_id }} --json jobs -q '.jobs[] | select(.conclusion == "failure") | .steps[] | select(.conclusion == "failure") | .name + ": " + .conclusion')
+          echo "error=$ERROR" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
   notify:
     runs-on: ubuntu-latest
     name: Email notification
-    needs: [build]
-    if: github.event_name == 'pull_request' && failure()
+    needs: [generate-matrix, build]
+    if: failure() && github.event_name == 'pull_request'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:
@@ -86,7 +101,7 @@ jobs:
             You can view the full run details here:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            Error Information:
-            ${{ job.status }}
-
+            Error Details:
+            ${{ needs.capture-error.outputs.error-message }}
+            
             This is an automated notification. Please check the GitHub Actions page for more details about the failure.

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -47,7 +47,7 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       env-var-script: packaging/env_var_script_linux.sh
-      pre-script: packaging/pre_build_script.shs #ERROR
+      pre-script: packaging/pre_build_script.sh
       post-script: packaging/post_build_script.sh
       smoke-test-script: packaging/smoke_test.py
       package-name: torchao
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Email notification
     needs: [generate-matrix, build]
-    if: failure() && github.event_name == 'pull_request' # SHOULD BE schedule
+    if: failure() && github.event_name == 'schedule'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Email notification
     needs: [build]
-    if: github.event_name == 'pull_request' && job.status != 'success'
+    if: github.event_name == 'pull_request' && failure()
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,46 +21,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: wheel
-      os: linux
-      with-cpu: enable
-      with-cuda: enable
-      with-rocm: enable
-      with-xpu: enable
+  # generate-matrix:
+  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+  #   with:
+  #     package-type: wheel
+  #     os: linux
+  #     with-cpu: enable
+  #     with-cuda: enable
+  #     with-rocm: enable
+  #     with-xpu: enable
 
-  build:
-    needs: generate-matrix
-    permissions:
-      id-token: write
-      contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    with:
-      # Set the ref to an empty string instead of the default nightly because
-      # torchao doesn't have nightly branch setup yet, instead the build is
-      # triggered daily from main with a schedule
-      repository: pytorch/ao
-      ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      env-var-script: packaging/env_var_script_linux.sh
-      pre-script: packaging/pre_build_script.sh
-      post-script: packaging/post_build_script.sh
-      smoke-test-script: packaging/smoke_test.py
-      package-name: torchao
-      trigger-event: ${{ github.event_name }}
-      # This is the CUDA version to be uploaded to torchao-nightly pypi
-      upload-to-pypi: cu121
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  # build:
+  #   needs: generate-matrix
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+  #   with:
+  #     # Set the ref to an empty string instead of the default nightly because
+  #     # torchao doesn't have nightly branch setup yet, instead the build is
+  #     # triggered daily from main with a schedule
+  #     repository: pytorch/ao
+  #     ref: ""
+  #     test-infra-repository: pytorch/test-infra
+  #     test-infra-ref: main
+  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+  #     env-var-script: packaging/env_var_script_linux.sh
+  #     pre-script: packaging/pre_build_script.sh
+  #     post-script: packaging/post_build_script.sh
+  #     smoke-test-script: packaging/smoke_test.py
+  #     package-name: torchao
+  #     trigger-event: ${{ github.event_name }}
+  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
+  #     upload-to-pypi: cu121
+  #   secrets:
+  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     name: Email notification
-    needs: [generate-matrix, build]
-    if: failure() && github.event_name == 'pull_request'
+    # needs: [generate-matrix, build]
+    # if: failure() && github.event_name == 'pull_request'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,46 +21,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  # generate-matrix:
-  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-  #   with:
-  #     package-type: wheel
-  #     os: linux
-  #     with-cpu: enable
-  #     with-cuda: enable
-  #     with-rocm: enable
-  #     with-xpu: enable
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      with-cpu: enable
+      with-cuda: enable
+      with-rocm: enable
+      with-xpu: enable
 
-  # build:
-  #   needs: generate-matrix
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-  #   with:
-  #     # Set the ref to an empty string instead of the default nightly because
-  #     # torchao doesn't have nightly branch setup yet, instead the build is
-  #     # triggered daily from main with a schedule
-  #     repository: pytorch/ao
-  #     ref: ""
-  #     test-infra-repository: pytorch/test-infra
-  #     test-infra-ref: main
-  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-  #     env-var-script: packaging/env_var_script_linux.sh
-  #     pre-script: packaging/pre_build_script.sh
-  #     post-script: packaging/post_build_script.sh
-  #     smoke-test-script: packaging/smoke_test.py
-  #     package-name: torchao
-  #     trigger-event: ${{ github.event_name }}
-  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
-  #     upload-to-pypi: cu121
-  #   secrets:
-  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  build:
+    needs: generate-matrix
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      # Set the ref to an empty string instead of the default nightly because
+      # torchao doesn't have nightly branch setup yet, instead the build is
+      # triggered daily from main with a schedule
+      repository: pytorch/ao
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      env-var-script: packaging/env_var_script_linux.sh
+      pre-script: packaging/pre_build_script.sh
+      post-script: packaging/post_build_script.sh
+      smoke-test-script: packaging/smoke_test.py
+      package-name: torchao
+      trigger-event: ${{ github.event_name }}
+      # This is the CUDA version to be uploaded to torchao-nightly pypi
+      upload-to-pypi: cu121
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     name: Email notification
-    # needs: [generate-matrix, build]
-    # if: failure() && github.event_name == 'pull_request'
+    needs: [generate-matrix, build]
+    if: failure() && github.event_name == 'schedule'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -56,15 +56,18 @@ jobs:
   #     upload-to-pypi: cu121
   #   secrets:
   #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  send-email-on-failure:
+  notify:
+    runs-on: ubuntu-latest
+    name: Email notification
+    steps:
     # if: failure()
-    uses: dawidd6/action-send-mail@v4
-    with:
-      server_address: smtp.gmail.com
-      server_port: 587
-      from_address: torchao.notify@gmail.com
-      to_address: cdhernandez@meta.com
-      subject: Scheduled CI Failure for TorchAO
-      body: "Workflow failed: Build Linux Wheels\ngetlink"
-      username: torchao.notify
-      password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}
+      - uses: dawidd6/action-send-mail@v4
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          from_address: torchao.notify@gmail.com
+          to_address: cdhernandez@meta.com
+          subject: Scheduled CI Failure for TorchAO
+          body: "Workflow failed: Build Linux Wheels\ngetlink"
+          username: torchao.notify
+          password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,38 +21,50 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: wheel
-      os: linux
-      with-cpu: enable
-      with-cuda: enable
-      with-rocm: enable
-      with-xpu: enable
+  # generate-matrix:
+  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+  #   with:
+  #     package-type: wheel
+  #     os: linux
+  #     with-cpu: enable
+  #     with-cuda: enable
+  #     with-rocm: enable
+  #     with-xpu: enable
 
-  build:
-    needs: generate-matrix
-    permissions:
-      id-token: write
-      contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+  # build:
+  #   needs: generate-matrix
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+  #   with:
+  #     # Set the ref to an empty string instead of the default nightly because
+  #     # torchao doesn't have nightly branch setup yet, instead the build is
+  #     # triggered daily from main with a schedule
+  #     repository: pytorch/ao
+  #     ref: ""
+  #     test-infra-repository: pytorch/test-infra
+  #     test-infra-ref: main
+  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+  #     env-var-script: packaging/env_var_script_linux.sh
+  #     pre-script: packaging/pre_build_script.sh
+  #     post-script: packaging/post_build_script.sh
+  #     smoke-test-script: packaging/smoke_test.py
+  #     package-name: torchao
+  #     trigger-event: ${{ github.event_name }}
+  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
+  #     upload-to-pypi: cu121
+  #   secrets:
+  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  send-email-on-failure:
+    # if: failure()
+    uses: dawidd6/action-send-mail@v4
     with:
-      # Set the ref to an empty string instead of the default nightly because
-      # torchao doesn't have nightly branch setup yet, instead the build is
-      # triggered daily from main with a schedule
-      repository: pytorch/ao
-      ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      env-var-script: packaging/env_var_script_linux.sh
-      pre-script: packaging/pre_build_script.sh
-      post-script: packaging/post_build_script.sh
-      smoke-test-script: packaging/smoke_test.py
-      package-name: torchao
-      trigger-event: ${{ github.event_name }}
-      # This is the CUDA version to be uploaded to torchao-nightly pypi
-      upload-to-pypi: cu121
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      server_address: smtp.gmail.com
+      server_port: 587
+      from_address: torchao.notify@gmail.com
+      to_address: cdhernandez@meta.com
+      subject: Scheduled CI Failure for TorchAO
+      body: "Workflow failed: Build Linux Wheels\ngetlink"
+      username: torchao.notify
+      password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,46 +21,47 @@ on:
   workflow_dispatch:
 
 jobs:
-  # generate-matrix:
-  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-  #   with:
-  #     package-type: wheel
-  #     os: linux
-  #     with-cpu: enable
-  #     with-cuda: enable
-  #     with-rocm: enable
-  #     with-xpu: enable
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      with-cpu: enable
+      with-cuda: enable
+      with-rocm: enable
+      with-xpu: enable
 
-  # build:
-  #   needs: generate-matrix
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-  #   with:
-  #     # Set the ref to an empty string instead of the default nightly because
-  #     # torchao doesn't have nightly branch setup yet, instead the build is
-  #     # triggered daily from main with a schedule
-  #     repository: pytorch/ao
-  #     ref: ""
-  #     test-infra-repository: pytorch/test-infra
-  #     test-infra-ref: main
-  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-  #     env-var-script: packaging/env_var_script_linux.sh
-  #     pre-script: packaging/pre_build_script.sh
-  #     post-script: packaging/post_build_script.sh
-  #     smoke-test-script: packaging/smoke_test.py
-  #     package-name: torchao
-  #     trigger-event: ${{ github.event_name }}
-  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
-  #     upload-to-pypi: cu121
-  #   secrets:
-  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  build:
+    needs: generate-matrix
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      # Set the ref to an empty string instead of the default nightly because
+      # torchao doesn't have nightly branch setup yet, instead the build is
+      # triggered daily from main with a schedule
+      repository: pytorch/ao
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      env-var-script: packaging/env_var_script_linux.sh
+      pre-script: packaging/pre_build_script.sh
+      post-script: packaging/post_build_script.sh
+      smoke-test-script: packaging/smoke_test.py
+      package-name: torchao
+      trigger-event: ${{ github.event_name }}
+      # This is the CUDA version to be uploaded to torchao-nightly pypi
+      upload-to-pypi: cu121
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     name: Email notification
+    needs: [build]
+    if: github.event_name == 'pull_request'
     steps:
-    # if: failure()
       - uses: dawidd6/action-send-mail@v4
         with:
           server_address: smtp.gmail.com
@@ -70,5 +71,28 @@ jobs:
           from: torchao.notify@gmail.com
           to: cdhernandez@meta.com
           subject: Scheduled CI Failure for TorchAO
-          body: "Workflow failed: Build Linux Wheels\ngetlink"
+          body: |
+            Workflow failed: ${{ name }}.
+            The error is: ${{ env.WORKFLOW_CONCLUSION }}.
+            see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            ${{ github.event_name }} and ${{ github.event_name == 'pull_request' }}
+            ${{ env.WORKFLOW_CONCLUSION }}
+            ------ claude message ------
+            Build Failure Notification for TorchAO
 
+            A failure occurred in the Build Linux Wheels workflow.
+
+            Run Details:
+            - Workflow: ${{ github.workflow }}
+            - Run Type: ${{ github.event_name }}
+            - Repository: ${{ github.repository }}
+            - Branch/PR: ${{ github.ref }}
+            - Commit: ${{ github.sha }}
+
+            You can view the full run details here:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Error Information:
+            ${{ job.status }}
+
+            This is an automated notification. Please check the GitHub Actions page for more details about the failure.

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          from_address: torchao.notify@gmail.com
+          from: torchao.notify@gmail.com
           to_address: cdhernandez@meta.com
           subject: Scheduled CI Failure for TorchAO
           body: "Workflow failed: Build Linux Wheels\ngetlink"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,46 +21,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  # generate-matrix:
-  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-  #   with:
-  #     package-type: wheel
-  #     os: linux
-  #     with-cpu: enable
-  #     with-cuda: enable
-  #     with-rocm: enable
-  #     with-xpu: enable
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      with-cpu: enable
+      with-cuda: enable
+      with-rocm: enable
+      with-xpu: enable
 
-  # build:
-  #   needs: generate-matrix
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-  #   with:
-  #     # Set the ref to an empty string instead of the default nightly because
-  #     # torchao doesn't have nightly branch setup yet, instead the build is
-  #     # triggered daily from main with a schedule
-  #     repository: pytorch/ao
-  #     ref: ""
-  #     test-infra-repository: pytorch/test-infra
-  #     test-infra-ref: main
-  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-  #     env-var-script: packaging/env_var_script_linux.sh
-  #     pre-script: packaging/pre_build_script.sh
-  #     post-script: packaging/post_build_script.sh
-  #     smoke-test-script: packaging/smoke_test.py
-  #     package-name: torchao
-  #     trigger-event: ${{ github.event_name }}
-  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
-  #     upload-to-pypi: cu121
-  #   secrets:
-  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  build:
+    needs: generate-matrix
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      # Set the ref to an empty string instead of the default nightly because
+      # torchao doesn't have nightly branch setup yet, instead the build is
+      # triggered daily from main with a schedule
+      repository: pytorch/ao
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      env-var-script: packaging/env_var_script_linux.sh
+      pre-script: packaging/pre_build_script.shs #ERROR
+      post-script: packaging/post_build_script.sh
+      smoke-test-script: packaging/smoke_test.py
+      package-name: torchao
+      trigger-event: ${{ github.event_name }}
+      # This is the CUDA version to be uploaded to torchao-nightly pypi
+      upload-to-pypi: cu121
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     name: Email notification
-    # needs: [build]
-    # if: github.event_name == 'pull_request'
+    needs: [build]
+    if: github.event_name == 'pull_request' && job.status != 'success'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:
@@ -70,14 +70,8 @@ jobs:
           password: ${{ secrets.TORCHAO_NOTIFY_PASSWORD }}
           from: torchao.notify@gmail.com
           to: cdhernandez@meta.com
-          subject: Scheduled CI Failure for TorchAO
+          subject: Scheduled Build Failure for TorchAO
           body: |
-            Workflow failed: Build Linux Wheels.
-            The error is: ${{ env.WORKFLOW_CONCLUSION }}.
-            see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            ${{ github.event_name }} and ${{ github.event_name == 'pull_request' }}
-            ${{ env.WORKFLOW_CONCLUSION }}
-            ------ claude message ------
             Build Failure Notification for TorchAO
 
             A failure occurred in the Build Linux Wheels workflow.

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,46 +21,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: wheel
-      os: linux
-      with-cpu: enable
-      with-cuda: enable
-      with-rocm: enable
-      with-xpu: enable
+  # generate-matrix:
+  #   uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+  #   with:
+  #     package-type: wheel
+  #     os: linux
+  #     with-cpu: enable
+  #     with-cuda: enable
+  #     with-rocm: enable
+  #     with-xpu: enable
 
-  build:
-    needs: generate-matrix
-    permissions:
-      id-token: write
-      contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
-    with:
-      # Set the ref to an empty string instead of the default nightly because
-      # torchao doesn't have nightly branch setup yet, instead the build is
-      # triggered daily from main with a schedule
-      repository: pytorch/ao
-      ref: ""
-      test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      env-var-script: packaging/env_var_script_linux.sh
-      pre-script: packaging/pre_build_script.sh
-      post-script: packaging/post_build_script.sh
-      smoke-test-script: packaging/smoke_test.py
-      package-name: torchao
-      trigger-event: ${{ github.event_name }}
-      # This is the CUDA version to be uploaded to torchao-nightly pypi
-      upload-to-pypi: cu121
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  # build:
+  #   needs: generate-matrix
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+  #   with:
+  #     # Set the ref to an empty string instead of the default nightly because
+  #     # torchao doesn't have nightly branch setup yet, instead the build is
+  #     # triggered daily from main with a schedule
+  #     repository: pytorch/ao
+  #     ref: ""
+  #     test-infra-repository: pytorch/test-infra
+  #     test-infra-ref: main
+  #     build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+  #     env-var-script: packaging/env_var_script_linux.sh
+  #     pre-script: packaging/pre_build_script.sh
+  #     post-script: packaging/post_build_script.sh
+  #     smoke-test-script: packaging/smoke_test.py
+  #     package-name: torchao
+  #     trigger-event: ${{ github.event_name }}
+  #     # This is the CUDA version to be uploaded to torchao-nightly pypi
+  #     upload-to-pypi: cu121
+  #   secrets:
+  #     PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   notify:
     runs-on: ubuntu-latest
     name: Email notification
-    needs: [build]
-    if: github.event_name == 'pull_request'
+    # needs: [build]
+    # if: github.event_name == 'pull_request'
     steps:
       - uses: dawidd6/action-send-mail@v4
         with:


### PR DESCRIPTION
This sends an email notification when the scheduled build job fails.

it uses a gmail account i made for the purpose, sends an email to myself with some information about the failure
this email will be picked up on the other side and an internal message will be sent to the TorchAO oncall

see tests in

https://github.com/pytorch/ao/pull/1547/commits/1a04771ac2e384cf984918b40783ca39332dfe7e

and 

https://github.com/pytorch/ao/pull/1547/commits/33cb9d750cfa5d6fe575ce07e2d66d2567a1c9a6