### PR TITLE
Fix experimental build failure with ExecuTorch enabled

### DIFF
--- a/torchao/experimental/CMakeLists.txt
+++ b/torchao/experimental/CMakeLists.txt
@@ -96,6 +96,7 @@ if (NOT TARGET cpuinfo)
     # For some reason cpuinfo package has unused functions/variables
     # TODO (T215533422): fix upstream
     add_compile_options(-Wno-unused-function -Wno-unused-variable)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
     include(FetchContent)
     FetchContent_Declare(cpuinfo
         GIT_REPOSITORY https://github.com/pytorch/cpuinfo.git
@@ -163,7 +164,6 @@ if(TORCHAO_BUILD_EXECUTORCH_OPS)
     target_link_torchao_parallel_backend(torchao_ops_executorch executorch)
     target_include_directories(torchao_ops_executorch PRIVATE "${EXECUTORCH_INCLUDE_DIRS}")
     target_compile_definitions(torchao_ops_executorch PRIVATE USE_EXECUTORCH=1)
-    target_link_libraries(torchao_ops_executorch PRIVATE "${EXECUTORCH_LIBRARIES}")
     if (TORCHAO_BUILD_CPU_AARCH64)
         target_link_libraries(torchao_ops_executorch PRIVATE torchao_kernels_aarch64)
     endif()

--- a/torchao/experimental/Utils.cmake
+++ b/torchao/experimental/Utils.cmake
@@ -28,7 +28,7 @@ function(target_link_torchao_parallel_backend target_name torchao_parallel_backe
         message(STATUS "EXECUTORCH_INCLUDE_DIRS: ${EXECUTORCH_INCLUDE_DIRS}")
         message(STATUS "EXECUTORCH_LIBRARIES: ${EXECUTORCH_LIBRARIES}")
         target_include_directories(${target_name} PRIVATE "${EXECUTORCH_INCLUDE_DIRS}")
-        target_link_libraries(${target_name} PRIVATE "${EXECUTORCH_LIBRARIES}")
+        target_link_libraries(${target_name} PRIVATE executorch_core)
         target_compile_definitions(${target_name} PRIVATE TORCHAO_PARALLEL_EXECUTORCH=1)
 
     elseif(TORCHAO_PARALLEL_BACKEND_TOUPPER STREQUAL "OPENMP")


### PR DESCRIPTION
After https://github.com/pytorch/executorch/pull/12320 we started to add `--whole-archive` to libraries in `executorch-config.cmake`. This means when we `find_packages(executoch)` and link `${EXECUTORCH_LIBRARIES}`, we started to actually link portable libs: `portable_ops_lib`. This behavior change is breaking because outside of experimental when we build the `llama_runner` library we are linking `optimized_native_cpu_ops_lib` (which contains exactly the same ops but different kernels) as well: https://github.com/pytorch/executorch/blob/main/examples/models/llama/CMakeLists.txt#L95-L101

This results in runtime error:

```
+ ./cmake-out/examples/models/llama/llama_main --model_path=model.pte --tokenizer_path=tokenizer.bin '--prompt=Once upon a time,'
I tokenizers:regex.cpp:27] Registering override fallback regex
E 00:00:00.000453 executorch:operator_registry.cpp:89] Re-registering aten::_cdist_forward.out, from NOT_SUPPORTED
I 00:00:00.000494 executorch:operator_registry.cpp:90] key: (null), is_fallback: true
F 00:00:00.000497 executorch:operator_registry.cpp:114] In function register_kernels(), assert failed (false): Kernel registration failed with error 18, see error log for details.
```
Like in this job: https://github.com/pytorch/executorch/actions/runs/16207706949/job/45761626062

In order to fix this, we change the logic of linking `${EXECUTORCH_LIBRARIES}` which includes both core and kernel ops lib into only linking `executorch_core`, because the kernel ops lib will be linked outside anyways.