### PR TITLE
[Wip] Update torch versions in regression test

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -67,7 +67,7 @@ jobs:
             gpu-arch-version: "12.1"
           - name: CUDA 2.6.0
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cu121'
+            torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cu124'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
 

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -59,35 +59,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: CUDA 2.3
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.3.0'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
-          - name: CUDA 2.4
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.4.0'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
+
           - name: CUDA 2.5.1
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.1"
+          - name: CUDA 2.6.0
+            runs-on: linux.g5.12xlarge.nvidia.gpu
+            torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cu121'
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.1"
 
-          - name: CPU 2.3
-            runs-on: linux.4xlarge
-            torch-spec: 'torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
-          - name: CPU 2.4
-            runs-on: linux.4xlarge
-            torch-spec: 'torch==2.4.0 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
+
           - name: CPU 2.5.1
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu'
+            gpu-arch-type: "cpu"
+            gpu-arch-version: ""
+          - name: CPU 2.6.0
+            runs-on: linux.4xlarge
+            torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
 

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -27,7 +27,7 @@ jobs:
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: '--pre torch==2.7.0.dev20250122 --index-url https://download.pytorch.org/whl/nightly/cu124'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.4"
+            gpu-arch-version: "12.8"
           - name: CPU Nightly
             runs-on: linux.4xlarge
             torch-spec: '--pre torch==2.7.0.dev20250122 --index-url https://download.pytorch.org/whl/nightly/cpu'
@@ -69,7 +69,7 @@ jobs:
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
+            gpu-arch-version: "12.4"
 
 
           - name: CPU 2.5.1


### PR DESCRIPTION
We were still testing torch 2.3, 2.4 and 2.5 and nightly

Stable release is 2.6 and nightly is now 2.7

We should be testing at most 3 versions at a time which as of this PR is 2.5, 2.6 and 2.7 (nightly)