### PR TITLE
[Benchmarks] Remove additional baseline calculation

### DIFF
--- a/benchmarks/microbenchmarks/benchmark_runner.py
+++ b/benchmarks/microbenchmarks/benchmark_runner.py
@@ -139,9 +139,6 @@ def get_quantization_sparsity_recipes(
     """
     config_recipes = set()
 
-    # Always include baseline without sparsity
-    config_recipes.add(("baseline", None))
-
     # Add all quantization techniques without sparsity
     for quant_config in quantization_recipes:
         config_recipes.add((quant_config, None))

--- a/benchmarks/microbenchmarks/utils.py
+++ b/benchmarks/microbenchmarks/utils.py
@@ -358,7 +358,7 @@ def generate_results_csv(
     os.makedirs(output_dir, exist_ok=True)
     # Generate the filename with the current date and time in the specified format
     if file_name is None:
-        file_name = datetime.now().strftime("results_%d%m%Y_%H%M%S.csv")
+        file_name = datetime.now().strftime("results_%m%d%Y_%H%M%S.csv")
 
     file_path = os.path.join(output_dir, file_name)
 


### PR DESCRIPTION
The baseline was being double calculated for every shape. Removing multiple baseline calculations help with speeding up the benchmarking process.