### PR TITLE
Skip Test`test_galore_quant.py` for ROCm

### DIFF
--- a/test/quantization/test_galore_quant.py
+++ b/test/quantization/test_galore_quant.py
@@ -13,6 +13,14 @@ try:  # noqa: F401
 except ImportError:  # noqa: F401
     pytest.skip("triton is not installed", allow_module_level=True)  # noqa: F401
 import torch
+
+# Skip entire test if CUDA is not available or ROCM is enabled
+if not torch.cuda.is_available() or torch.version.hip is not None:
+    pytest.skip(
+        "CUDA is not available/ ROCM support is under development",
+        allow_module_level=True,
+    )
+
 from bitsandbytes.functional import (
     create_dynamic_map,
     dequantize_blockwise,


### PR DESCRIPTION
This pull request includes a change to the `test/quantization/test_galore_quant.py` file to improve the test environment handling. The most important change is the addition of a condition to skip the entire test if CUDA is not available or if ROCM is enabled.

Test environment handling:

* [`test/quantization/test_galore_quant.py`](diffhunk://#diff-51ddab022797064be44ca38c87a56c6e87cd69444f4c6151a11b7f0141aef2b9R16-R23): Added a condition to skip the entire test if CUDA is not available or if ROCM is enabled, ensuring compatibility and avoiding test failures in unsupported environments.