### PR TITLE
Add pct_achievable_gemm_tops and pct_achievable_mem_bw to fp8 roofline utils

### DIFF
--- a/torchao/testing/float8/roofline_utils.py
+++ b/torchao/testing/float8/roofline_utils.py
@@ -47,12 +47,10 @@ gpu_name_to_specs = {
         "fp8_peak_tops": 2614e12,
         # 5.3 TB per second
         "peak_mem_bw_bytes_sec": 5.3e12,
-        # for now, copy over from H100
-        # TODO(future): run measurement on hardware
-        "pct_achievable_gemm_tops": 0.78,
-        # for now, copy over from H100
-        # TODO(future): run measurement on hardware
-        "pct_achievable_mem_bw": 0.92,
+        # based on microbenchmark (fw + bw gemms) with M,K,N = 3 * (8192,)
+        "pct_achievable_gemm_tops": 0.47,
+        # based on microbenchmark with pointwise triton kernel with large inputs
+        "pct_achievable_mem_bw": 0.72,
     },
     # TODO(future): more GPU names
 }


### PR DESCRIPTION
This PR adds pct_achievable_gemm_tops and pct_achievable_mem_bw to fp8 roofline utils.

The values were determined through microbenchmarking and match previously published values.