### PR TITLE
Add back AOPerModuleConfig for BC

### DIFF
--- a/test/integration/test_vllm.py
+++ b/test/integration/test_vllm.py
@@ -17,10 +17,10 @@ import pytest
 import torch
 
 from packaging import version
-from torchao.utils import TORCH_VERSION_AT_LEAST_2_7
+from torchao.utils import TORCH_VERSION_AT_LEAST_2_8
 
-if not TORCH_VERSION_AT_LEAST_2_7:
-    pytest.skip("Requires PyTorch 2.7 or higher", allow_module_level=True)
+if not TORCH_VERSION_AT_LEAST_2_8:
+    pytest.skip("Requires PyTorch 2.8 or higher", allow_module_level=True)
 
 
 VLLM_AVAILABLE = importlib.util.find_spec("vllm") is not None

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -108,6 +108,9 @@ from .utils import (
 )
 from .weight_only import WeightOnlyInt8QuantLinear
 
+# TODO: remove after migration of APIs are done
+AOPerModuleConfig = ModuleFqnToConfig
+
 __all__ = [
     # top level API - auto
     "autoquant",
@@ -148,6 +151,7 @@ __all__ = [
     "IntxWeightOnlyConfig",
     "FPXWeightOnlyConfig",
     "GemliteUIntXWeightOnlyConfig",
+    "AOPerModuleConfig",
     "ModuleFqnToConfig",
     "FbgemmConfig",
     # smooth quant - subject to change


### PR DESCRIPTION
Summary:
att, just temporary so that integrations keep working

Test Plan:
tests in other libs

Reviewers:

Subscribers:

Tasks:

Tags: