### PR TITLE
[float8] add perf benchmarks for float8 training with rowwise + tensorwise scaling

### DIFF
--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -214,17 +214,20 @@ and tensorwise scaling. The training benchmarks were all run using:
 - Steps 100
 - `torch.compile`
 - FSDP2
+- pytorch version: `2.7.0a0+gitb98af95`
+- torchao version: `0.10.0+git890e0ac8`
+- torchtitan version: `0.0.2`
 
-| Model         | Scaling                           | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over baseline
-| ------------- | --------------------------------- | ------------------------ | ------------------| -------------------- | ---------------------
-| Llama3-8b     |  none (bf16)                      | per op SAC               | 47.65             |  6150                | -
-| Llama3-8b     |  tensorwise with optimal settings | per op SAC               | 47.77             |  7689.5              | 25.03%
-| Llama3-8b     |  rowwise                          | per op SAC               | 47.79             |  6768                | 10.05%
+
+| Model         | Scaling                            | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over baseline
+| ------------- | ---------------------------------- | ------------------------ | ------------------| -------------------- | ---------------------
+| Llama3-8b     |  none (bfloat16)                   | per op SAC               | 47.65             |  6150                | -
+| Llama3-8b     |  tensorwise with float8 all-gather | per op SAC               | 47.77             |  7689.5              | 25.03%
+| Llama3-8b     |  rowwise with bfloat16 all-gather  | per op SAC               | 47.79             |  6768                | 10.05%
 
 **Important notes**:
-- Speedups increase as M,K,N (GEMM dimensions) increase. Speedups as high as 1.5x have been measured with larger shapes ((example)[https://pytorch.org/blog/training-using-float8-fsdp2/]).
+- E2E speedups increase as M,K,N (GEMM dimensions) increase. Speedups as high as 1.5x have been measured with larger shapes ((example)[https://pytorch.org/blog/training-using-float8-fsdp2/]).
 - Rowwise scaling is better at handling outliers than tensorwise scaling, so these recipes are different points on the accuracy vs performance curve.
-- Tensorwise scaling benchmarks were ran with optimal settings, namely: `enable_fsdp_float8_all_gather`, `precompute_float8_dynamic_scale_for_fsdp`, `force_recompute_fp8_weight_in_bwd`.
 
 **Reproducing training benchmarks**
 To reproduce these benchmarks, you can follow these steps:

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -237,7 +237,7 @@ including [downloading a tokenizer](https://github.com/pytorch/torchtitan?tab=re
 2. Install torchao following these [steps](https://github.com/pytorch/ao/tree/main?tab=readme-ov-file#installation).
 3. From the `torchao/float8/benchmarking/` directory, you can run the following commands to reproduce the benchmarks above:
    - bf16 + compile: `TORCHTITAN_ROOT=<path> ./float8_training_benchmark.sh`
-   - float8 tensorwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./float8_training_benchmark.sh`
-   - float8 rowwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="rowwise" ./float8_training_benchmark.sh`
+   - float8 tensorwise with float8 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./float8_training_benchmark.sh`
+   - float8 rowwise with bf16 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="rowwise" ./float8_training_benchmark.sh`
 
 See the float8 training benchmarking [guide](.torchao/float8/benchmarking/README.md) for more details.

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -215,15 +215,15 @@ and tensorwise scaling. The training benchmarks were all run using:
 - `torch.compile`
 - FSDP2
 
-| Model         | Scaling      | Activation checkpointing | Median tokens/second      | Peak Memory (GB) |
-| ------------- | ------------ | ------------------------ | ------------------------- | ---------------- |
-| Llama3-8b     |  none (bf16) | per op SAC               | 6019                      | 47.65            |
-| Llama3-8b     |  tensorwise  | per op SAC               | 7190                      | 47.77            |
-| Llama3-8b     |  rowwise     | per op SAC               | 6649                      | 47.79            |
+| Model         | Scaling      | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over basline
+| ------------- | ------------ | ------------------------ | ------------------| -------------------- | ---------------------
+| Llama3-8b     |  none (bf16) | per op SAC               | 47.65             |  6019                | -
+| Llama3-8b     |  tensorwise  | per op SAC               | 47.77             |  7190                | 19.45%
+| Llama3-8b     |  rowwise     | per op SAC               | 47.79             |  6649                | 10.47%
 
-In these benchmarks tensorwise scaling achieved ~8% higher tokens/second over rowwise scaling, and ~19.5% higher than the bf16 baseline.
-However, it is important to note that rowwise scaling has been shown to yield improvments in training loss/accuracy due to reduced quantization error, particularly
-when training large models for many steps.
+**Important notes**:
+- Speedups increase as M,K,N (GEMM dimensions) increase. Speedups as high as 1.5x have been measured with larger shapes ((example)[https://pytorch.org/blog/training-using-float8-fsdp2/]).
+- Rowwise scaling is better at handling outliers than tensorwise scaling, so these recipes are different points on the accuracy vs performance curve.
 
 **Reproducing training benchmarks**
 To reproduce these benchmarks, you can follow these steps:

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -215,7 +215,7 @@ and tensorwise scaling. The training benchmarks were all run using:
 - `torch.compile`
 - FSDP2
 
-| Model         | Scaling      | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over basline
+| Model         | Scaling      | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over baseline
 | ------------- | ------------ | ------------------------ | ------------------| -------------------- | ---------------------
 | Llama3-8b     |  none (bf16) | per op SAC               | 47.65             |  6019                | -
 | Llama3-8b     |  tensorwise  | per op SAC               | 47.77             |  7190                | 19.45%

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -215,15 +215,16 @@ and tensorwise scaling. The training benchmarks were all run using:
 - `torch.compile`
 - FSDP2
 
-| Model         | Scaling      | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over baseline
-| ------------- | ------------ | ------------------------ | ------------------| -------------------- | ---------------------
-| Llama3-8b     |  none (bf16) | per op SAC               | 47.65             |  6019                | -
-| Llama3-8b     |  tensorwise  | per op SAC               | 47.77             |  7190                | 19.45%
-| Llama3-8b     |  rowwise     | per op SAC               | 47.79             |  6649                | 10.47%
+| Model         | Scaling                           | Activation checkpointing | Peak Memory (GB)  | Median tokens/second | Speedup over baseline
+| ------------- | --------------------------------- | ------------------------ | ------------------| -------------------- | ---------------------
+| Llama3-8b     |  none (bf16)                      | per op SAC               | 47.65             |  6150                | -
+| Llama3-8b     |  tensorwise with optimal settings | per op SAC               | 47.77             |  7689.5              | 25.03%
+| Llama3-8b     |  rowwise                          | per op SAC               | 47.79             |  6768                | 10.05%
 
 **Important notes**:
 - Speedups increase as M,K,N (GEMM dimensions) increase. Speedups as high as 1.5x have been measured with larger shapes ((example)[https://pytorch.org/blog/training-using-float8-fsdp2/]).
 - Rowwise scaling is better at handling outliers than tensorwise scaling, so these recipes are different points on the accuracy vs performance curve.
+- Tensorwise scaling benchmarks were ran with optimal settings, namely: `enable_fsdp_float8_all_gather`, `precompute_float8_dynamic_scale_for_fsdp`, `force_recompute_fp8_weight_in_bwd`.
 
 **Reproducing training benchmarks**
 To reproduce these benchmarks, you can follow these steps:
@@ -233,7 +234,7 @@ including [downloading a tokenizer](https://github.com/pytorch/torchtitan?tab=re
 2. Install torchao following these [steps](https://github.com/pytorch/ao/tree/main?tab=readme-ov-file#installation).
 3. From the `torchao/float8/benchmarking/` directory, you can run the following commands to reproduce the benchmarks above:
    - bf16 + compile: `TORCHTITAN_ROOT=<path> ./float8_training_benchmark.sh`
-   - float8 tensorwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE="tensorwise" ./float8_training_benchmark.sh`
-   - float8 rowwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE="rowwise" ./float8_training_benchmark.sh`
+   - float8 tensorwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./float8_training_benchmark.sh`
+   - float8 rowwise: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="rowwise" ./float8_training_benchmark.sh`
 
 See the float8 training benchmarking [guide](.torchao/float8/benchmarking/README.md) for more details.


### PR DESCRIPTION
**Summary**
- Add float8 training performance benchmarks for rowwise + tensorwise scaling.
- Add repro steps for these benchmarks.