### PR TITLE
[float8] add _auto_filter_for_recipe to float8

### DIFF
--- a/torchao/float8/__init__.py
+++ b/torchao/float8/__init__.py
@@ -6,7 +6,10 @@ from torchao.float8.config import (
     ScalingGranularity,
     ScalingType,
 )
-from torchao.float8.float8_linear_utils import convert_to_float8_training
+from torchao.float8.float8_linear_utils import (
+    _auto_filter_for_recipe,
+    convert_to_float8_training,
+)
 from torchao.float8.float8_tensor import (
     Float8Tensor,
     GemmInputRole,
@@ -44,6 +47,7 @@ __all__ = [
     # top level UX
     "convert_to_float8_training",
     "precompute_float8_dynamic_scale_for_fsdp",
+    "_auto_filter_for_recipe",
     # types
     "FP8Granularity",
     # note: Float8Tensor and Float8Linear are not public APIs

--- a/torchao/float8/float8_linear_utils.py
+++ b/torchao/float8/float8_linear_utils.py
@@ -116,7 +116,7 @@ def convert_to_float8_training(
     )
 
 
-def auto_filter_for_recipe(
+def _auto_filter_for_recipe(
     recipe: Float8LinearRecipeName, filter_fqns: List[str]
 ) -> Callable[[nn.Module, str], bool]:
     """Automatically filters nn.Linear modules that meet at least one of the following criteria:
@@ -127,7 +127,9 @@ def auto_filter_for_recipe(
     NOTE: the thresholds are simple heuristics based on performance testing, and may not be optimal
     for your model. For the best performance, we recommend defining your own module_filter_fn customized for
     your module, using the performance tables for the given float8 recipe here:
-    https://github.com/pytorch/ao/tree/main/torchao/float8#performance).
+    https://github.com/pytorch/ao/tree/main/torchao/float8#performance). Note that the benchmarks referenced
+    for auto filtering layers were run on H100 GPUs, and may not be representative of other hardware.
+
 
     The design of this function may change in the future.
     """
@@ -156,8 +158,10 @@ def _auto_filter_for_rowwise(mod: nn.Module, fqn: str, filter_fqns: List[str]) -
     if not dims_multiples_of_16:
         return False
 
-    # Dims below these thresholds will result in worse performance
+    # Dims below these thresholds may result in worse performance
     # (see https://github.com/pytorch/ao/tree/main/torchao/float8#rowwise-scaling)
+    # Note that these benchmarks referenced for auto filtering layers were run on
+    # H100 GPUs, and may not be representative of other hardware.
     if N <= 2048:
         return False
     elif K <= 1024:
@@ -184,8 +188,10 @@ def _auto_filter_for_tensorwise(
     if not dims_multiples_of_16:
         return False
 
-    # Dims below these thresholds will result in worse performance
+    # Dims below these thresholds may result in worse performance
     # (see https://github.com/pytorch/ao/tree/main/torchao/float8#tensorwise-scaling)
+    # Note that these benchmarks referenced for auto filtering layers were run on
+    # H100 GPUs, and may not be representative of other hardware.
     if K <= 4096 and N <= 1024:
         return False
     return True

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -8,6 +8,7 @@ from typing import Iterable, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
+from torch import nn
 from torch.distributed._functional_collectives import AsyncCollectiveTensor, all_reduce
 
 from torchao.float8.config import ScalingGranularity

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -8,7 +8,6 @@ from typing import Iterable, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
-from torch import nn
 from torch.distributed._functional_collectives import AsyncCollectiveTensor, all_reduce
 
 from torchao.float8.config import ScalingGranularity


### PR DESCRIPTION
Part of https://github.com/pytorch/torchtitan/issues/1207

## Problem
- float8 rowwise + vanilla TP in torchtitan had flat perf with respect to bfloat. 
- RCA In https://github.com/pytorch/torchtitan/issues/1207 found attention.wk and attention.wv layers were so small that float8 rowwise conversion resulted in significant slowdown (approx 40%) for those linears, thus the perf benefits from fp8 rowwise conversion on larger linears were nullified.
- This is because the default `filter_fqns` for float8 model conversion are fine for the fp8 tensorwise recipe, but bad for the float8 rowwise recipe. 

### Solution 

This has been a footgun for various users as well (including Poolside), so I created an "auto filter" (https://github.com/pytorch/ao/pull/2410) which automatically filters Linears for a given float8 recipe, by checking for the following criteria:

1. dims not divisible by 16 (hardware requirement for float8)
2. dim sizes below thresholds that will result in worse perf **for that given recipe**, using simple heuristics based on the linked recipe perf tables above.
3. fqn matches one of the user defined `filter_fqns`

I integrated a [PoC into torchtitan](https://github.com/pytorch/torchtitan/pull/1319) and the auto filter improved fp8 rowwise perf both local Llama3 8b run and Llama3 70b MAST run, compared to the default filter_fn we have now.

It prevents users from hitting this common footgun, while also preserving the flexibility to define their model-specific fqns.

## Results 
See https://github.com/pytorch/torchtitan/issues/1207 for Llama3 70b results, TL;DR is filtering wk and wv improves TPS  ~10% for vanilla TP and ~15% for async TP.
