### PR TITLE
Enable {conv3d, conv_transpose3d} + bn fusion in pt2e

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2410,7 +2410,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                     observer_or_fake_quant_ctr=observer.PlaceholderObserver,
                 )
                 # conv_transpose + bn is fused automatically in PTQ (not configurable)
-                # so we just need to annotate conv_transpose + relu for conv_transpose + bn + relu
+                # so we just need to annotate conv + relu for conv + bn + relu
                 # pattern
                 for n in model.graph.nodes:
                     if (

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -626,6 +626,7 @@ def _is_conv_node(n: Node):
     return n.op == "call_function" and n.target in [
         torch.ops.aten.conv1d.default,
         torch.ops.aten.conv2d.default,
+        torch.ops.aten.conv3d.default,
     ]
 
 
@@ -638,6 +639,8 @@ def _is_conv_transpose_node(n: Node):
         torch.ops.aten.conv_transpose1d.default,
         torch.ops.aten.conv_transpose2d,
         torch.ops.aten.conv_transpose2d.input,
+        torch.ops.aten.conv_transpose3d,
+        torch.ops.aten.conv_transpose3d.input,
     ]
 
 
@@ -649,7 +652,7 @@ def _is_conv_or_conv_transpose_node(n: Node):
 
 
 def _is_conv_transpose_fn(conv_fn: Callable):
-    return conv_fn in [F.conv_transpose1d, F.conv_transpose2d]
+    return conv_fn in [F.conv_transpose1d, F.conv_transpose2d, F.conv_transposed3d]
 
 
 def _is_bn_node(n: Node):

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -652,7 +652,7 @@ def _is_conv_or_conv_transpose_node(n: Node):
 
 
 def _is_conv_transpose_fn(conv_fn: Callable):
-    return conv_fn in [F.conv_transpose1d, F.conv_transpose2d, F.conv_transposed3d]
+    return conv_fn in [F.conv_transpose1d, F.conv_transpose2d, F.conv_transpose3d]
 
 
 def _is_bn_node(n: Node):


### PR DESCRIPTION
Summary:
att, previously only 1d and 2d fusion are supported, this PR adds 3d support

Test Plan:
python test/quantization/pt2e/test_quantize_pt2e.py -k test_conv3d_bn_relu python test/quantization/pt2e/test_quantize_pt2e.py -k test_conv_transpose3d_bn_relu

Reviewers:

Subscribers:

Tasks:

Tags: