### PR TITLE
Fix compile issues

### DIFF
--- a/torchao/experimental/kernels/cpu/aarch64/benchmarks/benchmark_bitpacking.cpp
+++ b/torchao/experimental/kernels/cpu/aarch64/benchmarks/benchmark_bitpacking.cpp
@@ -27,7 +27,7 @@ template <
     typename pack_8_values_fn_type,
     typename vec_pack_64_values_fn_type,
     typename vec_pack_128_values_fn_type>
-TORCHAO_ALWAYS_INLINE void pack_uint_odd_bit_values(
+TORCHAO_ALWAYS_INLINE inline void pack_uint_odd_bit_values(
     pack_8_values_fn_type pack_8_values_func,
     vec_pack_64_values_fn_type vec_pack_64_values_func,
     vec_pack_128_values_fn_type vec_pack_128_values_func,
@@ -94,7 +94,7 @@ template <
     typename unpack_8_values_fn_type,
     typename vec_unpack_64_values_fn_type,
     typename vec_unpack_128_values_fn_type>
-TORCHAO_ALWAYS_INLINE void unpack_uint_odd_bit_values(
+TORCHAO_ALWAYS_INLINE inline void unpack_uint_odd_bit_values(
     unpack_8_values_fn_type unpack_8_values_func,
     vec_unpack_64_values_fn_type vec_unpack_64_values_func,
     vec_unpack_128_values_fn_type vec_unpack_128_values_func,

--- a/torchao/experimental/kernels/cpu/aarch64/matmul/channelwise_8bit_a_channelwise_8bit_b_1x16x16_f32_smlal-impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/matmul/channelwise_8bit_a_channelwise_8bit_b_1x16x16_f32_smlal-impl.h
@@ -45,7 +45,7 @@ Possibly better to transpose 16x16 of b and use dotprod. Left for future.
 */
 
 template <int lane>
-TORCHAO_ALWAYS_INLINE void block_mul_1x16x1(
+TORCHAO_ALWAYS_INLINE inline void block_mul_1x16x1(
     const int16x4_t& a_vec,
     const int8x16_t& b_vec,
     const int8x16_t& b_zero_point_vec,
@@ -129,7 +129,7 @@ void block_mul_1x16x16(
       vget_high_s16(a_vec_high), b_vec, b_zero_point_vec, partial_sums);
 }
 
-TORCHAO_ALWAYS_INLINE void dequantize_1x16_int32_t(
+TORCHAO_ALWAYS_INLINE inline void dequantize_1x16_int32_t(
     const int32x4_t (&sums)[4],
     const float* lhs_scales,
     const float* rhs_scales,

--- a/torchao/experimental/kernels/cpu/aarch64/matmul/fp32_a_input_channelwise_8bit_b_1x16x4_f32_impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/matmul/fp32_a_input_channelwise_8bit_b_1x16x4_f32_impl.h
@@ -40,7 +40,7 @@ For each int8x16_t of b:
 - By doing the above 4 times (lane=[0-3]), we used all values along k dim of a
   and accumulated 4 float32x4_t values
 */
-TORCHAO_ALWAYS_INLINE void block_mul_1x16x1(
+TORCHAO_ALWAYS_INLINE inline void block_mul_1x16x1(
     const float32_t a,
     const int8x16_t& b_vec,
     const int8_t b_zero_point,

--- a/torchao/experimental/kernels/cpu/aarch64/matmul/fp32_a_input_channelwise_8bit_b_4x16x4_f32_impl.h
+++ b/torchao/experimental/kernels/cpu/aarch64/matmul/fp32_a_input_channelwise_8bit_b_4x16x4_f32_impl.h
@@ -40,7 +40,7 @@ For each int8x16_t of b:
 - By doing the above 4 times (lane=[0-3]), we used all values along k dim of a
   and accumulated 4 float32x4_t values
 */
-TORCHAO_ALWAYS_INLINE void block_mul_4x16x1(
+TORCHAO_ALWAYS_INLINE inline void block_mul_4x16x1(
     const float32x4_t& a,
     const int8x16_t& b_vec,
     const int8_t b_zero_point,
@@ -82,7 +82,7 @@ TORCHAO_ALWAYS_INLINE void block_mul_4x16x1(
   partial_sums[3][3] = vfmaq_n_f32(partial_sums[3][3], b_vec_high_high, a[3]);
 }
 
-TORCHAO_ALWAYS_INLINE void block_mul_4x16x4(
+TORCHAO_ALWAYS_INLINE inline void block_mul_4x16x4(
     const float32_t* a,
     const size_t lda,
     const int8_t* b,

--- a/torchao/experimental/kernels/cpu/aarch64/matmul/matmul_utils.h
+++ b/torchao/experimental/kernels/cpu/aarch64/matmul/matmul_utils.h
@@ -71,7 +71,7 @@ void transpose_4x4(
     const size_t lda,
     float32x4_t (&tranposed)[4]);
 
-TORCHAO_ALWAYS_INLINE void transpose_4x4(
+TORCHAO_ALWAYS_INLINE inline void transpose_4x4(
     const float32_t* a,
     const size_t lda,
     float32x4_t (&tranposed)[4]) {


### PR DESCRIPTION
When trying to bump the torchao pin in ET, I see compile issues related to the new SDPA ops: https://github.com/pytorch/executorch/pull/10142

I think it relates to not including inline after TORCHAO_ALWAYS_INLINE in header files.  In this PR, I searched for all instances of TORCHAO_ALWAYS_INLINE in torchao and added inline after if it is missing. 