### PR TITLE
Relax dtype requirements for int4 and float8 quants in autoquant

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1759,26 +1759,28 @@ class TestAutoQuant(unittest.TestCase):
         dtype = torch.float32
         m, k, n = 128, 128, 128
         example_input = torch.randn(m, k, device=device, dtype=dtype)
-        model = (
-            torch.nn.Sequential(
-                torch.nn.ReLU(),
-                torch.nn.Linear(k, n),
-                torch.nn.ReLU(),
+        for qclass in torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST:
+            model = (
+                torch.nn.Sequential(
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(k, n, bias=True),
+                    torch.nn.ReLU(),
+                )
+                .to(device)
+                .to(dtype)
             )
-            .to(device)
-            .to(dtype)
-        )
-        ref = model(example_input)
-        torchao.autoquant(
-            model,
-            qtensor_class_list=torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
-        )
-        out = model(example_input)
-        self.assertIn(
-            type(model[1].weight),
-            torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
-        )
-        self.assertGreater(compute_error(out, ref), 60)
+            ref = model(example_input)
+            qtensor_class_list = [qclass]
+            torchao.autoquant(
+                model,
+                qtensor_class_list=qtensor_class_list,
+            )
+            out = model(example_input)
+            self.assertIn(
+                type(model[1].weight),
+                qtensor_class_list,
+            )
+            self.assertGreater(compute_error(out, ref), 40)
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
@@ -1801,7 +1803,7 @@ class TestAutoQuant(unittest.TestCase):
             model = (
                 torch.nn.Sequential(
                     torch.nn.ReLU(),
-                    torch.nn.Linear(k, n),
+                    torch.nn.Linear(k, n, bias=True),
                     torch.nn.ReLU(),
                 )
                 .to(device)
@@ -1823,7 +1825,7 @@ class TestAutoQuant(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_5, "autoquant int4 option requires 2.5+."
     )
-    def test_autoquant_fp8(self, device, dtype):
+    def test_autoquant_float8(self, device, dtype):
         if device == "cpu":
             self.skipTest(f"int4wo is for cuda, not {device}")
 
@@ -1839,7 +1841,7 @@ class TestAutoQuant(unittest.TestCase):
             model = (
                 torch.nn.Sequential(
                     torch.nn.ReLU(),
-                    torch.nn.Linear(k, n),
+                    torch.nn.Linear(k, n, bias=True),
                     torch.nn.ReLU(),
                 )
                 .to(device)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1754,7 +1754,6 @@ class TestAutoQuant(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "autoquant float option requires 2.4+."
     )
-
     def test_autoquant_hp_float(self):
         device = "cuda"
         dtype = torch.float32

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1780,8 +1780,51 @@ class TestAutoQuant(unittest.TestCase):
         self.assertIn(
             type(model[1].weight), [Float32Tensor, Float16Tensor, BFloat16Tensor]
         )
-        print(compute_error(out, ref))
         self.assertGreater(compute_error(out, ref), 60)
+
+    @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5, "autoquant int4 option requires 2.5+."
+    )
+    @unittest.skipIf(not has_gemlite, "gemlite not available")
+    def test_autoquant_int4wo(self, device, dtype):
+        if device == "cpu":
+            self.skipTest(f"int4wo is for cuda, not {device}")
+
+        # note: marlin sparse layout failed when scale_t has a dimension of 1d
+        m, k, n = 128, 128, 128
+        example_input = torch.randn(m, k, device=device, dtype=dtype)
+        from torchao.quantization.autoquant import (
+            AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
+            AQInt4G32WeightOnlyQuantizedLinearWeight,
+            AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
+        )
+
+        for qclass in [
+            AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
+            AQInt4G32WeightOnlyQuantizedLinearWeight,
+            AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
+        ]:
+            model = (
+                torch.nn.Sequential(
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(k, n),
+                    torch.nn.ReLU(),
+                )
+                .to(device)
+                .to(dtype)
+            )
+            ref = model(example_input)
+            qtensor_class_list = [qclass]
+            torchao.autoquant(
+                model,
+                qtensor_class_list=qtensor_class_list,
+            )
+            out = model(example_input)
+
+            self.assertIn(type(model[1].weight), qtensor_class_list)
+            self.assertGreater(compute_error(ref, out), 20)
 
 
 @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_5, "requires 2.5+.")

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -25,13 +25,13 @@ from torchao.quantization.autoquant import (
     AQFloat8PerRowScalingDynamicallyQuantizedLinearWeight,
     AQFloat8PerTensorScalingDynamicallyQuantizedLinearWeight,
     AQFloat8WeightOnlyQuantizedLinearWeight,
+    AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
+    AQInt4G32WeightOnlyQuantizedLinearWeight,
+    AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
     AQInt8DynamicallyQuantizedLinearWeight,
     AQInt8WeightOnlyQuantizedLinearWeight,
     AQInt8WeightOnlyQuantizedLinearWeight2,
     AQInt8WeightOnlyQuantizedLinearWeight3,
-    AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
-    AQInt4G32WeightOnlyQuantizedLinearWeight,
-    AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
     AutoQuantizableLinearWeight,
 )
 
@@ -1775,7 +1775,8 @@ class TestAutoQuant(unittest.TestCase):
         )
         out = model(example_input)
         self.assertIn(
-            type(model[1].weight), torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
+            type(model[1].weight),
+            torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
         )
         self.assertGreater(compute_error(out, ref), 60)
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -29,6 +29,9 @@ from torchao.quantization.autoquant import (
     AQInt8WeightOnlyQuantizedLinearWeight,
     AQInt8WeightOnlyQuantizedLinearWeight2,
     AQInt8WeightOnlyQuantizedLinearWeight3,
+    AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
+    AQInt4G32WeightOnlyQuantizedLinearWeight,
+    AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
     AutoQuantizableLinearWeight,
 )
 
@@ -1751,7 +1754,7 @@ class TestAutoQuant(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "autoquant float option requires 2.4+."
     )
-    def test_autoquant_float(self):
+    def test_autoquant_hp_float(self):
         device = "cuda"
         dtype = torch.float32
         m, k, n = 128, 128, 128
@@ -1771,14 +1774,8 @@ class TestAutoQuant(unittest.TestCase):
             qtensor_class_list=torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
         )
         out = model(example_input)
-        from torchao.quantization.autoquant import (
-            BFloat16Tensor,
-            Float16Tensor,
-            Float32Tensor,
-        )
-
         self.assertIn(
-            type(model[1].weight), [Float32Tensor, Float16Tensor, BFloat16Tensor]
+            type(model[1].weight), torchao.quantization.DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
         )
         self.assertGreater(compute_error(out, ref), 60)
 
@@ -1792,19 +1789,51 @@ class TestAutoQuant(unittest.TestCase):
         if device == "cpu":
             self.skipTest(f"int4wo is for cuda, not {device}")
 
-        # note: marlin sparse layout failed when scale_t has a dimension of 1d
         m, k, n = 128, 128, 128
         example_input = torch.randn(m, k, device=device, dtype=dtype)
-        from torchao.quantization.autoquant import (
-            AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
-            AQInt4G32WeightOnlyQuantizedLinearWeight,
-            AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
-        )
 
         for qclass in [
             AQGemliteInt4G64WeightOnlyQuantizedLinearWeight,
             AQInt4G32WeightOnlyQuantizedLinearWeight,
             AQInt4G128WeightOnlyQuantizedMarlinSparseLinearWeight,
+        ]:
+            model = (
+                torch.nn.Sequential(
+                    torch.nn.ReLU(),
+                    torch.nn.Linear(k, n),
+                    torch.nn.ReLU(),
+                )
+                .to(device)
+                .to(dtype)
+            )
+            ref = model(example_input)
+            qtensor_class_list = [qclass]
+            torchao.autoquant(
+                model,
+                qtensor_class_list=qtensor_class_list,
+            )
+            out = model(example_input)
+
+            self.assertIn(type(model[1].weight), qtensor_class_list)
+            self.assertGreater(compute_error(ref, out), 20)
+
+    @parameterized.expand(COMMON_DEVICE_DTYPE)
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5, "autoquant int4 option requires 2.5+."
+    )
+    def test_autoquant_fp8(self, device, dtype):
+        if device == "cpu":
+            self.skipTest(f"int4wo is for cuda, not {device}")
+
+        # note: marlin sparse layout failed when scale_t has a dimension of 1d
+        m, k, n = 128, 128, 128
+        example_input = torch.randn(m, k, device=device, dtype=dtype)
+
+        for qclass in [
+            AQFloat8PerRowScalingDynamicallyQuantizedLinearWeight,
+            AQFloat8PerTensorScalingDynamicallyQuantizedLinearWeight,
+            AQFloat8WeightOnlyQuantizedLinearWeight,
         ]:
             model = (
                 torch.nn.Sequential(

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1754,6 +1754,7 @@ class TestAutoQuant(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "autoquant float option requires 2.4+."
     )
+
     def test_autoquant_hp_float(self):
         device = "cuda"
         dtype = torch.float32

--- a/torchao/dtypes/uintx/marlin_sparse_layout.py
+++ b/torchao/dtypes/uintx/marlin_sparse_layout.py
@@ -255,7 +255,6 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
         if num_bits not in [4]:
             raise ValueError(f"Only {[4]} bits are supported, got {num_bits}.")
 
-        print("scale_t shape:", scale_t.shape, " in features:", in_features)
         group_size = in_features // scale_t.shape[0]
         if group_size == 0:
             group_size = in_features

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -669,8 +669,6 @@ class AQInt4G32WeightOnlyQuantizedLinearWeight(
         zero_point_domain = ZeroPointDomain.FLOAT
 
         if isinstance(_layout, MarlinSparseLayout):
-            print("group size:", group_size)
-            print("block size:", block_size)
             mapping_type = MappingType.SYMMETRIC
             preserve_zero = True
             zero_point_domain = ZeroPointDomain.INT

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -790,6 +790,7 @@ class AQDefaultLinearWeight(torch.Tensor, AQMixin):
         return weight
 
 
+# TODO: remove skip_weight_conversion arg
 class Float32Tensor(TorchAOBaseTensor):
     """Tensor subclass tensor for fp32 dtype"""
 

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -879,7 +879,6 @@ class BFloat16Tensor(Float32Tensor):
 
 
 
-
 class Float16Tensor(Float32Tensor):
     def __init__(self, weight, skip_weight_conversion=False):
         self.weight = weight if skip_weight_conversion else weight.to(torch.float16)

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -878,7 +878,6 @@ class BFloat16Tensor(Float32Tensor):
         return cls(weight, skip_weight_conversion)
 
 
-
 class Float16Tensor(Float32Tensor):
     def __init__(self, weight, skip_weight_conversion=False):
         self.weight = weight if skip_weight_conversion else weight.to(torch.float16)
@@ -956,9 +955,7 @@ class AQFloat8WeightOnlyQuantizedLinearWeight(AffineQuantizedTensor, AQMixin):
         )
 
 
-class AQFloat8PerRowScalingDynamicallyQuantizedLinearWeight(
-    AQMixin, BFloat16Tensor
-):
+class AQFloat8PerRowScalingDynamicallyQuantizedLinearWeight(AQMixin, BFloat16Tensor):
     """
     AutoQuantizable version of Float8DynamicallyQuantizedLinearWeight using per row scaling
     """
@@ -1001,7 +998,9 @@ class AQFloat8PerRowScalingDynamicallyQuantizedLinearWeight(
             _layout=_layout,
             scale_dtype=torch.float32,
         )
-        weight = to_linear_activation_quantized(weight, input_quant_func, quant_kwargs=input_quant_kwargs)
+        weight = to_linear_activation_quantized(
+            weight, input_quant_func, quant_kwargs=input_quant_kwargs
+        )
         # at inference time,
         # we first convert the input, weight and bias to bfloat16, and then quantize activation
         # and then dispatch to the quantized ops

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -627,7 +627,7 @@ class AQInt4G32WeightOnlyQuantizedLinearWeight(
     LinearActivationQuantizedTensor, AQMixin
 ):
     """
-    AutoQuantizable version of Int4WeightOnlyQuantizedLinearWeight
+    AutoQuantizable version of int4_weight_only
     """
 
     group_size: int = 32
@@ -646,6 +646,9 @@ class AQInt4G32WeightOnlyQuantizedLinearWeight(
 
         input_quant_func = None
 
+        # NOTE: we only convert activation dtype and weight dtype here
+        # because the kernel implementation for both TensorCoreTiledLayout and MarlinSparseLayout
+        # can work with multiple bias dtypes (by converting bias to the dtype of activation)
         if (
             isinstance(_layout, TensorCoreTiledLayout)
             and weight.dtype != torch.bfloat16

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -747,6 +747,8 @@ def int4_weight_only(
             assert (
                 group_size == 128 or group_size == weight.shape[-1]
             ), f"MarlinSparseLayout only supports 128 group size or per channel quantization, got {group_size}"
+            print("block size:", block_size)
+            print("weight size:", weight.shape)
 
         return to_affine_quantized_intx(
             weight,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -747,8 +747,6 @@ def int4_weight_only(
             assert (
                 group_size == 128 or group_size == weight.shape[-1]
             ), f"MarlinSparseLayout only supports 128 group size or per channel quantization, got {group_size}"
-            print("block size:", block_size)
-            print("weight size:", weight.shape)
 
         return to_affine_quantized_intx(
             weight,


### PR DESCRIPTION
Summary:
Some of the int4 quant and fp8 only works with bfloat16/float16, previously we require the model to be in correct dtype to apply these in autoquant, this PR relaxes the constraints by converting weight, bias and activation to compatible dtypes

Test Plan:
python test/integration/test_integration.py -k test_autoquant_int4wo

Reviewers:

Subscribers:

Tasks:

Tags: