### PR TITLE
Config serde

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -425,6 +425,9 @@ setup(
     version=version + version_suffix,
     packages=find_packages(),
     include_package_data=True,
+    install_requires=[
+        "pydantic>=2",
+    ],
     package_data={
         "torchao.kernel.configs": ["*.pkl"],
     },

--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -61,7 +61,7 @@ def get_quantization_functions(
             if device == "cuda" and not is_ROCM():
                 base_functions.append(
                     int8_dynamic_activation_int4_weight(
-                        group_size=None,
+                        group_size=32,
                         mapping_type=MappingType.SYMMETRIC,
                         act_mapping_type=MappingType.SYMMETRIC,
                         layout=CutlassInt4PackedLayout(),

--- a/test/quantization/test_config_serialization.py
+++ b/test/quantization/test_config_serialization.py
@@ -1,0 +1,231 @@
+import json
+import os
+import tempfile
+
+import pytest
+import torch
+
+from torchao.core.config import reconstruct_from_dict, to_reconstructable_dict
+from torchao.quantization.quant_api import (
+    Float8DynamicActivationFloat8WeightConfig,
+    Float8WeightOnlyConfig,
+    FPXWeightOnlyConfig,
+    GemliteUIntXWeightOnlyConfig,
+    Int4DynamicActivationInt4WeightConfig,
+    Int4WeightOnlyConfig,
+    Int8DynamicActivationInt4WeightConfig,
+    Int8DynamicActivationInt8WeightConfig,
+    Int8WeightOnlyConfig,
+    PerRow,
+    UIntXWeightOnlyConfig,
+)
+
+# Define test configurations as fixtures
+configs = [
+    Float8DynamicActivationFloat8WeightConfig(),
+    Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
+    Float8WeightOnlyConfig(
+        weight_dtype=torch.float8_e4m3fn,
+    ),
+    UIntXWeightOnlyConfig(dtype=torch.uint1),
+    Int4DynamicActivationInt4WeightConfig(),
+    Int4WeightOnlyConfig(
+        group_size=32,
+    ),
+    Int8DynamicActivationInt4WeightConfig(
+        group_size=64,
+    ),
+    Int8DynamicActivationInt8WeightConfig(),
+    # Int8DynamicActivationInt8WeightConfig(layout=SemiSparseLayout()),
+    Int8WeightOnlyConfig(
+        group_size=128,
+    ),
+    UIntXWeightOnlyConfig(
+        dtype=torch.uint3,
+        group_size=32,
+        use_hqq=True,
+    ),
+    GemliteUIntXWeightOnlyConfig(
+        group_size=128,  # Optional, has default of 64
+        bit_width=8,  # Optional, has default of 4
+        packing_bitwidth=8,  # Optional, has default of 32
+        contiguous=True,  # Optional, has default of None
+    ),
+    FPXWeightOnlyConfig(ebits=4, mbits=8),
+]
+
+
+# Create ids for better test naming
+def get_config_ids(configs):
+    return [config.__class__.__name__ for config in configs]
+
+
+# Parametrized tests
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_to_dict_serialization(config):
+    """Test that all configs can be serialized to a dictionary."""
+    # Test to_dict method exists and returns a dict
+    assert hasattr(
+        config, "to_dict"
+    ), f"{config.__class__.__name__} missing to_dict method"
+    result = config.to_dict()
+    assert isinstance(result, dict)
+
+    # Check that all essential attributes are present in the dict
+    for attr_name in config.__dict__:
+        if not attr_name.startswith("_"):  # Skip private attributes
+            assert attr_name in result, f"{attr_name} missing in serialized dict"
+
+
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_to_json_serialization(config):
+    """Test that all configs can be serialized to JSON."""
+    # Test to_json method exists and returns a string
+    assert hasattr(
+        config, "to_json"
+    ), f"{config.__class__.__name__} missing to_json method"
+    json_str = config.to_json()
+    assert isinstance(json_str, str)
+
+    # Verify it's valid JSON
+    try:
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+    except json.JSONDecodeError as e:
+        pytest.fail(f"Invalid JSON for {config.__class__.__name__}: {e}")
+
+
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_from_dict_deserialization(config):
+    """Test that all configs can be deserialized from a dictionary."""
+    # Get the class of the instance
+    cls = config.__class__
+
+    # Serialize to dict
+    data = config.to_dict()
+
+    # Test from_dict class method exists
+    assert hasattr(cls, "from_dict"), f"{cls.__name__} missing from_dict class method"
+
+    # Deserialize back to instance
+    deserialized = cls.from_dict(data)
+
+    # Check it's the right class
+    assert isinstance(deserialized, cls)
+
+    # Compare key attributes
+    for attr_name in config.__dict__:
+        if not attr_name.startswith("_"):  # Skip private attributes
+            original_value = getattr(config, attr_name)
+            deserialized_value = getattr(deserialized, attr_name)
+
+            # Special handling for torch dtypes
+            if (
+                hasattr(original_value, "__module__")
+                and original_value.__module__ == "torch"
+            ):
+                assert str(original_value) == str(
+                    deserialized_value
+                ), f"Attribute {attr_name} mismatch for {cls.__name__}"
+            else:
+                assert (
+                    original_value == deserialized_value
+                ), f"Attribute {attr_name} mismatch for {cls.__name__}"
+
+
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_from_json_deserialization(config):
+    """Test that all configs can be deserialized from JSON."""
+    # Get the class of the instance
+    cls = config.__class__
+
+    # Serialize to JSON
+    json_str = config.to_json()
+
+    # Test from_json class method exists
+    assert hasattr(cls, "from_json"), f"{cls.__name__} missing from_json class method"
+
+    # Deserialize back to instance
+    deserialized = cls.from_json(json_str)
+
+    # Check it's the right class
+    assert isinstance(deserialized, cls)
+
+    # Verify the instance is equivalent to the original
+    # This assumes __eq__ is properly implemented
+    assert (
+        config == deserialized
+    ), f"Deserialized instance doesn't match original for {cls.__name__}"
+
+
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_round_trip_equivalence(config):
+    """Test complete serialization and deserialization round trip."""
+    # JSON round trip
+    json_str = config.to_json()
+    deserialized_from_json = config.__class__.from_json(json_str)
+    assert (
+        config == deserialized_from_json
+    ), f"JSON round trip failed for {config.__class__.__name__}"
+
+    # Dict round trip
+    data_dict = config.to_dict()
+    deserialized_from_dict = config.__class__.from_dict(data_dict)
+    assert (
+        config == deserialized_from_dict
+    ), f"Dict round trip failed for {config.__class__.__name__}"
+
+
+@pytest.mark.parametrize("config", configs, ids=get_config_ids)
+def test_reconstructable_dict_file_round_trip(config):
+    """Test saving and loading reconstructable dicts to/from JSON files."""
+    # Get a reconstructable dict
+    reconstructable = to_reconstructable_dict(config)
+    breakpoint()
+
+    # Create a temporary file to save the JSON
+    with tempfile.NamedTemporaryFile(
+        mode="w+", suffix=".json", delete=False
+    ) as temp_file:
+        # Write the reconstructable dict as JSON
+        json.dump(reconstructable, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        # Read back the JSON file
+        with open(temp_file_path, "r") as file:
+            loaded_dict = json.load(file)
+
+        # Reconstruct from the loaded dict
+        reconstructed = reconstruct_from_dict(loaded_dict)
+
+        # Check it's the right class
+        assert isinstance(reconstructed, config.__class__)
+
+        # Verify attributes match
+        for attr_name in config.__dict__:
+            if not attr_name.startswith("_"):  # Skip private attributes
+                original_value = getattr(config, attr_name)
+                reconstructed_value = getattr(reconstructed, attr_name)
+
+                # Special handling for torch dtypes
+                if (
+                    hasattr(original_value, "__module__")
+                    and original_value.__module__ == "torch"
+                ):
+                    assert (
+                        str(original_value) == str(reconstructed_value)
+                    ), f"Attribute {attr_name} mismatch after file round trip for {config.__class__.__name__}"
+                else:
+                    assert (
+                        original_value == reconstructed_value
+                    ), f"Attribute {attr_name} mismatch after file round trip for {config.__class__.__name__}"
+
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/quantization/test_observer.py
+++ b/test/quantization/test_observer.py
@@ -90,7 +90,7 @@ class TestQuantFlow(TestCase):
         obs = AffineQuantizedMinMaxObserver(
             MappingType.SYMMETRIC,
             torch.float8_e4m3fn,
-            granularity=PerAxis(1),
+            granularity=PerAxis(axis=1),
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
@@ -105,7 +105,7 @@ class TestQuantFlow(TestCase):
         obs = AffineQuantizedMinMaxObserver(
             MappingType.SYMMETRIC,
             torch.float8_e4m3fn,
-            granularity=PerAxis(0),
+            granularity=PerAxis(axis=0),
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,
@@ -124,7 +124,7 @@ class TestQuantFlow(TestCase):
         obs = AffineQuantizedMinMaxObserver(
             MappingType.SYMMETRIC,
             torch.float8_e4m3fn,
-            granularity=PerAxis(1),
+            granularity=PerAxis(axis=1),
             eps=torch.finfo(torch.float32).eps,
             scale_dtype=torch.float,
             zero_point_dtype=torch.int,

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -798,7 +798,7 @@ class TestQAT(unittest.TestCase):
         self.assertIsInstance(per_token_config2.granularity, PerToken)
 
         # per channel
-        per_channel_config1 = FakeQuantizeConfig(torch.int8, PerAxis(0))
+        per_channel_config1 = FakeQuantizeConfig(torch.int8, PerAxis(axis=0))
         per_channel_config2 = FakeQuantizeConfig(torch.int8, "per_channel")
         self.assertIsInstance(per_channel_config1.granularity, PerAxis)
         self.assertIsInstance(per_channel_config2.granularity, PerAxis)
@@ -806,7 +806,7 @@ class TestQAT(unittest.TestCase):
         self.assertEqual(per_channel_config2.granularity.axis, 0)
 
         # per group
-        per_group_config1 = FakeQuantizeConfig(torch.int8, PerGroup(32))
+        per_group_config1 = FakeQuantizeConfig(torch.int8, PerGroup(group_size=32))
         per_group_config2 = FakeQuantizeConfig(torch.int8, "per_group", group_size=32)
         per_group_config3 = FakeQuantizeConfig(torch.int8, group_size=32)
         self.assertIsInstance(per_group_config1.granularity, PerGroup)
@@ -842,7 +842,7 @@ class TestQAT(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             FakeQuantizeConfig(torch.int8, PerToken(), group_size=32)
         with self.assertRaisesRegex(ValueError, msg):
-            FakeQuantizeConfig(torch.int8, PerGroup(64), group_size=32)
+            FakeQuantizeConfig(torch.int8, PerGroup(group_size=64), group_size=32)
         with self.assertRaisesRegex(ValueError, msg):
             FakeQuantizeConfig(torch.int8, "per_token", group_size=32)
 
@@ -855,7 +855,7 @@ class TestQAT(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not supported"):
             FakeQuantizeConfig(torch.int8, PerRow())
         with self.assertRaisesRegex(ValueError, "Only axis=0 is supported"):
-            FakeQuantizeConfig(torch.int8, PerAxis(1))
+            FakeQuantizeConfig(torch.int8, PerAxis(axis=1))
         with self.assertRaisesRegex(ValueError, "Unexpected granularity"):
             FakeQuantizeConfig(torch.int8, "blah")
         with self.assertRaisesRegex(ValueError, "unexpected type"):
@@ -1240,7 +1240,9 @@ class TestQAT(unittest.TestCase):
         weight_config = FakeQuantizeConfig(TorchAODType.INT4, group_size=group_size)
         quantize_(
             m,
-            intx_quantization_aware_training(activation_config, weight_config),
+            intx_quantization_aware_training(
+                activation_config=activation_config, weight_config=weight_config
+            ),
         )
         quantize_(
             m,
@@ -1273,7 +1275,9 @@ class TestQAT(unittest.TestCase):
         ):
             quantize_(
                 m,
-                intx_quantization_aware_training(my_config, my_config),
+                intx_quantization_aware_training(
+                    activation_config=my_config, weight_config=my_config
+                ),
                 lambda m, _: isinstance(m, torch.nn.Embedding),
             )
 
@@ -1281,7 +1285,9 @@ class TestQAT(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "does not have QAT support"):
             quantize_(
                 m,
-                intx_quantization_aware_training(my_config, my_config),
+                intx_quantization_aware_training(
+                    activation_config=my_config, weight_config=my_config
+                ),
                 lambda m, _: isinstance(m, torch.nn.ReLU),
             )
 
@@ -1320,7 +1326,9 @@ class TestQAT(unittest.TestCase):
         weight_config = FakeQuantizeConfig(TorchAODType.INT4, group_size=group_size)
         quantize_(
             m,
-            intx_quantization_aware_training(activation_config, weight_config),
+            intx_quantization_aware_training(
+                activation_config=activation_config, weight_config=weight_config
+            ),
         )
 
         # Compare prepared values
@@ -1395,7 +1403,9 @@ class TestQAT(unittest.TestCase):
         weight_config = FakeQuantizeConfig(TorchAODType.INT4, group_size=32)
         quantize_(
             m,
-            intx_quantization_aware_training(activation_config, weight_config),
+            intx_quantization_aware_training(
+                activation_config=activation_config, weight_config=weight_config
+            ),
         )
         example_inputs = m.example_inputs()
         m(*example_inputs)

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -1,29 +1,139 @@
-import abc
+from typing import Any, Dict
+
+import torch
+from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
 
 
-class AOBaseConfig(abc.ABC):
+class AOBaseConfig(BaseModel):
     """
-    If a workflow config inherits from this then `quantize_` knows
-    how to a apply it to a model. For example::
+    Base configuration class for TorchAO quantization workflows with native Pydantic handling for torch.dtype.
 
-        # user facing code
-        class WorkflowFooConfig(AOBaseConfig): ...
-            # configuration for workflow `Foo` is defined here
-            bar = 'baz'
+    When a workflow configuration inherits from AOBaseConfig, the `quantize_` function can automatically
+    apply the appropriate transformation to a model based on the configuration type.
 
-        # non user facing code
+    Usage example:
+        # 1. Define a configuration class for your workflow
+        class WorkflowFooConfig(AOBaseConfig):
+            # Configuration parameters for workflow 'Foo'
+            bar: str = 'baz'
+
+        # 2. Register a handler for this configuration (internal implementation)
         @register_quantize_module_handler(WorkflowFooConfig)
         def _transform(
             mod: torch.nn.Module,
             config: WorkflowFooConfig,
         ) -> torch.nn.Module:
-            # the transform is implemented here, usually a tensor sublass
-            # weight swap or a module swap
+            # Implementation of the transformation logic
+            # Typically performs tensor subclass weight swapping or module replacement
             ...
 
-        # then, the user calls `quantize_` with a config, and `_transform` is called
-        # under the hood by `quantize_.
+        # 3. Apply the configuration to a model
+        # The user simply calls `quantize_` with a model and config instance
+        # The appropriate handler is automatically selected based on the config type
+        model = ...
+        quantized_model = quantize_(model, WorkflowFooConfig(bar='custom_value'))
 
+    Note on serialization, if you add a new AOBaseConfig and want to support serialization,
+    please add a test in test/quantization/test_config_serialization.py
     """
 
-    pass
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        extra="forbid",
+        validate_default=True,
+        populate_by_name=True,
+    )
+
+    @field_serializer("*")
+    def serialize_torch_dtype(self, v, _info):
+        if isinstance(v, torch.dtype):
+            return str(v)
+        return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def convert_dtypes(cls, data: Any) -> Any:
+        """Simple converter for torch dtype strings"""
+        if isinstance(data, str) and data.startswith("torch."):
+            dtype_name = data.split("torch.")[1]
+            if hasattr(torch, dtype_name):
+                return getattr(torch, dtype_name)
+        elif isinstance(data, dict):
+            return {k: cls.convert_dtypes(v) for k, v in data.items()}
+        elif isinstance(data, list):
+            return [cls.convert_dtypes(item) for item in data]
+        return data
+
+    def to_dict(self) -> dict:
+        """Convert the configuration to a dictionary that is compat w/ json.dump"""
+        return self.model_dump(mode="json")
+
+    def to_json(self) -> str:
+        """Convert the configuration to a JSON string."""
+        return self.model_dump_json()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AOBaseConfig":
+        """Create a configuration from a dictionary."""
+        return cls.model_validate(data)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "AOBaseConfig":
+        """Create a configuration from a JSON string."""
+        return cls.model_validate_json(json_str)
+
+
+def to_reconstructable_dict(config: AOBaseConfig) -> dict:
+    """
+    Convert an AOBaseConfig instance to a dictionary format that can be reconstructed.
+    The output is designed to be JSON-serializable for storage.
+
+    Args:
+        config: An instance of AOBaseConfig or its subclass
+
+    Returns:
+        A dictionary with 'class_name' and 'config' keys, where config contains
+        a JSON string representation of the configuration
+
+    Example:
+        # Create a configuration
+        config = SomeConfig(param1="value1", param2=42)
+
+        # Convert to a reconstructable dict (JSON-serializable)
+        serialized = to_reconstructable_dict(config)
+
+        # Later, reconstruct
+        reconstructed = reconstruct_from_dict(serialized)
+    """
+    # Use Pydantic's to_json to get a JSON string representation
+    config_json = config.to_dict()
+
+    return {"class_name": config.__class__.__name__, "config": config_json}
+
+
+def reconstruct_from_dict(config_dict) -> AOBaseConfig:
+    """
+    Reconstruct a configuration class instance from a dictionary created by to_reconstructable_dict.
+
+    Args:
+        config_dict: Dictionary with 'class_name' and 'config' keys, where config contains
+                     a JSON string representation of the configuration
+
+    Returns:
+        An instance of the specified configuration class
+    """
+    # Get the class name and configuration parameters as JSON string
+    class_name = config_dict["class_name"]
+    config_params_json = config_dict["config"]
+
+    # Import the module where the class is defined
+    import importlib
+
+    module = importlib.import_module("torchao.quantization.quant_api")
+
+    # Get the class from the module
+    config_class = getattr(module, class_name)
+
+    # Create an instance of the class from the JSON config
+    return config_class.from_dict(config_params_json)


### PR DESCRIPTION
Stacked PRs:
 * __->__#1806
 * #1774


--- --- ---

# Summary: Convert base configs to use Pydantic
Related PRs
- Hugging Face: https://github.com/huggingface/transformers/pull/36526 

- VLLM:
https://github.com/vllm-project/vllm/pull/14231


## Overview
This PR adds serialization and deserialization capabilities to most* of our Config classes by migrating from dataclasses to Pydantic models. The implementation enables JSON serialization/deserialization and dictionary conversion for all quantization configuration classes.

**Note** that we have two options add this to our depedencies ( we weirdly dont have any specified currently) or I can probably write this in a way to only be enabled if we have the runtime dep>

## Testing
Added a new test file `test/quantization/test_config_serialization.py` with tests for alot of configuration classes

## Impact
W/ this we can serialize configs. However as implemented it also enforces that all params are kwarg only which may  BC BREAKING, you can hack around this w/ pydantic but not sure how much of a deal this is yet.

## Why do we need this?
I am currently auditing our end to end flow, and while yes the core serialization premise of tensor subclass to both define our data representation and modulate runtime behavior exists - that is not how the rest of the ecosystem is operating.


Currenlty our hugging face integration only supports 4 options:
https://huggingface.co/docs/transformers/main/en/main_classes/quantization#transformers.TorchAoConfig.quant_type

I for 1 want to have this support the full breadth of options and as well I want this to be configurable per layer. I think this gets us closer since we can specify the quant structure in a config.json on the serialized weight.


As well this config.json appears to be reused by VLLm and I am still working on the E2E flow as prototype by Jerry here: 
https://github.com/vllm-project/vllm/pull/13588