### PR TITLE
[docs] Replace deprecated configs with Config objects

### DIFF
--- a/docs/source/api_ref_sparsity.rst
+++ b/docs/source/api_ref_sparsity.rst
@@ -12,7 +12,6 @@ torchao.sparsity
 
     sparsify_
     semi_sparse_weight
-    int8_dynamic_activation_int8_semi_sparse_weight
     apply_fake_sparsity
     WandaSparsifier
     PerChannelNormObserver

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -56,8 +56,8 @@ for efficient mixed dtype matrix multiplication:
 .. code:: py
 
   # torch 2.4+ only
-  from torchao.quantization import int4_weight_only, quantize_
-  quantize_(model, int4_weight_only(group_size=32))
+  from torchao.quantization import Int4WeightOnlyConfig, quantize_
+  quantize_(model, Int4WeightOnlyConfig(group_size=32))
 
 The quantized model is now ready to use! Note that the quantization
 logic is inserted through tensor subclasses, so there is no change

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -14,7 +14,7 @@ Here is the serialization and deserialization flow::
   from torchao.utils import get_model_size_in_bytes
   from torchao.quantization.quant_api import (
       quantize_,
-      int4_weight_only,
+      Int4WeightOnlyConfig,
   )
 
   class ToyLinearModel(torch.nn.Module):
@@ -36,7 +36,7 @@ Here is the serialization and deserialization flow::
   print(f"original model size: {get_model_size_in_bytes(m) / 1024 / 1024} MB")
 
   example_inputs = m.example_inputs(dtype=dtype, device="cuda")
-  quantize_(m, int4_weight_only())
+  quantize_(m, Int4WeightOnlyConfig())
   print(f"quantized model size: {get_model_size_in_bytes(m) / 1024 / 1024} MB")
 
   ref = m(*example_inputs)
@@ -70,7 +70,7 @@ quantized model ``state_dict``::
   {"linear1.weight": quantized_weight1, "linear2.weight": quantized_weight2, ...}
 
 
-The size of the quantized model is typically going to be smaller to the original floating point model, but it also depends on the specific techinque and implementation you are using. You can print the model size with ``torchao.utils.get_model_size_in_bytes`` utility function, specifically for the above example using int4_weight_only quantization, we can see the size reduction is around 4x::
+The size of the quantized model is typically going to be smaller to the original floating point model, but it also depends on the specific techinque and implementation you are using. You can print the model size with ``torchao.utils.get_model_size_in_bytes`` utility function, specifically for the above example using Int4WeightOnlyConfig quantization, we can see the size reduction is around 4x::
 
   original model size: 4.0 MB
   quantized model size: 1.0625 MB

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -7,7 +7,7 @@ import copy
 
 import torch
 
-from torchao.quantization import int4_weight_only, quantize_
+from torchao.quantization import Int4WeightOnlyConfig, quantize_
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_5,
     benchmark_model,
@@ -43,7 +43,7 @@ model_bf16 = copy.deepcopy(model)
 # ========================
 
 # torch 2.4+ only
-quantize_(model, int4_weight_only(group_size=32))
+quantize_(model, Int4WeightOnlyConfig(group_size=32))
 
 
 # =============

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -381,7 +381,7 @@ We're trying to develop kernels for low bit quantization for intx quantization f
 
 You try can out these apis with the `quantize_` api as above alongside the config `UIntXWeightOnlyConfig`. An example can be found in  in `torchao/_models/llama/generate.py`.
 
-### int8_dynamic_activation_intx_weight Quantization
+### Int8DynamicActivationIntxWeightConfig Quantization
 We have kernels that do 8-bit dynamic quantization of activations and uintx groupwise quantization of weights.  These kernels are experimental and can only be run on a device with an ARM CPU (e.g., a Mac computers with Apple silicon).  The benchmarks below were run on an M1 Mac Pro, with 8 perf cores, and 2 efficiency cores, and 32GB of RAM.  In all cases, torch.compile was used.
 
 | Model         | Technique                                        | Tokens/Second | Memory Bandwidth (GB/s) | Peak Memory (GB) | Model Size (GB) |
@@ -390,7 +390,7 @@ We have kernels that do 8-bit dynamic quantization of activations and uintx grou
 |               | int8_dynamic_activation_intx_weight-4-256-false  |  16.03        |  65.81                  |  NA              | 4.11            |
 |               | int8_dynamic_activation_intx_weight-3-256-false  |  18.94        |  59.97                  |  NA              | 3.17            |
 
-You can try out these apis with the `quantize_` api as above alongside the constructor `int8_dynamic_activation_intx_weight`.  An example can be found in `torchao/_models/llama/generate.py`.
+You can try out these apis with the `quantize_` api as above alongside the config `Int8DynamicActivationIntxWeightConfig`.  An example can be found in `torchao/_models/llama/generate.py`.
 
 ### Codebook Quantization
 The benchmarks below were run on a single NVIDIA-A6000 GPU.
@@ -402,7 +402,7 @@ The benchmarks below were run on a single NVIDIA-A6000 GPU.
 | Llama-3.1-8B| Base (bfloat16)         |  7.713              |  32.16        |  482.70                 | 16.35            | 15.01           |
 |             | codebook-4-64           |  10.095             |  1.73         |  8.63                   | 23.11            |  4.98           |
 
-You try can out these apis with the `quantize_` api as above alongside the constructor `codebook_weight_only` an example can be found in  in `torchao/_models/llama/generate.py`.
+You try can out these apis with the `quantize_` api as above alongside the config `CodebookWeightOnlyConfig` an example can be found in  in `torchao/_models/llama/generate.py`.
 
 ### GPTQ Quantization
 We have a GPTQ quantization workflow that can be used to quantize a model to int4. More details can be found in [GPTQ](./GPTQ/README.md),

--- a/torchao/sparsity/README.md
+++ b/torchao/sparsity/README.md
@@ -52,12 +52,12 @@ These benchmarks were also ran on a NVIDIA-A100-80GB.
 Sparse-Marlin 2:4 is an optimized GPU kernel that extends the Mixed Auto-Regressive Linear (Marlin) dense kernel to support 4-bit quantized weights and 2:4 sparsity, improving performance in matrix multiplication and accumulation. Full documentation can be found [here](https://github.com/IST-DASLab/Sparse-Marlin).
 
 ```py
-from torchao.quantization.quant_api import quantize_, int4_weight_only
+from torchao.quantization.quant_api import quantize_, Int4WeightOnlyConfig
 from torchao.dtypes import MarlinSparseLayout
 
 # Your FP16 model
 model = model.cuda().half()
-quantize_(model, int4_weight_only(layout=MarlinSparseLayout()))
+quantize_(model, Int4WeightOnlyConfig(layout=MarlinSparseLayout()))
 ```
 
 Note the existing API results in an extremely high accuracy degredation and is intended to be used in concert with an already sparsified+finetuned checkpoint where possible until we develop
@@ -68,11 +68,11 @@ the necessary supporting flows in torchao.
 We support composing int8 dynaic quantization with 2:4 sparsity. We fuse one of the scalar dequant multiplications into our cuSPARSELt sparse mm in order to remain performant.
 
 ```py
-from torchao.quantization.quant_api import quantize_, int8_dynamic_activation_int8_weight
+from torchao.quantization.quant_api import quantize_, Int8DynamicActivationInt8WeightConfig
 from torchao.dtypes import SemiSparseLayout
 
 model = model.cuda()
-quantize_(model, int8_dynamic_activation_int8_weight(layout=SemiSparseLayout()))
+quantize_(model, Int8DynamicActivationInt8WeightConfig(layout=SemiSparseLayout()))
 ```
 
 ### 2:4 sparsity


### PR DESCRIPTION
**Summary:** We still mention old, deprecated "configs" like `int4_weight_only` in many user-facing docs. This commit replaces these occurrences with the actual corresponding config objects.

**Test Plan:**
```
git grep int4_weight_only
git grep int8_dynamic_activation_
git grep quantize_
git grep sparsify_
```