### PR TITLE
ROCm mx-fp8 Gemm

### DIFF
--- a/torchao/prototype/mx_formats/README.md
+++ b/torchao/prototype/mx_formats/README.md
@@ -1,7 +1,7 @@
 # MX training and inference with native PyTorch
 
 This is a workflow for e2e training and inference with MX dtypes from the [MX OCP spec](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) 
-in native PyTorch.  We are currently in prototype and are actively working on optimizing these workflows on the NVIDIA B200 hardware.
+in native PyTorch.  We are currently in prototype and are actively working on optimizing these workflows on the NVIDIA B200 and AMD MI355x hardware.
 
 ## Overall status
 
@@ -28,6 +28,9 @@ from torchao.prototype.mx_formats import MXLinearConfig, MXGemmKernelChoice
 # on NVIDIA Blackwell GPUs, you can use cuBLAS or CUTLASS mxfp8 kernels
 gemm_kernel_choice = MXGemmKernelChoice.CUBLAS
 # gemm_kernel_choice = MXGemmKernelChoice.CUTLASS
+
+# on AMD MI355x GPUs with ROCm 6.5+ and gfx950, you can use HIPBLASLT mxfp8 kernels
+# gemm_kernel_choice = MXGemmKernelChoice.HIPBLASLT
 
 # on older NVIDIA gpus, you can run training with emulated MX gemm
 # gemm_kernel_choice = MXGemmKernelChoice.EMULATED
@@ -96,6 +99,8 @@ on supported hardware, you can run the following command:
 > python benchmarks/float8/bench_matmul.py --recipe mxfp8_cublas
 // example output: https://gist.github.com/vkuzo/a1ddb782e6e1c2aef0c726b3df99efbc
 ```
+
+On AMD MI355x GPUs with ROCm 6.5+ and gfx950, we use HIPBLASLT for mxfp8 gemm. We are actively working on optimizing the end-to-end performance for AMD hardware.
 
 ## to_mx cast across dim0 and dim1
 

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -33,12 +33,16 @@ class MXGemmKernelChoice(Enum):
     # note: torch.compile does not work yet, see https://github.com/pytorch/pytorch/issues/147873
     CUBLAS = "cublas"
 
+    # available only on ROCm with HIPBLASLT support
+    HIPBLASLT = "hipblaslt"
+
 
 # Pre-made recipes for common configurations
 class MXLinearRecipeName(Enum):
     MXFP8_EMULATED = "mxfp8_emulated"
     MXFP8_CUBLAS = "mxfp8_cublas"
     MXFP8_CUTLASS = "mxfp8_cutlass"
+    MXFP8_HIPBLASLT = "mxfp8_hipblaslt"
     MXFP4_EMULATED = "mxfp4_emulated"
     MXFP4_CUTLASS = "mxfp4_cutlass"
 
@@ -66,6 +70,15 @@ def _validate_gemm_kernel_choice(gemm_kernel_choice, block_size, elem_dtype):
         assert (
             elem_dtype in valid_dtypes
         ), f"elem_dtype must be one of {valid_dtypes} to use the CUTLASS MX gemm kernels, got {elem_dtype}"
+    elif gemm_kernel_choice == MXGemmKernelChoice.HIPBLASLT:
+        assert (
+            block_size == 32
+        ), f"block_size must be 32 to use the HIPBLASLT MX gemm kernels, got {block_size}"
+        valid_dtypes = [torch.float8_e4m3fn]
+        assert (
+            elem_dtype in valid_dtypes
+        ), f"elem_dtype must be one of {valid_dtypes} to use the HIPBLASLT MX gemm kernels, got {elem_dtype}"
+        assert torch.version.hip is not None, "HIPBLASLT requires ROCm"
 
 
 @dataclass
@@ -128,6 +141,8 @@ class MXLinearConfig(AOBaseConfig):
             return MXLinearConfig(gemm_kernel_choice=MXGemmKernelChoice.CUBLAS)
         elif recipe_name is MXLinearRecipeName.MXFP8_CUTLASS:
             return MXLinearConfig(gemm_kernel_choice=MXGemmKernelChoice.CUTLASS)
+        elif recipe_name is MXLinearRecipeName.MXFP8_HIPBLASLT:
+            return MXLinearConfig(gemm_kernel_choice=MXGemmKernelChoice.HIPBLASLT)
         elif recipe_name is MXLinearRecipeName.MXFP4_EMULATED:
             return MXLinearConfig(elem_dtype=DTYPE_FP4)
         elif recipe_name is MXLinearRecipeName.MXFP4_CUTLASS:


### PR DESCRIPTION
TLDR: This pull request introduces support for AMD MI355x GPUs with HIPBLASLT kernels in the MX formats prototype. Note that this feature requires ROCm 6.5+ and gfx950

alongside several updates to improve compatibility and functionality for these GPUs. Key changes include updates to configuration options, validation logic, and GEMM kernel handling to integrate HIPBLASLT support.

### AMD MI355x GPU Support:

* `torchao/prototype/mx_formats/config.py`:
  - Added `HIPBLASLT` as a new `MXGemmKernelChoice` and included it in the `MXLinearRecipeName` for configuration presets. [[1]](diffhunk://#diff-05c537ef22a531be133da1afcbf0b4b348f0c33592ef05ce2bb39644b32874b8R36-R45) [[2]](diffhunk://#diff-05c537ef22a531be133da1afcbf0b4b348f0c33592ef05ce2bb39644b32874b8R144-R145)
  - Updated `_validate_gemm_kernel_choice` to include validation logic for `HIPBLASLT`, ensuring proper block size, data type, and ROCm availability.

* `torchao/prototype/mx_formats/mx_ops.py`:
  - Extended `mx_mm` to support `HIPBLASLT` for scaled matrix multiplication and real GEMM operations. [[1]](diffhunk://#diff-3d920d96f63a7e78236d4553d97fba0d6b6cd4fbfc71e8bdd730514e0b62be79L78-R85) [[2]](diffhunk://#diff-3d920d96f63a7e78236d4553d97fba0d6b6cd4fbfc71e8bdd730514e0b62be79L91-R102)
  - Adjusted error messaging for unsupported kernel choices in FP4 operations.

### Documentation Updates:

* `torchao/prototype/mx_formats/README.md`:
  - Updated the README to reflect AMD MI355x GPU support, including instructions for using HIPBLASLT kernels and ongoing optimization efforts for AMD hardware. [[1]](diffhunk://#diff-9a8d52ef538e0067ca1e6c1ba8ca71bbfc154602acaccfda3520bdb119e874f6L4-R4) [[2]](diffhunk://#diff-9a8d52ef538e0067ca1e6c1ba8ca71bbfc154602acaccfda3520bdb119e874f6R32-R34) [[3]](diffhunk://#diff-9a8d52ef538e0067ca1e6c1ba8ca71bbfc154602acaccfda3520bdb119e874f6R103-R104)

### Minor Code Refinements:

* `torchao/prototype/mx_formats/mx_ops.py`:
  - Improved readability in `mx_view_op` by reformatting conditions for FP6 element packing.