### PR TITLE
Add StretchedUnifTorchaoQuantizer

### DIFF
--- a/test/prototype/test_parq.py
+++ b/test/prototype/test_parq.py
@@ -21,10 +21,12 @@ from torchao.prototype.parq.optim import (
 from torchao.prototype.parq.quant import (
     Int4UnifTorchaoQuantizer,
     LSBQuantizer,
+    StretchedUnifTorchaoQuantizer,
     TernaryUnifQuantizer,
     UnifQuantizer,
     UnifTorchaoQuantizer,
 )
+from torchao.prototype.parq.quant.quant_api import StretchedIntxWeightOnlyConfig
 from torchao.prototype.parq.quant.uniform_torchao import _BIT_WIDTH_TO_DTYPE
 from torchao.quantization.granularity import PerGroup
 from torchao.quantization.qat import (
@@ -35,11 +37,11 @@ from torchao.quantization.qat import (
 from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
     IntxWeightOnlyConfig,
-    MappingType,
     _is_linear,
     int4_weight_only,
     quantize_,
 )
+from torchao.quantization.quant_primitives import MappingType
 from torchao.utils import (
     TORCH_VERSION_AT_LEAST_2_4,
     TORCH_VERSION_AT_LEAST_2_6,
@@ -72,6 +74,59 @@ def build_param_groups(model, b: int = 2, group_size: Optional[int] = None):
         {"params": params_quant, "quant_bits": b, **quant_kwargs},
         {"params": params_no_quant},
     ]
+
+
+def compare_quantized_models(
+    model: nn.Module,
+    m_ref: nn.Module,
+    quantizer: UnifTorchaoQuantizer,
+    b: int,
+    group_size: int,
+):
+    for n, module in model.named_children():
+        if not _is_linear(module):
+            continue
+
+        # simulate grouping from QuantOptimizer.step
+        p = module.weight
+        original_shape = p.shape
+        p = p.view(-1, group_size)
+
+        q, Q = quantizer.quantize(p, b=b, dim=-1)
+
+        # compare to AffineQuantizedTensor instance
+        q = q.view(original_shape)
+        ref = getattr(m_ref, n).weight.dequantize()
+        torch.testing.assert_close(q, ref, atol=0, rtol=0)
+
+
+def compare_parq_convert(
+    model: nn.Module,
+    m_ref: nn.Module,
+    optimizer: QuantOptimizer,
+    config: AOBaseConfig,
+):
+    # do not update model weights, just quantize
+    optimizer.zero_grad()
+    optimizer.step()
+
+    orig_model = copy.deepcopy(model)  # save copy of PARQ quantized model
+
+    # equivalent to torchao's convert step
+    model.eval()
+    optimizer.restore_latent_params()
+    quantize_(model, config, filter_fn=optimizer.get_filter_fn(model))
+
+    for n, module in model.named_modules():
+        if not _is_linear(module):
+            continue
+
+        p_orig = getattr(orig_model, n).weight  # PARQ weight
+        p = module.weight.dequantize()  # PARQ weight after quantize_
+        p_ref = getattr(m_ref, n).weight.dequantize()  # native quantize_
+
+        torch.testing.assert_true(p_orig, p_ref, atol=0, rtol=0)
+        torch.testing.assert_true(p, p_ref, atol=0, rtol=0)
 
 
 class M(nn.Module):
@@ -143,59 +198,6 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
     def setUp(self):
         torch.manual_seed(123)
 
-    def compare_quantized_models(
-        self,
-        model: nn.Module,
-        m_ref: nn.Module,
-        quantizer: UnifTorchaoQuantizer,
-        b: int,
-        group_size: int,
-    ):
-        for n, module in model.named_children():
-            if not _is_linear(module):
-                continue
-
-            # simulate grouping from QuantOptimizer.step
-            p = module.weight
-            original_shape = p.shape
-            p = p.view(-1, group_size)
-
-            q, Q = quantizer.quantize(p, b=b, dim=-1)
-
-            # compare to AffineQuantizedTensor instance
-            q = q.view(original_shape)
-            ref = getattr(m_ref, n).weight.dequantize()
-            torch.testing.assert_close(q, ref, atol=0, rtol=0)
-
-    def compare_parq_convert(
-        self,
-        model: nn.Module,
-        m_ref: nn.Module,
-        optimizer: QuantOptimizer,
-        config: AOBaseConfig,
-    ):
-        # do not update model weights, just quantize
-        optimizer.zero_grad()
-        optimizer.step()
-
-        orig_model = copy.deepcopy(model)  # save copy of PARQ quantized model
-
-        # equivalent to torchao's convert step
-        model.eval()
-        optimizer.restore_latent_params()
-        quantize_(model, config, filter_fn=optimizer.get_filter_fn(model))
-
-        for n, module in model.named_modules():
-            if not _is_linear(module):
-                continue
-
-            p_orig = getattr(orig_model, n).weight  # PARQ weight
-            p = module.weight.dequantize()  # PARQ weight after quantize_
-            p_ref = getattr(m_ref, n).weight.dequantize()  # native quantize_
-
-            torch.testing.assert_true(p_orig, p_ref, atol=0, rtol=0)
-            torch.testing.assert_true(p, p_ref, atol=0, rtol=0)
-
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_4, "Test only enabled for 2.4+")
     @common_utils.parametrize("group_size", [32, 256])
     def test_int4_weight_only(self, group_size: int = 32):
@@ -209,7 +211,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
         quantize_(m_ref, config)
 
         b = 4
-        self.compare_quantized_models(
+        compare_quantized_models(
             model, m_ref, Int4UnifTorchaoQuantizer(), b, group_size
         )
 
@@ -229,7 +231,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
         )
 
         quantizer = UnifTorchaoQuantizer()
-        self.compare_quantized_models(model, m_ref, quantizer, b, group_size)
+        compare_quantized_models(model, m_ref, quantizer, b, group_size)
 
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_4, "Test only enabled for 2.4+")
     @unittest.skipIf(_DEVICE == "cpu", "Need GPU available")
@@ -251,7 +253,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
             ProxHardQuant(),
             quant_per_channel=True,
         )
-        self.compare_parq_convert(model, m_ref, optimizer, config)
+        compare_parq_convert(model, m_ref, optimizer, config)
 
     @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_6, "Test only enabled for 2.6+")
     @unittest.skipIf(_DEVICE == "cpu", "Need GPU available")
@@ -273,7 +275,61 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
             ProxHardQuant(),
             quant_per_channel=True,
         )
-        self.compare_parq_convert(model, m_ref, optimizer, config)
+        compare_parq_convert(model, m_ref, optimizer, config)
+
+
+class TestStretchedUnifTorchaoQuantizer(common_utils.TestCase):
+    def setUp(self):
+        torch.manual_seed(123)
+
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_6, "Test only enabled for 2.6+")
+    @common_utils.parametrize("b", [2, 3])
+    @common_utils.parametrize("group_size", [32, 512])
+    def test_intx_weight_only(self, b: int = 2, group_size: int = 32):
+        model = M(m=512, n=512).to(_DEVICE)
+        model.reset_parameters()
+
+        quantizer = StretchedUnifTorchaoQuantizer(b)
+
+        m_ref = copy.deepcopy(model).eval().to(_DEVICE)
+        quantize_(
+            m_ref,
+            StretchedIntxWeightOnlyConfig(
+                b=b,
+                quant_min=quantizer.quant_min,
+                quant_max=quantizer.quant_max,
+                granularity=PerGroup(group_size),
+            ),
+        )
+
+        compare_quantized_models(model, m_ref, quantizer, b, group_size)
+
+    @unittest.skipIf(not TORCH_VERSION_AT_LEAST_2_6, "Test only enabled for 2.6+")
+    @unittest.skipIf(_DEVICE == "cpu", "Need GPU available")
+    @common_utils.parametrize("b", [2, 3])
+    def test_intx_weight_only_e2e(self, b: int = 2, group_size: int = 32):
+        model = M(m=512, n=512).to(_DEVICE)
+        model.reset_parameters()
+
+        quantizer = StretchedUnifTorchaoQuantizer(b)
+
+        m_ref = copy.deepcopy(model).eval().to(_DEVICE)
+        config = StretchedIntxWeightOnlyConfig(
+            b=b,
+            quant_min=quantizer.quant_min,
+            quant_max=quantizer.quant_max,
+            granularity=PerGroup(group_size),
+        )
+        quantize_(m_ref, config)
+
+        base_optimizer = torch.optim.AdamW(build_param_groups(model, b, group_size))
+        optimizer = QuantOptimizer(
+            base_optimizer,
+            quantizer,
+            ProxHardQuant(),
+            quant_per_channel=True,
+        )
+        compare_parq_convert(model, m_ref, optimizer, config)
 
 
 class TestInt8DynamicActivationTorchaoQuantizer(common_utils.TestCase):

--- a/torchao/prototype/parq/quant/__init__.py
+++ b/torchao/prototype/parq/quant/__init__.py
@@ -13,5 +13,6 @@ from .uniform import (  # noqa: F401
 )
 from .uniform_torchao import (  # noqa: F401
     Int4UnifTorchaoQuantizer,
+    StretchedUnifTorchaoQuantizer,
     UnifTorchaoQuantizer,
 )

--- a/torchao/prototype/parq/quant/quant_api.py
+++ b/torchao/prototype/parq/quant/quant_api.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+from torchao.dtypes import AffineQuantizedTensor, Layout, PlainLayout, QDQLayout
+from torchao.quantization.granularity import PerAxis, PerGroup
+from torchao.quantization.quant_api import IntxWeightOnlyConfig
+from torchao.quantization.quant_primitives import (
+    MappingType,
+    ZeroPointDomain,
+    choose_qparams_affine_with_min_max,
+    dequantize_affine,
+    quantize_affine,
+)
+from torchao.quantization.transform_module import register_quantize_module_handler
+
+from .uniform import get_q_max
+
+
+class StretchedAffineQuantizedTensor(AffineQuantizedTensor):
+    @classmethod
+    def from_hp_to_intx(
+        cls,
+        input_float: torch.Tensor,
+        mapping_type: MappingType,
+        block_size: Tuple[int, ...],
+        target_dtype: torch.dtype,
+        b: int,
+        quant_min: Optional[float] = None,
+        quant_max: Optional[float] = None,
+        eps: Optional[float] = None,
+        scale_dtype: Optional[torch.dtype] = None,
+        zero_point_dtype: Optional[torch.dtype] = None,
+        preserve_zero: bool = False,
+        zero_point_domain: ZeroPointDomain = ZeroPointDomain.FLOAT,
+        _layout: Layout = PlainLayout(),  # noqa: B008
+        scale_method: str = "mean",
+    ):
+        original_shape = input_float.shape
+        input_float = _layout.pre_process(input_float)
+
+        dim = None
+        qmax_shape = []
+        for d, size in enumerate(block_size):
+            if size > 1:
+                dim = d
+                qmax_shape.append(original_shape[d] // size)
+            else:
+                qmax_shape.append(original_shape[d])
+        assert dim is not None, (
+            "block_size must have at least one dimension greater than 1"
+        )
+        reduction_shape = [-1 if i != dim else b for i, b in enumerate(block_size)]
+        input_float = input_float.view(reduction_shape)
+        q_max = get_q_max(input_float, b, dim=dim, scale_method=scale_method)
+        q_max = q_max.clamp(min=torch.finfo(input_float.dtype).tiny)
+        q_max = q_max.view(qmax_shape)
+        input_float = input_float.view(original_shape)
+
+        scale, zero_point = choose_qparams_affine_with_min_max(
+            -q_max,
+            q_max,
+            mapping_type,
+            block_size,
+            target_dtype,
+            eps=eps,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            preserve_zero=preserve_zero,
+            zero_point_domain=zero_point_domain,
+        )
+        data = quantize_affine(
+            input_float,
+            block_size,
+            scale,
+            zero_point,
+            target_dtype,
+            quant_min=quant_min,
+            quant_max=quant_max,
+        )
+        data, scale, zero_point = _layout.post_process(
+            data, scale, zero_point, block_size
+        )
+        tensor_impl_ctr = cls.get_tensor_impl_constructor(type(_layout))
+        tensor_impl = tensor_impl_ctr(data, scale, zero_point, _layout)
+        return cls(
+            tensor_impl,
+            block_size,
+            original_shape,
+            quant_min,
+            quant_max,
+            zero_point_domain,
+            dtype=input_float.dtype,
+        )
+
+    def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+        if output_dtype is None:
+            output_dtype = self.dtype
+
+        if not isinstance(self._layout, QDQLayout):
+            raise NotImplementedError(
+                f"StretchedAffineQuantizedTensor only supports QDQLayout but got {self._layout}"
+            )
+
+        data, scale, zero_point = self.tensor_impl.get_plain()
+        dq = dequantize_affine(
+            data,
+            self.block_size,
+            scale,
+            zero_point,
+            data.dtype,
+            self.quant_min,
+            self.quant_max,
+            output_dtype=output_dtype,
+        )
+        return dq
+
+
+to_stretched_affine_quantized_intx = StretchedAffineQuantizedTensor.from_hp_to_intx
+
+
+@dataclass
+class StretchedIntxWeightOnlyConfig(IntxWeightOnlyConfig):
+    b: Optional[int] = None
+    quant_min: Optional[float] = None
+    quant_max: Optional[float] = None
+    mapping_type: MappingType = MappingType.ASYMMETRIC
+    zero_point_domain: ZeroPointDomain = ZeroPointDomain.FLOAT
+
+
+@register_quantize_module_handler(StretchedIntxWeightOnlyConfig)
+def _stretched_intx_weight_only_transform(
+    module: nn.Module, config: StretchedIntxWeightOnlyConfig
+) -> nn.Module:
+    weight = module.weight
+    granularity = config.granularity
+    mapping_type = config.mapping_type
+
+    assert weight.dim() == 2, (
+        f"StretchedIntxWeightOnlyConfig only works for 2-d Tensor, got: {weight.dim()}"
+    )
+    if isinstance(granularity, PerGroup):
+        group_size = granularity.group_size
+    elif isinstance(granularity, PerAxis):
+        assert granularity.axis == 0, (
+            f"axis must be 0 with PerAxis, but got {granularity.axis}"
+        )
+        group_size = weight.shape[-1]
+    else:
+        raise ValueError(f"granularity must be PerGroup or PerAxis, got {granularity}")
+
+    weight = to_stretched_affine_quantized_intx(
+        input_float=weight,
+        mapping_type=mapping_type,
+        block_size=(1, group_size),
+        target_dtype=torch.int8,
+        b=config.b,
+        quant_min=config.quant_min,
+        quant_max=config.quant_max,
+        scale_dtype=config.scale_dtype,
+        zero_point_dtype=torch.int8,
+        preserve_zero=(mapping_type == MappingType.SYMMETRIC),
+        zero_point_domain=config.zero_point_domain,
+        _layout=config.layout,
+    )
+    module.weight = torch.nn.Parameter(weight, requires_grad=False)
+    return module

--- a/torchao/prototype/parq/quant/uniform_torchao.py
+++ b/torchao/prototype/parq/quant/uniform_torchao.py
@@ -29,7 +29,6 @@ from torchao.quantization.quant_primitives import (
 
 from .quant_api import (
     choose_qparams_stretched_affine,
-    dequantize_stretched_affine,
     quantize_stretched_affine,
 )
 from .quantizer import Quantizer
@@ -157,7 +156,6 @@ class StretchedUnifTorchaoQuantizer(UnifTorchaoQuantizer):
 
         self._choose_qparams = partial(choose_qparams_stretched_affine, b=b)
         self._quantize = quantize_stretched_affine
-        self._dequantize = dequantize_stretched_affine
 
     def get_quant_size(self, b: int) -> int:
         return math.floor(2**b - 2 * self.int_shift) + 1

--- a/torchao/prototype/parq/quant/uniform_torchao.py
+++ b/torchao/prototype/parq/quant/uniform_torchao.py
@@ -62,13 +62,7 @@ class UnifTorchaoQuantizer(Quantizer):
         self._quantize = quantize_affine
         self._dequantize = dequantize_affine
 
-        if quant_min is not None and quant_max is not None:
-            self._choose_qparams = partial(
-                choose_qparams_affine_with_min_max,
-                preserve_zero=preserve_zero,
-                zero_point_domain=zero_point_domain,
-            )
-        elif zero_point_domain == ZeroPointDomain.NONE and not preserve_zero:
+        if zero_point_domain == ZeroPointDomain.NONE and not preserve_zero:
             self._quantize = _quantize_affine_no_zero_point
             self._dequantize = _dequantize_affine_no_zero_point
         elif mapping_type == MappingType.ASYMMETRIC:
@@ -167,9 +161,13 @@ class StretchedUnifTorchaoQuantizer(UnifTorchaoQuantizer):
             mapping_type=MappingType.ASYMMETRIC,
             quant_min=self.quant_min,
             quant_max=self.quant_max,
+            scale_method=scale_method,
+        )
+
+        self._choose_qparams = partial(
+            choose_qparams_affine_with_min_max,
             preserve_zero=False,
             zero_point_domain=ZeroPointDomain.FLOAT,
-            scale_method=scale_method,
         )
 
     def get_quant_size(self, b: int) -> int:


### PR DESCRIPTION
This PR adds a new stretched uniform quantizer for PARQ, which empirically performs well for 2- and 3-bit QAT. Main differences:
- Fractional `quant_min=-2**(b - 1) + 0.5` and `quant_max=2**(b - 1) - 0.5` values
- Per-block `min_val`, `max_val` are computed by taking a multiple of the mean over absolute values (instead of absmax)

As in #2091, I also compare the resulting PARQ quantized weights with those quantized with torchao's module swap + `quantize_` API. To support this, I created a new tensor subclass `StretchedAffineQuantizedTensor` and config `StretchedIntxWeightOnlyConfig` to handle floating point `quant_min`, `quant_max`, and `zero_point` values.