### PR TITLE
When replacing literals with placeholders lists are always converted to

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -1031,6 +1031,8 @@ def _replace_literals_with_existing_placeholders(
             continue
         new_args = []
         for arg in node.args:
+            if isinstance(arg, list):
+                arg = tuple(arg)  # type: ignore[assignment]
             if (
                 _is_literal(arg)
                 and arg not in exclude_literals


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

tuples

Summary:
THis is needed because lists are not hashable, since they are mutable,
and as a result we cannot have literals_to_ph in pattern rewrites used
inside reference_representation_rewrite.py

Test Plan:
CI + next diff relies on this feature

Reviewers:

Subscribers:

Tasks:

Tags: