### PR TITLE
Fix potential out-of-bound access in int8_mm.py

### DIFF
--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -79,7 +79,7 @@ def _scaled_int8_mm_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr = 8,
-    EVEN_K: tl.constexpr = False,
+    EVEN_K: tl.constexpr = True,
     COL_SCALE_SCALAR: tl.constexpr = False,
 ):
     # based on triton.ops.matmul

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -99,7 +99,7 @@ def _scaled_int8_mm_kernel(
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int32)
     for k in range(K, 0, -BLOCK_K):
-        if EVEN_K:
+        if K % BLOCK_K == 0:
             a = tl.load(A)
             b = tl.load(B)
         else:

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -74,7 +74,6 @@ def _scaled_int8_mm_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr = 8,
-    EVEN_K: tl.constexpr = True,
     COL_SCALE_SCALAR: tl.constexpr = False,
 ):
     # based on triton.ops.matmul
@@ -176,7 +175,6 @@ def scaled_int8_mm_cuda(A: Tensor, B: Tensor, row_scale: Tensor, col_scale: Tens
         *A.stride(),
         *B.stride(),
         *C.stride(),
-        EVEN_K=K % 2 == 0,
         COL_SCALE_SCALAR=col_scale.numel() == 1,
     )
     return C

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -79,6 +79,7 @@ def _scaled_int8_mm_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr = 8,
+    EVEN_K: tl.constexpr = False,
     COL_SCALE_SCALAR: tl.constexpr = False,
 ):
     # based on triton.ops.matmul

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -54,11 +54,7 @@ configs = [
 
 
 @triton.autotune(configs=configs, key=["M", "N", "K", "stride_ak", "stride_bk"])
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % args["BLOCK_K"] == 0
-    }
-)
+@triton.heuristics({"EVEN_K": lambda args: args["K"] % args["BLOCK_K"] == 0})
 @triton.jit
 def _scaled_int8_mm_kernel(
     A_ptr,

--- a/torchao/prototype/quantized_training/int8_mm.py
+++ b/torchao/prototype/quantized_training/int8_mm.py
@@ -56,7 +56,7 @@ configs = [
 @triton.autotune(configs=configs, key=["M", "N", "K", "stride_ak", "stride_bk"])
 @triton.heuristics(
     {
-        "EVEN_K": lambda args: args["K"] % args["BLOCK_M"] == 0
+        "EVEN_K": lambda args: args["K"] % args["BLOCK_K"] == 0
     }
 )
 @triton.jit


### PR DESCRIPTION
This PR fixes a bug in `_scaled_int8_mm_kernel` allowing unmasked `tl.load()` calls when `K` was even, but not necessarily a multiple of `BLOCK_K`, causing out-of-bounds reads. The fix changes the check to `K % BLOCK_K == 0`, ensuring unmasked loads occur only when the last block is fully valid.