### PR TITLE
Fix Int4WeightEmbeddingQATQuantizer.convert path

### DIFF
--- a/torchao/quantization/qat/embedding.py
+++ b/torchao/quantization/qat/embedding.py
@@ -245,8 +245,8 @@ class Int4WeightOnlyEmbeddingQATQuantizer(TwoStepQuantizer):
                     group_size,
                 )
                 quantized_embedding.weight = q_weight
-                quantized_embedding.scales = s
-                quantized_embedding.zeros = zp
+                quantized_embedding.scale = s.to(scale_precision)
+                quantized_embedding.zero_point = zp.to(zero_point_precision)
             else:
                 self._convert_helper(child)
 


### PR DESCRIPTION
**Summary:** Fixes the issue where `Int4WeightEmbeddingQATQuantizer`'s convert path assigned the scales and zero points to the wrong attributes ("scales" and "zeros" instead of "scale" and "zero point"), and also ensures the precisions are correctly set.

**Test Plan:**
python test/quantization/test_qat.py -k test_qat_4w_embedding