### PR TITLE
Add support for fbgemm fp8 kernels

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -24,7 +24,9 @@ from torchao.dtypes import (
     to_affine_quantized_intx,
     to_affine_quantized_intx_static,
 )
+from torchao.float8.config import e4m3_dtype
 from torchao.quantization import (
+    FbgemmConfig,
     GemliteUIntXWeightOnlyConfig,
     Int4WeightOnlyConfig,
     Int8DynamicActivationInt8WeightConfig,
@@ -45,6 +47,7 @@ from torchao.utils import (
     is_fbcode,
     is_ROCM,
     is_sm_at_least_89,
+    is_sm_at_least_90,
 )
 
 is_cusparselt_available = (
@@ -98,6 +101,10 @@ def get_quantization_functions(
 
     if is_sm_at_least_89():
         base_functions.append(float8_weight_only())
+
+    if is_sm_at_least_90():
+        base_functions.append(FbgemmConfig(torch.bfloat16, torch.int4, torch.bfloat16))
+        base_functions.append(FbgemmConfig(e4m3_dtype, e4m3_dtype, torch.bfloat16))
 
     return base_functions
 

--- a/test/dtypes/test_fbgemm_fp8.py
+++ b/test/dtypes/test_fbgemm_fp8.py
@@ -12,15 +12,20 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 
+from torchao.float8.config import e4m3_dtype
 from torchao.quantization import (
     FbgemmConfig,
     quantize_,
 )
 from torchao.quantization.utils import compute_error
-from torchao.utils import is_sm_at_least_90
+from torchao.utils import (
+    TORCH_VERSION_AT_LEAST_2_8,
+    is_sm_at_least_90,
+)
 
 
-class TestFbgemmInt4Tensor(TestCase):
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_8, "Need pytorch 2.8+")
+class TestFbgemmFp8Tensor(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
     def test_linear(self):
@@ -30,10 +35,9 @@ class TestFbgemmInt4Tensor(TestCase):
         linear = torch.nn.Linear(128, 256, dtype=dtype, device=device)
         original = linear(input)
         config = FbgemmConfig(
-            input_dtype=torch.bfloat16,
-            weight_dtype=torch.int4,
+            input_dtype=e4m3_dtype,
+            weight_dtype=e4m3_dtype,
             output_dtype=torch.bfloat16,
-            block_size=(1, 128),
         )
         quantize_(linear, config)
         quantized = linear(input)

--- a/test/dtypes/test_fbgemm_int4.py
+++ b/test/dtypes/test_fbgemm_int4.py
@@ -18,15 +18,15 @@ from torchao.quantization import (
 )
 from torchao.quantization.utils import compute_error
 from torchao.utils import (
-    TORCH_VERSION_AT_LEAST_2_6,
+    TORCH_VERSION_AT_LEAST_2_8,
     is_sm_at_least_90,
 )
 
 
+@unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_8, "Need pytorch 2.8+")
 class TestFbgemmInt4Tensor(TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
-    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_6, "Need torch >= 2.6")
     def test_linear(self):
         dtype = torch.bfloat16
         device = "cuda"

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -8,7 +8,8 @@ from .affine_quantized_tensor import (
     to_affine_quantized_intx,
     to_affine_quantized_intx_static,
 )
-from .fbgemm_quantized_tensor import to_fbgemm_quantized
+from .fbgemm_fp8_tensor import to_fbgemm_fp8
+from .fbgemm_int4_tensor import to_fbgemm_int4
 from .floatx import (
     CutlassSemiSparseLayout,
     Float8Layout,
@@ -62,5 +63,6 @@ __all__ = [
     "PackedLinearInt8DynamicActivationIntxWeightLayout",
     "to_affine_quantized_packed_linear_int8_dynamic_activation_intx_weight",
     "Int4XPULayout",
-    "to_fbgemm_quantized",
+    "to_fbgemm_int4",
+    "to_fbgemm_fp8",
 ]

--- a/torchao/dtypes/fbgemm_fp8_tensor.py
+++ b/torchao/dtypes/fbgemm_fp8_tensor.py
@@ -1,0 +1,154 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Optional
+
+import torch
+from torch.utils._python_dispatch import return_and_correct_aliasing
+
+from torchao.utils import (
+    TORCH_VERSION_AT_LEAST_2_5,
+    TorchAOBaseTensor,
+)
+
+__all__ = [
+    "to_fbgemm_fp8",
+]
+
+aten = torch.ops.aten
+
+
+class FbgemmFp8Tensor(TorchAOBaseTensor):
+    tensor_data_attrs = ["float8_data", "scale", "activation_scale_ub"]
+    tensor_attributes = ["dtype"]
+
+    def __new__(cls, float8_data, scale, activation_scale_ub, dtype):
+        shape = float8_data.shape
+        kwargs = {}
+        kwargs["device"] = float8_data.device
+        kwargs["dtype"] = dtype
+        kwargs["requires_grad"] = False
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(self, float8_data, scale, activation_scale_ub, dtype):
+        self.float8_data = float8_data
+        self.scale = scale
+        self.activation_scale_ub = activation_scale_ub
+
+    def __tensor_flatten__(self):
+        return self.tensor_data_attrs, [
+            getattr(self, attr) for attr in self.tensor_attributes
+        ]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        return cls(
+            *[tensor_data_dict[name] for name in cls.tensor_data_attrs],
+            *tensor_attributes,
+        )
+
+    def _apply_fn_to_data(self, fn):
+        return self.__class__(
+            *[fn(getattr(self, attr)) for attr in self.tensor_data_attrs],
+            *[getattr(self, attr) for attr in self.tensor_attributes],
+        )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(weight={self.float8_data}, scale={self.scale}, "
+            f"activation_scale_ub={self.activation_scale_ub}, "
+            f"shape={self.shape}, device={self.device}, dtype={self.dtype}, requires_grad={self.requires_grad})"
+        )
+
+    def _quantization_type(self):
+        return f"shape={self.shape}, activation_scale_ub={self.activation_scale_ub}, device={self.device}"
+
+    @classmethod
+    def from_float(
+        cls,
+        w: torch.Tensor,
+        activation_scale_ub: Optional[float] = None,
+    ):
+        if activation_scale_ub is None:
+            activation_scale_ub = 1200.0
+
+        activation_scale_ub = torch.tensor(
+            [activation_scale_ub],
+            dtype=torch.float,
+            device=w.device,
+        )
+        wq, w_scale = torch.ops.triton.quantize_fp8_row(w)
+        # wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_row(w)
+        dtype = w.dtype
+        del w
+        return FbgemmFp8Tensor(
+            wq,
+            w_scale,
+            activation_scale_ub=activation_scale_ub,
+            dtype=dtype,
+        )
+
+
+implements = FbgemmFp8Tensor.implements
+
+
+@implements([torch.nn.functional.linear, aten.linear.default])
+def _(func, types, args, kwargs):
+    input_tensor, weight_tensor, bias = (
+        args[0],
+        args[1],
+        args[2] if len(args) > 2 else None,
+    )
+    if not input_tensor.is_floating_point():
+        raise NotImplementedError(
+            f"{func} is not implemented for non floating point input"
+        )
+
+    orig_act_size = input_tensor.size()
+    orig_out_features = weight_tensor.shape[-2]
+
+    # not used
+    num_tokens = torch.empty([input_tensor.size(0)], device=input_tensor.device)
+    xq, x_scale = torch.ops.fbgemm.quantize_fp8_per_row(
+        input_tensor, num_tokens, weight_tensor.activation_scale_ub
+    )
+    res = torch.ops.fbgemm.f8f8bf16_rowwise(
+        xq,
+        weight_tensor.float8_data,
+        x_scale,
+        weight_tensor.scale,
+        use_fast_accum=True,
+    )
+    res = res.reshape(*orig_act_size[:-1], orig_out_features)
+    if bias is not None:
+        res = res + bias
+
+    return res
+
+
+@implements([aten.detach.default, aten.alias.default])
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.detach)
+    )
+
+
+@implements([aten.clone.default, aten.copy_.default])
+def _(func, types, args, kwargs):
+    return return_and_correct_aliasing(
+        func, args, kwargs, args[0]._apply_fn_to_data(torch.clone)
+    )
+
+
+to_fbgemm_fp8 = FbgemmFp8Tensor.from_float
+
+
+if TORCH_VERSION_AT_LEAST_2_5:
+    # Allow a model with FbgemmFp8Tensor weights to be loaded with `weights_only=True`
+    torch.serialization.add_safe_globals([FbgemmFp8Tensor])


### PR DESCRIPTION
Summary:
fp8 per row quantized weight with fp8 dynamic per row quantization only for now

|                 | overall tokens/sec | TTFT | Peak Memory | Model Size |
| ---------| -------------------| ------| --------------| -----------|
| baseline - 1 | 131.65 | 0.0220 | 16.24 GB | 15.01 GB |
| baseline - 128| 76.38 | 0.0544 | 26.92 GB | 15.01 GB|
| fp8dq-per-row - 1 | 95.95 | 0.0525 | 9.01 GB | 7.51 GB |
| fp8dq-per-row - 128 | 94.29 | 0.0655  |  19.90 GB | 7.51 GB |
| fbgemm-fp8 - 1  (no compile) | 37.02 | 0.0486 | 16.76 GB | 7.51 GB |
| fbgemm-fp8 - 128 (no compile) | 11.7 | 0.0768 | 21.92 GB | 7.51 GB |


Test Plan:
python test/dtypes/test_fbgemm_fp8.py

in torchao/_models/llama folder:
```
export CHECKPOINT_PATH=../../../checkpoints # path to checkpoints folder 
export MODEL_REPO=meta-llama/Meta-Llama-3.1-8B-Instruct

python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --quantization fbgemm-fp8 --batch_size 1
```

compile doesn't work yet

```
batch size 1

Average overall tokens/sec: 37.02
Average decode tokens/sec: 37.4586 s
Average TTFT: 0.0486 s
Average tokens/sec: 37.02
Average Bandwidth: 278.05 GB/s
Peak Memory Usage: 16.76 GB
Model Size: 7.51 GB

batch size 128 Average overall tokens/sec: 11.70
Average decode tokens/sec: 11.7677 s
Average TTFT: 0.0768 s
Average tokens/sec: 11.70
Average tokens/sec including batches 1498.09
Average Bandwidth: 87.91 GB/s
Peak Memory Usage: 21.92 GB
Model Size: 7.51 GB

float8dq-row batch size 1, w/ compile
Average overall tokens/sec: 95.95
Average decode tokens/sec: 99.0108 s
Average TTFT: 0.0525 s
Average tokens/sec: 95.95
Average Bandwidth: 720.68 GB/s
Peak Memory Usage: 9.01 GB
Model Size: 7.51 GB  float8dq-row batch size 128, w/ compile
Average overall tokens/sec: 94.29
Average decode tokens/sec: 97.3500 s
Average TTFT: 0.0655 s
Average tokens/sec: 94.29
Average tokens/sec including batches 12069.68
Average Bandwidth: 708.26 GB/s
Peak Memory Usage: 19.90 GB
Model Size: 7.51 GB
```
Reviewers:

Subscribers:

Tasks:

Tags: