### PR TITLE
Remove preserve_zero and zero_point_domain from choose_qparams_affine

### DIFF
--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -556,7 +556,6 @@ def get_group_qparams_symmetric(
         quant_max=quant_max,
         eps=eps,
         scale_dtype=precision,
-        zero_point_dtype=precision,
     )
     return scale.reshape(w.shape[0], -1), zero_point.reshape(w.shape[0], -1)
 


### PR DESCRIPTION
Created newer versions of choose_qparams_affine_* for different combinations of arguments preserve_zero and zero_point_domain. 
Removed the arguments preserve_zero and zero_point_domain from choose_qparams_afffine.

Now the list of choose_qparams_affine is :

