### PR TITLE
Enable AWQ on Intel GPU.

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -135,7 +135,7 @@ def _groupwise_affine_quantize_tensor_from_qparams(
     if TORCH_VERSION_AT_LEAST_2_5:
         if (not (check_cpu_version(w.device))) and (not (check_xpu_version(w.device))):
             w_int4x8 = (w_int4x8[::, ::2] << 4 | w_int4x8[::, 1::2]).to(torch.uint8)
-        if (check_xpu_version(w.device)):
+        if check_xpu_version(w.device):
             w_int4x8 = (w_int4x8[::, 1::2] << 4 | w_int4x8[::, ::2]).to(torch.uint8)
 
     return w_int4x8
@@ -732,7 +732,7 @@ class TestQuantPrimitives(unittest.TestCase):
                     not (check_xpu_version(input.device))
                 ):
                     input_tmp = (input[::, ::2] << 4 | input[::, 1::2]).to(torch.uint8)
-                if (check_xpu_version(input.device)):
+                if check_xpu_version(input.device):
                     input_tmp = (input[::, 1::2] << 4 | input[::, ::2]).to(torch.uint8)
                 w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
                     input_tmp, scales, zeros, n_bit, groupsize, zero_point_domain

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -135,6 +135,8 @@ def _groupwise_affine_quantize_tensor_from_qparams(
     if TORCH_VERSION_AT_LEAST_2_5:
         if (not (check_cpu_version(w.device))) and (not (check_xpu_version(w.device))):
             w_int4x8 = (w_int4x8[::, ::2] << 4 | w_int4x8[::, 1::2]).to(torch.uint8)
+        if (check_xpu_version(w.device)):
+            w_int4x8 = (w_int4x8[::, 1::2] << 4 | w_int4x8[::, ::2]).to(torch.uint8)
 
     return w_int4x8
 
@@ -730,6 +732,8 @@ class TestQuantPrimitives(unittest.TestCase):
                     not (check_xpu_version(input.device))
                 ):
                     input_tmp = (input[::, ::2] << 4 | input[::, 1::2]).to(torch.uint8)
+                if (check_xpu_version(input.device)):
+                    input_tmp = (input[::, 1::2] << 4 | input[::, ::2]).to(torch.uint8)
                 w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
                     input_tmp, scales, zeros, n_bit, groupsize, zero_point_domain
                 )

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -242,7 +242,6 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
     ):
         assert isinstance(_layout, Int4XPULayout)
 
-
         if TORCH_VERSION_AT_LEAST_2_8:
             assert int_data.dtype == torch.int32, (
                 "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -50,9 +50,9 @@ def _linear_bf16_act_uint4_weight_float_zero_check(input_tensor, weight_tensor, 
 
 
 def _linear_bf16_act_uint4_weight_float_zero_impl(input_tensor, weight_tensor, bias):
-    assert weight_tensor.block_size[0] == 1, (
-        f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
-    )
+    assert (
+        weight_tensor.block_size[0] == 1
+    ), f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
     assert input_tensor.shape[-1] == weight_tensor.shape[1], (
         f"need input_tensor shape: {input_tensor.shape} final"
         f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
@@ -105,9 +105,9 @@ def _linear_fp_act_uint4_weight_int8_zero_check(input_tensor, weight_tensor, bia
 
 
 def _linear_fp_act_uint4_weight_int8_zero_impl(input_tensor, weight_tensor, bias):
-    assert weight_tensor.block_size[0] == 1, (
-        f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
-    )
+    assert (
+        weight_tensor.block_size[0] == 1
+    ), f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
     assert input_tensor.shape[-1] == weight_tensor.shape[1], (
         f"need input_tensor shape: {input_tensor.shape} final"
         f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
@@ -243,9 +243,9 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
         assert isinstance(_layout, Int4XPULayout)
 
         if TORCH_VERSION_AT_LEAST_2_8:
-            assert int_data.dtype == torch.int32, (
-                "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"
-            )
+            assert (
+                int_data.dtype == torch.int32
+            ), "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"
             packed_weight = (int_data[::, 1::2] << 4 | int_data[::, ::2]).to(
                 torch.uint8
             )

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -371,7 +371,6 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
 
     def get_plain(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         from torchao.quantization.quant_primitives import (
-            ZeroPointDomain,
             quantize_affine,
             quantize_affine_float_zero_point,
         )

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -50,9 +50,9 @@ def _linear_bf16_act_uint4_weight_float_zero_check(input_tensor, weight_tensor, 
 
 
 def _linear_bf16_act_uint4_weight_float_zero_impl(input_tensor, weight_tensor, bias):
-    assert (
-        weight_tensor.block_size[0] == 1
-    ), f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
+    assert weight_tensor.block_size[0] == 1, (
+        f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
+    )
     assert input_tensor.shape[-1] == weight_tensor.shape[1], (
         f"need input_tensor shape: {input_tensor.shape} final"
         f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
@@ -105,9 +105,9 @@ def _linear_fp_act_uint4_weight_int8_zero_check(input_tensor, weight_tensor, bia
 
 
 def _linear_fp_act_uint4_weight_int8_zero_impl(input_tensor, weight_tensor, bias):
-    assert (
-        weight_tensor.block_size[0] == 1
-    ), f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
+    assert weight_tensor.block_size[0] == 1, (
+        f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
+    )
     assert input_tensor.shape[-1] == weight_tensor.shape[1], (
         f"need input_tensor shape: {input_tensor.shape} final"
         f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
@@ -243,9 +243,9 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
         assert isinstance(_layout, Int4XPULayout)
 
         if TORCH_VERSION_AT_LEAST_2_8:
-            assert (
-                int_data.dtype == torch.int32
-            ), "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"
+            assert int_data.dtype == torch.int32, (
+                "torch.ops.aten._convert_weight_to_int4pack_for_cpu expects `int32` dtype"
+            )
             packed_weight = (int_data[::, 1::2] << 4 | int_data[::, ::2]).to(
                 torch.uint8
             )

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -15,8 +15,8 @@ from torchao.dtypes import (
     TensorCoreTiledLayout,
     to_affine_quantized_intx,
     Int4XPULayout,
+    Layout,
 )
-from torchao.dtypes.utils import Layout
 from torchao.dtypes.uintx.uintx_layout import _DTYPE_TO_BIT_WIDTH, UintxLayout
 from torchao.quantization import to_weight_tensor_with_linear_activation_scale_metadata
 from torchao.quantization.granularity import PerGroup

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -38,9 +38,9 @@ from .core import (
     AWQObserver,
 )
 
-assert (
-    len(_DTYPE_TO_BIT_WIDTH) > 0
-), "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
+assert len(_DTYPE_TO_BIT_WIDTH) > 0, (
+    "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
+)
 
 
 def insert_awq_observer_(
@@ -63,9 +63,9 @@ def insert_awq_observer_(
         group_size: Quantization granularity. Use -1 for channel wise quantization
     """
     _is_linear = lambda m, fqn: isinstance(m, torch.nn.Linear)
-    assert (
-        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
-    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
+    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
+        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
+    )
     # AQT config
     mapping_type = MappingType.ASYMMETRIC
     quantization_granularity = PerGroup(group_size)
@@ -137,9 +137,9 @@ def _awq_uintx_transform(
         torchao.quantization.utils.recommended_inductor_config_setter()
     observed_linear = module
 
-    assert (
-        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
-    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
+    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
+        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
+    )
 
     equalization_scale = observed_linear.act_obs.calculate_qparams()
     # AQT config

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -38,9 +38,9 @@ from .core import (
     AWQObserver,
 )
 
-assert len(_DTYPE_TO_BIT_WIDTH) > 0, (
-    "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
-)
+assert (
+    len(_DTYPE_TO_BIT_WIDTH) > 0
+), "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
 
 
 def insert_awq_observer_(
@@ -63,9 +63,9 @@ def insert_awq_observer_(
         group_size: Quantization granularity. Use -1 for channel wise quantization
     """
     _is_linear = lambda m, fqn: isinstance(m, torch.nn.Linear)
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
+    assert (
+        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
+    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
     # AQT config
     mapping_type = MappingType.ASYMMETRIC
     quantization_granularity = PerGroup(group_size)
@@ -137,10 +137,10 @@ def _awq_uintx_transform(
         torchao.quantization.utils.recommended_inductor_config_setter()
     observed_linear = module
 
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
-    
+    assert (
+        quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8
+    ), "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
+
     equalization_scale = observed_linear.act_obs.calculate_qparams()
     # AQT config
     if quant_dtype == torch.uint4:

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -12,10 +12,10 @@ import torch
 import torchao
 from torchao.core.config import AOBaseConfig
 from torchao.dtypes import (
-    TensorCoreTiledLayout,
-    to_affine_quantized_intx,
     Int4XPULayout,
     Layout,
+    TensorCoreTiledLayout,
+    to_affine_quantized_intx,
 )
 from torchao.dtypes.uintx.uintx_layout import _DTYPE_TO_BIT_WIDTH, UintxLayout
 from torchao.quantization import to_weight_tensor_with_linear_activation_scale_metadata

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Optional
 
 import torch
 

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -143,6 +143,10 @@ def _awq_uintx_transform(
     equalization_scale = observed_linear.act_obs.calculate_qparams()
     # AQT config
     if quant_dtype == torch.uint4:
+        if ((config.zero_point_domain == ZeroPointDomain.INT) and ("xpu" not in device.type)):
+            raise ValueError(
+                f"_awq_uintx_transform with ZeroPointDomain.INT is only applicable to Intel GPU."
+            )
         target_dtype = torch.int32
         eps = 1e-6
         preserve_zero = False

--- a/torchao/prototype/awq/example.py
+++ b/torchao/prototype/awq/example.py
@@ -11,9 +11,9 @@ from datasets import load_dataset
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from torchao.dtypes import Int4XPULayout
 from torchao.prototype.awq import AWQObservedLinear, awq_uintx, insert_awq_observer_
 from torchao.quantization import int4_weight_only, quantize_
-from torchao.dtypes import Int4XPULayout
 
 
 # adapted from: https://github.com/mit-han-lab/llm-awq/blob/main/awq/entry.py#L255

--- a/torchao/prototype/awq/example.py
+++ b/torchao/prototype/awq/example.py
@@ -232,7 +232,9 @@ def wikitext2_ppl(
         use_hqq = "hqq" in quant
         print(f"running {quant_dtype} quantization")
         t0 = time.time()
-        awq_uintx_config = awq_uintx(quant_dtype=quant_dtype, group_size=group_size, use_hqq=use_hqq)
+        awq_uintx_config = awq_uintx(
+            quant_dtype=quant_dtype, group_size=group_size, use_hqq=use_hqq
+        )
         if "xpu" in device:
             awq_uintx_config.layout = Int4XPULayout()
         quantize_(
@@ -248,7 +250,9 @@ def wikitext2_ppl(
         group_size = int(quant.split("-")[1])
         use_hqq = "hqq" in quant
         print(f"running {quant} quantization with group size {group_size}")
-        int4_weight_only_config = int4_weight_only(group_size=group_size, use_hqq=use_hqq)
+        int4_weight_only_config = int4_weight_only(
+            group_size=group_size, use_hqq=use_hqq
+        )
         if "xpu" in device:
             int4_weight_only_config.layout = Int4XPULayout()
         quantize_(model, int4_weight_only_config)

--- a/torchao/prototype/awq/example.py
+++ b/torchao/prototype/awq/example.py
@@ -261,7 +261,6 @@ def wikitext2_ppl(
     if compile:
         model = torch.compile(model)
 
-    print("model:", model)
     return benchmark(model, tokenizer, sequence_length, tasks=tasks, device=device)
 
 

--- a/torchao/prototype/awq/example.py
+++ b/torchao/prototype/awq/example.py
@@ -13,9 +13,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from torchao.prototype.awq import AWQObservedLinear, awq_uintx, insert_awq_observer_
 from torchao.quantization import int4_weight_only, quantize_
-from torchao.quantization.quant_primitives import (
-    ZeroPointDomain,
-)
 from torchao.dtypes import Int4XPULayout
 
 
@@ -242,7 +239,6 @@ def wikitext2_ppl(
             model,
             awq_uintx_config,
             is_observed_linear,
-            torch.device(device),
         )
         print(f"time for quantization: {time.time() - t0:.02f} seconds")
         if model_save_path is not None:

--- a/torchao/quantization/subclass.py
+++ b/torchao/quantization/subclass.py
@@ -697,13 +697,6 @@ class Int4WeightOnlyQuantizedLinearWeight(QuantizedLinearWeightBase):
             int_data = aten._convert_weight_to_int4pack_for_cpu(
                 input_int4x8, inner_k_tiles
             )
-        if check_xpu_version(input_float.device):
-            from torchao.quantization.utils import convert_weight_to_int4pack_xpu
-
-            int_data = convert_weight_to_int4pack_xpu(
-                input_int4x8,
-                zero_point_domain_is_int=zero_point_domain == ZeroPointDomain.INT,
-            )
         else:
             int_data = aten._convert_weight_to_int4pack(input_int4x8, inner_k_tiles)
         return int_data, scales_and_zeros, False, groupsize, inner_k_tiles

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -231,20 +231,19 @@ def quant_int8_per_token_matmul(
       Y_i_j_fp32 = sx * sw dot(X_i, W_j)
     """
 
-    assert (
-        x_vals_int8.dtype == torch.int8
-    ), f"x dtype {x_vals_int8.dtype} not yet supported"
-    assert (
-        w_vals_int8_t.dtype == torch.int8
-    ), f"w dtype {w_vals_int8_t.dtype} not yet supported"
+    assert x_vals_int8.dtype == torch.int8, (
+        f"x dtype {x_vals_int8.dtype} not yet supported"
+    )
+    assert w_vals_int8_t.dtype == torch.int8, (
+        f"w dtype {w_vals_int8_t.dtype} not yet supported"
+    )
 
-    assert (
-        x_scales.dtype
-        in [
-            torch.float,
-            torch.bfloat16,
-        ]
-    ), f"x_scales needs to be a torch.float32 or torch.bfloat16 but got {x_scales.dtype}"
+    assert x_scales.dtype in [
+        torch.float,
+        torch.bfloat16,
+    ], (
+        f"x_scales needs to be a torch.float32 or torch.bfloat16 but got {x_scales.dtype}"
+    )
 
     #
     # 1. do the matrix form of dot(X_i, W_j)

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -231,19 +231,20 @@ def quant_int8_per_token_matmul(
       Y_i_j_fp32 = sx * sw dot(X_i, W_j)
     """
 
-    assert x_vals_int8.dtype == torch.int8, (
-        f"x dtype {x_vals_int8.dtype} not yet supported"
-    )
-    assert w_vals_int8_t.dtype == torch.int8, (
-        f"w dtype {w_vals_int8_t.dtype} not yet supported"
-    )
+    assert (
+        x_vals_int8.dtype == torch.int8
+    ), f"x dtype {x_vals_int8.dtype} not yet supported"
+    assert (
+        w_vals_int8_t.dtype == torch.int8
+    ), f"w dtype {w_vals_int8_t.dtype} not yet supported"
 
-    assert x_scales.dtype in [
-        torch.float,
-        torch.bfloat16,
-    ], (
-        f"x_scales needs to be a torch.float32 or torch.bfloat16 but got {x_scales.dtype}"
-    )
+    assert (
+        x_scales.dtype
+        in [
+            torch.float,
+            torch.bfloat16,
+        ]
+    ), f"x_scales needs to be a torch.float32 or torch.bfloat16 but got {x_scales.dtype}"
 
     #
     # 1. do the matrix form of dot(X_i, W_j)
@@ -488,8 +489,7 @@ def groupwise_affine_dequantize_tensor_from_qparams(
             dtype=torch.int32,
             device=w_int4x8.device,
         )
-        if (not (check_xpu_version(w_int4x8.device))
-        ):
+        if not (check_xpu_version(w_int4x8.device)):
             w_int32[::, ::2] = high_bits
             w_int32[::, 1::2] = low_bits
         else:

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -127,6 +127,11 @@ class _MultiInput:
             val.cuda() if isinstance(val, torch.Tensor) else val for val in self.values
         ]
 
+    def xpu(self):
+        self.values = [
+            val.xpu() if isinstance(val, torch.Tensor) else val for val in self.values
+        ]
+
 
 def guard_dtype_size(tensor_arg, arg_name, dtype=None, size=None):
     if dtype is not None and tensor_arg.dtype != dtype:
@@ -415,25 +420,6 @@ def unpack_tinygemm_scales_and_zeros(scales_and_zeros):
     return torch.split(scales_and_zeros.transpose(-3, -2), 1, -1)
 
 
-def convert_weight_to_int4pack_xpu(weight, zero_point_domain_is_int=False):
-    assert weight.device.type == "xpu"
-
-    if zero_point_domain_is_int:
-        # int_data = weight.to(dtype=torch.uint8)
-        int_data = (weight[::, 1::2] << 4 | weight[::, ::2]).to(torch.uint8)
-        packed_weight = torch.ops.aten._convert_weight_to_int4pack(
-            int_data,
-            8,  # TODO:remove
-        )
-    else:
-        out = weight.to(dtype=torch.uint8)
-        out = (out[::, 1::2] << 4 | out[::, ::2]).to(torch.uint8)
-        packed_weight = out.view(torch.int32)
-
-    # Second, N * K/2 uint8 -> N * K/8 int32
-    return packed_weight
-
-
 def groupwise_affine_quantize_tensor_from_qparams(
     w, scales, zeros, n_bit=4, groupsize=128, zero_point_domain=ZeroPointDomain.FLOAT
 ):
@@ -473,6 +459,8 @@ def groupwise_affine_quantize_tensor_from_qparams(
             not (check_xpu_version(int_data.device))
         ):
             int_data = (int_data[::, ::2] << 4 | int_data[::, 1::2]).to(torch.uint8)
+        if check_xpu_version(int_data.device):
+            int_data = (int_data[::, 1::2] << 4 | int_data[::, ::2]).to(torch.uint8)
     return int_data
 
 
@@ -491,7 +479,6 @@ def groupwise_affine_dequantize_tensor_from_qparams(
         TORCH_VERSION_AT_LEAST_2_5
         and (w_int4x8.dtype == torch.uint8 or w_int4x8.shape[-1] > 1)
         and not (check_cpu_version(w_int4x8.device))
-        and not (check_xpu_version(w_int4x8.device))
     ):
         data = w_int4x8.to(torch.int32)
         high_bits = data >> 4
@@ -501,8 +488,13 @@ def groupwise_affine_dequantize_tensor_from_qparams(
             dtype=torch.int32,
             device=w_int4x8.device,
         )
-        w_int32[::, ::2] = high_bits
-        w_int32[::, 1::2] = low_bits
+        if (not (check_xpu_version(w_int4x8.device))
+        ):
+            w_int32[::, ::2] = high_bits
+            w_int32[::, 1::2] = low_bits
+        else:
+            w_int32[::, ::2] = low_bits
+            w_int32[::, 1::2] = high_bits
     else:
         w_int32 = w_int4x8
 


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/issues/153019 requests, we enable awq-uint4 for Intel GPU in pytorch/ao after RTN ready. 

How to run awq quantization model:
```markdown
cd torchao/prototype/awq

python example.py --device xpu  huggingface-model(such as meta-llama/Llama-3.1-8B-Instruct) awq-uint4-128
```
#Results of meta-llama/Llama-3.1-8B-Instruct on Intel GPU:
{'perplexity': {'perplexity': 10.099576950073242, 'prediction_time': 0.20489671968780787}}

#Results of meta-llama/Llama-3.1-8B-Instruct on NVIDIA-A100 GPU:
Results: {'perplexity': {'perplexity': 10.160041809082031, 'prediction_time': 0.4466673863672577}}