### PR TITLE
Create separate float8 tensor subclass

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -338,64 +338,6 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         )
 
     @classmethod
-    def from_hp_to_floatx(
-        cls,
-        input_float: torch.Tensor,
-        block_size: Tuple[int, ...],
-        target_dtype: torch.dtype,
-        _layout: Layout,
-        scale_dtype: Optional[torch.dtype] = None,
-    ):
-        """Convert a high precision tensor to a float8 quantized tensor."""
-        if target_dtype in FP8_TYPES:
-            return cls.from_hp_to_intx(
-                input_float=input_float,
-                mapping_type=MappingType.SYMMETRIC,
-                block_size=block_size,
-                target_dtype=target_dtype,
-                quant_min=math.ceil(torch.finfo(target_dtype).min),
-                quant_max=math.ceil(torch.finfo(target_dtype).max),
-                eps=torch.finfo(torch.float32).eps,
-                scale_dtype=scale_dtype,
-                zero_point_dtype=None,
-                preserve_zero=True,
-                zero_point_domain=None,
-                _layout=_layout,
-                use_hqq=False,
-            )
-        else:
-            raise NotImplementedError(
-                f"Unsupported dtype {target_dtype} for from_hp_to_floatx"
-            )
-
-    @classmethod
-    def from_hp_to_floatx_static(
-        cls,
-        input_float: torch.Tensor,
-        scale: torch.Tensor,
-        block_size: Tuple[int, ...],
-        target_dtype: torch.dtype,
-        _layout: Layout,
-    ):
-        """Create a float8 AffineQuantizedTensor from a high precision tensor using static parameters."""
-        if target_dtype in FP8_TYPES:
-            return cls.from_hp_to_intx_static(
-                input_float=input_float,
-                scale=scale,
-                zero_point=None,
-                block_size=block_size,
-                target_dtype=target_dtype,
-                quant_min=math.ceil(torch.finfo(target_dtype).min),
-                quant_max=math.ceil(torch.finfo(target_dtype).max),
-                zero_point_domain=None,
-                _layout=_layout,
-            )
-        else:
-            raise NotImplementedError(
-                f"Unsupported dtype {target_dtype} for from_hp_to_floatx_static"
-            )
-
-    @classmethod
     def from_hp_to_fpx(
         cls,
         input_float: torch.Tensor,


### PR DESCRIPTION
Float8Tensor, a new subclass for float8, independent of AQT. It's a BC breaking change, hence will need to proceed with it, by deprecating the current API, and issuing a user warning about the deprecation. The new API will be available to users for use. After a substancial amount of time, once we know user has replaced the deprecated API with the updated one, we can delete it's code

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #1636
* #1635

