### PR TITLE
Add int8 LUT CPU ops

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/experimental/kernels/cpu/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -126,7 +126,7 @@ void pack_weights(
       bias);
 }
 
-template <int weight_nbit, int nr, int kr, int sr>
+template <int weight_nbit, int nr_, int kr_, int sr_>
 void pack_weights_with_lut(
     // Output
     void* packed_weights,
@@ -141,10 +141,16 @@ void pack_weights_with_lut(
     // weight_zeros not packed if nullptr
     const int8_t* weight_zeros,
     // bias not packed if nullptr
-    const float* bias) {
+    const float* bias,
+    int nr,
+    int kr,
+    int sr) {
+  (void)nr; // unused
+  (void)kr; // unused
+  (void)sr; // unused
   torchao::kernels::cpu::aarch64::linear::
       channelwise_8bit_activation_groupwise_lowbit_weight::weight_packing::
-          pack_weights_with_lut<weight_nbit, nr, kr, sr>(
+          pack_weights_with_lut<weight_nbit, nr_, kr_, sr_>(
               packed_weights,
               n,
               k,

--- a/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/tests/test_linear.cpp
@@ -478,7 +478,10 @@ void test_channelwise_8bit_activation_groupwise_lowbit_weight_lut(
       lut.data(),
       test_case.weight_scales.data(),
       has_weight_zeros ? test_case.weight_zeros.data() : nullptr,
-      has_bias ? test_case.bias.data() : nullptr);
+      has_bias ? test_case.bias.data() : nullptr,
+      nr,
+      kr,
+      sr);
 
   std::vector<float> output(m * n);
   kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, /*has_lut*/ true>(

--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
@@ -27,6 +27,21 @@ void pack_weights_operator(
     const int8_t* weight_zeros,
     const float* bias);
 
+void pack_weights_with_lut_operator(
+    const UKernelConfig& uk,
+    // Outputs
+    void* packed_weights,
+    // Inputs
+    int n,
+    int k,
+    int group_size,
+    const int8_t* weight_qval_idxs,
+    int n_luts,
+    const int8_t* luts,
+    const float* weight_scales,
+    const int8_t* weight_zeros,
+    const float* bias);
+
 // Linear functions
 struct LinearTilingParams {
   int mc{0};

--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/op_linear_8bit_act_xbit_weight_aten.cpp
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/op_linear_8bit_act_xbit_weight_aten.cpp
@@ -30,11 +30,24 @@
 
 #define DEFINE_META_IMPL(weight_nbit)                 \
   m.impl(                                             \
-      "_pack_8bit_act_" #weight_nbit "bit0zp_weight", \
-      &pack_weights_meta<weight_nbit>);               \
-  m.impl(                                             \
       "_pack_8bit_act_" #weight_nbit "bit_weight",    \
       &pack_weights_meta<weight_nbit>)
+
+#define DEFINE_LUT_PACK_OP(weight_nbit)                                                                                                       \
+  m.def(                                                                                                                                      \
+      "_pack_8bit_act_" #weight_nbit                                                                                                          \
+      "bit_weight_with_lut(Tensor weight_qval_ids, Tensor luts, Tensor weight_scales, int group_size, Tensor? bias, str? target) -> Tensor")
+
+#define DEFINE_LUT_PACK_CPU_IMPL(weight_nbit)               \
+  m.impl(                                                   \
+      "_pack_8bit_act_" #weight_nbit "bit_weight_with_lut", \
+      &pack_weights_with_lut_cpu<weight_nbit>)
+
+#define DEFINE_LUT_PACK_META_IMPL(weight_nbit)              \
+  m.impl(                                                   \
+      "_pack_8bit_act_" #weight_nbit "bit_weight_with_lut", \
+      &pack_weights_with_lut_meta<weight_nbit>)
+
 
 TORCH_LIBRARY_FRAGMENT(torchao, m) {
   DEFINE_OP(1);
@@ -45,6 +58,11 @@ TORCH_LIBRARY_FRAGMENT(torchao, m) {
   DEFINE_OP(6);
   DEFINE_OP(7);
   DEFINE_OP(8);
+
+  DEFINE_LUT_PACK_OP(1);
+  DEFINE_LUT_PACK_OP(2);
+  DEFINE_LUT_PACK_OP(3);
+  DEFINE_LUT_PACK_OP(4);
 }
 
 TORCH_LIBRARY_IMPL(torchao, CPU, m) {
@@ -56,6 +74,11 @@ TORCH_LIBRARY_IMPL(torchao, CPU, m) {
   DEFINE_CPU_IMPL(6);
   DEFINE_CPU_IMPL(7);
   DEFINE_CPU_IMPL(8);
+
+  DEFINE_LUT_PACK_CPU_IMPL(1);
+  DEFINE_LUT_PACK_CPU_IMPL(2);
+  DEFINE_LUT_PACK_CPU_IMPL(3);
+  DEFINE_LUT_PACK_CPU_IMPL(4);
 }
 
 TORCH_LIBRARY_IMPL(torchao, Meta, m) {
@@ -67,4 +90,9 @@ TORCH_LIBRARY_IMPL(torchao, Meta, m) {
   DEFINE_META_IMPL(6);
   DEFINE_META_IMPL(7);
   DEFINE_META_IMPL(8);
+
+  DEFINE_LUT_PACK_META_IMPL(1);
+  DEFINE_LUT_PACK_META_IMPL(2);
+  DEFINE_LUT_PACK_META_IMPL(3);
+  DEFINE_LUT_PACK_META_IMPL(4);
 }

--- a/torchao/experimental/ops/packed_weights_header.h
+++ b/torchao/experimental/ops/packed_weights_header.h
@@ -16,7 +16,8 @@ enum class PackedWeightsType : uint32_t {
   unknown = 0,
   linear_8bit_act_xbit_weight_universal = 1,
   embedding_xbit_universal = 2,
-  kleidi_ai = 3
+  kleidi_ai = 3,
+  linear_8bit_act_xbit_weight_lut = 4,
 };
 
 class PackedWeightsHeader {


### PR DESCRIPTION
Adds op support for 1-4 bit LUT kernels (int8 multiple of FP32 scale).