### PR TITLE
Skip test_slice_int4wo for ROCm

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -345,6 +345,7 @@ class TestAffineQuantizedBasic(TestCase):
     @common_utils.parametrize("device", ["cuda"])
     @common_utils.parametrize("dtype", [torch.bfloat16])
     @skip_if_no_cuda()
+    @skip_if_rocm("ROCm enablement in progress")
     def test_slice_int4wo(self, device, dtype):
         # in_feature not divisible by 1024
         # out_feature not divisible by 8


### PR DESCRIPTION
This pull request introduces a minor modification to the `test_alias` function in the `test/dtypes/test_affine_quantized.py` file. The change adds a new decorator to skip the test on ROCm-enabled systems with a note indicating that ROCm enablement is in progress.

Testing adjustments:

* [`test/dtypes/test_affine_quantized.py`](diffhunk://#diff-31b1ffcd78674b79cc65749176354ea4743683070120034709c1da7a3eac31f6R348): Added the `@skip_if_rocm` decorator with a message "ROCm enablement in progress" to the `test_slice_int4wo` test function to conditionally skip it on ROCm platforms.