### PR TITLE
Add round_scales_to_power_of_2 option for float quantization

### DIFF
--- a/.github/workflows/float8_test.yml
+++ b/.github/workflows/float8_test.yml
@@ -25,14 +25,14 @@ jobs:
         include:
           - name: SM-89
             runs-on: linux.g6.4xlarge.experimental.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu128'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
+            gpu-arch-version: "12.8"
           - name: H100
             runs-on: linux.aws.h100
-            torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.4"
+            gpu-arch-version: "12.8"
     permissions:
       id-token: write
       contents: read

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -236,6 +236,7 @@ def pad_tensor_for_matmul(
     return torch.nn.functional.pad(tensor, (0, pad_dim2, 0, pad_dim1))
 
 
-def _round_scale_down_to_power_of_2(scale: torch.Tensor):
+def _round_scale_down_to_power_of_2(scale: torch.Tensor) -> torch.Tensor:
+    """Rounds the scale down to the nearest power of 2."""
     assert scale.dtype == torch.float32, "scale must be float32 tensor"
     return torch.exp2(torch.floor(torch.log2(scale)))


### PR DESCRIPTION
Stacked PRs:
 * #2398
 * __->__#2323


--- --- ---

Add round_scales_to_power_of_2 option for float quantization

This adds support for rounding scaling factors down to the nearest power of 2
for float quantization, following the pattern established in Float8LinearConfig.

Key changes:
- Add round_scales_to_power_of_2 parameter to all float quantization configs
- Update choose_qparams_affine_floatx and to_scaled_tc_floatx functions to apply power of 2 rounding
- Thread the parameter through all relevant function calls in quant_api.py

Lets users who train with this setting run in inference