### PR TITLE
Update __init__.py to load experimental ops even if other C++ ops are not found

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -29,9 +29,12 @@ if not _IS_FBCODE:
         from pathlib import Path
 
         so_files = list(Path(__file__).parent.glob("_C*.so"))
-        assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
-        torch.ops.load_library(so_files[0])
-        from . import ops
+        if len(so_files) > 0:
+            assert (
+                len(so_files) == 1
+            ), f"Expected one _C*.so file, found {len(so_files)}"
+            torch.ops.load_library(so_files[0])
+            from . import ops
 
         # The following library contains CPU kernels from torchao/experimental
         # They are built automatically by ao/setup.py if on an ARM machine.


### PR DESCRIPTION
Currently if so_files are not found, loading experimental_lib is skipped.  We always want to try loading experimental lib if it is found.