### PR TITLE
Add round weight_scale to bf16 to Int8DynamicActivationIntxWeightConfig

### DIFF
--- a/.github/workflows/torchao_experimental_test.yml
+++ b/.github/workflows/torchao_experimental_test.yml
@@ -40,7 +40,7 @@ jobs:
           pip install numpy
           pip install pytest
           pip install parameterized
-          USE_CPP=1 pip install .
+          USE_CPP=1 TOCHAO_BUILD_KLEIDIAI=1 pip install .
       - name: Run python tests
         run: |
           conda activate venv

--- a/torchao/experimental/packed_linear_int8_dynamic_activation_intx_weight_layout.py
+++ b/torchao/experimental/packed_linear_int8_dynamic_activation_intx_weight_layout.py
@@ -187,7 +187,7 @@ class PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl(AQTTensorImpl):
 
         if not scale_rounded_to_bf16:
             assert (
-                layout.Target == Target.UNIVERSAL
+                layout.target == Target.UNIVERSAL
             ), "Must use Target.UNIVERSAL if scales are not rounded to BF16"
 
         args = [

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -953,6 +953,7 @@ class SharedEmbeddingQuantizer:
                 weight_dtype=self.weight_dtype,
                 granularity=self.granularity,
                 has_weight_zeros=self.has_weight_zeros,
+                round_weight_scale_to_bf16=False,
                 # Only universal layout is supported for shared embedding
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="universal"

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -652,12 +652,12 @@ class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
         has_weight_zeros: Whether or not to include zeros in the weight quantization.
         weight_mapping_type: The type of mapping to use for the weight quantization.  Must be one of MappingType.ASYMMETRIC or MappingType.SYMMETRIC.
         act_mapping_type: The type of mapping to use for the activation quantization.  Must be one of MappingType.ASYMMETRIC or MappingType.SYMMETRIC.
+        round_weight_scale_to_bf16: Whether or not to round the weight scale to bfloat16.  This is different than weight_scales being bfloat16,
+            because computation and dequantization still happens in float32.
         layout: The layout to use for the packed weight tensor.  The layout does not affect the quantization numerically and different
             layouts will give similar results.  The following are available layouts:
             - PackedLinearInt8DynamicActivationIntxWeightLayout: This layout is optimized for CPU performance.
             - QDQLayout: This layout is designed for export to ExecuTorch
-            - PlainLayout: This layout is a simple python-based layout.  It has low performance, but can be used
-                when PackedLinearInt8DynamicActivationIntxWeightLayout is unavailable.
     """
 
     weight_dtype: torch.dtype = torch.int4

--- a/torchao/experimental/tests/test_embedding_xbit_quantizer.py
+++ b/torchao/experimental/tests/test_embedding_xbit_quantizer.py
@@ -143,6 +143,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 granularity=granularity,
                 has_weight_zeros=has_weight_zeros,
+                round_weight_scale_to_bf16=False,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="universal"
                 ),

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -33,6 +33,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         )
         for layout in [
             PackedLinearInt8DynamicActivationIntxWeightLayout(),
+            PackedLinearInt8DynamicActivationIntxWeightLayout(target="universal"),
             QDQLayout(),
         ]
         for weight_dtype in [

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -71,6 +71,10 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             *[torch.nn.Linear(k, k, bias=False), torch.nn.Linear(k, n, bias=True)]
         )
 
+        # We set round_weight_scale_to_bf16 to True for accuracy testing because
+        # some kernels do this internally (e.g., KleidiAI kernels)
+        round_weight_scale_to_bf16 = True
+
         quantized_model = copy.deepcopy(model)
         quantize_(
             quantized_model,
@@ -79,6 +83,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 granularity=granularity,
                 has_weight_zeros=has_weight_zeros,
                 layout=layout,
+                round_weight_scale_to_bf16=round_weight_scale_to_bf16,
             ),
         )
 
@@ -90,17 +95,14 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 granularity=granularity,
                 has_weight_zeros=has_weight_zeros,
                 layout=self._reference_layout(),
+                round_weight_scale_to_bf16=round_weight_scale_to_bf16,
             ),
         )
 
         with torch.no_grad():
             result = quantized_model(activations)
             expected_result = quantized_model_reference(activations)
-
-        # When weight_dtype is int4, we need low tolerance when comparing
-        # to the reference because KleidiAI kernels (based on bfloat16 scales)
-        # may be used
-        self._assert_close(result, expected_result, strict=(weight_dtype != torch.int4))
+        self._assert_close(result, expected_result)
 
     def test_accuracy_aten(self):
         m = 3
@@ -114,6 +116,10 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         granularity = PerGroup(128)
         has_weight_zeros = False
 
+        # We set round_weight_scale_to_bf16 to True for accuracy testing because
+        # some KleidiAI kernels do this internally
+        round_weight_scale_to_bf16 = True
+
         quantized_model = copy.deepcopy(model)
         quantize_(
             quantized_model,
@@ -122,6 +128,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 granularity=granularity,
                 has_weight_zeros=has_weight_zeros,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(target="aten"),
+                round_weight_scale_to_bf16=round_weight_scale_to_bf16,
             ),
         )
 
@@ -133,6 +140,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 granularity=granularity,
                 has_weight_zeros=has_weight_zeros,
                 layout=self._reference_layout(),
+                round_weight_scale_to_bf16=round_weight_scale_to_bf16,
             ),
         )
 
@@ -140,20 +148,11 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             result = quantized_model(activations)
             expected_result = quantized_model_reference(activations)
 
-        # KleidiAI aten kernels need low tolerance when comparing to reference
-        # because they use bfloat16 scales
-        self._assert_close(result, expected_result, strict=False)
+        self._assert_close(result, expected_result)
 
-    def _assert_close(self, result, expected_result, strict: bool = False):
-        if strict:
-            self.assertTrue(
-                torch.nn.functional.mse_loss(result, expected_result) <= 1e-6
-            )
-            self.assertTrue(torch.allclose(result, expected_result, atol=1e-2))
-        else:
-            self.assertTrue(
-                torch.nn.functional.mse_loss(result, expected_result) <= 1e-3
-            )
+    def _assert_close(self, result, expected_result):
+        self.assertTrue(torch.nn.functional.mse_loss(result, expected_result) <= 1e-6)
+        self.assertTrue(torch.allclose(result, expected_result, atol=1e-2))
 
     def _reference_layout(self):
         return PlainLayout()


### PR DESCRIPTION
This adds option to round weight scales to BF16 in the Int8DynamicActivationIntxWeightConfig.

This is useful because KleidiAI kernels do this internally.