### PR TITLE
fix _replace_with_custom_fn_if_matches_filter in quant_api.py

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -285,7 +285,7 @@ def _replace_with_custom_fn_if_matches_filter(
         new_module.weight = model.weight
         new_module.bias = model.bias
         model = new_module
-    if filter_fn(model, cur_fqn[:-1]):
+    if filter_fn(model):
         if device is not None:
             model.to(device=device)  # move to device before quantization
         model = replacement_fn(model, *extra_args)


### PR DESCRIPTION
so it calls `filter_fn` according to definition:

```
def _replace_with_custom_fn_if_matches_filter(
...
) -> None:
    """
    Recursively replaces each child module in `model` with the result of `replacement_fn(child)`
    if `filter_fn(child)` returns `True`.
    Args:
        ...
        filter_fn (Callable[[torch.nn.Module], bool]): The filter function to determine which modules to replace.

```

I think this call was a copy paste from `_replace_with_custom_fn_if_matches_filter_with_name` below, where it makes sense that the `filter_fn` gets name passed as a second argument.

If this is wrong and `filter_fn` should get the param, I can change this PR to have just doc string for `filter_fn` fixed. 
Please let me know.