### PR TITLE
fix-ci

### DIFF
--- a/torchao/experimental/ops/mps/test/test_lowbit.py
+++ b/torchao/experimental/ops/mps/test/test_lowbit.py
@@ -10,7 +10,8 @@ import unittest
 import torch
 from parameterized import parameterized
 
-import torchao  # noqa: F401
+# Need to import to load the ops
+from torchao.experimental.quant_api import UIntxWeightOnlyLinearQuantizer  # noqa: F401
 
 try:
     for nbit in range(1, 8):


### PR DESCRIPTION
Current test uses "import torchao" to load the MPS ops, but "import torchao" has not been very stable lately.  Instead importing something specific in torchao.experimental.