### PR TITLE
Prepare for -DPy_LIMITED_API flag in pytorch #145764

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ from setuptools import Extension, find_packages, setup
 
 current_date = datetime.now().strftime("%Y%m%d")
 
+PY3_9_HEXCODE = "0x03090000"
 
 def get_git_commit_id():
     try:
@@ -212,6 +213,7 @@ def get_extensions():
 
     extra_link_args = []
     extra_compile_args = {
+        "cxx": [f"-DPy_LIMITED_API={PY3_9_HEXCODE}"],
         "nvcc": [
             "-O3" if not debug_mode else "-O0",
             "-t=0",
@@ -219,17 +221,16 @@ def get_extensions():
     }
 
     if not IS_WINDOWS:
-        extra_compile_args["cxx"] = [
-            "-O3" if not debug_mode else "-O0",
-            "-fdiagnostics-color=always",
-        ]
+        extra_compile_args["cxx"].extend([
+            "-O3" if not debug_mode else "-O0", "-fdiagnostics-color=always"])
 
         if debug_mode:
             extra_compile_args["cxx"].append("-g")
             extra_compile_args["nvcc"].append("-g")
             extra_link_args.extend(["-O0", "-g"])
     else:
-        extra_compile_args["cxx"] = ["/O2" if not debug_mode else "/Od", "/permissive-"]
+        extra_compile_args["cxx"].extend([
+            "/O2" if not debug_mode else "/Od", "/permissive-"])
 
         if debug_mode:
             extra_compile_args["cxx"].append("/ZI")

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ current_date = datetime.now().strftime("%Y%m%d")
 
 PY3_9_HEXCODE = "0x03090000"
 
+
 def get_git_commit_id():
     try:
         return (
@@ -217,20 +218,22 @@ def get_extensions():
         "nvcc": [
             "-O3" if not debug_mode else "-O0",
             "-t=0",
-        ]
+        ],
     }
 
     if not IS_WINDOWS:
-        extra_compile_args["cxx"].extend([
-            "-O3" if not debug_mode else "-O0", "-fdiagnostics-color=always"])
+        extra_compile_args["cxx"].extend(
+            ["-O3" if not debug_mode else "-O0", "-fdiagnostics-color=always"]
+        )
 
         if debug_mode:
             extra_compile_args["cxx"].append("-g")
             extra_compile_args["nvcc"].append("-g")
             extra_link_args.extend(["-O0", "-g"])
     else:
-        extra_compile_args["cxx"].extend([
-            "/O2" if not debug_mode else "/Od", "/permissive-"])
+        extra_compile_args["cxx"].extend(
+            ["/O2" if not debug_mode else "/Od", "/permissive-"]
+        )
 
         if debug_mode:
             extra_compile_args["cxx"].append("/ZI")

--- a/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
+++ b/torchao/csrc/cuda/fp6_llm/fp6_linear.cu
@@ -25,9 +25,9 @@
 #include <stdio.h>
 #include <assert.h>
 
-#include <torch/extension.h>
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <torch/all.h>
 #include <torch/library.h>
 
 

--- a/torchao/csrc/cuda/s8s4_linear_cutlass/s8s4_linear_cutlass.cu
+++ b/torchao/csrc/cuda/s8s4_linear_cutlass/s8s4_linear_cutlass.cu
@@ -1,4 +1,4 @@
-#include <torch/extension.h>
+#include <torch/library.h>
 
 #include <ATen/ATen.h>
 #include <ATen/core/Tensor.h>

--- a/torchao/csrc/cuda/tensor_core_tiled_layout/tensor_core_tiled_layout.cu
+++ b/torchao/csrc/cuda/tensor_core_tiled_layout/tensor_core_tiled_layout.cu
@@ -5,7 +5,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/DeviceGuard.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <torch/extension.h>
+#include <torch/library.h>
 
 template <typename U, typename V>
 constexpr __host__ __device__ auto divUp(U a, V b) -> decltype(a + b) {


### PR DESCRIPTION
PyTorch core is going to start enforcing the Py_LIMITED_API flag definition for best practices + sanity whenever the py_limited_api is passed in. This PR prepares AO to smoothly handle that change when the nightly is updated.

PT PR:  https://github.com/pytorch/pytorch/pull/145764

Test plan:
This should be a noop for both build and runtime.