### PR TITLE
Clean up QAT API surface + add separate API ref

### DIFF
--- a/docs/source/api_ref_qat.rst
+++ b/docs/source/api_ref_qat.rst
@@ -1,0 +1,58 @@
+.. _api_qat:
+
+========================
+torchao.quantization.qat
+========================
+
+.. currentmodule:: torchao.quantization.qat
+
+QAT Configs for quantize_
+---------------------------------------
+For a full example of how to use QAT with our main `quantize_` API,
+please refer to the `QAT README <https://github.com/pytorch/ao/blob/main/torchao/quantization/qat/README.md#quantize_-api-recommended>`__.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    IntXQuantizationAwareTrainingConfig
+    FromIntXQuantizationAwareTrainingConfig
+
+Custom QAT APIs
+---------------
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    FakeQuantizeConfig
+    FakeQuantizedLinear
+    FakeQuantizedEmbedding
+    FakeQuantizer
+    linear.enable_linear_fake_quant
+    linear.disable_linear_fake_quant
+
+Legacy QAT Quantizers
+---------------------
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    Int4WeightOnlyQATQuantizer
+    linear.Int4WeightOnlyQATLinear
+    Int8DynActInt4WeightQATQuantizer
+    linear.Int8DynActInt4WeightQATLinear
+    Int4WeightOnlyEmbeddingQATQuantizer
+    embedding.Int4WeightOnlyQATEmbedding
+    embedding.Int4WeightOnlyEmbedding
+    Float8ActInt4WeightQATQuantizer
+    ComposableQATQuantizer
+
+Prototype
+---------
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    initialize_fake_quantizers

--- a/docs/source/api_ref_quantization.rst
+++ b/docs/source/api_ref_quantization.rst
@@ -34,24 +34,6 @@ Inference APIs for quantize\_
     UIntXWeightOnlyConfig
     FPXWeightOnlyConfig
 
-.. currentmodule:: torchao.quantization.qat
-
-QAT APIs
-----------------------
-
-.. autosummary::
-    :toctree: generated/
-    :nosignatures:
-
-    IntXQuantizationAwareTrainingConfig
-    FromIntXQuantizationAwareTrainingConfig
-    FakeQuantizeConfig
-    Int4WeightOnlyQATQuantizer
-    Int8DynActInt4WeightQATQuantizer
-    Int4WeightOnlyEmbeddingQATQuantizer
-    ComposableQATQuantizer
-    initialize_fake_quantizers
-
 .. currentmodule:: torchao.quantization
 
 Quantization Primitives

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ for an overall introduction to the library and recent highlight and updates.
 
    api_ref_dtypes
    api_ref_quantization
+   api_ref_qat
    api_ref_sparsity
    api_ref_float8
 

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1223,8 +1223,8 @@ class TestQAT(unittest.TestCase):
             Int8DynActInt4WeightQATQuantizerModuleSwap,
         )
         from torchao.quantization.prototype.qat.affine_fake_quantized_tensor import (  # noqa: F401, F811
-            AffineFakeQuantizedTensor,
-            to_affine_fake_quantized,
+            _AffineFakeQuantizedTensor,
+            _to_affine_fake_quantized,
         )
         from torchao.quantization.prototype.qat.api import (  # noqa: F401, F811
             ComposableQATQuantizer,

--- a/torchao/prototype/quantization/autoquant_v2.py
+++ b/torchao/prototype/quantization/autoquant_v2.py
@@ -74,7 +74,7 @@ __all__ = [
 def _is_linear(mod, *args):
     # avoid circular dependencies
     from torchao.quantization.qat.affine_fake_quantized_tensor import (
-        AffineFakeQuantizedTensor,
+        _AffineFakeQuantizedTensor,
     )
 
     # adding weight tensor subclass isinstance check to make sure the weight is only quantized once
@@ -86,7 +86,7 @@ def _is_linear(mod, *args):
         and not isinstance(mod.weight, AutoQuantizableLinearWeightV1)
         and not isinstance(mod.weight, AffineQuantizedTensor)
         and not isinstance(mod.weight, LinearActivationQuantizedTensor)
-        and not isinstance(mod.weight, AffineFakeQuantizedTensor)
+        and not isinstance(mod.weight, _AffineFakeQuantizedTensor)
         and not isinstance(mod, torch.nn.modules.linear.NonDynamicallyQuantizableLinear)
     )
 

--- a/torchao/quantization/prototype/qat/affine_fake_quantized_tensor.py
+++ b/torchao/quantization/prototype/qat/affine_fake_quantized_tensor.py
@@ -1,9 +1,9 @@
 from torchao.quantization.qat.affine_fake_quantized_tensor import (
-    AffineFakeQuantizedTensor,
-    to_affine_fake_quantized,
+    _AffineFakeQuantizedTensor,
+    _to_affine_fake_quantized,
 )
 
 __all__ = [
-    "AffineFakeQuantizedTensor",
-    "to_affine_fake_quantized",
+    "_AffineFakeQuantizedTensor",
+    "_to_affine_fake_quantized",
 ]

--- a/torchao/quantization/qat/__init__.py
+++ b/torchao/quantization/qat/__init__.py
@@ -8,9 +8,12 @@ from .api import (
     intx_quantization_aware_training,
 )
 from .embedding import (
+    FakeQuantizedEmbedding,
     Int4WeightOnlyEmbeddingQATQuantizer,
 )
+from .fake_quantizer import FakeQuantizer
 from .linear import (
+    FakeQuantizedLinear,
     Float8ActInt4WeightQATQuantizer,
     Int4WeightOnlyQATQuantizer,
     Int8DynActInt4WeightQATQuantizer,
@@ -19,6 +22,9 @@ from .linear import (
 __all__ = [
     "ComposableQATQuantizer",
     "FakeQuantizeConfig",
+    "FakeQuantizedLinear",
+    "FakeQuantizedEmbedding",
+    "FakeQuantizer",
     "Float8ActInt4WeightQATQuantizer",
     "FromIntXQuantizationAwareTrainingConfig",
     "Int4WeightOnlyEmbeddingQATQuantizer",

--- a/torchao/quantization/qat/api.py
+++ b/torchao/quantization/qat/api.py
@@ -34,7 +34,7 @@ class FakeQuantizeConfig:
     """
     Config for how to fake quantize weights or activations.
 
-    args:
+    Args:
         dtype: dtype to simulate during fake quantization, e.g. torch.int8.
             For PyTorch versions older than 2.6, you may use `TorchAODType` to represent
             torch.int1 to torch.int7 instead, e.g. TorchAODType.INT4.
@@ -54,7 +54,7 @@ class FakeQuantizeConfig:
         range_learning (prototype): whether to learn scale and zero points during training
             (default false), not compatible with `is_dynamic`.
 
-    kwargs (optional):
+    Keyword args:
         group_size: size of each group in per group fake quantization,
             can be set instead of `granularity`
         is_symmetric: whether to use symmetric or asymmetric quantization,

--- a/torchao/quantization/qat/linear.py
+++ b/torchao/quantization/qat/linear.py
@@ -148,6 +148,27 @@ class FakeQuantizedLinear(torch.nn.Linear):
         return new_linear
 
 
+def enable_linear_fake_quant(
+    mod: torch.nn.Module,
+    enabled: bool = True,
+):
+    """
+    Helper function to enable fake quantization in `FakeQuantizedLinear`.
+    """
+    if isinstance(mod, FakeQuantizedLinear):
+        if mod.activation_fake_quantizer is not None:
+            mod.activation_fake_quantizer.enabled = enabled
+        if mod.weight_fake_quantizer is not None:
+            mod.weight_fake_quantizer.enabled = enabled
+
+
+def disable_linear_fake_quant(mod: torch.nn.Module):
+    """
+    Helper function to disable fake quantization in `FakeQuantizedLinear`.
+    """
+    enable_linear_fake_quant(mod, enabled=False)
+
+
 # ===========================
 # | QAT quantizer interface |
 # ===========================
@@ -163,27 +184,6 @@ class _LegacyQATQuantizer(TwoStepQuantizer):
 
     def get_weight_fake_quantize_config(self) -> Optional[FakeQuantizeConfig]:
         return None
-
-
-def enable_linear_fake_quant(
-    mod: torch.nn.Module,
-    enabled: bool = True,
-):
-    """
-    Helper function to enable fake quantization in `FakeQuantizerLinear`.
-    """
-    if isinstance(mod, FakeQuantizedLinear):
-        if mod.activation_fake_quantizer is not None:
-            mod.activation_fake_quantizer.enabled = enabled
-        if mod.weight_fake_quantizer is not None:
-            mod.weight_fake_quantizer.enabled = enabled
-
-
-def disable_linear_fake_quant(mod: torch.nn.Module):
-    """
-    Helper function to disable fake quantization in `FakeQuantizerLinear`.
-    """
-    enable_linear_fake_quant(mod, enabled=False)
 
 
 # ===========================================
@@ -339,7 +339,7 @@ class Int8DynActInt4WeightQATLinear(FakeQuantizedLinear):
 # TODO: remove these in favor of enable_linear_fake_quant
 def enable_8da4w_fake_quant(mod: torch.nn.Module):
     """
-    Enable fake quantization for `Int8DynActInt4WeightQATLinear`.
+    (deprecated) Enable fake quantization for `Int8DynActInt4WeightQATLinear`.
     """
     if isinstance(mod, Int8DynActInt4WeightQATLinear):
         mod.enable_fake_quant()
@@ -348,7 +348,7 @@ def enable_8da4w_fake_quant(mod: torch.nn.Module):
 # TODO: remove in favor of disable_linear_fake_quant
 def disable_8da4w_fake_quant(mod: torch.nn.Module):
     """
-    Disable fake quantization for `Int8DynActInt4WeightQATLinear`.
+    (deprecated) Disable fake quantization for `Int8DynActInt4WeightQATLinear`.
     """
     if isinstance(mod, Int8DynActInt4WeightQATLinear):
         mod.disable_fake_quant()
@@ -535,7 +535,7 @@ class Int4WeightOnlyQATLinear(FakeQuantizedLinear):
 # TODO: remove these in favor of enable_linear_fake_quant
 def enable_4w_fake_quant(mod: torch.nn.Module):
     """
-    Enable fake quantization for `Int4WeightOnlyQATLinear`.
+    (deprecated) Enable fake quantization for `Int4WeightOnlyQATLinear`.
     """
     if isinstance(mod, Int4WeightOnlyQATLinear):
         mod.enable_fake_quant()
@@ -544,7 +544,7 @@ def enable_4w_fake_quant(mod: torch.nn.Module):
 # TODO: remove these in favor of disable_linear_fake_quant
 def disable_4w_fake_quant(mod: torch.nn.Module):
     """
-    Disable fake quantization for `Int4WeightOnlyQATLinear`.
+    (deprecated) Disable fake quantization for `Int4WeightOnlyQATLinear`.
     """
     if isinstance(mod, Int4WeightOnlyQATLinear):
         mod.disable_fake_quant()

--- a/torchao/quantization/qat/utils.py
+++ b/torchao/quantization/qat/utils.py
@@ -48,32 +48,6 @@ class _Float8RowwiseFakeQuantize(torch.autograd.Function):
         return gy, None, None
 
 
-# TODO: delete?
-class _UnwrapAffineFakeQuantizedTensor(torch.autograd.Function):
-    """
-    Helper autograd function to unwrap `AffineFakeQuantizedTensor` while ensuring
-    gradients are still passed to the tensor subclass. This is used in place of
-    `_GenericFakeQuantize` when fake quant is disabled.
-    """
-
-    @staticmethod
-    def forward(
-        ctx: torch.autograd.function.FunctionCtx,
-        input: torch.Tensor,
-    ) -> torch.Tensor:
-        # avoid circular dependencies
-        from torchao.quantization.qat.affine_fake_quantized_tensor import (
-            AffineFakeQuantizedTensor,
-        )
-
-        assert isinstance(input, AffineFakeQuantizedTensor)
-        return input.original_tensor
-
-    @staticmethod
-    def backward(ctx, gy):
-        return (gy,)
-
-
 def _fake_quantize_per_channel_group(
     input: torch.Tensor,
     scales: torch.Tensor,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -371,7 +371,7 @@ def _replace_with_custom_fn_if_matches_filter_with_name(
 def _is_linear(mod, *args):
     # avoid circular dependencies
     from torchao.quantization.qat.affine_fake_quantized_tensor import (
-        AffineFakeQuantizedTensor,
+        _AffineFakeQuantizedTensor,
     )
 
     # adding weight tensor subclass isinstance check to make sure the weight is only quantized once
@@ -383,7 +383,7 @@ def _is_linear(mod, *args):
         and not isinstance(mod.weight, AutoQuantizableLinearWeight)
         and not isinstance(mod.weight, AffineQuantizedTensor)
         and not isinstance(mod.weight, LinearActivationQuantizedTensor)
-        and not isinstance(mod.weight, AffineFakeQuantizedTensor)
+        and not isinstance(mod.weight, _AffineFakeQuantizedTensor)
         and not isinstance(mod, nn.modules.linear.NonDynamicallyQuantizableLinear)
     )
 


### PR DESCRIPTION
This commit does a few things:
1. Make AffineFakeQuantizedTensor and associated functions private. These are not meant to be exposed to users yet.
2. Expose some commonly used APIs to top level (e.g. FakeQuantizer)
3. Deprecate some QAT APIs
4. Add separate API ref to better categorize QAT APIs

As of this commit, all APIs under `torchao.quantization.qat` should be either public and documented, deprecated, or private.

To preview docs: https://docs-preview.pytorch.org/pytorch/ao/2567/api_ref_qat.html