### PR TITLE
Use FORCE_CUDA to allow build on host with no device

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ def get_extensions():
     if debug_mode:
         print("Compiling in debug mode")
 
-    if not torch.cuda.is_available():
+    if not (torch.cuda.is_available() or bool(os.environ.get("FORCE_CUDA",0))):
         print(
             "PyTorch GPU support is not available. Skipping compilation of CUDA extensions"
         )
@@ -263,7 +263,7 @@ def get_extensions():
             "If you'd like to compile CUDA extensions locally please install the cudatoolkit from https://anaconda.org/nvidia/cuda-toolkit"
         )
 
-    use_cuda = torch.cuda.is_available() and (
+    use_cuda = (torch.cuda.is_available() or bool(os.environ.get("FORCE_CUDA",0))) and (
         CUDA_HOME is not None or ROCM_HOME is not None
     )
     extension = CUDAExtension if use_cuda else CppExtension


### PR DESCRIPTION
`torch.cuda.is_available()` returns if a physical device exists, not if cuda is actually available.

On build host where no gpu device exists but cuda is in fact available, the `FORCE_CUDA` env. variable allow one to build torchao.