### PR TITLE
Silence loud error on torchao cpu builds

### DIFF
--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -6,7 +6,7 @@ import torch
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_2, TORCH_VERSION_AT_LEAST_2_6
 
 logger = logging.getLogger(__name__)
-
+logger.addHandler(logging.NullHandler())
 
 try:
     # Only works for torch2.2 or newer.

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -1,8 +1,12 @@
+import logging
 import os
 
 import torch
 
 from torchao.utils import TORCH_VERSION_AT_LEAST_2_2, TORCH_VERSION_AT_LEAST_2_6
+
+logger = logging.getLogger(__name__)
+
 
 try:
     # Only works for torch2.2 or newer.
@@ -11,7 +15,7 @@ try:
     else:
         intmm_triton = None
 except ImportError as e:
-    print("import error:", e)
+    logger.debug("import error:", e)
     # On cpu-only builds might not be available.
     intmm_triton = None
 


### PR DESCRIPTION
before this fix, just importing torchao in a cpu only environment would print `import error: triton not found`

Came up live in this talk by @manuelcandales https://www.youtube.com/watch?v=0vv9K0RvOfo&ab_channel=GPUMODE

To repro on your M1 laptop

```
USE_CPP=0 pip install .
python
import torchao
```