### PR TITLE
Write weight packing/unpacking functions for universal kernels

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x4x16_f32_neondot-impl.h
@@ -10,8 +10,7 @@
 
 #include <torchao/experimental/kernels/cpu/aarch64/bitpacking/bitpack.h>
 #include <torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_prepare_activation_data_1xk_f32-impl.h>
-#include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
-#include <torchao/experimental/kernels/cpu/aarch64/valpacking/valpack.h>
+#include <torchao/experimental/kernels/cpu/aarch64/linear/pack_weights.h>
 #include <cassert>
 #include <cstring>
 
@@ -257,33 +256,14 @@ size_t inline weight_data_size_impl(
     int weight_nbit,
     bool has_weight_zeros,
     bool has_bias) {
-  assert(k % group_size == 0);
-  int groups_per_col = k / group_size;
-  int col_size = 0;
-
-  // qvals
-  col_size += (k / 8) * weight_nbit;
-
-  // scales
-  col_size += sizeof(float) * groups_per_col;
-
-  // qvals_sum
-  col_size += sizeof(int32_t) * groups_per_col;
-
-  // zeros
-  if (has_weight_zeros) {
-    col_size += sizeof(int32_t) * groups_per_col;
-  }
-
-  // bias
-  if (has_bias) {
-    col_size += sizeof(float);
-  }
-
-  // Replace n with next multiple of 4 >= n
-  n = ((n + 3) / 4) * 4;
-
-  return col_size * n;
+  return torchao::kernels::cpu::aarch64::linear::packing::packed_weights_size(
+      n,
+      k,
+      group_size,
+      weight_nbit,
+      has_weight_zeros,
+      has_bias,
+      /*nr*/ 4);
 }
 
 template <int weight_nbit>
@@ -299,125 +279,16 @@ void prepare_weight_data_impl(
     // Ignored if has_weight_zeros = false
     const int8_t* weight_zeros,
     const float* bias) {
-  assert(k % group_size == 0);
-  assert(group_size % 16 == 0);
-
-  bool has_weight_zeros = (weight_zeros != nullptr);
-  bool has_bias = (bias != nullptr);
-
-  int groups_per_k = k / group_size;
-  constexpr int bytes_per_64_weight_values = 8 * weight_nbit;
-
-  auto weight_data_byte_ptr = (char*)weight_data;
-  const int8_t* qvals_ptr = weight_qvals;
-  const float* scales_ptr = weight_scales;
-  const int8_t* zeros_ptr = weight_zeros;
-  const float* bias_ptr = bias;
-
-  int8_t interleaved_buffer[64];
-  int8_t buffer[64];
-
-  for (int n_idx = 0; n_idx < n; n_idx += 4) {
-    for (int k_idx = 0; k_idx < k; k_idx += group_size) {
-      // Loop over group in chunks of 16, processing 4 columns at at time
-      int qvals_sum[4] = {0, 0, 0, 0};
-      for (int i = 0; i < group_size; i += 16) {
-        std::memset(buffer, 0, 64);
-        // Loop over 4 cols
-#pragma unroll(4)
-        for (int j = 0; j < 4; j++) {
-          if (n_idx + j < n) {
-            // If qvals_ptr are pre-packed in a naive way, this is where
-            // unpacking can occur
-            std::memcpy(buffer + 16 * j, qvals_ptr + k * j, 16);
-            qvals_sum[j] +=
-                torchao::kernels::cpu::aarch64::reduction::compute_sum(
-                    buffer + 16 * j, 16);
-          }
-        }
-        torchao::kernels::cpu::valpacking::interleave_data(
-            /*data_interleaved=*/interleaved_buffer,
-            /*data=*/buffer,
-            /*bytes_per_val=*/1,
-            /*vals_per_channel=*/16,
-            /*vals_per_group=*/16,
-            /*vals_per_chunk=*/8,
-            /*channels=*/4,
-            /*channel_stride_in_vals=*/16);
-        torchao::bitpacking::vec_pack_64_lowbit_values<weight_nbit>(
-            (uint8_t*)weight_data_byte_ptr,
-            vld1q_s8(interleaved_buffer),
-            vld1q_s8(interleaved_buffer + 16),
-            vld1q_s8(interleaved_buffer + 32),
-            vld1q_s8(interleaved_buffer + 48));
-        qvals_ptr += 16;
-        weight_data_byte_ptr += bytes_per_64_weight_values;
-      } // loop over group
-
-      // Store weight scales
-#pragma unroll(4)
-      for (int j = 0; j < 4; j++) {
-        float32_t scale = 0.0;
-        if (n_idx + j < n) {
-          scale = *(scales_ptr + j * groups_per_k);
-        }
-        *((float*)weight_data_byte_ptr) = scale;
-        weight_data_byte_ptr += sizeof(float);
-      }
-      scales_ptr += 1;
-
-      // Store weight qvals_sum
-#pragma unroll(4)
-      for (int j = 0; j < 4; j++) {
-        *((int*)weight_data_byte_ptr) = qvals_sum[j];
-        weight_data_byte_ptr += sizeof(int);
-      }
-
-      // Store weight zeros
-      // I went back and forth on how to store weight_zero.
-      // Kernel computation is done in int32, so I'm converting these to
-      // int32 before storing (load 4 int32s in kernel).
-      // In the 1x8 kernel, we may want to store as int16_t, which reduces
-      // a load in the kernel (load 8 int16_ts in kernel, instead of 2
-      // load 4 int32_ts), but adds 2 moves (int16 to int32).
-      if (has_weight_zeros) {
-#pragma unroll(4)
-        for (int j = 0; j < 4; j++) {
-          int32_t zero = 0;
-          if (n_idx + j < n) {
-            zero = (int)(*(zeros_ptr + j * groups_per_k));
-          }
-          *((int32_t*)weight_data_byte_ptr) = zero;
-          weight_data_byte_ptr += sizeof(int32_t);
-        }
-        zeros_ptr += 1;
-      }
-    } // k_idx
-    if (has_bias) {
-#pragma unroll(4)
-      for (int j = 0; j < 4; j++) {
-        float bias_ = 0.0;
-        if (n_idx + j < n) {
-          bias_ = *(bias_ptr + j);
-        }
-        *((float*)weight_data_byte_ptr) = bias_;
-        weight_data_byte_ptr += sizeof(float);
-      }
-      bias_ptr += 1;
-    }
-
-    // In the previous loop over k, we processed 4 columns at a time,
-    // but only advanced our pointers over the first column.
-    // So we advance over the other 3 columns here.
-    qvals_ptr += 3 * k;
-    scales_ptr += 3 * groups_per_k;
-    if (has_weight_zeros) {
-      zeros_ptr += 3 * groups_per_k;
-    }
-    if (has_bias) {
-      bias_ptr += 3;
-    }
-  } // n_idx
+  torchao::kernels::cpu::aarch64::linear::packing::
+      pack_weights<weight_nbit, /*nr*/ 4, /*kr*/ 16, /*sr*/ 2>(
+          weight_data,
+          n,
+          k,
+          group_size,
+          weight_qvals,
+          weight_scales,
+          weight_zeros,
+          bias);
 }
 
 } // namespace

--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot-impl.h
@@ -10,8 +10,7 @@
 
 #include <torchao/experimental/kernels/cpu/aarch64/bitpacking/bitpack.h>
 #include <torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_prepare_activation_data_1xk_f32-impl.h>
-#include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
-#include <torchao/experimental/kernels/cpu/aarch64/valpacking/valpack.h>
+#include <torchao/experimental/kernels/cpu/aarch64/linear/pack_weights.h>
 #include <cassert>
 #include <cstring>
 
@@ -346,33 +345,14 @@ size_t inline weight_data_size_impl(
     int weight_nbit,
     bool has_weight_zeros,
     bool has_bias) {
-  assert(k % group_size == 0);
-  int groups_per_col = k / group_size;
-  int col_size = 0;
-
-  // qvals
-  col_size += (k / 8) * weight_nbit;
-
-  // scales
-  col_size += sizeof(float) * groups_per_col;
-
-  // qvals_sum
-  col_size += sizeof(int32_t) * groups_per_col;
-
-  // zeros
-  if (has_weight_zeros) {
-    col_size += sizeof(int32_t) * groups_per_col;
-  }
-
-  // bias
-  if (has_bias) {
-    col_size += sizeof(float);
-  }
-
-  // Replace n with next multiple of 8 >= n
-  n = ((n + 7) / 8) * 8;
-
-  return col_size * n;
+  return torchao::kernels::cpu::aarch64::linear::packing::packed_weights_size(
+      n,
+      k,
+      group_size,
+      weight_nbit,
+      has_weight_zeros,
+      has_bias,
+      /*nr*/ 8);
 }
 
 template <int weight_nbit>
@@ -388,127 +368,17 @@ void prepare_weight_data_impl(
     // Ignored if has_weight_zeros = false
     const int8_t* weight_zeros,
     const float* bias) {
-  assert(k % group_size == 0);
-  assert(group_size % 16 == 0);
-  bool has_weight_zeros = (weight_zeros != nullptr);
-  bool has_bias = (bias != nullptr);
-
-  int groups_per_k = k / group_size;
-  constexpr int bytes_per_128_weight_values = 16 * weight_nbit;
-
-  auto weight_data_byte_ptr = (char*)weight_data;
-  const int8_t* qvals_ptr = weight_qvals;
-  const float* scales_ptr = weight_scales;
-  const int8_t* zeros_ptr = weight_zeros;
-  const float* bias_ptr = bias;
-
-  int8_t interleaved_buffer[128];
-  int8_t buffer[128];
-
-  for (int n_idx = 0; n_idx < n; n_idx += 8) {
-    for (int k_idx = 0; k_idx < k; k_idx += group_size) {
-      // Loop over group in chunks of 16, processing 8 columns at at time
-      int qvals_sum[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-      for (int i = 0; i < group_size; i += 16) {
-        std::memset(buffer, 0, 128);
-        // Loop over 8 cols
-#pragma unroll(8)
-        for (int j = 0; j < 8; j++) {
-          if (n_idx + j < n) {
-            // If qvals_ptr are pre-packed in a naive way, this is where
-            // unpacking can occur
-            std::memcpy(buffer + 16 * j, qvals_ptr + k * j, 16);
-            qvals_sum[j] +=
-                torchao::kernels::cpu::aarch64::reduction::compute_sum(
-                    buffer + 16 * j, 16);
-          }
-        }
-        torchao::kernels::cpu::valpacking::interleave_data(
-            /*data_interleaved=*/interleaved_buffer,
-            /*data=*/buffer,
-            /*bytes_per_val=*/1,
-            /*vals_per_channel=*/16,
-            /*vals_per_group=*/16,
-            /*vals_per_chunk=*/8,
-            /*channels=*/8,
-            /*channel_stride_in_vals=*/16);
-        torchao::bitpacking::vec_pack_128_lowbit_values<weight_nbit>(
-            (uint8_t*)weight_data_byte_ptr,
-            vld1q_s8(interleaved_buffer),
-            vld1q_s8(interleaved_buffer + 16),
-            vld1q_s8(interleaved_buffer + 32),
-            vld1q_s8(interleaved_buffer + 48),
-            vld1q_s8(interleaved_buffer + 64),
-            vld1q_s8(interleaved_buffer + 80),
-            vld1q_s8(interleaved_buffer + 96),
-            vld1q_s8(interleaved_buffer + 112));
-        qvals_ptr += 16;
-        weight_data_byte_ptr += bytes_per_128_weight_values;
-      } // loop over group
-
-      // Store weight scales
-#pragma unroll(8)
-      for (int j = 0; j < 8; j++) {
-        float32_t scale = 0.0;
-        if (n_idx + j < n) {
-          scale = *(scales_ptr + j * groups_per_k);
-        }
-        *((float*)weight_data_byte_ptr) = scale;
-        weight_data_byte_ptr += sizeof(float);
-      }
-      scales_ptr += 1;
-
-      // Store weight qvals_sum
-#pragma unroll(8)
-      for (int j = 0; j < 8; j++) {
-        *((int*)weight_data_byte_ptr) = qvals_sum[j];
-        weight_data_byte_ptr += sizeof(int);
-      }
-
-      // Store weight zeros
-      // TODO: test storing these as int16_t, which reduces
-      // a load in the kernel (load 8 int16_ts in kernel, instead of 2
-      // load 4 int32_ts), but adds 2 moves (int16 to int32).
-      if (has_weight_zeros) {
-#pragma unroll(8)
-        for (int j = 0; j < 8; j++) {
-          int32_t zero = 0;
-          if (n_idx + j < n) {
-            zero = (int)(*(zeros_ptr + j * groups_per_k));
-          }
-          *((int32_t*)weight_data_byte_ptr) = zero;
-          weight_data_byte_ptr += sizeof(int32_t);
-        }
-        zeros_ptr += 1;
-      }
-    } // k_idx
-    if (has_bias) {
-#pragma unroll(8)
-      for (int j = 0; j < 8; j++) {
-        float bias_ = 0.0;
-        if (n_idx + j < n) {
-          bias_ = *(bias_ptr + j);
-        }
-        *((float*)weight_data_byte_ptr) = bias_;
-        weight_data_byte_ptr += sizeof(float);
-      }
-      bias_ptr += 1;
-    }
-
-    // In the previous loop over k, we processed 8 columns at a time,
-    // but only advanced our pointers over the first column.
-    // So we advance over the other 7 columns here.
-    qvals_ptr += 7 * k;
-    scales_ptr += 7 * groups_per_k;
-    if (has_weight_zeros) {
-      zeros_ptr += 7 * groups_per_k;
-    }
-    if (has_bias) {
-      bias_ptr += 7;
-    }
-  } // n_idx
+  torchao::kernels::cpu::aarch64::linear::packing::
+      pack_weights<weight_nbit, /*nr*/ 8, /*kr*/ 16, /*sr*/ 2>(
+          weight_data,
+          n,
+          k,
+          group_size,
+          weight_qvals,
+          weight_scales,
+          weight_zeros,
+          bias);
 }
-
 } // namespace
   // channelwise_8bit_activation_groupwise_lowbit_weight_1x8x16_f32_neondot::internal
 } // namespace torchao::kernels::cpu::aarch64::linear

--- a/torchao/experimental/kernels/cpu/aarch64/linear/pack_weights.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/pack_weights.h
@@ -1,0 +1,417 @@
+#pragma once
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+
+#include <torchao/experimental/kernels/cpu/aarch64/bitpacking/bitpack.h>
+#include <torchao/experimental/kernels/cpu/aarch64/macro.h>
+#include <torchao/experimental/kernels/cpu/aarch64/reduction/reduction.h>
+#include <cstring>
+
+namespace torchao::kernels::cpu::aarch64::linear::packing {
+
+namespace internal {
+
+// Packs a buffer of (kr * nr) lowbit values (stored as int8_t) down to bits
+template <int weight_nbit, int kr, int nr>
+TORCHAO_ALWAYS_INLINE inline void pack_buffer(
+    void* packed_weights,
+    const int8_t* buffer) {
+  if constexpr (kr * nr == 128) {
+    bitpacking::vec_pack_128_lowbit_values<weight_nbit>(
+        (uint8_t*)packed_weights,
+        vld1q_s8(buffer),
+        vld1q_s8(buffer + 16),
+        vld1q_s8(buffer + 32),
+        vld1q_s8(buffer + 48),
+        vld1q_s8(buffer + 64),
+        vld1q_s8(buffer + 80),
+        vld1q_s8(buffer + 96),
+        vld1q_s8(buffer + 112));
+    return;
+  }
+  if constexpr (kr * nr == 64) {
+    bitpacking::vec_pack_64_lowbit_values<weight_nbit>(
+        (uint8_t*)packed_weights,
+        vld1q_s8(buffer),
+        vld1q_s8(buffer + 16),
+        vld1q_s8(buffer + 32),
+        vld1q_s8(buffer + 48));
+    return;
+  }
+  if constexpr (kr * nr == 32) {
+    bitpacking::vec_pack_32_lowbit_values<weight_nbit>(
+        (uint8_t*)packed_weights, vld1q_s8(buffer), vld1q_s8(buffer + 16));
+    return;
+  }
+  assert(false);
+}
+
+// Unpacks bits to a buffer of (kr * nr) lowbit values (stored as int8_t)
+template <int weight_nbit, int kr, int nr>
+TORCHAO_ALWAYS_INLINE inline void unpack_buffer(
+    int8_t* buffer,
+    const void* packed_weights) {
+  int8x16_t vals0;
+  int8x16_t vals1;
+  int8x16_t vals2;
+  int8x16_t vals3;
+  int8x16_t vals4;
+  int8x16_t vals5;
+  int8x16_t vals6;
+  int8x16_t vals7;
+
+  if constexpr (kr * nr == 128) {
+    bitpacking::vec_unpack_128_lowbit_values<weight_nbit>(
+        vals0,
+        vals1,
+        vals2,
+        vals3,
+        vals4,
+        vals5,
+        vals6,
+        vals7,
+        (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    vst1q_s8(buffer + 32, vals2);
+    vst1q_s8(buffer + 48, vals3);
+    vst1q_s8(buffer + 64, vals4);
+    vst1q_s8(buffer + 80, vals5);
+    vst1q_s8(buffer + 96, vals6);
+    vst1q_s8(buffer + 112, vals7);
+    return;
+  }
+  if constexpr (kr * nr == 64) {
+    torchao::bitpacking::vec_unpack_64_lowbit_values<weight_nbit>(
+        vals0, vals1, vals2, vals3, (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    vst1q_s8(buffer + 32, vals2);
+    vst1q_s8(buffer + 48, vals3);
+    return;
+  }
+  if constexpr (kr * nr == 32) {
+    bitpacking::vec_unpack_32_lowbit_values<weight_nbit>(
+        vals0, vals1, (const uint8_t*)packed_weights);
+    vst1q_s8(buffer, vals0);
+    vst1q_s8(buffer + 16, vals1);
+    return;
+  }
+  assert(false);
+}
+
+// Packs nr * kr values for GEMM with packing params (nr, kr, sr)
+// It takes (kr / sr) values from each of nr columns and writes to packed_values
+// This is repeated sr times
+template <typename T>
+void pack_values(
+    // Output
+    T* packed_values,
+    // Inputs
+    const T* values,
+    int nr,
+    int kr,
+    int sr) {
+  assert(kr % sr == 0);
+  int kr_per_sr = kr / sr;
+  int dst_idx = 0;
+  for (int sr_idx = 0; sr_idx < sr; sr_idx++) {
+    for (int n_idx = 0; n_idx < nr; n_idx++) {
+      // Take kr_per_sr values from column n_idx
+      std::memcpy(
+          packed_values + dst_idx,
+          values + n_idx * kr + sr_idx * kr_per_sr,
+          sizeof(T) * kr_per_sr);
+      dst_idx += kr_per_sr;
+    }
+  }
+}
+
+// Undoes pack_values
+template <typename T>
+void unpack_values(
+    // Output
+    T* values,
+    // Inputs
+    const T* packed_values,
+    int nr,
+    int kr,
+    int sr) {
+  // packed_values and values should have size nr * kr
+  // This function takes (kr / sr) from each column of nr columns and writes to
+  // output This is repeated sr times
+  assert(kr % sr == 0);
+  int kr_per_sr = kr / sr;
+  int dst_idx = 0;
+  for (int sr_idx = 0; sr_idx < sr; sr_idx++) {
+    for (int n_idx = 0; n_idx < nr; n_idx++) {
+      // Take kr_per_sr values from column n_idx
+      std::memcpy(
+          values + n_idx * kr + sr_idx * kr_per_sr,
+          packed_values + dst_idx,
+          sizeof(T) * kr_per_sr);
+      dst_idx += kr_per_sr;
+    }
+  }
+}
+
+} // namespace internal
+
+template <int weight_nbit, int nr, int kr, int sr>
+void pack_weights(
+    // Output
+    void* packed_weights,
+    // Inputs
+    int n,
+    int k,
+    int group_size,
+    const int8_t* weight_qvals,
+    const float* weight_scales,
+    // weight_zeros not packed if nullptr
+    const int8_t* weight_zeros,
+    // bias not packed if nullptr
+    const float* bias) {
+  assert(k % group_size == 0);
+  assert(group_size % kr == 0);
+  bool has_weight_zeros = (weight_zeros != nullptr);
+  bool has_bias = (bias != nullptr);
+
+  int groups_per_k = k / group_size;
+
+  // Buffer to hold (kr * nr) values
+  std::array<int8_t, nr * kr> buffer;
+
+  // Buffer to hold (kr * nr) values after theose values
+  // are packed by params (nr, kr, sr)
+  int8_t packed_values[buffer.size()];
+
+  // Bytes of packed buffer of (nr * kr) values
+  assert(nr * kr % 8 == 0);
+  constexpr int packed_buffer_bytes = weight_nbit * nr * kr / 8;
+
+  // Buffer to hold sum of weight_qvals in each column group
+  std::array<int, nr> qvals_sum;
+
+  // Data pointer for packed weights
+  auto packed_weights_byte_ptr = (char*)packed_weights;
+
+  // Loop over n by nr
+  for (int n_idx = 0; n_idx < n; n_idx += nr) {
+    // Look over groups along k
+    for (int group_idx = 0; group_idx < groups_per_k; group_idx++) {
+      // Initialize qvals_sum for each group to 0
+      qvals_sum.fill(0);
+
+      // Loop over group by kr and pack the weights for the next nr columns
+      int k_idx = group_idx * group_size;
+      for (int idx_in_group = 0; idx_in_group < group_size;
+           idx_in_group += kr) {
+        // Fill buffer with next kr values from the next nr columns
+        // If there are fewer than nr columns, 0s are stored
+        buffer.fill(0);
+        for (int j = 0; j < nr; j++) {
+          if (n_idx + j < n) {
+            std::memcpy(
+                buffer.data() + kr * j,
+                weight_qvals + (n_idx + j) * k + (k_idx + idx_in_group),
+                kr);
+            qvals_sum[j] += reduction::compute_sum(buffer.data() + kr * j, kr);
+          }
+        }
+
+        // Pack buffer
+        internal::pack_values(packed_values, buffer.data(), nr, kr, sr);
+        internal::pack_buffer<weight_nbit, kr, nr>(
+            packed_weights_byte_ptr, packed_values);
+        packed_weights_byte_ptr += packed_buffer_bytes;
+      } // loop over group (idx_in_group)
+
+      // Store group attributes scale, qval_sums, and zeros for next nr columns
+      // If there are fewer than nr columns, 0s are stored
+
+      // Store weight scales
+      for (int j = 0; j < nr; j++) {
+        float32_t scale = 0.0;
+        if (n_idx + j < n) {
+          scale = weight_scales[(n_idx + j) * groups_per_k + group_idx];
+        }
+        *((float*)packed_weights_byte_ptr) = scale;
+        packed_weights_byte_ptr += sizeof(float);
+      }
+
+      // Store weight qval sums
+      for (int j = 0; j < nr; j++) {
+        *((int*)packed_weights_byte_ptr) = qvals_sum[j];
+        packed_weights_byte_ptr += sizeof(int);
+      }
+
+      // Store weight zeros
+      if (has_weight_zeros) {
+        for (int j = 0; j < nr; j++) {
+          int32_t zero = 0;
+          if (n_idx + j < n) {
+            zero = weight_zeros[(n_idx + j) * groups_per_k + group_idx];
+          }
+          *((int32_t*)packed_weights_byte_ptr) = zero;
+          packed_weights_byte_ptr += sizeof(int32_t);
+        }
+      }
+    } // loop over k (group_idx)
+
+    // Store bias for next nr columns
+    if (has_bias) {
+      for (int j = 0; j < nr; j++) {
+        float bias_ = 0.0;
+        if (n_idx + j < n) {
+          bias_ = bias[n_idx + j];
+        }
+        *((float*)packed_weights_byte_ptr) = bias_;
+        packed_weights_byte_ptr += sizeof(float);
+      }
+    }
+  } // n_idx
+}
+
+// Returns number of bytes required for weight_data
+size_t inline packed_weights_size(
+    int n,
+    int k,
+    int group_size,
+    int weight_nbit,
+    bool has_weight_zeros,
+    bool has_bias,
+    int nr) {
+  assert(k % group_size == 0);
+  int groups_per_col = k / group_size;
+  int col_size = 0;
+
+  // qvals
+  col_size += (k / 8) * weight_nbit;
+
+  // scales
+  col_size += sizeof(float) * groups_per_col;
+
+  // qvals_sum
+  col_size += sizeof(int32_t) * groups_per_col;
+
+  // zeros
+  if (has_weight_zeros) {
+    col_size += sizeof(int32_t) * groups_per_col;
+  }
+
+  // bias
+  if (has_bias) {
+    col_size += sizeof(float);
+  }
+
+  // Replace n with next multiple of nr >= n
+  n = ((n + nr - 1) / nr) * nr;
+
+  return col_size * n;
+}
+
+// Unpack weights
+template <int weight_nbit, int nr, int kr, int sr>
+void unpack_weights(
+    // Output
+    int8_t* weight_qvals,
+    float* weight_scales,
+    // weight_zeros is not extracted if has_weight_zeros is false
+    int8_t* weight_zeros,
+    // bias is not extracted if has_bias is false
+    float* bias,
+    // Inputs
+    int n,
+    int k,
+    int group_size,
+    bool has_weight_zeros,
+    bool has_bias,
+    void* packed_weights) {
+  assert(k % group_size == 0);
+  assert(group_size % kr == 0);
+
+  int groups_per_k = k / group_size;
+
+  // Buffer to hold (kr * nr) values
+  std::array<int8_t, nr * kr> buffer;
+
+  // Buffer to hold (kr * nr) values after theose values
+  // are packed by params (nr, kr, sr)
+  int8_t packed_values[buffer.size()];
+
+  // Bytes of packed buffer of (nr * kr) values
+  assert(nr * kr % 8 == 0);
+  constexpr int packed_buffer_bytes = weight_nbit * nr * kr / 8;
+
+  // Data pointer for packed weights
+  auto packed_weights_byte_ptr = (char*)packed_weights;
+
+  // Loop over n by nr
+  for (int n_idx = 0; n_idx < n; n_idx += nr) {
+    // Look over groups along k
+    for (int group_idx = 0; group_idx < groups_per_k; group_idx++) {
+      // Loop over group by kr and pack the weights for the next nr columns
+      int k_idx = group_idx * group_size;
+      for (int idx_in_group = 0; idx_in_group < group_size;
+           idx_in_group += kr) {
+        // Unpack qvals
+        internal::unpack_buffer<weight_nbit, kr, nr>(
+            packed_values, packed_weights_byte_ptr);
+        packed_weights_byte_ptr += packed_buffer_bytes;
+        internal::unpack_values(buffer.data(), packed_values, nr, kr, sr);
+
+        // Write weight_qvals
+        for (int j = 0; j < nr; j++) {
+          if (n_idx + j < n) {
+            std::memcpy(
+                weight_qvals + (n_idx + j) * k + (k_idx + idx_in_group),
+                buffer.data() + kr * j,
+                kr);
+          }
+        }
+
+      } // loop over group (idx_in_group)
+
+      // Write group scales and zeros for next nr columns
+
+      // Write weight scales
+      for (int j = 0; j < nr; j++) {
+        float scale = *((float*)packed_weights_byte_ptr);
+        packed_weights_byte_ptr += sizeof(float);
+        if (n_idx + j < n) {
+          weight_scales[(n_idx + j) * groups_per_k + group_idx] = scale;
+        }
+      }
+
+      // Skip over weight qval sums
+      packed_weights_byte_ptr += nr * sizeof(int);
+
+      // Write weight zeros
+      if (has_weight_zeros) {
+        for (int j = 0; j < nr; j++) {
+          int32_t zero = *((int32_t*)packed_weights_byte_ptr);
+          packed_weights_byte_ptr += sizeof(int32_t);
+          if (n_idx + j < n) {
+            weight_zeros[(n_idx + j) * groups_per_k + group_idx] = (int8_t)zero;
+          }
+        }
+      }
+
+    } // loop over k (group_idx)
+
+    // Write bias
+    if (has_bias) {
+      for (int j = 0; j < nr; j++) {
+        float bias_ = *((float*)packed_weights_byte_ptr);
+        packed_weights_byte_ptr += sizeof(float);
+        if (n_idx + j < n) {
+          bias[n_idx + j] = bias_;
+        }
+      }
+    }
+  } // n_idx
+}
+
+} // namespace torchao::kernels::cpu::aarch64::linear::packing
+
+#endif // defined(__aarch64__) || defined(__ARM_NEON)

--- a/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/CMakeLists.txt
@@ -111,6 +111,14 @@ target_link_libraries(
     dep
 )
 
+add_executable(test_weight_packing test_weight_packing.cpp)
+target_link_libraries(
+  test_weight_packing
+    PRIVATE
+    GTest::gtest_main
+    dep
+)
+
 include(GoogleTest)
 gtest_discover_tests(test_quantization)
 gtest_discover_tests(test_reduction)
@@ -118,3 +126,4 @@ gtest_discover_tests(test_bitpacking)
 gtest_discover_tests(test_linear)
 gtest_discover_tests(test_valpacking)
 gtest_discover_tests(test_embedding)
+gtest_discover_tests(test_weight_packing)

--- a/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/build_and_run_tests.sh
@@ -60,3 +60,4 @@ ${CMAKE_OUT}/test_bitpacking
 ${CMAKE_OUT}/test_linear
 ${CMAKE_OUT}/test_valpacking
 ${CMAKE_OUT}/test_embedding
+${CMAKE_OUT}/test_weight_packing

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_weight_packing.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_weight_packing.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+#include <torchao/experimental/kernels/cpu/aarch64/linear/pack_weights.h>
+#include <torchao/experimental/kernels/cpu/aarch64/tests/test_utils.h>
+
+template <int weight_nbit, int nr, int kr, int sr>
+void test_weight_packing(
+    int k,
+    int n,
+    int group_size,
+    bool has_weight_zeros,
+    bool has_bias) {
+  auto test_case = torchao::
+      channelwise_8bit_activation_groupwise_lowbit_weight_test_case::generate(
+          /*m*/ 1,
+          k,
+          n,
+          group_size,
+          weight_nbit,
+          has_weight_zeros,
+          has_bias,
+          /*has_clamp*/ false);
+
+  using namespace torchao::kernels::cpu::aarch64::linear::packing;
+
+  std::vector<char> packed_weights(packed_weights_size(
+      n, k, group_size, weight_nbit, has_weight_zeros, has_bias, nr));
+
+  int8_t* weight_qvals_in = test_case.weight_qvals.data();
+  float* weight_scales_in = test_case.weight_scales.data();
+  int8_t* weight_zeros_in = nullptr;
+  if (has_weight_zeros) {
+    weight_zeros_in = test_case.weight_zeros.data();
+  }
+  float* bias_in = nullptr;
+  if (has_bias) {
+    bias_in = test_case.bias.data();
+  }
+
+  std::vector<int8_t> weight_qvals_out(test_case.weight_qvals.size());
+  std::vector<float> weight_scales_out(test_case.weight_scales.size());
+  std::vector<int8_t> weight_zeros_out(test_case.weight_zeros.size());
+  std::vector<float> bias_out(test_case.bias.size());
+
+  torchao::kernels::cpu::aarch64::linear::packing::
+      pack_weights<weight_nbit, nr, kr, sr>(
+          packed_weights.data(),
+          n,
+          k,
+          group_size,
+          weight_qvals_in,
+          weight_scales_in,
+          weight_zeros_in,
+          bias_in);
+  torchao::kernels::cpu::aarch64::linear::packing::
+      unpack_weights<weight_nbit, nr, kr, sr>(
+          weight_qvals_out.data(),
+          weight_scales_out.data(),
+          weight_zeros_out.data(),
+          bias_out.data(),
+          n,
+          k,
+          group_size,
+          has_weight_zeros,
+          has_bias,
+          packed_weights.data());
+
+  for (int i = 0; i < test_case.weight_qvals.size(); ++i) {
+    EXPECT_EQ(weight_qvals_out[i], test_case.weight_qvals[i]);
+  }
+  for (int i = 0; i < test_case.weight_scales.size(); ++i) {
+    EXPECT_EQ(weight_scales_out[i], test_case.weight_scales[i]);
+  }
+  for (int i = 0; i < test_case.weight_zeros.size(); ++i) {
+    EXPECT_EQ(weight_zeros_out[i], test_case.weight_zeros[i]);
+  }
+  for (int i = 0; i < test_case.bias.size(); ++i) {
+    EXPECT_EQ(bias_out[i], test_case.bias[i]);
+  }
+}
+
+TEST(TestWeightPacking, PackUnpackAreSame) {
+  int n = 13;
+  int group_size = 32;
+  int k = group_size * 17;
+
+  test_weight_packing<4, /*nr*/ 8, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ true);
+  test_weight_packing<4, /*nr*/ 8, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ true);
+  test_weight_packing<4, /*nr*/ 8, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ false);
+  test_weight_packing<4, /*nr*/ 8, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ false);
+
+  test_weight_packing<3, /*nr*/ 4, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ true);
+  test_weight_packing<3, /*nr*/ 4, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ true);
+  test_weight_packing<3, /*nr*/ 4, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ false);
+  test_weight_packing<3, /*nr*/ 4, /*kr*/ 16, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ false);
+
+  test_weight_packing<2, /*nr*/ 1, /*kr*/ 32, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ true);
+  test_weight_packing<2, /*nr*/ 1, /*kr*/ 32, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ true);
+  test_weight_packing<2, /*nr*/ 1, /*kr*/ 32, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ true, /*has_bias*/ false);
+  test_weight_packing<2, /*nr*/ 1, /*kr*/ 32, /*sr*/ 2>(
+      k, n, group_size, /*has_weight_zeros*/ false, /*has_bias*/ false);
+}


### PR DESCRIPTION
Summary:
This diff implements unpacking functions for the existing universal kernels.

To strealine the changes across the 3 tile sizes, I also rewrote the packing functions to be parametrized by nr, kr, sr.  In this way, I only needed to rewrite the unpacking function once.

New tests are added to show that when we pack and then unpack, we recover the weight qvals, scales, zeros, and bias.

This diff is most of the work for implementing an embedding kernel that understands the universal linear packing format.

The remaining work is:

* Write unpack to accept n_idx as an arg, rather than compute all columns.
* Use the unpack weight function in the embedding kernel, followed by a dequant op.

Reviewed By: digantdesai

Differential Revision: D71163696


