### PR TITLE
Enable doc build to run on PRs

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -12,7 +12,6 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '!docs/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Enable doc build to run on PRs when files in `docs/**` path are changed to enable preview. 