### PR TITLE
Disable ROCm support in the Linux wheels build workflow

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -28,7 +28,7 @@ jobs:
       os: linux
       with-cpu: enable
       with-cuda: enable
-      with-rocm: enable
+      with-rocm: disable
       with-xpu: enable
       # Note: if free-threaded python is required add py3.13t here
       python-versions: '["3.9"]'


### PR DESCRIPTION
TLDR: disable ROCm wheel build to investigate regression from #2044 



This pull request includes a small change to the `.github/workflows/build_wheels_linux.yml` file. The change disables the ROCm build by setting `with-rocm` to `disable` instead of `enable`.