### PR TITLE
Install bitsandbytes for ROCm

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -43,6 +43,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
+        pip uninstall -y bitsandbytes
+        pip install --force-reinstall 'https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-release_multi-backend-refactor/bitsandbytes-0.44.1.dev0-py3-none-manylinux_2_24_x86_64.whl'
         pip install .
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH


### PR DESCRIPTION
TLDR: … bitsandbytes for rocm

This pull request includes a change to the `jobs:` section in the `.github/workflows/regression_test_rocm.yml` file. The change ensures that the `bitsandbytes` package is uninstalled and then reinstalled from a specific URL to use a development version.

Changes in `jobs:` section:

* [`.github/workflows/regression_test_rocm.yml`](diffhunk://#diff-bb2c4a149119667d94126f7485165b6a7af65bba62e56b20ed648cf3585b9dd5R46-R47): Added commands to uninstall `bitsandbytes` and reinstall it from a specific URL to use a development version.