### PR TITLE
Add kernel

### DIFF
--- a/test/prototype/mx_formats/test_mx_linear.py
+++ b/test/prototype/mx_formats/test_mx_linear.py
@@ -37,6 +37,7 @@ from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_8,
     is_sm_at_least_89,
+    is_sm_at_least_90,
     is_sm_at_least_100,
 )
 
@@ -459,10 +460,29 @@ def test_inference_subclass(elem_dtype, bias: bool, compile: bool):
     "mm_config", [NVFP4MMConfig.DYNAMIC, NVFP4MMConfig.WEIGHT_ONLY]
 )
 @pytest.mark.parametrize("inpt_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("use_triton_kernel", [True, False])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        (128, 64, 256),
+        (256, 128, 512),
+        (145, 64, 256),
+        (128, 96, 256),
+        (128, 160, 256),
+        (64, 64, 256),
+        (200, 192, 256),
+    ],
+    ids=lambda s: f"{s[0]}x{s[1]}x{s[2]}",
+)
 @torch.no_grad()
 @skip_if_rocm("ROCm float4 gemm require gfx950")
 def test_inference_subclass_nvfp4(
-    bias: bool, compile: bool, mm_config: NVFP4MMConfig, inpt_dtype: torch.dtype
+    bias: bool,
+    compile: bool,
+    mm_config: NVFP4MMConfig,
+    inpt_dtype: torch.dtype,
+    use_triton_kernel: bool,
+    shapes: tuple,
 ):
     """
     Test NVFP4 recipe with scale_dtype=float8_e4m3fn and block_size=16
@@ -477,16 +497,20 @@ def test_inference_subclass_nvfp4(
 
     if mm_config == NVFP4MMConfig.WEIGHT_ONLY and compile:
         pytest.skip("TODO: NVFP4MMConfig.WEIGHT_ONLY currently errors w/ compile")
-    m = nn.Linear(64, 256, bias=bias, dtype=inpt_dtype, device="cuda")
+    batch_size, in_features, out_features = shapes
+
+    m = nn.Linear(in_features, out_features, bias=bias, dtype=inpt_dtype, device="cuda")
     m_mx = copy.deepcopy(m)
 
-    config = NVFP4InferenceConfig(mm_config=mm_config)
+    config = NVFP4InferenceConfig(
+        mm_config=mm_config, use_triton_kernel=use_triton_kernel
+    )
     quantize_(m_mx, config=config)
 
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True, backend="aot_eager")
 
-    x = torch.randn(128, 64, device="cuda", dtype=inpt_dtype)
+    x = torch.randn(batch_size, in_features, device="cuda", dtype=inpt_dtype)
     y_ref = m(x)
     y_mx = m_mx(x)
     sqnr = compute_error(y_ref, y_mx)
@@ -513,14 +537,33 @@ def test_inference_subclass_nvfp4(
 @pytest.mark.parametrize("compile", [False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("inpt_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("use_triton_kernel", [True, False])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        (128, 64, 256),
+        (256, 128, 512),
+        (157, 64, 256),
+        (128, 96, 256),
+        (128, 160, 256),
+        (64, 64, 256),
+        (200, 192, 256),
+    ],
+    ids=lambda s: f"{s[0]}x{s[1]}x{s[2]}",
+)
 @torch.no_grad()
 @skip_if_rocm("ROCm float4 gemm require gfx950")
+@pytest.mark.skipif(
+    not is_sm_at_least_90(), reason="CUDA capability >= 9.0 required for fp8e4nv"
+)
 def test_nvfp4_matmul_with_amax(
     use_gelu: bool,
     mm_config: NVFP4MMConfig,
     compile: bool,
     bias: bool,
     inpt_dtype: torch.dtype,
+    use_triton_kernel: bool,
+    shapes: tuple,
 ):
     from torchao.prototype.mx_formats.nvfp4_tensor import (
         NVFP4Tensor,
@@ -537,7 +580,7 @@ def test_nvfp4_matmul_with_amax(
     if mm_config == NVFP4MMConfig.WEIGHT_ONLY and compile:
         pytest.skip("TODO: NVFP4MMConfig.WEIGHT_ONLY currently errors w/ compile")
 
-    m, k, n = 64, 256, 128
+    m, k, n = shapes
 
     # Create activation tensor
     if use_gelu:
@@ -559,12 +602,14 @@ def test_nvfp4_matmul_with_amax(
         per_tensor_scale=a_scale,
         mm_config=mm_config,
         is_swizzled_scales=True,
+        use_triton_kernel=use_triton_kernel,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
         mm_config=mm_config,
         is_swizzled_scales=True,
+        use_triton_kernel=use_triton_kernel,
     )
 
     func = torch.compile(F.linear, fullgraph=True) if compile else F.linear

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import torch
@@ -1487,6 +1487,218 @@ if TORCH_VERSION_AT_LEAST_2_7 and has_triton():
 
         return out
 
+    @triton.jit
+    def convert_fp32_to_fp4_packed(x_pairs):
+        """Convert FP32 pairs to packed FP4 format.
+
+        This function takes tensor where consecutive values along the last dimension
+        are packed together into single bytes.
+
+        Args:
+            x_pairs: [Tensor, Tensor] both w/ shapes [..., 1] where zipped last dimension contains
+                    interleaved pairs of FP32 values to be packed together.
+
+        Returns:
+            Packed tensor with shape [...] (last dimension removed) where each
+            element is an int8 containing 2 FP4 values:
+            - First value of pair → high nibble (bits 4-7)
+            - Second value of pair → low nibble (bits 0-3)
+
+        Example:
+            Input:  [128, 32, 2] containing FP32 pairs
+            Output: [128, 32] containing packed FP4 bytes
+
+        """
+
+        x_fp4x2 = tl.inline_asm_elementwise(
+            asm="""
+            {
+            .reg .b8 byte0, byte1, byte2, byte3;
+            cvt.rn.satfinite.e2m1x2.f32 byte0, $1, $5;
+            cvt.rn.satfinite.e2m1x2.f32 byte1, $2, $6;
+            cvt.rn.satfinite.e2m1x2.f32 byte2, $3, $7;
+            cvt.rn.satfinite.e2m1x2.f32 byte3, $4, $8;
+            mov.b32 $0, {byte0, byte1, byte2, byte3};
+            }
+            """,
+            constraints=("=r,r,r,r,r,r,r,r,r"),
+            args=x_pairs,
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=4,
+        )
+
+        return x_fp4x2
+
+    # Sauce: https://github.com/gau-nernst/quantized-training
+    @triton.jit
+    def quantize_nvfp4_triton_kernel(
+        x_ptr,
+        tensor_scale_ptr,
+        q_ptr,
+        s_ptr,
+        stride_xm,
+        stride_xn,
+        M,
+        N,
+        USE_TENSOR_SCALE: tl.constexpr,
+        MASK_SCALES: tl.constexpr,
+    ):
+        F4_E2M1_MAX = 6.0
+        F8E4M3_MAX = 448.0
+        E4M3_EPS = 1.5258789e-05
+
+        pid_m = tl.program_id(1)
+        pid_n = tl.program_id(0)
+
+        offs_m = pid_m * 128 + tl.arange(0, 128)[:, None]
+        offs_n = pid_n * 64 + tl.arange(0, 64)[None, :]
+        if MASK_SCALES:
+            mask = (offs_m < M) & (offs_n < N)
+            other = 0.0
+        else:
+            mask = None
+            other = None
+        x = tl.load(
+            x_ptr + offs_m * stride_xm + offs_n * stride_xn, mask=mask, other=other
+        )  # [128, 64]
+        x_blocks = x.to(tl.float32).reshape(128, 4, 16)  # [128, 4, 16]
+
+        # Compute block-wise scales
+        block_amax = tl.max(x_blocks.abs(), axis=2)  # [128, 4]
+
+        if USE_TENSOR_SCALE:
+            # Two-level scaling: quantize block scales with per-tensor scale
+            tensor_scale = tl.load(tensor_scale_ptr)
+
+            # First compute block scales
+            block_scale_f32 = (block_amax / F4_E2M1_MAX).to(tl.float32)
+
+            # Quantize the block scales with per-tensor scale
+            scaled_block_scales = block_scale_f32 / tensor_scale
+            scaled_block_scales = tl.clamp(scaled_block_scales, E4M3_EPS, F8E4M3_MAX)
+            scales = scaled_block_scales.to(tl.float8e4nv)
+
+            # Apply combined scale to data: per_tensor_scale * quantized_block_scale
+            total_scale = tensor_scale * scales.to(tl.float32)[:, :, None]
+            x_blocks = tl.div_rn(x_blocks, total_scale)
+        else:
+            # Single-level scaling: use block scales directly
+            scales_f32 = block_amax / F4_E2M1_MAX
+            scales_f32 = tl.clamp(scales_f32, E4M3_EPS, F8E4M3_MAX)
+            scales = scales_f32.to(tl.float8e4nv)
+
+            # Apply block scale to data
+            total_scale = scales.to(tl.float32)[:, :, None]
+            x_blocks = tl.div_rn(x_blocks, total_scale)
+
+        # NVIDIA layout for scales
+        if MASK_SCALES:
+            # Create offsets for the scale dimensions (4 blocks per row)
+            scale_offs_n = pid_n * 4 + tl.arange(0, 4)[None, :]
+
+            # Mask out scales to 0 if we are not aligned to 128 x 64
+            scales = tl.where(
+                (offs_m < M) & (scale_offs_n < N // 16),
+                scales,
+                0.0,
+            )
+        packed_scales = scales.reshape(4, 32, 4).permute(1, 0, 2).reshape(32, 16)
+        offs_m = tl.arange(0, 32)[:, None]
+        offs_n = tl.arange(0, 16)[None, :]
+        tl.store(
+            s_ptr
+            + (pid_m * tl.num_programs(0) + pid_n) * (32 * 16)
+            + offs_m * 16
+            + offs_n,
+            packed_scales,
+        )
+
+        # Convert to FP4
+        x_fp4x2 = convert_fp32_to_fp4_packed(x_blocks.reshape(128, 32, 2).split())
+        offs_m = pid_m * 128 + tl.arange(0, 128)[:, None]
+        offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
+        if MASK_SCALES:
+            mask = (offs_m < M) & (offs_n < N // 2)
+        else:
+            mask = None
+        tl.store(q_ptr + offs_m * (N // 2) + offs_n, x_fp4x2, mask=mask)
+
+    @torch.library.custom_op("ao::triton_quantize_nvfp4", mutates_args=())
+    def triton_quantize_nvfp4(
+        x: torch.Tensor, per_tensor_scale: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize a tensor to NVFP4 format.
+
+        Args:
+            x (torch.Tensor): Input tensor to be quantized.
+            tensor_scale (Optional[torch.Tensor]): Per-tensor scale for two-level quantization.
+                If None, uses single-level block-wise quantization only.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Quantized tensor and scales tensor in swizzled layout.
+
+        Note:
+            Since VLLM does not use dyanmo guards we need to make this a custom op
+            to avoid the triton kernel being invoked w/ the wrong use of `MASK_SCALES`
+        """
+        M, N = x.shape
+        # assert M % 128 == 0 and N % 64 == 0
+        assert N % 16 == 0, "N must be divisible by 16 for NVFP4 quantization"
+
+        # Calculate blocks needed
+        num_scales = N // 16
+        n_row_blocks = triton.cdiv(M, 128)
+        n_col_blocks = triton.cdiv(num_scales, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+
+        # mask out scales to 0 if we are not aligned to 128 x 64
+        MASK_SCALES = M % 128 != 0 or N % 64 != 0
+
+        xq = x.new_empty(M, N // 2, dtype=torch.uint8)
+        scales = x.new_empty(padded_rows, padded_cols, dtype=torch.float8_e4m3fn)
+
+        grid = (triton.cdiv(N, 64), triton.cdiv(M, 128))
+
+        if per_tensor_scale is None:
+            # Don't allocate tensor, we just steal this since it won't be used in kernel
+            tensor_scale_ptr = x
+            use_tensor_scale = False
+        else:
+            tensor_scale_ptr = per_tensor_scale
+            use_tensor_scale = True
+
+        quantize_nvfp4_triton_kernel[grid](
+            x,
+            tensor_scale_ptr,
+            xq,
+            scales,
+            x.stride(0),
+            x.stride(1),
+            M,
+            N,
+            USE_TENSOR_SCALE=use_tensor_scale,
+            MASK_SCALES=MASK_SCALES,
+        )
+
+        return scales, xq.view(torch.uint8)
+
+    @triton_quantize_nvfp4.register_fake
+    def _(x, per_tensor_scale=None):
+        M, N = x.shape
+        num_scales = N // 16
+        n_row_blocks = triton.cdiv(M, 128)
+        n_col_blocks = triton.cdiv(num_scales, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+
+        scales = torch.empty(
+            padded_rows, padded_cols, device=x.device, dtype=torch.float8_e4m3fn
+        )
+        xq = torch.empty(M, N // 2, device=x.device, dtype=torch.uint8)
+        return scales, xq
+
 else:
 
     def triton_to_mxfp8_dim1(
@@ -1500,4 +1712,9 @@ else:
         raise AssertionError("needs torch version 2.8+ and triton")
 
     def triton_mx_block_rearrange(scale_tensor: torch.Tensor) -> torch.Tensor:
+        raise AssertionError("needs torch version 2.8+ and triton")
+
+    def triton_quantize_nvfp4(
+        x: torch.Tensor, tensor_scale: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise AssertionError("needs torch version 2.8+ and triton")

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -685,16 +685,47 @@ class MXTensor(torch.Tensor):
 
     @classmethod
     def _same_metadata(cls, self: "MXTensor", src: "MXTensor") -> bool:
-        return (
-            isinstance(self, MXTensor)
-            and isinstance(src, MXTensor)
-            and self._elem_dtype == src._elem_dtype
-            and self._block_size == src._block_size
-            and self._orig_dtype == src._orig_dtype
-            and self._use_fp4_custom_triton_dequant_kernel
-            == src._use_fp4_custom_triton_dequant_kernel
-            and self._gemm_kernel_choice == src._gemm_kernel_choice
-            and self._pack_fp6 == src._pack_fp6
-            and self._scale_e8m0.shape == src._scale_e8m0.shape
-            and self._data.shape == src._data.shape
-        )
+        checks = [
+            (isinstance(self, MXTensor), "self is not MXTensor"),
+            (isinstance(src, MXTensor), "src is not MXTensor"),
+            (
+                self._elem_dtype == src._elem_dtype,
+                f"elem_dtype: {self._elem_dtype} != {src._elem_dtype}",
+            ),
+            (
+                self._block_size == src._block_size,
+                f"block_size: {self._block_size} != {src._block_size}",
+            ),
+            (
+                self._orig_dtype == src._orig_dtype,
+                f"orig_dtype: {self._orig_dtype} != {src._orig_dtype}",
+            ),
+            (
+                self._use_fp4_custom_triton_dequant_kernel
+                == src._use_fp4_custom_triton_dequant_kernel,
+                "use_fp4_custom_triton_dequant_kernel mismatch",
+            ),
+            (
+                self._gemm_kernel_choice == src._gemm_kernel_choice,
+                f"gemm_kernel_choice: {self._gemm_kernel_choice} != {src._gemm_kernel_choice}",
+            ),
+            (
+                self._pack_fp6 == src._pack_fp6,
+                f"pack_fp6: {self._pack_fp6} != {src._pack_fp6}",
+            ),
+            (
+                self._scale_e8m0.shape == src._scale_e8m0.shape,
+                f"scale_e8m0.shape: {self._scale_e8m0.shape} != {src._scale_e8m0.shape}",
+            ),
+            (
+                self._data.shape == src._data.shape,
+                f"data.shape: {self._data.shape} != {src._data.shape}",
+            ),
+        ]
+
+        for condition, error_msg in checks:
+            if not condition:
+                raise ValueError(f"Metadata mismatch: {error_msg}")
+                return False
+
+        return True


### PR DESCRIPTION
Stacked PRs:
 * __->__#2439


--- --- ---

Add Kernel 

w/ this we get 3.7 real world speed up for llama 70b MLP 1024 tokes -> not user per-tensor scaling path

With kernel
https://fburl.com/0g0knhic

320us ignoring graph copy_

<img width="1005" alt="Screenshot 2025-06-25 at 12 12 28 AM" src="https://github.com/user-attachments/assets/50b1e8e4-040e-4940-8ab8-e66a8bfacd0d" />

Without kernel:
420us ignoring graph copy_
https://fburl.com/t46eeb9d
<img width="971" alt="Screenshot 2025-06-25 at 12 13 30 AM" src="https://github.com/user-attachments/assets/94919adb-f98a-46eb-8aaf-328f45073fb3" />

### Perf
#### VLLM
<img width="760" alt="Screenshot 2025-07-02 at 1 06 04 PM" src="https://github.com/user-attachments/assets/e1c17c6d-851e-41da-8760-0799121aba91" />


#### Diffusers:
|           ckpt_id            |   batch_size |  fuse  |  compile  |  compile_vae  |  quantization  |  sparsify  |   model_memory |   inference_memory |   time |
|:----------------------------:|-------------:|:------:|:---------:|:-------------:|:--------------:|:----------:|---------------:|-------------------:|-------:|
| black-forest-labs/FLUX.1-dev |            1 | False  |   True    |     True      |     nvfp4      |   False    |         15.567 |             32.786 |  1.461 |

W/ no kernel:
|           ckpt_id            |   batch_size |  fuse  |  compile  |  compile_vae  |  quantization  |  sparsify  |   model_memory |   inference_memory |   time |
|:----------------------------:|-------------:|:------:|:---------:|:-------------:|:--------------:|:----------:|---------------:|-------------------:|-------:|
| black-forest-labs/FLUX.1-dev |            1 | False  |   True    |     True      |     nvfp4      |   False    |         15.569 |             33.102 |  1.794 |


Versus a baseline of for bf16
|           ckpt_id            |   batch_size |  fuse  |  compile  |  compile_vae  |  quantization  |  sparsify  |   model_memory |   inference_memory |   time |
|:----------------------------:|-------------:|:------:|:---------:|:-------------:|:--------------:|:----------:|---------------:|-------------------:|-------:|
| black-forest-labs/FLUX.1-dev |            1 | False  |   True    |     True      |      None      |   False    |         31.437 |             33.451 |  2.392 |

### Side note
Idk if the model memory and ifnerence memory makes sense to me... need to get some memory traces




### Numeric debugingg

Claude Summing up this journey I went on:
 ⏺ NVFP4 Quantization Precision Bug Hunt Summary

  The Problem

  - NVFP4 quantization test failing with 1 ULP difference
  - Triton kernel: 2.500000238418579 (hex: 0x40200001)
  - Expected: 2.5 exactly (hex: 0x40200000)

  Investigation Phases

  Phase 1: Scale Calculation Mismatch
  - Initially found different block amax values (2.859 vs 3.390)
  - Root cause: PyTorch reference computed individual block scales vs full tensor

  Phase 2: Isolated the Real Issue
  - Fixed PyTorch reference to match Triton's full tensor processing
  - Result: Block amax values identical, scales identical
  - Real issue: Division operation producing different results

  Phase 3: Division Precision
  - Mathematical fact: 1.171875 / 0.46875 = 2.5 is exactly representable in IEEE 754
  - PyTorch CPU: exact result
  - Triton GPU: 1 ULP off

  The Solution

  - Root cause: Triton's / operator vs tl.div_rn
  - Fix: Replace x_blocks / final_scales_expanded with tl.div_rn(x_blocks, final_scales_expanded)
  - Result: Mathematically correct division