### PR TITLE
Fix unwrap_tensor_subclass

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -314,6 +314,8 @@ def unwrap_tensor_subclass(model, filter_fn=None):
             and type(child.weight) is not torch.nn.Parameter
             and isinstance(child.weight, torch.Tensor)
             and issubclass(type(child.weight), torch.Tensor)
+            and isinstance(child.weight, TorchAOBaseTensor)
+            and not parametrize.is_parametrized(child)
         ):
             parametrize.register_parametrization(
                 child, "weight", UnwrapTensorSubclass()


### PR DESCRIPTION
unwrap_tensor_subclass fails if called multiple times with error AttributeError: 'UnwrapTensorSubclass' object has no attribute 'rebuild_stack'.

This PR fixes the error by not registering a parametrization on a tensor that has already been unwrapped.