### PR TITLE
Resolve logger warnings

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor_ops.py
+++ b/torchao/dtypes/affine_quantized_tensor_ops.py
@@ -130,8 +130,8 @@ def deregister_aqt_quantized_linear_dispatch(dispatch_condition):
     if dispatch_condition in _AQT_QLINEAR_DISPATCH_TABLE:
         del _AQT_QLINEAR_DISPATCH_TABLE[dispatch_condition]
     else:
-        logger.warn(
-            f"Attempting to remove non-existant dispatch condition {dispatch_condition}"
+        logger.warning(
+            f"Attempting to remove non-existent dispatch condition {dispatch_condition}"
         )
 
 
@@ -274,7 +274,7 @@ def _(func, types, args, kwargs):
     try:
         return weight_tensor._quantized_linear_op(input_tensor, weight_tensor, bias)
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfic quantized linear implementation with `_layout.quantized_linear_impl`
+        # fallback path is only called when user did not specify a specific quantized linear implementation with `_layout.quantized_linear_impl`
         if (
             isinstance(weight_tensor, AffineQuantizedTensor)
             and hasattr(weight_tensor._layout, "quantized_linear_impl")
@@ -363,7 +363,7 @@ def _(func, types, args, kwargs):
             input_tensor, transposed_weight_tensor, bias
         )
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfic quantized linear implementation with `_layout.quantized_linear_impl`
+        # fallback path is only called when user did not specify a specific quantized linear implementation with `_layout.quantized_linear_impl`
         if (
             isinstance(weight_tensor, AffineQuantizedTensor)
             and hasattr(weight_tensor._layout, "quantized_linear_impl")
@@ -397,7 +397,7 @@ def _(func, types, args, kwargs):
             input_tensor, transposed_weight_tensor, bias
         )
     except QuantizedLinearNotImplementedError as e:
-        # fallback path is only called when user did not specify a specfic quantized linear implementation with `_layout.quantized_linear_impl`
+        # fallback path is only called when user did not specify a specific quantized linear implementation with `_layout.quantized_linear_impl`
         if (
             isinstance(weight_tensor, AffineQuantizedTensor)
             and hasattr(weight_tensor._layout, "quantized_linear_impl")

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1830,7 +1830,7 @@ def _uintx_weight_only_transform(
 
     if use_hqq:
         if dtype == torch.uint4:
-            logger.warn(
+            logger.warning(
                 "Recommended to use `int4_weight_only(group_size, use_hqq=True)` for the best performance"
             )
         quant_min, quant_max = _DTYPE_TO_QVALUE_BOUNDS[dtype]


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.