### PR TITLE
ROCm OCP FP8 Support

### DIFF
--- a/torchao/dtypes/uintx/marlin_qqq_tensor.py
+++ b/torchao/dtypes/uintx/marlin_qqq_tensor.py
@@ -179,7 +179,7 @@ class MarlinQQQAQTTensorImpl(AQTTensorImpl):
     def get_plain(self):
         from torchao.quantization.marlin_qqq import (
             unpack_from_marlin_qqq,
-        )  # avoid circular import
+        )
 
         int_data_expanded, s_group_expanded, s_channel_expanded = (
             unpack_from_marlin_qqq(
@@ -207,7 +207,7 @@ class MarlinQQQAQTTensorImpl(AQTTensorImpl):
         from torchao.quantization.marlin_qqq import (
             const,
             pack_to_marlin_qqq,
-        )  # avoid circular import
+        )
 
         assert isinstance(_layout, MarlinQQQLayout)
 

--- a/torchao/dtypes/uintx/marlin_sparse_layout.py
+++ b/torchao/dtypes/uintx/marlin_sparse_layout.py
@@ -195,7 +195,7 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
     def get_plain(self):
         from torchao.sparsity.marlin import (
             unpack_from_marlin_24,
-        )  # avoid circular import
+        )
 
         int_data_expanded, scales_expanded = unpack_from_marlin_24(
             self.int_data,
@@ -220,7 +220,7 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
         from torchao.sparsity.marlin import (
             const,
             pack_to_marlin_24,
-        )  # avoid circular import
+        )
 
         assert isinstance(_layout, MarlinSparseLayout)
 

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -58,7 +58,7 @@ class Float8TypeConfig:
     """
     Configuration for selecting the preferred float8 type pair, either e4m3fn/e5m2 or e4m3fnuz/e5m2fnuz.
 
-    Currently, ROCm only supports fnuz variants.
+    Currently, ROCm supports 1. fnuz variants in MI300. 2. OCP F8 variants in MI350/Navi4.
     """
 
     # The preferred e4m3 type.

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from torchao.utils import is_MI300
 
 logger: logging.Logger = logging.getLogger()
 
@@ -68,12 +69,9 @@ class Float8TypeConfig:
     e5m2_dtype = torch.float8_e5m2
 
     def __post_init__(self):
-        if torch.version.hip and torch.cuda.is_available():
-            prop = torch.cuda.get_device_properties(0)
-            MI300_ARCH = ("gfx940", "gfx941", "gfx942")
-            if prop.gcnArchName.split(":")[0] in MI300_ARCH:
-                self.e4m3_dtype = torch.float8_e4m3fnuz
-                self.e5m2_dtype = torch.float8_e5m2fnuz
+        if torch.version.hip and torch.cuda.is_available() and is_MI300():
+            self.e4m3_dtype = torch.float8_e4m3fnuz
+            self.e5m2_dtype = torch.float8_e5m2fnuz
 
 
 # User defined type for using the individual F8 type based on config

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+
 from torchao.utils import is_MI300
 
 logger: logging.Logger = logging.getLogger()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -603,6 +603,13 @@ def fill_defaults(args, n, defaults_tail):
 def _torch_version_at_least(min_version):
     return is_fbcode() or version("torch") >= min_version
 
+# Supported AMD GPU Models and their LLVM gfx Codes:
+#
+# | AMD GPU Model | LLVM gfx Code          |
+# |---------------|------------------------|
+# | Navi4         | gfx1200, gfx1201       |
+# | MI300X        | gfx940, gfx941, gfx942 |
+# | MI350         | gfx950                 |
 
 def is_MI300():
     if torch.cuda.is_available() and torch.version.hip:

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -603,6 +603,7 @@ def fill_defaults(args, n, defaults_tail):
 def _torch_version_at_least(min_version):
     return is_fbcode() or version("torch") >= min_version
 
+
 # Supported AMD GPU Models and their LLVM gfx Codes:
 #
 # | AMD GPU Model | LLVM gfx Code          |
@@ -610,6 +611,7 @@ def _torch_version_at_least(min_version):
 # | Navi4         | gfx1200, gfx1201       |
 # | MI300X        | gfx940, gfx941, gfx942 |
 # | MI350         | gfx950                 |
+
 
 def is_MI300():
     if torch.cuda.is_available() and torch.version.hip:

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -607,10 +607,26 @@ def _torch_version_at_least(min_version):
 def is_MI300():
     if torch.cuda.is_available() and torch.version.hip:
         mxArchName = ["gfx940", "gfx941", "gfx942"]
-        archName = torch.cuda.get_device_properties().gcnArchName
+        archName = torch.cuda.get_device_properties(0).gcnArchName
         for arch in mxArchName:
             if arch in archName:
                 return True
+    return False
+
+
+def is_MI350():
+    if torch.cuda.is_available() and torch.version.hip:
+        archName = torch.cuda.get_device_properties(0).gcnArchName
+        if "gfx950" in archName:
+            return True
+    return False
+
+
+def is_Navi4():
+    if torch.cuda.is_available() and torch.version.hip:
+        archName = torch.cuda.get_device_properties(0).gcnArchName
+        if "gfx1200" or "gfx1201" in archName:
+            return True
     return False
 
 


### PR DESCRIPTION
TLDR:  Quick fix for ROCm device check. OCP FP8 support status update.

This pull request includes changes to improve the handling of imports, update configurations, and add new utility functions in the `torchao` library. The most important changes include removing comments to avoid circular imports, updating the configuration for supported float8 types, and adding utility functions to check for specific GPU architectures.
refer to : https://github.com/pytorch/pytorch/pull/146632


Configuration updates:

* [`torchao/float8/config.py`](diffhunk://#diff-760fac20cbb84d97d511be79c91644138a24b94c47556a8626d5301f354221eaL61-R61): Updated the configuration for selecting the preferred float8 type pair to include support for OCP F8 variants in MI350/Navi4.

New utility functions:

* [`torchao/utils.py`](diffhunk://#diff-d2a11602a79e83305208472f1abe6a4106f02ce62a7f9524007181813863fcf6L610-R632): Added new utility functions `is_MI350` and `is_Navi4` to check for specific GPU architectures.

Improvements to import handling:

* [`torchao/dtypes/uintx/marlin_qqq_tensor.py`](diffhunk://#diff-7ae93a02e7a189c58ed00f1fe0539ddbc9b84b104e45f175a37e553d801ab561L182-R182): Removed comments to avoid circular imports in the `__tensor_unflatten__` and `from_plain` methods. [[1]](diffhunk://#diff-7ae93a02e7a189c58ed00f1fe0539ddbc9b84b104e45f175a37e553d801ab561L182-R182) [[2]](diffhunk://#diff-7ae93a02e7a189c58ed00f1fe0539ddbc9b84b104e45f175a37e553d801ab561L210-R210)
* [`torchao/dtypes/uintx/marlin_sparse_layout.py`](diffhunk://#diff-0ee2aca992fa978404f83ecfb080993f057366e2b5ab58c46e92493d51567f04L198-R198): Removed comments to avoid circular imports in the `__tensor_unflatten__` and `from_plain` methods. [[1]](diffhunk://#diff-0ee2aca992fa978404f83ecfb080993f057366e2b5ab58c46e92493d51567f04L198-R198) [[2]](diffhunk://#diff-0ee2aca992fa978404f83ecfb080993f057366e2b5ab58c46e92493d51567f04L223-R223)