### PR TITLE
Update torchao.prototype.parq and add 4-bit Llama 3.2 1B benchmark

### DIFF
--- a/torchao/prototype/parq/__init__.py
+++ b/torchao/prototype/parq/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .optim import (  # noqa: F401
     ProxBinaryRelax,
     ProxHardQuant,

--- a/torchao/prototype/parq/optim/__init__.py
+++ b/torchao/prototype/parq/optim/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .binarelax import ProxBinaryRelax  # noqa: F401
 from .parq import ProxPARQ  # noqa: F401
 from .proxmap import ProxHardQuant, ProxMap  # noqa: F401

--- a/torchao/prototype/parq/optim/binarelax.py
+++ b/torchao/prototype/parq/optim/binarelax.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
 from typing import Optional
 
 import torch
@@ -41,7 +42,6 @@ class ProxBinaryRelax(ProxMap):
 
         if step_count >= self.anneal_end:
             p.copy_(q)
-            return
         else:
             # linear annealing of relaxation coefficient
             theta = (step_count - self.anneal_start) / (

--- a/torchao/prototype/parq/optim/proxmap.py
+++ b/torchao/prototype/parq/optim/proxmap.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 from typing import Optional
 

--- a/torchao/prototype/parq/optim/quantopt.py
+++ b/torchao/prototype/parq/optim/quantopt.py
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
 from collections.abc import Callable
 from functools import partial
 from typing import Any, Optional
@@ -11,15 +13,14 @@ import torch
 from torch import Tensor
 from torch.optim import Optimizer
 
-from ..quant import LSBQuantizer, Quantizer
+from ..quant import Quantizer
+from ..utils import HAS_DTENSOR, is_dtensor
 from .proxmap import ProxMap
 
-try:
-    from torch.distributed.tensor import DTensor
-
-    HAS_DTENSOR = True
-except ImportError:
-    HAS_DTENSOR = False
+if HAS_DTENSOR:
+    from torch.distributed.tensor import distribute_tensor
+    from torch.distributed.tensor.experimental import local_map
+    from torch.distributed.tensor.placement_types import Shard
 
 
 class QuantOptimizer(Optimizer):
@@ -31,7 +32,7 @@ class QuantOptimizer(Optimizer):
     a proximal mapping (e.g, HardQuant/STE, PARQ, BinaryRelax)
         - update model parameters based on the above two updates
     Other parameters:
-        - warmup_steps: int > 0
+        - warmup_steps: int >= 0
         - quant_period: int > 0
         - quant_per_channel: True or False
         - quant_shrink: True or False
@@ -86,23 +87,23 @@ class QuantOptimizer(Optimizer):
         extra_repr = "\n  ".join(("(", base_optimizer, f"{quantizer=}", f"{prox_map=}"))
         return f"{self.__class__.__name__} {extra_repr}\n)"
 
+    @property
+    def state(self) -> defaultdict[Tensor, Any]:  # pyre-ignore[3]
+        return self._state if hasattr(self, "_state") else self.base_optimizer.state
+
     @staticmethod
     def quantize_(
         p: Tensor,
         quants: Tensor,
         quantizer: Quantizer,
         b: int,
-        quant_update: bool,
         dim: Optional[int] = None,
     ) -> Optional[Tensor]:
         """Optionally update the quantization targets `quants` in place.
         Return the quantized `p` as a by-product if `quant_update=True`.
         """
-        if quant_update:  # update Q for each channel
-            q, Q = quantizer.quantize(p, b, dim=dim)  # pyre-ignore[28]
-            quants.copy_(Q)
-        else:
-            q = None
+        q, Q = quantizer.quantize(p, b, dim=dim)  # pyre-ignore[28]
+        quants.copy_(Q)
         return q
 
     def regularized_param_groups(self):  # pyre-ignore[3]
@@ -122,12 +123,13 @@ class QuantOptimizer(Optimizer):
     def load_state_dict(
         self, state_dict: dict[str, Any], start_step: Optional[int] = None
     ) -> None:
-        qat_state = state_dict.pop("qat_state")
+        qat_state = state_dict.get("qat_state")
         # resume from check points usually not corresponds to saved num_steps
         # so allow explicit start_step computed from epochs * steps_per_epoc
         if start_step is not None:
             self.num_steps = start_step
-        else:  # hope discrepancy in num_steps does not cause major problem!
+        elif qat_state is not None:
+            # hope discrepancy in num_steps does not cause major problem!
             self.num_steps = qat_state["num_steps"]
         self.base_optimizer.load_state_dict(state_dict)
 
@@ -144,15 +146,22 @@ class QuantOptimizer(Optimizer):
             self.num_steps += 1
             return loss
 
-        # call base optimizer step() method to update latent parameters
-        loss = self.base_optimizer.step(closure=closure)  # pyre-ignore[6]
-
         if self.num_steps == self.warmup_steps:
             # first step of qat, save latent params, instead of restore
             self.save_latent_params()
         else:
             # qat: restore latent params for update by the base optimizer
             self.restore_latent_params()
+
+        # call base optimizer step() method to update latent parameters
+        loss = self.base_optimizer.step(closure=closure)  # pyre-ignore[6]
+
+        if hasattr(self, "_state"):
+            assert self.warmup_steps == 0
+            # restore the temporary state to the base optimizer's state
+            for p in self._state.keys():
+                self.base_optimizer.state[p]["latent"] = self._state[p]["latent"]
+            del self._state
 
         # check if it is time to update set of quantization values Q
         if (self.num_steps - self.warmup_steps) % self.quant_period == 0:
@@ -165,6 +174,7 @@ class QuantOptimizer(Optimizer):
             group["cumu_lr"] += group["lr"]
             gamma = max(1.0, group["cumu_lr"])
             b = group["quant_bits"]
+            block_size = group.get("quant_block_size")
             inv_slope = 0.0
             for p in group["params"]:
                 if not p.requires_grad:
@@ -177,44 +187,66 @@ class QuantOptimizer(Optimizer):
                 if self.quant_shrink:
                     p.div_(gamma)
 
+                # reshape p according to block size if specified
+                if block_size is not None:
+                    assert (
+                        p.size(-1) % block_size == 0
+                    ), f"{p.size(-1)=} is not divisible by {block_size=}"
+                    assert p.dim() <= 2, f"Invalid {p.dim()=} for {block_size=}"
+                    if p.dim() == 1:
+                        p = p.unsqueeze(0)
+
+                    # row-major ordering ensures this is correct
+                    p = p.view(-1, block_size)
+
                 # quantization by channel or by layer
                 # update quantization targets periodically
                 per_channel = self.quant_per_channel and p.dim() > 1
                 if quant_update:
-                    quants_size = 3 if b == 0 else 2**b
-                    if per_channel:
-                        quants_size = (p.size(0), quants_size)
-                    state["quants"] = torch.empty(
-                        quants_size, device=p.device
-                    )  # pyre-ignore[6]
+                    quant_size = self.quantizer.get_quant_size(b)
 
-                # avoid type mismatch between sharded and full tensors
-                if HAS_DTENSOR and isinstance(p, DTensor):
-                    p = p.full_tensor()
+                    if per_channel:
+                        quant_size = (p.size(0), quant_size)
+                    state["quants"] = torch.empty(quant_size, device=p.device)
+                    if is_dtensor(p):
+                        state["quants"] = distribute_tensor(
+                            state["quants"],
+                            device_mesh=p.device_mesh,
+                            placements=p.placements,
+                        )
 
                 dim = -1 if per_channel else None
                 if per_channel and p.dim() > 2:
                     p = p.flatten(start_dim=1)
 
-                # NOTE: for LSBQ and optimal=False, use faster per-channel
-                # implementation instead of vmap
-                if isinstance(self.quantizer, LSBQuantizer) and self.quantizer.optimal:
+                q = None
+                if quant_update:
                     qfunc = partial(
-                        self.quantize_,
-                        quantizer=self.quantizer,
-                        b=b,
-                        quant_update=quant_update,
+                        self.quantize_, quantizer=self.quantizer, b=b, dim=dim
                     )
-                    q = torch.vmap(qfunc, in_dims=0, out_dims=0)(p, state["quants"])
-                else:
-                    q = self.quantize_(
-                        p, state["quants"], self.quantizer, b, quant_update, dim=dim
-                    )
+                    if is_dtensor(p):
+                        qfunc = local_map(
+                            qfunc,
+                            out_placements=[*p.placements],
+                            in_placements=([Shard(0)], [Shard(0)]),
+                        )
+                    q = qfunc(p, state["quants"])
 
                 # apply (step-dependent) proximal mapping in place
-                inv_slope = self.prox_map.apply_(  # pyre-ignore[28]
-                    p, q, state["quants"], self.num_steps, dim=dim
+                pfunc = partial(
+                    self.prox_map.apply_, step_count=self.num_steps, dim=dim
                 )
+                if is_dtensor(p):
+                    pfunc = local_map(
+                        pfunc,
+                        out_placements=None,
+                        in_placements=(
+                            [Shard(0)],
+                            None if q is None else [Shard(0)],
+                            [Shard(0)],
+                        ),
+                    )
+                inv_slope = pfunc(p, q, state["quants"])
 
             # quantized parameters share the same PARQ inverse slope
             if inv_slope:
@@ -239,6 +271,12 @@ class QuantOptimizer(Optimizer):
     @torch._disable_dynamo
     def save_latent_params(self) -> None:
         """Save updated latent parameters before applying prox-map"""
+        if self.warmup_steps == 0:
+            assert len(self.state) == 0, "Expected empty state at first step()"
+            # Maintain the invariant that `len(self.state) == 0` before first
+            # self.base_optimizer.step() call by using a temporary state buffer
+            self._state = defaultdict(dict)
+
         for group in self.regularized_param_groups():
             for p in group["params"]:
                 if p.requires_grad:

--- a/torchao/prototype/parq/quant/__init__.py
+++ b/torchao/prototype/parq/quant/__init__.py
@@ -1,3 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .lsbq import LSBQuantizer  # noqa: F401
 from .quantizer import Quantizer  # noqa: F401
-from .uniform import UnifQuantizer  # noqa: F401
+from .uniform import (  # noqa: F401
+    MaxUnifQuantizer,
+    TernaryUnifQuantizer,
+    UnifQuantizer,
+)

--- a/torchao/prototype/parq/quant/quantizer.py
+++ b/torchao/prototype/parq/quant/quantizer.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -14,6 +15,10 @@ class Quantizer(ABC):
 
     def __init__(self, center: bool = False) -> None:
         self.center = center
+
+    @abstractmethod
+    def get_quant_size(self, b: int) -> int:
+        """Given number of bits b, return total number of quantization values"""
 
     @abstractmethod
     def quantize(self, p: Tensor, b: int) -> tuple[Tensor, Tensor]:

--- a/torchao/prototype/parq/quant/uniform.py
+++ b/torchao/prototype/parq/quant/uniform.py
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
+import math
 from typing import Optional
 
 import torch
@@ -11,49 +13,201 @@ from torch import Tensor
 from .quantizer import Quantizer
 
 
-class UnifQuantizer(Quantizer):
-    """Uniform quantizer, range determined by multiples of |p|.mean()"""
+def get_q_max(
+    q: Tensor, b: int, dim: Optional[int] = None, scale_method: str = "mean"
+) -> Tensor:
+    if scale_method == "mean":
+        # set range of quantization: min(b * |q|.mean(), |q|.max())
+        q_abs = q.abs()
+        if dim is not None:
+            q_max = torch.minimum(
+                b * q_abs.mean(dim=dim, keepdim=True),  # pyre-ignore[6,9]
+                torch.max(q_abs, dim=dim, keepdim=True).values,  # pyre-ignore[6]
+            )
+        else:
+            q_max = torch.minimum(b * q_abs.mean(), torch.max(q_abs))  # pyre-ignore[6]
+    elif scale_method == "max":
+        q_max = (
+            q.abs().max(dim=dim, keepdim=True).values
+            if dim is not None
+            else q.abs().max()
+        )
+    else:
+        raise NotImplementedError(f"Invalid {scale_method=}, choices=('mean','max')")
+    return q_max
 
-    def __init__(self, center: bool = False) -> None:
-        super().__init__(center)
+
+class UnifQuantizer(Quantizer):
+    """Uniform and symmetric quantizer"""
+
+    def __init__(
+        self,
+        center: bool = False,
+        scale_method: str = "mean",
+        int_shift: float = 0.5,
+        zero_point: float = 0.5,
+    ):
+        """Set quantization function parameters.
+
+        Args:
+            center: whether to subtract p.mean() prior to quantization
+            scale_method: compute scale based 'mean', multiples of |p|.mean(),
+                or 'max', |p|.max() (default: 'mean')
+            int_shift: float value to shift the lower bound of integer range by:
+                -2^{b - 1} + int_shift (default: 0.5). Using 0.5 results in 2^b
+                values. E.g., [-1.5, -0.5, 0.5, 1.5] for b=2.
+            zero_point: float value to shift p by after scale and round.
+        """
+        assert scale_method in ("max", "mean"), f"Invalid {scale_method=}"
+        super().__init__(center=center)
+
+        self.scale_method = scale_method
+        self.int_shift = int_shift
+        self.zero_point = zero_point
+
+    def get_quant_size(self, b: int) -> int:
+        """Levels in [-2^{b-1} + self.int_shift, 2^{b-1} - self.int_shift].
+
+        Note that range_absmax = 2^{b-1} - self.int_shift on both ends of the
+        boundary and the interval is closed."""
+        return math.floor(2**b - 2 * self.int_shift) + 1
 
     def quantize(
         self, p: Tensor, b: int, dim: Optional[int] = None
     ) -> tuple[Tensor, Tensor]:
         """Instantiation of Quantizer.quantize() method"""
-        assert b >= 1
+        assert b != 0, "Please use TernaryUnifQuantizer instead"
+
+        if self.center:
+            q, mean = super().remove_mean(p.detach(), dim=dim)
+        else:
+            q = p.detach().clone()
+            mean = torch.zeros(1, dtype=p.dtype, device=p.device)
+        q_max = get_q_max(q, b, dim=dim, scale_method=self.scale_method)
+        q_max.clamp_(min=torch.finfo(q.dtype).tiny)
+
+        # clamp to quantization range
+        q.copy_(torch.minimum(torch.maximum(q, -q_max), q_max))
+
+        # scale from [-2^{b-1}+int_shift, 2^{b-1}-int_shift] to [-q_max, q_max]
+        range_absmax = 2 ** (b - 1) - self.int_shift
+        s = q_max / range_absmax
+
+        # scale by 1/s -> shift -zero_point -> round -> shift +zero_point ->
+        # scale by s, where shift ensures rounding to integers
+        q.div_(s).sub_(self.zero_point).round_().add_(self.zero_point).mul_(s)
+
+        # set of all target quantization values
+        Q = torch.arange(
+            -range_absmax, range_absmax + 1e-5, dtype=p.dtype, device=p.device
+        )
+        if dim is not None:
+            Q = Q.unsqueeze(0).mul(s)  # broadcasted multiply requires copy
+        else:
+            Q.mul_(s)
+
+        # return quantized tensor and set of possible quantization values
+        if self.center:
+            q += mean
+            Q += mean
+        return q, Q
+
+
+class MaxUnifQuantizer(UnifQuantizer):
+    def __init__(
+        self,
+        center: bool = False,
+        scale_method: str = "max",
+        int_shift: float = 1.0,
+        zero_point: float = 0.0,
+    ):
+        """Set quantization function with int_shift=1.0.
+
+        The final quantization range includes 2^b - 1 quantized values. E.g.,
+        [-1, 0, 1] for b=2. The quantization scale is determined by |p|.max()
+        by default and zero point is 0.0.
+        """
+        super().__init__(
+            center=center,
+            scale_method=scale_method,
+            int_shift=int_shift,
+            zero_point=zero_point,
+        )
+
+
+class AsymUnifQuantizer(Quantizer):
+    def get_quant_size(self, b: int) -> int:
+        """Equivalent to int_max - int_min + 1, where int_min = -2^{b-1} and
+        int_max = 2^{b-1} - 1."""
+        return 2**b
+
+    def quantize(
+        self, p: Tensor, b: int, dim: Optional[int] = None
+    ) -> tuple[Tensor, Tensor]:
+        assert b != 0, "Please use TernaryUnifQuantizer instead"
+
         if self.center:
             q, mean = super().remove_mean(p.detach(), dim=dim)
         else:
             q = p.detach().clone()
             mean = torch.zeros(1, dtype=p.dtype, device=p.device)
 
-        # set range of quantization: min( b * |q|.mean(), |q|.max())
-        q_abs = q.abs()
         if dim is not None:
-            q_max = torch.minimum(
-                b * q_abs.mean(dim=dim, keepdim=True),  # pyre-ignore[6,9]
-                torch.max(q_abs, dim=dim, keepdim=True)[0],  # pyre-ignore[6]
-            )
+            q_min = q.min(dim=dim, keepdim=True).values
+            q_max = q.max(dim=dim, keepdim=True).values
         else:
-            q_max = torch.minimum(b * q_abs.mean(), torch.max(q_abs))  # pyre-ignore[6]
+            q_min = q.min()
+            q_max = q.max()
 
-        # clamp to quantization range
-        q.copy_(torch.minimum(torch.maximum(q, -q_max), q_max))
+        int_min = -(2 ** (b - 1))
+        int_max = 2 ** (b - 1) - 1
+        s = (q_max - q_min) / (int_max - int_min)
+        s.clamp_(min=torch.finfo(q.dtype).tiny)
 
-        # compute scale from [-2^{b-1}+0.5, 2^{b-1}-0.5] to [-q_max, q_max]
-        s = q_max / (2 ** (b - 1) - 0.5)
+        zero_point = q_min.div_(s).round_()
+        q.div_(s).round_().sub_(zero_point).add_(zero_point).mul_(s)
 
-        # scale by 1/s -> shift -0.5 -> round -> shift +0.5 -> scale by s
-        # where shift ensures rounding to integers 2^{b-1}, ..., 2^{b-1}-1
-        q.div_(s).sub_(0.5).round_().add_(0.5).mul_(s)
-
-        # set of all target quantization values
-        Q = s * (
-            torch.arange(-(2 ** (b - 1)) + 0.5, 2 ** (b - 1), step=1, device=q.device)
-        )
+        Q = torch.arange(int_min, int_max + 1, dtype=p.dtype, device=p.device)
+        if dim is not None:
+            Q = Q.unsqueeze(0).mul(s)  # broadcasted multiply requires copy
+        else:
+            Q.mul_(s)
 
         # return quantized tensor and set of possible quantization values
+        if self.center:
+            q += mean
+            Q += mean
+        return q, Q
+
+
+class TernaryUnifQuantizer(Quantizer):
+    """Uniform quantizer for ternary bit case. Quantization range is [-1, 1]."""
+
+    def get_quant_size(self, b: int) -> int:
+        return 3
+
+    def quantize(
+        self, p: Tensor, b: int, dim: Optional[int] = None
+    ) -> tuple[Tensor, Tensor]:
+        assert b == 0, f"Unexpected {b=} for ternary case"
+
+        if self.center:
+            q, mean = super().remove_mean(p.detach(), dim=dim)
+        else:
+            q = p.detach().clone()
+            mean = torch.zeros(1, dtype=p.dtype, device=p.device)
+
+        q_max = get_q_max(q, b, dim=dim, scale_method="max")
+        q_max.clamp_(min=torch.finfo(q.dtype).tiny)
+        s = q_max / 1.5
+        q.div_(s).round_().clamp_(min=-1, max=1).mul_(s)
+
+        Q = torch.tensor([-1, 0, 1], dtype=p.dtype, device=p.device)
+        if dim is not None:
+            Q = Q.unsqueeze(0).mul(s)
+        else:
+            Q.mul_(s)
+
         if self.center:
             q += mean
             Q += mean

--- a/torchao/prototype/parq/utils.py
+++ b/torchao/prototype/parq/utils.py
@@ -3,8 +3,20 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
 import torch
 from torch import Tensor
+
+try:
+    from torch.distributed.tensor import DTensor
+
+    HAS_DTENSOR = True
+except ImportError:
+    HAS_DTENSOR = False
+
+
+def is_dtensor(x):
+    return HAS_DTENSOR and isinstance(x, DTensor)
 
 
 def channel_bucketize(input: Tensor, boundaries: Tensor, right: bool = False) -> Tensor:
@@ -18,4 +30,4 @@ def channel_bucketize(input: Tensor, boundaries: Tensor, right: bool = False) ->
     boundaries = boundaries.unsqueeze(1)
     input = input.unsqueeze(-1)
     mask = input.ge(boundaries) if right else input.le(boundaries)
-    return mask.int().argmax(dim=-1)
+    return mask.to(torch.uint8).argmax(dim=-1)


### PR DESCRIPTION
We would like to merge recent changes from our open sourced library at https://github.com/facebookresearch/parq.

We have also benchmarked 4-bit Llama 3.2 1B fine-tuned for 25K steps on fineweb-edu using torchtune. We used PARQ's [`MaxUnifQuantizer`](https://github.com/facebookresearch/parq/blob/b41f00e7e59fb6dc939ce371d2b6f40f71582895/parq/quant/uniform.py#L114) and [`ProxHardQuant`](https://github.com/facebookresearch/parq/blob/b41f00e7e59fb6dc939ce371d2b6f40f71582895/parq/optim/proxmap.py#L28) proximal mapping, which is equivalent to STE. Below are the relevant training config changes to the [llama3_2/1B_full.yaml](https://github.com/pytorch/torchtune/blob/84aea68d90ff5f8e65af33fd004e7b84424bc712/recipes/configs/llama3_2/1B_full.yaml) recipe.
```
batch_size: 8
epochs: 1
optimizer:
  _component_: torch.optim.AdamW
  lr: 4e-5
  weight_decay: 0.0
  betas: [0.9, 0.95]
  fused: True

lr_scheduler:
  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
  num_warmup_steps: 2500
 ```

As shown in the table below, the resulting 4-bit model achieves well under 10% accuracy on most commonsense reasoning benchmarks relative to the pre-trained model.
    Tasks    |16-bit|4-bit |% diff
-------------|-----:|-----:|-----:
arc_challenge|0.3805|0.3575|-6.4  
arc_easy     |0.6309|0.6077|-3.7  
hellaswag    |0.6081|0.5423|-10.8 
piqa         |0.7410|0.7122|-3.9  
winogrande   |0.6022|0.5549|-7.8  