### PR TITLE
[NF4] Support nf4 tensor shard and gather

### DIFF
--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -14,28 +14,28 @@ from typing import Tuple, Union
 import pytest
 import torch
 import torch.nn.functional as F
+
+import torchao
+from packaging import version
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    CheckpointWrapper,
     apply_activation_checkpointing,
+    CheckpointWrapper,
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TestCase,
 )
-
-import torchao
-from packaging import version
 from torchao.dtypes._nf4tensor_api import nf4_weight_only
 from torchao.dtypes.nf4tensor import (
     _INNER_TENSOR_NAMES_FOR_SHARDING,
-    NF4Tensor,
     linear_nf4,
+    NF4Tensor,
     to_nf4,
 )
 from torchao.testing.utils import skip_if_rocm
@@ -739,6 +739,46 @@ class TestQLoRA(FSDPTest):
                     )
             base_optim.step()
             self.assertEqual(fsdp_loss, base_loss)
+
+
+class TestComm(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @pytest.mark.skipif(
+        version.parse(torch.__version__).base_version < "2.4.0",
+        reason="torch >= 2.4 required",
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_comm(self):
+        self.run_subtests(
+            {"input_size": [512, 2048]},
+            self._test_comm,
+        )
+
+    def _test_comm(self, input_size: int):
+        from torch.distributed._composable.fsdp import fully_shard
+        from torch.distributed._tensor import distribute_tensor
+
+        model = nn.Linear(input_size, input_size, device="cuda")
+        origin_tensor = model.weight
+        origin_nf4_tensor = to_nf4(origin_tensor)
+        model = fully_shard(model)
+        sharded_tensor = model.weight
+        sharded_origin_nf4_tensor = distribute_tensor(
+            origin_nf4_tensor,
+            sharded_tensor.device_mesh,
+            sharded_tensor.placements,
+        )
+
+        sharded_nf4_detach = sharded_origin_nf4_tensor.detach()
+        resumed_full_tensor = sharded_nf4_detach.full_tensor()
+
+        self.assertEqual(
+            origin_nf4_tensor.get_original_weight(),
+            resumed_full_tensor.get_original_weight(),
+        )
 
 
 instantiate_parametrized_tests(TestNF4Linear)

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -435,7 +435,7 @@ class TestFSDPOps(TestCase):
             inner_tensor = getattr(viewed_tensor, attr)
             self.assertEqual(inner_tensor.size(0), inner_tensor.numel())
 
-    @parametrize("input_size", [(512 * 512,), (512, 512)])
+    @parametrize("input_size", [(512 * 512,)])
     def test_tensor_view_invalid(self, input_size: Union[Tuple[int], int]):
         nf4_tensor = to_nf4(torch.randn(input_size))
         if len(input_size) == 1:

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -14,28 +14,28 @@ from typing import Tuple, Union
 import pytest
 import torch
 import torch.nn.functional as F
-
-import torchao
-from packaging import version
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    apply_activation_checkpointing,
     CheckpointWrapper,
+    apply_activation_checkpointing,
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
+    TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TestCase,
 )
+
+import torchao
+from packaging import version
 from torchao.dtypes._nf4tensor_api import nf4_weight_only
 from torchao.dtypes.nf4tensor import (
     _INNER_TENSOR_NAMES_FOR_SHARDING,
-    linear_nf4,
     NF4Tensor,
+    linear_nf4,
     to_nf4,
 )
 from torchao.testing.utils import skip_if_rocm

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -7,7 +7,7 @@ import functools
 import math
 import sys
 from dataclasses import dataclass, replace
-from enum import auto, Enum
+from enum import Enum, auto
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
@@ -242,9 +242,9 @@ def nf4_split(aten_op, args, kwargs=None):
     attr_to_chunks = {}
     for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
         inner_tensor = getattr(nf4tensor, attr)
-        assert (
-            inner_tensor.numel() % num_chunks == 0
-        ), f"{attr}.numel() not divisible by {num_chunks}"
+        assert inner_tensor.numel() % num_chunks == 0, (
+            f"{attr}.numel() not divisible by {num_chunks}"
+        )
         chunks = aten_op(inner_tensor, inner_tensor.numel() // num_chunks, **kwargs)
         attr_to_chunks[attr] = chunks
 
@@ -285,9 +285,9 @@ def nf4_new_zeros(aten_op, args, kwargs=None):
     updated_attrs = {}
     for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
         inner_tensor = getattr(nf4tensor, attr)
-        assert (
-            inner_tensor.size(0) % ratio == 0
-        ), f"{attr}.numel() must be divisible by {ratio}"
+        assert inner_tensor.size(0) % ratio == 0, (
+            f"{attr}.numel() must be divisible by {ratio}"
+        )
         inner_tensor = aten_op(inner_tensor, [inner_tensor.size(0) // ratio], **kwargs)
         updated_attrs[attr] = inner_tensor
     updated_attrs["size"] = new_size
@@ -552,9 +552,9 @@ def get_block_absmax(input_tensor: torch.Tensor, block_size: int) -> torch.Tenso
         torch.Tensor: Tensor of scalers for each block
     """
     assert input_tensor.dim() == 1, "Input tensor must be flattened"
-    assert (
-        input_tensor.numel() % block_size
-    ) == 0, f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {block_size}"
+    assert (input_tensor.numel() % block_size) == 0, (
+        f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {block_size}"
+    )
 
     n_blocks = input_tensor.numel() // block_size
     blocks = input_tensor.view(n_blocks, block_size)
@@ -637,12 +637,12 @@ class NF4Tensor(torch.Tensor):
         block_size: int,
         scaler_block_size: int,
     ):
-        assert (
-            input_tensor.dim() <= 2
-        ), f"expect input tensor dim <= 2 but got dim = {input_tensor.dim()}"
-        assert (
-            input_tensor.numel() % block_size == 0
-        ), f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {block_size}"
+        assert input_tensor.dim() <= 2, (
+            f"expect input tensor dim <= 2 but got dim = {input_tensor.dim()}"
+        )
+        assert input_tensor.numel() % block_size == 0, (
+            f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {block_size}"
+        )
         assert input_tensor.is_contiguous, "Input tensor must be contiguous!"
         # I think I want do this
         # assert not input_tensor.requires_grad, "Input tensor must not require grad"
@@ -723,9 +723,9 @@ class NF4Tensor(torch.Tensor):
                 size: (n_scaler_blocks)
         """
         assert input_tensor.dim() == 1, "Input tensor must be flattened"
-        assert (
-            input_tensor.numel() % scaler_block_size
-        ) == 0, f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {scaler_block_size}"
+        assert (input_tensor.numel() % scaler_block_size) == 0, (
+            f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {scaler_block_size}"
+        )
 
         # First round of quantization
         # Produces: A tensor of size (n_blocks) of input_tensor.dtype
@@ -733,9 +733,9 @@ class NF4Tensor(torch.Tensor):
         scalers_1_mean = scalers_1.mean()
         scalers_1 = scalers_1 - scalers_1_mean
         # Second round of quantization
-        assert (
-            scalers_1.numel() % scaler_block_size == 0
-        ), f"Number of scalers must be divisible by scaler block size, got {scalers_1.numel()} scaler_block_size {scaler_block_size} "
+        assert scalers_1.numel() % scaler_block_size == 0, (
+            f"Number of scalers must be divisible by scaler block size, got {scalers_1.numel()} scaler_block_size {scaler_block_size} "
+        )
         n_scaler_blocks = scalers_1.numel() // scaler_block_size
         scaler_blocks = scalers_1.view(n_scaler_blocks, scaler_block_size)
 
@@ -777,9 +777,9 @@ class NF4Tensor(torch.Tensor):
 
         """
         assert input_tensor.dim() == 1, "Input tensor must be flattened"
-        assert (
-            input_tensor.numel() % scaler_block_size
-        ) == 0, f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {scaler_block_size}"
+        assert (input_tensor.numel() % scaler_block_size) == 0, (
+            f"Input tensor must be divisible by block size, got {input_tensor.numel()} and {scaler_block_size}"
+        )
         n_scaler_blocks = input_tensor.numel() // scaler_block_size
         input_tensor = input_tensor.view(n_scaler_blocks, scaler_block_size)
         dequantized = (input_tensor / quantization_factor.unsqueeze(-1)).flatten().to(
@@ -795,9 +795,9 @@ class NF4Tensor(torch.Tensor):
         flattened_tensor = input_tensor.flatten()
         #  Since we are using uint8 we will encode 2 entries per byte
         numel = input_tensor.numel()
-        assert (
-            numel % 2 == 0
-        ), "Number of elements must be even just to not have to think about the end"
+        assert numel % 2 == 0, (
+            "Number of elements must be even just to not have to think about the end"
+        )
         # Reshape the flattened tensor into blocks of size self.block_size
         blocks = flattened_tensor.view(n_blocks, block_size)
 


### PR DESCRIPTION
Add  nf4_all_gather_into_tensor and scatter_nf4tensor to enable dispatch of `scatter` and `all_gather_into_tensor`
Add unit test to show that nf4 tensor keeps the same after distribute and gather.