### PR TITLE
[WIP]: Reduce torchao import time

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -1,10 +1,10 @@
 import logging
+import warnings
+from importlib.util import find_spec
+from typing import Any
 
 # torch/nested/_internal/nested_tensor.py:417: UserWarning: Failed to initialize NumPy: No module named 'numpy'
-import warnings
-
-import torch
-
+# Suppress numpy warning
 warnings.filterwarnings(
     "ignore", message="Failed to initialize NumPy: No module named 'numpy'"
 )
@@ -20,30 +20,128 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"  # In case this logic breaks don't break the build
 
-try:
-    from pathlib import Path
+# Lazy loading mechanism
+class LazyLoader:
+    def __init__(self, lib_name: str):
+        self.lib_name = lib_name
+        self._mod = None
+        self._loading = False
 
-    so_files = list(Path(__file__).parent.glob("_C*.so"))
-    if len(so_files) > 0:
-        assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
-        torch.ops.load_library(str(so_files[0]))
-        from . import ops
+    def __getattr__(self, name: str) -> Any:
+        if self._loading:
+            raise AttributeError(f"No attribute {name} - recursive load detected")
+        if self._mod is None:
+            self._loading = True
+            try:
+                import importlib
+                self._mod = importlib.import_module(self.lib_name)
+            finally:
+                self._loading = False
+        return getattr(self._mod, name)
 
-    # The following library contains CPU kernels from torchao/experimental
-    # They are built automatically by ao/setup.py if on an ARM machine.
-    # They can also be built outside of the torchao install process by
-    # running the script `torchao/experimental/build_torchao_ops.sh <aten|executorch>`
-    # For more information, see https://github.com/pytorch/ao/blob/main/torchao/experimental/docs/readme.md
-    from torchao.experimental.op_lib import *  # noqa: F403
-except Exception as e:
-    logging.debug(f"Skipping import of cpp extensions: {e}")
+    def __repr__(self):
+        return f"LazyLoader({self.lib_name})"
 
-from torchao.quantization import (
-    autoquant,
-    quantize_,
-)
+# C++ extensions loader
+class CppExtensionLoader:
+    def __init__(self):
+        self._loaded = False
+        self._ops = None
+        self._loading = False
+        self._torch = None
 
-from . import dtypes, optim, swizzle, testing
+    def __getattr__(self, name: str) -> Any:
+        if self._loading:
+            raise AttributeError(f"No attribute {name} - recursive load detected")
+        if not self._loaded:
+            self._loading = True
+            try:
+                self._load_extensions()
+            finally:
+                self._loading = False
+                self._loaded = True
+        if self._ops is None:
+            raise AttributeError(f"No attribute {name} - C++ extensions not available")
+        return getattr(self._ops, name)
+
+    def _load_extensions(self):
+        try:
+            # Lazy import torch only when needed
+            if self._torch is None:
+                import torch
+                self._torch = torch
+            from pathlib import Path
+            
+            so_files = list(Path(__file__).parent.glob("_C*.so"))
+            if len(so_files) > 0:
+                assert len(so_files) == 1, f"Expected one _C*.so file, found {len(so_files)}"
+                self._torch.ops.load_library(str(so_files[0]))
+                import importlib
+                self._ops = importlib.import_module("torchao.ops")
+        except Exception as e:
+            logging.warning(f"Failed to load C++ extensions: {e}")
+
+    def __repr__(self):
+        status = "loading" if self._loading else "not_loaded" if not self._loaded else "loaded"
+        return f"CppExtensionLoader({status})"
+
+# Experimental ops loader
+class ExperimentalOpsLoader:
+    def __init__(self):
+        self._loaded = False
+        self._ops = {}
+        self._loading = False
+
+    def __getattr__(self, name: str) -> Any:
+        if self._loading:
+            raise AttributeError(f"No attribute {name} - recursive load detected")
+        if not self._loaded:
+            self._loading = True
+            try:
+                self._load_ops()
+            finally:
+                self._loading = False
+                self._loaded = True
+        if name not in self._ops:
+            raise AttributeError(f"No attribute {name} in experimental ops")
+        return self._ops[name]
+
+    def _load_ops(self):
+        try:
+            if find_spec("torchao.experimental.op_lib"):
+                import importlib
+                op_lib = importlib.import_module("torchao.experimental.op_lib")
+                for name in getattr(op_lib, "__all__", []):
+                    self._ops[name] = getattr(op_lib, name)
+        except Exception as e:
+            logging.warning(f"Failed to load experimental ops: {e}")
+
+    def __repr__(self):
+        status = "loading" if self._loading else "not_loaded" if not self._loaded else "loaded"
+        return f"ExperimentalOpsLoader({status})"
+
+def _lazy_import(name: str):
+    """Helper to create lazy imports"""
+    return LazyLoader(name)
+
+# Initialize all loaders
+dtypes = _lazy_import("torchao.dtypes")
+optim = _lazy_import("torchao.optim")
+swizzle = _lazy_import("torchao.swizzle")
+testing = _lazy_import("torchao.testing")
+ops = CppExtensionLoader()
+experimental = ExperimentalOpsLoader()
+
+# Lazy functions that avoid importing torch/numpy until absolutely needed
+def quantize_():
+    """Lazy load quantization module"""
+    from torchao.quantization import quantize_ as _quantize
+    return _quantize
+
+def autoquant():
+    """Lazy load autoquant module"""
+    from torchao.quantization import autoquant as _autoquant
+    return _autoquant
 
 __all__ = [
     "dtypes",
@@ -53,4 +151,5 @@ __all__ = [
     "swizzle",
     "testing",
     "ops",
+    "experimental",
 ]

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -1,39 +1,142 @@
-from . import affine_quantized_tensor_ops
-from .affine_quantized_tensor import (
-    AffineQuantizedTensor,
-    to_affine_quantized_floatx,
-    to_affine_quantized_floatx_static,
-    # experimental, will be merged into floatx in the future
-    to_affine_quantized_fpx,
-    to_affine_quantized_intx,
-    to_affine_quantized_intx_static,
-)
-from .floatx import (
-    CutlassSemiSparseLayout,
-    Float8Layout,
-)
-from .nf4tensor import NF4Tensor, to_nf4
-from .uintx import (
-    BlockSparseLayout,
-    CutlassInt4PackedLayout,
-    Int4CPULayout,
-    Int4XPULayout,
-    MarlinQQQLayout,
-    MarlinQQQTensor,
-    MarlinSparseLayout,
-    PackedLinearInt8DynamicActivationIntxWeightLayout,
-    QDQLayout,
-    SemiSparseLayout,
-    TensorCoreTiledLayout,
-    UintxLayout,
-    to_marlinqqq_quantized_intx,
-)
+# Import the utility modules first
 from .utils import (
     Layout,
     PlainLayout,
 )
 
+# Import low-level ops that don't depend on tensor subclasses
+from . import affine_quantized_tensor_ops
+
+# Import tensor subclasses and conversion functions, but use import statements inside functions 
+# to break circular dependencies. These will be lazy-loaded when accessed.
+def _import_affine_quantized_tensor():
+    from .affine_quantized_tensor import (
+        AffineQuantizedTensor,
+        to_affine_quantized_floatx,
+        to_affine_quantized_floatx_static,
+        to_affine_quantized_fpx,
+        to_affine_quantized_intx,
+        to_affine_quantized_intx_static,
+    )
+    return (
+        AffineQuantizedTensor,
+        to_affine_quantized_floatx,
+        to_affine_quantized_floatx_static,
+        to_affine_quantized_fpx,
+        to_affine_quantized_intx,
+        to_affine_quantized_intx_static,
+    )
+
+def _import_nf4tensor():
+    from .nf4tensor import NF4Tensor, to_nf4
+    return NF4Tensor, to_nf4
+
+def _import_floatx():
+    from .floatx import (
+        CutlassSemiSparseLayout,
+        Float8Layout,
+    )
+    return CutlassSemiSparseLayout, Float8Layout
+
+def _import_uintx():
+    from .uintx import (
+        BlockSparseLayout,
+        CutlassInt4PackedLayout,
+        Int4CPULayout,
+        Int4XPULayout,
+        MarlinQQQLayout,
+        MarlinQQQTensor,
+        MarlinSparseLayout,
+        PackedLinearInt8DynamicActivationIntxWeightLayout,
+        QDQLayout,
+        SemiSparseLayout,
+        TensorCoreTiledLayout,
+        UintxLayout,
+        to_marlinqqq_quantized_intx,
+    )
+    return (
+        BlockSparseLayout,
+        CutlassInt4PackedLayout,
+        Int4CPULayout,
+        Int4XPULayout,
+        MarlinQQQLayout,
+        MarlinQQQTensor,
+        MarlinSparseLayout,
+        PackedLinearInt8DynamicActivationIntxWeightLayout,
+        QDQLayout,
+        SemiSparseLayout,
+        TensorCoreTiledLayout,
+        UintxLayout,
+        to_marlinqqq_quantized_intx,
+    )
+
+# Create properties for each of the exports
+# When accessed for the first time, they'll trigger the import
+# and cache the result
+_cache = {}
+
+def __getattr__(name):
+    # Define which modules to import for each attribute
+    import_map = {
+        "AffineQuantizedTensor": _import_affine_quantized_tensor,
+        "to_affine_quantized_floatx": _import_affine_quantized_tensor,
+        "to_affine_quantized_floatx_static": _import_affine_quantized_tensor,
+        "to_affine_quantized_fpx": _import_affine_quantized_tensor,
+        "to_affine_quantized_intx": _import_affine_quantized_tensor,
+        "to_affine_quantized_intx_static": _import_affine_quantized_tensor,
+        "NF4Tensor": _import_nf4tensor,
+        "to_nf4": _import_nf4tensor,
+        "CutlassSemiSparseLayout": _import_floatx,
+        "Float8Layout": _import_floatx,
+        "BlockSparseLayout": _import_uintx,
+        "CutlassInt4PackedLayout": _import_uintx,
+        "Int4CPULayout": _import_uintx,
+        "Int4XPULayout": _import_uintx,
+        "MarlinQQQLayout": _import_uintx,
+        "MarlinQQQTensor": _import_uintx,
+        "MarlinSparseLayout": _import_uintx,
+        "PackedLinearInt8DynamicActivationIntxWeightLayout": _import_uintx,
+        "QDQLayout": _import_uintx,
+        "SemiSparseLayout": _import_uintx,
+        "TensorCoreTiledLayout": _import_uintx,
+        "UintxLayout": _import_uintx,
+        "to_marlinqqq_quantized_intx": _import_uintx,
+    }
+    
+    if name in import_map:
+        if name not in _cache:
+            # Get the import function for this name
+            import_func = import_map[name]
+            
+            # Call the import function and store all results in cache
+            values = import_func()
+            
+            # Map the values to their names based on the import function
+            if import_func == _import_affine_quantized_tensor:
+                names = ["AffineQuantizedTensor", "to_affine_quantized_floatx", 
+                         "to_affine_quantized_floatx_static", "to_affine_quantized_fpx", 
+                         "to_affine_quantized_intx", "to_affine_quantized_intx_static"]
+            elif import_func == _import_nf4tensor:
+                names = ["NF4Tensor", "to_nf4"]
+            elif import_func == _import_floatx:
+                names = ["CutlassSemiSparseLayout", "Float8Layout"]
+            elif import_func == _import_uintx:
+                names = ["BlockSparseLayout", "CutlassInt4PackedLayout", "Int4CPULayout", 
+                         "Int4XPULayout", "MarlinQQQLayout", "MarlinQQQTensor", 
+                         "MarlinSparseLayout", "PackedLinearInt8DynamicActivationIntxWeightLayout", 
+                         "QDQLayout", "SemiSparseLayout", "TensorCoreTiledLayout", 
+                         "UintxLayout", "to_marlinqqq_quantized_intx"]
+            
+            # Cache all the imported values
+            for n, v in zip(names, values):
+                _cache[n] = v
+        
+        return _cache[name]
+    
+    raise AttributeError(f"module 'torchao.dtypes' has no attribute '{name}'")
+
 __all__ = [
+    # These will be loaded lazily via __getattr__
     "NF4Tensor",
     "to_nf4",
     "AffineQuantizedTensor",
@@ -43,8 +146,10 @@ __all__ = [
     "to_affine_quantized_floatx",
     "to_affine_quantized_floatx_static",
     "to_marlinqqq_quantized_intx",
+    # These are directly imported
     "Layout",
     "PlainLayout",
+    # These will be loaded lazily via __getattr__
     "SemiSparseLayout",
     "TensorCoreTiledLayout",
     "Float8Layout",

--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -8,15 +8,17 @@ import torch.nn.functional as F
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 import torchao
-from torchao.base import (
+from torchao.dtypes.utils import (
     Layout,
     PlainLayout,
-    Float8Layout,
-    MarlinSparseLayout,
-    SemiSparseLayout,
-    TensorCoreTiledLayout,
-    TorchAOBaseTensor,
 )
+
+from torchao.dtypes.floatx import Float8Layout
+from torchao.dtypes.uintx.marlin_sparse_layout import MarlinSparseLayout
+from torchao.dtypes.uintx.semi_sparse_layout import SemiSparseLayout
+from torchao.utils import TorchAOBaseTensor
+from torchao.dtypes.uintx.tensor_core_tiled_layout import TensorCoreTiledLayout
+
 from torchao.float8.inference import Float8MMConfig
 from torchao.kernel import safe_int_mm
 from torchao.quantization.linear_activation_quantized_tensor import (


### PR DESCRIPTION
Making heavy use of lazy imports to get the torchao import times from around 14s on a first import to 0.04s

Still fighting test suite with circular imports so don't review yet

```
(nv) ➜  ~ python -c "import time; start = time.perf_counter(); import torchao; end = time.perf_counter(); print('time import: ', end - start)"

time import:  0.04569916985929012
```