### PR TITLE
Uses torch.version.cuda to compile CUDA extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -266,9 +266,7 @@ def get_extensions():
         print("ROCm is not available. Skipping compilation of ROCm extensions")
         print("If you'd like to compile ROCm extensions locally please install ROCm")
 
-    use_cuda = (
-        torch.version.cuda and CUDA_HOME is not None
-    )
+    use_cuda = torch.version.cuda and CUDA_HOME is not None
     use_hip = torch.version.hip and ROCM_HOME is not None
     extension = CUDAExtension if (use_cuda or use_hip) else CppExtension
 

--- a/setup.py
+++ b/setup.py
@@ -253,23 +253,23 @@ def get_extensions():
     if debug_mode:
         print("Compiling in debug mode")
 
-    if not torch.cuda.is_available():
+    if not torch.version.cuda:
         print(
             "PyTorch GPU support is not available. Skipping compilation of CUDA extensions"
         )
-    if CUDA_HOME is None and torch.cuda.is_available() and torch.version.cuda:
+    if CUDA_HOME is None and torch.version.cuda:
         print("CUDA toolkit is not available. Skipping compilation of CUDA extensions")
         print(
             "If you'd like to compile CUDA extensions locally please install the cudatoolkit from https://anaconda.org/nvidia/cuda-toolkit"
         )
-    if ROCM_HOME is None and torch.cuda.is_available() and torch.version.hip:
+    if ROCM_HOME is None and torch.version.hip:
         print("ROCm is not available. Skipping compilation of ROCm extensions")
         print("If you'd like to compile ROCm extensions locally please install ROCm")
 
     use_cuda = (
-        torch.cuda.is_available() and torch.version.cuda and CUDA_HOME is not None
+        torch.version.cuda and CUDA_HOME is not None
     )
-    use_hip = torch.cuda.is_available() and torch.version.hip and ROCM_HOME is not None
+    use_hip = torch.version.hip and ROCM_HOME is not None
     extension = CUDAExtension if (use_cuda or use_hip) else CppExtension
 
     nvcc_args = [


### PR DESCRIPTION
Fixes: https://github.com/pytorch/ao/issues/2152

Tested this by installing a cpu only version of PyTorch and then running `pip install -e . -vvv`. "PyTorch GPU support is not available. Skipping compilation of CUDA extensions" is in the logs, confirming that the previous behavior is preserved.
```
Using pip 25.1 from /usr/local/lib/python3.12/dist-packages/pip (python 3.12)                 
Non-user install because site-packages writeable                                              
Created temporary directory: /tmp/pip-build-tracker-a0n8qmb2                                  
Initialized build tracking at /tmp/pip-build-tracker-a0n8qmb2                                 
Created build tracker: /tmp/pip-build-tracker-a0n8qmb2                                        
Entered build tracker: /tmp/pip-build-tracker-a0n8qmb2                                        
Created temporary directory: /tmp/pip-install-tn_td1mv                                        
Created temporary directory: /tmp/pip-ephem-wheel-cache-iflb4k6r                              
Obtaining file:///workspace/ao                                                                
  Added file:///workspace/ao to build tracker '/tmp/pip-build-tracker-a0n8qmb2'               
  Running setup.py (path:/workspace/ao/setup.py) egg_info for package from file:///workspace/a
o                                                                                             
  Created temporary directory: /tmp/pip-pip-egg-info-j4p5drqz                                 
  Running command python setup.py egg_info                                                    
  INFO:root:running egg_info                                                                  
  INFO:root:creating /tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info                          
  INFO:root:writing /tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/PKG-INFO                  
  INFO:root:writing dependency_links to /tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/depend
ency_links.txt                                                                                
  INFO:root:writing requirements to /tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/requires.t
xt                                                                                            
  INFO:root:writing top-level names to /tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/top_lev
el.txt                                                                                        
  INFO:root:writing manifest file '/tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/SOURCES.txt
'                                                                                             
  INFO:root:reading manifest file '/tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/SOURCES.txt
'                                                                                             
  INFO:root:adding license file 'LICENSE'                                                     
  INFO:root:writing manifest file '/tmp/pip-pip-egg-info-j4p5drqz/torchao.egg-info/SOURCES.txt
'                                                                                             
  PyTorch GPU support is not available. Skipping compilation of CUDA extensions
```