### PR TITLE
skip the sparse rowwise fp8 cutlass kernel test on ROCm

### DIFF
--- a/test/test_ops_rowwise_scaled_linear_sparse_cutlass.py
+++ b/test/test_ops_rowwise_scaled_linear_sparse_cutlass.py
@@ -13,6 +13,7 @@ from torchao.quantization.quant_api import (
     _float8_cutlass_quant_sparse,
 )
 from torchao.sparsity.utils import create_semi_structured_tensor
+from torchao.testing.utils import skip_if_rocm
 
 DTYPES = [torch.float16, torch.bfloat16]
 XQ_WQ_DTYPES = [
@@ -99,6 +100,7 @@ def run_test_for_op(
     )
 
 
+@skip_if_rocm("does not yet work on ROCm")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(not SM90OrLater, reason="FP8 is only supported on H100+ devices")
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary:

This test was added by https://github.com/pytorch/ao/pull/1671.

This test doesn't pass on ROCm, skip it to unbreak CI and we can fix it
later

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags: