### PR TITLE
[Fix]: Fallback to KleidiAI channelwise kernel groupsize isnt suitable

### DIFF
--- a/torchao/experimental/tests/test_packed_linear_int8_dynamic_activation_intx_weight_layout_target_aten.py
+++ b/torchao/experimental/tests/test_packed_linear_int8_dynamic_activation_intx_weight_layout_target_aten.py
@@ -6,7 +6,6 @@
 
 import copy
 import unittest
-
 import torch
 
 from torchao.dtypes import PlainLayout
@@ -43,8 +42,7 @@ class TestPackedLinearInt8DynamicActivationIntxWeightLayoutAten(unittest.TestCas
             for has_weight_zeros in [True]:
                 for granularity in granularities:
                     print(
-                        f"Testing weight_dtype={weight_dtype}, has_weight_zeros={
-                            has_weight_zeros}, granularity={granularity}"
+                        f"Testing weight_dtype={weight_dtype}, has_weight_zeros={has_weight_zeros}, granularity={granularity}"
                     )
                     quantized_model = copy.deepcopy(model)
                     quantize_(


### PR DESCRIPTION
Description:
1. Some models can have certain odd shapes which can not be used with blocked quantization. Fallback to channelwise quantization for those shapes.
2. Fix Formatting issue with experimental tests