### PR TITLE
[moe training] add benchmarking script for grouped mm

### DIFF
--- a/benchmarks/float8/bench_grouped_mm.py
+++ b/benchmarks/float8/bench_grouped_mm.py
@@ -1,0 +1,222 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Optional
+
+import fire
+import pandas as pd
+import torch
+import torch.utils.benchmark as benchmark
+from utils import (
+    get_gpu_kernel_gemm_time_s,
+)
+
+from torchao.testing.training.roofline_utils import get_specs
+
+
+def benchmark_fn_in_sec(f, *args, **kwargs):
+    # Manual warmup
+    for _ in range(4):
+        f(*args, **kwargs)
+    t0 = benchmark.Timer(
+        stmt="f(*args, **kwargs)", globals={"args": args, "kwargs": kwargs, "f": f}
+    )
+    measurement = t0.blocked_autorange()
+    return measurement.mean
+
+
+def do_benchmarks(
+    tops,
+    peak_tops,
+    use_gpu_kernel_time,
+    f,
+    *args,
+    **kwargs,
+):
+    if use_gpu_kernel_time:
+        # just the gemm GPU kernel
+        time_sec = get_gpu_kernel_gemm_time_s(f, *args, **kwargs)
+    else:
+        # e2e time including kernel launch overhead
+        time_sec = benchmark_fn_in_sec(f, *args, **kwargs)
+    tops_sec = float(tops) / time_sec
+    pct_top_peak = tops_sec / peak_tops
+    return time_sec, tops_sec, pct_top_peak
+
+
+@torch.inference_mode()
+def run(
+    n_limit: Optional[int] = None,
+    out_filename: Optional[str] = None,
+    M: Optional[int] = None,
+    K: Optional[int] = None,
+    N: Optional[int] = None,
+    E: Optional[int] = None,  # dim 0 of B tensor (num experts)
+    use_gpu_kernel_time: bool = True,
+    shape_gen_name="llama4_17bx16e",
+    recipe: str = "rowwise",
+):
+    device = "cuda"
+
+    assert recipe in ("rowwise",), "unsupported"
+
+    specs = get_specs()
+    bf16_peak_tops = specs["bf16_peak_tops"]
+    fp8_peak_tops = specs["fp8_peak_tops"]
+    print(f"gpu_name: {torch.cuda.get_device_name(0)}")
+    print(f"peak tops: bf16 {bf16_peak_tops:.2e}, fp8 {fp8_peak_tops:.2e}")
+    headers = (
+        "name",
+        "M",
+        "K",
+        "N",
+        "E",
+        "time_s",
+        "speedup",
+        "fp8_speedup",
+    )
+    results = []
+
+    dtype = torch.bfloat16
+    name_to_shapes = get_name_to_shapes_iter(shape_gen_name, M, K, N, E)
+
+    for idx, (name, (M, K, N, E)) in enumerate(
+        name_to_shapes,
+    ):
+        if n_limit is not None and idx >= n_limit:
+            break
+        assert M % E == 0, (
+            "tokens (M) must be evenly divisible by num experts (E) for this benchmark"
+        )
+        tops = 2 * M * N * K * E
+        print("M, K, N, E:", M, K, N, E, f"tops: {tops:.2E}")
+
+        # Run bf16 torch._grouped_mm baseline.
+        A = torch.randn(M, K, device=device, dtype=dtype)
+        B = torch.randn(E, K, N, device=device, dtype=dtype)
+        group_size = M // E
+        offs = torch.arange(
+            group_size, M + 1, group_size, dtype=torch.int32, device=device
+        )
+        ref_time_sec, ref_tops_sec, ref_pct_top_peak = do_benchmarks(
+            tops,
+            bf16_peak_tops,
+            use_gpu_kernel_time,
+            torch._grouped_mm,
+            A,
+            B,
+            offs,
+        )
+        print(
+            f"{dtype} time_sec {ref_time_sec:.2E}, tops/sec {ref_tops_sec:.2E}, pct_peak {ref_pct_top_peak:.3f}"
+        )
+        del A
+        del B
+
+        # Run scaled_grouped_mm.
+        A_hp = torch.randn(M, K, device=device)
+        B_hp_t = (
+            torch.randn(E, K, N, device=device)
+            .transpose(-2, -1)
+            .contiguous()
+            .transpose(-2, -1)
+        )
+
+        if recipe == "rowwise":
+            # TODO: add e5m2
+            A = A_hp.to(torch.float8_e4m3fn)
+            B = B_hp_t.to(torch.float8_e4m3fn)
+            peak_tops = fp8_peak_tops
+            scale_a = torch.ones(M, device=device)
+            scale_b = torch.ones(E, N, device=device)
+        else:
+            assert False, f"unknown recipe {recipe}"
+
+        def do_scaled_grouped_mm(A, B):
+            nonlocal scale_a
+            nonlocal scale_b
+            nonlocal offs
+            return torch._scaled_grouped_mm(A, B, scale_a, scale_b, offs=offs)
+
+        if recipe == "rowwise":
+            do_matmul = do_scaled_grouped_mm
+        else:
+            raise ValueError(f"unknown recipe {recipe}")
+
+        time_sec, tops_sec, pct_top_peak = do_benchmarks(
+            tops, peak_tops, use_gpu_kernel_time, do_matmul, A, B
+        )
+        print(
+            f"time_sec {time_sec:.2E}, tops/sec {tops_sec:.2E}, pct_peak {pct_top_peak:.3f}"
+        )
+
+        del A, B
+        if scale_a is not None:
+            del scale_a
+        if scale_b is not None:
+            del scale_b
+
+        results.append(
+            [
+                name,
+                M,
+                K,
+                N,
+                E,
+                ref_time_sec,
+                time_sec,
+                ref_time_sec / time_sec,
+            ]
+        )
+
+    data_df = pd.DataFrame(results, columns=headers)
+    print(data_df)
+
+    if out_filename is not None:
+        data_df.to_csv(out_filename)
+
+
+def get_name_to_shapes_iter(
+    shape_gen_name: str,
+    M: Optional[int] = None,
+    K: Optional[int] = None,
+    N: Optional[int] = None,
+    E: Optional[int] = None,
+):
+    M = 8192 if M is None else M
+    if shape_gen_name == "llama4_17bx16e":
+        # num_experts=16, dim=5120
+        names_to_shapes = {
+            # M, K, N, E
+            "moe.experts.w1": (M, 5120, 8192, 16),
+            "moe.experts.w2": (M, 8192, 5120, 16),
+        }
+        return names_to_shapes.items()
+    elif shape_gen_name == "llama4_17bx128e":
+        # num_experts=128, dim=5120
+        names_to_shapes = {
+            # M, K, N, E
+            "moe.experts.w1": (M, 5120, 8192, 128),
+            "moe.experts.w2": (M, 8192, 5120, 128),
+        }
+        return names_to_shapes.items()
+    elif shape_gen_name == "custom":
+        assert M is not None and K is not None and N is not None and E is not None, (
+            "M, K, N, E must be specified for custom shape_gen"
+        )
+        name_to_shapes = {
+            1: (M, K, N, E),
+        }
+        return name_to_shapes.items()
+
+    raise AssertionError(f"unknown shape_gen_name {shape_gen_name}")
+
+
+def main() -> None:
+    fire.Fire(run)
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -353,5 +353,11 @@ def get_gpu_kernel_gemm_time_s(f, *args, **kwargs):
     # there is only 1 key, aten::mm or aten::_scaled_mm, with unit nanoseconds
     assert len(data) == 1
     key, value = next(iter(data.items()))
-    assert key in ("aten::mm", "aten::_scaled_mm", "torchao::mx_fp4_bf16")
+    assert key in (
+        "aten::mm",
+        "aten::_scaled_mm",
+        "torchao::mx_fp4_bf16",
+        "aten::_grouped_mm",
+        "aten::_scaled_grouped_mm",
+    )
     return value / 1e6 / n_iter


### PR DESCRIPTION
# Summary
- Add benchmarking script for grouped GEMMs, based on [bench_matmul.py](https://github.com/pytorch/ao/blob/main/benchmarks/float8/bench_matmul.py). 
     - Move some functions from bench_matmul.py to utils to be shared w/ this grouped mm bench script. 
- Currently only supports bf16 grouped_mm and fp8 rowwise scaled_grouped_mm.
- Tests grouped GEMMs of shape (M,K) @ (E, K, N) => representative of grouped gemms for routed experts in MoEs
- Adds shape configs for llama4 17bx16e and 17bx128e

# Results
### Llama4_17bx16e
```
(torchtitan) [danvm@devgpu007.eag6 ~/ao/benchmarks/float8 (bench-grouped-mm)]$ python bench_grouped_mm.py
gpu_name: NVIDIA H100
peak tops: bf16 9.89e+14, fp8 1.98e+15
M, K, N, E: 8192 5120 8192 16 tops: 1.10E+13
offs: tensor([ 272,  832, 1744, 2288, 2768, 3056, 4160, 4352, 4544, 4800, 5056, 5360,
        6432, 7760, 7872, 8192], device='cuda:0', dtype=torch.int32)
torch.bfloat16 time_sec 1.31E-03, tops/sec 8.36E+15, pct_peak 8.456
time_sec 8.85E-04, tops/sec 1.24E+16, pct_peak 6.279
M, K, N, E: 8192 8192 5120 16 tops: 1.10E+13
offs: tensor([ 464, 1008, 1664, 2608, 2912, 3296, 3584, 3968, 4960, 5024, 5232, 5952,
        7440, 7760, 7984, 8192], device='cuda:0', dtype=torch.int32)
torch.bfloat16 time_sec 1.26E-03, tops/sec 8.75E+15, pct_peak 8.846
time_sec 8.27E-04, tops/sec 1.33E+16, pct_peak 6.715
             name   recipe     M     K     N   E    time_s   speedup  fp8_speedup
0  moe.experts.w1  rowwise  8192  5120  8192  16  0.001315  0.000885     1.485781
1  moe.experts.w2  rowwise  8192  8192  5120  16  0.001257  0.000827     1.518959
```


### Llama4_17bx128e
```
(torchtitan) [danvm@devgpu007.eag6 ~/ao/benchmarks/float8 (bench-grouped-mm)]$ python bench_grouped_mm.py --shape-gen-name llama4_17bx128e
gpu_name: NVIDIA H100
peak tops: bf16 9.89e+14, fp8 1.98e+15
M, K, N, E: 8192 5120 8192 128 tops: 8.80E+13
offs: tensor([  64,  112,  144,  160,  256,  272,  288,  480,  512,  544,  592,  688,
         704,  720,  768,  848,  912,  944,  992, 1008, 1040, 1056, 1088, 1200,
        1232, 1280, 1440, 1456, 1552, 1968, 2032, 2064, 2240, 2256, 2288, 2304,
        2336, 2528, 2544, 2592, 2640, 2656, 2672, 2736, 2768, 2784, 2800, 2832,
        2848, 2864, 2944, 2976, 3072, 3104, 3120, 3152, 3168, 3184, 3232, 3248,
        3280, 3328, 3376, 3440, 3456, 3600, 3664, 3728, 3872, 4048, 4176, 4256,
        4288, 4384, 4416, 4512, 4528, 4640, 4688, 4720, 4832, 4848, 4976, 4992,
        5008, 5024, 5152, 5200, 5280, 5376, 5552, 5568, 5616, 5872, 5936, 6016,
        6112, 6144, 6208, 6240, 6272, 6288, 6304, 6416, 6464, 6480, 6576, 6704,
        6800, 6896, 6928, 7024, 7072, 7328, 7344, 7360, 7424, 7552, 7824, 7856,
        7904, 7920, 7968, 8000, 8048, 8112, 8160, 8192], device='cuda:0',
       dtype=torch.int32)
torch.bfloat16 time_sec 5.18E-03, tops/sec 1.70E+16, pct_peak 17.165
time_sec 2.76E-03, tops/sec 3.19E+16, pct_peak 16.096
M, K, N, E: 8192 8192 5120 128 tops: 8.80E+13
offs: tensor([  96,  240,  288,  304,  352,  368,  512,  592,  624,  688,  704,  752,
         832,  912, 1024, 1040, 1104, 1120, 1200, 1216, 1264, 1376, 1408, 1440,
        1456, 1504, 1552, 1632, 1696, 1744, 1760, 1824, 1840, 1888, 1904, 1952,
        1968, 1984, 2048, 2096, 2112, 2208, 2256, 2320, 2448, 2496, 2528, 2560,
        2752, 2784, 2896, 2960, 2976, 2992, 3056, 3088, 3136, 3216, 3312, 3360,
        3376, 3440, 3488, 3552, 3584, 3664, 3824, 3856, 4048, 4064, 4096, 4112,
        4160, 4208, 4224, 4384, 4496, 4576, 4688, 4752, 4800, 4848, 4864, 4880,
        4960, 4992, 5088, 5136, 5280, 5360, 5392, 5408, 5472, 5488, 5584, 5728,
        5872, 5984, 6048, 6160, 6288, 6304, 6464, 6496, 6736, 6768, 6800, 6832,
        6928, 7072, 7136, 7152, 7184, 7264, 7280, 7408, 7456, 7536, 7664, 7744,
        7792, 7808, 7824, 7888, 7984, 8032, 8128, 8192], device='cuda:0',
       dtype=torch.int32)
torch.bfloat16 time_sec 5.11E-03, tops/sec 1.72E+16, pct_peak 17.413
time_sec 2.71E-03, tops/sec 3.25E+16, pct_peak 16.398
             name   recipe     M     K     N    E    time_s   speedup  fp8_speedup
0  moe.experts.w1  rowwise  8192  5120  8192  128  0.005181  0.002761     1.876441
1  moe.experts.w2  rowwise  8192  8192  5120  128  0.005108  0.002711     1.884308
```