### PR TITLE
Make AWQ more general

### DIFF
--- a/test/core/test_config.py
+++ b/test/core/test_config.py
@@ -19,6 +19,10 @@ from torchao.core.config import (
     config_from_dict,
     config_to_dict,
 )
+from torchao.prototype.awq import (
+    AWQConfig,
+    AWQStep,
+)
 from torchao.quantization.quant_api import (
     FbgemmConfig,
     Float8DynamicActivationFloat8WeightConfig,
@@ -79,6 +83,8 @@ configs = [
             "linear2": Int8DynamicActivationInt4WeightConfig(),
         }
     ),
+    AWQConfig(Int4WeightOnlyConfig(group_size=128), step=AWQStep.PREPARE_FOR_LOADING),
+    AWQConfig(Int4WeightOnlyConfig(group_size=128), step="prepare_for_loading"),
 ]
 
 if TORCH_VERSION_AT_LEAST_2_6:

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -3,21 +3,22 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import os
-from copy import deepcopy
+import copy
+import tempfile
+import unittest
 
-import pytest
 import torch
-
-from torchao.quantization import quantize_
-from torchao.testing.utils import skip_if_rocm
-from torchao.utils import (
-    TORCH_VERSION_AT_LEAST_2_3,
-    TORCH_VERSION_AT_LEAST_2_5,
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
 )
 
-if TORCH_VERSION_AT_LEAST_2_3:
-    from torchao.prototype.awq import AWQObservedLinear, awq_uintx, insert_awq_observer_
+from torchao.prototype.awq import AWQConfig, AWQStep
+from torchao.quantization import FbgemmConfig, Int4WeightOnlyConfig, quantize_
+from torchao.utils import (
+    TORCH_VERSION_AT_LEAST_2_6,
+    _is_fbgemm_genai_gpu_available,
+)
 
 
 class ToyLinearModel(torch.nn.Module):
@@ -25,7 +26,7 @@ class ToyLinearModel(torch.nn.Module):
         super().__init__()
         self.linear1 = torch.nn.Linear(m, n, bias=False)
         self.linear2 = torch.nn.Linear(n, k, bias=False)
-        self.linear3 = torch.nn.Linear(k, 1, bias=False)
+        self.linear3 = torch.nn.Linear(k, 64, bias=False)
 
     def example_inputs(
         self, batch_size, sequence_length=10, dtype=torch.bfloat16, device="cuda"
@@ -44,137 +45,197 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-devices = ["cpu", "cuda"]
-# torch.uintx dtypes are introduced in 2.3
-if TORCH_VERSION_AT_LEAST_2_3:
-    qdtypes = (torch.uint4, torch.uint7)
-else:
-    qdtypes = ()
+@unittest.skipIf(not torch.cuda.is_available(), reason="CUDA not available")
+@unittest.skipIf(
+    not _is_fbgemm_genai_gpu_available(),
+    reason="need to install fbgemm_gpu_genai package",
+)
+@unittest.skipIf(
+    not TORCH_VERSION_AT_LEAST_2_6,
+    reason="torch.int4 needs torch 2.6+, can remove after we are not using FbgemmConfig",
+)
+class TestAWQ(TestCase):
+    def test_awq_config(self):
+        base_config = Int4WeightOnlyConfig()
+        AWQConfig(base_config, step=AWQStep.PREPARE)
+        AWQConfig(base_config, step=AWQStep.PREPARE_FOR_LOADING)
+        AWQConfig(base_config, step=AWQStep.CONVERT)
 
+        AWQConfig(base_config, step="prepare")
+        AWQConfig(base_config, step="prepare_for_loading")
+        AWQConfig(base_config, step="convert")
 
-@pytest.fixture(autouse=True)
-def run_before_and_after_tests():
-    yield
-    torch._dynamo.reset()  # reset cache between tests
+        with self.assertRaisesRegex(ValueError, "is not one of"):
+            AWQConfig(base_config, step="not_supported")
 
+    def test_awq_functionality(self):
+        device = "cuda"
+        dataset_size = 100
+        l1, l2, l3 = 512, 256, 128
+        original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
+        group_size = 128
+        n_calibration_examples = 10
+        sequence_length = 5
 
-@pytest.mark.parametrize("device", devices)
-@pytest.mark.parametrize("qdtype", qdtypes)
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="requires nightly pytorch")
-@pytest.mark.skip("Temporarily skipping to unpin nightiles")
-def test_awq_loading(device, qdtype):
-    if qdtype == torch.uint4 and device == "cpu":
-        pytest.skip("uint4 not supported on cpu")
+        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
 
-    dataset_size = 100
-    l1, l2, l3 = 512, 256, 128
-    original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
-    quant_dtype = qdtype
-    group_size = 128
-    n_calibration_examples = 10
-    n_validation_examples = 10
-    sequence_length = 5
+        # baseline quantization
+        base_config = FbgemmConfig(
+            input_dtype=torch.bfloat16,
+            weight_dtype=torch.int4,
+            output_dtype=torch.bfloat16,
+            block_size=[1, group_size],
+            preshuffle=False,
+        )
+        m_baseline = copy.deepcopy(m)
+        quantize_(m_baseline, base_config)
 
-    m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-    dataset = m.example_inputs(
-        dataset_size,
-        sequence_length=sequence_length,
-        dtype=original_dtype,
-        device=device,
-    )
-    calibration_data = dataset[:n_calibration_examples]
+        # awq quantization
+        dataset = m.example_inputs(
+            dataset_size,
+            sequence_length=sequence_length,
+            dtype=original_dtype,
+            device=device,
+        )
+        ref_out = torch.cat([m(d.squeeze(0)) for d in dataset])
 
-    # calibrate
-    insert_awq_observer_(
-        m,
-        n_validation_examples,
-        sequence_length,
-        quant_dtype=quant_dtype,
-        group_size=group_size,
-    )
+        calibration_data = dataset[:n_calibration_examples]
 
-    for example in calibration_data:
-        m(example.to(device))
+        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+        quantize_(m, quant_config)
 
-    # quantize
-    is_observed_linear = lambda m, fqn: isinstance(m, AWQObservedLinear)
-    quantize_(
-        m, awq_uintx(quant_dtype=quant_dtype, group_size=group_size), is_observed_linear
-    )
+        for example in calibration_data:
+            m(example)
 
-    model_save_path = "awq_model.pth"
-    torch.save(m, model_save_path)
-    loaded_model = torch.load(model_save_path)
-    os.remove(model_save_path)
+        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+        quantize_(m, quant_config)
 
-    if torch.cuda.is_available():
+        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
+        baseline_out = torch.cat([m_baseline(d.squeeze(0)) for d in dataset])
+
+        loss_awq = (ref_out - awq_out).pow(2).mean().item()
+        loss_base = (ref_out - baseline_out).pow(2).mean().item()
+        assert loss_awq < loss_base
+
+    def test_awq_loading(self):
+        device = "cuda"
+        dataset_size = 100
+        l1, l2, l3 = 512, 256, 128
+        original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
+        group_size = 128
+        n_calibration_examples = 10
+        sequence_length = 5
+
+        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+        dataset = m.example_inputs(
+            dataset_size,
+            sequence_length=sequence_length,
+            dtype=original_dtype,
+            device=device,
+        )
+        calibration_data = dataset[:n_calibration_examples]
+
+        # calibrate
+        base_config = FbgemmConfig(
+            input_dtype=torch.bfloat16,
+            weight_dtype=torch.int4,
+            output_dtype=torch.bfloat16,
+            block_size=[1, group_size],
+            preshuffle=False,
+        )
+        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+        quantize_(m, quant_config)
+
+        for example in calibration_data:
+            m(example)
+
+        # quantize
+        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+        quantize_(m, quant_config)
+
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(m.state_dict(), f)
+            f.seek(0)
+            state_dict = torch.load(f)
+
+        loaded_model = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+        loaded_model.load_state_dict(state_dict, assign=True)
+
         m = torch.compile(m, fullgraph=True)
         loaded_model = torch.compile(loaded_model, fullgraph=True)
 
-    awq_out = torch.cat([m(i.squeeze(0)) for i in dataset])
-    awq_save_load_out = torch.cat([loaded_model(i.squeeze(0)) for i in dataset])
+        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
+        awq_save_load_out = torch.cat([loaded_model(d.squeeze(0)) for d in dataset])
 
-    assert awq_out is not None
-    assert awq_save_load_out is not None
-    assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
+        assert awq_out is not None
+        assert awq_save_load_out is not None
+        assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
+
+    def test_awq_loading_vllm(self):
+        """Simulate weight loading in vllm:
+        * prepare model weight to the same format (awq weight)
+        * use weight.copy_(state_dict["weight"]) to copy over the quantized weights from checkpoint
+
+        There is also a slicing op that is ommitted here, overall e2e is tested in tests in vllm repo
+        """
+        device = "cuda"
+        dataset_size = 100
+        l1, l2, l3 = 512, 256, 128
+        original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
+        group_size = 128
+        n_calibration_examples = 10
+        sequence_length = 5
+
+        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+        dataset = m.example_inputs(
+            dataset_size,
+            sequence_length=sequence_length,
+            dtype=original_dtype,
+            device=device,
+        )
+        calibration_data = dataset[:n_calibration_examples]
+
+        # calibrate
+        base_config = FbgemmConfig(
+            input_dtype=torch.bfloat16,
+            weight_dtype=torch.int4,
+            output_dtype=torch.bfloat16,
+            block_size=[1, group_size],
+            preshuffle=False,
+        )
+        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+        quantize_(m, quant_config)
+
+        for example in calibration_data:
+            m(example)
+
+        # quantize
+        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+        quantize_(m, quant_config)
+
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(m.state_dict(), f)
+            f.seek(0)
+            state_dict = torch.load(f)
+
+        loaded_model = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE_FOR_LOADING)
+        quantize_(loaded_model, quant_config)
+
+        loaded_model.linear1.weight.copy_(state_dict["linear1.weight"])
+        loaded_model.linear2.weight.copy_(state_dict["linear2.weight"])
+        loaded_model.linear3.weight.copy_(state_dict["linear3.weight"])
+
+        m = torch.compile(m, fullgraph=True)
+        loaded_model = torch.compile(loaded_model, fullgraph=True)
+
+        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
+        awq_save_load_out = torch.cat([loaded_model(d.squeeze(0)) for d in dataset])
+
+        assert awq_out is not None
+        assert awq_save_load_out is not None
+        assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
 
 
-@pytest.mark.skipif(not TORCH_VERSION_AT_LEAST_2_5, reason="requires nightly pytorch")
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@skip_if_rocm("ROCm enablement in progress")
-def test_save_weights_only():
-    dataset_size = 100
-    l1, l2, l3 = 512, 256, 128
-    original_dtype = torch.bfloat16
-    quant_dtype = torch.uint4
-    device = "cuda"
-    group_size = 128
-    n_calibration_examples = 10
-    n_validation_examples = 10
-    sequence_length = 5
-
-    m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-    m2 = deepcopy(m)
-    dataset = m.example_inputs(
-        dataset_size,
-        sequence_length=sequence_length,
-        dtype=original_dtype,
-        device=device,
-    )
-    calibration_data = dataset[:n_calibration_examples]
-
-    # calibrate
-    insert_awq_observer_(
-        m,
-        n_validation_examples,
-        sequence_length,
-        quant_dtype=quant_dtype,
-        group_size=group_size,
-    )
-
-    for example in calibration_data:
-        m(example.to(device))
-
-    # quantize
-    is_observed_linear = lambda m, fqn: isinstance(m, AWQObservedLinear)
-    quantize_(
-        m, awq_uintx(quant_dtype=quant_dtype, group_size=group_size), is_observed_linear
-    )
-
-    model_save_path = "awq_model.pth"
-    torch.save(m.state_dict(), model_save_path)
-    m2.load_state_dict(
-        torch.load(model_save_path), assign=True
-    )  # load weights only.torch.load(model_save_path)
-    os.remove(model_save_path)
-
-    m = torch.compile(m, fullgraph=True)
-    m2 = torch.compile(m2, fullgraph=True)
-
-    awq_out = torch.cat([m(i.squeeze(0)) for i in dataset])
-    awq_save_load_out = torch.cat([m2(i.squeeze(0)) for i in dataset])
-
-    assert awq_out is not None
-    assert awq_save_load_out is not None
-    assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -202,6 +202,7 @@ ALLOWED_AO_MODULES = {
     "torchao.prototype.quantization",
     "torchao.prototype.mx_formats",
     "torchao.dtypes",
+    "torchao.prototype.awq",
 }
 
 

--- a/torchao/prototype/awq/__init__.py
+++ b/torchao/prototype/awq/__init__.py
@@ -1,8 +1,8 @@
-from .api import awq_uintx, insert_awq_observer_
-from .core import AWQObservedLinear
+from .api import AWQConfig
+from .core import AWQObservedLinear, AWQStep
 
 __all__ = [
-    "awq_uintx",
-    "insert_awq_observer_",
     "AWQObservedLinear",
+    "AWQConfig",
+    "AWQStep",
 ]

--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -3,184 +3,108 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import logging
 import types
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 
-import torchao
 from torchao.core.config import AOBaseConfig
-from torchao.dtypes import (
-    Int4XPULayout,
-    Layout,
-    TensorCoreTiledLayout,
-    to_affine_quantized_intx,
-)
-from torchao.dtypes.uintx.uintx_layout import _DTYPE_TO_BIT_WIDTH, UintxLayout
 from torchao.quantization import to_weight_tensor_with_linear_activation_scale_metadata
-from torchao.quantization.granularity import PerGroup
 from torchao.quantization.quant_api import (
     _linear_extra_repr,
-    _replace_with_custom_fn_if_matches_filter,
-)
-from torchao.quantization.quant_primitives import (
-    _DTYPE_TO_QVALUE_BOUNDS,
-    MappingType,
-    ZeroPointDomain,
 )
 from torchao.quantization.transform_module import (
+    _QUANTIZE_CONFIG_HANDLER,
     register_quantize_module_handler,
 )
+from torchao.utils import DummyModule
 
 from .core import (
     AWQObservedLinear,
     AWQObserver,
+    AWQStep,
 )
 
-assert len(_DTYPE_TO_BIT_WIDTH) > 0, (
-    "Error importing low bit torch.uint dtypes. Please upgrade to torch 2.3+"
-)
-
-
-def insert_awq_observer_(
-    model: torch.nn.Module,
-    n_validation_examples: int,
-    validation_sequence_len: int,
-    quant_dtype: torch.dtype = torch.uint4,
-    scale_search_space_size: int = 20,
-    group_size: int = 128,
-):
-    """
-    Inserts AWQObserver into Linear layers of a given model.
-
-    Args:
-        model: The model to be modified (in place). Ensure model is on the desired device for calibration
-        n_validation_examples: Number of examples used to validate scale options
-        validation_sequence_len: Number of tokens in each validation example
-        quant_dtype: The data type of the quantized weights. Currently only torch.uint4 is intended to be used but can be used with torch.uint1 -> torch.uint8
-        scale search space size: how many different scale options to try. Original AWQ implementation uses 20. A larger size can lead to better results but takes longer to calibrate
-        group_size: Quantization granularity. Use -1 for channel wise quantization
-    """
-    _is_linear = lambda m, fqn: isinstance(m, torch.nn.Linear)
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
-    # AQT config
-    mapping_type = MappingType.ASYMMETRIC
-    quantization_granularity = PerGroup(group_size)
-    quant_min = 0
-    quant_max = (
-        255 if quant_dtype == torch.uint8 else 2 ** _DTYPE_TO_BIT_WIDTH[quant_dtype] - 1
-    )
-    eps = torch.finfo(torch.float32).eps
-    preserve_zero = True
-    zero_point_dtype = torch.int64
-    zero_point_domain = ZeroPointDomain.INT
-
-    def replace_with_observer(layer):
-        # creates observer and replaces linear layers with AWQObservedLinear layers
-        observer = AWQObserver(
-            layer.weight,
-            layer.bias,
-            quantization_granularity,
-            mapping_type,
-            quant_dtype,
-            n_validation_examples,
-            validation_sequence_len,
-            scale_search_space_size,
-            preserve_zero=preserve_zero,
-            zero_point_domain=zero_point_domain,
-            zero_point_dtype=zero_point_dtype,
-            quant_min=quant_min,
-            quant_max=quant_max,
-            eps=eps,
-        )
-        return AWQObservedLinear.from_float(layer, observer)
-
-    _replace_with_custom_fn_if_matches_filter(model, replace_with_observer, _is_linear)
+logger = logging.getLogger(__name__)
 
 
 @dataclass
-class AWQUIntXConfig(AOBaseConfig):
+class AWQConfig(AOBaseConfig):
     """
     Configuration for quantizing linear layers when passed into quantize_()
 
     Args:
-        quant_dtype: The data type of the quantized weights. Currently only torch.uint4 is intended to be used but can be used with torch.uint1 -> torch.uint8
-        `layout`: layout type for quantized tensor, default is `TensorCoreTiledLayout(inner_k_tiles=8)`
-        group_size: Quantization granularity. Use -1 for channel wise quantization
-        weight_quant_fn: The quantization function to be used, which takes in the weight and returns the quantized weight. If None, then affine uint4 quantization is used
-        set_inductor_config: if True, adjusts `torchinductor` settings to recommended values.
+        base_config (AOBaseConfig): The quantization config that we can apply awq on top of, e.g. 8da4w, int4 weight only
+        step (AWQStep): specifies the step for AWQ, one of PREPARE, CONVERT and PREPARE_FOR_LOADING indicating the step of AWQ process
+            PREPARE: insert AWQ Observers to linear
+            CONVERT: convert the observed linear modules to linear modules with awq quantized weights
+            PREPARE_FOR_LOADING: convert the floating point model to a dummy awq quantized model, so we can
+            load the quantized weights through copy_ later
+            can use the corresponding string "prepare", "convert", "prepare_for_loading" for simplicity
+        scale_search_space_size (int): the number of scales to search for
     """
 
-    quant_dtype: torch.dtype = torch.uint4
-    layout: Optional[Layout] = TensorCoreTiledLayout(inner_k_tiles=8)
-    group_size: int = 64
-    use_hqq: bool = False
-    set_inductor_config: bool = True
+    base_config: AOBaseConfig
+    step: AWQStep
+    scale_search_space_size: int = 20
+
+    def __post_init__(self):
+        self.step = self.step.lower()
+        all_step_values = [s.value for s in AWQStep]
+        if self.step not in all_step_values:
+            raise ValueError(f"{self.step} is not one of {all_step_values}")
 
 
-# for bc
-awq_uintx = AWQUIntXConfig
-
-
-@register_quantize_module_handler(AWQUIntXConfig)
-def _awq_uintx_transform(
+@register_quantize_module_handler(AWQConfig)
+def _awq_transform(
     module: torch.nn.Module,
-    config: AWQUIntXConfig,
+    config: AWQConfig,
 ) -> torch.nn.Module:
-    quant_dtype = config.quant_dtype
-    group_size = config.group_size
-    use_hqq = config.use_hqq
-    if config.set_inductor_config:
-        torchao.quantization.utils.recommended_inductor_config_setter()
-    observed_linear = module
+    step = config.step
+    scale_search_space_size = config.scale_search_space_size
+    observed_linear = None
+    base_config = config.base_config
 
-    assert quant_dtype in _DTYPE_TO_BIT_WIDTH or quant_dtype == torch.uint8, (
-        "Invalid quant_dtype. Please use torch.uint1 .. torch.uint8"
-    )
-
-    equalization_scale = observed_linear.act_obs.calculate_qparams()
-    # AQT config
-    if quant_dtype == torch.uint4:
-        target_dtype = torch.int32
-        eps = 1e-6
-        preserve_zero = False
-        _layout = config.layout
-        if isinstance(_layout, Int4XPULayout):
-            zero_point_dtype = torch.int8
-            zero_point_domain = ZeroPointDomain.INT
-        else:
-            zero_point_dtype = torch.bfloat16
-            zero_point_domain = ZeroPointDomain.FLOAT
+    if step == AWQStep.PREPARE:
+        observer = AWQObserver(
+            module.weight,
+            module.bias,
+            base_config,
+            scale_search_space_size,
+        )
+        return AWQObservedLinear.from_float(module, observer)
+    elif step == AWQStep.PREPARE_FOR_LOADING:
+        # loading from pre-quantized checkpoint
+        observer = AWQObserver(
+            module.weight,
+            module.bias,
+            base_config,
+            scale_search_space_size,
+        )
+        observed_linear = AWQObservedLinear.from_float(module, observer)
+        example_input = torch.randn(
+            (1, module.weight.shape[1]),
+            device=module.weight.device,
+            dtype=module.weight.dtype,
+        )
+        observed_linear(example_input)
     else:
-        target_dtype = torch.uint8
-        eps = torch.finfo(torch.float32).eps
-        preserve_zero = True
-        zero_point_dtype = torch.int64
-        zero_point_domain = ZeroPointDomain.INT
-        _layout = UintxLayout(quant_dtype)
+        assert step == AWQStep.CONVERT, f"Unexpected step: {step}"
+        if not isinstance(module, AWQObservedLinear):
+            logger.info(
+                f"convert: module is not AWQObservedLinear, skipping: {type(module)}"
+            )
+            return module
+        observed_linear = module
 
-    mapping_type = MappingType.ASYMMETRIC
-    block_size = (1, group_size)
-    quant_min = _DTYPE_TO_QVALUE_BOUNDS[quant_dtype][0]
-    quant_max = _DTYPE_TO_QVALUE_BOUNDS[quant_dtype][1]
-    qw = to_affine_quantized_intx(
-        observed_linear.weight * equalization_scale,
-        mapping_type,
-        block_size,
-        target_dtype,
-        quant_min,
-        quant_max,
-        eps,
-        zero_point_dtype=zero_point_dtype,
-        preserve_zero=preserve_zero,
-        zero_point_domain=zero_point_domain,
-        _layout=_layout,
-        use_hqq=use_hqq,
-    )
+    assert observed_linear is not None
+    equalization_scale = observed_linear.act_obs.calculate_qparams()
 
+    base_config_handler = _QUANTIZE_CONFIG_HANDLER[type(config.base_config)]
+    dummy_mod = DummyModule(observed_linear.weight * equalization_scale)
+    quant_mod = base_config_handler(dummy_mod, config.base_config)
+    qw = quant_mod.weight
     qw = to_weight_tensor_with_linear_activation_scale_metadata(qw, equalization_scale)
 
     linear = torch.nn.Linear(
@@ -191,6 +115,6 @@ def _awq_uintx_transform(
         dtype=observed_linear.weight.dtype,
     )
     linear.weight = torch.nn.Parameter(qw, requires_grad=False)
-    linear.extra_repr = types.MethodType(_linear_extra_repr, module)
+    linear.extra_repr = types.MethodType(_linear_extra_repr, linear)
     linear.bias = observed_linear.bias
     return linear

--- a/torchao/prototype/moe_quant/utils.py
+++ b/torchao/prototype/moe_quant/utils.py
@@ -20,18 +20,7 @@ from torchao.quantization.quant_api import (
     dataclass,
     register_quantize_module_handler,
 )
-from torchao.utils import fill_defaults
-
-
-class DummyModule(torch.nn.Module):
-    """This is used because the TorchAO quantization functions tend to operate on modules so to apply the transform to a tensor, we can load a
-    DummyModule with the target tensor and then apply the transformation to the module and then extract the transformed tensor.
-    """
-
-    def __init__(self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
-        super().__init__()
-        self.weight = weight
-        self.bias = bias
+from torchao.utils import DummyModule, fill_defaults
 
 
 class FakeExtraDimTensor(torch.Tensor):

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -545,10 +545,10 @@ def _quantization_type(weight: torch.Tensor):
     if hasattr(weight, "_quantization_type"):
         return f"{weight.__class__.__name__}({weight._quantization_type()})"
 
-    if type(weight) is torch.Tensor:
-        return "not quantized"
+    if type(weight) is torch.Tensor or isinstance(weight, torch.nn.Parameter):
+        return f"Tensor: {type(weight)}"
 
-    return "not recognized"
+    return f"not recognized: {type(weight)}"
 
 
 def _linear_extra_repr(self):

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -11,7 +11,7 @@ import time
 from functools import reduce
 from importlib.metadata import version
 from math import gcd
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import torch
 import torch.nn.utils.parametrize as parametrize
@@ -43,6 +43,7 @@ __all__ = [
     "is_sm_at_least_89",
     "is_sm_at_least_90",
     "is_package_at_least",
+    "DummyModule",
 ]
 
 
@@ -882,3 +883,14 @@ def _is_fbgemm_genai_gpu_available():
         return False
 
     return True
+
+
+class DummyModule(torch.nn.Module):
+    """This is used because the TorchAO quantization functions tend to operate on modules so to apply the transform to a tensor, we can load a
+    DummyModule with the target tensor and then apply the transformation to the module and then extract the transformed tensor.
+    """
+
+    def __init__(self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
+        super().__init__()
+        self.weight = weight
+        self.bias = bias


### PR DESCRIPTION
Summary:
* Added AWQConfig that takes a base config and made corresponding changes
in other parts of the flow

Test Plan:
Tested on Phi4-mini and Qwen3-8B

Qwen3-8B

|Task | calibration_limit | no-awq | awq |
|-----|------------------| ------|------|
|leaderboard_math_hard (v3) | 2 | 0.3543 | 0.4371 |
|gpqa_main_zeroshot | 50 | 0.32 | 0.36 |
|mmlu | 5 | 0.7372 | 0.7463 |
|bbh | 1 | 0.7385 | 0.7556|


Phi4-mini

| Task | calibration_limit | no-awq | awq |
|------|------------------|--------|-----|
| mmlu_pro | 2 | 0.4057 | 0.4757 |
| gsm8k | 5 | 0.72 | 0.76 |

Reviewers:

Subscribers:

Tasks:

Tags: