### PR TITLE
Small fix to allowed modules

### DIFF
--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -175,6 +175,7 @@ ALLOWED_AO_MODULES = {
     "torchao.quantization",
     "torchao.sparsity.sparse_api",
     "torchao.prototype.quantization",
+    "torchao.dtypes",
 }
 
 


### PR DESCRIPTION
When loading a model quantized on cpu using `Int4CPULayout` i have the error : 

```
ValueError: Failed to find class Int4CPULayout in any of the allowed modules: torchao.quantization, torchao.sparsity.sparse_api
```
This PR simply adds the `torchao.dtypes` to the list of `ALLOWED_AO_MODULES`. I'm not sure if this was intended or not