### PR TITLE
[float8nocompile] Only run float8nocompile CI on h100

### DIFF
--- a/.github/workflows/float8nocompile_test.yaml
+++ b/.github/workflows/float8nocompile_test.yaml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: SM-89
-            runs-on: linux.g6.4xlarge.experimental.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu121'
+          - name: H100
+            runs-on: linux.aws.h100
+            torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.1"
+            gpu-arch-version: "12.4"
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:


### PR DESCRIPTION
float8 does not work properly on sm89, the tests only pass on H100s.