### PR TITLE
Allow `weights_only=True` load for gemlite layout

### DIFF
--- a/torchao/dtypes/uintx/gemlite_layout.py
+++ b/torchao/dtypes/uintx/gemlite_layout.py
@@ -20,7 +20,7 @@ from torchao.dtypes.affine_quantized_tensor import (
 from torchao.dtypes.uintx.tensor_core_tiled_layout import TensorCoreTiledAQTTensorImpl
 from torchao.dtypes.utils import Layout, is_device
 from torchao.quantization.quant_primitives import quantize_affine
-from torchao.utils import fill_defaults
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5, fill_defaults
 
 aten = torch.ops.aten
 
@@ -402,3 +402,13 @@ def _linear_fp_act_int4_weight_gemlite_check(input_tensor, weight_tensor, bias):
         and isinstance(weight_tensor, AffineQuantizedTensor)
         and isinstance(weight_tensor._layout, GemlitePackedLayout)
     )
+
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    try:
+        from gemlite.core import DType, GemLiteLinearTriton
+
+        # TODO: we need to remove `getattr` since it's unsafe (by picklescan)
+        torch.serialization.add_safe_globals([DType, GemLiteLinearTriton, getattr])
+    except:
+        pass


### PR DESCRIPTION
Summary:
This PR adds a few imports from gemlite so that the gemlite checkpoint can be loaded with weights_only = True in huggingface (which is the default)

`torch.load(gemlite_checkpoint, weights_only=True`

Note: we need to remove `getattr` in the future

Test Plan:
```
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig

model_id = "jerryzh168/phi4-mini-int4wo-gemlite"

quantized_model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", torch_dtype="auto")
tokenizer = AutoTokenizer.from_pretrained(model_id)

prompt = "Hey, are you conscious? Can you talk to me?"
inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
generated_ids = quantized_model.generate(**inputs, max_new_tokens=128)
output_text = tokenizer.batch_decode(
    generated_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
)
print(output_text)
```

Reviewers:

Subscribers:

Tasks:

Tags: