### PR TITLE
Remove zero_point_domain from quant configs

### DIFF
--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -568,7 +568,6 @@ def main(
             from torchao.quantization.granularity import PerAxis, PerGroup
             from torchao.quantization.quant_api import (
                 Int8DynamicActivationIntxWeightConfig,
-                ZeroPointDomain,
             )
 
             # Quantize model
@@ -576,16 +575,15 @@ def main(
             weight_dtype = getattr(torch, f"int{_quant_args[1]}")
             group_size = int(_quant_args[2])
             granularity = PerGroup(group_size) if group_size > 0 else PerAxis(0)
-            has_weight_zeros = bool(_quant_args[3])
+            is_asymmetric = bool(_quant_args[3])
             quantize_(
                 model,
                 Int8DynamicActivationIntxWeightConfig(
                     weight_dtype=weight_dtype,
                     weight_granularity=granularity,
-                    weight_zero_point_domain=ZeroPointDomain.INT
-                    if has_weight_zeros
-                    else ZeroPointDomain.NONE,
-                    weight_mapping_type=MappingType.ASYMMETRIC,
+                    weight_mapping_type=MappingType.ASYMMETRIC
+                    if is_asymmetric
+                    else MappingType.SYMMETRIC,
                     weight_scale_dtype=torch.bfloat16,
                     layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
                 ),

--- a/torchao/dtypes/uintx/packed_linear_int8_dynamic_activation_intx_weight_layout.py
+++ b/torchao/dtypes/uintx/packed_linear_int8_dynamic_activation_intx_weight_layout.py
@@ -156,48 +156,109 @@ class PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl(AQTTensorImpl):
         zero_point: Optional[torch.Tensor],
         layout: Layout,
         bias: Optional[torch.Tensor] = None,
+        *,
+        validate_inputs: bool = True,
     ):
         assert isinstance(layout, PackedLinearInt8DynamicActivationIntxWeightLayout)
-        assert layout.has_params_set(), "PackedLinearInt8DynamicActivationIntxWeightLayout params must be set before calling from_plain"
         assert layout.target in [
             t for t, _ in _TARGET_AND_STR
         ], f"Unexpected target: {layout.target}"
+        assert layout.has_params_set(), "PackedLinearInt8DynamicActivationIntxWeightLayout params must be set before calling from_plain"
 
-        int_types = [torch.int8, torch.int16, torch.int32, torch.int64]
-
-        n, k = int_data.shape
-        assert int_data.dtype in int_types, f"int_data.dtype must be {int_types}"
-        assert k % layout.group_size == 0, "k must be divisible by group_size"
-        int_data = int_data.to(torch.int8)
-
-        assert scale.dtype == torch.float32, "scale must be float32"
-        assert (
-            scale.numel() * layout.group_size == int_data.numel()
-        ), "must have 1 scale per group"
-
-        assert (zero_point is not None) == (
-            layout.has_weight_zeros
-        ), "zero_point being None must be consistent with layout.has_weight_zeros"
-        if zero_point is not None:
-            assert (
-                zero_point.dtype in int_types
-            ), f"zero_point.dtype must be {int_types}"
-            assert (
-                zero_point.numel() * layout.group_size == int_data.numel()
-            ), "must have 1 zero_point per group"
-            zero_point = zero_point.to(torch.int8)
-
-        assert (bias is not None) == (
-            layout.has_bias
-        ), "bias being None must be consistent with layout.has_bias"
-        if bias is not None:
-            assert bias.dtype == torch.float32, "bias.dtype must be float32"
-            assert bias.shape == (n,), "bias must have shape n"
-
-        if layout.target == Target.ATEN:
+        if layout.target != Target.ATEN:
+            _check_torchao_ops_loaded()
+        else:
             assert (
                 TORCH_VERSION_AT_LEAST_2_6
             ), "aten target is requires torch version > 2.6.0"
+            assert (
+                torch.backends.kleidiai.is_available()
+            ), "ATEN target requires torch.backends.kleidiai.is_available()"
+            layout.bit_width == 4, "ATEN target only supports torch.int4"
+            assert not layout.has_weight_zeros, "ATEN target does not support zeros"
+
+        data_dtype = getattr(torch, f"int{layout.bit_width}")
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[data_dtype]
+
+        int_types = [torch.int8, torch.int16, torch.int32, torch.int64]
+
+        # Check int_data
+        assert int_data.device == torch.device("cpu")
+        assert int_data.dtype in int_types
+        n, k = int_data.shape
+        assert k % layout.group_size == 0, "k must be divisible by group_size"
+        if validate_inputs:
+            assert int_data.min().item() >= qmin
+            assert int_data.max().item() <= qmax
+        int_data = int_data.to(torch.int8)
+
+        # Check scale
+        assert scale.device == torch.device("cpu")
+        if scale.dtype != torch.float32:
+            logging.info(f"scale has dtype {scale.dtype}, converting to torch.float32")
+            scale = scale.to(torch.float32)
+        n_, _ = scale.shape
+        assert n_ == n
+        assert (
+            scale.numel() * layout.group_size == int_data.numel()
+        ), "must have 1 scale per group"
+        if validate_inputs:
+            assert scale.min().item() > 0
+            # Some targets round scales to bfloat16, give warning if scales are at higher precision
+            scale_is_rounded_to_bf16 = torch.allclose(
+                scale, scale.to(torch.bfloat16).to(torch.float32)
+            )
+            if not scale_is_rounded_to_bf16:
+                if layout.target == Target.ATEN and (layout.group_size < k):
+                    logging.warning(
+                        "When using Target.ATEN with group_size < k, scales will be rounded to bfloat16"
+                    )
+                if layout.target in [Target.AUTO, Target.KLEIDIAI]:
+                    logging.warning(
+                        "When using [Target.AUTO, Target.KLEIDIAI], scales will be rounded to bfloat16"
+                    )
+
+        # Check zero_point
+        if zero_point is None:
+            assert (
+                not layout.has_weight_zeros
+            ), "zero_point must be provided if has_weight_zeros=True"
+        else:
+            assert zero_point.device == torch.device("cpu")
+            assert zero_point.shape == scale.shape
+            assert zero_point.dtype in int_types
+            assert (
+                zero_point.numel() * layout.group_size == int_data.numel()
+            ), "must have 1 zero_point per group"
+            if validate_inputs:
+                zero_point_min = zero_point.min().item()
+                zero_point_max = zero_point.max().item()
+                assert zero_point.min().item() >= qmin
+                assert zero_point.max().item() <= qmax
+                has_weight_zeros = True
+                if zero_point_min == 0 and zero_point_max == 0:
+                    has_weight_zeros = False
+                assert (
+                    has_weight_zeros == layout.has_weight_zeros
+                ), "zero_point being all zeros must be consistent with layout.has_weight_zeros"
+            zero_point = zero_point.to(torch.int8)
+
+        # Check bias
+        has_bias = bias is not None
+        assert (
+            has_bias == layout.has_bias
+        ), "bias being None must be consistent with layout.has_bias"
+        if has_bias:
+            assert bias.device == torch.device("cpu")
+            if bias.dtype != torch.float32:
+                logging.info(
+                    f"bias has dtype {bias.dtype}, converting to torch.float32"
+                )
+                bias = bias.to(torch.float32)
+            assert bias.shape == (n,)
+
+        # Construct packed_weight
+        if layout.target == Target.ATEN:
             int_data = int_data.add(8)
             int_data = (int_data[::, 1::2] << 4 | int_data[::, ::2]).to(torch.uint8)
 
@@ -213,12 +274,11 @@ class PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl(AQTTensorImpl):
         args = [
             int_data,
             scale.reshape(-1),
-            zero_point.reshape(-1) if zero_point is not None else None,
+            zero_point.reshape(-1) if layout.has_weight_zeros else None,
             layout.group_size,
             bias,
             target_to_str(layout.target) if layout.target != Target.AUTO else None,
         ]
-
         packed_weight = getattr(
             torch.ops.torchao,
             f"_pack_8bit_act_{layout.bit_width}bit_weight",
@@ -358,79 +418,35 @@ def make_packed_linear_int8_dynamic_activation_intx_weight_tensor(
     assert TORCH_VERSION_AT_LEAST_2_6, "Using PackedLinearInt8DynamicActivationIntxWeightLayout requires torch version > 2.6.0"
 
     layout = PackedLinearInt8DynamicActivationIntxWeightLayout(target=target)
-    if layout.target != Target.ATEN:
-        _check_torchao_ops_loaded()
-    else:
-        assert (
-            torch.backends.kleidiai.is_available()
-        ), "ATEN target requires torch.backends.kleidiai.is_available()"
-        assert data_dtype == torch.int4, "ATEN target only supports torch.int4"
-        assert zero_point is None, "ATEN target does not support zeros"
 
-    assert data_dtype in [getattr(torch, f"int{x}") for x in range(1, 9)]
-    qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[data_dtype]
     bit_width = _DTYPE_TO_BIT_WIDTH[data_dtype]
+    qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[data_dtype]
 
-    int_types = [torch.int8, torch.int16, torch.int32, torch.int64]
-
-    # Check int_data
-    assert int_data.device == torch.device("cpu")
-    assert int_data.dtype in int_types
     n, k = int_data.shape
-    if validate_inputs:
-        assert int_data.min().item() >= qmin
-        assert int_data.max().item() <= qmax
-
-    # Check scale
-    assert scale.device == torch.device("cpu")
-    if scale.dtype != torch.float32:
-        logging.info(f"scale has dtype {scale.dtype}, converting to torch.float32")
-        scale = scale.to(torch.float32)
     n_, groups_per_k = scale.shape
-    assert n_ == n
     assert k % groups_per_k == 0
     group_size = k // groups_per_k
-    if validate_inputs:
-        assert scale.min().item() > 0
 
-    if validate_inputs:
-        # Some targets round scales to bfloat16, give warning if scales are at higher precision
-        scale_is_rounded_to_bf16 = torch.allclose(
-            scale, scale.to(torch.bfloat16).to(torch.float32)
-        )
-        if not scale_is_rounded_to_bf16:
-            if layout.target == Target.ATEN and (group_size < k):
-                logging.warning(
-                    "When using Target.ATEN with group_size < k, scales will be rounded to bfloat16"
-                )
-            if layout.target in [Target.AUTO, Target.KLEIDIAI]:
-                logging.warning(
-                    "When using [Target.AUTO, Target.KLEIDIAI], scales will be rounded to bfloat16"
-                )
+    has_weight_zeros = True
+    if zero_point is None:
+        has_weight_zeros = False
+    else:
+        zero_point_min = zero_point.min().item()
+        zero_point_max = zero_point.max().item()
+        if zero_point_min == 0 and zero_point_max == 0:
+            has_weight_zeros = False
 
-    # Check zero_point
-    has_weight_zeros = zero_point is not None
-    if has_weight_zeros:
-        assert zero_point.device == torch.device("cpu")
-        assert zero_point.shape == scale.shape
-        assert zero_point.dtype in int_types
-        if validate_inputs:
-            assert zero_point.min().item() >= qmin
-            assert zero_point.max().item() <= qmax
-
-    # Check bias
     has_bias = bias is not None
-    if has_bias:
-        assert bias.device == torch.device("cpu")
-        if bias.dtype != torch.float32:
-            logging.info(f"bias has dtype {bias.dtype}, converting to torch.float32")
-            bias = bias.to(torch.float32)
-        assert bias.shape == (n,)
 
     layout.set_params(bit_width, group_size, has_weight_zeros, has_bias)
     assert layout.has_params_set()
     tensor_impl = PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl.from_plain(
-        int_data, scale, zero_point, layout, bias
+        int_data,
+        scale,
+        zero_point,
+        layout,
+        bias,
+        validate_inputs=validate_inputs,
     )
 
     return AffineQuantizedTensor(
@@ -439,7 +455,5 @@ def make_packed_linear_int8_dynamic_activation_intx_weight_tensor(
         shape=int_data.shape,
         quant_min=qmin,
         quant_max=qmax,
-        zero_point_domain=ZeroPointDomain.INT
-        if has_weight_zeros
-        else ZeroPointDomain.NONE,
+        zero_point_domain=ZeroPointDomain.INT,
     )

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -62,8 +62,8 @@ class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
             "Int8DynamicActivationIntxWeightConfig has moved from torchao.experimental.quant_api to torchao.quantization.quant_api.\n"
             "Please migrate to using the new version.  The following args are renamed in the new version:\n"
             "* granularity -> weight_granularity\n"
-            "* has_weight_zeros=True -> weight_zero_point_domain=torchao.quantization.quant_api.ZeroPointDomain.INT\n"
-            "* has_weight_zeros=False -> weight_zero_point_domain=torchao.quantization.quant_api.ZeroPointDomain.NONE\n"
+            "* has_weight_zeros=True -> weight_mapping_type=torchao.quantization.quant_api.MappingType.ASYMMETRIC\n"
+            "* has_weight_zeros=False -> weight_zero_point_domain=torchao.quantization.quant_api.MappingType.SYMMETRIC\n"
             "* round_weight_scale_to_bf16=True -> weight_scale_dtype=torch.bfloat16\n"
             "* layout default has changed to QDQLayout().  IF YOU WANT CPU PERFORMANCE, USE layout=PackedLinearInt8DynamicActivationIntxWeightLayout()."
         )

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -41,7 +41,6 @@ from torchao.quantization.quant_api import (
 from torchao.quantization.quant_api import (
     IntxWeightOnlyConfig,
     MappingType,
-    ZeroPointDomain,
     quantize_,
 )
 from torchao.quantization.quant_primitives import _DTYPE_TO_BIT_WIDTH

--- a/torchao/experimental/tests/test_embedding_xbit_quantizer.py
+++ b/torchao/experimental/tests/test_embedding_xbit_quantizer.py
@@ -36,22 +36,19 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         )
         indices = torch.randint(0, num_embeddings, (7,), dtype=torch.int32)
 
-        for weight_dtype in [
-            torch.int1,
-            torch.int2,
-            torch.int3,
-            torch.int4,
-            torch.int5,
-            torch.int6,
-            torch.int7,
-            torch.int8,
-        ]:
-            print(f"Testing weight_dtype={weight_dtype}")
+        for weight_dtype, granularity, mapping_type in zip(
+            list(getattr(torch, f"int{x}") for x in range(1, 9)),
+            [PerGroup(128), PerAxis(0)],
+            [MappingType.ASYMMETRIC, MappingType.SYMMETRIC],
+        ):
+            print(
+                f"Testing weight_dtype={weight_dtype}, granularity={granularity}, mapping_type={mapping_type}"
+            )
             quantized_model = copy.deepcopy(model)
             quantizer = EmbeddingQuantizer(
                 weight_dtype=weight_dtype,
                 granularity=granularity,
-                has_weight_zeros=True,
+                mapping_type=mapping_type,
                 use_fallback=False,
             )
             quantized_model = quantizer.quantize(quantized_model)
@@ -60,7 +57,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
                 reference_quantizer = EmbeddingQuantizer(
                     weight_dtype=weight_dtype,
                     granularity=granularity,
-                    has_weight_zeros=True,
+                    mapping_type=mapping_type,
                     use_fallback=True,
                 )
                 reference_model = copy.deepcopy(model)
@@ -72,6 +69,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
     def test_export_compile_aoti(self):
         weight_dtype = torch.int4
         granularity = PerAxis(0)
+        weight_mapping_type = MappingType.ASYMMETRIC
         embedding_dim = 4096
         num_embeddings = 131
         model = torch.nn.Sequential(
@@ -83,7 +81,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         quantizer = EmbeddingQuantizer(
             weight_dtype=weight_dtype,
             granularity=granularity,
-            has_weight_zeros=True,
+            mapping_type=weight_mapping_type,
             use_fallback=False,
         )
         quantized_model = quantizer.quantize(model)
@@ -116,7 +114,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
 
     def test_shared_embedding(self):
         weight_dtype = torch.int4
-        has_weight_zeros = True
+        weight_mapping_type = MappingType.ASYMMETRIC
         embedding_dim = 4096
         num_embeddings = 131
         embedding = torch.nn.Embedding(num_embeddings, embedding_dim)
@@ -137,16 +135,14 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         EmbeddingQuantizer(
             weight_dtype=weight_dtype,
             granularity=PerAxis(0),
-            has_weight_zeros=has_weight_zeros,
+            mapping_type=weight_mapping_type,
         ).quantize(quantized_model_reference)
         quantize_(
             quantized_model_reference,
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=weight_dtype,
                 weight_granularity=PerAxis(0),
-                weight_mapping_type=MappingType.ASYMMETRIC
-                if has_weight_zeros
-                else MappingType.SYMMETRIC,
+                weight_mapping_type=weight_mapping_type,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="universal"
                 ),
@@ -159,7 +155,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         SharedEmbeddingQuantizer(
             weight_dtype=weight_dtype,
             granularity=PerAxis(0),
-            has_weight_zeros=has_weight_zeros,
+            weight_mapping_type=weight_mapping_type,
         ).quantize(quantized_model)
 
         # Check results are same and weights share the same id

--- a/torchao/experimental/tests/test_embedding_xbit_quantizer.py
+++ b/torchao/experimental/tests/test_embedding_xbit_quantizer.py
@@ -155,7 +155,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         SharedEmbeddingQuantizer(
             weight_dtype=weight_dtype,
             granularity=PerAxis(0),
-            weight_mapping_type=weight_mapping_type,
+            mapping_type=weight_mapping_type,
         ).quantize(quantized_model)
 
         # Check results are same and weights share the same id

--- a/torchao/experimental/tests/test_embedding_xbit_quantizer.py
+++ b/torchao/experimental/tests/test_embedding_xbit_quantizer.py
@@ -22,7 +22,6 @@ from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
     MappingType,
-    ZeroPointDomain,
     quantize_,
 )
 
@@ -145,10 +144,9 @@ class TestEmbeddingQuantizer(unittest.TestCase):
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=weight_dtype,
                 weight_granularity=PerAxis(0),
-                weight_zero_point_domain=ZeroPointDomain.INT
+                weight_mapping_type=MappingType.ASYMMETRIC
                 if has_weight_zeros
-                else ZeroPointDomain.NONE,
-                weight_mapping_type=MappingType.ASYMMETRIC,
+                else MappingType.SYMMETRIC,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="universal"
                 ),

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -355,7 +355,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             "torch.ops.torchao.choose_qparams_affine.default(input_1, 'ASYMMETRIC', [1, 512], torch.int8, None, None, None, torch.float64, torch.int64)",
             "torch.ops.torchao.quantize_affine.default(input_1, [1, 512], getitem, getitem_1, torch.int8)",
             "torch.ops.torchao.dequantize_affine.default(quantize_affine, [1, 512], getitem, getitem_1, torch.int8)",
-            "torch.ops.torchao.dequantize_affine.default(access_subclass_inner_tensor_default_72, [1, 64], access_subclass_inner_tensor_default_73, access_subclass_inner_tensor_default_74, torch.int8, -8, 7)"
+            "torch.ops.torchao.dequantize_affine.default",
             "torch.ops.aten.linear.default(dequantize_affine, dequantize_affine_1)",
         ]
         for line in expected_lines:

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -17,7 +17,6 @@ from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
     MappingType,
-    ZeroPointDomain,
     quantize_,
 )
 
@@ -27,7 +26,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         param(
             layout=layout,
             weight_dtype=weight_dtype,
-            weight_zero_point_domain=weight_zero_point_domain,
+            weight_mapping_type=weight_mapping_type,
             weight_granularity=weight_granularity,
         )
         for layout in [
@@ -44,9 +43,9 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             torch.int7,
             torch.int8,
         ]
-        for weight_zero_point_domain in [
-            ZeroPointDomain.NONE,
-            ZeroPointDomain.INT,
+        for weight_mapping_type in [
+            MappingType.SYMMETRIC,
+            MappingType.ASYMMETRIC,
         ]
         for weight_granularity in [
             PerGroup(128),
@@ -59,7 +58,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         name_func=lambda f, _, params: f.__name__ + f"_{params.kwargs}",
     )
     def test_accuracy(
-        self, layout, weight_dtype, weight_zero_point_domain, weight_granularity
+        self, layout, weight_dtype, weight_mapping_type, weight_granularity
     ):
         """
         Checks the accuracy of packed layouts
@@ -71,7 +70,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         model = torch.nn.Sequential(
             *[torch.nn.Linear(k, k, bias=False), torch.nn.Linear(k, n, bias=True)]
         )
-        weight_mapping_type = MappingType.ASYMMETRIC
 
         # We set round weights to bf16 and set scale dtype to bf16 because
         # some kernels do this internally (e.g., KleidiAI kernels)
@@ -85,7 +83,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=layout,
             ),
@@ -97,8 +94,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
-                weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
             ),
@@ -117,8 +112,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         )
         weight_dtype = torch.int4
         weight_granularity = PerGroup(128)
-        weight_mapping_type = MappingType.ASYMMETRIC
-        weight_zero_point_domain = ZeroPointDomain.NONE
+        weight_mapping_type = MappingType.SYMMETRIC
 
         # KleidiAI kernels round scales to bf16 internally
         model = model.to(torch.bfloat16).to(torch.float32)
@@ -131,7 +125,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="kleidiai"
@@ -146,7 +139,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
             ),
@@ -174,8 +166,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         )
         weight_dtype = torch.int4
         weight_granularity = PerGroup(128)
-        weight_mapping_type = MappingType.ASYMMETRIC
-        weight_zero_point_domain = ZeroPointDomain.NONE
+        weight_mapping_type = MappingType.SYMMETRIC
 
         # We set round_weight_scale_to_bf16 to True for accuracy testing because
         # some KleidiAI kernels do this internally
@@ -189,7 +180,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(target="aten"),
             ),
@@ -202,7 +192,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
             ),
@@ -248,7 +237,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         weight_dtype = torch.int4
         weight_granularity = PerAxis(0)
         weight_mapping_type = MappingType.ASYMMETRIC
-        weight_zero_point_domain = ZeroPointDomain.INT
         layers = [
             torch.nn.Linear(k0, k1, bias=False),
             torch.nn.Linear(k1, k2, bias=True),
@@ -263,7 +251,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=torch.bfloat16,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
             ),
@@ -302,7 +289,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         weight_dtype = torch.int4
         weight_granularity = PerAxis(0)
         weight_mapping_type = MappingType.ASYMMETRIC
-        weight_zero_point_domain = ZeroPointDomain.INT
 
         layers = [
             torch.nn.Linear(k0, k1, bias=False),
@@ -326,7 +312,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                weight_zero_point_domain=weight_zero_point_domain,
                 weight_scale_dtype=torch.bfloat16,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
             ),
@@ -355,7 +340,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=torch.int4,
                 weight_granularity=PerGroup(64),
-                weight_zero_point_domain=ZeroPointDomain.NONE,
+                weight_mapping_type=MappingType.SYMMETRIC,
                 layout=QDQLayout(),
             ),
         )
@@ -370,7 +355,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             "torch.ops.torchao.choose_qparams_affine.default(input_1, 'ASYMMETRIC', [1, 512], torch.int8, None, None, None, torch.float64, torch.int64)",
             "torch.ops.torchao.quantize_affine.default(input_1, [1, 512], getitem, getitem_1, torch.int8)",
             "torch.ops.torchao.dequantize_affine.default(quantize_affine, [1, 512], getitem, getitem_1, torch.int8)",
-            "torch.ops.torchao.dequantize_affine.default(access_subclass_inner_tensor_default_72, [1, 64], access_subclass_inner_tensor_default_73, None, torch.int8, -8, 7, 'NONE')",
+            "torch.ops.torchao.dequantize_affine.default(access_subclass_inner_tensor_default_72, [1, 64], access_subclass_inner_tensor_default_73, access_subclass_inner_tensor_default_74, torch.int8, -8, 7)"
             "torch.ops.aten.linear.default(dequantize_affine, dequantize_affine_1)",
         ]
         for line in expected_lines:

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -94,6 +94,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
+                weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
             ),
@@ -359,7 +360,10 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             "torch.ops.aten.linear.default(dequantize_affine, dequantize_affine_1)",
         ]
         for line in expected_lines:
-            FileCheck().check_count(line, 1, exactly=True).run(
+            count = 1
+            if line == "torch.ops.torchao.dequantize_affine.default":
+                count = 2
+            FileCheck().check_count(line, count, exactly=True).run(
                 exported.graph_module.code
             )
 


### PR DESCRIPTION
ZeroPointDomain will be removed from the quant primitives, so this PR removes it from the configs and instead relies on MappingType to convey similar information.