### PR TITLE
[wip] Rocm sparse fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -292,20 +292,8 @@ def get_extensions():
             extra_compile_args["nvcc"].append("-g")
             extra_link_args.append("/DEBUG")
 
-    curdir = os.path.dirname(os.path.curdir)
-    extensions_dir = os.path.join(curdir, "torchao", "csrc")
-    sources = list(glob.glob(os.path.join(extensions_dir, "**/*.cpp"), recursive=True))
-
-    extensions_cuda_dir = os.path.join(extensions_dir, "cuda")
-    cuda_sources = list(
-        glob.glob(os.path.join(extensions_cuda_dir, "**/*.cu"), recursive=True)
-    )
-
-    if use_cuda:
-        sources += cuda_sources
-
     use_cutlass = False
-    if use_cuda and not IS_WINDOWS:
+    if use_cuda and not IS_ROCM and not IS_WINDOWS:
         use_cutlass = True
         cutlass_dir = os.path.join(third_party_path, "cutlass")
         cutlass_include_dir = os.path.join(cutlass_dir, "include")

--- a/setup.py
+++ b/setup.py
@@ -363,8 +363,8 @@ def get_extensions():
     # TOOD: Remove this and use what CUDA has once we fix all the builds.
     if IS_ROCM and use_cuda:
         # Add ROCm GPU architecture check
-        gpu_arch = torch.cuda.get_device_properties(0).name
-        if gpu_arch != "gfx942":
+        gpu_arch = torch.cuda.get_device_properties(0).gcnArchName
+        if "gfx942" not in gpu_arch:
             print(f"Warning: Unsupported ROCm GPU architecture: {gpu_arch}")
             print(
                 "Currently only gfx942 is supported. Skipping compilation of ROCm extensions"

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ def get_extensions():
     extra_link_args = []
     extra_compile_args = {
         "cxx": [f"-DPy_LIMITED_API={PY3_9_HEXCODE}"],
-        "nvcc": ["-O3" if not debug_mode else "-O0", "-t=0", "-std=c++17"],
+        "nvcc": ["-O3" if not debug_mode else "-O0", "-std=c++17"],
     }
 
     if not IS_WINDOWS:

--- a/setup.py
+++ b/setup.py
@@ -292,25 +292,6 @@ def get_extensions():
             extra_compile_args["nvcc"].append("-g")
             extra_link_args.append("/DEBUG")
 
-    use_cutlass = False
-    if use_cuda and not IS_ROCM and not IS_WINDOWS:
-        use_cutlass = True
-        cutlass_dir = os.path.join(third_party_path, "cutlass")
-        cutlass_include_dir = os.path.join(cutlass_dir, "include")
-        cutlass_tools_include_dir = os.path.join(
-            cutlass_dir, "tools", "util", "include"
-        )
-        cutlass_extensions_include_dir = os.path.join(cwd, extensions_cuda_dir)
-    if use_cutlass:
-        extra_compile_args["nvcc"].extend(
-            [
-                "-DTORCHAO_USE_CUTLASS",
-                "-I" + cutlass_include_dir,
-                "-I" + cutlass_tools_include_dir,
-                "-I" + cutlass_extensions_include_dir,
-            ]
-        )
-
     # Get base directory and source paths
     curdir = os.path.dirname(os.path.curdir)
     extensions_dir = os.path.join(curdir, "torchao", "csrc")
@@ -334,6 +315,25 @@ def get_extensions():
     hip_sources += list(
         glob.glob(os.path.join(extensions_hip_dir, "*.cu"), recursive=True)
     )
+
+    use_cutlass = False
+    if use_cuda and not IS_ROCM and not IS_WINDOWS:
+        use_cutlass = True
+        cutlass_dir = os.path.join(third_party_path, "cutlass")
+        cutlass_include_dir = os.path.join(cutlass_dir, "include")
+        cutlass_tools_include_dir = os.path.join(
+            cutlass_dir, "tools", "util", "include"
+        )
+        cutlass_extensions_include_dir = os.path.join(cwd, extensions_cuda_dir)
+    if use_cutlass:
+        extra_compile_args["nvcc"].extend(
+            [
+                "-DTORCHAO_USE_CUTLASS",
+                "-I" + cutlass_include_dir,
+                "-I" + cutlass_tools_include_dir,
+                "-I" + cutlass_extensions_include_dir,
+            ]
+        )
 
     # Collect CUDA source files if needed
     if not IS_ROCM and use_cuda:


### PR DESCRIPTION
TLDR: fix sparse marlin kernel for rocm

This pull request includes several changes to the `setup.py` file, focusing on improving assertion formatting, modifying compilation arguments, and enhancing the handling of CUDA and ROCm extensions. The most important changes include reformatting assertions for better readability, updating compilation flags, and refining the logic for collecting and compiling source files based on the environment and GPU architecture.

Assertion formatting improvements:

* Reformatted assertions to be more concise and readable in the `__init__` method. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L94-R96) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L105-R107) [[3]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L116-R118)

Compilation argument updates:

* Removed the `-t=0` flag from the `nvcc` compilation arguments in the `get_extensions` method.

Source file handling enhancements:

* Added comments to clarify the process of getting base directories and collecting source files.
* Refined the logic for collecting HIP source files and added a check for ROCm GPU architecture compatibility.
* Removed redundant ROCm GPU architecture check and related code.