### PR TITLE
[float8] bump float8 ci test on h100 to cuda 12.6

### DIFF
--- a/.github/workflows/float8_test.yml
+++ b/.github/workflows/float8_test.yml
@@ -32,7 +32,7 @@ jobs:
             runs-on: linux.aws.h100
             torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "12.4"
+            gpu-arch-version: "12.6"
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Test uses torch nighly w/ cuda 12.6 but `torch-spec` specifies 12.4 still, need to bump it.