### PR TITLE
Update GemLite to support vLLM V1

### DIFF
--- a/torchao/dtypes/uintx/gemlite_layout.py
+++ b/torchao/dtypes/uintx/gemlite_layout.py
@@ -192,9 +192,12 @@ class GemliteAQTTensorImpl(TensorCoreTiledAQTTensorImpl):
         group_size, bit_width = _layout.group_size, _layout.bit_width
         out_features, in_features = int_data.shape
 
-        gemlite_linear = gemlite.helper.A16Wn(device=int_data.device).from_weights(
-            int_data, scale, zero_point, bit_width, group_size, bias=None
-        )
+        if(bit_width == 8 and group_size == in_features):
+            gemlite_linear = gemlite.helper.A16W8(device=int_data.device).from_weights(int_data, scales=scale, bias=None)
+        else:
+            gemlite_linear = gemlite.helper.A16Wn(device=int_data.device).from_weights(
+                int_data, scale, zero_point, bit_width, group_size, bias=None
+            )
 
         gemlite_kwargs = {
             "in_features": in_features,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -978,8 +978,6 @@ class GemliteUIntXWeightOnlyConfig(AOBaseConfig):
 
     group_size: Optional[int] = 64
     bit_width: int = 4
-    packing_bitwidth: int = 32
-    contiguous: Optional[bool] = None
     set_inductor_config: bool = True
 
 
@@ -993,8 +991,6 @@ def _gemlite_uintx_weight_only_transform(
 ):
     group_size = config.group_size
     bit_width = config.bit_width
-    packing_bitwidth = config.packing_bitwidth
-    contiguous = config.contiguous
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
 
@@ -1006,7 +1002,7 @@ def _gemlite_uintx_weight_only_transform(
     new_weight = to_affine_quantized_intx(
         weight,
         **get_gemlite_aqt_kwargs(
-            weight, group_size, bit_width, packing_bitwidth, contiguous, use_hqq
+            weight, group_size, bit_width, use_hqq
         ),
     )
     module.weight = torch.nn.Parameter(new_weight, requires_grad=False)

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1001,9 +1001,7 @@ def _gemlite_uintx_weight_only_transform(
     use_hqq = True if bit_width == 4 else False
     new_weight = to_affine_quantized_intx(
         weight,
-        **get_gemlite_aqt_kwargs(
-            weight, group_size, bit_width, use_hqq
-        ),
+        **get_gemlite_aqt_kwargs(weight, group_size, bit_width, use_hqq),
     )
     module.weight = torch.nn.Parameter(new_weight, requires_grad=False)
     module.extra_repr = types.MethodType(_linear_extra_repr, module)


### PR DESCRIPTION
Updated <a href="https://github.com/mobiusml/gemlite/">GemLite</a> changes to make it compatible with vLLM V1.
I also corrected the unpacking which should use the output feature size and added symmetric A16W8 support since the arguments support it but it was not implemented. 

```Python
#pip install git+https://github.com/mobiusml/gemlite/ --upgrade
from transformers import TorchAoConfig
from torchao.quantization import GemliteUIntXWeightOnlyConfig
quant_config = TorchAoConfig(quant_type=GemliteUIntXWeightOnlyConfig(bit_width=4, group_size=128)) #A16W4
#quant_config = TorchAoConfig(quant_type=GemliteUIntXWeightOnlyConfig(bit_width=8, group_size=None)) #A16W8
model = AutoModelForCausalLM.from_pretrained(
    model_id,
    torch_dtype=torch.float16,
    attn_implementation="sdpa",
    device_map="cuda",
    quantization_config=quant_config,
)
```