### PR TITLE
Make torchao pt2e prepare/convert functions compatible with quantizers in torch.ao

### DIFF
--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -251,7 +251,8 @@ def _is_torchao_prepared_do_not_use_outside_this_file(model):
         if isinstance(m, torchao_FakeQuantize) or isinstance(m, torchao_ObserverBase):
             is_torchao_prepared = True
     assert is_torch_ao_prepared or is_torchao_prepared, (
-        "Must be prepared using torch.ao or torchao"
+        "Must be prepared using torch.ao or torchao, but did not see any FakeQuantize or ObserverBase modules in model: "
+        + str([f"{n}: {type(m)}" for n, m in model.named_modules()])
     )
     if is_torch_ao_prepared:
         assert not is_torchao_prepared, (

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -239,10 +239,10 @@ def _is_torchao_prepared_do_not_use_outside_this_file(model):
     from torchao.quantization.pt2e.fake_quantize import (
         FakeQuantize as torchao_FakeQuantize,
     )
-    from torchao.quantization.pt2e.observer import ObserverBase as torchao_ObserverBase
     from torchao.quantization.pt2e.observer import (
         AffineQuantizedObserverBase as torchao_AffineQuantizedObserverBase,
     )
+    from torchao.quantization.pt2e.observer import ObserverBase as torchao_ObserverBase
 
     is_torch_ao_prepared = False
     is_torchao_prepared = False

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -259,14 +259,16 @@ def _is_torchao_prepared_do_not_use_outside_this_file(model):
             or isinstance(m, torchao_AffineQuantizedObserverBase)
         ):
             is_torchao_prepared = True
-    assert is_torch_ao_prepared or is_torchao_prepared, (
-        "Must be prepared using torch.ao or torchao, but did not see any FakeQuantize or ObserverBase modules in model: "
-        + str([f"{n}: {type(m)}" for n, m in model.named_modules()])
-    )
+
     if is_torch_ao_prepared:
         assert not is_torchao_prepared, (
             "Cannot be prepared using both torch.ao and torchao"
         )
+    if is_torchao_prepared:
+        assert not is_torch_ao_prepared, (
+            "Cannot be prepared using both torch.ao and torchao"
+        )
+
     return is_torchao_prepared
 
 

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -240,15 +240,24 @@ def _is_torchao_prepared_do_not_use_outside_this_file(model):
         FakeQuantize as torchao_FakeQuantize,
     )
     from torchao.quantization.pt2e.observer import ObserverBase as torchao_ObserverBase
+    from torchao.quantization.pt2e.observer import (
+        AffineQuantizedObserverBase as torchao_AffineQuantizedObserverBase,
+    )
 
     is_torch_ao_prepared = False
     is_torchao_prepared = False
     for _, m in model.named_modules():
-        if isinstance(
-            m, torch.ao.quantization.fake_quantize.FakeQuantize
-        ) or isinstance(m, torch.ao.quantization.observer.ObserverBase):
+        if (
+            isinstance(m, torch.ao.quantization.fake_quantize.FakeQuantize)
+            or isinstance(m, torch.ao.quantization.observer.ObserverBase)
+            or isinstance(m, torch.ao.quantization.observer.AffineQuantizedObserverBase)
+        ):
             is_torch_ao_prepared = True
-        if isinstance(m, torchao_FakeQuantize) or isinstance(m, torchao_ObserverBase):
+        if (
+            isinstance(m, torchao_FakeQuantize)
+            or isinstance(m, torchao_ObserverBase)
+            or isinstance(m, torchao_AffineQuantizedObserverBase)
+        ):
             is_torchao_prepared = True
     assert is_torch_ao_prepared or is_torchao_prepared, (
         "Must be prepared using torch.ao or torchao, but did not see any FakeQuantize or ObserverBase modules in model: "


### PR DESCRIPTION
Currently we cannot use torchao's prepare/convert functions with quantizers based on torch.ao.quantization.quantizer.quantizer.Quantizer.  This makes migration difficult to do in pieces.

In this PR, we add logic to prepare/convert functions to recognize torch.ao.quantization.quantizer.quantizer.Quantizer and call the previous prepare/convert APIs.