### PR TITLE
[float8 moe training] make using triton kernels for per-group scaling configurable

### DIFF
--- a/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
@@ -110,19 +110,12 @@ def run_experiment(
         torch.cuda.synchronize()
 
     # benchmark torch
-    if args.compile:
-        compiled_fwd_bwd = torch.compile(forward_backward)
-        warmup(compiled_fwd_bwd, A, B_t, offs, use_triton=False)
-        start_time_ns = time.perf_counter_ns()
-        compiled_fwd_bwd(A, B_t, offs, use_triton=False)
-        torch_time_ns = time.perf_counter_ns() - start_time_ns
-        torch_time_us = torch_time_ns / 1e3
-    else:
-        warmup(forward_backward, A, B_t, offs, use_triton=False)
-        start_time_ns = time.perf_counter_ns()
-        forward_backward(A, B_t, offs, use_triton=False)
-        torch_time_ns = time.perf_counter_ns() - start_time_ns
-        torch_time_us = torch_time_ns / 1e3
+    torch_func = torch.compile(forward_backward) if args.compile else forward_backward
+    warmup(torch_func, A, B_t, offs, use_triton=False)
+    start_time_ns = time.perf_counter_ns()
+    torch_func(A, B_t, offs, use_triton=False)
+    torch_time_ns = time.perf_counter_ns() - start_time_ns
+    torch_time_us = torch_time_ns / 1e3
 
     # benchmark triton
     warmup(forward_backward, A, B_t, offs, use_triton=True)

--- a/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 # this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
-
+import argparse
 import itertools
 import time
 from dataclasses import dataclass
@@ -28,11 +28,11 @@ class ExperimentConfig:
     A_shape: tuple[int]
     B_shape: tuple[int]
 
-
 @dataclass(frozen=True)
 class ExperimentResult:
-    time_us: float
-
+    torch_time_us: float
+    triton_time_us: bool
+    triton_speedup: float
 
 @dataclass(frozen=True)
 class Experiment:
@@ -41,12 +41,12 @@ class Experiment:
 
 
 def get_configs() -> List[ExperimentConfig]:
-    A_shapes = [(2**8, 4096), (2**12, 4096), (2**16, 4096)]
-    B_shapes = [(4, 4096, 4096), (8, 4096, 4096), (16, 4096, 4096)]
+    A_shapes = [(2**8, 8192), (2**12, 8192), (2**16, 8192)]
+    B_shapes = [(4, 8192, 8192), (8, 8192, 8192), (16, 8192, 8192)]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for A_shape, B_shape, high_precision_dtype in itertools.product(
-        A_shapes, B_shapes, high_precision_dtypes
+        A_shapes, B_shapes, high_precision_dtypes, 
     ):
         configs.append(
             ExperimentConfig(
@@ -58,7 +58,7 @@ def get_configs() -> List[ExperimentConfig]:
     return configs
 
 
-def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+def run_experiment(config: ExperimentConfig, args: argparse.Namespace) -> ExperimentResult:
     # define test inputs
     A = torch.randn(
         *config.A_shape,
@@ -92,26 +92,54 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
         for _ in range(10):
             func(*args, **kwargs)
 
-    def forward_backward(A, B_t, offs):
-        out = _scaled_grouped_mm(A, B_t, offs=offs, out_dtype=torch.bfloat16)
+    def forward_backward(A, B_t, offs, use_triton=True):
+        out = _scaled_grouped_mm(
+            A,
+            B_t,
+            offs=offs,
+            out_dtype=torch.bfloat16,
+            use_triton_for_per_group_scales=use_triton,
+        )
         out.sum().backward()
+        torch.cuda.synchronize()
 
-    # bench triton
-    warmup(forward_backward, A, B_t, offs)
+    # benchmark torch
+    if args.compile:
+        compiled_fwd_bwd = torch.compile(forward_backward)
+        warmup(compiled_fwd_bwd, A, B_t, offs, use_triton=False)
+        start_time_ns = time.perf_counter_ns()
+        compiled_fwd_bwd(A, B_t, offs, use_triton=False)
+        torch_time_ns = time.perf_counter_ns() - start_time_ns
+        torch_time_us = torch_time_ns / 1e3
+    else:
+        warmup(forward_backward, A, B_t, offs, use_triton=False)
+        start_time_ns = time.perf_counter_ns()
+        forward_backward(A, B_t, offs, use_triton=False)
+        torch_time_ns = time.perf_counter_ns() - start_time_ns
+        torch_time_us = torch_time_ns / 1e3
+
+    # benchmark triton
+    warmup(forward_backward, A, B_t, offs, use_triton=True)
     start_time_ns = time.perf_counter_ns()
-    forward_backward(A, B_t, offs)
-    time_ns = time.perf_counter_ns() - start_time_ns
-    time_us = time_ns / 1e3
+    forward_backward(A, B_t, offs, use_triton=True)
+    triton_time_ns = time.perf_counter_ns() - start_time_ns
+    triton_time_us = triton_time_ns / 1e3 
 
-    return ExperimentResult(time_us=time_us)
 
+    
+    return ExperimentResult(
+        torch_time_us=round(torch_time_us, 3),
+        triton_time_us=round(triton_time_us, 3),
+        triton_speedup=round(torch_time_us / triton_time_us, 3),
+    )
 
 def print_results(experiments: List[Experiment]):
     headers = [
         "A_shape",
         "B_shape",
-        "high_precision_dtype",
-        "time_us",
+        "torch_time_us",
+        "triton_time_us",
+        "triton_speedup",
     ]
     rows = []
     for experiment in experiments:
@@ -121,19 +149,20 @@ def print_results(experiments: List[Experiment]):
             [
                 A_shape,
                 B_shape,
-                experiment.config.high_precision_dtype,
-                experiment.result.time_us,
+                experiment.result.torch_time_us,
+                experiment.result.triton_time_us,
+                experiment.result.triton_speedup,
             ]
         )
     print(tabulate(rows, headers=headers))
 
 
-def main():
+def main(args: argparse.Namespace):
     torch.random.manual_seed(123)
     configs = get_configs()
     results = []
     for config in tqdm(configs):
-        result = run_experiment(config)
+        result = run_experiment(config, args)
         results.append(Experiment(config=config, result=result))
 
     # Use Tabulate to print results
@@ -141,4 +170,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("--compile", action="store_true")
+    args = arg_parser.parse_args()
+    main(args)

--- a/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/benchmarks/benchmark_scaled_grouped_mm.py
@@ -28,11 +28,13 @@ class ExperimentConfig:
     A_shape: tuple[int]
     B_shape: tuple[int]
 
+
 @dataclass(frozen=True)
 class ExperimentResult:
     torch_time_us: float
     triton_time_us: bool
     triton_speedup: float
+
 
 @dataclass(frozen=True)
 class Experiment:
@@ -46,7 +48,9 @@ def get_configs() -> List[ExperimentConfig]:
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for A_shape, B_shape, high_precision_dtype in itertools.product(
-        A_shapes, B_shapes, high_precision_dtypes, 
+        A_shapes,
+        B_shapes,
+        high_precision_dtypes,
     ):
         configs.append(
             ExperimentConfig(
@@ -58,7 +62,9 @@ def get_configs() -> List[ExperimentConfig]:
     return configs
 
 
-def run_experiment(config: ExperimentConfig, args: argparse.Namespace) -> ExperimentResult:
+def run_experiment(
+    config: ExperimentConfig, args: argparse.Namespace
+) -> ExperimentResult:
     # define test inputs
     A = torch.randn(
         *config.A_shape,
@@ -123,15 +129,14 @@ def run_experiment(config: ExperimentConfig, args: argparse.Namespace) -> Experi
     start_time_ns = time.perf_counter_ns()
     forward_backward(A, B_t, offs, use_triton=True)
     triton_time_ns = time.perf_counter_ns() - start_time_ns
-    triton_time_us = triton_time_ns / 1e3 
+    triton_time_us = triton_time_ns / 1e3
 
-
-    
     return ExperimentResult(
         torch_time_us=round(torch_time_us, 3),
         triton_time_us=round(triton_time_us, 3),
         triton_speedup=round(torch_time_us / triton_time_us, 3),
     )
+
 
 def print_results(experiments: List[Experiment]):
     headers = [

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -28,6 +28,7 @@ class MoETrainingConfig(AOBaseConfig):
     For all other ops, ScaledGroupedMMTensor behaves like a regular torch.Tensor.
     """
 
+    # temporary config flag for testing/benchmarking, will remove before graduating out of prototype
     use_triton_for_per_group_scales: bool = True
 
 

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -27,6 +27,7 @@ class MoETrainingConfig(AOBaseConfig):
 
     For all other ops, ScaledGroupedMMTensor behaves like a regular torch.Tensor.
     """
+
     use_triton_for_per_group_scales: bool = True
 
 
@@ -78,7 +79,9 @@ def _swap_params(
                 f"Does not support a root nn.Parameter with children: {module}"
             )
         if not isinstance(module.data, ScaledGroupedMMTensor):
-            new_data = ScaledGroupedMMTensor(module.data, use_triton_for_per_group_scales=use_triton)
+            new_data = ScaledGroupedMMTensor(
+                module.data, use_triton_for_per_group_scales=use_triton
+            )
             return nn.Parameter(new_data, requires_grad=module.requires_grad)
         return module
 

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -38,10 +38,12 @@ class ScaledGroupedMMTensor(torch.Tensor):
             B_is_3d = B.dim() == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
             if A_is_2d and B_is_3d and has_offs:
+                # prefer to use B to check use_triton, as that will be the weight/nn.Parameter
+                # that is converted to ScaledGroupedMMTensor
                 use_triton = (
-                    A._use_triton_for_per_group_scales
-                    if isinstance(A, cls)
-                    else B._use_triton_for_per_group_scales
+                    B._use_triton_for_per_group_scales
+                    if isinstance(B, cls)
+                    else A._use_triton_for_per_group_scales
                 )
                 return _scaled_grouped_mm(
                     *args,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -14,18 +14,14 @@ class ScaledGroupedMMTensor(torch.Tensor):
     offs_arg_name = "offs"
     use_triton_for_per_group_scales = True
 
-    def __new__(cls, data: torch.Tensor, use_triton_for_per_group_scales: bool = True):
-        cls.use_triton_for_per_group_scales = use_triton_for_per_group_scales
-        return cls
-
     def __init__(
         self, data: torch.Tensor, use_triton_for_per_group_scales: bool = True
     ):
         self._data = data
-        self.use_triton_for_per_group_scales = use_triton_for_per_group_scales
+        self._use_triton_for_per_group_scales = use_triton_for_per_group_scales
 
     def __repr__(self):
-        return f"ScaledGroupedMMTensor(use_triton_for_per_group_scales={self.use_triton_for_per_group_scales}, {self._data})"
+        return f"ScaledGroupedMMTensor(use_triton_for_per_group_scales={self._use_triton_for_per_group_scales}, {self._data})"
 
     @classmethod
     def __torch_function__(cls, func, types, args, kwargs={}):
@@ -42,9 +38,14 @@ class ScaledGroupedMMTensor(torch.Tensor):
             B_is_3d = B.dim() == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
             if A_is_2d and B_is_3d and has_offs:
+                use_triton = (
+                    A._use_triton_for_per_group_scales
+                    if isinstance(A, cls)
+                    else B._use_triton_for_per_group_scales
+                )
                 return _scaled_grouped_mm(
                     *args,
-                    use_triton_for_per_group_scales=cls.use_triton_for_per_group_scales,
+                    use_triton_for_per_group_scales=use_triton,
                     **kwargs,
                 )
         return super().__torch_function__(func, types, args, kwargs)

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -18,7 +18,9 @@ class ScaledGroupedMMTensor(torch.Tensor):
         cls.use_triton_for_per_group_scales = use_triton_for_per_group_scales
         return cls
 
-    def __init__(self, data: torch.Tensor, use_triton_for_per_group_scales: bool = True):
+    def __init__(
+        self, data: torch.Tensor, use_triton_for_per_group_scales: bool = True
+    ):
         self._data = data
         self.use_triton_for_per_group_scales = use_triton_for_per_group_scales
 
@@ -40,5 +42,9 @@ class ScaledGroupedMMTensor(torch.Tensor):
             B_is_3d = B.dim() == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
             if A_is_2d and B_is_3d and has_offs:
-                return _scaled_grouped_mm(*args, use_triton_for_per_group_scales=self.use_triton_for_per_group_scales, **kwargs)
+                return _scaled_grouped_mm(
+                    *args,
+                    use_triton_for_per_group_scales=cls.use_triton_for_per_group_scales,
+                    **kwargs,
+                )
         return super().__torch_function__(func, types, args, kwargs)


### PR DESCRIPTION
## Summary
- Make using triton kernels for per-group scaling configurable so we can measure speedup from avoiding d2h sync when benchmarking e2e training, and validate the expected speedup. We can remove this before graduating out of prototype.
- Improve benchmarking script, make compile configurable via an argument (I discovered a [bug](https://github.com/pytorch/pytorch/issues/156325) in torch.compile tune_scaled_grouped_mm so want the benchmark script to be usable as a repro for debugging)