### PR TITLE
Add ciflow/rocm to bot-created tags

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -2,3 +2,4 @@ mergebot: True
 ciflow_push_tags:
 - ciflow/benchmark
 - ciflow/tutorials
+- ciflow/rocm


### PR DESCRIPTION
This is intended to help us trigger ROCm CI tests on certain torchao PRs which will have the `ciflow/rocm` label.