### PR TITLE
Fix float8nocompile CI workflow

### DIFF
--- a/.github/workflows/float8nocompile_test.yaml
+++ b/.github/workflows/float8nocompile_test.yaml
@@ -7,14 +7,12 @@ on:
       - 'gh/**'
     paths:
       - 'torchao/prototype/float8nocompile/**'
-      - '!torchao/prototype/float8nocompile/**'
   pull_request:
     branches:
       - main
       - 'gh/**'
     paths:
       - 'torchao/prototype/float8nocompile/**'
-      - '!torchao/prototype/float8nocompile/**'
 
 concurrency:
   group: floatnocompile_test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}


### PR DESCRIPTION
I noticed that I misinterpreted the example in this section of the Github actions [docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths) and need to update this CI workflow accordingly.

The intent here is to ensure that the float8nocompile tests only run when code in `torchao/prototype/float8nocompile/` changes. The removed line in the diff negates the previous line, so the result was the CI workflow never ran. Removing it will fix this.