### PR TITLE
Add support for copy_ for plain layout and tensor core tiled layout (#1791)

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -97,6 +97,27 @@ def deregister_aqt_quantized_linear_dispatch(dispatch_condition):
         )
 
 
+def _same_metadata(self: AffineQuantizedTensor, src: AffineQuantizedTensor):
+    return (
+        isinstance(self, AffineQuantizedTensor)
+        and isinstance(src, AffineQuantizedTensor)
+        and all(
+            [
+                getattr(self, attr) == getattr(src, attr)
+                for attr in [
+                    "block_size",
+                    "shape",
+                    "quant_min",
+                    "quant_max",
+                    "zero_point_domain",
+                    "dtype",
+                ]
+            ]
+        )
+        and isinstance(self.tensor_impl, type(src.tensor_impl))
+    )
+
+
 class QuantizedLinearNotImplementedError(NotImplementedError):
     """Thin wrapper around NotImplementedError to make it easier to catch this error in the dispatch table"""
 
@@ -328,6 +349,20 @@ def _(func, types, args, kwargs):
         args,
         kwargs,
         args[0].to(*args[1:], **kwargs)._apply_fn_to_data(torch.clone),
+    )
+
+
+@implements(aten.copy_.default)
+def _(func, types, args, kwargs):
+    self = args[0]
+    src = args[1]
+    if _same_metadata(self, src):
+        self_tensors = self.__tensor_flatten__()[0]
+        for tensor_name in self_tensors:
+            getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+        return
+    raise ValueError(
+        f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
     )
 
 

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -614,9 +614,12 @@ def _torch_version_at_least(min_version):
 # | MI300X        | gfx940, gfx941, gfx942 |
 # | MI350         | gfx950                 |
 
+def is_ROCM():
+    return torch.cuda.is_available() and torch.version.hip
+
 
 def is_MI300():
-    if torch.cuda.is_available() and torch.version.hip:
+    if is_ROCM():
         mxArchName = ["gfx940", "gfx941", "gfx942"]
         archName = torch.cuda.get_device_properties(0).gcnArchName
         for arch in mxArchName:
@@ -626,7 +629,7 @@ def is_MI300():
 
 
 def is_MI350():
-    if torch.cuda.is_available() and torch.version.hip:
+    if is_ROCM():
         archName = torch.cuda.get_device_properties(0).gcnArchName
         if "gfx950" in archName:
             return True
@@ -634,7 +637,7 @@ def is_MI350():
 
 
 def is_Navi4():
-    if torch.cuda.is_available() and torch.version.hip:
+    if is_ROCM():
         archName = torch.cuda.get_device_properties(0).gcnArchName
         if "gfx1200" or "gfx1201" in archName:
             return True


### PR DESCRIPTION
Stacked PRs:
 * __->__#1804


--- --- ---

Take two / running on ROCM to surface errors

Add support for copy_ for plain layout and tensor core tiled layout (#1791)

* Add support for copy_ for plain layout and tensor core tiled layout

Summary:
att, only support copy_ from AQT to another AQT with same metadata (shapes etc.)

Tested int4wo, int8wo, int8dq

Test Plan:
python test/dtypes/test_affine_quantized.py -k test_copy_

Reviewers:

Subscribers:

Tasks:

Tags:

* remove print

* add metadata mismatch test

* rebase and add float8

* cutlass int4 support