### PR TITLE
Try fixing CI by pinning pytest

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -64,7 +64,7 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
-            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
+            dev-requirements-overrides: "s/^pytest.*$/pytest==7.4.0/"
           - name: CUDA 2.6
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.6.0'
@@ -83,7 +83,7 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
-            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
+            dev-requirements-overrides: "s/^pytest.*$/pytest==7.4.0/"
           - name: CPU 2.6
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Test utilities
-pytest
+pytest==8.3.4
 unittest-xml-reporting
 parameterized
 packaging


### PR DESCRIPTION
Looks like pytest is failing with Segfault even when I execute simple pytest --version
```
exec: line 14:   238 Segmentation fault      (core dumped) python -u -m pytest --version
```
Hence Pinning the pytest to previous version fixes the Segfault

Test PR: https://github.com/pytorch/ao/pull/2237
Failure: https://github.com/pytorch/ao/actions/runs/15176248032/job/42676994119?pr=2237#step:15:1427

We would probably need to followup on this to understand why this have happended, since latest pytest update was March 2, 2025: https://pypi.org/project/pytest/8.3.5/ 
