### PR TITLE
only run docs CI jobs on PRs when docs have changed

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -9,10 +9,10 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  pull_request:
     paths:
       - 'docs/**'
       - '!docs/**'
-  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Follow up to #1589 - this should be under `pull_request` not `push`

Relevant github workflow syntax docs for this: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths