### PR TITLE
Convert Pytest to Unittest for tests under test/dtypes/ 

### DIFF
--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -3,78 +3,91 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+import unittest
 import torch
 from torch.utils._triton import has_triton
 
 from torchao.dtypes.uintx.bitpacking import pack, pack_cpu, unpack, unpack_cpu
 
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+
 bit_widths = (1, 2, 3, 4, 5, 6, 7)
 dimensions = (0, -1, 1)
 
 
-@pytest.fixture(autouse=True)
-def run_before_and_after_tests():
-    yield
-    torch._dynamo.reset()  # reset cache between tests
+class TestBitpacking(TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+    
+    def tearDown(self):
+        torch._dynamo.reset()
+
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    def test_CPU(self, bit_width, dim):
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8, device="cpu"
+        )
+        packed = pack_cpu(test_tensor, bit_width, dim=dim)
+        unpacked = unpack_cpu(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
 
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_CPU(bit_width, dim):
-    test_tensor = torch.randint(
-        0, 2**bit_width, (32, 32, 32), dtype=torch.uint8, device="cpu"
-    )
-    packed = pack_cpu(test_tensor, bit_width, dim=dim)
-    unpacked = unpack_cpu(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_GPU(self, bit_width, dim):
+        test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
+        packed = pack(test_tensor, bit_width, dim=dim)
+        unpacked = unpack(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_GPU(bit_width, dim):
-    test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
-    packed = pack(test_tensor, bit_width, dim=dim)
-    unpacked = unpack(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not has_triton(), reason="unsupported without triton")
+    def test_compile(self, bit_width, dim):
+        torch._dynamo.config.specialize_int = True
+        torch.compile(pack, fullgraph=True)
+        torch.compile(unpack, fullgraph=True)
+        test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
+        packed = pack(test_tensor, bit_width, dim=dim)
+        unpacked = unpack(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_compile(bit_width, dim):
-    torch._dynamo.config.specialize_int = True
-    torch.compile(pack, fullgraph=True)
-    torch.compile(unpack, fullgraph=True)
-    test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
-    packed = pack(test_tensor, bit_width, dim=dim)
-    unpacked = unpack(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    # these test cases are for the example pack walk through in the bitpacking.py file
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_pack_example(self):
+        test_tensor = torch.tensor(
+            [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
+        ).cuda()
+        shard_4, shard_2 = pack(test_tensor, 6)
+        print(shard_4, shard_2)
+        assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).cuda().allclose(shard_4)
+        assert torch.tensor([39, 146], dtype=torch.uint8).cuda().allclose(shard_2)
+        unpacked = unpack([shard_4, shard_2], 6)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
 
-# these test cases are for the example pack walk through in the bitpacking.py file
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_pack_example():
-    test_tensor = torch.tensor(
-        [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
-    ).cuda()
-    shard_4, shard_2 = pack(test_tensor, 6)
-    print(shard_4, shard_2)
-    assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).cuda().allclose(shard_4)
-    assert torch.tensor([39, 146], dtype=torch.uint8).cuda().allclose(shard_2)
-    unpacked = unpack([shard_4, shard_2], 6)
-    assert unpacked.allclose(test_tensor)
+    def test_pack_example_CPU(self):
+        test_tensor = torch.tensor(
+            [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
+        )
+        shard_4, shard_2 = pack(test_tensor, 6)
+        print(shard_4, shard_2)
+        assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).allclose(shard_4)
+        assert torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
+        unpacked = unpack([shard_4, shard_2], 6)
+        assert unpacked.allclose(test_tensor)
 
+instantiate_parametrized_tests(TestBitpacking)
 
-def test_pack_example_CPU():
-    test_tensor = torch.tensor(
-        [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
-    )
-    shard_4, shard_2 = pack(test_tensor, 6)
-    print(shard_4, shard_2)
-    assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).allclose(shard_4)
-    assert torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
-    unpacked = unpack([shard_4, shard_2], 6)
-    assert unpacked.allclose(test_tensor)
+if __name__ == "__main__":
+    run_tests()

--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -4,17 +4,17 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import unittest
+
 import torch
-from torch.utils._triton import has_triton
-
-from torchao.dtypes.uintx.bitpacking import pack, pack_cpu, unpack, unpack_cpu
-
 from torch.testing._internal.common_utils import (
     TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
 )
+from torch.utils._triton import has_triton
+
+from torchao.dtypes.uintx.bitpacking import pack, pack_cpu, unpack, unpack_cpu
 
 bit_widths = (1, 2, 3, 4, 5, 6, 7)
 dimensions = (0, -1, 1)
@@ -23,7 +23,7 @@ dimensions = (0, -1, 1)
 class TestBitpacking(TestCase):
     def setUp(self):
         torch._dynamo.reset()
-    
+
     def tearDown(self):
         torch._dynamo.reset()
 
@@ -37,16 +37,16 @@ class TestBitpacking(TestCase):
         unpacked = unpack_cpu(packed, bit_width, dim=dim)
         self.assertTrue(unpacked.allclose(test_tensor))
 
-
     @parametrize("bit_width", bit_widths)
     @parametrize("dim", dimensions)
     @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
     def test_GPU(self, bit_width, dim):
-        test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8
+        ).cuda()
         packed = pack(test_tensor, bit_width, dim=dim)
         unpacked = unpack(packed, bit_width, dim=dim)
         self.assertTrue(unpacked.allclose(test_tensor))
-
 
     @parametrize("bit_width", bit_widths)
     @parametrize("dim", dimensions)
@@ -56,11 +56,12 @@ class TestBitpacking(TestCase):
         torch._dynamo.config.specialize_int = True
         torch.compile(pack, fullgraph=True)
         torch.compile(unpack, fullgraph=True)
-        test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).cuda()
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8
+        ).cuda()
         packed = pack(test_tensor, bit_width, dim=dim)
         unpacked = unpack(packed, bit_width, dim=dim)
         self.assertTrue(unpacked.allclose(test_tensor))
-
 
     # these test cases are for the example pack walk through in the bitpacking.py file
     @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
@@ -70,11 +71,12 @@ class TestBitpacking(TestCase):
         ).cuda()
         shard_4, shard_2 = pack(test_tensor, 6)
         print(shard_4, shard_2)
-        assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).cuda().allclose(shard_4)
+        assert (
+            torch.tensor([0, 105, 151, 37], dtype=torch.uint8).cuda().allclose(shard_4)
+        )
         assert torch.tensor([39, 146], dtype=torch.uint8).cuda().allclose(shard_2)
         unpacked = unpack([shard_4, shard_2], 6)
         self.assertTrue(unpacked.allclose(test_tensor))
-
 
     def test_pack_example_CPU(self):
         test_tensor = torch.tensor(
@@ -86,6 +88,7 @@ class TestBitpacking(TestCase):
         assert torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
         unpacked = unpack([shard_4, shard_2], 6)
         assert unpacked.allclose(test_tensor)
+
 
 instantiate_parametrized_tests(TestBitpacking)
 

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -11,7 +11,6 @@ import unittest
 from collections import OrderedDict
 from typing import Tuple, Union
 
-import pytest
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -623,9 +622,9 @@ class TestQLoRA(FSDPTest):
     def world_size(self) -> int:
         return 2
 
-    @pytest.mark.skipif(
+    @unittest.skipIf(
         version.parse(torch.__version__).base_version < "2.4.0",
-        reason="torch >= 2.4 required",
+        "torch >= 2.4 required",
     )
     @skip_if_lt_x_gpu(2)
     def test_qlora_fsdp2(self):

--- a/test/dtypes/test_uintx.py
+++ b/test/dtypes/test_uintx.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+import unittest
 import torch
 
 from torchao.dtypes.uintx.uintx_layout import to_uintx
@@ -19,6 +19,13 @@ from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_3,
     TORCH_VERSION_AT_LEAST_2_5,
 )
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+from torch.testing._internal.common_quantization import QuantizationTestCase
+
 
 # torch.uintx dtypes are introduced in 2.3
 if TORCH_VERSION_AT_LEAST_2_3:
@@ -36,12 +43,6 @@ else:
 
 group_sizes = [32, 64, 128]
 devices = ["cpu", "cuda"]
-
-
-@pytest.fixture(autouse=True)
-def run_before_and_after_tests():
-    yield
-    torch._dynamo.reset()  # reset cache between tests
 
 
 class Linear16(torch.nn.Module):
@@ -63,144 +64,157 @@ class Linear16(torch.nn.Module):
         return self.net(x)
 
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
-)
-def test_uintx_quant_on_cpu_then_move_to_cuda(dtype, group_size):
-    scale = 512
-    fp16_mod_on_cpu = Linear16(scale, "cpu")
-    quantize_(fp16_mod_on_cpu, uintx_weight_only(dtype, group_size=group_size))
-    test_input_on_cpu = torch.randn(scale * 2, dtype=torch.float16, device="cpu")
-    output_on_cpu = fp16_mod_on_cpu(test_input_on_cpu)
-    fp16_mod_on_cuda = fp16_mod_on_cpu.to("cuda")
-    test_input_on_cuda = test_input_on_cpu.to("cuda")
-    output_on_cuda = fp16_mod_on_cuda(test_input_on_cuda)
-    assert torch.allclose(output_on_cpu, output_on_cuda.cpu(), atol=1.0e-3), (
-        "The output of the model on CPU and CUDA should be close"
+class TestUintx(QuantizationTestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
+    def tearDown(self):
+        torch._dynamo.reset()
+
+    @parametrize("dtype", dtypes)
+    @parametrize("group_size", group_sizes)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
     )
+    def test_uintx_quant_on_cpu_then_move_to_cuda(self, dtype, group_size):
+        scale = 512
+        fp16_mod_on_cpu = Linear16(scale, "cpu")
+        quantize_(fp16_mod_on_cpu, uintx_weight_only(dtype, group_size=group_size))
+        test_input_on_cpu = torch.randn(scale * 2, dtype=torch.float16, device="cpu")
+        output_on_cpu = fp16_mod_on_cpu(test_input_on_cpu)
+        fp16_mod_on_cuda = fp16_mod_on_cpu.to("cuda")
+        test_input_on_cuda = test_input_on_cpu.to("cuda")
+        output_on_cuda = fp16_mod_on_cuda(test_input_on_cuda)
+        self.assertTrue(
+            torch.allclose(output_on_cpu, output_on_cuda.cpu(), atol=1.0e-3),
+            "The output of the model on CPU and CUDA should be close"
+        )
 
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
-)
-def test_uintx_weight_only_model_quant(dtype, group_size, device):
-    scale = 512
-    fp16 = Linear16(scale, device)
-    quantize_(fp16, uintx_weight_only(dtype, group_size=group_size))
-    uintx = torch.compile(fp16, fullgraph=True)
-    test_input = torch.randn(scale * 2, dtype=torch.float16, device=device)
-    output = uintx.forward(test_input)
-    assert output is not None, "model quantization failed"
-
-
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.parametrize("group_size", group_sizes)
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
-)
-def test_uintx_weight_only_quant(dtype, group_size, device):
-    input_float = torch.randn((1, 256), dtype=torch.float16, device=device)
-    mapping_type = MappingType.SYMMETRIC
-    eps = torch.finfo(torch.float32).eps
-    zero_point_dtype = torch.int32
-    zero_point_domain = ZeroPointDomain.INT
-    block_size = (1, group_size)
-
-    scale, zero_point = choose_qparams_affine(
-        input_float,
-        mapping_type,
-        block_size,
-        dtype,
-        eps=eps,
-        scale_dtype=torch.float32,
-        zero_point_dtype=zero_point_dtype,
-        preserve_zero=True,
-        zero_point_domain=zero_point_domain,
+    @parametrize("dtype", dtypes)
+    @parametrize("group_size", group_sizes)
+    @parametrize("device", devices)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
     )
+    def test_uintx_weight_only_model_quant(self,dtype, group_size, device):
+        scale = 512
+        fp16 = Linear16(scale, device)
+        quantize_(fp16, uintx_weight_only(dtype, group_size=group_size))
+        uintx = torch.compile(fp16, fullgraph=True)
+        test_input = torch.randn(scale * 2, dtype=torch.float16, device=device)
+        output = uintx.forward(test_input)
+        self.assertTrue(output is not None, "model quantization failed")
 
-    aqt = quantize_affine(
-        input_float,
-        block_size,
-        scale,
-        zero_point,
-        dtype,
-        zero_point_domain=zero_point_domain,
+
+    @parametrize("dtype", dtypes)
+    @parametrize("group_size", group_sizes)
+    @parametrize("device", devices)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5, reason="only works with fix in the nightly build"
     )
-    # Note: output will be uint8 tensor for sub byte tensors for now
+    def test_uintx_weight_only_quant(self,dtype, group_size, device):
+        input_float = torch.randn((1, 256), dtype=torch.float16, device=device)
+        mapping_type = MappingType.SYMMETRIC
+        eps = torch.finfo(torch.float32).eps
+        zero_point_dtype = torch.int32
+        zero_point_domain = ZeroPointDomain.INT
+        block_size = (1, group_size)
 
-    q = to_uintx(aqt, dtype, -1)
-    assert q is not None, "quantization failed"
-    deqaunt = dequantize_affine(
-        q, block_size, scale, zero_point, dtype, zero_point_domain=zero_point_domain
+        scale, zero_point = choose_qparams_affine(
+            input_float,
+            mapping_type,
+            block_size,
+            dtype,
+            eps=eps,
+            scale_dtype=torch.float32,
+            zero_point_dtype=zero_point_dtype,
+            preserve_zero=True,
+            zero_point_domain=zero_point_domain,
+        )
+
+        aqt = quantize_affine(
+            input_float,
+            block_size,
+            scale,
+            zero_point,
+            dtype,
+            zero_point_domain=zero_point_domain,
+        )
+        # Note: output will be uint8 tensor for sub byte tensors for now
+
+        q = to_uintx(aqt, dtype, -1)
+        self.assertTrue(q is not None, "quantization failed")
+        deqaunt = dequantize_affine(
+            q, block_size, scale, zero_point, dtype, zero_point_domain=zero_point_domain
+        )
+        self.assertTrue(deqaunt is not None, "deqauntization failed")
+
+
+    @parametrize("dtype", dtypes)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+"
     )
-    assert deqaunt is not None, "deqauntization failed"
+    def test_uintx_target_dtype(self,dtype):
+        from torchao.quantization.quant_api import uintx_weight_only
+
+        linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
+        # make sure it runs
+        quantize_(linear, uintx_weight_only(dtype))
+        linear(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
 
 
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+"
-)
-def test_uintx_target_dtype(dtype):
-    from torchao.quantization.quant_api import uintx_weight_only
-
-    linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
-    # make sure it runs
-    quantize_(linear, uintx_weight_only(dtype))
-    linear(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
-
-
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_5,
-    reason="torch.compile without unwrap_tensor_subclass requires torch 2.5+",
-)
-def test_uintx_target_dtype_compile(dtype):
-    from torchao.quantization.quant_api import uintx_weight_only
-
-    linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
-    # make sure it runs
-    quantize_(linear, uintx_weight_only(dtype))
-    linear = torch.compile(linear)
-    linear(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
-
-
-@pytest.mark.parametrize("dtype", dtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
-@pytest.mark.skipif(
-    not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+"
-)
-def test_uintx_model_size(dtype):
-    from torchao.quantization.quant_api import uintx_weight_only
-    from torchao.utils import get_model_size_in_bytes
-
-    # scale size = 1/64 * 2 bytes = 1/32 bytes
-    # zero_point size = 1/64 * 4 bytes = 1/16 bytes
-    # dtype data size = 1 * bit_width/8 = bit_width/8 bytes
-    _dtype_to_ratio = {
-        torch.uint1: (1 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint2: (2 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint3: (3 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint4: (4 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint5: (5 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint6: (6 / 8 + 1 / 16 + 1 / 32) / 2,
-        torch.uint7: (7 / 8 + 1 / 16 + 1 / 32) / 2,
-    }
-    linear = torch.nn.Sequential(
-        torch.nn.Linear(128, 256, bias=False, dtype=torch.bfloat16, device="cuda")
+    @parametrize("dtype", dtypes)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_5,
+        reason="torch.compile without unwrap_tensor_subclass requires torch 2.5+",
     )
-    bf16_size = get_model_size_in_bytes(linear)
-    # make sure it runs
-    quantize_(linear[0], uintx_weight_only(dtype))
-    quantized_size = get_model_size_in_bytes(linear)
-    assert bf16_size * _dtype_to_ratio[dtype] == quantized_size
+    def test_uintx_target_dtype_compile(self, dtype):
+        from torchao.quantization.quant_api import uintx_weight_only
+
+        linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
+        # make sure it runs
+        quantize_(linear, uintx_weight_only(dtype))
+        linear = torch.compile(linear)
+        linear(torch.randn(1, 128, dtype=torch.bfloat16, device="cuda"))
+
+
+    @parametrize("dtype", dtypes)
+    @unittest.skipIf(not torch.cuda.is_available(), reason="Need CUDA available")
+    @unittest.skipIf(
+        not TORCH_VERSION_AT_LEAST_2_3, reason="sub byte dtype requires torch 2.3+"
+    )
+    def test_uintx_model_size(self, dtype):
+        from torchao.quantization.quant_api import uintx_weight_only
+        from torchao.utils import get_model_size_in_bytes
+
+        # scale size = 1/64 * 2 bytes = 1/32 bytes
+        # zero_point size = 1/64 * 4 bytes = 1/16 bytes
+        # dtype data size = 1 * bit_width/8 = bit_width/8 bytes
+        _dtype_to_ratio = {
+            torch.uint1: (1 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint2: (2 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint3: (3 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint4: (4 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint5: (5 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint6: (6 / 8 + 1 / 16 + 1 / 32) / 2,
+            torch.uint7: (7 / 8 + 1 / 16 + 1 / 32) / 2,
+        }
+        linear = torch.nn.Sequential(
+            torch.nn.Linear(128, 256, bias=False, dtype=torch.bfloat16, device="cuda")
+        )
+        bf16_size = get_model_size_in_bytes(linear)
+        # make sure it runs
+        quantize_(linear[0], uintx_weight_only(dtype))
+        quantized_size = get_model_size_in_bytes(linear)
+        self.assertTrue(bf16_size * _dtype_to_ratio[dtype] == quantized_size)
+
+instantiate_parametrized_tests(TestUintx)
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Relates to #1622

This PR converts the following test files under `test/dtypes/` from pytest to unittest style:
  - `test_bitpacking.py`
  - `test_uintx.py`
  - `test_nf4.py`

There is one additional file `test_affine_quantized_float.py` that still uses some pytest. This file is not included in this PR because some test cases are currently failing. 