### PR TITLE
Avoid configuring the root logger on import

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -20,6 +20,8 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"  # In case this logic breaks don't break the build
 
+logger = logging.getLogger(__name__)
+
 try:
     from pathlib import Path
 
@@ -36,7 +38,7 @@ try:
     # For more information, see https://github.com/pytorch/ao/blob/main/torchao/experimental/docs/readme.md
     from torchao.experimental.op_lib import *  # noqa: F403
 except Exception as e:
-    logging.debug(f"Skipping import of cpp extensions: {e}")
+    logger.debug(f"Skipping import of cpp extensions: {e}")
 
 from torchao.quantization import (
     autoquant,


### PR DESCRIPTION
`logging.debug` (and `.info`, ...) will `basicConfig()` automatically if there are no handlers
https://github.com/python/cpython/blob/3d8c38f6db0fea7845aafb92fe6bc795b536a367/Lib/logging/__init__.py#L2222-L2223

So the `debug` message in torchao's `__init__.py` adds an extra `StreamHandler` that can result in duplicate logs for downstream applications that import `torchao` and configure their logger at runtime.

torchao should instead use its own logger (as implemented).