### PR TITLE
fix ROCM test failures

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      timeout: 120
+      timeout: 150
       no-sudo: ${{ matrix.gpu-arch-type == 'rocm' }}
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}


### PR DESCRIPTION
ROCM tests are timing out and breaking trunk so increase timeout period.