### PR TITLE
Add support for copy_ for plain layout and tensor core tiled layout

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -214,7 +214,6 @@ class TestAffineQuantized(TestCase):
         "apply_quant", get_quantization_functions(False, True, "cuda", False)
     )
     def test_copy_(self, apply_quant):
-        print("apply_quant:", apply_quant)
         linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
         ql = apply_quant(linear)
         linear2 = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -215,9 +215,16 @@ class TestAffineQuantized(TestCase):
     )
     def test_copy_(self, apply_quant):
         linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
-        ql = apply_quant(linear)
         linear2 = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
-        ql2 = apply_quant(linear2)
+
+        if isinstance(apply_quant, AOBaseConfig):
+            quantize_(linear, apply_quant)
+            ql = linear
+            quantize_(linear2, apply_quant)
+            ql2 = linear2
+        else:
+            ql = apply_quant(linear)
+            ql2 = apply_quant(linear2)
 
         example_input = torch.randn(1, 128, dtype=torch.bfloat16, device="cuda")
         output = ql(example_input)
@@ -232,9 +239,16 @@ class TestAffineQuantized(TestCase):
     )
     def test_copy__mismatch_metadata(self, apply_quant):
         linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
-        ql = apply_quant(linear)
         linear2 = torch.nn.Linear(128, 512, dtype=torch.bfloat16, device="cuda")
-        ql2 = apply_quant(linear2)
+
+        if isinstance(apply_quant, AOBaseConfig):
+            quantize_(linear, apply_quant)
+            ql = linear
+            quantize_(linear2, apply_quant)
+            ql2 = linear2
+        else:
+            ql = apply_quant(linear)
+            ql2 = apply_quant(linear2)
 
         # copy should fail due to shape mismatch
         with self.assertRaisesRegex(

--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -97,6 +97,27 @@ def deregister_aqt_quantized_linear_dispatch(dispatch_condition):
         )
 
 
+def _same_metadata(self: AffineQuantizedTensor, src: AffineQuantizedTensor):
+    return (
+        isinstance(self, AffineQuantizedTensor)
+        and isinstance(src, AffineQuantizedTensor)
+        and all(
+            [
+                getattr(self, attr) == getattr(src, attr)
+                for attr in [
+                    "block_size",
+                    "shape",
+                    "quant_min",
+                    "quant_max",
+                    "zero_point_domain",
+                    "dtype",
+                ]
+            ]
+        )
+        and type(self.tensor_impl) == type(src.tensor_impl)
+    )
+
+
 class QuantizedLinearNotImplementedError(NotImplementedError):
     """Thin wrapper around NotImplementedError to make it easier to catch this error in the dispatch table"""
 
@@ -328,6 +349,20 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
+    )
+
+
+@implements(aten.copy_.default)
+def _(func, types, args, kwargs):
+    self = args[0]
+    src = args[1]
+    if _same_metadata(self, src):
+        self_tensors = self.__tensor_flatten__()[0]
+        for tensor_name in self_tensors:
+            getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+        return
+    raise ValueError(
+        f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
     )
 
 

--- a/torchao/dtypes/floatx/float8_layout.py
+++ b/torchao/dtypes/floatx/float8_layout.py
@@ -23,6 +23,18 @@ from torchao.utils import _is_float8_type, fill_defaults
 aten = torch.ops.aten
 
 
+def _same_metadata(self: "Float8AQTTensorImpl", src: "Float8AQTTensorImpl") -> bool:
+    return (
+        isinstance(self, Float8AQTTensorImpl)
+        and isinstance(src, Float8AQTTensorImpl)
+        and self.shape == src.shape
+        and self.float8_data.shape == src.float8_data.shape
+        and self.scale.shape == src.scale.shape
+        and self.transposed == src.transposed
+        and type(self._layout) == type(src._layout)
+    )
+
+
 @dataclass(frozen=True)
 class Float8Layout(Layout):
     """Represents the layout configuration for Float8 affine quantized tensors.
@@ -126,6 +138,17 @@ class Float8AQTTensorImpl(AQTTensorImpl):
             """
             args[0].transposed = not args[0].transposed
             return return_and_correct_aliasing(func, args, kwargs, args[0])
+        elif func is aten.copy_.default:
+            self = args[0]
+            src = args[1]
+            if _same_metadata(self, src):
+                self_tensors = self.__tensor_flatten__()[0]
+                for tensor_name in self_tensors:
+                    getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+                return
+            raise ValueError(
+                f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
+            )
         elif func is aten.slice.Tensor:
             self, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
             if dim == 0:

--- a/torchao/dtypes/uintx/plain_layout.py
+++ b/torchao/dtypes/uintx/plain_layout.py
@@ -26,6 +26,7 @@ def _same_metadata(self: "PlainAQTTensorImpl", src: "PlainAQTTensorImpl") -> boo
     return (
         isinstance(self, PlainAQTTensorImpl)
         and isinstance(src, PlainAQTTensorImpl)
+        and self.shape == src.shape
         and self.int_data.shape == src.int_data.shape
         and self.scale.shape == src.scale.shape
         and self.zero_point.shape == src.zero_point.shape

--- a/torchao/dtypes/uintx/plain_layout.py
+++ b/torchao/dtypes/uintx/plain_layout.py
@@ -22,6 +22,17 @@ from torchao.utils import fill_defaults
 aten = torch.ops.aten
 
 
+def _same_metadata(self: "PlainAQTTensorImpl", src: "PlainAQTTensorImpl") -> bool:
+    return (
+        isinstance(self, PlainAQTTensorImpl)
+        and isinstance(src, PlainAQTTensorImpl)
+        and self.int_data.shape == src.int_data.shape
+        and self.scale.shape == src.scale.shape
+        and self.zero_point.shape == src.zero_point.shape
+        and type(self._layout) == type(src._layout)
+    )
+
+
 @register_layout(PlainLayout)
 class PlainAQTTensorImpl(AQTTensorImpl):
     """
@@ -111,6 +122,18 @@ class PlainAQTTensorImpl(AQTTensorImpl):
         if func is aten.clone.default:
             return return_and_correct_aliasing(
                 func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+            )
+
+        if func is aten.copy_.default:
+            self = args[0]
+            src = args[1]
+            if _same_metadata(self, src):
+                self_tensors = self.__tensor_flatten__()[0]
+                for tensor_name in self_tensors:
+                    getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+                return
+            raise ValueError(
+                f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
             )
 
         elif func is aten.t.default:

--- a/torchao/dtypes/uintx/tensor_core_tiled_layout.py
+++ b/torchao/dtypes/uintx/tensor_core_tiled_layout.py
@@ -38,6 +38,7 @@ def _same_metadata(
     return (
         isinstance(self, TensorCoreTiledAQTTensorImpl)
         and isinstance(src, TensorCoreTiledAQTTensorImpl)
+        and self.shape == src.shape
         and self.packed_weight.shape == src.packed_weight.shape
         and self.scale_and_zero.shape == src.scale_and_zero.shape
         and self.transposed == src.transposed

--- a/torchao/dtypes/uintx/tensor_core_tiled_layout.py
+++ b/torchao/dtypes/uintx/tensor_core_tiled_layout.py
@@ -32,6 +32,22 @@ def _aqt_is_tensor_core_tile_uint4(aqt):
     )
 
 
+def _same_metadata(
+    self: "TensorCoreTiledAQTTensorImpl", src: "TensorCoreTiledAQTTensorImpl"
+) -> bool:
+    print(
+        f"{isinstance(self, TensorCoreTiledAQTTensorImpl)}, {isinstance(src, TensorCoreTiledAQTTensorImpl)}, {self.packed_weight.shape == src.packed_weight.shape}, {self.scale_and_zero.shape == src.scale_and_zero.shape}, {self.transposed, src.transposed}, {type(self._layout)}, {type(src._layout)}"
+    )
+    return (
+        isinstance(self, TensorCoreTiledAQTTensorImpl)
+        and isinstance(src, TensorCoreTiledAQTTensorImpl)
+        and self.packed_weight.shape == src.packed_weight.shape
+        and self.scale_and_zero.shape == src.scale_and_zero.shape
+        and self.transposed == src.transposed
+        and type(self._layout) == type(src._layout)
+    )
+
+
 def _linear_bf16_act_uint4_weight_check(input_tensor, weight_tensor, bias):
     return (
         # input is native bfloat16 tensor
@@ -288,6 +304,18 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         if func is aten.clone.default:
             return return_and_correct_aliasing(
                 func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+            )
+
+        if func is aten.copy_.default:
+            self = args[0]
+            src = args[1]
+            if _same_metadata(self, src):
+                self_tensors = self.__tensor_flatten__()[0]
+                for tensor_name in self_tensors:
+                    getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+                return
+            raise ValueError(
+                f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
             )
 
         if func is aten.t.default:

--- a/torchao/dtypes/uintx/tensor_core_tiled_layout.py
+++ b/torchao/dtypes/uintx/tensor_core_tiled_layout.py
@@ -35,9 +35,6 @@ def _aqt_is_tensor_core_tile_uint4(aqt):
 def _same_metadata(
     self: "TensorCoreTiledAQTTensorImpl", src: "TensorCoreTiledAQTTensorImpl"
 ) -> bool:
-    print(
-        f"{isinstance(self, TensorCoreTiledAQTTensorImpl)}, {isinstance(src, TensorCoreTiledAQTTensorImpl)}, {self.packed_weight.shape == src.packed_weight.shape}, {self.scale_and_zero.shape == src.scale_and_zero.shape}, {self.transposed, src.transposed}, {type(self._layout)}, {type(src._layout)}"
-    )
     return (
         isinstance(self, TensorCoreTiledAQTTensorImpl)
         and isinstance(src, TensorCoreTiledAQTTensorImpl)

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -118,6 +118,7 @@ def _same_metadata(
     return (
         isinstance(self, LinearActivationQuantizedTensor)
         and isinstance(src, LinearActivationQuantizedTensor)
+        and self.shape == src.shape
         and self.input_quant_func == src.input_quant_func
         and self.quant_kwargs == src.quant_kwargs
     )

--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -112,6 +112,17 @@ class LinearActivationQuantizedTensor(TorchAOBaseTensor):
         )
 
 
+def _same_metadata(
+    self: LinearActivationQuantizedTensor, src: LinearActivationQuantizedTensor
+):
+    return (
+        isinstance(self, LinearActivationQuantizedTensor)
+        and isinstance(src, LinearActivationQuantizedTensor)
+        and self.input_quant_func == src.input_quant_func
+        and self.quant_kwargs == src.quant_kwargs
+    )
+
+
 implements = LinearActivationQuantizedTensor.implements
 
 
@@ -188,6 +199,20 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
+    )
+
+
+@implements(aten.copy_.default)
+def _(func, types, args, kwargs):
+    self = args[0]
+    src = args[1]
+    if _same_metadata(self, src):
+        self_tensors = self.__tensor_flatten__()[0]
+        for tensor_name in self_tensors:
+            getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+        return
+    raise ValueError(
+        f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
     )
 
 


### PR DESCRIPTION
Summary:
att, only support copy_ from AQT to another AQT with same metadata (shapes etc.)

Tested int4wo, int8wo, int8dq

This is to support the `param.data.copy_` usage in vllm/sglang

Test Plan:
python test/dtypes/test_affine_quantized.py -k test_copy_

Reviewers:

Subscribers:

Tasks:

Tags: