### PR TITLE
[scaled grouped mm] add triton kernels for float8 rowwise quantization with per-group/jagged scales

### DIFF
--- a/torchao/prototype/scaled_grouped_mm/kernels/benchmark.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/benchmark.py
@@ -77,9 +77,10 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     input_col_major = input_tensor.clone().detach().t()
 
     # - configure input to be row-major with groups divided along the column dimension,
-    #   mimicking the left operand of grad_weight = grad_output_t @ input
+    #   representing the left operand of grad_weight = grad_output_t @ input
     #   that occurs in the backward pass of the differentiable scaled grouped mm.
-    # - the transposed tensor in col-major format will then mimick the right operand.
+    # - the transposed tensor in col-major format with groups along the row dimension,
+    #    which represents the right operand.
     group_size = input_row_major.shape[1] // config.n_groups
     n_groups = config.n_groups
     offs = torch.arange(

--- a/torchao/prototype/scaled_grouped_mm/kernels/benchmark.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/benchmark.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+# this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
+
+import time
+import itertools
+from dataclasses import dataclass
+from typing import Callable, List
+
+import torch
+from tabulate import tabulate
+from torch import nn
+from torch._inductor.utils import do_bench_using_profiling
+from torch.nn import functional as F
+from tqdm import tqdm
+
+from torchao.prototype.scaled_grouped_mm.scaled_grouped_mm import (
+    _to_2d_jagged_float8_tensor_colwise,
+    _to_2d_jagged_float8_tensor_rowwise,
+)
+from torchao.prototype.scaled_grouped_mm.kernels import (
+    triton_fp8_col_major_jagged_colwise_scales,
+    triton_fp8_row_major_jagged_rowwise_scales,
+)
+
+device = torch.device("cuda")
+
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    high_precision_dtype: torch.dtype
+    input_shape: tuple[int]
+    n_groups: int
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    torch_time_ms: float
+    triton_time_ms: float
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    input_shapes = [(2**8, 4096), (2**12, 4096), (2**16, 4096)]
+    n_groups_list = [4,8,16]
+    high_precision_dtypes = [torch.bfloat16]
+    configs = []
+    for input_shape, n_groups, high_precision_dtype in itertools.product(
+        input_shapes, n_groups_list, high_precision_dtypes
+    ):
+        configs.append(
+            ExperimentConfig(
+                input_shape=input_shape,
+                n_groups=n_groups,
+                high_precision_dtype=high_precision_dtype,
+            )
+        )
+    return configs
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    # define test inputs
+    input_tensor = torch.randn(
+        *config.input_shape,
+        dtype=config.high_precision_dtype,
+        device=device,
+    )
+    input_row_major = input_tensor.clone().detach()
+    input_col_major = input_tensor.clone().detach().t().contiguous().t()
+    m = input_row_major.shape[0]
+    n_groups = config.n_groups
+    offs = torch.arange(m, m * n_groups + 1, m, device=device, dtype=torch.int32)
+
+    def warmup(func, *args, **kwargs):
+        for _ in range(10):
+            func(*args, **kwargs)
+
+    def run_torch(
+        input_row_major: torch.Tensor,
+        input_col_major: torch.Tensor,
+        offs: torch.Tensor
+    ):
+        out_row_major = _to_2d_jagged_float8_tensor_rowwise(
+            input_row_major,
+            offs,
+            target_dtype=torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+        out_col_major = _to_2d_jagged_float8_tensor_colwise(
+            input_col_major,
+            offs,
+            target_dtype=torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+
+    def run_triton(
+        input_row_major: torch.Tensor,
+        input_col_major: torch.Tensor,
+        offs: torch.Tensor
+    ):
+        out_row_major = triton_fp8_row_major_jagged_rowwise_scales(
+            input_row_major,
+            offs,
+            output_dtype=torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+        out_col_major = triton_fp8_col_major_jagged_colwise_scales(
+            input_col_major,
+            offs,
+            output_dtype=torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+
+    # bench torch
+    warmup(run_torch, input_row_major, input_col_major, offs)
+    start_time_ns = time.perf_counter_ns()
+    run_torch(input_row_major, input_col_major, offs)
+    torch_time_ns = time.perf_counter_ns() - start_time_ns
+    torch_time_ms = torch_time_ns * 1e6
+
+    # bench triton
+    warmup(run_triton, input_row_major, input_col_major, offs)
+    start_time_ns = time.perf_counter_ns()
+    run_triton(input_row_major, input_col_major, offs)
+    triton_time_ns = time.perf_counter_ns()
+    triton_time_ms = triton_time_ns * 1e6
+
+    return ExperimentResult(
+        torch_time_ms=torch_time_ms,
+        triton_time_ms=triton_time_ms,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "input_shape",
+        "n_groups",
+        "high_precision_dtype",
+        "torch_time_ms",
+        "triton_time_ms",
+    ]
+    rows = []
+    for experiment in experiments:
+        input_shape = (
+            f"({experiment.config.input_shape[0]}, {experiment.config.input_shape[1]})"
+        )
+        rows.append(
+            [
+                input_shape,
+                experiment.config.n_groups,
+                experiment.config.high_precision_dtype,
+                experiment.result.torch_time_ms,
+                experiment.result.triton_time_ms,
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -182,7 +182,9 @@ def _triton_fp8_row_major_jagged_rowwise_scales(
             block_row_offs[:, None] * stride_input_row
             + block_col_offs[None, :] * stride_input_col
         )
-        block_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < group_col_end_idx)
+        block_mask = (block_row_offs[:, None] < M) & (
+            block_col_offs[None, :] < group_col_end_idx
+        )
         data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
             input_dtype
         )

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -1,0 +1,348 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Triton kernels for scaling high precision tensors to float8.
+"""
+import itertools
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from torchao.prototype.scaled_grouped_mm.utils import _is_column_major
+
+EPS = 1e-12
+
+FP8_DTYPE_MAP = {
+    torch.int8: tl.int8,
+    torch.int16: tl.int16,
+    torch.int32: tl.int32,
+    torch.int64: tl.int64,
+    torch.float8_e4m3fn: tl.float8e4nv,
+    torch.float8_e5m2: tl.float8e5,
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+    torch.float32: tl.float32,
+    torch.float64: tl.float64,
+}
+
+block_sizes = [128, 256]
+kernel_configs_2D = [
+    triton.Config({"BLOCK_SIZE_ROWS": block_size_rows, "BLOCK_SIZE_COLS": block_size_cols})
+    for block_size_rows in block_sizes
+    for block_size_cols in block_sizes
+]
+
+
+def triton_fp8_row_major_jagged_rowwise_scales(
+    hp_tensor: torch.Tensor,
+    offsets: torch.Tensor,
+    output_dtype: torch.dtype = torch.float8_e4m3fn,
+    round_scales_to_power_of_2: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Converts a high precision tensor to a float8 tensor is row-major memory layout,
+    using 'jagged' rowwise scales (i.e., separate scales for each group/subtensor as
+    determined by the offsets).
+
+    Args:
+        - hp_tensor: 2D high precision tensor to be converted
+        - fp8_dtype: desired fp8 dtype
+        - offsets: end index for each group/subtensor along dim 1
+    Returns:
+        - float8 tensor
+        - jagged rowwise scales (i.e., rowwise scales for each group)
+    """
+    assert hp_tensor.ndim == 2, "input tensor must be 2D"
+    assert hp_tensor.is_contiguous(), "input tensor must be contiguous"
+
+    num_elements = hp_tensor.numel()
+    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+
+    fp8_dtype_min = torch.finfo(output_dtype).min
+    fp8_dtype_max = torch.finfo(output_dtype).max
+
+    m, k = hp_tensor.shape
+    n_groups = offsets.numel()
+
+    # perform fp8 conversion
+    output_buffer = torch.empty_like(
+        hp_tensor, dtype=output_dtype, device=hp_tensor.device
+    )
+    scales_buffer = torch.empty(
+        (m * n_groups), dtype=torch.float32, device=hp_tensor.device
+    )
+
+    # parallelize across rows and groups (offsets)
+    grid = lambda meta: (
+        triton.cdiv(m, meta["BLOCK_SIZE_ROWS"]),
+        offsets.numel(),
+    )
+    _triton_fp8_row_major_jagged_rowwise_scales[grid](
+        hp_tensor,
+        offsets,
+        output_buffer,
+        scales_buffer,
+        m,
+        k,
+        hp_tensor.stride(0),
+        hp_tensor.stride(1),
+        output_buffer.stride(0),
+        output_buffer.stride(1),
+        num_elements,
+        fp8_dtype_min,
+        fp8_dtype_max,
+        tl_input_dtype,
+        tl_output_dtype,
+        round_scales_to_power_of_2,
+        EPS=EPS,
+    )
+    return output_buffer, scales_buffer
+
+
+@triton.autotune(configs=kernel_configs_2D, key=["num_elements"])
+@triton.jit
+def _triton_fp8_row_major_jagged_rowwise_scales(
+    input_ptr,
+    offsets_ptr,
+    out_ptr,
+    scales_ptr,
+    M: int,
+    K: int,
+    stride_input_row: int,
+    stride_input_col: int,
+    stride_output_row: int,
+    stride_output_col: int,
+    num_elements: int,
+    fp8_dtype_min: tl.constexpr,
+    fp8_dtype_max: tl.constexpr,
+    input_dtype: tl.constexpr,
+    output_dtype: tl.constexpr,
+    round_scales_to_power_of_2: tl.constexpr,
+    BLOCK_SIZE_ROWS: tl.constexpr,
+    BLOCK_SIZE_COLS: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    # parallel across rows and groups (offsets)
+    block_row_id = tl.program_id(axis=0)
+    offset_idx = tl.program_id(axis=1)
+
+    # determine start and end column idx for this group
+    block_row_offs = block_row_id * BLOCK_SIZE_ROWS + tl.arange(0, BLOCK_SIZE_ROWS)
+    group_col_start_idx = tl.load(
+        offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
+    )
+    group_col_end_idx = tl.load(offsets_ptr + offset_idx)
+
+    # compute rowwise amaxes for this group
+    amax_buffer = tl.zeros((BLOCK_SIZE_ROWS,), dtype=tl.float64)
+    for col_start_idx in range(group_col_start_idx, group_col_end_idx, BLOCK_SIZE_COLS):
+        block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_COLS)
+        block_offs = (
+            block_row_offs[:, None] * stride_input_row
+            + block_col_offs[None, :] * stride_input_col
+        )
+        block_mask = (block_row_offs[:, None] < M) & (
+            block_col_offs[None, :] < group_col_end_idx
+        )
+        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+            input_dtype
+        )
+        amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=1))
+
+    # compute rowwise scales for this group. round scales to nearest power of 2.
+    scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
+        tl.float32
+    )
+    if round_scales_to_power_of_2:
+        scales = tl.exp2(tl.floor(tl.log2(scales)))
+
+    # store rowwise scales for each group in contiguous memory:
+    # [group0_row0, group_0_row1, ..., group2_row0, group2_row1]
+    scales_offs = block_row_offs + (M * offset_idx)
+    scales_mask = tl.arange(0, BLOCK_SIZE_ROWS) < M
+    tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
+
+    # perform float8 conversion for this group
+    for col_start_idx in range(group_col_start_idx, group_col_end_idx, BLOCK_SIZE_COLS):
+        block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_COLS)
+        block_offs = (
+            block_row_offs[:, None] * stride_input_row
+            + block_col_offs[None, :] * stride_input_col
+        )
+        block_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < K)
+        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+            input_dtype
+        )
+        scaled_data = data * scales[:, None]
+        fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
+            output_dtype
+        )
+        out_offs = (
+            block_row_offs[:, None] * stride_output_row
+            + block_col_offs[None, :] * stride_output_col
+        )
+        out_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < K)
+        tl.store(out_ptr + out_offs, fp8_data, mask=out_mask)
+
+
+def triton_fp8_col_major_jagged_colwise_scales(
+    hp_tensor: torch.Tensor,
+    offsets: torch.Tensor,
+    output_dtype: torch.dtype = torch.float8_e4m3fn,
+    round_scales_to_power_of_2: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Converts a high precision tensor to a float8 tensor is row-major memory layout,
+    using 'jagged' column-wise scales (i.e., separate scales for each group/subtensor as
+    determined by the offsets).
+
+    Args:
+        - hp_tensor: 2D high precision tensor to be converted
+        - fp8_dtype: desired fp8 dtype
+        - offsets: end index for each group/subtensor along dim 0
+    Returns:
+        - float8 tensor
+        - jagged column-wise scales (i.e., column-wise scales for each group)
+    """
+    assert hp_tensor.ndim == 2, "input tensor must be 2D"
+    assert _is_column_major(hp_tensor), "input tensor must be column-major"
+
+    num_elements = hp_tensor.numel()
+    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+
+    fp8_dtype_min = torch.finfo(output_dtype).min
+    fp8_dtype_max = torch.finfo(output_dtype).max
+
+    k, n = hp_tensor.shape
+    n_groups = offsets.numel()
+
+    # perform fp8 conversion
+    output_buffer = torch.empty_like(
+        hp_tensor, dtype=output_dtype, device=hp_tensor.device
+    )
+    scales_buffer = torch.empty(
+        (n * n_groups), dtype=torch.float32, device=hp_tensor.device
+    )
+
+    # parallelize across columns and groups (offsets)
+    grid = lambda meta: (
+        triton.cdiv(n, meta["BLOCK_SIZE_COLS"]),
+        offsets.numel(),
+    )
+    _triton_fp8_col_major_jagged_colwise_scales[grid](
+        hp_tensor,
+        offsets,
+        output_buffer,
+        scales_buffer,
+        k,
+        n,
+        hp_tensor.stride(0),
+        hp_tensor.stride(1),
+        output_buffer.stride(0),
+        output_buffer.stride(1),
+        num_elements,
+        fp8_dtype_min,
+        fp8_dtype_max,
+        tl_input_dtype,
+        tl_output_dtype,
+        round_scales_to_power_of_2,
+        EPS=EPS,
+    )
+    return output_buffer, scales_buffer
+
+
+@triton.autotune(configs=kernel_configs_2D, key=["num_elements"])
+@triton.jit
+def _triton_fp8_col_major_jagged_colwise_scales(
+    input_ptr,
+    offsets_ptr,
+    out_ptr,
+    scales_ptr,
+    K: int,
+    N: int,
+    stride_input_row: int,
+    stride_input_col: int,
+    stride_output_row: int,
+    stride_output_col: int,
+    num_elements: int,
+    fp8_dtype_min: tl.constexpr,
+    fp8_dtype_max: tl.constexpr,
+    input_dtype: tl.constexpr,
+    output_dtype: tl.constexpr,
+    round_scales_to_power_of_2: tl.constexpr,
+    BLOCK_SIZE_ROWS: tl.constexpr,
+    BLOCK_SIZE_COLS: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    # parallel across columns and groups (offsets)
+    block_col_id = tl.program_id(axis=0)
+    offset_idx = tl.program_id(axis=1)
+
+    # determine start and end row idx for this group
+    block_col_offs = block_col_id * BLOCK_SIZE_COLS + tl.arange(0, BLOCK_SIZE_COLS)
+    group_row_start_idx = tl.load(
+        offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
+    )
+    group_row_end_idx = tl.load(offsets_ptr + offset_idx)
+
+    # compute colwise amaxes for this group
+    amax_buffer = tl.zeros((BLOCK_SIZE_COLS,), dtype=tl.float64)
+    for row_start_idx in range(group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ROWS):
+        block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ROWS)
+        block_offs = (
+            block_row_offs[:, None] * stride_input_row
+            + block_col_offs[None, :] * stride_input_col
+        )
+        block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
+            block_col_offs[None, :] < N
+        )
+        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+            input_dtype
+        )
+        amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=0))
+
+    # compute rowwise scales for this group.
+    scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
+        tl.float32
+    )
+    if round_scales_to_power_of_2:
+        scales = tl.exp2(tl.floor(tl.log2(scales)))
+
+    # store colwise scales for each group in contiguous memory:
+    # [group0_col0, group_0_col1, ..., group2_col0, group2_col1]
+    # note: input tensor is in col-major memory layout.
+    scales_offs = block_col_offs + (N * offset_idx)
+    scales_mask = tl.arange(0, BLOCK_SIZE_COLS) < N
+    tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
+
+    # perform float8 conversion for this group
+    for row_start_idx in range(group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ROWS):
+        block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ROWS)
+        block_offs = (
+            block_row_offs[:, None] * stride_input_row
+            + block_col_offs[None, :] * stride_input_col
+        )
+        block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
+            block_col_offs[None, :] < N
+        )
+        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+            input_dtype
+        )
+        scaled_data = data * scales[None, :]
+        fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
+            output_dtype
+        )
+        out_offs = (
+            block_row_offs[:, None] * stride_output_row
+            + block_col_offs[None, :] * stride_output_col
+        )
+        out_mask = (block_row_offs[:, None] < K) & (block_col_offs[None, :] < N)
+        tl.store(out_ptr + out_offs, fp8_data, mask=out_mask)

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -182,7 +182,7 @@ def _triton_fp8_row_major_jagged_rowwise_scales(
             block_row_offs[:, None] * stride_input_row
             + block_col_offs[None, :] * stride_input_col
         )
-        block_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < K)
+        block_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < group_col_end_idx)
         data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
             input_dtype
         )
@@ -194,8 +194,7 @@ def _triton_fp8_row_major_jagged_rowwise_scales(
             block_row_offs[:, None] * stride_output_row
             + block_col_offs[None, :] * stride_output_col
         )
-        out_mask = (block_row_offs[:, None] < M) & (block_col_offs[None, :] < K)
-        tl.store(out_ptr + out_offs, fp8_data, mask=out_mask)
+        tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)
 
 
 def triton_fp8_col_major_jagged_colwise_scales(
@@ -352,5 +351,4 @@ def _triton_fp8_col_major_jagged_colwise_scales(
             block_row_offs[:, None] * stride_output_row
             + block_col_offs[None, :] * stride_output_col
         )
-        out_mask = (block_row_offs[:, None] < K) & (block_col_offs[None, :] < N)
-        tl.store(out_ptr + out_offs, fp8_data, mask=out_mask)
+        tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -140,11 +140,11 @@ def _triton_fp8_row_major_jagged_rowwise_scales(
     offset_idx = tl.program_id(axis=1)
 
     # determine start and end column idx for this group
-    block_row_offs = block_row_id * BLOCK_SIZE_ROWS + tl.arange(0, BLOCK_SIZE_ROWS)
     group_col_start_idx = tl.load(
         offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
     )
     group_col_end_idx = tl.load(offsets_ptr + offset_idx)
+    block_row_offs = block_row_id * BLOCK_SIZE_ROWS + tl.arange(0, BLOCK_SIZE_ROWS)
 
     # compute rowwise amaxes for this group
     amax_buffer = tl.zeros((BLOCK_SIZE_ROWS,), dtype=tl.float64)
@@ -295,11 +295,11 @@ def _triton_fp8_col_major_jagged_colwise_scales(
     offset_idx = tl.program_id(axis=1)
 
     # determine start and end row idx for this group
-    block_col_offs = block_col_id * BLOCK_SIZE_COLS + tl.arange(0, BLOCK_SIZE_COLS)
     group_row_start_idx = tl.load(
         offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
     )
     group_row_end_idx = tl.load(offsets_ptr + offset_idx)
+    block_col_offs = block_col_id * BLOCK_SIZE_COLS + tl.arange(0, BLOCK_SIZE_COLS)
 
     # compute colwise amaxes for this group
     amax_buffer = tl.zeros((BLOCK_SIZE_COLS,), dtype=tl.float64)

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -50,14 +50,16 @@ def triton_fp8_row_major_jagged_rowwise_scales(
     round_scales_to_power_of_2: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
-    Converts a high precision tensor to a float8 tensor is row-major memory layout,
+    Converts a high precision tensor to a float8 tensor in row-major memory layout,
     using 'jagged' rowwise scales (i.e., separate scales for each group/subtensor as
     determined by the offsets).
 
     Args:
         - hp_tensor: 2D high precision tensor to be converted
-        - fp8_dtype: desired fp8 dtype
-        - offsets: end index for each group/subtensor along dim 1
+        - offsets: end index for each group/subtensor along dim 0
+        - output_dtype: desired float8 dtype for the output tensor
+        - round_scales_to_power_of_2: boolean indicating if scales should be rounded
+            down to the nearest power of 2.
     Returns:
         - float8 tensor
         - jagged rowwise scales (i.e., rowwise scales for each group)
@@ -75,7 +77,7 @@ def triton_fp8_row_major_jagged_rowwise_scales(
     m, k = hp_tensor.shape
     n_groups = offsets.numel()
 
-    # perform fp8 conversion
+    # allocate on-device buffers for output and scales
     output_buffer = torch.empty_like(
         hp_tensor, dtype=output_dtype, device=hp_tensor.device
     )
@@ -203,14 +205,16 @@ def triton_fp8_col_major_jagged_colwise_scales(
     round_scales_to_power_of_2: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
-    Converts a high precision tensor to a float8 tensor is row-major memory layout,
+    Converts a high precision tensor to a float8 tensor in row-major memory layout,
     using 'jagged' column-wise scales (i.e., separate scales for each group/subtensor as
     determined by the offsets).
 
     Args:
         - hp_tensor: 2D high precision tensor to be converted
-        - fp8_dtype: desired fp8 dtype
         - offsets: end index for each group/subtensor along dim 0
+        - output_dtype: desired float8 dtype for the output tensor
+        - round_scales_to_power_of_2: boolean indicating if scales should be rounded
+            down to the nearest power of 2.
     Returns:
         - float8 tensor
         - jagged column-wise scales (i.e., column-wise scales for each group)
@@ -228,7 +232,7 @@ def triton_fp8_col_major_jagged_colwise_scales(
     k, n = hp_tensor.shape
     n_groups = offsets.numel()
 
-    # perform fp8 conversion
+    # allocate on-device buffers for output and scales
     output_buffer = torch.empty_like(
         hp_tensor, dtype=output_dtype, device=hp_tensor.device
     )

--- a/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/jagged_float8_scales.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Triton kernels for scaling high precision tensors to float8.
+Triton kernels for scaling high precision tensors to float8 using "jagged"
+rowwise scales (i.e., separate scales for each group/subtensor as determined by
+the offsets).
 """
-import itertools
+
 from typing import Tuple
 
 import torch
@@ -33,7 +35,9 @@ FP8_DTYPE_MAP = {
 
 block_sizes = [128, 256]
 kernel_configs_2D = [
-    triton.Config({"BLOCK_SIZE_ROWS": block_size_rows, "BLOCK_SIZE_COLS": block_size_cols})
+    triton.Config(
+        {"BLOCK_SIZE_ROWS": block_size_rows, "BLOCK_SIZE_COLS": block_size_cols}
+    )
     for block_size_rows in block_sizes
     for block_size_cols in block_sizes
 ]

--- a/torchao/prototype/scaled_grouped_mm/kernels/test_jagged_float8_scales.py
+++ b/torchao/prototype/scaled_grouped_mm/kernels/test_jagged_float8_scales.py
@@ -1,0 +1,72 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchao.prototype.scaled_grouped_mm.kernels.jagged_float8_scales import (
+    triton_fp8_col_major_jagged_colwise_scales,
+    triton_fp8_row_major_jagged_rowwise_scales,
+)
+from torchao.prototype.scaled_grouped_mm.scaled_grouped_mm import (
+    _to_2d_jagged_float8_tensor_colwise,
+    _to_2d_jagged_float8_tensor_rowwise,
+)
+from torchao.prototype.scaled_grouped_mm.utils import _is_column_major
+
+
+@pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
+def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
+    # tests case where rowwise scales are computed for multiple distinct subtensors,
+    # with end boundary of each group is determine by their end column indexes (offsets).
+    device = "cuda"
+    m, k, n_groups = 256, 256, 4
+    x = torch.randn(m, k * n_groups, device=device)
+    colwise_offs = torch.arange(k, k * n_groups + 1, k, device=device)
+
+    # compute reference with torch impl
+    ref_fp8_data, ref_scales = _to_2d_jagged_float8_tensor_rowwise(
+        x,
+        colwise_offs,
+        target_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
+    )
+    kernel_fp8_data, kernel_scales = triton_fp8_row_major_jagged_rowwise_scales(
+        x,
+        colwise_offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
+    )
+    assert torch.eq(ref_fp8_data, kernel_fp8_data).all(), "fp8 data not equal"
+    assert torch.eq(ref_scales, kernel_scales).all(), "scales not equal"
+    assert not _is_column_major(kernel_fp8_data), "fp8 data is not row major"
+
+
+@pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
+def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: bool):
+    # tests case where colwise scales are computed for multiple distinct subtensors,
+    # with end boundary of each group is determine by their end row indexes (offsets).
+    device = "cuda"
+    m, k, n_groups = 256, 256, 4
+    x = torch.randn(m * n_groups, k, device=device).t().contiguous().t()
+    rowwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
+
+    # compute reference with torch impl
+    ref_fp8_data, ref_scales = _to_2d_jagged_float8_tensor_colwise(
+        x,
+        rowwise_offs,
+        target_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
+    )
+    kernel_fp8_data, kernel_scales = triton_fp8_col_major_jagged_colwise_scales(
+        x,
+        rowwise_offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
+    )
+    assert torch.eq(ref_fp8_data, kernel_fp8_data).all(), "fp8 data not equal"
+    assert torch.eq(ref_scales, kernel_scales).all(), "scales not equal"
+    assert _is_column_major(kernel_fp8_data), "fp8 data is not column major"

--- a/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py
+++ b/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py
@@ -54,26 +54,26 @@ class _Float8GroupedMM(torch.autograd.Function):
         assert A.ndim == 2, "A must be 2D"
         assert B_t.ndim == 3, "B must be 3D"
 
-        assert A.size(-1) % 16 == 0, (
-            f"A must have a last dim divisible by 16, but got shape: {A.shape}"
-        )
-        assert B_t.size(-2) % 16 == 0 and B_t.size(-1) % 16 == 0, (
-            f"B must have last 2 dims divisible by 16, but got shape: {B_t.shape}"
-        )
+        assert (
+            A.size(-1) % 16 == 0
+        ), f"A must have a last dim divisible by 16, but got shape: {A.shape}"
+        assert (
+            B_t.size(-2) % 16 == 0 and B_t.size(-1) % 16 == 0
+        ), f"B must have last 2 dims divisible by 16, but got shape: {B_t.shape}"
 
         # Assert input tensors are in high-precision dtypes.
-        assert A.dtype == torch.float32 or A.dtype == torch.bfloat16, (
-            "A must be float32 or bfloat16"
-        )
-        assert B_t.dtype == torch.float32 or B_t.dtype == torch.bfloat16, (
-            "B must be float32 or bfloat16"
-        )
+        assert (
+            A.dtype == torch.float32 or A.dtype == torch.bfloat16
+        ), "A must be float32 or bfloat16"
+        assert (
+            B_t.dtype == torch.float32 or B_t.dtype == torch.bfloat16
+        ), "B must be float32 or bfloat16"
         assert offs.dtype == torch.int32, "offs must be int32"
 
         # Assert A and B dims are compatible for a scaled grouped GEMM.
-        assert A.size(-1) == B_t.size(-2), (
-            f"shape {A.shape} and {B_t.shape} are not compatible for _scaled_grouped_mm"
-        )
+        assert A.size(-1) == B_t.size(
+            -2
+        ), f"shape {A.shape} and {B_t.shape} are not compatible for _scaled_grouped_mm"
 
         # The left operand in the scaled grouped GEMM must be row-major due to hardware requirements.
         assert not _is_column_major(A), "A must be row-major"

--- a/torchao/prototype/scaled_grouped_mm/test_scaled_grouped_mm.py
+++ b/torchao/prototype/scaled_grouped_mm/test_scaled_grouped_mm.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import pytest
 import torch
 

--- a/torchao/prototype/scaled_grouped_mm/utils.py
+++ b/torchao/prototype/scaled_grouped_mm/utils.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+
+def _is_column_major(x: torch.Tensor) -> bool:
+    """
+    This function checks if the input tensor is column-major.
+
+    Args:
+        x (torch.Tensor): The input tensor to be checked.
+
+    Returns:
+        A boolean indicating whether the input tensor is column-major.
+    """
+    assert x.ndim == 2 or x.ndim == 3, "input tensor must be 2D or 3D"
+    return x.stride(-2) == 1 and x.stride(-1) > 1


### PR DESCRIPTION
Next PR in stack: https://github.com/pytorch/ao/pull/2077

## Motivation
- In the first iteration of the differentiable scaled grouped mm prototype, to perform float8 quantization with per-group/"jagged" scales, we naively iterate through the offsets on the CPU in for loop, launching separate scaling kernels for each subtensor (see [here](https://github.com/pytorch/ao/blob/a61e3024e220753d592cff9ef2d77c104fde1609/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py#L253)). This approach requires host-device sync, to loop over the values via `offs.tolist()` on the CPU, which negatively impacts performance.
- Solution: do all of this in a single triton kernel to avoid host-device sync and improve performance.

## Summary

This PR adds 2 Triton kernels:
- `_triton_fp8_row_major_jagged_rowwise_scales`: performs dynamic float8 quantization with row-wise scales for each group (as determined by the offsets), and writes the output in row-major memory layout. This kernel is to be used for quantizing left operand of the scaled grouped mm in the backward pass of the differentiable scaled grouped mm, to compute `grad_weight` (see [here](https://github.com/pytorch/ao/blob/a61e3024e220753d592cff9ef2d77c104fde1609/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py#L184-L191)).
- `_triton_fp8_col_major_jagged_colwise_scales`: performs dynamic float8 quantization with row-wise scales *computed over logical columns* for each group (as determined by the offsets), and writes the output in col-major memory layout. This kernel is to be used for quantization of the right operand of the scaled grouped mm in the backward pass of the differentiable scaled grouped mm, to compute `grad_weight` (see [here](https://github.com/pytorch/ao/blob/a61e3024e220753d592cff9ef2d77c104fde1609/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py#L192-L197)).

## Test plan
- Added unit tests confirming triton kernels produce same outputs as corresponding pure pytorch implementations.

## Performance
- Adding a benchmark script which compares **compiled torch native code** versus **triton kernels** for the float8 quantization w/ per-group scales. 
- To be clear, this does NOT benchmark the e2e differentiable scaled grouped mm, just the quantization of these 2D tensors with per-group scales.
- The benchmark measures the wall clock time in microseconds to perform [both conversions](https://github.com/pytorch/ao/blob/7fa9c69dc0999023add31d000d4750e0ac2cd799/torchao/prototype/scaled_grouped_mm/scaled_grouped_mm.py#L182-L197) needed for the `grad_weight = grad_output_t @ input` in the backward pass.
- Initial perf numbers are below and show huge speedups, by avoiding the slow host-device sync necessary in the torch native code:
```
input_shape      n_groups  high_precision_dtype      torch_time_us    triton_time_us
-------------  ----------  ----------------------  ---------------  ----------------
(256, 4096)             4  torch.bfloat16                  1109.9             82.133
(256, 4096)             8  torch.bfloat16                  2369.09            84.036
(256, 4096)            16  torch.bfloat16                  4469.31            82.534
(4096, 4096)            4  torch.bfloat16                  1289.95            88.023
(4096, 4096)            8  torch.bfloat16                  2358.04            88.563
(4096, 4096)           16  torch.bfloat16                  4430.14            84.527
(65536, 4096)           4  torch.bfloat16                  7810.48            83.115
(65536, 4096)           8  torch.bfloat16                  8658.81            85.899
(65536, 4096)          16  torch.bfloat16                 10339.6             85.017
```

## Next steps
- Measure e2e differentiable scaled grouped mm perf with vs without these changes
- Integrate the triton kernels into the autograd func
- Do any additional perf improvements as necessary
- Add JaggedFloat8Tensor subclass w/ override for torch._grouped_mm (bf16 op)
- Add user-facing prototype API for converting MoE layers to use float8 training