### PR TITLE
Skips for ROCm (X86 Inductor Tests)

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -28,12 +28,13 @@ from torch.testing._internal.common_utils import (
     IS_X86,
     instantiate_parametrized_tests,
     parametrize,
-    skipIfRocm,
 )
 from torch.testing._internal.inductor_utils import (
     HAS_CPU,
     _check_has_dynamic_shape,
 )
+
+from torchao.testing.utils import skip_if_rocm
 
 import torchao
 import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
@@ -328,7 +329,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qconv2d_cpu(self):
         r"""
         This testcase will quantize a single Conv2d module.
@@ -338,7 +339,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNNBF16
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qconv2d_int8_mixed_bf16(self):
         r"""
         This testcase will quantize a single Conv2d module with int8_mixed_bf16 quantization.
@@ -932,7 +933,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("ROCm enablement in progress")
     def test_qat_qconv2d(self):
         r"""
         This testcase will quantize a single Conv2d module with qat flow.
@@ -1075,7 +1076,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qat_qconv2d_add(self):
         r"""
         This testcase will quantize a Conv2d->Add pattern as:
@@ -1141,7 +1142,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qat_qconv2d_add_relu(self):
         r"""
         This testcase will quantize a Conv2d->Add->ReLU pattern as:
@@ -1281,7 +1282,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skipIfRocm
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qconv2d_dequant_promotion_cpu(self):
         self._test_qconv2d_dequant_promotion_helper()
 

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -932,7 +932,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @skip_if_rocm("ROCm enablement in progress")
+    @skip_if_rocm("Not applicable to ROCm")
     def test_qat_qconv2d(self):
         r"""
         This testcase will quantize a single Conv2d module with qat flow.

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -34,8 +34,6 @@ from torch.testing._internal.inductor_utils import (
     _check_has_dynamic_shape,
 )
 
-from torchao.testing.utils import skip_if_rocm
-
 import torchao
 import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
 from torchao.quantization.pt2e.quantize_pt2e import (
@@ -46,6 +44,7 @@ from torchao.quantization.pt2e.quantize_pt2e import (
 from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import (
     X86InductorQuantizer,
 )
+from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_6,
     TORCH_VERSION_AT_LEAST_2_8,


### PR DESCRIPTION
TLDR: Proper skips for tests not applicable on ROCM
-----------

This pull request refactors the usage of the `@skipIfRocm` decorator in the `test/quantization/pt2e/test_x86inductor_fusion.py` file to improve clarity and maintain consistency by replacing it with the `@skip_if_rocm` decorator. Additionally, custom messages have been added to specify the reason for skipping tests on ROCm.

### Refactoring of test skipping logic:

* Replaced `@skipIfRocm` with `@skip_if_rocm` in all relevant test cases to align with updated conventions. Custom messages were added to provide context for why the test is skipped on ROCm, such as "Not applicable to ROCm" or "ROCm enablement in progress." [[1]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL331-R331) [[2]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL341-R341) [[3]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL935-R935) [[4]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL1078-R1078) [[5]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL1144-R1144) [[6]](diffhunk://#diff-812113dadc83f99a6e5df52239007151db6db1dedb91168c4cb243d1a9871f6aL1284-R1284)

### Dependency updates:

* Imported the `skip_if_rocm` decorator from `torchao.testing.utils` to replace the old `skipIfRocm` decorator.

### Code cleanup:

* Removed the unused import of `skipIfRocm` from the file, as it is no longer required.