### PR TITLE
[float8] update float8 training benchmark readme

### DIFF
--- a/benchmarks/float8/training/README.md
+++ b/benchmarks/float8/training/README.md
@@ -4,15 +4,15 @@ The `float8_training_benchmark.sh` script in this directory can be used to launc
 
 ## Usage
 
-Example: `TORCHTITAN_ROOT=${HOME}/torchtitan FLOAT8_RECIPE=rowwise ./float8_training_benchmark.sh`
+Example: `TORCHTITAN_ROOT=${HOME}/torchtitan FLOAT8_RECIPE_WITH_BEST_SETTINGS=rowwise ./float8_training_benchmark.sh`
 
 Training parameters can be configured via environment variables.
 
 - Required:
-    - `TORCHTITAN_ROOT`
+    - `TORCHTITAN_ROOT`: Root directory of torchtitan in your local filesystem
 - Optional:
-    - `RECIPE`: rowwise|tensorwise. defaults to tensorwise.
-    - `BATCH_SIZE`: defaults to 1.
-    - `STEPS`: defaults to 100.
+    - `FLOAT8_RECIPE_WITH_BEST_SETTINGS`: "rowwise" or "tensorwise". Applies float8 training with the specified scaling recipe, as well as additional training configs which are optimal for that scaling recipe. See `float8_training_benchmark.sh` for more details.
+    - `BATCH_SIZE`: Defaults to 1.
+    - `STEPS`: Defaults to 100.
 
 **NOTE**: `torch.compile` and FSDP2 are always used. Other forms of parallelism supported in torchtitan are not yet supported in this script.


### PR DESCRIPTION
**Summary**
- Updating the readme to use the new, more accurately named environment variables used by the benchmarking script.
- Cleaning up capitalization, adding some more details.