### PR TITLE
Bug Fix (#1559): sparsity instead of sparstiy

### DIFF
--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -345,7 +345,7 @@ if __name__ == "__main__":
         args.device,
         args.precision,
         args.quantization,
-        args.sparstiy,
+        args.sparsity,
         args.compile,
         args.max_length,
         args.calibration_tasks,


### PR DESCRIPTION
```
  File "/home/workspace/ao/torchao/_models/llama/eval.py", line 348, in <module>
    args.sparstiy,
    ^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'sparstiy'. Did you mean: 'sparsity'?
```

The file `ao/torchao/_models/llama/eval.py` has a typo at line 348 which causes `AttributeError`.

This PR will fix the issue #1559