### PR TITLE
[sparsity] Add PartialLinear module for structured sparsity

### DIFF
--- a/torchao/prototype/sparsity/PartialLinear/__init__.py
+++ b/torchao/prototype/sparsity/PartialLinear/__init__.py
@@ -1,0 +1,3 @@
+from .partial_linear import PartialLinear
+
+__all__ = ["PartialLinear"]

--- a/torchao/prototype/sparsity/PartialLinear/partial_linear.py
+++ b/torchao/prototype/sparsity/PartialLinear/partial_linear.py
@@ -1,0 +1,181 @@
+import math
+import torch
+from torch import Tensor
+from torch.nn import functional as F, init
+from torch.nn.parameter import Parameter
+from torch.nn import Module
+
+class PartialLinear(Module):
+    r"""Applies a linear transformation where each output feature connects to only the top-k
+    input features by weight magnitude: :math:`y = x * (M \odot W^T) + b`,
+    where $\odot$ is the element-wise product and $M$ is a binary mask.
+    This module implements a form of structured sparsity that can reduce computation
+    and memory usage during inference.
+    Args:
+        in_features: size of each input sample
+        out_features: size of each output sample
+        top_k: number of weights to retain per output feature (default: in_features // 2)
+        bias: If set to ``False``, the layer will not learn an additive bias.
+            Default: ``True``
+        update_mask_every: update the mask every N forward passes during training (default: 50)
+    Shape:
+        - Input: :math:`(*, H_\text{in})` where :math:`*` means any number of
+          dimensions including none and :math:`H_\text{in} = \text{in\_features}`.
+        - Output: :math:`(*, H_\text{out})` where all but the last dimension
+          are the same shape as the input and :math:`H_\text{out} = \text{out\_features}`.
+    Attributes:
+        weight: the learnable weights of the module of shape
+            :math:`(\text{out\_features}, \text{in\_features})`. The values are
+            initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`, where
+            :math:`k = \frac{1}{\text{in\_features}}`
+        mask: binary mask of shape :math:`(\text{out\_features}, \text{in\_features})`
+            indicating which weights are retained (1) or pruned (0)
+        bias:   the learnable bias of the module of shape :math:`(\text{out\_features})`.
+                If :attr:`bias` is ``True``, the values are initialized from
+                :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})` where
+                :math:`k = \frac{1}{\text{in\_features}}`
+        is_sparse_forward: when True, uses a completely sparse computation for forward pass
+    Examples::
+        >>> m = nn.PartialLinear(20, 30, top_k=5)  # Each output connected to top 5 inputs
+        >>> input = torch.randn(128, 20)
+        >>> output = m(input)
+        >>> print(output.size())
+        torch.Size([128, 30])
+    """
+    __constants__ = ["in_features", "out_features", "top_k", "update_mask_every", "is_sparse_forward"]
+    in_features: int
+    out_features: int
+    top_k: int
+    update_mask_every: int
+    is_sparse_forward: bool
+    weight: Tensor
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        top_k: int = None,
+        bias: bool = True,
+        update_mask_every: int = 50,
+        is_sparse_forward: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+
+        self.in_features = in_features
+        self.out_features = out_features
+
+        # Default to half of the input features if not specified
+        if top_k is None:
+            top_k = max(1, in_features // 2)
+
+        if top_k <= 0 or top_k > in_features:
+            raise ValueError(f"top_k must be between 1 and {in_features}, got {top_k}")
+
+        self.top_k = top_k
+        self.update_mask_every = update_mask_every
+        self.is_sparse_forward = is_sparse_forward
+        self._forward_counter = 0
+
+        # Create a full weight matrix
+        self.weight = Parameter(
+            torch.empty((out_features, in_features), **factory_kwargs)
+        )
+
+        # Create a binary mask for the weights
+        mask = torch.ones((out_features, in_features), **factory_kwargs)
+        self.register_buffer('mask', mask)
+
+        if bias:
+            self.bias = Parameter(torch.empty(out_features, **factory_kwargs))
+        else:
+            self.register_parameter("bias", None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        # Standard initialization as in nn.Linear
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+        # Reset the mask to all ones
+        self.mask.fill_(1.0)
+
+        # Initialize the mask to keep only top-k weights
+        self._update_mask()
+
+    def _update_mask(self):
+        with torch.no_grad():
+            # Compute the magnitude of weights
+            weight_mag = self.weight.abs()
+
+            # Create a new binary mask
+            new_mask = torch.zeros_like(self.mask)
+
+            # For each output feature, find the top-k input connections
+            _, top_k_indices = weight_mag.topk(self.top_k, dim=1)
+
+            # Set mask to 1 for top-k weights for each output
+            for i in range(self.out_features):
+                new_mask[i, top_k_indices[i]] = 1.0
+
+            # Update the mask
+            self.mask.copy_(new_mask)
+
+    def _sparse_forward(self, input):
+        # Create output tensor
+        output = torch.zeros(input.shape[:-1] + (self.out_features,), 
+                          device=input.device, dtype=input.dtype)
+
+        # Get non-zero indices of the mask
+        nonzero_indices = self.mask.nonzero(as_tuple=True)
+
+        # For each non-zero weight, add its contribution to the output
+        for out_idx, in_idx in zip(*nonzero_indices):
+            # Get the corresponding weight
+            weight_val = self.weight[out_idx, in_idx]
+
+            # Get the corresponding input values (handle batched inputs)
+            if input.dim() > 1:
+                in_vals = input[..., in_idx]
+                # Add contribution to output (broadcasting handles batched inputs)
+                output[..., out_idx] += in_vals * weight_val
+            else:
+                # For single input vector
+                output[out_idx] += input[in_idx] * weight_val
+
+        # Add bias if needed
+        if self.bias is not None:
+            output += self.bias
+
+        return output
+
+    def forward(self, input: Tensor) -> Tensor:
+        # During training, periodically update the mask
+        if self.training:
+            self._forward_counter += 1
+            if self._forward_counter >= self.update_mask_every:
+                self._update_mask()
+                self._forward_counter = 0
+
+        # Use sparse computation if requested
+        if self.is_sparse_forward:
+            return self._sparse_forward(input)
+
+        # Apply the mask to the weights
+        masked_weight = self.weight * self.mask
+
+        # Use the masked weights for the linear transformation
+        return F.linear(input, masked_weight, self.bias)
+
+    def extra_repr(self) -> str:
+        return (f"in_features={self.in_features}, out_features={self.out_features}, "
+                f"top_k={self.top_k}, bias={self.bias is not None}, "
+                f"update_mask_every={self.update_mask_every}, "
+                f"is_sparse_forward={self.is_sparse_forward}")


### PR DESCRIPTION
This PR adds the PartialLinear module to `torchao.prototype.sparsity` as suggested by @jcaip in pytorch/pytorch#149853.

## Implementation Details
- PartialLinear is a linear layer that implements structured sparsity by connecting each output neuron to only the top-k input features by weight magnitude
- Supports dynamic connectivity updates during training with configurable update frequency
- Provides both masked-dense computation and fully sparse computation paths

The implementation is placed in a PartialLinear folder as suggested. I'm open to any feedback or modifications needed to better integrate with the torchao ecosystem and sparsity framework.

This addresses the TODO in pytorch/pytorch's `linear.py` module that mentions "PartialLinear - maybe in sparse?".

Related issue: pytorch/pytorch#135091

cc @jcaip 