### PR TITLE
fixing trunk - autoquant test failure

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1624,6 +1624,9 @@ class TestAutoQuant(unittest.TestCase):
         # Skip certain shapes on older PyTorch versions
         if (m1 == 1 or m2 == 1) and not TORCH_VERSION_AT_LEAST_2_5:
             self.skipTest(f"Shape {(m1, m2, k, n)} requires torch version > 2.4")
+        # TODO remove this once https://github.com/pytorch/pytorch/issues/155838 is resolved
+        if m1 == 1 or m2 == 1:
+            self.skipTest(f"Shape {(m1, m2, k, n)} is flaky, skipping")
         model = (
             torch.nn.Sequential(
                 torch.nn.ReLU(),


### PR DESCRIPTION
Summary:

fix autoquant failure.

tests started failing recently in pytorch nightly: https://github.com/pytorch/ao/actions/runs/15590189942/job/43907010550

its unclear where this error is coming from for autoquant, i can't repro it locally

made an issue here: https://github.com/pytorch/pytorch/issues/155838 the test can be re-enabled once this is resolved

Test Plan:

see CI

Reviewers:

Subscribers:

Tasks:

Tags: