### PR TITLE
add MX support to lowp training profiling script

### DIFF
--- a/benchmarks/float8/profile_linear_float8.py
+++ b/benchmarks/float8/profile_linear_float8.py
@@ -48,10 +48,9 @@ from torchao.float8.config import (
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
 )
-from torchao.testing.float8.test_utils import get_test_float8_linear_config
+from torchao.prototype.mx_formats.config import MXLinearConfig
 from torchao.prototype.mx_formats.mx_linear import swap_linear_with_mx_linear
-from torchao.prototype.mx_formats.config import MXLinearConfig, MXGemmKernelChoice
-from torchao.utils import is_sm_at_least_100
+from torchao.testing.float8.test_utils import get_test_float8_linear_config
 
 # don't truncate long kernel names
 pd.options.display.max_colwidth = 100
@@ -305,8 +304,9 @@ def main(
     scaling_type_weight = ScalingType(scaling_type_weight)
     scaling_type_grad_output = ScalingType(scaling_type_grad_output)
 
-    assert not (float8_recipe_name is not None and mx_recipe_name is not None), \
-        "either float8_recipe_name or mx_recipe_name can be specified, but not both"
+    assert not (
+        float8_recipe_name is not None and mx_recipe_name is not None
+    ), "either float8_recipe_name or mx_recipe_name can be specified, but not both"
 
     if float8_recipe_name is None and mx_recipe_name is None:
         config = get_test_float8_linear_config(

--- a/benchmarks/float8/profile_lowp_training.py
+++ b/benchmarks/float8/profile_lowp_training.py
@@ -6,8 +6,6 @@
 
 # This is a convenience script to profile fwd+bwd of individual layers with
 # float8 training or mx training on a single GPU.
-# TODO(future PR): make it clearer that it now supports float8 and MX, ideally
-# rename.
 
 import copy
 import functools

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -110,23 +110,8 @@ def kernel_name_to_category(k):
         "torchao::mx_fp4_bf16",
     ):
         return "0_gemm"
-    elif (
-        # max(abs(tensor))
-        ("abs" in k and "max" in k)
-        or
-        # casting pointwise to float8
-        ("clamp" in k)
-        or
-        # things related to scaled_mm
-        ("scaled_mm" in k)
-        or
-        # syncing amaxes and scales
-        ("roll" in k)
-    ):
-        # note: the above filter is approximate and will give false
-        # positives if model code contains other code to abs/max/clamp
-        return "1_f8_overhead"
-    return "2_other"
+    else:
+        return "1_other"
 
 
 def parse_bw_and_kernel_name(line):

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -73,14 +73,6 @@ def profiler_output_to_filtered_time_by_kernel_name(
             # forward pass sum
             assert e.count == num_iter, f"unexpected number of iter for {e.key}"
             continue
-        elif e.key == "aten::fill_":
-            # filling the forward pass sum with 1.0
-            assert e.count == num_iter, f"unexpected number of iter for {e.key}"
-            continue
-        elif e.key == "aten::copy_":
-            # copying 1.0 from grad_out of `sum` to grad_out of next op
-            assert e.count == num_iter, f"unexpected number of iter for {e.key}"
-            continue
         elif e.key == "aten::add_":
             # accumulating gradients into leaf tensors
             assert e.count == (
@@ -110,7 +102,7 @@ def profiler_output_to_gpu_time_for_key(prof, key):
 
 def kernel_name_to_category(k):
     # number prefix is for easy sorting
-    if k in ("aten::mm", "aten::addmm", "aten::_scaled_mm"):
+    if k in ("aten::mm", "aten::addmm", "aten::_scaled_mm", "torchao::mx_fp8_bf16", "torchao::mx_fp4_bf16"):
         return "0_gemm"
     elif (
         # max(abs(tensor))

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -102,7 +102,13 @@ def profiler_output_to_gpu_time_for_key(prof, key):
 
 def kernel_name_to_category(k):
     # number prefix is for easy sorting
-    if k in ("aten::mm", "aten::addmm", "aten::_scaled_mm", "torchao::mx_fp8_bf16", "torchao::mx_fp4_bf16"):
+    if k in (
+        "aten::mm",
+        "aten::addmm",
+        "aten::_scaled_mm",
+        "torchao::mx_fp8_bf16",
+        "torchao::mx_fp4_bf16",
+    ):
         return "0_gemm"
     elif (
         # max(abs(tensor))

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import torch
 
@@ -25,6 +25,14 @@ class MXGemmKernelChoice(Enum):
     CUTLASS = "cutlass"
 
     # TODO(future PR): add cuBLAS here once we land pytorch/pytorch support
+
+
+# Pre-made recipes for common configurations
+class MXLinearRecipeName(Enum):
+    MXFP8_EMULATED = "mxfp8_emulated"
+    MXFP8_CUTLASS = "mxfp8_cutlass"
+    MXFP4_EMULATED = "mxfp4_emulated"
+    MXFP4_CUTLASS = "mxfp4_cutlass"
 
 
 @dataclass
@@ -78,3 +86,29 @@ class MXLinearConfig:
             assert (
                 self.elem_dtype_grad_output_override is None
             ), "elem_dtype_grad_output_override not supported for CUTLASS MX gemm kernels"
+
+    @staticmethod
+    def from_recipe_name(
+        recipe_name: Union[MXLinearRecipeName, str],
+    ) -> "MXLinearConfig":
+        """
+        Input: `MXLinearRecipeName` value, or a string representing a `MXLinearRecipeName` value
+        Output: a `MXLinearConfig` configured to implement the specified recipe
+        """
+        if type(recipe_name) == str:
+            valid_names = [n.value for n in MXLinearRecipeName]
+            assert (
+                recipe_name in valid_names
+            ), f"recipe_name {recipe_name} not in valid names {valid_names}"
+            recipe_name = MXLinearRecipeName(recipe_name)
+
+        if recipe_name is MXLinearRecipeName.MXFP8_EMULATED:
+            return MXLinearConfig()
+        elif recipe_name is MXLinearRecipeName.MXFP8_CUTLASS:
+            return MXLinearConfig(gemm_kernel_choice=MXGemmKernelChoice.CUTLASS)
+        elif recipe_name is MXLinearRecipeName.MXFP4_EMULATED:
+            return MXLinearConfig(elem_dtype=DTYPE_FP4)
+        elif recipe_name is MXLinearRecipeName.MXFP8_CUTLASS:
+            return MXLinearConfig(elem_dtype=DTYPE_FP4, gemm_kernel_choice=MXGemmKernelChoice.CUTLASS)
+        else:
+            raise AssertionError(f"unknown recipe_name {recipe_name}")

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -109,6 +109,8 @@ class MXLinearConfig:
         elif recipe_name is MXLinearRecipeName.MXFP4_EMULATED:
             return MXLinearConfig(elem_dtype=DTYPE_FP4)
         elif recipe_name is MXLinearRecipeName.MXFP8_CUTLASS:
-            return MXLinearConfig(elem_dtype=DTYPE_FP4, gemm_kernel_choice=MXGemmKernelChoice.CUTLASS)
+            return MXLinearConfig(
+                elem_dtype=DTYPE_FP4, gemm_kernel_choice=MXGemmKernelChoice.CUTLASS
+            )
         else:
             raise AssertionError(f"unknown recipe_name {recipe_name}")


### PR DESCRIPTION
Summary:

1. rename `benchmarks/float8/profile_linear_float8.py` to `benchmarks/float8/profile_lowp_training.py`
2. add MX training support to the script
3. various cleanups and QOL improvements to the script
4. add a recipe-lookup-by-name functionality to MX, similar to float8

Test Plan:

```
(pytorch) [vasiliy@devgpu006.vll6 ~/local/ao (20250223_mx_bench)]$ python benchmarks/float8/profile_lowp_training.py ~/local/tmp/20250223_test --mx_recipe_name mxfp8_emulated --forward_only --experiment_filter lowp
Compile is set to       | True
model_type is set to    | linear
enable_activation_checkpointing is set to False
forward_only is set to True
config: MXLinearConfig(block_size=32, elem_dtype=torch.float8_e4m3fn, elem_dtype_weight_override=None, elem_dtype_grad_output_override=None, gemm_kernel_choice=<MXGemmKernelChoice.EMULATED: 'emulated'>, use_fp4_custom_triton_dequant_kernel=False)
m_ref Sequential(
  (0): Linear(in_features=4096, out_features=8192, bias=False)
)
m_lowp Sequential(
  (0): MXLinear(in_features=4096, out_features=8192, bias=False)
)
input_tensor.shape torch.Size([2048, 4096])
grad_output.shape torch.Size([2048, 8192])

profiling lowp
/data/users/vasiliy/pytorch/torch/_dynamo/pgo.py:464: UserWarning: dynamo_pgo force disabled by torch._inductor.config.force_disable_caches
  warn_once(
saved profiling trace to /home/vasiliy/local/tmp/20250223_test_linear_lowp_compile_True.json

Summary of GPU time by CPU kernel

   experiment                                kernel category  time_ms  pct_gpu_time bw_gpbs
4     1_lowp                              aten::mm   0_gemm    0.200         0.504    None
3     1_lowp       triton_poi_fused__to_copy_mul_3  1_other    0.110         0.278    None
2     1_lowp  triton_per_fused__to_copy_abs_amax_2  1_other    0.044         0.111    None
1     1_lowp       triton_poi_fused__to_copy_mul_1  1_other    0.029         0.073    None
0     1_lowp  triton_per_fused__to_copy_abs_amax_0  1_other    0.014         0.034    None

Summary of time (ms) by kernel category

 experiment  1_lowp
category          
0_gemm       0.200
1_other      0.197
All          0.396

```

Reviewers:

Subscribers:

Tasks:

Tags: