### PR TITLE
[float8 training] remove duplicate override for view

### DIFF
--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -100,7 +100,6 @@ def implements(aten_ops):
 
 @implements(
     [
-        aten.view.default,
         aten._unsafe_view.default,
         aten.as_strided.default,
         aten.clone.default,


### PR DESCRIPTION
I noticed there's 2 overrides for `aten.view.default`:

1. standard desugaring op at the top.
2. special `float8_view` override lower down. 

The 2nd one overwrites the 1st entry in the FLOAT8_OPS_TABLE, so we can remove it.