### PR TITLE
Add skip condition for ROCm in QAT test case

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1474,6 +1474,7 @@ class TestQAT(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "skipping when torch version is 2.4 or lower"
     )
+    @skip_if_rocm("ROCm enablement in progress")
     def test_qat_8da4w_prepare_vs_convert(self, dtype: torch.dtype):
         """
         Test that the prepare and convert steps of Int8DynActInt4QATQuantizer produces


### PR DESCRIPTION
This commit adds a decorator to skip the `test_qat_8da4w_prepare_vs_convert` test if ROCm support is not fully enabled, improving test management for different environments.