### PR TITLE
Add support for power of 2 scaling factors in float8 training

### DIFF
--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -147,6 +147,20 @@ class Float8GemmConfig:
 
 
 @dataclass(frozen=True)
+class Float8ScalingFactorConfig:
+    """
+    Configuration for scaling factor used for float8 quantization.
+    """
+
+    # If this option is enabled, the scaling factor used for float8 quantization
+    # will be rounded down to the nearest power of 2. This has been shown to help
+    # reduce quantization error by avoiding rounding errors when multiplying/dividing
+    # by the scaling factor, as well as ensuring large values are quantized to the
+    # same value in the forward pass as the backward pass.
+    power_of_2_scale: bool = False
+
+
+@dataclass(frozen=True)
 class Float8LinearConfig:
     """
     Configuration for converting a `torch.nn.Linear` module to float8
@@ -233,6 +247,9 @@ class Float8LinearConfig:
     # TODO(future PR): either enable by default or have a warning and set up the
     # tests so that the warning does not spam the CI stdout.
     force_recompute_fp8_weight_in_bwd: bool = False
+
+    # configuration used for calculating the scaling factor used in float8 quantization.
+    scaling_factor_config: Float8ScalingFactorConfig = None
 
     def __post_init__(self):
         # Populate the additional cast overrides, if the user did not specify them


### PR DESCRIPTION
**Summary**

Add support for power of 2 scaling factors in float8 training with dynamic scaling.

- For row-wise scaling, power of 2 scaling is on by default, but can be optionally disabled.
- For all other scaling granularities, power of 2 scaling is not used by default, and must be explicitly enabled by the caller.

**REVIEWER NOTE:** To support the behavior of "default on, but can be optionally disabled", we must be able to distinguish
between the values for the "unset default" and "explicit negative setting."
This is why I didn't use a simple boolean flag for power of 2 scaling, because the unset default and explicit negative setting would both be `False`. By using a dataclass config, we can distinguish between the unset default (None) and explicit negative setting (config exists and `scaling_config.power_of_2_scale is False`).

I'm open to feedback/suggestions if there is a better way to do this, let me know.


**Test Plan**

- All float8 tests (`test/float8/`) are passing. 
- Since power of 2 scaling factor is on by default for row-wise scaling, all row-wise tests are now exercising this code path, and the quantization error etc is still within expected threshold (i.e., tests are passing).