### PR TITLE
Add subclass based method for inference w/ MXFP8

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -43,7 +43,7 @@ from torchao.quantization import (
     quantize_,
 )
 
-from . import dtypes, optim, testing
+from . import dtypes, optim, quantization, testing
 
 __all__ = [
     "dtypes",
@@ -52,4 +52,5 @@ __all__ = [
     "quantize_",
     "testing",
     "ops",
+    "quantization",
 ]

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -175,6 +175,7 @@ ALLOWED_AO_MODULES = {
     "torchao.quantization",
     "torchao.sparsity.sparse_api",
     "torchao.prototype.quantization",
+    "torchao.prototype.mx_formats",
 }
 
 

--- a/torchao/prototype/mx_formats/__init__.py
+++ b/torchao/prototype/mx_formats/__init__.py
@@ -5,6 +5,9 @@ from torchao.prototype.mx_formats.config import (
     MXLinearRecipeName,
 )
 
+# Note: Prototype and subject to change
+from torchao.prototype.mx_formats.mx_subclass import MXFPInferenceConfig
+
 # import mx_linear here to register the quantize_ transform logic
 # ruff: noqa: I001
 import torchao.prototype.mx_formats.mx_linear  # noqa: F401
@@ -14,4 +17,5 @@ __all__ = [
     "MXInferenceLinearConfig",
     "MXLinearConfig",
     "MXLinearRecipeName",
+    "MXFPInferenceConfig",
 ]

--- a/torchao/prototype/mx_formats/mx_funcs.py
+++ b/torchao/prototype/mx_formats/mx_funcs.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This file defines the top level torch ops that are extended by MXTensor
+See: https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch-with-a-tensor-wrapper-type
+for more details.
+"""
+
+from typing import Any, Dict
+
+import torch
+
+from torchao.prototype.mx_formats.mx_ops import _addmm_mx_dispatch
+from torchao.prototype.mx_formats.mx_tensor import (  # noqa: E501
+    MXTensor,
+)
+
+aten = torch.ops.aten
+
+MX_FUNC_TABLE: Dict[Any, Any] = {}
+
+
+def implements_func(torch_ops):
+    """Register torch ops to the mx op table for torch function"""
+
+    def decorator(func):
+        for op in torch_ops:
+            MX_FUNC_TABLE[op] = func
+        return func
+
+    return decorator
+
+
+@implements_func([aten.linear.default])
+def mx_linear(func, types, args, kwargs):
+    a, b = args[0], args[1]
+    assert isinstance(a, MXTensor) and isinstance(b, MXTensor)
+    bias = args[2] if len(args) == 3 else None
+    return _addmm_mx_dispatch(a, b.t(), func, bias=bias)

--- a/torchao/prototype/mx_formats/mx_ops.py
+++ b/torchao/prototype/mx_formats/mx_ops.py
@@ -17,9 +17,12 @@ then the ops in this file are used under the hood to properly route
 the underlying data fields to the MX matmul.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch
+from torch.utils._python_dispatch import (
+    return_and_correct_aliasing,
+)
 from torch.utils._pytree import tree_map
 
 import torchao.ops
@@ -35,10 +38,12 @@ from torchao.prototype.mx_formats.mx_tensor import (  # noqa: E501
     tensor_size_hpx3_to_fp6x4,
 )
 from torchao.prototype.mx_formats.utils import to_blocked
+from torchao.utils import fill_defaults
 
 aten = torch.ops.aten
 
 MX_OPS_TABLE: Dict[Any, Any] = {}
+MX_FUNCTION_TABLE: Dict[Any, Any] = {}
 
 
 def implements(aten_ops):
@@ -52,59 +57,77 @@ def implements(aten_ops):
     return decorator
 
 
-@implements([aten.detach.default])
-def mx_desugar_op(aten_op, args, kwargs=None):
-    old = args[0]
-    new_data = aten_op(old._data, *args[1:], **kwargs)
-    new = MXTensor(
-        old._scale_e8m0,
-        new_data,
-        old._elem_dtype,
-        old._block_size,
-        old._orig_dtype,
-        old._use_fp4_custom_triton_dequant_kernel,
-        old._gemm_kernel_choice,
-        old._pack_fp6,
+@implements([aten.detach.default, aten.alias.default])
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(func)
     )
-    return new
 
 
-@implements([aten.mm.default, aten.matmul.default])
-def mx_mm(aten_op, args, kwargs=None):
-    a = args[0]
-    b = args[1]
-    assert isinstance(a, MXTensor) and isinstance(b, MXTensor)
-    assert a._gemm_kernel_choice == b._gemm_kernel_choice, "unsupported"
-    if a._gemm_kernel_choice in (MXGemmKernelChoice.CUBLAS, MXGemmKernelChoice.CUTLASS):
+def _get_gemm_choice(
+    choice_a: Optional[MXGemmKernelChoice], choice_b: Optional[MXGemmKernelChoice]
+) -> MXGemmKernelChoice:
+    if choice_a is not None and choice_b is not None:
+        assert choice_a == choice_b, (
+            "Both MXTensor inputs must have the same gemm config if specified"
+        )
+        return choice_a
+
+    # Assert that at least one is set and return that one
+    assert choice_a is not None or choice_b is not None, (
+        "At least one gemm choice must be specified"
+    )
+    return choice_a if choice_a is not None else choice_b
+
+
+def _addmm_mx_dispatch(
+    a: MXTensor, b: MXTensor, aten_op, bias: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    """
+    Core implementation shared between mx_mm and mx_addmm.
+    The only difference is whether bias is None or not.
+    """
+    gemm_choice = _get_gemm_choice(a._gemm_kernel_choice, b._gemm_kernel_choice)
+
+    if gemm_choice in (MXGemmKernelChoice.CUBLAS, MXGemmKernelChoice.CUTLASS):
         # real MX gemm backed by torchao's CUTLASS kernels
         M, K, N = a.shape[0], a.shape[1], b.shape[1]
         assert a._data.is_contiguous()
         assert b._data.t().is_contiguous()
+        assert a._block_size == 32, f"Invalid block size {a._block_size}"
+        assert b._block_size == 32, f"Invalid block size {b._block_size}"
 
-        # TODO(future PR): use block_size instead of hardcoding 32
-        a_scale = a._scale_e8m0.view(M, K // 32)
-        b_scale = b._scale_e8m0.view(N, K // 32)
+        a_scale = a._scale_e8m0.view(M, K // a._block_size)
+        b_scale = b._scale_e8m0.view(N, K // b._block_size)
         a_scale_block = to_blocked(a_scale)
         b_scale_block = to_blocked(b_scale)
+
         if a._elem_dtype == torch.float8_e4m3fn:
             assert b._elem_dtype == torch.float8_e4m3fn
-            assert a._gemm_kernel_choice is MXGemmKernelChoice.CUBLAS, (
+            assert gemm_choice is MXGemmKernelChoice.CUBLAS, (
                 "CUBLAS is the only supported kernel choice for MX FP8 operations"
             )
+
             res = torch._scaled_mm(
                 a._data,
                 b._data,
                 a_scale_block.view(torch.float8_e8m0fnu),
                 b_scale_block.view(torch.float8_e8m0fnu),
+                bias=bias,
                 out_dtype=torch.bfloat16,
             )
         else:
             assert a._elem_dtype == DTYPE_FP4
             assert b._elem_dtype == DTYPE_FP4
-            assert a._gemm_kernel_choice is MXGemmKernelChoice.CUTLASS, "unsupported"
+            assert gemm_choice is MXGemmKernelChoice.CUTLASS, "unsupported"
+            # FP4 operations
             res = torchao.ops.mx_fp4_bf16(
                 a._data, b._data, a_scale_block, b_scale_block
             )
+            # TODO add optional bias to kernel
+            if bias is not None:
+                res = res + bias
+
     else:
         # emulated MX gemm
         a_hp = a.to_dtype(a._orig_dtype)
@@ -112,12 +135,40 @@ def mx_mm(aten_op, args, kwargs=None):
         # assert memory layout we expect to be required in hardware
         assert a_hp.is_contiguous()
         assert b_hp.t().is_contiguous()
-        res = aten_op(a_hp, b_hp)
+
+        # Call appropriate aten_op based on whether bias is provided
+        if bias is not None:
+            res = aten_op(bias, a_hp, b_hp)  # addmm
+        else:
+            res = aten_op(a_hp, b_hp)  # mm
+
     return res
 
 
+@implements([aten.mm.default, aten.matmul.default])
+def mx_mm(func, types, args, kwargs):
+    a = args[0]
+    b = args[1]
+    assert isinstance(a, MXTensor) and isinstance(b, MXTensor)
+
+    return _addmm_mx_dispatch(a, b, func)
+
+
+@implements([aten.addmm.default])
+def mx_addmm(func, types, args, kwargs):
+    assert (
+        isinstance(args[0], torch.Tensor)
+        and isinstance(args[1], MXTensor)
+        and isinstance(args[2], MXTensor)
+    )
+    bias = args[0]
+    a = args[1]
+    b = args[2]
+    return _addmm_mx_dispatch(a, b, func, bias=bias)
+
+
 @implements([aten.t.default])
-def mx_t(aten_op, args, kwargs=None):
+def mx_t(func, types, args, kwargs):
     # For now, only transpose(input, 0, 1) is supported.
     old = args[0]
     new = MXTensor(
@@ -134,7 +185,7 @@ def mx_t(aten_op, args, kwargs=None):
 
 
 @implements([aten.sum.dim_IntList])
-def mx_cast_up_op(aten_op, args, kwargs=None):
+def mx_cast_up_op(func, types, args, kwargs):
     """Be careful with this function, this is a "fallback" op that
     casts the output of the op to the original precision. And performs the op.
 
@@ -150,11 +201,11 @@ def mx_cast_up_op(aten_op, args, kwargs=None):
 
     new_args = tree_map(unwrap, args)
     new_kwargs = tree_map(unwrap, kwargs)
-    return aten_op(*new_args, **new_kwargs)
+    return func(*new_args, **new_kwargs)
 
 
 @implements([aten.view.default])
-def mx_view_op(aten_op, args, kwargs=None):
+def mx_view_op(func, types, args, kwargs):
     data = args[0]._data
     new_size = args[1]
     if args[0]._elem_dtype == DTYPE_FP4:
@@ -163,7 +214,7 @@ def mx_view_op(aten_op, args, kwargs=None):
     elif args[0]._elem_dtype in [DTYPE_FP6_E3M2, DTYPE_FP6_E2M3] and args[0]._pack_fp6:
         # special case fp6 as we pack 4 elements in 3 bytes
         new_size = tensor_size_hpx3_to_fp6x4(new_size, data.is_contiguous())
-    new_data = aten_op(data, new_size, *args[2:], **kwargs)
+    new_data = func(data, new_size, *args[2:], **kwargs)
     return MXTensor(
         args[0]._scale_e8m0,
         new_data,
@@ -176,28 +227,120 @@ def mx_view_op(aten_op, args, kwargs=None):
     )
 
 
+@implements([aten.slice.Tensor])
+def mx_slice(func, types, args, kwargs):
+    x, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
+
+    if step != 1:
+        raise ValueError("Only support aten.slice with step=1")
+
+    M, K = x.shape[0], x.shape[1]
+
+    # TODO why doesn't scale have shape?
+    scale_shaped = x._scale_e8m0.view(M, K // x._block_size)
+
+    if dim == 0:
+        # Slicing along the first dimension (rows) TODO assuming that dim 1 is reduciton dim for now
+        sliced_scale = aten.slice.Tensor(scale_shaped, dim, start, end, step).flatten()
+        sliced_data = aten.slice.Tensor(x._data, dim, start, end, step)
+    elif dim == 1:
+        # Slicing along reduciton dim
+        if start is not None:
+            # Assert start is a multiple of block_size
+            assert start % x._block_size == 0, (
+                f"Start index {start} must be a multiple of block_size {x._block_size}"
+            )
+
+        if end is not None:
+            # Assert end is a multiple of block_size
+            assert end % x._block_size == 0, (
+                f"End index {end} must be a multiple of block_size {x._block_size}"
+            )
+
+        sliced_data = aten.slice.Tensor(x._data, dim, start, end, step)
+
+        # Calculate which scale elements to keep
+        start_block = 0 if start is None else start // x._block_size
+        end_block = -1 if end is None else end // x._block_size
+
+        # Slice the scale tensor accordingly
+        sliced_scale = aten.slice.Tensor(
+            scale_shaped, 1, start_block, end_block, step
+        ).flatten()
+    else:
+        raise ValueError(
+            f"MXTensor only supports slicing along dimensions 0 and 1, got dim={dim}"
+        )
+
+    return return_and_correct_aliasing(
+        func,
+        args,
+        kwargs,
+        MXTensor(
+            sliced_scale,
+            sliced_data,
+            x._elem_dtype,
+            x._block_size,
+            x._orig_dtype,
+            x._use_fp4_custom_triton_dequant_kernel,
+            x._gemm_kernel_choice,
+            x._pack_fp6,
+        ),
+    )
+
+
+@implements([aten.copy_.default])
+def mx_copy_(func, types, args, kwargs):
+    self = args[0]
+    src = args[1]
+    if MXTensor._same_metadata(self, src):
+        self_tensors = self.__tensor_flatten__()[0]
+        for tensor_name in self_tensors:
+            getattr(self, tensor_name).copy_(getattr(src, tensor_name))
+        return
+    raise ValueError(
+        f"Not supported args for copy_ due to metadata mistach: {args[0], args[1]}"
+    )
+
+
 @implements([aten._to_copy.default])
-def autocast_to_copy(aten_op, args, kwargs=None):
-    """This gets called when running matmul under autocast
-    when the input is a MXTensor, presenting as a fp32
-    tensor.
-    """
+def autocast_to_copy(func, types, args, kwargs):
+    """Autocast + device movement"""
     assert isinstance(args[0], MXTensor)
-    assert len(kwargs) == 1 and "dtype" in kwargs, (
-        "Only support dtype kwarg for autocast"
-    )
-    assert kwargs["dtype"] in {
-        torch.float16,
-        torch.bfloat16,
-    }, "Only support floating point conversion for autocast w/ MXTensor"
-    res = MXTensor(
-        args[0]._scale_e8m0,
-        args[0]._data,
-        args[0]._elem_dtype,
-        args[0]._block_size,
-        kwargs["dtype"],
-        args[0]._use_fp4_custom_triton_dequant_kernel,
-        args[0]._gemm_kernel_choice,
-        args[0]._pack_fp6,
-    )
-    return res
+
+    # Handle dtype parameter
+    dtype = kwargs.pop("dtype", None)
+    if dtype is not None:
+        assert dtype in {
+            torch.float16,
+            torch.bfloat16,
+        }, "Only support floating point conversion for autocast w/ MXTensor"
+
+    # Handle device parameter
+    device = kwargs.pop("device", None)
+    if device is not None:
+        # Apply device change using _apply_fn_to_data
+        tensor = args[0]._apply_fn_to_data(lambda x: func(x, device=device))
+        tensor = return_and_correct_aliasing(func, args, {}, tensor)
+    else:
+        tensor = args[0]
+
+    # Verify no other kwargs remain
+    assert len(kwargs) == 0, "Only support dtype and device kwargs for autocast"
+
+    # If dtype is specified, create a new MXTensor with the requested dtype
+    if dtype is not None:
+        res = MXTensor(
+            tensor._scale_e8m0,
+            tensor._data,
+            tensor._elem_dtype,
+            tensor._block_size,
+            dtype,
+            tensor._use_fp4_custom_triton_dequant_kernel,
+            tensor._gemm_kernel_choice,
+            tensor._pack_fp6,
+        )
+        return res
+
+    # If only device was changed, return the device-changed tensor
+    return tensor

--- a/torchao/prototype/mx_formats/mx_subclass.py
+++ b/torchao/prototype/mx_formats/mx_subclass.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import types
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+import torchao
+from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats import (
+    MXGemmKernelChoice,
+)
+from torchao.prototype.mx_formats.config import (
+    _validate_elem_dtype,
+    _validate_gemm_kernel_choice,
+)
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.quantization.quant_api import to_linear_activation_quantized
+from torchao.quantization.transform_module import (
+    register_quantize_module_handler,
+)
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_5, is_sm_at_least_100
+
+
+# Note: This API is extra prototype and will change in the future
+@dataclass
+class MXFPInferenceConfig(AOBaseConfig):
+    """
+    MX Format Inference Quantization
+
+    This module provides support for running inference with float8 quantization using MX formats.
+    The quantization flow works as follows:
+
+    1. Weight Quantization:
+    - In _mx_inference_linear_transform(), the module's weight is converted to an MXTensor
+    - The weight is quantized to the specified dtype (float8_e4m3fn by default)
+    - This happens when quantize_() is called with an MXFPInferenceConfig
+
+    2. Activation Quantization:
+    - A callable (_input_activation_quant_func_mxfp) is defined that will quantize
+        activations during inference to the same dtype
+    - This function is passed to to_linear_activation_quantized() along with the
+        already-quantized weight
+
+    3. Runtime Flow:
+    - When the quantized module is called, the input goes through the LinearActivationQuantizedTensor
+    - The input (activation) is quantized just-in-time using the provided function
+    - The MX quantized activation and MX weight are used together in F.linear
+
+    Requirements:
+    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
+    - PyTorch 2.5+ for proper serialization support
+
+    See also:
+    - LinearActivationQuantizedTensor in torchao.quantization.quant_api
+    - MXTensor in torchao.prototype.mx_formats.mx_tensor
+    """
+
+    block_size: int = 32
+
+    # Dtypes for Input and Weights
+    activation_dtype: torch.dtype = torch.float8_e4m3fn
+    weight_dtype: torch.dtype = torch.float8_e4m3fn
+
+    # Which kernel to run for mm
+    gemm_kernel_choice: MXGemmKernelChoice = MXGemmKernelChoice.CUBLAS
+
+    # Set some magic perf settings
+    set_inductor_config: bool = False
+
+    def __post_init__(self):
+        assert self.activation_dtype == self.weight_dtype, (
+            "For now - we only support matching input/weight dtypes."
+        )
+        _validate_elem_dtype(self.activation_dtype)
+        _validate_elem_dtype(self.weight_dtype)
+        _validate_gemm_kernel_choice(
+            self.gemm_kernel_choice, self.block_size, self.weight_dtype
+        )
+
+
+def _linear_extra_repr(self):
+    return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={repr(self.weight)}"
+
+
+def _input_activation_quant_func_mxfp(
+    x: torch.Tensor,
+    activation_dtype: torch.dtype,
+    block_size: int,
+    scale: Optional[torch.Tensor] = None,
+):
+    """ """
+
+    # TODO scale for static quant
+
+    activation = MXTensor.to_mx(
+        x,
+        activation_dtype,
+        block_size=block_size,
+        gemm_kernel_choice=None,  # Get from weight
+        pack_fp6=False,  # TODO
+    )
+    return activation
+
+
+@register_quantize_module_handler(MXFPInferenceConfig)
+def _mx_inference_linear_transform(
+    module: torch.nn.Module, config: MXFPInferenceConfig
+):
+    # TODO Sm120 has slightly more restrictive reqs
+    # TODO handle AMD
+    assert is_sm_at_least_100(), "MXFP is only supported on sm100 machiens for now"
+    if config.set_inductor_config:
+        torchao.quantization.utils.recommended_inductor_config_setter()
+
+    activation_dtype = config.activation_dtype
+    weight_dtype = config.weight_dtype
+    weight = module.weight
+
+    assert weight.dtype == torch.bfloat16, (
+        f"Only supporting bf16 out dtype for now, got {weight.dtype}"
+    )
+
+    # Convert weight to MX Tensor
+    quantized_weight = MXTensor.to_mx(
+        weight,
+        weight_dtype,
+        block_size=config.block_size,
+        gemm_kernel_choice=config.gemm_kernel_choice,
+        pack_fp6=False,  # TODO
+    )
+
+    input_quant_func = _input_activation_quant_func_mxfp
+    input_quant_kwargs = {
+        "block_size": config.block_size,
+        "activation_dtype": activation_dtype,
+        "scale": None,
+    }
+
+    quantized_weight = to_linear_activation_quantized(
+        quantized_weight, input_quant_func, quant_kwargs=input_quant_kwargs
+    )
+
+    module.weight = torch.nn.Parameter(quantized_weight, requires_grad=False)
+    module.extra_repr = types.MethodType(_linear_extra_repr, module)
+    return module
+
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    torch.serialization.add_safe_globals(
+        [MXTensor, MXGemmKernelChoice, _input_activation_quant_func_mxfp]
+    )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -18,7 +18,7 @@ Exponent E8M0 encoding details (OCP spec section 5.4.1):
 """
 
 from enum import Enum, auto
-from typing import Dict, Union
+from typing import Callable, Dict, Union
 
 import torch
 
@@ -559,10 +559,17 @@ class MXTensor(torch.Tensor):
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs=None):
         # avoid circular dependency
+        from torchao.prototype.mx_formats.mx_funcs import MX_FUNC_TABLE
         from torchao.prototype.mx_formats.mx_ops import MX_OPS_TABLE
 
         if func in MX_OPS_TABLE:
-            return MX_OPS_TABLE[func](func, args, kwargs)
+            return MX_OPS_TABLE[func](func, types, args, kwargs)
+
+        # TODO AO BASE_TENSOR doesn't respect dispatch and function modes
+        # We are calling nn.functional.linear from within LinearAct Tensor even though
+        # We are in a __torch__dispatch. This disables the decomposition and we get this op
+        if func == torch.ops.aten.linear.default:
+            return MX_FUNC_TABLE[func](func, types, args, kwargs)
 
         raise NotImplementedError(f"{func} not implemented")
 
@@ -631,5 +638,37 @@ class MXTensor(torch.Tensor):
             metadata["_pack_fp6"],
         )
 
+    def _apply_fn_to_data(self, fn: Callable):
+        """Applies a fn to all tensor components stored on this class"""
+        tensor_names, ctx = self.__tensor_flatten__()
+
+        # Apply the function to each tensor component
+        new_tensors = {}
+        for name in tensor_names:
+            new_tensors[name] = fn(getattr(self, name))
+
+        return self.__class__.__tensor_unflatten__(
+            new_tensors,
+            ctx,
+            None,  # outer_size parameter
+            None,  # outer_stride parameter
+        )
+
     # Do not force the MXTensor type on the returned tensor
     __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def _same_metadata(cls, self: "MXTensor", src: "MXTensor") -> bool:
+        return (
+            isinstance(self, MXTensor)
+            and isinstance(src, MXTensor)
+            and self._elem_dtype == src._elem_dtype
+            and self._block_size == src._block_size
+            and self._orig_dtype == src._orig_dtype
+            and self._use_fp4_custom_triton_dequant_kernel
+            == src._use_fp4_custom_triton_dequant_kernel
+            and self._gemm_kernel_choice == src._gemm_kernel_choice
+            and self._pack_fp6 == src._pack_fp6
+            and self._scale_e8m0.shape == src._scale_e8m0.shape
+            and self._data.shape == src._data.shape
+        )

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -43,8 +43,7 @@ def to_blocked(input_matrix, use_triton_kernel: bool = True) -> Tensor:
 
     padded = input_matrix
     # TODO This is to work around VLLM's usage of compile w/ dynamic shapes
-    # if torch.compiler.is_compiling() or (rows, cols) != (padded_rows, padded_cols):
-    if (rows, cols) != (padded_rows, padded_cols):
+    if torch.compiler.is_compiling() or (rows, cols) != (padded_rows, padded_cols):
         padded = torch.zeros(
             (padded_rows, padded_cols),
             device=input_matrix.device,


### PR DESCRIPTION
Stacked PRs:
 * __->__#2132


--- --- ---

add subclass based method for inference
 
 
 ## Perf comparisons
 ### Micro
 https://fburl.com/whh557d1
 
 I am seeing extra overhead then expected 
 
 ### Macro
 Runnng
 ```
python benchmarks/benchmark_serving.py \
  --backend vllm \
  --model "Qwen/Qwen2-7B-Instruct" \
  --endpoint /v1/completions \
  --dataset-name sharegpt \
  --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 1024
  ```
  


``` shell
 ============ Serving Benchmark Result ============
Successful requests:                     1024      
Benchmark duration (s):                  13.14     
Total input tokens:                      225502    
Total generated tokens:                  185804    
Request throughput (req/s):              77.91     
Output token throughput (tok/s):         14137.59  
Total Token throughput (tok/s):          31295.75  
---------------Time to First Token----------------
Mean TTFT (ms):                          2659.95   
Median TTFT (ms):                        2613.38   
P99 TTFT (ms):                           4457.53   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.95     
Median TPOT (ms):                        28.56     
P99 TPOT (ms):                           167.73    
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.52     
Median ITL (ms):                         15.42     
P99 ITL (ms):                            148.78    
==================================================
```


Running against MXFP8:
```
python benchmarks/benchmark_serving.py \  
  --backend vllm \
  --model "/home/drisspg/meta/scripts/data/mxfp8-Qwen2-7B-Instruct" \
  --endpoint /v1/completions \
  --dataset-name sharegpt \
  --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 1024
 ```
 ```Shell
============ Serving Benchmark Result ============
Successful requests:                     1024      
Benchmark duration (s):                  13.43     
Total input tokens:                      225502    
Total generated tokens:                  185297    
Request throughput (req/s):              76.26     
Output token throughput (tok/s):         13800.30  
Total Token throughput (tok/s):          30594.93  
---------------Time to First Token----------------
Mean TTFT (ms):                          1119.68   
Median TTFT (ms):                        1100.86   
P99 TTFT (ms):                           1721.80   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.11     
Median TPOT (ms):                        27.07     
P99 TPOT (ms):                           46.91     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.38     
Median ITL (ms):                         17.28     
P99 ITL (ms):                            49.45     
==================================================
 
 ```
 
Trace NonQuant:
https://fburl.com/sput3bmn
 
Trace Quant:
https://fburl.com/0pgmyrge