### PR TITLE
fix torchao quantized model in fbcode

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -81,6 +81,7 @@ from torchao.utils import (
     is_MI300,
     is_sm_at_least_89,
     is_sm_at_least_90,
+    is_fbcode,
 )
 
 from .autoquant import AutoQuantizableLinearWeight, autoquant
@@ -2010,7 +2011,7 @@ def _(module: torch.nn.Module, config: FbgemmConfig) -> torch.nn.Module:
 
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401
 
-    if fbgemm_gpu.__version__ < "1.2.0":
+    if not is_fbcode() and fbgemm_gpu.__version__ < "1.2.0":
         raise ImportError("Requires fbgemm-gpu-genai >= 1.2.0")
 
     _SUPPORTED_DTYPES = {


### PR DESCRIPTION
Summary:
Without this change, ran into:
> AttributeError: module 'fbgemm_gpu' has no attribute '__version__'

Differential Revision: D76858513
