### PR TITLE
Add power-of-2 scaling infrastructure and Float8WeightOnlyConfig support

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -457,6 +457,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         target_dtype: torch.dtype,
         _layout: Layout,
         scale_dtype: Optional[torch.dtype] = None,
+        round_scales_to_power_of_2: bool = False,
     ):
         """Convert a high precision tensor to a float8 quantized tensor."""
         if target_dtype in FP8_TYPES:
@@ -530,6 +531,7 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         cls,
         input_float: torch.Tensor,
         _layout: Layout,
+        round_scales_to_power_of_2: bool = False,
     ):
         """Create a floatx AffineQuantizedTensor from a high precision tensor. Floatx is represented as ebits and mbits, and supports the representation of float1-float7."""
         from torchao.dtypes.floatx import FloatxTensorCoreLayout
@@ -545,7 +547,9 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
 
         ebits, mbits = _layout.ebits, _layout.mbits
         # Note: these ops are hardcoded to have per axis quantization (axis=1) right now
-        scale = choose_qparams_affine_floatx(input_float, ebits, mbits)
+        scale = choose_qparams_affine_floatx(
+            input_float, ebits, mbits, round_scales_to_power_of_2
+        )
         floatx_unpacked = quantize_affine_floatx(input_float, scale, ebits, mbits)
         floatx_packed, scale, _ = _layout.post_process(
             floatx_unpacked, scale, None, block_size

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -236,6 +236,7 @@ def pad_tensor_for_matmul(
     return torch.nn.functional.pad(tensor, (0, pad_dim2, 0, pad_dim1))
 
 
-def _round_scale_down_to_power_of_2(scale: torch.Tensor):
+def _round_scale_down_to_power_of_2(scale: torch.Tensor) -> torch.Tensor:
+    """Rounds the scale down to the nearest power of 2."""
     assert scale.dtype == torch.float32, "scale must be float32 tensor"
     return torch.exp2(torch.floor(torch.log2(scale)))

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1270,6 +1270,7 @@ def _int4_symm_cutlass_quant(x: torch.Tensor) -> torch.Tensor:
 def _float8_cutlass_quant(
     x: torch.Tensor,
     target_dtype: torch.dtype,
+    round_scales_to_power_of_2: bool = False,
 ) -> torch.Tensor:
     return to_affine_quantized_floatx(
         x,
@@ -1277,6 +1278,7 @@ def _float8_cutlass_quant(
         scale_dtype=torch.float32,
         target_dtype=target_dtype,
         _layout=Float8Layout(mm_config=None),
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
     )
 
 
@@ -1399,6 +1401,7 @@ class Float8WeightOnlyConfig(AOBaseConfig):
     Args:
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m3fn.
         set_inductor_config (bool): if True, adjusts `torchinductor` settings to recommended values.
+        round_scales_to_power_of_2 (bool): If True, round scaling factors down to the nearest power of 2.
 
     Note:
         The actual matmul will be computed in original precision of the weight tensor.
@@ -1406,6 +1409,7 @@ class Float8WeightOnlyConfig(AOBaseConfig):
 
     weight_dtype: torch.dtype = e4m3_dtype
     set_inductor_config: bool = True
+    round_scales_to_power_of_2: bool = False
 
 
 # for BC
@@ -1422,6 +1426,7 @@ def _float8_weight_only_quant_tensor(weight, config):
         target_dtype=config.weight_dtype,
         scale_dtype=None,
         _layout=Float8Layout(mm_config=None),
+        round_scales_to_power_of_2=config.round_scales_to_power_of_2,
     )
     return new_weight
 


### PR DESCRIPTION
Stacked PRs:
 * #2332
 * #2331
 * #2330
 * __->__#2329


--- --- ---

Add power-of-2 scaling infrastructure and Float8WeightOnlyConfig support

This commit establishes the core infrastructure for power-of-2 scaling in float
quantization and adds support to Float8WeightOnlyConfig. This allows people who were using this during training to run the same model at inference 

Key changes:
- Export and document _round_scale_down_to_power_of_2 utility function
- Add round_scales_to_power_of_2 parameter to choose_qparams_affine_floatx and to_scaled_tc_floatx
- Thread parameter through AffineQuantizedTensor.from_hp_to_fpx method
- Add round_scales_to_power_of_2 parameter to Float8WeightOnlyConfig (defaults to False)
- Update _float8_weight_only_quant_tensor to use the new parameter
- Add comprehensive tests for Float8WeightOnlyConfig power-of-2 functionality