### PR TITLE
[mps] Add offsets to enable aoti

### DIFF
--- a/torchao/experimental/kernels/mps/src/lowbit.h
+++ b/torchao/experimental/kernels/mps/src/lowbit.h
@@ -74,10 +74,15 @@ using DispatchFn =
 
 inline void linear_lowbit_quant_weights_mps_impl(
     id<MTLBuffer> a_buf,
+    size_t a_offset,
     id<MTLBuffer> b_buf,
+    size_t b_offset,
     id<MTLBuffer> s_buf,
+    size_t s_offset,
     id<MTLBuffer> z_buf,
+    size_t z_offset,
     id<MTLBuffer> out_buf,
+    size_t out_offset,
     int32_t M,
     int32_t K,
     int32_t N,
@@ -97,11 +102,11 @@ inline void linear_lowbit_quant_weights_mps_impl(
           metal_lowbit_quantized_lib.getPipelineStateForFunc(shader_func);
       const auto maxThreadsPerGroup = [cpl maxTotalThreadsPerThreadgroup];
       [computeEncoder setComputePipelineState:cpl];
-      [computeEncoder setBuffer:a_buf offset:0 atIndex:0];
-      [computeEncoder setBuffer:b_buf offset:0 atIndex:1];
-      [computeEncoder setBuffer:s_buf offset:0 atIndex:2];
-      [computeEncoder setBuffer:z_buf offset:0 atIndex:3];
-      [computeEncoder setBuffer:out_buf offset:0 atIndex:4];
+      [computeEncoder setBuffer:a_buf offset:a_offset atIndex:0];
+      [computeEncoder setBuffer:b_buf offset:b_offset atIndex:1];
+      [computeEncoder setBuffer:s_buf offset:s_offset atIndex:2];
+      [computeEncoder setBuffer:z_buf offset:z_offset atIndex:3];
+      [computeEncoder setBuffer:out_buf offset:out_offset atIndex:4];
       [computeEncoder setBytes:sizes.data()
                         length:sizeof(uint32_t) * sizes.size()
                        atIndex:5];
@@ -134,11 +139,16 @@ std::tuple<const std::string, DispatchFn> get_shader_func_and_dispatch(
 template <int nbit>
 void linear_lowbit_quant_weights_mps(
     id<MTLBuffer> a_buf,
+    size_t a_offset,
     id<MTLBuffer> b_buf,
+    size_t b_offset,
     int64_t qGroupSize,
     id<MTLBuffer> s_buf,
+    size_t s_offset,
     id<MTLBuffer> z_buf,
+    size_t z_offset,
     id<MTLBuffer> out_buf,
+    size_t out_offset,
     int32_t M,
     int32_t K,
     int32_t N,
@@ -155,10 +165,15 @@ void linear_lowbit_quant_weights_mps(
 
   return linear_lowbit_quant_weights_mps_impl(
       a_buf,
+      a_offset,
       b_buf,
+      b_offset,
       s_buf,
+      s_offset,
       z_buf,
+      z_offset,
       out_buf,
+      out_offset,
       M,
       K,
       N,

--- a/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_aten.mm
+++ b/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_aten.mm
@@ -98,11 +98,16 @@ Tensor linear_mps_kernel_out(
 
   LowBitQuantWeights<nbit>::linear(
       getMTLBufferStorage(A),
+      A.storage_offset() * A.element_size(),
       getMTLBufferStorage(B),
+      B.storage_offset() * B.element_size(),
       group_size,
       getMTLBufferStorage(S),
+      S.storage_offset() * S.element_size(),
       getMTLBufferStorage(Z),
+      Z.storage_offset() * Z.element_size(),
       getMTLBufferStorage(C),
+      C.storage_offset() * C.element_size(),
       M,
       K,
       N,


### PR DESCRIPTION
In AOTI we allocate all weights in one blob and index into the blob based on the offsets. This caused an accuracy error when running the lowbit kernels since it assumes all the offsets are 0.