### PR TITLE
Removes pinned version for pytest

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -64,32 +64,38 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
+            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
           - name: CUDA 2.6
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.6.0'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
+            dev-requirements-overrides: ""
           - name: CUDA 2.7
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.7.0'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
+            dev-requirements-overrides: ""
 
           - name: CPU 2.5.1
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
+            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
           - name: CPU 2.6
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
+            dev-requirements-overrides: ""
           - name: CPU 2.7
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
+            dev-requirements-overrides: ""
 
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -106,6 +112,7 @@ jobs:
         export PATH=/opt/rh/gcc-toolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
+        sed -i '${{ matrix.dev-requirements-overrides }}' dev-requirements.txt
         pip install -r dev-requirements.txt
         pip install .
         export CONDA=$(dirname $(dirname $(which conda)))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Test utilities
-pytest==7.4.0
+pytest
 unittest-xml-reporting
 parameterized
 packaging


### PR DESCRIPTION
Unless 7.4.0 is actually required, we should remove this so that pip is able to resolve dependencies in other environments:
```
ERROR: Cannot install pytest==7.4.0 because these package versions have conflicting dependencies.                                                                                                    
                                                                                                                                                                                                     
The conflict is caused by:                                                                                                                                                                           
    The user requested pytest==7.4.0                                                                                                                                                                 
    The user requested (constraint) pytest==8.1.1                                                                                                                                                    

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```