### PR TITLE
Unskip test_qat_8da4w_prepare_vs_convert

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1474,7 +1474,6 @@ class TestQAT(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "skipping when torch version is 2.4 or lower"
     )
-    @unittest.skip("Currently failing on sqnr")
     def test_qat_8da4w_prepare_vs_convert(self, dtype: torch.dtype):
         """
         Test that the prepare and convert steps of Int8DynActInt4QATQuantizer produces
@@ -1493,7 +1492,11 @@ class TestQAT(unittest.TestCase):
             torch.manual_seed(seed)
             x = m.example_inputs()
 
-            quantizer = Int8DynActInt4WeightQATQuantizer(groupsize=group_size)
+            quantizer = Int8DynActInt4WeightQATQuantizer(
+                groupsize=group_size,
+                precision=dtype,
+                scales_precision=dtype,
+            )
             prepared = quantizer.prepare(m)
             prepared_out = prepared(*x)
             converted = quantizer.convert(prepared)

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -933,7 +933,11 @@ def linear_forward_8da4w(
     groupsize,
     precision,
 ):
-    x = per_token_dynamic_quant(x, scale_dtype=precision, zero_point_dtype=precision)
+    x = per_token_dynamic_quant(
+        x,
+        scale_dtype=torch.float32,
+        zero_point_dtype=torch.int8,
+    )
     # TODO: verify and remove following reshape code
     # origin_x_size = x.size()
     # x = x.reshape(-1, origin_x_size[-1])

--- a/torchao/quantization/qat/linear.py
+++ b/torchao/quantization/qat/linear.py
@@ -219,8 +219,12 @@ class Int8DynActInt4WeightQATQuantizer(_LegacyQATQuantizer):
                 n_bit = 4
                 (qmin, qmax) = _get_qmin_qmax(n_bit)
                 (s, zp) = get_group_qparams_symmetric(
-                    child.weight, n_bit, config.group_size
+                    child.weight,
+                    n_bit,
+                    config.group_size,
+                    config.scale_precision,
                 )
+                zp = zp.to(config.zero_point_precision)
                 from torchao._executorch_ops import (
                     _quantized_decomposed_quantize_per_channel_group_wrapper,
                 )
@@ -270,7 +274,7 @@ class Int8DynActInt4WeightQATLinear(FakeQuantizedLinear):
         precision: torch.dtype = torch.float32,
         scales_precision: torch.dtype = torch.float32,
     ) -> None:
-        activation_config = _get_8da4w_activation_config(scales_precision)
+        activation_config = _get_8da4w_activation_config(torch.float32)
         weight_config = _get_8da4w_weight_config(groupsize, scales_precision)
         super().__init__(
             in_features,


### PR DESCRIPTION
Following @metascroy's investigation in #2085, we can unskip this test, which was caused by activation scales having different precisions between prepare and convert.

**Test Plan:**
python test/quantization/test_qat.py -k test_qat_8da4w_prepare_vs_convert