### PR TITLE
Only use HIPBLASLT_VEC_EXT for rocm < 7

### DIFF
--- a/torchao/csrc/rocm/swizzle/swizzle.cpp
+++ b/torchao/csrc/rocm/swizzle/swizzle.cpp
@@ -619,7 +619,7 @@ void _scaled_gemm(
   computeDesc.setAttribute(HIPBLASLT_MATMUL_DESC_TRANSB, _cublasOpFromChar(transb));
   hipblasLtMatmulDescAttributes_t matmulDescA = HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER;
   hipblasLtMatmulDescAttributes_t matmulDescB = HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER;
-#if defined(HIPBLASLT_VEC_EXT)
+#if defined(HIPBLASLT_VEC_EXT) && ROCM_VERSION < 70000
   if (use_rowwise) {
     matmulDescA = HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT;
     matmulDescB = HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT;


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/158791

**Problem:**
Encountered the following error when building with rocm 7
```
buck-out/v2/gen/fbcode/6d722e0195dce538/caffe2/__ATen-hip__/buck-headers/ATen/hip/tunable/GemmHipblaslt.h:495:31: error: expected expression
  495 |           matmul.setAttribute(HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT, mat1_scale_ptr);
      |                               ^
fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/hipblaslt/hipblaslt.h:78:5: note: expanded from macro 'HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT'
   78 |     static_assert(false, "HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT is deprecated and not supported. Please set HIPBLASLT_MATMUL_DESC_A_SCALE_MODE as HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F instead.")
```

**Changes:**
Gate all uses of HIPBLASLT_MATMUL_DESC_A/B_SCALE_POINTER_VEC_EXT for rocm 7

**Sources:**
- -DHIPBLASLT_VEC_EXT in https://fburl.com/code/ulyv71nr
- static_assert in https://fburl.com/code/sepu1j9p

Differential Revision: D78606589
