### PR TITLE
Fix static AQT flow

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -19,7 +19,9 @@ from torchao.dtypes import (
     CutlassInt4PackedLayout,
     Int4CPULayout,
     Int4XPULayout,
+    PlainLayout,
     SemiSparseLayout,
+    to_affine_quantized_intx_static,
 )
 from torchao.quantization import (
     Int4WeightOnlyConfig,
@@ -279,6 +281,16 @@ class TestAffineQuantized(TestCase):
             ValueError, "Not supported args for copy_ due to metadata mistach:"
         ):
             ql2.weight.copy_(ql.weight)
+
+    def test_to_affine_quantized_intx_static(self):
+        to_affine_quantized_intx_static(
+            torch.randn(2, 3),
+            scale=torch.randn(1),
+            zero_point=torch.zeros(1),
+            block_size=(2, 3),
+            target_dtype=torch.int8,
+            _layout=PlainLayout(),
+        )
 
 
 class TestAffineQuantizedBasic(TestCase):

--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -337,7 +337,12 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
             zero_point_domain,
         )
 
-        int_data, scale, zero_point = _layout.post_process(int_data, scale, zero_point)
+        int_data, scale, zero_point = _layout.post_process(
+            int_data,
+            scale,
+            zero_point,
+            block_size,
+        )
 
         tensor_impl_ctr = get_tensor_impl_constructor(type(_layout))
         tensor_impl = tensor_impl_ctr(int_data, scale, zero_point, _layout)


### PR DESCRIPTION
**Summary:** Fixes this error with the static AQT flow:
```
  File "/home/andrewor/local/ao/test/dtypes/test_affine_quantized.py", line 269, in test_to_affine_quantized_intx_static
    to_affine_quantized_intx_static(
  File "/home/andrewor/local/ao/torchao/dtypes/affine_quantized_tensor.py", line 325, in from_hp_to_intx_static
    input_float, scale, zero_point = _layout.pre_process_static(
TypeError: Layout.pre_process_static() missing 1 required positional argument: 'block_size'
```

**Test Plan:**
python test/dtypes/test_affine_quantized.py -k test_to_affine_quantized_intx_static
python tutorials/calibration_flow/static_quant.py