### PR TITLE
Uses torch.version.cuda to compile CUDA extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,9 +263,7 @@ def get_extensions():
             "If you'd like to compile CUDA extensions locally please install the cudatoolkit from https://anaconda.org/nvidia/cuda-toolkit"
         )
 
-    use_cuda = torch.version.cuda and (
-        CUDA_HOME is not None or ROCM_HOME is not None
-    )
+    use_cuda = torch.version.cuda and (CUDA_HOME is not None or ROCM_HOME is not None)
     extension = CUDAExtension if use_cuda else CppExtension
 
     extra_link_args = []

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ def get_extensions():
         print(
             "PyTorch GPU support is not available. Skipping compilation of CUDA extensions"
         )
-    if (CUDA_HOME is None and ROCM_HOME is None) and torch.cuda.is_available():
+    if (CUDA_HOME is None and ROCM_HOME is None) and torch.version.cuda:
         print(
             "CUDA toolkit or ROCm is not available. Skipping compilation of CUDA extensions"
         )
@@ -263,7 +263,7 @@ def get_extensions():
             "If you'd like to compile CUDA extensions locally please install the cudatoolkit from https://anaconda.org/nvidia/cuda-toolkit"
         )
 
-    use_cuda = torch.cuda.is_available() and (
+    use_cuda = torch.version.cuda and (
         CUDA_HOME is not None or ROCM_HOME is not None
     )
     extension = CUDAExtension if use_cuda else CppExtension


### PR DESCRIPTION
@atalman the changes in https://github.com/pytorch/ao/pull/2170 removed my changes from https://github.com/pytorch/ao/pull/2163. Note that torch.cuda.is_available() fails in a system where CUDA toolkit is available for compilation but there are no GPUs. As a result, extension won't get compiled in that system.