### PR TITLE
Add power-of-2 scaling support to Float8DynamicActivationFloat8WeightConfig

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -673,6 +673,50 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
         error = compute_error(ref_output, quant_output)
         self.assertGreater(error, 15, f"Quantization SQNR too low: {error}")
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(
+        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+    )
+    @common_utils.parametrize("granularity", [PerTensor(), PerRow()])
+    def test_power_of_2_scaling_dynamic_activation(self, granularity):
+        """Test that Float8DynamicActivationFloat8WeightConfig with round_scales_to_power_of_2=True works correctly"""
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        # Create model with dimensions that are multiples of 16
+        model = torch.nn.Linear(64, 32, bias=False).to(device).to(dtype)
+
+        # Test with round_scales_to_power_of_2=True
+        config = Float8DynamicActivationFloat8WeightConfig(
+            granularity=granularity, round_scales_to_power_of_2=True
+        )
+        quantized_model = copy.deepcopy(model)
+        quantize_(quantized_model, config)
+
+        # Verify the model was quantized
+        self.assertTrue(hasattr(quantized_model.weight, "original_weight_tensor"))
+        weight_impl = quantized_model.weight.original_weight_tensor.tensor_impl
+        self.assertTrue(hasattr(weight_impl, "scale"))
+
+        # Check that weight scales are powers of 2
+        scale = weight_impl.scale.float()
+        log2_scale = torch.log2(scale)
+        is_power_of_2 = torch.allclose(log2_scale, torch.round(log2_scale), atol=1e-6)
+        self.assertTrue(is_power_of_2, "Weight scales should be powers of 2")
+
+        # Test inference works
+        input_tensor = torch.randn(8, 64, device=device, dtype=dtype)
+        with torch.no_grad():
+            ref_output = model(input_tensor)
+            quant_output = quantized_model(input_tensor)
+
+        # Verify shapes match
+        self.assertEqual(ref_output.shape, quant_output.shape)
+
+        # Verify reasonable quantization error
+        error = compute_error(ref_output, quant_output)
+        self.assertGreater(error, 12.5, f"Quantization SQNR too low: {error}")
+
 
 common_utils.instantiate_parametrized_tests(TestAffineQuantizedFloat8Compile)
 


### PR DESCRIPTION
Stacked PRs:
 * #2336
 * __->__#2335
 * #2334


--- --- ---

Add power-of-2 scaling support to Float8DynamicActivationFloat8WeightConfig

This commit extends power-of-2 scaling support to Float8DynamicActivationFloat8WeightConfig
for both activation and weight quantization.

Key changes:
- Add round_scales_to_power_of_2 parameter to Float8DynamicActivationFloat8WeightConfig
- Update _input_activation_quant_func_fp8 to support power-of-2 scaling for activations
- Thread parameter through weight quantization in _float8_dynamic_activation_float8_weight_quantize_tensor
- Add comprehensive tests with both PerTensor and PerRow granularities
- Ensure scales are verified to be powers of 2 in tests

The power-of-2 scaling is applied to both activation and weight quantization,
providing consistent quantization behavior across forward and backward passes.