### PR TITLE
Add MI300.2 GPU to Torchao CI

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - name: ROCM Nightly
-            runs-on: linux.rocm.gpu.torchao
+            runs-on: linux.rocm.gpu.mi300.2
             torch-spec: '--pre torch==2.7.0.dev20250122 --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
             gpu-arch-type: "rocm"
             gpu-arch-version: "6.3"


### PR DESCRIPTION
This pull request includes a modification to the ROCM regression test workflow configuration. The change updates the runner used for the ROCM Nightly job.

* [`.github/workflows/regression_test_rocm.yml`](diffhunk://#diff-bb2c4a149119667d94126f7485165b6a7af65bba62e56b20ed648cf3585b9dd5L24-R24): Updated the `runs-on` attribute for the ROCM Nightly job from `linux.rocm.gpu.torchao` to `linux.rocm.gpu.mi300.2`.