### PR TITLE
Add dynamic shape support for lowbit kernels

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -34,7 +34,7 @@ try:
     # They can also be built outside of the torchao install process by
     # running the script `torchao/experimental/build_torchao_ops.sh <aten|executorch>`
     # For more information, see https://github.com/pytorch/ao/blob/main/torchao/experimental/docs/readme.md
-    from torchao.experimental.op_lib import *
+    from torchao.experimental.op_lib import *  # noqa: F403
 except Exception as e:
     logging.debug(f"Skipping import of cpp extensions: {e}")
 

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -34,14 +34,9 @@ try:
     # They can also be built outside of the torchao install process by
     # running the script `torchao/experimental/build_torchao_ops.sh <aten|executorch>`
     # For more information, see https://github.com/pytorch/ao/blob/main/torchao/experimental/docs/readme.md
-    experimental_lib = list(Path(__file__).parent.glob("libtorchao_ops_aten.*"))
-    if len(experimental_lib) > 0:
-        assert (
-            len(experimental_lib) == 1
-        ), f"Expected at most one libtorchao_ops_aten.* file, found {len(experimental_lib)}"
-        torch.ops.load_library(str(experimental_lib[0]))
-except:
-    logging.debug("Skipping import of cpp extensions")
+    from torchao.experimental.op_lib import *
+except Exception as e:
+    logging.debug(f"Skipping import of cpp extensions: {e}")
 
 from torchao.quantization import (
     autoquant,

--- a/torchao/experimental/op_lib.py
+++ b/torchao/experimental/op_lib.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+
+import torch
+from torch import Tensor
+from torch.library import impl
+
+# Load C++ ops
+lib_path = Path(__file__).parent.parent
+libs = list(lib_path.glob("libtorchao_ops_aten.*"))
+assert (
+    len(libs) == 1
+), f"Expected to find one libtorchao_ops_aten.* library at {lib_path}, but found {len(libs)}"
+torch.ops.load_library(str(libs[0]))
+
+
+# Define meta ops.  To support dynamic shapes, some meta ops need to
+# be defined in python instead of C++.
+torchao_lib = torch.library.Library("torchao", "IMPL")
+for weight_nbit in range(1, 9):
+
+    @impl(torchao_lib, f"_linear_8bit_act_{weight_nbit}bit_weight", "Meta")
+    def _(
+        activations: Tensor,
+        packed_weights: Tensor,
+        group_size: int,
+        n: int,
+        k: int,
+    ):
+        assert activations.dim() == 2
+        m, k_ = activations.shape
+        assert k_ == k
+        return torch.empty(m, n, dtype=activations.dtype, device="meta")
+
+    @impl(torchao_lib, f"_embedding_{weight_nbit}bit", "Meta")
+    def _(
+        packed_weight_qvals: Tensor,
+        num_embeddings: int,
+        embedding_dim: int,
+        weight_scales: Tensor,
+        weight_zeros: Tensor,
+        indices: Tensor,
+    ):
+        assert indices.dim() == 1
+        num_out = indices.shape[0]
+        return torch.empty(num_out, embedding_dim, dtype=torch.float32, device="meta")
+
+    @impl(torchao_lib, f"_shared_embedding_{weight_nbit}bit", "Meta")
+    def _(packed_weights: Tensor, group_size: int, n: int, k: int, indices: Tensor):
+        assert indices.dim() == 1
+        num_out = indices.shape[0]
+        return torch.empty(num_out, k, dtype=torch.float32, device="meta")

--- a/torchao/experimental/ops/embedding_xbit/op_embedding_xbit_aten.cpp
+++ b/torchao/experimental/ops/embedding_xbit/op_embedding_xbit_aten.cpp
@@ -10,10 +10,10 @@
   m.def("_pack_embedding_" #weight_nbit "bit(Tensor weight_qvals) -> Tensor");                                                                                                                       \
   m.def(                                                                                                                                                                                             \
       "_embedding_" #weight_nbit                                                                                                                                                                     \
-      "bit(Tensor packed_weight_qvals, Tensor num_embeddings_tensor, Tensor embedding_dim_tensor, Tensor weight_scales, Tensor weight_zeros, Tensor indices) -> Tensor");                            \
+      "bit(Tensor packed_weight_qvals, int num_embeddings, int embedding_dim, Tensor weight_scales, Tensor weight_zeros, Tensor indices) -> Tensor");                                                \
   m.def(                                                                                                                                                                                             \
       "_embedding_" #weight_nbit                                                                                                                                                                     \
-      "bit.out(Tensor packed_weight_qvals, Tensor num_embeddings_tensor, Tensor embedding_dim_tensor, Tensor weight_scales, Tensor weight_zeros, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)"); \
+      "bit.out(Tensor packed_weight_qvals, int num_embeddings, int embedding_dim, Tensor weight_scales, Tensor weight_zeros, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)");                     \
   m.def(                                                                                                                                                                                             \
       "_shared_embedding_" #weight_nbit                                                                                                                                                              \
       "bit.out(Tensor packed_weights, int group_size, int n, int k, Tensor indices, *, Tensor(a!) out) -> Tensor(a!)");                                                                              \
@@ -38,11 +38,7 @@
 #define DEFINE_META_IMPL(weight_nbit)                                     \
   m.impl(                                                                 \
       "_pack_embedding_" #weight_nbit "bit",                              \
-      &pack_embedding_meta<weight_nbit>);                                 \
-  m.impl("_embedding_" #weight_nbit "bit", &embedding_meta<weight_nbit>); \
-  m.impl(                                                                 \
-      "_shared_embedding_" #weight_nbit "bit",                            \
-      &shared_embedding_meta<weight_nbit>);
+      &pack_embedding_meta<weight_nbit>);
 
 TORCH_LIBRARY_FRAGMENT(torchao, m) {
   DEFINE_OP(1);

--- a/torchao/experimental/ops/embedding_xbit/op_embedding_xbit_executorch.cpp
+++ b/torchao/experimental/ops/embedding_xbit/op_embedding_xbit_executorch.cpp
@@ -10,8 +10,8 @@
   Tensor _op_out_##weight_nbit(            \
       RuntimeContext& ctx,                 \
       const Tensor& packed_weight_qvals,   \
-      const Tensor& num_embeddings_tensor, \
-      const Tensor& embedding_dim_tensor,  \
+      const int64_t& num_embeddings,       \
+      const int64_t& embedding_dim,        \
       const Tensor& weight_scales,         \
       const Tensor& weight_zeros,          \
       const Tensor& indices,               \
@@ -19,8 +19,8 @@
     (void)ctx;                             \
     embedding_out_cpu<weight_nbit>(        \
         packed_weight_qvals,               \
-        num_embeddings_tensor,             \
-        embedding_dim_tensor,              \
+        num_embeddings,                    \
+        embedding_dim,                     \
         weight_scales,                     \
         weight_zeros,                      \
         indices,                           \

--- a/torchao/experimental/ops/library.h
+++ b/torchao/experimental/ops/library.h
@@ -13,16 +13,20 @@ using Tensor = at::Tensor;
 #define Tensor_dtype_kInt32 torch::kInt32
 #define Tensor_dtype_kInt64 torch::kInt64
 #define TORCHAO_CHECK(cond, msg) TORCH_CHECK(cond, msg)
+#define TORCHAO_RESIZE_TENSOR(tensor, ...) tensor.resize_({__VA_ARGS__})
 
 #elif defined(USE_EXECUTORCH) && !defined(USE_ATEN)
 #pragma message("USE_EXECUTORCH")
 #include <executorch/extension/kernel_util/make_boxed_from_unboxed_functor.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 using Tensor = torch::executor::Tensor;
 using RuntimeContext = torch::executor::KernelRuntimeContext;
 #define Tensor_dtype_kInt32 torch::executor::ScalarType::Int
 #define Tensor_dtype_kInt64 torch::executor::ScalarType::Long
 #define TORCHAO_CHECK(cond, msg) ET_CHECK_MSG(cond, msg)
+#define TORCHAO_RESIZE_TENSOR(tensor, ...) \
+  ET_CHECK_MSG(torch::executor::resize_tensor(tensor, {__VA_ARGS__}) == torch::executor::Error::Ok, "resize failed")
 
 #elif !defined(USE_EXECUTORCH) && !defined(USE_ATEN)
 #pragma message("Neither USE_ATEN or USE_EXECUTORCH defined")

--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/op_linear_8bit_act_xbit_weight_aten.cpp
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/op_linear_8bit_act_xbit_weight_aten.cpp
@@ -34,10 +34,7 @@
       &pack_weights_meta<weight_nbit>);               \
   m.impl(                                             \
       "_pack_8bit_act_" #weight_nbit "bit_weight",    \
-      &pack_weights_meta<weight_nbit>);               \
-  m.impl(                                             \
-      "_linear_8bit_act_" #weight_nbit "bit_weight",  \
-      &linear_meta<weight_nbit>);
+      &pack_weights_meta<weight_nbit>)
 
 TORCH_LIBRARY_FRAGMENT(torchao, m) {
   DEFINE_OP(1);

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -384,12 +384,8 @@ class QuantizedEmbedding(nn.Module):
         self.register_buffer(
             "packed_weight_qvals", self.pack_weights_op(weight_qvals.to(torch.int8))
         )
-        self.register_buffer(
-            "num_embeddings", torch.empty(0, num_embeddings, dtype=torch.int8)
-        )
-        self.register_buffer(
-            "embedding_dim", torch.empty(0, embedding_dim, dtype=torch.int8)
-        )
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
         self.register_buffer("weight_scales", weight_scales)
         self.register_buffer("weight_zeros", weight_zeros.to(torch.int8))
 


### PR DESCRIPTION
To support dynamic shapes, the linear/embedding meta kernels must be written in python.

The packing meta kernels are still in C++ because 1) packing shapes are not dynamic, and 2) the packed size is not readily available in python.  For these, I move to create meta tensors directly per https://github.com/pytorch/ao/issues/1936.   