### PR TITLE
[float8 moe training] Add TP support

### DIFF
--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -40,11 +40,7 @@ def _scaled_grouped_mm(
         offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
         out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Currently only torch.bfloat16 is supported.
     """
-<<<<<<< HEAD
     logger.info("Using scaled_grouped_mm")
-=======
-    logger.info("Using differentiable _scaled_grouped_mm")
->>>>>>> eb2dd3e0 (fix dtype bug)
     return _Float8GroupedMM.apply(
         A,
         B_t,

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -40,7 +40,11 @@ def _scaled_grouped_mm(
         offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
         out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Currently only torch.bfloat16 is supported.
     """
+<<<<<<< HEAD
     logger.info("Using scaled_grouped_mm")
+=======
+    logger.info("Using differentiable _scaled_grouped_mm")
+>>>>>>> eb2dd3e0 (fix dtype bug)
     return _Float8GroupedMM.apply(
         A,
         B_t,

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -19,14 +19,13 @@ from torchao.prototype.moe_training.utils import (
     _is_column_major,
 )
 
-
 logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _scaled_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,
-    offs: torch.Tensor,
+    offs: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = torch.bfloat16,
 ) -> torch.Tensor:
     """
@@ -58,9 +57,8 @@ class _Float8GroupedMM(torch.autograd.Function):
         ctx,
         A: torch.Tensor,
         B_t: torch.Tensor,
-        offs: torch.Tensor,
+        offs: Optional[torch.Tensor] = None,
         out_dtype: Optional[torch.dtype] = torch.bfloat16,
-        use_triton_for_per_group_scales: bool = True,
     ) -> torch.Tensor:
         # torchao _scaled_grouped_mm only supports A=2D, B=3D.
         assert A.ndim == 2, "A must be 2D"
@@ -80,7 +78,6 @@ class _Float8GroupedMM(torch.autograd.Function):
         assert B_t.dtype == torch.float32 or B_t.dtype == torch.bfloat16, (
             "B must be float32 or bfloat16"
         )
-        assert offs.dtype == torch.int32, "offs must be int32"
 
         # Assert A and B dims are compatible for a scaled grouped GEMM.
         assert A.size(-1) == B_t.size(-2), (

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from typing import Optional
 
 import torch
@@ -17,6 +18,9 @@ from torchao.prototype.moe_training.kernels import (
 from torchao.prototype.moe_training.utils import (
     _is_column_major,
 )
+
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _scaled_grouped_mm(
@@ -36,8 +40,8 @@ def _scaled_grouped_mm(
             and in column-major memory layout.
         offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
         out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Currently only torch.bfloat16 is supported.
-        use_triton_for_per_group_scales (bool): Whether to use custom triton kernels to compute per-group scales. Default is True.
     """
+    logger.info("Using scaled_grouped_mm")
     return _Float8GroupedMM.apply(
         A,
         B_t,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -19,10 +19,6 @@ from torchao.prototype.moe_training import _scaled_grouped_mm
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-<<<<<<< HEAD
-=======
-
->>>>>>> eb2dd3e0 (fix dtype bug)
 _ops_to_preserve_subclass = {
     torch.ops.aten.empty_like.default,
     torch.ops.aten.new_zeros.default,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 from typing import Any, Optional, Tuple
 
 import torch
@@ -18,7 +17,6 @@ from torch.autograd.grad_mode import _unsafe_preserve_version_counter
 from torchao.prototype.moe_training import _scaled_grouped_mm
 
 logger: logging.Logger = logging.getLogger(__name__)
-
 
 _ops_to_preserve_subclass = {
     torch.ops.aten.empty_like.default,
@@ -85,9 +83,6 @@ class ScaledGroupedMMTensor(torch.Tensor):
             A, B = args[0], args[1]
             A_is_2d_or_3d = A.dim() in (2, 3)
             B_is_3d = B.dim() == 3
-            has_offs = kwargs.get(cls.offs_arg_name) is not None
-            logger.debug(f"A.shape={A.shape}, B.shape={B.shape}, has_offs={has_offs}")
-
             if A_is_2d_or_3d and B_is_3d:
                 return _scaled_grouped_mm(
                     *args,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -83,12 +83,12 @@ class ScaledGroupedMMTensor(torch.Tensor):
             # used for shared experts. This is basically the grouped_mm
             # kernel handling a bmm.
             A, B = args[0], args[1]
-            A_is_2d = A.dim() == 2
+            A_is_2d_or_3d = A.dim() in (2, 3)
             B_is_3d = B.dim() == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
-            logger.info(f"A.shape={A.shape}, B.shape={B.shape}, has_offs={has_offs}")
-            
-            if A_is_2d and B_is_3d:
+            logger.debug(f"A.shape={A.shape}, B.shape={B.shape}, has_offs={has_offs}")
+
+            if A_is_2d_or_3d and B_is_3d:
                 return _scaled_grouped_mm(
                     *args,
                     **kwargs,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from typing import Any, Optional, Tuple
 
 import torch
@@ -18,6 +19,10 @@ from torchao.prototype.moe_training import _scaled_grouped_mm
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> eb2dd3e0 (fix dtype bug)
 _ops_to_preserve_subclass = {
     torch.ops.aten.empty_like.default,
     torch.ops.aten.new_zeros.default,
@@ -96,6 +101,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs={}):
+        logger.debug(f"{func.__name__}, args={args}, kwargs={kwargs}")
         # detach is special case
         if func == torch.ops.aten.detach.default:
             return ScaledGroupedMMTensor(args[0]._data, args[0]._dtype)
@@ -134,6 +140,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
     def __tensor_flatten__(self):
         return ["_data"], {"_dtype": self._dtype}
+
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):


### PR DESCRIPTION
Note: this should be merged AFTER this bug fix: https://github.com/pytorch/ao/pull/2451 I will rebase and retest all of this once that's merged.

## Summary
- Add TP support for routed experts and shared expert.
    - Make target dim of scale squeze() ops explicit to handle both 2D and 3D "A" tensors (routed experts case has 2D "A", shared expert has 3D "A").
    - Make `offs` optional to handle shared_expert case where num_experts=1 (scaled grouped GEMM only processing 1 expert)
- Add debug logging

## Test plan
- Added integration test using torchtitan llama4 TP implementation. Test cases for (1) routed experts, and  (2) routed experts + shared expert.
- Manual testing with torchtitan llama4 debug model with TP=2, targeting routed experts AND shared experts works ([logs](https://www.internalfb.com/phabricator/paste/view/P1849252048)). 
- Manual testing with torch titan llama4 debug model with FSDP=2 + TP=2 confirms this 2D parallelism is working for routed experts ([logs](https://www.internalfb.com/phabricator/paste/view/P1848969337))

## Limitations
- 2D parallel witih FDSP+TP for **shared experts** is not yet supported yet (see [comment](https://github.com/pytorch/ao/pull/2425#issuecomment-2997952768)) below). Need to debug this, which I will do in a subsequent PR.