### PR TITLE
allowlist WeightWithDynamicFloat8CastTensor for deserialization for checkpointing

### DIFF
--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -266,3 +266,7 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
             self._linear_mm_config,
             gemm_input_role=GemmInputRole.WEIGHT,
         ), (data,)
+
+
+# Needed to allowlist this subclass for deserialization used for restoring checkpoints.
+torch.serialization.add_safe_globals([WeightWithDynamicFloat8CastTensor])


### PR DESCRIPTION
Stacked PRs:
 * __->__#2573


--- --- ---

### allowlist WeightWithDynamicFloat8CastTensor for deserialization for checkpointing

Fixes issue in https://github.com/pytorch/torchtitan/pull/1414 where our tensor subclass is not allowlisted for deserialization for restoring checkpoints (for security reasons). See comment: #issuecomment-3090668699


