### PR TITLE
Skip ROCm MoE Quantization

### DIFF
--- a/test/quantization/test_moe_quant.py
+++ b/test/quantization/test_moe_quant.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 import torch
 from parameterized import parameterized
 
@@ -31,6 +32,12 @@ from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_6,
     is_sm_at_least_90,
 )
+
+if torch.version.hip is not None:
+    pytest.skip(
+        "ROCm support for MoE quantization is under development",
+        allow_module_level=True,
+    )
 
 
 class TestMoEQuantCompile(unittest.TestCase):


### PR DESCRIPTION
This commit introduces a conditional skip for the MoE quantization tests when running on ROCm, indicating that support for this feature is still under development. The change ensures that tests do not fail prematurely in environments lacking complete ROCm functionality.

Test Plan:
- Run tests in environments with and without ROCm support to verify the skip behavior.