### PR TITLE
Add MI300X specs to roofline benchmark

### DIFF
--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -372,7 +372,7 @@ def run(
             ).requires_grad_()
 
             # get the gradient of the right shape
-            grad_output = torch.randn(N_val, K_val, dtype=torch.bfloat16, device="cuda")
+            grad_output = torch.randn(M_val, N_val, dtype=torch.bfloat16, device="cuda")
 
             # get the bf16 gpu kernel time
             torch._dynamo.reset()

--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -139,7 +139,7 @@ Example 2 (large shapes):
 To reproduce the raw data for table above, you can run the following script
 
 ```lang=shell
-python benchmarks/float8/float8_roofline.py your_output_filename.csv --gemm_time_strategy benchmarks --shape_gen_name sweep
+python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen_name sweep
 ```
 
 ## Derivation

--- a/torchao/testing/float8/roofline_utils.py
+++ b/torchao/testing/float8/roofline_utils.py
@@ -41,6 +41,19 @@ gpu_name_to_specs = {
         # TODO(future): measure once we have the hardware
         "pct_achievable_mem_bw": 0.92,
     },
+    "AMD Instinct MI300X": {
+        # https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf, page 1,
+        "bf16_peak_tops": 1307e12,
+        "fp8_peak_tops": 2614e12,
+        # 5.3 TB per second
+        "peak_mem_bw_bytes_sec": 5.3e12,
+        # for now, copy over from H100
+        # TODO(future): run measurement on hardware
+        "pct_achievable_gemm_tops": 0.78,
+        # for now, copy over from H100
+        # TODO(future): run measurement on hardware
+        "pct_achievable_mem_bw": 0.92,
+    },
     # TODO(future): more GPU names
 }
 


### PR DESCRIPTION
This PR fixes #1914 and adds the basic peak specs for AMD MI300X to the float8 roofline benchmark script.

```
$ python benchmarks/float8/float8_roofline.py your_output_filename.csv  --shape_gen_name sweep
/home/mreso/ao/benchmarks/float8/utils.py:125: SyntaxWarning: invalid escape sequence '\.'
  result = re.search(".* ([0-9\.]+)GB/s.*(triton_[a-z_0-9]+)", line)
/home/mreso/ao/benchmarks/float8/utils.py:242: SyntaxWarning: invalid escape sequence '\['
  match = re.match(".* \[__output_code\] (.*)", line)
/home/mreso/ao/benchmarks/float8/utils.py:259: SyntaxWarning: invalid escape sequence '\#'
  match_start = re.match("\# kernel path: .*", line)
/home/mreso/ao/benchmarks/float8/utils.py:264: SyntaxWarning: invalid escape sequence '\w'
  match_name = re.match("([\w_]+) = async_compile.*", line)
/home/mreso/ao/benchmarks/float8/utils.py:268: SyntaxWarning: invalid escape sequence '\)'
  match_end = re.match("''', device_str='cuda'\)", line)
GPU: AMD Instinct MI300X
do_benchmarks: True
shape_gen_name: sweep
float8_recipe_name: tensorwise
mx_recipe_name: None
enable_fusion_modeling: False
bf16_gemm_time_sympy 3*Max(2.0e-6, 1.96182292586271e-15*K*M*N, 4.10172272354389e-13*K*M + 4.10172272354389e-13*K*N + 4.10172272354389e-13*M*N)
fp8_gemm_time_sympy Max(2.0e-6, 9.80911462931356e-16*K*M*N, 2.05086136177194e-13*K*M + 2.05086136177194e-13*K*N + 4.10172272354389e-13*M*N) + Max(2.0e-6, 9.80911462931356e-16*K*M*N, 2.05086136177194e-13*K*M + 4.10172272354389e-13*K*N + 2.05086136177194e-13*M*N) + Max(2.0e-6, 9.80911462931356e-16*K*M*N, 4.10172272354389e-13*K*M + 2.05086136177194e-13*K*N + 2.05086136177194e-13*M*N)
fp8_ovhd_time_sympy Max(2.0e-6, 4.10172272354389e-13*K*M) + Max(2.0e-6, 8.20344544708778e-13*K*M) + Max(2.0e-6, 4.10172272354389e-13*K*N) + 2*Max(2.0e-6, 6.15258408531583e-13*K*N) + Max(2.0e-6, 4.10172272354389e-13*M*N) + Max(2.0e-6, 8.20344544708778e-13*M*N) + 6.0e-6

  0%|                                                                                                                                                                                                                                                                                                                                             | 0/512 [00:00<?, ?it/s]
[W317 17:36:49.128930544 collection.cpp:1110] Warning: ROCTracer produced duplicate flow start: 4 (function operator())
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [11:23<00:00,  1.34s/it]
     fwd_M  fwd_K  fwd_N  r_bf16_gemm_s  r_fp8_gemm_s  r_fp8_ovhd_s  r_fp8_gemm_and_ovhd_s  r_fp8_gemm_and_ovhd_spdp  b_bf16_gemm_s  b_fp8_gemm_s  b_bf16_e2e_s  b_fp8_e2e_s  b_fp8_e2e_spdp  rb_bf16_gemm_ratio  rb_fp8_gemm_ratio
0      256    256    256       6.00e-06      6.00e-06      2.00e-05               2.60e-05                      0.23       1.65e-05      1.30e-05      1.52e-05     6.67e-05            0.23                0.36               0.46
1      256    256    512       6.00e-06      6.00e-06      2.00e-05               2.60e-05                      0.23       1.66e-05      1.31e-05      1.58e-05     6.63e-05            0.24                0.36               0.46
2      256    256   1024       6.00e-06      6.00e-06      2.00e-05               2.60e-05                      0.23       1.74e-05      1.34e-05      1.87e-05     6.68e-05            0.28                0.34               0.45
3      256    256   2048       6.00e-06      6.00e-06      2.00e-05               2.60e-05                      0.23       1.97e-05      1.53e-05      2.12e-05     7.87e-05            0.27                0.30               0.39
4      256    256   4096       6.00e-06      6.00e-06      2.00e-05               2.60e-05                      0.23       2.39e-05      1.75e-05      2.62e-05     8.36e-05            0.31                0.25               0.34
..     ...    ...    ...            ...           ...           ...                    ...                       ...            ...           ...           ...          ...             ...                 ...                ...
507  32768  32768   2048       1.29e-02      6.47e-03      1.52e-03               7.99e-03                      1.62       2.43e-02      9.97e-03      2.52e-02     1.84e-02            1.37                0.53               0.65
508  32768  32768   4096       2.59e-02      1.29e-02      1.71e-03               1.47e-02                      1.77       4.59e-02      1.95e-02      4.91e-02     3.32e-02            1.48                0.56               0.67
509  32768  32768   8192       5.18e-02      2.59e-02      2.10e-03               2.80e-02                      1.85       9.20e-02      3.95e-02      9.56e-02     6.36e-02            1.50                0.56               0.66
510  32768  32768  16384       1.04e-01      5.18e-02      2.87e-03               5.46e-02                      1.89       1.83e-01      7.72e-02      1.85e-01     1.19e-01            1.56                0.56               0.67
511  32768  32768  32768       2.07e-01      1.04e-01      4.41e-03               1.08e-01                      1.92       3.76e-01      1.63e-01      3.71e-01     2.37e-01            1.57                0.55               0.63

[512 rows x 15 columns]
done
```