### PR TITLE
Update utils_parallel_dequant.cuh

### DIFF
--- a/torchao/csrc/cuda/fp6_llm/utils_parallel_dequant.cuh
+++ b/torchao/csrc/cuda/fp6_llm/utils_parallel_dequant.cuh
@@ -25,9 +25,7 @@
 
 #include <cuda.h>
 #include <cuda_fp16.h>
-#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
 #include <cuda_bf16.h>
-#endif
 #include <cuda_runtime.h>
 
 /*


### PR DESCRIPTION
bfloat16 header is needed to compile MultScale with __nv_bfloat16 argument