### PR TITLE
Set eps in end-to-end QAT flow

### DIFF
--- a/torchao/experimental/quant_passes.py
+++ b/torchao/experimental/quant_passes.py
@@ -87,7 +87,7 @@ def _get_q_dq_linear_patterns_replacements_and_filters(
     glbs["a_quant_max"] = None
     glbs["a_mapping_type"] = "ASYMMETRIC"
     glbs["a_scale_dtype"] = torch.float32
-    glbs["a_eps"] = None
+    glbs["a_eps"] = torch.finfo(torch.float32).eps
 
     lcls = {}
 

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -361,7 +361,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         self.assertTrue(torch.allclose(eager_results, exported_results))
 
         expected_lines = [
-            "torch.ops.torchao.choose_qparams_affine.default(input_1, 'ASYMMETRIC', [1, 512], torch.int8, None, None, None, torch.float32, torch.int8)",
+            "torch.ops.torchao.choose_qparams_affine.default(input_1, 'ASYMMETRIC', [1, 512], torch.int8, None, None, 1.1920928955078125e-07, torch.float32, torch.int8)",
             "torch.ops.torchao.quantize_affine.default(input_1, [1, 512], getitem, getitem_1, torch.int8)",
             "torch.ops.torchao.dequantize_affine.default(quantize_affine, [1, 512], getitem, getitem_1, torch.int8)",
             "torch.ops.torchao.dequantize_affine.default",

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -938,7 +938,10 @@ def linear_forward_8da4w(
     # TODO: in future add ability to specify activation_scale_dtype to PTQ configs
     # and enable similar change here
     x = per_token_dynamic_quant(
-        x, scale_dtype=torch.float32, zero_point_dtype=torch.float32
+        x,
+        scale_dtype=torch.float32,
+        zero_point_dtype=torch.float32,
+        eps=torch.finfo(torch.float32).eps,
     )
 
     # TODO: verify and remove following reshape code

--- a/torchao/quantization/qat/api.py
+++ b/torchao/quantization/qat/api.py
@@ -85,6 +85,7 @@ class FakeQuantizeConfig:
     zero_point_domain: ZeroPointDomain
     is_dynamic: bool = True
     range_learning: bool = False
+    eps: Optional[float] = None
 
     def __init__(
         self,
@@ -96,6 +97,7 @@ class FakeQuantizeConfig:
         zero_point_domain: ZeroPointDomain = ZeroPointDomain.INT,
         is_dynamic: bool = True,
         range_learning: bool = False,
+        eps: Optional[float] = None,
         *,
         group_size: Optional[int] = None,
         is_symmetric: Optional[bool] = None,
@@ -110,6 +112,7 @@ class FakeQuantizeConfig:
         self.zero_point_domain = zero_point_domain
         self.is_dynamic = is_dynamic
         self.range_learning = range_learning
+        self.eps = eps
 
         # Validate dtype
         all_dtypes = [torch.int8, torch.uint8]

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -81,6 +81,7 @@ class FakeQuantizer(torch.nn.Module):
                 target_dtype=self.config.dtype,
                 quant_min=qmin,
                 quant_max=qmax,
+                eps=self.config.eps,
                 scale_dtype=self.config.scale_precision,
                 zero_point_dtype=self.config.zero_point_precision,
             )
@@ -117,6 +118,7 @@ class FakeQuantizer(torch.nn.Module):
                     bit_width,
                     group_size,
                     scale_precision,
+                    eps=self.config.eps,
                 )
             else:
                 (self.scale, self.zero_point) = get_groupwise_affine_qparams(
@@ -124,6 +126,7 @@ class FakeQuantizer(torch.nn.Module):
                     bit_width,
                     group_size,
                     scale_precision,
+                    eps=self.config.eps,
                 )
             self.zero_point = self.zero_point.to(zero_point_precision)
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -627,6 +627,7 @@ def _int8_asymm_per_token_quant(x: torch.Tensor) -> torch.Tensor:
     mapping_type = MappingType.ASYMMETRIC
     target_dtype = torch.int8
     scale_dtype = torch.float32
+    eps = torch.finfo(torch.float32).eps
     zero_point_dtype = torch.int8
     if TORCH_VERSION_AT_LEAST_2_6:
         return to_affine_quantized_intx(
@@ -634,6 +635,7 @@ def _int8_asymm_per_token_quant(x: torch.Tensor) -> torch.Tensor:
             mapping_type,
             _get_per_token_block_size(x),
             target_dtype,
+            eps=eps,
             scale_dtype=scale_dtype,
             zero_point_dtype=zero_point_dtype,
         )


### PR DESCRIPTION
**Summary:** This commit does two things:

(1) Allow users to set eps in `FakeQuantizeConfig`
(2) For other parts of the QAT flow, set eps to `torch.finfo(torch.float32).eps` for input linear activations to match the existing hardcoded input activation scale dtype (which is fp32)

The motivation is to enable users who wish to lower their models to XNNPACK. This would require them to use the following combination of dtypes during training for end-to-end numerical match:

- input activations: bf16
- input activation scales: fp32
- input activation eps: `torch.finfo(torch.float32).eps`
- weight: bf16
- weight scales: bf16
- weight eps: `torch.finfo(torch.bfloat16).eps`

However, today there is no way to specify the above in any of the QAT flows. For the recommended `FakeQuantizeConfig` flow, we always use `torch.finfo(x.dtype).eps`, where x is bf16 in this case, and there is no way for users to configure this. This is resolved by (1).

For the legacy `Int8DynActInt4QATQuantizer` flow, we hardcode input activation scales to always use fp32 in
https://github.com/pytorch/ao/pull/2085, but did not set the corresponding eps. Today, this also uses `torch.finfo(x.dtype).eps` by default, where x is bf16, and so we use the wrong eps value. This is resolved by (2).

**Test Plan:**
python test/quantization/test_qat.py -k test_fake_quantize_config_eps
python test/quantization/test_qat.py -k test_qat_8da4w_eps