### PR TITLE
Fix AO SAM2 issues

### DIFF
--- a/torchao/_models/sam2/modeling/sam2_base.py
+++ b/torchao/_models/sam2/modeling/sam2_base.py
@@ -788,9 +788,10 @@ class SAM2Base(torch.nn.Module):
             if prev_sam_mask_logits is not None:
                 assert point_inputs is not None and mask_inputs is None
                 mask_inputs = prev_sam_mask_logits
+            else:
+                assert mask_inputs is None
             multimask_output = self._use_multimask(is_init_cond_frame, point_inputs)
 
-            assert mask_inputs is None
             assert multimask_output
             if point_inputs is not None:
                 point_inputs = {k: point_inputs[k].contiguous() for k in point_inputs}


### PR DESCRIPTION
Summary:
SAM2 issues
- Whenever ```clear_old_points``` was enabled SAM2 would crash
AAS Track mult issues
- Enables ```multimask``` flags

Rootcaused issues to failed assertion in the following lines in ```sam2_base.py::_track_step:L788```:

```
            if prev_sam_mask_logits is not None:
                assert point_inputs is not None and mask_inputs is None
                mask_inputs = prev_sam_mask_logits
            multimask_output = self._use_multimask(is_init_cond_frame, point_inputs)
            assert mask_inputs is None
```
Whenever ```prev_sam_mask_logits``` has a value it results in a crash. There are several situations where this is expected to be the case including during streamed runs, or when clearing points.

Differential Revision: D73460163

Pulled By: jlbmorales
