### PR TITLE
Resolve __hfma2 intrinsic error by excluding unsupported Maxwell architecture in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,14 @@ def get_extensions():
             "-fdiagnostics-color=always",
         ]
 
+        extra_compile_args["nvcc"].extend([
+            "-gencode=arch=compute_60,code=sm_60",  # Pascal
+            "-gencode=arch=compute_70,code=sm_70",  # Volta
+            "-gencode=arch=compute_75,code=sm_75",  # Turing
+            "-gencode=arch=compute_80,code=sm_80",  # Ampere
+            "-gencode=arch=compute_90,code=sm_90",  # Hopper
+        ])
+
         if debug_mode:
             extra_compile_args["cxx"].append("-g")
             extra_compile_args["nvcc"].append("-g")


### PR DESCRIPTION
When attempting to compile torchao from source for Hopper GPUs using `pip install -e .`, I encountered a build issue. nvcc version in my env is 12.6. The error occurs in torchao/csrc/cuda/sparse_marlin/mma.h:

```
FAILED: /projects/ao/build/temp.linux-x86_64-cpython-310/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.o
        /usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output /cpfs01/shared/llm_ddd/caoweihan/projects/ao/build/temp.linux-x86_64-cpython-310/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.o.d -I/usr/local/lib/python3.10/dist-packages/torch/include -I/usr/local/lib/python3.10/dist-packages/torch/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch/include/TH -I/usr/local/lib/python3.10/dist-packages/torch/include/THC -I/usr/local/cuda/include -I/usr/include/python3.10 -c -c /projects/ao/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.cu -o /projects/ao/build/temp.linux-x86_64-cpython-310/torchao/csrc/cuda/sparse_marlin/marlin_kernel_nm.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -O3 -t=0 -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=1 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_72,code=sm_72 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_87,code=sm_87 -gencode=arch=compute_90,code=compute_90 -gencode=arch=compute_90,code=sm_90 -std=c++17
        /projects/ao/torchao/csrc/cuda/sparse_marlin/mma.h(142): error: identifier "__hfma2" is undefined
```

The issue arises because the __hfma2 intrinsic is not supported by the compute_52 (Maxwell) architecture, even though I am targeting the compute_90 (Hopper) architecture. It seems that we should explicitly specify the supported GPU architectures in setup.py to ensure compatibility with newer architectures. Here's the proposed update:

```
extra_compile_args["nvcc"].extend([
      "-gencode=arch=compute_60,code=sm_60",  # Pascal
      "-gencode=arch=compute_70,code=sm_70",  # Volta
      "-gencode=arch=compute_75,code=sm_75",  # Turing
      "-gencode=arch=compute_80,code=sm_80",  # Ampere
      "-gencode=arch=compute_90,code=sm_90",  # Hopper
  ])
```

Looking forward to your feedback!
