### PR TITLE
Add power-of-2 scaling support to Float8StaticActivationFloat8WeightConfig

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -29,6 +29,7 @@ from torchao.dtypes.floatx.float8_layout import Float8AQTTensorImpl
 from torchao.float8.float8_utils import compute_error
 from torchao.quantization import (
     Float8DynamicActivationFloat8WeightConfig,
+    Float8StaticActivationFloat8WeightConfig,
     Float8WeightOnlyConfig,
     float8_dynamic_activation_float8_weight,
     float8_weight_only,
@@ -807,6 +808,53 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
         # Verify reasonable quantization error
         error = compute_error(ref_output, quant_output)
         self.assertGreater(error, 15, f"Quantization SQNR too low: {error}")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(
+        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+    )
+    @common_utils.parametrize("granularity", [PerTensor(), PerRow()])
+    def test_power_of_2_scaling_static_activation(self, granularity):
+        """Test that Float8StaticActivationFloat8WeightConfig with round_scales_to_power_of_2=True works correctly"""
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        # Create model with dimensions that are multiples of 16
+        model = torch.nn.Linear(64, 32, bias=False).to(device).to(dtype)
+
+        # Create a scale tensor for static quantization
+        scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+        # Test with round_scales_to_power_of_2=True
+        config = Float8StaticActivationFloat8WeightConfig(
+            scale=scale, granularity=granularity, round_scales_to_power_of_2=True
+        )
+        quantized_model = copy.deepcopy(model)
+        quantize_(quantized_model, config)
+
+        # Verify the model was quantized
+        self.assertTrue(hasattr(quantized_model.weight, "original_weight_tensor"))
+        weight_impl = quantized_model.weight.original_weight_tensor.tensor_impl
+        self.assertTrue(hasattr(weight_impl, "scale"))
+
+        # Check that weight scales are powers of 2
+        weight_scale = weight_impl.scale.float()
+        log2_scale = torch.log2(weight_scale)
+        is_power_of_2 = torch.allclose(log2_scale, torch.round(log2_scale), atol=1e-6)
+        self.assertTrue(is_power_of_2, "Weight scales should be powers of 2")
+
+        # Test inference works
+        input_tensor = torch.randn(8, 64, device=device, dtype=dtype)
+        with torch.no_grad():
+            ref_output = model(input_tensor)
+            quant_output = quantized_model(input_tensor)
+
+        # Verify shapes match
+        self.assertEqual(ref_output.shape, quant_output.shape)
+
+        # Verify reasonable quantization error
+        error = compute_error(ref_output, quant_output)
+        self.assertGreater(error, 16, f"Quantization SQNR too low: {error}")
 
 
 common_utils.instantiate_parametrized_tests(TestAffineQuantizedFloat8Compile)

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1680,6 +1680,7 @@ class Float8StaticActivationFloat8WeightConfig(AOBaseConfig):
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m
         mm_config (Float8MMConfig): Configuration for the matrix multiplication. Default uses fast accumulation.
         set_inductor_config (bool): if True, adjusts `torchinductor` settings to recommended values.
+        round_scales_to_power_of_2 (bool): If True, round scaling factors down to the nearest power of 2.
     """
 
     scale: torch.Tensor
@@ -1690,6 +1691,7 @@ class Float8StaticActivationFloat8WeightConfig(AOBaseConfig):
     ] = None
     mm_config: Optional[Float8MMConfig] = None
     set_inductor_config: bool = True
+    round_scales_to_power_of_2: bool = False
 
     def __post_init__(self):
         if self.mm_config is None:
@@ -1733,12 +1735,14 @@ def _float8_static_activation_float8_weight_transform(
         target_dtype=weight_dtype,
         scale_dtype=torch.float32,
         _layout=Float8Layout(mm_config=mm_config),
+        round_scales_to_power_of_2=config.round_scales_to_power_of_2,
     )
 
     input_quant_func = _input_activation_quant_func_fp8
     input_quant_kwargs = {
         "activation_granularity": activation_granularity,
         "activation_dtype": activation_dtype,
+        "round_scales_to_power_of_2": config.round_scales_to_power_of_2,
     }
 
     quantized_weight = to_weight_tensor_with_linear_activation_quantization_metadata(


### PR DESCRIPTION
Stacked PRs:
 * #2332
 * __->__#2331
 * #2330
 * #2329


--- --- ---

Add power-of-2 scaling support to Float8StaticActivationFloat8WeightConfig

This commit extends power-of-2 scaling support to Float8StaticActivationFloat8WeightConfig
for both weight and activation quantization.

Key changes:
- Add round_scales_to_power_of_2 parameter to Float8StaticActivationFloat8WeightConfig (defaults to False)
- Update _float8_static_activation_float8_weight_transform to use the parameter for both weight and activation quantization
- Add comprehensive tests for both PerTensor and PerRow granularities

This enables power-of-2 scaling for static activation quantization scenarios,
completing support for all major Float8 quantization modes.