### PR TITLE
Revert "Try fixing CI by pinning pytest (#2238)"

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -64,7 +64,7 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
-            dev-requirements-overrides: "s/^pytest.*$/pytest==7.4.0/"
+            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
           - name: CUDA 2.6
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.6.0'
@@ -83,7 +83,7 @@ jobs:
             torch-spec: 'torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
-            dev-requirements-overrides: "s/^pytest.*$/pytest==7.4.0/"
+            dev-requirements-overrides: "s/^pytest$/pytest==7.4.0/"
           - name: CPU 2.6
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Test utilities
-pytest==8.3.4
+pytest
 unittest-xml-reporting
 parameterized
 packaging


### PR DESCRIPTION
This reverts commit f0f976cede3ed51edf1b690d82bfc0d72d81b79b.
The root cause is Almalinux  update. The issue with the update was addressed by this PR: https://github.com/pytorch/pytorch/pull/154364

Hence this patch is not required anymore.