### PR TITLE
[lint] reformat qat files

### DIFF
--- a/torchao/quantization/qat/embedding.py
+++ b/torchao/quantization/qat/embedding.py
@@ -196,7 +196,7 @@ class Int4WeightOnlyEmbeddingQATQuantizer(TwoStepQuantizer):
         """
         self._convert_helper(model)
         return model
-    
+
     @staticmethod
     def quantize_weights(
         weight: torch.Tensor,
@@ -207,12 +207,11 @@ class Int4WeightOnlyEmbeddingQATQuantizer(TwoStepQuantizer):
         Helper function to quantize weights
         """
         (qmin, qmax) = _get_qmin_qmax(bit_width)
-        (s, zp) = get_group_qparams_symmetric(
-            weight, bit_width, group_size
-        )
+        (s, zp) = get_group_qparams_symmetric(weight, bit_width, group_size)
         from torchao._executorch_ops import (
             _quantized_decomposed_quantize_per_channel_group_wrapper,
         )
+
         q_weight = _quantized_decomposed_quantize_per_channel_group_wrapper(
             weight,
             s,
@@ -223,7 +222,6 @@ class Int4WeightOnlyEmbeddingQATQuantizer(TwoStepQuantizer):
             group_size,
         )
         return (q_weight, s, zp)
-
 
     def _convert_helper(self, module: torch.nn.Module):
         """
@@ -255,7 +253,9 @@ class Int4WeightOnlyEmbeddingQATQuantizer(TwoStepQuantizer):
                 )
                 setattr(module, name, quantized_embedding)
 
-                q_weight, s, zp = self.quantize_weights(child.weight, self.bit_width, group_size)
+                q_weight, s, zp = self.quantize_weights(
+                    child.weight, self.bit_width, group_size
+                )
                 # Load weights and qparams into quantized embedding
                 quantized_embedding.weight = q_weight
                 quantized_embedding.scale = s.to(scale_precision)

--- a/torchao/quantization/qat/linear.py
+++ b/torchao/quantization/qat/linear.py
@@ -197,7 +197,7 @@ class Int8DynActInt4WeightQATQuantizer(_LegacyQATQuantizer):
     ) -> torch.nn.Module:
         self._convert_qat_linear_8da4w(model)
         return model
-    
+
     @staticmethod
     def quantize_weights(
         weight: torch.Tensor,
@@ -209,9 +209,7 @@ class Int8DynActInt4WeightQATQuantizer(_LegacyQATQuantizer):
         # Load weights and qparams into quantized linear
         n_bit = 4
         (qmin, qmax) = _get_qmin_qmax(n_bit)
-        (s, zp) = get_group_qparams_symmetric(
-            weight, n_bit, group_size
-        )
+        (s, zp) = get_group_qparams_symmetric(weight, n_bit, group_size)
         from torchao._executorch_ops import (
             _quantized_decomposed_quantize_per_channel_group_wrapper,
         )
@@ -226,7 +224,6 @@ class Int8DynActInt4WeightQATQuantizer(_LegacyQATQuantizer):
             group_size,
         )
         return (q_weight, s, zp)
-
 
     def _convert_qat_linear_8da4w(self, module: torch.nn.Module):
         """
@@ -245,7 +242,9 @@ class Int8DynActInt4WeightQATQuantizer(_LegacyQATQuantizer):
                 )
                 setattr(module, name, quantized_linear)
 
-                q_weight, scales, zeros = self.quantize_weights(child.weight, config.group_size)         
+                q_weight, scales, zeros = self.quantize_weights(
+                    child.weight, config.group_size
+                )
                 quantized_linear.weight = q_weight
                 quantized_linear.scales = scales
                 quantized_linear.zeros = zeros


### PR DESCRIPTION
## Summary
- I noticed CI linter failing on some QAT related files unrelated to my PR: https://github.com/pytorch/ao/actions/runs/14581509830/job/40899042247?pr=2077
- This change reformats `torchao/quantization/qat/` with `ruff format` so CI linter stops failing.