### PR TITLE
Initial stab at string based config parser

### DIFF
--- a/test/quantization/test_config_parser.py
+++ b/test/quantization/test_config_parser.py
@@ -1,0 +1,132 @@
+import unittest
+
+import torch
+
+from torchao.quantization.config_parser import ConfigParser
+from torchao.quantization.quant_api import (
+    Float8DynamicActivationFloat8WeightConfig,
+    Float8WeightOnlyConfig,
+    Int4DynamicActivationInt4WeightConfig,
+    Int4WeightOnlyConfig,
+    Int8DynamicActivationInt4WeightConfig,
+    Int8DynamicActivationInt8WeightConfig,
+    Int8WeightOnlyConfig,
+    MappingType,
+    UIntXWeightOnlyConfig,
+)
+
+
+class TestConfigParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = ConfigParser()
+
+    def test_int4wo_config(self):
+        # Basic Int4WeightOnlyConfig
+        config = self.parser.parse("int4wo_g32")
+        self.assertIsInstance(config, Int4WeightOnlyConfig)
+        self.assertEqual(config.group_size, 32)
+
+        # With symmetry specified
+        config = self.parser.parse("int4wo_g64")
+        self.assertIsInstance(config, Int4WeightOnlyConfig)
+        self.assertEqual(config.group_size, 64)
+
+    def test_int8wo_config(self):
+        # Basic Int8WeightOnlyConfig
+        config = self.parser.parse("int8wo_g128")
+        self.assertIsInstance(config, Int8WeightOnlyConfig)
+        self.assertEqual(config.group_size, 128)
+
+        # Verify that symmetry parameter raises error since not supported
+        with self.assertRaises(ValueError) as context:
+            self.parser.parse("int8wo_g128_sym")
+
+        self.assertIn(
+            "Invalid parameters for Int8WeightOnlyConfig", str(context.exception)
+        )
+        self.assertIn("mapping_type", str(context.exception))
+
+    def test_int8dqint4_config(self):
+        # Int8 dynamic activation with Int4 weight
+        config = self.parser.parse("int8dqint4_g32")
+        self.assertIsInstance(config, Int8DynamicActivationInt4WeightConfig)
+        self.assertEqual(config.group_size, 32)
+
+        # With symmetry
+        config = self.parser.parse("int8dqint4_g32_sym")
+        self.assertIsInstance(config, Int8DynamicActivationInt4WeightConfig)
+        self.assertEqual(config.group_size, 32)
+        self.assertEqual(config.mapping_type, MappingType.SYMMETRIC)
+
+    def test_int8dqint8_config(self):
+        # Int8 dynamic activation with Int8 weight
+        config = self.parser.parse("int8dqint8")
+        self.assertIsInstance(config, Int8DynamicActivationInt8WeightConfig)
+
+    def test_int4dqint4_config(self):
+        # Int4 dynamic activation with Int4 weight
+        config = self.parser.parse("int4dqint4_sym")
+        self.assertIsInstance(config, Int4DynamicActivationInt4WeightConfig)
+        self.assertEqual(config.mapping_type, MappingType.SYMMETRIC)
+
+    def test_float8wo_config(self):
+        # Basic Float8WeightOnlyConfig with e4m3 dtype
+        config = self.parser.parse("float8wo_e4m3")
+        self.assertIsInstance(config, Float8WeightOnlyConfig)
+        self.assertEqual(config.weight_dtype, torch.float8_e4m3fn)
+
+        # With e5m2 dtype
+        config = self.parser.parse("float8wo_e5m2")
+        self.assertIsInstance(config, Float8WeightOnlyConfig)
+        self.assertEqual(config.weight_dtype, torch.float8_e5m2)
+
+    def test_float8dqfloat8_config(self):
+        # Float8 dynamic activation with Float8 weight
+        config = self.parser.parse("float8dqfloat8_e4m3")
+        self.assertIsInstance(config, Float8DynamicActivationFloat8WeightConfig)
+        self.assertEqual(config.activation_dtype, torch.float8_e4m3fn)
+        self.assertEqual(config.weight_dtype, torch.float8_e4m3fn)
+
+    def test_uintxwo_config(self):
+        # UIntX config with uint4
+        config = self.parser.parse("uintxwo_uint4_g32")
+        self.assertIsInstance(config, UIntXWeightOnlyConfig)
+
+        # With uint8
+        config = self.parser.parse("uintxwo_uint8_g64")
+        self.assertIsInstance(config, UIntXWeightOnlyConfig)
+
+    # def test_fpx_config(self):
+    #     # FPX config
+    #     config = self.parser.parse("fpx_e4m3")
+    #     self.assertIsInstance(config, FPXWeightOnlyConfig)
+    #     self.assertEqual(config.ebits, 4)
+    #     self.assertEqual(config.mbits, 3)
+
+    def test_invalid_config_string(self):
+        # Test empty string
+        with self.assertRaises(ValueError):
+            self.parser.parse("")
+
+        # Test unknown base config
+        with self.assertRaises(ValueError):
+            self.parser.parse("unknown_config")
+
+        # Test invalid parameter token
+        with self.assertRaises(ValueError):
+            self.parser.parse("int4wo_invalid_token")
+
+    def test_complex_configurations(self):
+        # Adjust tests for complex configurations to match actual parameter names
+        config = self.parser.parse("int4wo_g32")
+        self.assertIsInstance(config, Int4WeightOnlyConfig)
+        self.assertEqual(config.group_size, 32)
+
+        config = self.parser.parse("int8dqint4_g32_asym")
+        self.assertIsInstance(config, Int8DynamicActivationInt4WeightConfig)
+        self.assertEqual(config.group_size, 32)
+        self.assertEqual(config.mapping_type, MappingType.ASYMMETRIC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchao/quantization/config_parser.py
+++ b/torchao/quantization/config_parser.py
@@ -1,0 +1,226 @@
+import dataclasses
+import re
+from typing import Any, Dict, List, Protocol, Tuple, Type
+
+import torch
+
+from torchao.core.config import AOBaseConfig
+from torchao.quantization.quant_api import (
+    Float8DynamicActivationFloat8WeightConfig,
+    Float8WeightOnlyConfig,
+    Int4DynamicActivationInt4WeightConfig,
+    Int4WeightOnlyConfig,
+    Int8DynamicActivationInt4WeightConfig,
+    Int8DynamicActivationInt8WeightConfig,
+    Int8WeightOnlyConfig,
+    MappingType,
+    # Float8StaticActivationFloat8WeightConfig,
+    UIntXWeightOnlyConfig,
+)
+
+# Create a type alias for AOBaseConfig classes
+ConfigType = Type[AOBaseConfig]
+
+
+# Define a Protocol for parameter processors
+class ParameterProcessor(Protocol):
+    """Protocol defining the interface for parameter processors"""
+
+    def __call__(self, match: re.Match, quant_config: ConfigType) -> Tuple[str, Any]:
+        """
+        Process a regex match into a parameter name and value
+
+        Args:
+            match: The regex match object containing captured groups
+            quant_config: The quantization config class being instantiated
+
+        Returns:
+            Tuple of (parameter_name, parameter_value)
+
+        Note:
+            If you need special handling based on the quant_config type,
+            be sure to use issubclass instead of isinstance.
+        """
+        ...
+
+
+def process_bits(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    return "bits", int(match.group(1))
+
+
+def process_group_size(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    return "group_size", int(match.group(1))
+
+
+def process_activation_bits(
+    match: re.Match, quant_config: AOBaseConfig
+) -> Tuple[str, Any]:
+    return "activation_bits", int(match.group(1))
+
+
+def process_weight_bits(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    return "weight_bits", int(match.group(1))
+
+
+def process_symmetry(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    mapping_type = (
+        MappingType.SYMMETRIC if match.group(1) == "sym" else MappingType.ASYMMETRIC
+    )
+    return "mapping_type", mapping_type
+
+
+def process_dtype(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    dtype_map = {
+        "int4": torch.int4,
+        "int8": torch.int8,
+        "uint4": torch.uint4,
+        "uint8": torch.uint8,
+        "e4m3": torch.float8_e4m3fn,
+        "e5m2": torch.float8_e5m2,
+    }
+    # The float8's have different key names :(
+    key = (
+        "weight_dtype"
+        if issubclass(
+            quant_config,
+            (
+                Float8WeightOnlyConfig,
+                Float8DynamicActivationFloat8WeightConfig,
+            ),
+        )
+        else "dtype"
+    )
+    return key, dtype_map[match.group(1)]
+
+
+def process_per_row(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
+    return "per_row", True
+
+
+class ConfigParser:
+    """Parser for string-based configuration patterns"""
+
+    # Parameter patterns with their processing functions
+    param_patterns: Dict[re.Pattern, ParameterProcessor] = {
+        re.compile(r"(\d+)bit"): process_bits,
+        re.compile(r"g(\d+)"): process_group_size,
+        # re.compile(r"act(\d+)"): process_activation_bits,
+        # re.compile(r"w(\d+)"): process_weight_bits,
+        re.compile(r"(sym|asym)"): process_symmetry,
+        re.compile(r"(int4|int8|uint4|uint8|e4m3|e5m2)"): process_dtype,
+        re.compile(r"(per_row)"): process_per_row,
+    }
+
+    # Map from string prefix to QuantType
+    type_mapping = {
+        "int4wo": Int4WeightOnlyConfig,
+        "int8wo": Int8WeightOnlyConfig,
+        "int8dqint4": Int8DynamicActivationInt4WeightConfig,
+        "int8dqint8": Int8DynamicActivationInt8WeightConfig,
+        "int4dqint4": Int4DynamicActivationInt4WeightConfig,
+        "float8wo": Float8WeightOnlyConfig,
+        "float8dqfloat8": Float8DynamicActivationFloat8WeightConfig,
+        # "float8staticfloat8": Float8StaticActivationFloat8WeightConfig,
+        "uintxwo": UIntXWeightOnlyConfig,
+        # "fpx": FPXWeightOnlyConfig,
+    }
+
+    def parse(self, config_str: str) -> AOBaseConfig:
+        """
+        Parse a configuration string into an AO quantization configuration object.
+
+        This is the main entrypoint for converting string-based configuration into actual config objects.
+        The expected format is "base_param1-value1_param2-value2" where "base" identifies the base
+        quantization type and subsequent tokens specify parameter values.
+
+        Examples:
+            config_parser.parse("int8dqint8")
+            config_parser.parse("int8dqint4_g32")
+
+        Args:
+            config_str: String representation of the quantization configuration
+
+        Returns:
+            AOBaseConfig: Instantiated quantization configuration object
+
+        Raises:
+            ValueError: If the config string is empty or invalid
+        """
+        tokens = config_str.split("_")
+
+        if not tokens:
+            raise ValueError("Empty config string")
+
+        # The first token is the base quantization type
+        quant_config = self._get_config(tokens[0])
+
+        # We know the base quant type, now we convert each token to its parameter
+        params = self._extract_params(quant_config, tokens[1:])
+
+        return self._instantiate_config(quant_config, params)
+
+    def _get_config(self, first_token: str) -> AOBaseConfig:
+        """Get the quantization config from a string"""
+        try:
+            quant_config = self.type_mapping[first_token]
+        except KeyError:
+            # Print available base configurations before raising error
+            available_configs = list(self.type_mapping.keys())
+            raise ValueError(
+                f"Unknown quantization type in string: {first_token} \n Available base configurations: {available_configs}"
+            )
+        return quant_config
+
+    def _instantiate_config(
+        self, quant_config: AOBaseConfig, params: Dict[str, Any]
+    ) -> AOBaseConfig:
+        """Sprinkle some extra logic for helping w/ instantiation failures"""
+        try:
+            return quant_config(**params)
+        except TypeError as e:
+            # Get proper field information for error message
+            valid_fields = {
+                field.name
+                for field in dataclasses.fields(quant_config)
+                if field.name != "self"
+            }
+            invalid_params = {k: v for k, v in params.items() if k not in valid_fields}
+
+            field_info = [field.name for field in dataclasses.fields(quant_config)]
+
+            raise ValueError(
+                f"Invalid parameters for {quant_config.__name__}: {list(invalid_params.keys())}.\n"
+                f"Available parameters for {quant_config.__name__}: {field_info}"
+            ) from e
+
+    def _extract_params(
+        self, quant_config: AOBaseConfig, param_tokens: List[str]
+    ) -> Dict[str, Any]:
+        """Extract parameters from tokens"""
+        params = {}
+
+        for token in param_tokens:
+            if not token:
+                continue
+
+            matched = False
+            # Try to match against parameter patterns
+            # We could specify an ordering but for now we just try all
+            for pattern, processor in self.param_patterns.items():
+                match = pattern.fullmatch(token)
+                if match:
+                    param_name, value = processor(match, quant_config)
+                    params[param_name] = value
+                    matched = True
+                    break
+
+            if not matched:
+                field_info = [
+                    (field.name, field.type)
+                    for field in dataclasses.fields(quant_config)
+                ]
+                raise ValueError(
+                    f"Unrecognized parameter token: {token} in {param_tokens}\nAvailable parameters for {quant_config.__name__}: {field_info}"
+                )
+
+        return params


### PR DESCRIPTION
Stacked PRs:
 * #1806
 * __->__#1774


--- --- ---

# Configuration String Parser for TorchAO Quantization

This document explains how this prototype example string-based configuration system could* work for TorchAO quantization, including the parsing process and how to extend it for future needs.

## Configuration String Schema

The configuration strings follow this general pattern:
`<base_config>_<param1>_<param2>_...`
Where:
- `<base_type>` defines the fundamental quantization config (e.g., `Int8WeightOnlyConfig`, `Float8DynamicActivationFloat8WeightConfig`)
- Each `<param>` adds specific configurations like bit width, group size, or data type

### Base Types

The following base types are supported:

| Base Type | Configuration Class |
|-----------|---------------------|
| `int4wo` | `Int4WeightOnlyConfig` |
| `int8wo` | `Int8WeightOnlyConfig` |
| `int8dqint4` | `Int8DynamicActivationInt4WeightConfig` |
| `int8dqint8` | `Int8DynamicActivationInt8WeightConfig` |
| `int4dqint4` | `Int4DynamicActivationInt4WeightConfig` |
| `float8wo` | `Float8WeightOnlyConfig` |
| `float8dqfloat8` | `Float8DynamicActivationFloat8WeightConfig` |
| `uintxwo` | `UIntXWeightOnlyConfig` |

### Parameter Tokens

WIP: Need to finalize on what params we think we should support and which ones we shouldn't as well as naming scheme

Parameters are specified as tokens after the base type, separated by underscores. Each parameter has its own format:

| Token Pattern | Example | Description | Parameter Name |
|--------------|---------|-------------|----------------|
| `<N>bit` | `4bit` | Specifies bit width | `bits` |
| `g<N>` | `g32` | Specifies group size | `group_size` |
| `sym` or `asym` | `sym` | Symmetry type | `mapping_type` |
| `int4`, `int8`, `uint4`, `uint8`, `e4m3`, `e5m2` | `int8` | Data type | `dtype` or `weight_dtype` |
| `per_row` | `per_row` | Per-row quantization | `per_row` |


## The Parsing Process

The parsing process follows these steps:

1. The input string is split by underscores (`_`) into tokens
2. The first token determines the base quantization configuration type
3. Each subsequent token is matched against regex patterns to extract parameter values
4. The configuration object is instantiated with the extracted parameters
5. Error handling provides informative messages about invalid or unrecognized parameters

## Example Parsing

Example configuration string: `int8dqint4_g32_sym`

1. Split into tokens: `["int8dqint4", "g32", "sym"]`
2. First token `int8dqint4` maps to `Int8DynamicActivationInt4WeightConfig`
3. Token `g32` matches the pattern `g(\d+)` and sets `group_size=32`
4. Token `sym` matches the pattern `(sym|asym)` and sets `mapping_type=MappingType.SYMMETRIC`
5. Instantiate `Int8DynamicActivationInt4WeightConfig(group_size=32, mapping_type=MappingType.SYMMETRIC)`

## Extending the Parser

You can extend the parser in several ways:

### 1. Add New Base Configuration Types

To add a new base configuration type:

```python
# 1. Import your new config class
from torchao.quantization.quant_api import YourNewConfig

# 2. Add it to the type_mapping dictionary in ConfigParser
ConfigParser.type_mapping["yournewtype"] = YourNewConfig
```

### 2. Add New Parameter Types

To add a new parameter type:

```python
# 1. Define a new parameter processor function
def process_your_param(match: re.Match, quant_config: Type[AOBaseConfig]) -> Tuple[str, Any]:
    return "your_param_name", process_value(match)

# 2. Add the regex pattern and processor to the param_patterns dictionary
ConfigParser.param_patterns[re.compile(r"your_pattern")] = process_your_param
```

### 3. Create Special Processing Logic

If you need special handling based on the config type:

```python
def process_special_param(match: re.Match, quant_config: AOBaseConfig) -> Tuple[str, Any]:
    if issubclass(quant_config, YourSpecialConfig):
        # Special handling for this config type
        return "special_param", special_value(match.group(1))
    else:
        # Regular handling
        return "regular_param", regular_value(match.group(1))
```

## Best Practices for Extensions

When extending the parser:

1. **Well-defined patterns**: Create regex patterns that are specific and won't conflict with existing patterns
2. **Descriptive errors**: Provide helpful error messages when parameters are invalid
3. **Type safety**: Ensure your processor returns the correct types expected by the config classes
4. **Documentation**: Update documentation to include your new base types or parameters
5. **Testing**: Add tests for your new patterns and configurations

## Complete Example

To add support for a new "fast" parameter that enables faster computation:

```python
# 1. Define processor function
def process_fast_mode(match: re.Match, quant_config: Type[AOBaseConfig]) -> Tuple[str, Any]:
    return "fast_mode", True

# 2. Add to param_patterns
ConfigParser.param_patterns[re.compile(r"fast")] = process_fast_mode

# Now you can use strings like "int8wo_g32_fast"
```

## Open Questions

### 1. Parameter Selection and Naming
- Which parameters should be exposed in the string interface?
- Should we prioritize brevity (`g32`) or clarity (`group32`)?
- How to handle parameters only applicable to specific base types?

### 2. Parameter Validation
- How to handle conflicting parameters? For instance it is possible to have two parameter patterns that want similiar string representations. I kind of side stepped this by passing in the matched quant config

### 3. Default Values
- How to communicate defaults to users?
- We are currently relying on the fact that most (all?) configs have defaults and just utilizing those

### 4. Extensibility
- I think that third-party users might and should be able to extend slash build on this. E.g. Does that make sense?
- What's our deprecation strategy for parameters/base types?

### 6. Backward Compatibility
- How to evolve the string format over time?



### Parsing Flow Diagram 

```mermaid
flowchart TD
    Start([Input String]) --> Split[Split by underscores]
    Split --> FirstToken[Extract First Token]
    FirstToken --> ConfigType[Map to Config Class]
    Split --> RemainingTokens[Process Remaining Tokens]
    
    RemainingTokens --> ParamLoop{For each token}
    ParamLoop --> MatchPatterns[Match against regex patterns]
    MatchPatterns --> ProcessMatch[Process match using\nappropriate processor]
    ProcessMatch --> ParamDict[Add to parameters dictionary]
    ParamDict --> ParamLoop
    
    ConfigType --> Instantiate[Instantiate Config Class]
    ParamLoop -- All tokens processed --> Instantiate
    Instantiate --> ValidateFields[Validate Fields]
    ValidateFields --> End([Return Config Object])
    
    ValidateFields -- Invalid params --> ErrorHandling[Error Handling]
    MatchPatterns -- No match --> TokenError[Unrecognized Parameter Error]