### PR TITLE
Skip ROCm Tests : Affine Quantized and Scaled Group Gemm

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -222,6 +222,7 @@ class TestAffineQuantized(TestCase):
 
         deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
+    @skip_if_rocm("ROCm enablement in progress")
     @unittest.skipIf(len(GPU_DEVICES) == 0, "Need GPU available")
     def test_print_quantized_module(self):
         for device in self.GPU_DEVICES:

--- a/test/prototype/scaled_grouped_mm/test_kernels.py
+++ b/test/prototype/scaled_grouped_mm/test_kernels.py
@@ -28,8 +28,10 @@ from torchao.prototype.scaled_grouped_mm.utils import (
     _to_2d_jagged_float8_tensor_colwise,
     _to_2d_jagged_float8_tensor_rowwise,
 )
+from torchao.testing.utils import skip_if_rocm
 
 
+@skip_if_rocm("ROCm enablement in progress")
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
     # tests case where rowwise scales are computed for multiple distinct subtensors,
@@ -57,6 +59,7 @@ def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
     assert not _is_column_major(kernel_fp8_data), "fp8 data is not row major"
 
 
+@skip_if_rocm("ROCm enablement in progress")
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: bool):
     # tests case where colwise scales are computed for multiple distinct subtensors,

--- a/test/prototype/scaled_grouped_mm/test_scaled_grouped_mm.py
+++ b/test/prototype/scaled_grouped_mm/test_scaled_grouped_mm.py
@@ -29,8 +29,10 @@ from torchao.float8.float8_utils import tensor_to_scale, to_fp8_saturated
 from torchao.prototype.scaled_grouped_mm.scaled_grouped_mm import (
     _scaled_grouped_mm,
 )
+from torchao.testing.utils import skip_if_rocm
 
 
+@skip_if_rocm("ROCm enablement in progress")
 def test_valid_scaled_grouped_mm_2d_3d():
     out_dtype = torch.bfloat16
     device = "cuda"


### PR DESCRIPTION
TLDR: skip tests that is inapplicable or under development for ROCm

This pull request introduces changes to testing files to improve compatibility with the ROCm platform. The main updates include adding a new decorator, `@skip_if_rocm`, to tests that are not yet supported on ROCm-enabled systems.

### ROCm Compatibility Updates:

* **`test/dtypes/test_affine_quantized.py`:** Added the `@skip_if_rocm` decorator to the `test_print_quantized_module` method to skip this test on ROCm systems.

* **`test/prototype/scaled_grouped_mm/test_kernels.py`:**
  - Imported the `skip_if_rocm` utility from `torchao.testing.utils`.
  - Added the `@skip_if_rocm` decorator to the `test_row_major_with_jagged_rowwise_scales` and `test_column_major_with_jagged_colwise_scales` methods to skip these tests on ROCm systems. [[1]](diffhunk://#diff-01c51017e5ea3894f63d47c1d175db89e3816aa2bfd8351e9c7d36db779d783dR31-R34) [[2]](diffhunk://#diff-01c51017e5ea3894f63d47c1d175db89e3816aa2bfd8351e9c7d36db779d783dR62)

* **`test/prototype/scaled_grouped_mm/test_scaled_grouped_mm.py`:**
  - Imported the `skip_if_rocm` utility from `torchao.testing.utils`.
  - Added the `@skip_if_rocm` decorator to the `test_valid_scaled_grouped_mm_2d_3d` method to skip this test on ROCm systems.