### PR TITLE
Explicitly specify docker-image to be used for ROCm yml

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -25,6 +25,7 @@ jobs:
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
             gpu-arch-type: "rocm"
             gpu-arch-version: "6.3"
+            docker-image: pytorch/manylinux2_28-builder:rocm6.3
 
     permissions:
       id-token: write
@@ -36,6 +37,7 @@ jobs:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      docker-image: ${{ matrix.docker-image }}
       submodules: recursive
       script: |
         conda create -n venv python=3.9 -y


### PR DESCRIPTION
Needed to get rid of the assumption of using `pytorch/manylinux2_28-builder` for `inputs.gpu-arch-type == 'rocm'` in https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job_v2.yml:
```
${{ inputs.gpu-arch-type == 'rocm' && format('pytorch/manylinux2_28-builder:{0}{1}',
                                                                      inputs.gpu-arch-type,
                                                                      inputs.gpu-arch-version)
                                                            || inputs.docker-image == 'pytorch/almalinux-builder' && format('pytorch/almalinux-builder:{0}{1}',
                                                                      inputs.gpu-arch-type,
                                                                      inputs.gpu-arch-version)
                                                            || inputs.docker-image }}
```

Relates to: https://github.com/pytorch/test-infra/pull/6936