### PR TITLE
[BE/docs] Add float8 training api ref to docsite

### DIFF
--- a/docs/source/api_ref_float8.rst
+++ b/docs/source/api_ref_float8.rst
@@ -1,0 +1,30 @@
+.. _api_quantization:
+
+====================
+torchao.float8
+====================
+
+.. currentmodule:: torchao.float8
+
+Main float8 training APIs
+----------------------
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    convert_to_float8_training
+
+Other float8 training types
+-------------------------------
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    Float8LinearConfig
+    Float8GEMMConfig
+    CastConfig
+    ScalingType
+    ScalingGranularity
+    precompute_float8_dynamic_scale_for_fsdp

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ for an overall introduction to the library and recent highlight and updates.
    api_ref_dtypes
    api_ref_quantization
    api_ref_sparsity
+   api_ref_float8
 
 .. toctree::
    :glob:


### PR DESCRIPTION
Test plan:
- Ran local preview of docsite and confirmed API ref renders properly. I will move ScalingGranularity to be available at the module level in a subsequent PR, so that it will appear in the API ref too (it's needed for user-facing API to convert model to use float8 rowwise training)