### PR TITLE
add-to-benchmarks

### DIFF
--- a/benchmarks/float8/bench_matmul.py
+++ b/benchmarks/float8/bench_matmul.py
@@ -16,6 +16,8 @@ from utils import (
     get_name_to_shapes_iter,
 )
 
+from torchao.ops import mx_fp4_bf16
+from torchao.prototype.mx_formats.mx_tensor import to_mx
 from torchao.testing.training.roofline_utils import get_specs
 
 
@@ -62,29 +64,38 @@ def run(
 ):
     device = "cuda"
     # TODO(future PR): this is ugly
-    assert recipe in ("tensorwise", "rowwise", "mxfp8_cublas"), "unsupported"
+    assert recipe in (
+        "tensorwise",
+        "rowwise",
+        "mxfp8_cublas",
+        "mxfp4_cutlass",
+        "nvfp4",
+    ), "unsupported"
+    use_fp4 = recipe in ("mxfp4_cutlass", "nvfp4")
 
     specs = get_specs()
     bf16_peak_tops = specs["bf16_peak_tops"]
     fp8_peak_tops = specs["fp8_peak_tops"]
+    fp4_peak_tops = specs["fp4_peak_tops"]
     print(f"gpu_name: {torch.cuda.get_device_name(0)}")
-    print(f"peak tops: bf16 {bf16_peak_tops:.2e}, fp8 {fp8_peak_tops:.2e}")
-
+    print(
+        f"peak tops: bf16 {bf16_peak_tops:.2e}, fp8 {fp8_peak_tops:.2e}, fp4 {fp4_peak_tops:.2e}"
+    )
     headers = (
         "fast_accum",
         "name",
         "M",
         "K",
         "N",
-        "ref_time_s",
-        "fp8_time_s",
+        "time_s",
+        "speedup",
         "fp8_speedup",
     )
     results = []
 
     dtype = torch.bfloat16
     name_to_shapes = get_name_to_shapes_iter(shape_gen_name, M, K, N)
-    fast_accum_vals = [True, False]
+    fast_accum_vals = [False] if use_fp4 else [True, False]
 
     for idx, (fast_accum, (name, (M, K, N))) in enumerate(
         itertools.product(fast_accum_vals, name_to_shapes)
@@ -107,38 +118,82 @@ def run(
 
         del A
 
-        # raw float8 matmul (upper bound for what we can achive in eager mode)
-        # TODO(future): add e5m2
-        d1, d2, d3 = torch.float8_e4m3fn, torch.float8_e4m3fn, dtype
-        A = torch.zeros(M, K, device=device, dtype=d1)
-        B = torch.zeros(K, N, device=device, dtype=d2).t().contiguous().t()
+        A_hp = torch.randn(M, K, device=device)
+        B_hp_t = torch.randn(N, K, device=device)
+
+        if recipe == "mxfp4_cutlass":
+            _, A = to_mx(A_hp, torch.float4_e2m1fn_x2, 32)
+            _, Bt = to_mx(B_hp_t, torch.float4_e2m1fn_x2, 32)
+            B = Bt.contiguous().T
+            peak_tops = fp4_peak_tops
+        elif recipe == "nvfp4":
+            from torchao.prototype.mx_formats.nvfp4_tensor import nvfp4_quantize
+
+            A_scales, A_data = nvfp4_quantize(A_hp, block_size=16)
+            B_scales, B_data = nvfp4_quantize(B_hp_t, block_size=16)
+            A = A_data.view(torch.float4_e2m1fn_x2)
+            B = B_data.view(torch.float4_e2m1fn_x2).T
+            peak_tops = fp4_peak_tops
+        else:
+            # raw float8 matmul (upper bound for what we can achive in eager mode)
+            # TODO(future): add e5m2
+            d1, d2, d3 = torch.float8_e4m3fn, torch.float8_e4m3fn, dtype
+            A = A_hp.to(d1)
+            B = B_hp_t.to(d2).contiguous().T
+            peak_tops = fp8_peak_tops
+
         if recipe == "tensorwise":
             scale_a = torch.tensor([1.0], device=device)
             scale_b = torch.tensor([1.0], device=device)
         elif recipe == "rowwise":
             scale_a = torch.ones(M, 1, device=device)
             scale_b = torch.ones(1, N, device=device)
-        elif recipe == "mxfp8_cublas":
+        elif recipe in ("mxfp8_cublas", "mxfp4_cutlass"):
             scale_a = torch.ones(M, K // 32, device=device, dtype=torch.float8_e8m0fnu)
             scale_b = torch.ones(N, K // 32, device=device, dtype=torch.float8_e8m0fnu)
+        elif recipe == "nvfp4":
+            # Use the blockwise scales from nvfp4_quantize
+            scale_a = A_scales.view(torch.float8_e4m3fn)
+            scale_b = B_scales.view(torch.float8_e4m3fn)
         else:
             assert False, f"unknown recipe {recipe}"
 
-        def do_matmul(A, B):
+        def do_matmul_fp8(A, B):
             nonlocal scale_a
             nonlocal scale_b
             return torch._scaled_mm(
                 A, B, scale_a, scale_b, out_dtype=d3, use_fast_accum=fast_accum
             )
 
-        fp8_time_sec, fp8_tops_sec, fp8_pct_top_peak = do_benchmarks(
-            tops, fp8_peak_tops, use_gpu_kernel_time, do_matmul, A, B
+        def do_matmul_mxfp4(A, B):
+            nonlocal scale_a
+            nonlocal scale_b
+            return mx_fp4_bf16(A, B, scale_a, scale_b)
+
+        def do_matmul_nvfp4(A, B):
+            nonlocal scale_a
+            nonlocal scale_b
+            return torch._scaled_mm(A, B, scale_a, scale_b, out_dtype=dtype)
+
+        if recipe == "mxfp4_cutlass":
+            do_matmul = do_matmul_mxfp4
+        elif recipe == "nvfp4":
+            do_matmul = do_matmul_nvfp4
+        else:
+            do_matmul = do_matmul_fp8
+
+        time_sec, tops_sec, pct_top_peak = do_benchmarks(
+            tops, peak_tops, use_gpu_kernel_time, do_matmul, A, B
         )
         print(
-            f"fp8 time_sec {fp8_time_sec:.2E}, tops/sec {fp8_tops_sec:.2E}, pct_peak {fp8_pct_top_peak:.3f}"
+            f"time_sec {time_sec:.2E}, tops/sec {tops_sec:.2E}, pct_peak {pct_top_peak:.3f}"
         )
 
-        del A, B, scale_a, scale_b
+        del A, B
+        if scale_a is not None:
+            del scale_a
+        if scale_b is not None:
+            del scale_b
 
         results.append(
             [
@@ -148,8 +203,8 @@ def run(
                 K,
                 N,
                 ref_time_sec,
-                fp8_time_sec,
-                ref_time_sec / fp8_time_sec,
+                time_sec,
+                ref_time_sec / time_sec,
             ]
         )
 

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -352,9 +352,6 @@ def get_gpu_kernel_gemm_time_s(f, *args, **kwargs):
     )
     # there is only 1 key, aten::mm or aten::_scaled_mm, with unit nanoseconds
     assert len(data) == 1
-    if "aten::mm" in data:
-        return data["aten::mm"] / 1e6 / n_iter
-    elif "aten::_scaled_mm" in data:
-        return data["aten::_scaled_mm"] / 1e6 / n_iter
-    else:
-        raise AssertionError("unexpected format of data")
+    key, value = next(iter(data.items()))
+    assert key in ("aten::mm", "aten::_scaled_mm", "torchao::mx_fp4_bf16")
+    return value / 1e6 / n_iter

--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -54,6 +54,13 @@ gpu_name_to_specs = {
         # TODO(future): run measurement on hardware
         "pct_achievable_mem_bw": 0.92,
     },
+    "NVIDIA GeForce RTX 5090": {
+        # https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf
+        "bf16_peak_tops": 209.5e12,
+        "fp8_peak_tops": 419e12,
+        "fp4_peak_tops": 1676e12,
+        "peak_mem_bw_bytes_sec": 1.792e15,
+    },
     # TODO(future): more GPU names
 }
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#2427


--- --- ---

add-to-benchmarks

``` Shell
❯ python benchmarks/float8/bench_matmul.py --recipe "nvfp4"
TMA benchmarks will be running with experimental grid constant TMA descriptor.
gpu_name: NVIDIA B200
peak tops: bf16 2.25e+15, fp8 4.50e+15, fp4 9.00e+15
M, K, N: 1024 1024 1024 tops: 2.15E+09
torch.bfloat16 time_sec 5.08E-06, tops/sec 4.23E+14, pct_peak 0.188
time_sec 5.87E-06, tops/sec 3.66E+14, pct_peak 0.041
M, K, N: 1536 1536 1536 tops: 7.25E+09
torch.bfloat16 time_sec 7.87E-06, tops/sec 9.21E+14, pct_peak 0.410
time_sec 6.73E-06, tops/sec 1.08E+15, pct_peak 0.120
M, K, N: 2048 2048 2048 tops: 1.72E+10
torch.bfloat16 time_sec 1.52E-05, tops/sec 1.13E+15, pct_peak 0.503
time_sec 1.02E-05, tops/sec 1.68E+15, pct_peak 0.187
M, K, N: 3072 3072 3072 tops: 5.80E+10
torch.bfloat16 time_sec 3.84E-05, tops/sec 1.51E+15, pct_peak 0.672
time_sec 1.65E-05, tops/sec 3.51E+15, pct_peak 0.390
M, K, N: 4096 4096 4096 tops: 1.37E+11
torch.bfloat16 time_sec 9.74E-05, tops/sec 1.41E+15, pct_peak 0.627
time_sec 3.08E-05, tops/sec 4.46E+15, pct_peak 0.495
M, K, N: 6144 6144 6144 tops: 4.64E+11
torch.bfloat16 time_sec 3.19E-04, tops/sec 1.45E+15, pct_peak 0.646
time_sec 8.44E-05, tops/sec 5.50E+15, pct_peak 0.611
M, K, N: 8192 8192 8192 tops: 1.10E+12
torch.bfloat16 time_sec 7.74E-04, tops/sec 1.42E+15, pct_peak 0.631
time_sec 2.05E-04, tops/sec 5.37E+15, pct_peak 0.597
M, K, N: 12288 12288 12288 tops: 3.71E+12
torch.bfloat16 time_sec 2.68E-03, tops/sec 1.38E+15, pct_peak 0.615
time_sec 9.06E-04, tops/sec 4.10E+15, pct_peak 0.455
M, K, N: 16384 16384 16384 tops: 8.80E+12
torch.bfloat16 time_sec 6.26E-03, tops/sec 1.41E+15, pct_peak 0.625
time_sec 2.18E-03, tops/sec 4.04E+15, pct_peak 0.449
M, K, N: 24576 24576 24576 tops: 2.97E+13
torch.bfloat16 time_sec 2.30E-02, tops/sec 1.29E+15, pct_peak 0.574
time_sec 7.59E-03, tops/sec 3.91E+15, pct_peak 0.435
   fast_accum  name      M      K      N  ref_time_s    time_s   speedup
0       False     0   1024   1024   1024    0.000005  0.000006  0.865867
1       False     1   1536   1536   1536    0.000008  0.000007  1.168251
2       False     2   2048   2048   2048    0.000015  0.000010  1.485314
3       False     3   3072   3072   3072    0.000038  0.000016  2.325474
4       False     4   4096   4096   4096    0.000097  0.000031  3.158025
5       False     5   6144   6144   6144    0.000319  0.000084  3.781864
6       False     6   8192   8192   8192    0.000774  0.000205  3.784100
7       False     7  12288  12288  12288    0.002681  0.000906  2.960314
8       False     8  16384  16384  16384    0.006258  0.002178  2.872720
9       False     9  24576  24576  24576    0.022977  0.007589  3.027770
```