### PR TITLE
Add Float8ActInt4WeightQATQuantizer

### DIFF
--- a/torchao/quantization/qat/__init__.py
+++ b/torchao/quantization/qat/__init__.py
@@ -11,6 +11,7 @@ from .embedding import (
     Int4WeightOnlyEmbeddingQATQuantizer,
 )
 from .linear import (
+    Float8ActInt4WeightQATQuantizer,
     Int4WeightOnlyQATQuantizer,
     Int8DynActInt4WeightQATQuantizer,
 )
@@ -18,6 +19,7 @@ from .linear import (
 __all__ = [
     "ComposableQATQuantizer",
     "FakeQuantizeConfig",
+    "Float8ActInt4WeightQATQuantizer",
     "FromIntXQuantizationAwareTrainingConfig",
     "Int4WeightOnlyEmbeddingQATQuantizer",
     "Int4WeightOnlyQATQuantizer",

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -32,6 +32,7 @@ from .api import (
 from .utils import (
     _fake_quantize_per_channel_group,
     _fake_quantize_per_token,
+    _Float8RowwiseFakeQuantize,
 )
 
 
@@ -186,3 +187,23 @@ class FakeQuantizer(torch.nn.Module):
         Return a human readable representation of this `FakeQuantizer` with config details.
         """
         return "FakeQuantizer(%s)" % self.config
+
+
+class _Float8RowwiseActivationFakeQuantizer(torch.nn.Module):
+    """
+    Simple fake quantizer for float8 rowwise fake quantization, intended for activations only.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.enabled = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.enabled:
+            return _Float8RowwiseFakeQuantize.apply(
+                x,
+                torch.float8_e4m3fn,
+                -1,
+            )
+        else:
+            return x


### PR DESCRIPTION
**Summary:** This commit adds a QAT quantizer that performs float8 dynamic activation + int4 symmetric per channel weight fake quantization. Note that there is no corresponding config for float8 QAT yet. This will be added in a future PR.

**Test Plan:**
python test/quantization/test_qat.py -k test_float8_fake_quantize
python test/quantization/test_qat.py -k test_qat_fp8a4w_quantizer