### PR TITLE
[optim] Fix bug when default dtype is BF16

### DIFF
--- a/torchao/optim/subclass_4bit.py
+++ b/torchao/optim/subclass_4bit.py
@@ -69,6 +69,7 @@ class OptimState4bit(TorchAOBaseTensor):
         assert codes.dtype is torch.uint8
         assert codes.ndim == 1  # flattened buffer
         assert scale.ndim == 1
+        assert qmap.dtype is torch.float32
         self.codes = codes
         self.scale = scale
         self.qmap = qmap
@@ -101,9 +102,8 @@ class OptimState4bit(TorchAOBaseTensor):
 
         codes = torch.zeros(n_elems // 2, dtype=torch.uint8, device=device)
         scale = torch.zeros(n_elems // block_size, device=device)
-        qmap = torch.tensor(
-            get_qmap_signed() if signed else get_qmap_unsigned(), device=device
-        )
+        qmap_list = get_qmap_signed() if signed else get_qmap_unsigned()
+        qmap = torch.tensor(qmap_list, dtype=torch.float32, device=device)
         return cls(codes, scale, qmap, signed, shape)
 
     def __repr__(self):

--- a/torchao/optim/subclass_8bit.py
+++ b/torchao/optim/subclass_8bit.py
@@ -62,6 +62,7 @@ class OptimState8bit(TorchAOBaseTensor):
         """
         assert codes.dtype is torch.uint8
         assert scale.ndim == 1
+        assert qmap.dtype is torch.float32
         self.codes = codes
         self.scale = scale
         self.qmap = qmap
@@ -89,9 +90,8 @@ class OptimState8bit(TorchAOBaseTensor):
     def zeros(cls, shape, signed: bool = True, block_size: int = 256, device=None):
         codes = torch.zeros(shape, dtype=torch.uint8, device=device)
         scale = torch.zeros(codes.numel() // block_size, device=device)
-        qmap = torch.tensor(
-            get_qmap_signed() if signed else get_qmap_unsigned(), device=device
-        )
+        qmap_list = get_qmap_signed() if signed else get_qmap_unsigned()
+        qmap = torch.tensor(qmap_list, dtype=torch.float32, device=device)
         return cls(codes, scale, qmap, signed)
 
     def __repr__(self):


### PR DESCRIPTION
Happened in #2235

When `torch.set_default_dtype(torch.bfloat16)` is set, `qmap = torch.tensor(...)` becomes BF16. Hence, dequantizing the low-bit tensor subclass results in BF16, leading to dtype mismatch in Adam logic.