### PR TITLE
Improve tiling params to speed up prefill

### DIFF
--- a/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
+++ b/torchao/experimental/ops/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
@@ -203,7 +203,8 @@ void linear_operator(
     nc = tiling_params->nc;
   } else {
     auto params = LinearTilingParams::from_target_tiles_per_thread(
-        m,
+        // We process m sequentially, so m_step is the "m" for the purpose of computing tiling params
+        m_step,
         m_step,
         n,
         n_step,


### PR DESCRIPTION
We process m_step rows sequentially, so all of m should not be used when computing tiling params.

With this change, llama1B prefill on M1 Mac in ExecuTorch improves performance by:

* ~50 tokens/sec --> ~188 tokens/sec [3.76x speedup]
* ~194 tokens/sec --> ~380 tokense/sec (with KleidiAI) [1.95x speedup]

Decode performance is the same (~90 tokens/sec).