### PR TITLE
remove torchao dependency from torchao build script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,6 @@ build_macos_arm_auto = use_cpp == "1" and is_arm64 and is_macos
 #       └── TORCHAO_PARALLEL_BACKEND → Backend selection (aten_openmp, executorch, etc.)
 
 
-from torchao.utils import TORCH_VERSION_AT_LEAST_2_7
-
 version_prefix = read_version()
 # Version is version.dev year month date if using nightlies and version if not
 version = (
@@ -388,16 +386,18 @@ def get_extensions():
             ["-O3" if not debug_mode else "-O0", "-fdiagnostics-color=always"]
         )
 
-        if use_cpu_kernels and is_linux and TORCH_VERSION_AT_LEAST_2_7:
-            if torch._C._cpu._is_avx512_supported():
-                extra_compile_args["cxx"].extend(
-                    [
-                        "-DCPU_CAPABILITY_AVX512",
-                        "-march=native",
-                        "-mfma",
-                        "-fopenmp",
-                    ]
-                )
+        # TODO(future PR): make this work without using `TORCH_VERSION_AT_LEAST_2_7`,
+        # because we should not be using anything from `torchao` to build `torchao`.
+        # if use_cpu_kernels and is_linux and TORCH_VERSION_AT_LEAST_2_7:
+        #     if torch._C._cpu._is_avx512_supported():
+        #         extra_compile_args["cxx"].extend(
+        #             [
+        #                 "-DCPU_CAPABILITY_AVX512",
+        #                 "-march=native",
+        #                 "-mfma",
+        #                 "-fopenmp",
+        #             ]
+        #         )
 
         if debug_mode:
             extra_compile_args["cxx"].append("-g")


### PR DESCRIPTION
Summary:

We should not use torchao to build torchao. Before this PR, I got stuck in a loop where I had a broken install (for some other reason) and could not uninstall torchao with this setup script, because the script required a working torchao to run.

Commenting out the offending code in this PR, leaving for a future person to actually fix it.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: