### PR TITLE
add non-square bsr support

### DIFF
--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -24,6 +24,8 @@ from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
     TORCH_VERSION_AT_LEAST_2_6,
 )
+from torchao.sparsity.blocksparse import BlockSparseTensor
+from torchao.sparsity.utils import create_block_sparse_tensor
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
@@ -166,6 +168,38 @@ class TestBlockSparseWeight(common_utils.TestCase):
         sparse_result = model(input)
 
         torch.testing.assert_close(dense_result, sparse_result, rtol=1e-3, atol=1e-3)
+
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_4,
+        "pytorch 2.4+ feature due to need for custom op support",
+    )
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @common_utils.parametrize("compile", [False])
+    @common_utils.parametrize("blocksize", [(64, 8), (8, 64)])
+    def test_non_square_sparse(self, compile, blocksize):
+        input_shape = 1024
+        input = torch.rand((input_shape, 1024)).half().cuda()
+        model = (
+            nn.Sequential(
+                nn.Linear(1024, 2048),
+                nn.Linear(2048, 1024),
+            )
+            .half()
+            .cuda()
+            .eval()
+        )
+
+        M, N = model[0].weight.shape
+        model[0].weight.data = create_block_sparse_tensor(M, N, blocksize, 0.5, torch.float16)
+        M, N = model[1].weight.shape
+        model[1].weight.data = create_block_sparse_tensor(M, N, blocksize, 0.5, torch.float16)
+        dense_result = model(input)
+
+        from torchao.sparsity import block_sparse_weight
+        sparsify_(model, block_sparse_weight(blocksize=blocksize))
+        sparse_result = model(input)
+
+        torch.testing.assert_close(dense_result, sparse_result, rtol=1e-2, atol=1e-2)
 
 
 class TestQuantBlockSparseWeight(common_utils.TestCase):

--- a/torchao/sparsity/blocksparse.py
+++ b/torchao/sparsity/blocksparse.py
@@ -129,7 +129,7 @@ class BlockSparseTensor(TorchAOBaseTensor):
     bsr_crow_indices: Optional[torch.Tensor]
     bsr_col_indices: Optional[torch.Tensor]
     bsr_values: Optional[torch.Tensor]
-    blocksize: int
+    blocksize: Tuple[int, int]
 
     __slots__ = ["bsr_crow_indices", "bsr_col_indices", "bsr_values"]
 
@@ -137,7 +137,7 @@ class BlockSparseTensor(TorchAOBaseTensor):
     def __new__(  # noqa: PYI034
         cls,
         shape: torch.Size,
-        blocksize: int,
+        blocksize: Tuple[int, int],
         bsr_crow_indices: Optional[torch.Tensor],
         bsr_col_indices: Optional[torch.Tensor],
         bsr_values: Optional[torch.Tensor],
@@ -165,7 +165,7 @@ class BlockSparseTensor(TorchAOBaseTensor):
 
     def __repr__(self) -> str:  # type: ignore[override]
         assert hasattr(self, "shape")
-        return f"{self.__class__.__name__}(shape={self.shape})"
+        return f"{self.__class__.__name__}(shape={self.shape}, blocksize={self.blocksize})"
 
     def __tensor_flatten__(self) -> Tuple[List[str], Tuple[torch.Size, bool, int]]:
         inner_tensors = list(
@@ -178,7 +178,7 @@ class BlockSparseTensor(TorchAOBaseTensor):
     def __tensor_unflatten__(
         cls,
         inner_tensors,
-        tensor_meta: Tuple[torch.Size, bool, int],
+        tensor_meta: Tuple[torch.Size, bool, Tuple[int, int]],
         outer_size,
         outer_stride,
     ) -> torch.Tensor:
@@ -259,7 +259,8 @@ def block_sparse_mul(func, types, args, kwargs):
         assert t.dim() == 3
         assert not bsr.requires_grad
         assert t.size(0) == 1
-        t_blocked = t.view(t.size(0), t.size(1) // bsr.blocksize, bsr.blocksize, 1)
+        BM, BK = bsr.blocksize
+        t_blocked = t.view(t.size(0), t.size(1) // BM, BM, 1)
         masked_t = t_blocked.transpose(0, 1).index_select(0, bsr.col_indices())
         new_values = bsr.values() * masked_t
         return BlockSparseTensor(
@@ -307,6 +308,7 @@ def block_sparse_linear(func, types, args, kwargs):
     x = x_orig.reshape(-1, x_orig.size(-1)).t()
     M = w.shape[0]
     K = w.shape[1]
+    BM, BK = w.blocksize
 
     out = torch.ops.blocksparse.addmm(
         x,


### PR DESCRIPTION
Add non-square bsr support for supporting non-square SuperBlock. Currently does not work due to padding issue restrictions from Triton but still submitting a PR due to time constraint. 

Will also need to add a forward pass with custom autograd function in the future.