### PR TITLE
Add AOPerModuleConfig

### DIFF
--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -26,7 +26,8 @@ class AOBaseConfig(abc.ABC):
         # non user facing code
         @register_quantize_module_handler(WorkflowFooConfig)
         def _transform(
-            mod: torch.nn.Module,
+            module: torch.nn.Module,
+            module_name: str,
             config: WorkflowFooConfig,
         ) -> torch.nn.Module:
             # the transform is implemented here, usually a tensor sublass

--- a/torchao/dtypes/_nf4tensor_api.py
+++ b/torchao/dtypes/_nf4tensor_api.py
@@ -29,6 +29,7 @@ nf4_weight_only = NF4WeightOnlyConfig
 @register_quantize_module_handler(NF4WeightOnlyConfig)
 def _nf4_weight_only_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: NF4WeightOnlyConfig,
 ) -> torch.nn.Module:
     block_size = config.block_size

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -35,9 +35,9 @@ from .core import (
     AWQObserver,
 )
 
-assert len(_DTYPE_TO_BIT_WIDTH) > 0, (
-    "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
-)
+assert (
+    len(_DTYPE_TO_BIT_WIDTH) > 0
+), "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
 
 
 def insert_awq_observer_(
@@ -60,9 +60,9 @@ def insert_awq_observer_(
         group_size: Quantization granularity. Use -1 for channel wise quantization
     """
     _is_linear = lambda m, fqn: isinstance(m, torch.nn.Linear)
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
+    assert (
+        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
+    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
     # AQT config
     mapping_type = MappingType.ASYMMETRIC
     quantization_granularity = PerGroup(group_size)
@@ -123,6 +123,7 @@ awq_uintx = AWQUIntXConfig
 @register_quantize_module_handler(AWQUIntXConfig)
 def _awq_uintx_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: AWQUIntXConfig,
 ) -> torch.nn.Module:
     quant_dtype = config.quant_dtype
@@ -132,9 +133,9 @@ def _awq_uintx_transform(
         torchao.quantization.utils.recommended_inductor_config_setter()
     observed_linear = module
 
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
+    assert (
+        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
+    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
 
     equalization_scale = observed_linear.act_obs.calculate_qparams()
     # AQT config

--- a/torchao/prototype/mx_formats/mx_linear.py
+++ b/torchao/prototype/mx_formats/mx_linear.py
@@ -272,12 +272,14 @@ class MXInferenceLinear(torch.nn.Linear):
 
 
 @register_quantize_module_handler(MXLinearConfig)
-def _mx_linear_transform(module: torch.nn.Module, config: MXLinearConfig):
+def _mx_linear_transform(
+    module: torch.nn.Module, module_name: str, config: MXLinearConfig
+):
     return MXLinear.from_float(module, config=config)
 
 
 @register_quantize_module_handler(MXInferenceLinearConfig)
 def _mx_inference_linear_transform(
-    module: torch.nn.Module, config: MXInferenceLinearConfig
+    module: torch.nn.Module, module_name: str, config: MXInferenceLinearConfig
 ):
     return MXInferenceLinear.from_float(module, config=config)

--- a/torchao/prototype/quantization/codebook/codebook_quantized_tensor.py
+++ b/torchao/prototype/quantization/codebook/codebook_quantized_tensor.py
@@ -277,6 +277,7 @@ codebook_weight_only = CodebookWeightOnlyConfig
 @register_quantize_module_handler(CodebookWeightOnlyConfig)
 def _codebook_weight_only_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: CodebookWeightOnlyConfig,
 ):
     """

--- a/torchao/prototype/quantization/gguf/api.py
+++ b/torchao/prototype/quantization/gguf/api.py
@@ -27,6 +27,7 @@ class GGUFWeightOnlyConfig(AOBaseConfig):
 @register_quantize_module_handler(GGUFWeightOnlyConfig)
 def _gguf_weight_only_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: GGUFWeightOnlyConfig,
 ):
     """

--- a/torchao/prototype/quantization/mixed_precision/scripts/naive_intNwo.py
+++ b/torchao/prototype/quantization/mixed_precision/scripts/naive_intNwo.py
@@ -43,6 +43,7 @@ intN_weight_only = IntNWeightOnlyConfig
 @register_quantize_module_handler(IntNWeightOnlyConfig)
 def _intN_weight_only_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: IntNWeightOnlyConfig,
 ) -> torch.nn.Module:
     group_size = config.group_size

--- a/torchao/prototype/quantized_training/bitnet.py
+++ b/torchao/prototype/quantized_training/bitnet.py
@@ -251,6 +251,7 @@ bitnet_training = BitNetTrainingConfig
 @register_quantize_module_handler(BitNetTrainingConfig)
 def _bitnet_training_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: BitNetTrainingConfig,
 ) -> torch.nn.Module:
     new_weight = BitNetTrainingLinearWeight(module.weight)

--- a/torchao/prototype/quantized_training/int8.py
+++ b/torchao/prototype/quantized_training/int8.py
@@ -312,6 +312,7 @@ int8_weight_only_quantized_training = Int8WeightOnlyQuantizedTrainingConfig
 @register_quantize_module_handler(Int8WeightOnlyQuantizedTrainingConfig)
 def _int8_weight_only_quantized_training_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: Int8WeightOnlyQuantizedTrainingConfig,
 ) -> torch.nn.Module:
     new_weight = Int8QuantizedTrainingLinearWeight.from_float(module.weight)

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -283,6 +283,7 @@ class _Int8MixedPrecisionTrainingLinearFunction(torch.autograd.Function):
 @register_quantize_module_handler(Int8MixedPrecisionTrainingConfig)
 def _int8_mixed_precision_training_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: Int8MixedPrecisionTrainingConfig,
 ):
     module_swap = config.module_swap

--- a/torchao/prototype/smoothquant/api.py
+++ b/torchao/prototype/smoothquant/api.py
@@ -176,6 +176,7 @@ class SmoothQuantConfig(AOBaseConfig):
 @register_quantize_module_handler(SmoothQuantConfig)
 def _smooth_quant_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: SmoothQuantConfig,
 ):
     smoothing_factor = config.smoothing_factor

--- a/torchao/quantization/qat/api.py
+++ b/torchao/quantization/qat/api.py
@@ -258,6 +258,7 @@ intx_quantization_aware_training = IntXQuantizationAwareTrainingConfig
 @register_quantize_module_handler(IntXQuantizationAwareTrainingConfig)
 def _intx_quantization_aware_training_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: IntXQuantizationAwareTrainingConfig,
 ) -> torch.nn.Module:
     """
@@ -338,6 +339,7 @@ from_intx_quantization_aware_training = FromIntXQuantizationAwareTrainingConfig
 @register_quantize_module_handler(FromIntXQuantizationAwareTrainingConfig)
 def _from_intx_quantization_aware_training_transform(
     mod: torch.nn.Module,
+    module_name: str,
     config: FromIntXQuantizationAwareTrainingConfig,
 ) -> torch.nn.Module:
     """

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -18,8 +18,8 @@ and mixed GEMM kernels
 import logging
 import types
 import warnings
-from dataclasses import dataclass
-from typing import Any, Callable, Optional, Tuple, Union
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -269,7 +269,7 @@ def _replace_with_custom_fn_if_matches_filter(
 
     Args:
         model (torch.nn.Module): The model containing modules to be replaced.
-        replacement_fn (Callable[[torch.nn.Module], torch.nn.Module]): The function to replace matching modules.
+        replacement_fn (Callable[[torch.nn.Module, str], torch.nn.Module]): The function to replace matching modules, takes nn.Module instance and module name as input.
         filter_fn (Callable[[torch.nn.Module], bool]): The filter function to determine which modules to replace.
         cur_fqn (str, optional): The current fully qualified name of the module being processed. Defaults to "".
         device (device, optional): Device to move the model to before applying `filter_fn`. Defaults to None.
@@ -287,7 +287,7 @@ def _replace_with_custom_fn_if_matches_filter(
     if filter_fn(model, cur_fqn[:-1]):
         if device is not None:
             model.to(device=device)  # move to device before quantization
-        model = replacement_fn(model, *extra_args)
+        model = replacement_fn(model, cur_fqn[:-1], *extra_args)
         return model
     else:
         named_children_list = list(model.named_children())
@@ -630,7 +630,9 @@ int8_dynamic_activation_int4_weight = Int8DynamicActivationInt4WeightConfig
 
 @register_quantize_module_handler(Int8DynamicActivationInt4WeightConfig)
 def _int8_dynamic_activation_int4_weight_transform(
-    module: torch.nn.Module, config: Int8DynamicActivationInt4WeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Int8DynamicActivationInt4WeightConfig,
 ):
     group_size = config.group_size
     layout = config.layout
@@ -723,36 +725,36 @@ class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
     layout: Layout = QDQLayout()
 
     def __post_init__(self):
-        assert TORCH_VERSION_AT_LEAST_2_6, (
-            "Int8DynamicActivationIntxWeightConfig requires torch 2.6+"
-        )
-        assert self.weight_dtype in [getattr(torch, f"int{b}") for b in range(1, 9)], (
-            f"weight_dtype must be torch.intx, where 1 <= x <= 8, but got {self.weight_dtype}"
-        )
-        assert isinstance(self.weight_granularity, (PerAxis, PerGroup)), (
-            f"weight_granularity must be PerAxis or PerGroup, but got {self.weight_granularity}"
-        )
+        assert (
+            TORCH_VERSION_AT_LEAST_2_6
+        ), "Int8DynamicActivationIntxWeightConfig requires torch 2.6+"
+        assert (
+            self.weight_dtype in [getattr(torch, f"int{b}") for b in range(1, 9)]
+        ), f"weight_dtype must be torch.intx, where 1 <= x <= 8, but got {self.weight_dtype}"
+        assert isinstance(
+            self.weight_granularity, (PerAxis, PerGroup)
+        ), f"weight_granularity must be PerAxis or PerGroup, but got {self.weight_granularity}"
         if isinstance(self.weight_granularity, PerAxis):
-            assert self.weight_granularity.axis == 0, (
-                f"axis must be 0, but got {self.weight_granularity.axis}"
-            )
-        assert self.weight_mapping_type in [
-            MappingType.ASYMMETRIC,
-            MappingType.SYMMETRIC,
-        ], (
-            f"weight_mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.weight_mapping_type}"
-        )
-        assert self.act_mapping_type in [
-            MappingType.ASYMMETRIC,
-            MappingType.SYMMETRIC,
-        ], (
-            f"act_mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.act_mapping_type}"
-        )
+            assert (
+                self.weight_granularity.axis == 0
+            ), f"axis must be 0, but got {self.weight_granularity.axis}"
+        assert (
+            self.weight_mapping_type
+            in [
+                MappingType.ASYMMETRIC,
+                MappingType.SYMMETRIC,
+            ]
+        ), f"weight_mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.weight_mapping_type}"
+        assert (
+            self.act_mapping_type
+            in [
+                MappingType.ASYMMETRIC,
+                MappingType.SYMMETRIC,
+            ]
+        ), f"act_mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.act_mapping_type}"
         assert isinstance(
             self.layout, (PackedLinearInt8DynamicActivationIntxWeightLayout, QDQLayout)
-        ), (
-            f"layout must be PackedLinearInt8DynamicActivationIntxWeightLayout or QDQLayout, but got {self.layout}"
-        )
+        ), f"layout must be PackedLinearInt8DynamicActivationIntxWeightLayout or QDQLayout, but got {self.layout}"
 
         if isinstance(self.layout, PackedLinearInt8DynamicActivationIntxWeightLayout):
             if self.layout.target in [Target.AUTO, Target.KLEIDIAI, Target.ATEN]:
@@ -769,7 +771,9 @@ class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
 
 @register_quantize_module_handler(Int8DynamicActivationIntxWeightConfig)
 def _int8_dynamic_activation_intx_weight_transform(
-    module: torch.nn.Module, config: Int8DynamicActivationIntxWeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Int8DynamicActivationIntxWeightConfig,
 ) -> torch.nn.Module:
     weight = module.weight
     bias = module.bias
@@ -823,9 +827,9 @@ def _int8_dynamic_activation_intx_weight_transform(
     elif isinstance(layout, PackedLinearInt8DynamicActivationIntxWeightLayout):
         # PackedLinearInt8DynamicActivationIntxWeightLayout has dynamic activation quantization
         # fused with the kernel and it should not be applied separately
-        assert act_mapping_type == MappingType.ASYMMETRIC, (
-            "PackedLinearInt8DynamicActivationIntxWeightLayout requires act_mapping_type=MappingType.ASYMMETRIC"
-        )
+        assert (
+            act_mapping_type == MappingType.ASYMMETRIC
+        ), "PackedLinearInt8DynamicActivationIntxWeightLayout requires act_mapping_type=MappingType.ASYMMETRIC"
         data, scale, zero_point = weight.tensor_impl.get_plain()
         groups_per_row = weight.shape[-1] // group_size
         scale = scale.reshape(-1, groups_per_row)
@@ -874,7 +878,9 @@ int4_dynamic_activation_int4_weight = Int4DynamicActivationInt4WeightConfig
 
 @register_quantize_module_handler(Int4DynamicActivationInt4WeightConfig)
 def _int4_dynamic_activation_int4_weight_transform(
-    module: torch.nn.Module, config: Int4DynamicActivationInt4WeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Int4DynamicActivationInt4WeightConfig,
 ) -> torch.nn.Module:
     weight = module.weight
     layout = config.layout
@@ -995,7 +1001,7 @@ int4_weight_only = Int4WeightOnlyConfig
 
 @register_quantize_module_handler(Int4WeightOnlyConfig)
 def _int4_weight_only_transform(
-    module: torch.nn.Module, config: Int4WeightOnlyConfig
+    module: torch.nn.Module, module_name: str, config: Int4WeightOnlyConfig
 ) -> torch.nn.Module:
     # TODO(future PR): perhaps move this logic to a different file, to keep the API
     # file clean of implementation details
@@ -1027,16 +1033,16 @@ def _int4_weight_only_transform(
     )
 
     # nonlocal zero_point_domain
-    assert type(layout) in LAYOUT_TO_ZERO_POINT_DOMAIN.keys(), (
-        f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
-    )
+    assert (
+        type(layout) in LAYOUT_TO_ZERO_POINT_DOMAIN.keys()
+    ), f"Only support layout: {LAYOUT_TO_ZERO_POINT_DOMAIN.keys()}"
     if zero_point_domain == ZeroPointDomain.NONE:
         # the first value is the default one
         zero_point_domain = LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)][0]
     else:
-        assert zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)], (
-            f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
-        )
+        assert (
+            zero_point_domain in LAYOUT_TO_ZERO_POINT_DOMAIN[type(layout)]
+        ), f"Layout only support {LAYOUT_TO_ZERO_POINT_DOMAIN[layout]}"
 
     if zero_point_domain == ZeroPointDomain.INT and isinstance(layout, Int4XPULayout):
         zero_point_dtype = torch.int32
@@ -1051,9 +1057,9 @@ def _int4_weight_only_transform(
     # we should consider moving this logic somewhere else.
     if isinstance(layout, MarlinSparseLayout):
         mapping_type = MappingType.SYMMETRIC
-        assert group_size == 128 or group_size == weight.shape[-1], (
-            f"MarlinSparseLayout only supports 128 group size or per channel quantization, got {group_size}"
-        )
+        assert (
+            group_size == 128 or group_size == weight.shape[-1]
+        ), f"MarlinSparseLayout only supports 128 group size or per channel quantization, got {group_size}"
 
     new_weight = to_affine_quantized_intx(
         weight,
@@ -1089,7 +1095,9 @@ int8_weight_only = Int8WeightOnlyConfig
 
 
 @register_quantize_module_handler(Int8WeightOnlyConfig)
-def _int8_weight_only_transform(module: torch.nn.Module, config: Int8WeightOnlyConfig):
+def _int8_weight_only_transform(
+    module: torch.nn.Module, module_name: str, config: Int8WeightOnlyConfig
+):
     group_size = config.group_size
     weight = module.weight
     if config.set_inductor_config:
@@ -1228,7 +1236,9 @@ int8_dynamic_activation_int8_weight = Int8DynamicActivationInt8WeightConfig
 
 @register_quantize_module_handler(Int8DynamicActivationInt8WeightConfig)
 def _int8_dynamic_activation_int8_weight_transform(
-    module: torch.nn.Module, config: Int8DynamicActivationInt8WeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Int8DynamicActivationInt8WeightConfig,
 ) -> torch.nn.Module:
     layout = config.layout
     act_mapping_type = config.act_mapping_type
@@ -1320,7 +1330,7 @@ float8_weight_only = Float8WeightOnlyConfig
 
 @register_quantize_module_handler(Float8WeightOnlyConfig)
 def _float8_weight_only_transform(
-    module: torch.nn.Module, config: Float8WeightOnlyConfig
+    module: torch.nn.Module, module_name: str, config: Float8WeightOnlyConfig
 ) -> torch.nn.Module:
     from torchao.dtypes import to_affine_quantized_floatx
 
@@ -1375,13 +1385,13 @@ def _normalize_granularity(
     # Validate granularity with supported Hardware
     for _granularity in processed_granularity:
         if isinstance(_granularity, PerTensor):
-            assert is_sm_at_least_89() or is_MI300(), (
-                "PerTensor quantization only works for CUDA>=8.9 and MI300+"
-            )
+            assert (
+                is_sm_at_least_89() or is_MI300()
+            ), "PerTensor quantization only works for CUDA>=8.9 and MI300+"
         elif isinstance(_granularity, PerRow):
-            assert is_sm_at_least_90() or is_MI300(), (
-                "PerRow quantization only works for CUDA>=9.0 and MI300+"
-            )
+            assert (
+                is_sm_at_least_90() or is_MI300()
+            ), "PerRow quantization only works for CUDA>=9.0 and MI300+"
         else:
             raise ValueError(f"Invalid granularity type: {_granularity}")
 
@@ -1398,13 +1408,13 @@ def _input_activation_quant_func_fp8(
     """This function is used to quantize the input activation tensor for an aqt_float variant. If scale
     is not provided it will be dynamically calculate the scales otherwise it will use the provided scale.
     """
-    assert zero_point is None, (
-        "Zero point is not supported for dynamic FP8 quantization"
-    )
+    assert (
+        zero_point is None
+    ), "Zero point is not supported for dynamic FP8 quantization"
     if isinstance(activation_granularity, PerRow):
-        assert x.dtype == torch.bfloat16, (
-            "PerRow quantization only works for bfloat16 precision input activation"
-        )
+        assert (
+            x.dtype == torch.bfloat16
+        ), "PerRow quantization only works for bfloat16 precision input activation"
 
     block_size = get_block_size(x.shape, activation_granularity)
     if scale is None:
@@ -1416,9 +1426,9 @@ def _input_activation_quant_func_fp8(
             _layout=Float8Layout(mm_config=None),  # Config is stored on weight
         )
     else:
-        assert isinstance(activation_granularity, PerTensor), (
-            "Static quantization only supports PerTensor granularity"
-        )
+        assert isinstance(
+            activation_granularity, PerTensor
+        ), "Static quantization only supports PerTensor granularity"
         activation = to_affine_quantized_floatx_static(
             input_float=x,
             block_size=block_size,
@@ -1439,9 +1449,9 @@ def _fp8_mm_compat(weight: torch.Tensor) -> bool:
     Returns:
         bool: True if the tensor can be quantized to float8, False otherwise
     """
-    assert weight.dim() == 2, (
-        f"float8 quantization only works for 2-D tensors, got {weight.dim()}D tensor"
-    )
+    assert (
+        weight.dim() == 2
+    ), f"float8 quantization only works for 2-D tensors, got {weight.dim()}D tensor"
 
     out_dim, in_dim = weight.shape
     is_compatible = (in_dim % 16 == 0) and (out_dim % 16 == 0)
@@ -1492,11 +1502,13 @@ float8_dynamic_activation_float8_weight = Float8DynamicActivationFloat8WeightCon
 
 @register_quantize_module_handler(Float8DynamicActivationFloat8WeightConfig)
 def _float8_dynamic_activation_float8_weight_transform(
-    module: torch.nn.Module, config: Float8DynamicActivationFloat8WeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Float8DynamicActivationFloat8WeightConfig,
 ):
-    assert is_sm_at_least_89() or is_MI300(), (
-        "Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+"
-    )
+    assert (
+        is_sm_at_least_89() or is_MI300()
+    ), "Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+"
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
 
@@ -1513,9 +1525,9 @@ def _float8_dynamic_activation_float8_weight_transform(
         # not doing what the user asked
         return module
     if isinstance(weight_granularity, PerRow):
-        assert weight.dtype == torch.bfloat16, (
-            "PerRow quantization only works for bfloat16 precision input weight"
-        )
+        assert (
+            weight.dtype == torch.bfloat16
+        ), "PerRow quantization only works for bfloat16 precision input weight"
 
     block_size = get_block_size(weight.shape, weight_granularity)
     quantized_weight = to_affine_quantized_floatx(
@@ -1559,7 +1571,9 @@ class Float8DynamicActivationFloat8SemiSparseWeightConfig(AOBaseConfig):
 
 @register_quantize_module_handler(Float8DynamicActivationFloat8SemiSparseWeightConfig)
 def _float8_dynamic_activation_float8_semi_sparse_weight_transform(
-    module: torch.nn.Module, config: Float8DynamicActivationFloat8SemiSparseWeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Float8DynamicActivationFloat8SemiSparseWeightConfig,
 ):
     assert is_sm_at_least_90(), "Float8 quantization is only supported on CUDA>=9.0"
 
@@ -1618,11 +1632,13 @@ float8_static_activation_float8_weight = Float8StaticActivationFloat8WeightConfi
 
 @register_quantize_module_handler(Float8StaticActivationFloat8WeightConfig)
 def _float8_static_activation_float8_weight_transform(
-    module: torch.nn.Module, config: Float8StaticActivationFloat8WeightConfig
+    module: torch.nn.Module,
+    module_name: str,
+    config: Float8StaticActivationFloat8WeightConfig,
 ):
-    assert is_sm_at_least_89() or is_MI300(), (
-        "Float8 static activation quantization is only supported on CUDA 8.9 and above"
-    )
+    assert (
+        is_sm_at_least_89() or is_MI300()
+    ), "Float8 static activation quantization is only supported on CUDA 8.9 and above"
 
     scale = config.scale
     activation_dtype = config.activation_dtype
@@ -1634,9 +1650,9 @@ def _float8_static_activation_float8_weight_transform(
 
     weight = module.weight
     activation_granularity, weight_granularity = _normalize_granularity(granularity)
-    assert isinstance(activation_granularity, PerTensor), (
-        "Static quantization only supports PerTensor granularity"
-    )
+    assert isinstance(
+        activation_granularity, PerTensor
+    ), "Static quantization only supports PerTensor granularity"
 
     if not _fp8_mm_compat(weight):
         # TODO(future PR): this should really throw an exception instead of silently
@@ -1698,7 +1714,7 @@ uintx_weight_only = UIntXWeightOnlyConfig
 
 @register_quantize_module_handler(UIntXWeightOnlyConfig)
 def _uintx_weight_only_transform(
-    module: torch.nn.Module, config: UIntXWeightOnlyConfig
+    module: torch.nn.Module, module_name: str, config: UIntXWeightOnlyConfig
 ):
     dtype = config.dtype
     group_size = config.group_size
@@ -1791,24 +1807,24 @@ class IntxWeightOnlyConfig(AOBaseConfig):
 
     def __post_init__(self):
         assert TORCH_VERSION_AT_LEAST_2_6, "IntxWeightOnlyConfig requires torch 2.6+"
-        assert self.weight_dtype in [getattr(torch, f"int{b}") for b in range(1, 9)], (
-            f"weight_dtype must be torch.intx, where 1 <= x <= 8, but got {self.weight_dtype}"
-        )
-        assert isinstance(self.granularity, (PerAxis, PerGroup)), (
-            f"granularity must be PerAxis or PerGroup, but got {self.granularity}"
-        )
+        assert (
+            self.weight_dtype in [getattr(torch, f"int{b}") for b in range(1, 9)]
+        ), f"weight_dtype must be torch.intx, where 1 <= x <= 8, but got {self.weight_dtype}"
+        assert isinstance(
+            self.granularity, (PerAxis, PerGroup)
+        ), f"granularity must be PerAxis or PerGroup, but got {self.granularity}"
         if isinstance(self.granularity, PerAxis):
-            assert self.granularity.axis == 0, (
-                f"axis must be 0 with PerAxis, but got {self.granularity.axis}"
-            )
-        assert self.mapping_type in [MappingType.ASYMMETRIC, MappingType.SYMMETRIC], (
-            f"mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.mapping_type}"
-        )
+            assert (
+                self.granularity.axis == 0
+            ), f"axis must be 0 with PerAxis, but got {self.granularity.axis}"
+        assert (
+            self.mapping_type in [MappingType.ASYMMETRIC, MappingType.SYMMETRIC]
+        ), f"mapping_type must be MappingType.ASYMMETRIC or MappingType.SYMMETRIC, but got {self.mapping_type}"
 
 
 @register_quantize_module_handler(IntxWeightOnlyConfig)
 def _intx_weight_only_transform(
-    module: torch.nn.Module, config: IntxWeightOnlyConfig
+    module: torch.nn.Module, module_name: str, config: IntxWeightOnlyConfig
 ) -> torch.nn.Module:
     weight = module.weight
     weight_dtype = config.weight_dtype
@@ -1817,15 +1833,15 @@ def _intx_weight_only_transform(
     scale_dtype = config.scale_dtype
     layout = config.layout
 
-    assert weight.dim() == 2, (
-        f"IntxWeightOnlyConfig only works for 2-d Tensor, got: {weight.dim()}"
-    )
+    assert (
+        weight.dim() == 2
+    ), f"IntxWeightOnlyConfig only works for 2-d Tensor, got: {weight.dim()}"
     if isinstance(granularity, PerGroup):
         group_size = granularity.group_size
     elif isinstance(granularity, PerAxis):
-        assert granularity.axis == 0, (
-            f"axis must be 0 with PerAxis, but got {granularity.axis}"
-        )
+        assert (
+            granularity.axis == 0
+        ), f"axis must be 0 with PerAxis, but got {granularity.axis}"
         group_size = weight.shape[-1]
     else:
         raise ValueError(f"granularity must be PerGroup or PerAxis, got {granularity}")
@@ -1872,7 +1888,7 @@ fpx_weight_only = FPXWeightOnlyConfig
 
 @register_quantize_module_handler(FPXWeightOnlyConfig)
 def _fpx_weight_only_transform(
-    module: torch.nn.Module, config: FPXWeightOnlyConfig
+    module: torch.nn.Module, module_name: str, config: FPXWeightOnlyConfig
 ) -> torch.nn.Module:
     ebits = config.ebits
     mbits = config.mbits
@@ -1913,3 +1929,28 @@ if TORCH_VERSION_AT_LEAST_2_5:
             Target,
         ]
     )
+
+
+@dataclass
+class AOPerModuleConfig(AOBaseConfig):
+    module_name_to_config: Dict[str, Optional[AOBaseConfig]] = field(
+        default_factory=dict
+    )
+
+
+@register_quantize_module_handler(AOPerModuleConfig)
+def _ao_per_module_config_transform(
+    module: torch.nn.Module, module_name: str, config: AOPerModuleConfig
+):
+    c = config.module_name_to_config.get(module_name, None)
+    # Maybe: we can add module type specific config in the future, in needed
+    # fallback to use default if no module specific config is provided
+    default_c = config.module_name_to_config.get("_default", None)
+    if default_c is not None and c is None:
+        c = default_c
+
+    if c is not None:
+        handler = _QUANTIZE_CONFIG_HANDLER[type(c)]
+        return handler(module, module_name, c)
+
+    return handler(module, module_name, c)

--- a/torchao/sparsity/sparse_api.py
+++ b/torchao/sparsity/sparse_api.py
@@ -58,6 +58,7 @@ block_sparse_weight = BlockSparseWeightConfig
 @register_quantize_module_handler(BlockSparseWeightConfig)
 def _block_sparse_weight_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: BlockSparseWeightConfig,
 ):
     blocksize = config.blocksize
@@ -82,6 +83,7 @@ semi_sparse_weight = SemiSparseWeightConfig
 @register_quantize_module_handler(SemiSparseWeightConfig)
 def _semi_sparse_weight_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: SemiSparseWeightConfig,
 ) -> torch.nn.Module:
     new_weight = to_sparse_semi_structured(module.weight)

--- a/tutorials/calibration_flow/awq_like.py
+++ b/tutorials/calibration_flow/awq_like.py
@@ -105,6 +105,7 @@ class ApplyAWQConfig(AOBaseConfig):
 @register_quantize_module_handler(ApplyAWQConfig)
 def _apply_awq_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: ApplyAWQConfig,
 ):
     target_dtype = config.target_dtype

--- a/tutorials/calibration_flow/gptq_like.py
+++ b/tutorials/calibration_flow/gptq_like.py
@@ -88,9 +88,9 @@ class MultiTensor(torch.Tensor):
             for inp in input:
                 self.add_tensors(inp)
         else:
-            assert isinstance(input, torch.Tensor), (
-                f"MultiTensor can only use add_tensors for Tensors or lists of tensors but got {type(input)}"
-            )
+            assert isinstance(
+                input, torch.Tensor
+            ), f"MultiTensor can only use add_tensors for Tensors or lists of tensors but got {type(input)}"
             self.count += 1
             self.values.append(input)
         return self
@@ -269,6 +269,7 @@ class ApplyActivationStaticWeightQuantConfig(AOBaseConfig):
 @register_quantize_module_handler(ApplyActivationStaticWeightQuantConfig)
 def _apply_activation_static_weight_quant_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: ApplyActivationStaticWeightQuantConfig,
 ):
     observed_linear = module

--- a/tutorials/calibration_flow/static_quant.py
+++ b/tutorials/calibration_flow/static_quant.py
@@ -97,6 +97,7 @@ class ApplyStaticQuantConfig(AOBaseConfig):
 @register_quantize_module_handler(ApplyStaticQuantConfig)
 def _apply_static_quant_transform(
     module: torch.nn.Module,
+    module_name: str,
     config: ApplyStaticQuantConfig,
 ):
     target_dtype = config.target_dtype


### PR DESCRIPTION
Summary:
This allows:
1. per module config by name, e.g. linear: config1, embedding: config2
2. skipping config by module name
3. specify default config for all supported modules by default (modules that passes the filter function)

```py
# default + override
config1 = Int4WeightOnlyConfig(group_size=32)
config2 = Int8WeightOnlyConfig()
config = AOPerModuleConfig({"_default": config1, "linear2": config2})

# specify config for each module by fully qualified name
config1 = Int4WeightOnlyConfig(group_size=32)
config2 = Int8WeightOnlyConfig()
config = AOPerModuleConfig({"linear1": config1, "linear2": config2})
```

Test Plan:
python test/quantization/test_quant_api.py -k test_ao_per_module_config

Reviewers:

Subscribers:

Tasks:

Tags: