### PR TITLE
Store NVFP4 block scales in swwizzled layout on tensor

### DIFF
--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -558,11 +558,13 @@ def test_nvfp4_matmul_with_amax(
         A,
         per_tensor_scale=a_scale,
         mm_config=mm_config,
+        is_swizzled_scales=True,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
         mm_config=mm_config,
+        is_swizzled_scales=True,
     )
 
     func = torch.compile(F.linear, fullgraph=True) if compile else F.linear

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -657,3 +657,301 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
     assert x.t().dtype == x_reconstructed_t.dtype, (
         f"Transpose dtype mismatch: {x.t().dtype} vs {x_reconstructed_t.dtype}"
     )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (128, 4),
+        (256, 8),
+        (100, 3),
+        (4, 4),
+        (50, 10),
+        (384, 12),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_triton_kernel", [False, True] if torch.cuda.is_available() else [False]
+)
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="torch.compile requires PyTorch 2.8+"
+)
+def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
+    from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
+
+    rows, cols = shape
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
+
+    blocked = to_blocked(original, use_triton_kernel=use_triton_kernel)
+    reconstructed = from_blocked(blocked, rows, cols)
+
+    torch.testing.assert_close(
+        original,
+        reconstructed,
+        atol=0.0,
+        rtol=0.0,
+        msg=f"Roundtrip failed for shape {shape} with use_triton_kernel={use_triton_kernel}",
+    )
+
+
+@pytest.mark.parametrize("is_swizzled_scales", [False, True])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (32, 64),
+        (16, 32),
+        (64, 128),
+        (384, 128),
+    ],
+)
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="torch.compile requires PyTorch 2.8+"
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape):
+    """
+    Test that NVFP4Tensor can be constructed with swizzled scales and
+    that the _is_swizzled_scales flag is set correctly.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    M, K = shape
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+
+    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=is_swizzled_scales)
+    assert tensor._is_swizzled_scales == is_swizzled_scales
+    reconstructed = tensor.to_dtype(torch.bfloat16)
+    assert reconstructed.shape == data.shape
+
+
+@pytest.mark.parametrize(
+    "slice_dim,slice_spec",
+    [
+        # Row slicing - must align with 128-row boundaries
+        pytest.param(0, slice(0, 128), id="slice_rows[0:128]"),
+        pytest.param(0, slice(128, 256), id="slice_rows[128:256]"),
+        # Column slicing - must align with 64-column boundaries (4 scale columns * 16 block_size)
+        pytest.param(1, slice(0, 64), id="slice_cols[0:64]"),
+        pytest.param(1, slice(64, 128), id="slice_cols[64:128]"),
+        pytest.param(1, slice(0, 128), id="slice_cols[0:128]_full_width"),
+        # Test tensor parallelism patterns (half splits)
+        pytest.param(1, slice(0, 2048), id="slice_cols[0:2048]_tp_first_half"),
+        pytest.param(1, slice(2048, 4096), id="slice_cols[2048:4096]_tp_second_half"),
+        # Test quarter splits
+        pytest.param(1, slice(0, 1024), id="slice_cols[0:1024]_quarter"),
+        pytest.param(1, slice(1024, 2048), id="slice_cols[1024:2048]_quarter"),
+    ],
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec):
+    """
+    Test that slicing works correctly with swizzled scales and maintains
+    the swizzled state in the output tensor.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    # Use larger tensor sizes that align with swizzled requirements
+    if slice_dim == 0:
+        # For row slicing, need at least 256 rows to test 128-row boundaries
+        M, K = 256, 4096
+    else:
+        # For column slicing, need multiples of 64 columns for alignment
+        M, K = 128, 4096
+
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+
+    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    assert tensor._is_swizzled_scales == True
+
+    if slice_dim == 0:
+        sliced_tensor = tensor[slice_spec, :]
+    else:
+        sliced_tensor = tensor[:, slice_spec]
+
+    # Verify sliced tensor maintains swizzled state
+    assert sliced_tensor._is_swizzled_scales == True
+
+    # Verify sliced tensor can be dequantized
+    sliced_reconstructed = sliced_tensor.to_dtype(torch.bfloat16)
+
+    # Compare with direct slicing of original data
+    original_reconstructed = tensor.to_dtype(torch.bfloat16)
+    if slice_dim == 0:
+        expected = original_reconstructed[slice_spec, :]
+    else:
+        expected = original_reconstructed[:, slice_spec]
+
+    torch.testing.assert_close(sliced_reconstructed, expected, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "slice_dim,slice_spec,expected_error",
+    [
+        # Row slicing with misaligned boundaries
+        pytest.param(
+            0,
+            slice(0, 100),
+            "Row slicing of NVFP4Tensor with swizzled scales requires",
+            id="misaligned_row_end",
+        ),
+        pytest.param(
+            0,
+            slice(50, 150),
+            "Row slicing of NVFP4Tensor with swizzled scales requires",
+            id="misaligned_row_start",
+        ),
+        # Column slicing with misaligned boundaries
+        pytest.param(
+            1,
+            slice(0, 32),
+            "Column slicing of NVFP4Tensor with swizzled scales requires",
+            id="misaligned_col_32",
+        ),
+        pytest.param(
+            1,
+            slice(16, 80),
+            "Column slicing of NVFP4Tensor with swizzled scales requires",
+            id="misaligned_col_start",
+        ),
+        pytest.param(
+            1,
+            slice(0, 100),
+            "Column slicing of NVFP4Tensor with swizzled scales requires",
+            id="misaligned_col_end",
+        ),
+        # Odd column boundaries (FP4 packing requirement)
+        pytest.param(
+            1,
+            slice(1, 65),
+            "start index to be a multiple of 64, got 1",
+            id="odd_start",
+        ),
+        pytest.param(
+            1,
+            slice(0, 65),
+            " multiple of 64 or equal to tensor size 4096, got 65",
+            id="odd_end",
+        ),
+    ],
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_error):
+    """
+    Test that slicing raises appropriate errors for misaligned boundaries.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    M, K = 256, 4096
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        if slice_dim == 0:
+            _ = tensor[slice_spec, :]
+        else:
+            _ = tensor[:, slice_spec]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_swizzled_scales_view_semantics():
+    """
+    Test that slicing maintains proper view semantics where possible.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    M, K = 256, 4096
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+
+    # Test row slicing (should maintain views)
+    sliced_tensor = tensor[0:128, :]
+
+    # Test that the sliced tensor shares storage with original for data
+    # (Note: scales might not share storage due to swizzled layout complexity)
+    assert sliced_tensor._data.data_ptr() == tensor._data.data_ptr()
+
+    # Test full-width column slicing (should maintain views)
+    full_width_slice = tensor[:, 0:K]
+    assert full_width_slice._scale_e4m3.data_ptr() == tensor._scale_e4m3.data_ptr()
+    assert full_width_slice._data.data_ptr() == tensor._data.data_ptr()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_swizzled_scales_serialization():
+    """
+    Test that tensor flatten/unflatten preserves the swizzled scales state.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    M, K = 32, 64
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+
+    # Create tensor with swizzled scales
+    original_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+
+    # Test serialization
+    tensor_list, ctx = original_tensor.__tensor_flatten__()
+
+    # Verify swizzled flag is preserved in context
+    assert "_is_swizzled_scales" in ctx
+    assert ctx["_is_swizzled_scales"] == True
+
+    # Test deserialization
+    inner_tensors = {}
+    for name in tensor_list:
+        inner_tensors[name] = getattr(original_tensor, name)
+
+    reconstructed_tensor = NVFP4Tensor.__tensor_unflatten__(
+        inner_tensors, ctx, None, None
+    )
+
+    # Verify the swizzled state is preserved
+    assert reconstructed_tensor._is_swizzled_scales == True
+
+    # Verify functionality is preserved
+    original_dq = original_tensor.to_dtype(torch.bfloat16)
+    reconstructed_dq = reconstructed_tensor.to_dtype(torch.bfloat16)
+
+    torch.testing.assert_close(original_dq, reconstructed_dq, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not TORCH_VERSION_AT_LEAST_2_8, reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_swizzled_scales_get_scales_method():
+    """
+    Test that the get_scales() method correctly unswizzles scales when needed.
+    """
+    from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
+
+    M, K = 32, 64
+    data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+
+    # Create tensors with both storage methods
+    regular_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=False)
+    swizzled_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+
+    # Get scales from both tensors and verify they are equal
+    regular_scales = regular_tensor.get_hp_scales()
+    swizzled_scales = swizzled_tensor.get_hp_scales()
+    torch.testing.assert_close(regular_scales, swizzled_scales, atol=0.0, rtol=0.0)
+
+    # Verify scales have the expected shape
+    expected_shape = (M, K // 16)
+    assert regular_scales.shape == expected_shape
+    assert swizzled_scales.shape == expected_shape

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
 from enum import Enum
 from typing import Any, Callable, Dict, Optional
 
@@ -21,8 +22,8 @@ from torchao.prototype.mx_formats.mx_tensor import (
     tensor_size_fp4x2_to_hp,
     tensor_size_hp_to_fp4x2,
 )
-from torchao.prototype.mx_formats.utils import to_blocked
-from torchao.utils import fill_defaults
+from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
+from torchao.utils import ceil_div, fill_defaults
 
 E4M3_EPS = torch.finfo(torch.float8_e4m3fn).tiny
 
@@ -54,11 +55,12 @@ class NVFP4Tensor(torch.Tensor):
     quantization algorithm for FP4 data with UE4M3 scales.
 
     Attributes:
-        _scale_e4m3: Blockwise scales in float8_e4m3fn format
+        _scale_e4m3: Blockwise scales in float8_e4m3fn format (may be swizzled)
         _per_tensor_scale: Optional global per-tensor scale in float32 format
         _data: Packed FP4 data (2 values per byte)
         _block_size: Block size for quantization (fixed at 16)
         _orig_dtype: Original tensor dtype before quantization
+        _is_swizzled_scales: Whether scales are stored in swizzled (blocked) format
         mm_config: Matrix multiplication configuration
     """
 
@@ -67,6 +69,7 @@ class NVFP4Tensor(torch.Tensor):
     _data: torch.Tensor
     _block_size: int
     _orig_dtype: torch.dtype
+    _is_swizzled_scales: bool
     mm_config: NVFP4MMConfig
 
     def __new__(
@@ -77,12 +80,14 @@ class NVFP4Tensor(torch.Tensor):
         block_size,
         orig_dtype,
         mm_config=NVFP4MMConfig.DYNAMIC,
+        is_swizzled_scales=False,
     ):
-        # FP4 tensor size handling
+        # FP4 tensor size handling two paths, contiguous or not
         new_size = data_bits.size()
+
         new_size = tensor_size_fp4x2_to_hp(
             new_size,
-            data_bits.is_contiguous(),
+            data_bits.stride(0) > data_bits.stride(1),
         )
 
         self = torch.Tensor._make_wrapper_subclass(
@@ -94,6 +99,7 @@ class NVFP4Tensor(torch.Tensor):
         )
 
         self._scale_e4m3 = blockwise_scales
+        self._is_swizzled_scales = is_swizzled_scales
         self._per_tensor_scale = per_tensor_scale
         self._data = data_bits
         self._block_size = block_size
@@ -118,14 +124,17 @@ class NVFP4Tensor(torch.Tensor):
         block_size: int = 16,
         per_tensor_scale: Optional[torch.Tensor] = None,
         mm_config: NVFP4MMConfig = NVFP4MMConfig.DYNAMIC,
+        is_swizzled_scales: bool = False,
     ):
         """Convert high precision tensor to NVFP4 format.
 
         Args:
             data_hp: High precision input tensor (bfloat16 or float32)
             block_size: Block size for quantization (must be 16)
-            per_tensor_amax: Optional pre-computed absolute maximum for calibration.
+            per_tensor_scale: Optional pre-computed absolute maximum for calibration.
                 If provided, uses per-tensor scaling. If None, uses block-wise scaling only.
+            mm_config: Matrix multiplication configuration
+            is_swizzled_scales: If True, store scales in swizzled format for faster matrix multiplication
 
         Returns:
             NVFP4Tensor: Quantized tensor in NVFP4 format
@@ -133,6 +142,12 @@ class NVFP4Tensor(torch.Tensor):
         blockwise_scales, data_lp = nvfp4_quantize(
             data_hp, block_size, per_tensor_scale
         )
+
+        if is_swizzled_scales:
+            M, K = data_hp.shape[0], data_hp.shape[1]
+            scale_shape = (M, K // block_size)
+            blockwise_scales = to_blocked(blockwise_scales.view(scale_shape)).flatten()
+
         return NVFP4Tensor(
             blockwise_scales,
             per_tensor_scale,
@@ -140,12 +155,14 @@ class NVFP4Tensor(torch.Tensor):
             block_size,
             data_hp.dtype,
             mm_config,
+            is_swizzled_scales,
         )
 
     def __tensor_flatten__(self):
         ctx = {
             "_block_size": self._block_size,
             "_orig_dtype": self._orig_dtype,
+            "_is_swizzled_scales": self._is_swizzled_scales,
             "mm_config": self.mm_config,
         }
         tensor_list = ["_scale_e4m3", "_data"]
@@ -182,6 +199,7 @@ class NVFP4Tensor(torch.Tensor):
             metadata["_block_size"],
             metadata["_orig_dtype"],
             metadata["mm_config"],
+            metadata.get("_is_swizzled_scales", False),
         )
 
     # Do not force the NVFP4Tensor type on the returned tensor
@@ -196,7 +214,7 @@ class NVFP4Tensor(torch.Tensor):
         Returns:
             torch.Tensor: Dequantized tensor in the target dtype
         """
-        is_transposed = not self._data.is_contiguous()
+        is_transposed = self._data.stride(0) < self._data.stride(1)
         if is_transposed:
             M, K = self.shape[1], self.shape[0]
         else:
@@ -221,10 +239,21 @@ class NVFP4Tensor(torch.Tensor):
         Returns:
             torch.Tensor: Scales of the NVFP4Tensor
         """
+        is_transposed = self._data.stride(0) < self._data.stride(1)
+        if is_transposed:
+            M, K = self.shape[1], self.shape[0]
+        else:
+            M, K = self.shape[0], self.shape[1]
+
+        if self._is_swizzled_scales:
+            scale_e4m3 = from_blocked(self._scale_e4m3, M, K // self._block_size)
+        else:
+            scale_e4m3 = self._scale_e4m3
+
         return (
-            self._scale_e4m3.to(self._orig_dtype)
+            scale_e4m3.to(self._orig_dtype)
             if not self._per_tensor_scale
-            else self._per_tensor_scale * self._scale_e4m3.to(self._orig_dtype)
+            else self._per_tensor_scale * scale_e4m3.to(self._orig_dtype)
         )
 
     @classmethod
@@ -238,7 +267,6 @@ class NVFP4Tensor(torch.Tensor):
         Returns:
             bool: True if both tensors have identical metadata, False otherwise
         """
-        # Check per_tensor_scale equality
         per_tensor_scale_equal = (
             self._per_tensor_scale is None and src._per_tensor_scale is None
         ) or (self._per_tensor_scale.shape == src._per_tensor_scale.shape)
@@ -248,6 +276,7 @@ class NVFP4Tensor(torch.Tensor):
             and isinstance(src, NVFP4Tensor)
             and self._block_size == src._block_size
             and self._orig_dtype == src._orig_dtype
+            and self._is_swizzled_scales == src._is_swizzled_scales
             and self._scale_e4m3.shape == src._scale_e4m3.shape
             and per_tensor_scale_equal
             and self._data.shape == src._data.shape
@@ -292,6 +321,7 @@ def nvfp4_to_copy(func, types, args, kwargs):
             tensor._block_size,
             dtype,
             tensor.mm_config,
+            tensor._is_swizzled_scales,
         )
         return res
 
@@ -335,45 +365,165 @@ def nvfp4_slice(func, types, args, kwargs):
     assert x._data.is_contiguous(), "Only support contiguous data for now"
 
     M, K = x.shape[0], x.shape[1]
-    scale_shaped = x._scale_e4m3.view(M, K // x._block_size)
 
-    if dim == 0:
-        # Slicing along the first dimension (rows)
-        sliced_scale = aten.slice.Tensor(scale_shaped, dim, start, end, step).flatten()
-        sliced_data = aten.slice.Tensor(x._data, dim, start, end, step)
-    elif dim == 1:
-        # Slicing along reduction dim - must align with block boundaries
-        if start is not None:
-            assert start % x._block_size == 0, (
-                f"Start index {start} must be a multiple of block_size {x._block_size}"
+    if x._is_swizzled_scales:
+        scale_rows = M
+        scale_cols = K // x._block_size
+        n_row_blocks = ceil_div(scale_rows, 128)
+        n_col_blocks = ceil_div(scale_cols, 4)
+        elements_per_block = 32 * 16  # 512 elements
+
+        if dim == 0:
+            # Row slicing
+            # Handle sys.maxsize (default slice end)
+            if end == sys.maxsize:
+                end = M
+
+            # Check if start/end align with 128-row boundaries
+            if start is not None and start % 128 != 0:
+                raise RuntimeError(
+                    f"Row slicing of NVFP4Tensor with swizzled scales requires "
+                    f"start index to be a multiple of 128, got {start}"
+                )
+            if end is not None and end != M and end % 128 != 0:
+                raise RuntimeError(
+                    f"Row slicing of NVFP4Tensor with swizzled scales requires "
+                    f"end index to be a multiple of 128 or equal to tensor size {M}, got {end}"
+                )
+
+            # Calculate which row blocks to keep
+            start_block = 0 if start is None else start // 128
+            end_block = n_row_blocks if end is None or end >= M else end // 128
+
+            # The swizzled tensor has shape (n_row_blocks * n_col_blocks * 32 * 16,)
+            blocks_per_row = n_col_blocks
+            start_idx = start_block * blocks_per_row * elements_per_block
+            end_idx = (
+                end_block * blocks_per_row * elements_per_block
+                if end_block < n_row_blocks
+                else None
             )
 
-        if end is not None:
-            assert end % x._block_size == 0, (
-                f"End index {end} must be a multiple of block_size {x._block_size}"
+            sliced_scale = aten.slice.Tensor(x._scale_e4m3, 0, start_idx, end_idx, 1)
+            sliced_data = aten.slice.Tensor(x._data, 0, start, end, step)
+
+        elif dim == 1:
+            # Column slicing
+            # Handle sys.maxsize (default slice end)
+            if end == sys.maxsize:
+                end = K
+
+            # Check if start/end align with 64-column boundaries (4 scale columns * 16 block_size)
+            if start is not None and start % 64 != 0:
+                raise RuntimeError(
+                    f"Column slicing of NVFP4Tensor with swizzled scales requires "
+                    f"start index to be a multiple of 64, got {start}"
+                )
+            if end is not None and end != K and end % 64 != 0:
+                raise RuntimeError(
+                    f"Column slicing of NVFP4Tensor with swizzled scales requires "
+                    f"end index to be a multiple of 64 or equal to tensor size {K}, got {end}"
+                )
+
+            # Also check FP4 packing alignment
+            if start is not None and start % 2 != 0:
+                raise RuntimeError(f"Start index {start} must be even for FP4 packing")
+            if end is not None and end != K and end % 2 != 0:
+                raise RuntimeError(f"End index {end} must be even for FP4 packing")
+
+            # Calculate which column blocks to keep
+            start_scale_col = 0 if start is None else start // 16
+            end_scale_col = scale_cols if end is None or end >= K else end // 16
+
+            start_col_block = start_scale_col // 4
+            end_col_block = end_scale_col // 4
+
+            # Verify the end aligns with block boundary
+            if end_scale_col % 4 != 0:
+                raise RuntimeError(
+                    f"Column slicing end index {end} does not align with scale block boundaries. "
+                    f"End must result in a multiple of 4 scale columns (64 data columns)."
+                )
+
+            if start_col_block == 0 and end_col_block == n_col_blocks:
+                # Full width - no slicing needed
+                sliced_scale = x._scale_e4m3
+            else:
+                # Extract specific column blocks from each row block
+                # Each row block in swizzled format contains n_col_blocks chunks of (32, 16)
+                elements_per_row_block = n_col_blocks * elements_per_block
+
+                # Build list of slices to extract
+                slices_to_extract = []
+                for row_block in range(n_row_blocks):
+                    row_start = row_block * elements_per_row_block
+                    col_start = row_start + start_col_block * elements_per_block
+                    col_end = row_start + end_col_block * elements_per_block
+                    slices_to_extract.append(x._scale_e4m3[col_start:col_end])
+
+                # Concatenate all the slices
+                sliced_scale = torch.cat(slices_to_extract, dim=0)
+
+            # Slice the data tensor
+            packed_start = None if start is None else start // 2
+            packed_end = None if end is None else end // 2
+            sliced_data = aten.slice.Tensor(
+                x._data, dim, packed_start, packed_end, step
             )
 
-        sliced_data = aten.slice.Tensor(x._data, dim, start, end, step)
+        else:
+            raise ValueError(
+                f"NVFP4Tensor only supports slicing along dimensions 0 and 1, got dim={dim}"
+            )
 
-        # Calculate which scale blocks to keep
-        start_block = 0 if start is None else start // x._block_size
-        end_block = None if end is None else end // x._block_size
-
-        # Slice the scale tensor accordingly
-        sliced_scale = aten.slice.Tensor(scale_shaped, 1, start_block, end_block, step)
     else:
-        raise ValueError(
-            f"NVFP4Tensor only supports slicing along dimensions 0 and 1, got dim={dim}"
-        )
+        scale_shaped = x._scale_e4m3.view(M, K // x._block_size)
 
-    return NVFP4Tensor(
+        if dim == 0:
+            sliced_scale = aten.slice.Tensor(scale_shaped, dim, start, end, step)
+            sliced_data = aten.slice.Tensor(x._data, dim, start, end, step)
+
+        elif dim == 1:
+            if start is not None:
+                assert start % x._block_size == 0, (
+                    f"Start index {start} must be a multiple of block_size {x._block_size}"
+                )
+                assert start % 2 == 0, (
+                    f"Start index {start} must be even for FP4 packing"
+                )
+
+            if end is not None and end != sys.maxsize:
+                assert end % x._block_size == 0, (
+                    f"End index {end} must be a multiple of block_size {x._block_size}"
+                )
+                assert end % 2 == 0, f"End index {end} must be even for FP4 packing"
+
+            packed_start = None if start is None else start // 2
+            packed_end = None if end is None else end // 2
+            sliced_data = aten.slice.Tensor(
+                x._data, dim, packed_start, packed_end, step
+            )
+
+            start_block = 0 if start is None else start // x._block_size
+            end_block = None if end is None else end // x._block_size
+            sliced_scale = aten.slice.Tensor(
+                scale_shaped, 1, start_block, end_block, step
+            )
+
+        sliced_scale = sliced_scale.flatten()
+
+    # Create result tensor
+    result = NVFP4Tensor(
         sliced_scale,
-        x._per_tensor_scale,  # Unchanged per-tensor scale
+        x._per_tensor_scale,
         sliced_data,
         x._block_size,
         x._orig_dtype,
         x.mm_config,
+        x._is_swizzled_scales,
     )
+
+    return return_and_correct_aliasing(func, args, kwargs, result)
 
 
 @implements([aten.t.default])
@@ -387,6 +537,7 @@ def nvfp4_t(func, types, args, kwargs):
         old._block_size,
         old._orig_dtype,
         old.mm_config,
+        old._is_swizzled_scales,
     )
     return new
 
@@ -404,6 +555,7 @@ def nvfp4_view_op(func, types, args, kwargs):
         args[0]._block_size,
         args[0]._orig_dtype,
         args[0].mm_config,
+        args[0]._is_swizzled_scales,
     )
 
 
@@ -423,10 +575,17 @@ def _addmm_nvfp4_dispatch(
     N = b.shape[1]
 
     # Swizzle Dizzle
-    a_scale = a._scale_e4m3.view(M, K // a._block_size)
-    b_scale = b._scale_e4m3.view(N, K // b._block_size)
-    a_scale_blocked = to_blocked(a_scale)
-    b_scale_blocked = to_blocked(b_scale)
+    if a._is_swizzled_scales:
+        a_scale_blocked = a._scale_e4m3  # Already swizzled
+    else:
+        a_scale = a._scale_e4m3.view(M, K // a._block_size)
+        a_scale_blocked = to_blocked(a_scale)
+
+    if b._is_swizzled_scales:
+        b_scale_blocked = b._scale_e4m3  # Already swizzled
+    else:
+        b_scale = b._scale_e4m3.view(N, K // b._block_size)
+        b_scale_blocked = to_blocked(b_scale)
 
     # Merge double quant scales into 1 scale for Scale_In^D
     if a._per_tensor_scale is not None:
@@ -571,8 +730,8 @@ def nvfp4_quantize(
     assert data_hp.dtype in (torch.bfloat16, torch.float), (
         f"{data_hp.dtype} not supported"
     )
-    assert data_hp.numel() % block_size == 0, "unsupported"
-    assert data_hp.is_contiguous(), "unsupported"
+    assert data_hp.size(-1) % block_size == 0, "K dim must be divisible by block_size"
+    assert data_hp.is_contiguous(), "Only support contiguous data for now"
     assert block_size == 16, "NVFP4 requires block_size=16"
 
     orig_shape = data_hp.shape

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -698,6 +698,10 @@ def check_xpu_version(device, version="2.8.0"):
     return device == "xpu" and compare_versions(torch.__version__, version) >= 0
 
 
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
 TORCH_VERSION_AFTER_2_5 = _torch_version_at_least("2.5.0.dev")
 TORCH_VERSION_AFTER_2_4 = _torch_version_at_least("2.4.0.dev")
 TORCH_VERSION_AFTER_2_3 = _torch_version_at_least("2.3.0.dev")


### PR DESCRIPTION
Stacked PRs:
 * #2439
 * __->__#2438


--- --- ---

Store NVFP4 block scales in swizzled layout on tensor

For llama3 70b no TP sizes w/ 1024 tokens: 15% E2E speedup

## In eager Before: https://fburl.com/7w3j6b1q
nvfp4 
<img width="693" alt="Screenshot 2025-06-24 at 4 02 42 PM" src="https://github.com/user-attachments/assets/2c4c5b94-3162-4733-8c97-6f40f47b14aa" />
Runtime: 2436.98 μs per iteration

## In eager After: https://fburl.com/s7ggvm94
nvfp4 Runtime: 2356.77 μs per iteration
<img width="349" alt="Screenshot 2025-06-24 at 4 03 27 PM" src="https://github.com/user-attachments/assets/f08d3c6c-efe2-4381-9573-a53d33b6f5e4" />


# In compile


## Before:  https://fburl.com/1gvfjjlu
nvfp4 Runtime: 576.14 μs per iteration
<img width="568" alt="Screenshot 2025-06-24 at 4 11 36 PM" src="https://github.com/user-attachments/assets/6c4066cb-a1f4-45e6-867c-70bc91d93f80" />


## After: https://fburl.com/usp1xelj
nvfp4 Runtime: 486.69 μs per iteration
<img width="668" alt="Screenshot 2025-06-24 at 4 11 55 PM" src="https://github.com/user-attachments/assets/02deebee-8087-42b5-a926-8c88273ad571" />


```
Throughput: 47.12 requests/s, 19998.00 total tokens/s, 9635.87 output tokens/s
Total num prompt tokens:  225190
Total num output tokens:  209407
```