### PR TITLE
Fix some CPU offload optimizer issues

### DIFF
--- a/test/prototype/test_low_bit_optim.py
+++ b/test/prototype/test_low_bit_optim.py
@@ -274,6 +274,9 @@ class TestOptim(TestCase):
             offload_gradients=offload_grad,
         )
 
+        scheduler1 = torch.optim.lr_scheduler.CosineAnnealingLR(optim1, 100)
+        scheduler2 = torch.optim.lr_scheduler.CosineAnnealingLR(optim2, 100)
+
         for _ in range(2):
             for _ in range(grad_accum):
                 x = torch.randn(4, 32, device=device)
@@ -282,9 +285,11 @@ class TestOptim(TestCase):
 
             optim1.step()
             optim1.zero_grad()
+            scheduler1.step()
 
             optim2.step()
             optim2.zero_grad()
+            scheduler2.step()
 
         for p1, p2 in zip(model1.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1)

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -107,6 +107,8 @@ class CPUOffloadOptimizer:
             with getattr(torch, self.device).stream(self.stream):
                 p_device.copy_(p_host, non_blocking=True)
 
+        # make sure param H2D finishes before the next forward pass
+        self.stream.synchronize()
         self.queue.clear()
         return loss
 

--- a/torchao/prototype/low_bit_optim/cpu_offload.py
+++ b/torchao/prototype/low_bit_optim/cpu_offload.py
@@ -6,7 +6,11 @@ from torch.optim.optimizer import Optimizer, ParamsT
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_4, get_available_devices
 
 
-class CPUOffloadOptimizer:
+# NOTE: We make this inherit Optimizer so it works with PyTorch's built-in LR
+# schedulers. (those schedulers specifically check for instances of Optimizer).
+# However, it won't behave exactly like Optimizer e.g. we don't call
+# Optimizer.__init__(), there is no self.defaults.
+class CPUOffloadOptimizer(Optimizer):
     def __init__(
         self,
         params: ParamsT,


### PR DESCRIPTION
As @ngc92 pointed out, there should be a synchronization to make sure param H2D finishes before the next forward pass. Hence, I added it. Thank you for the notice!

I also take this opportunity to address an issue regarding PyTorch's built-in LR schedulers (#959, #1209)