### PR TITLE
Only assert when CUDA is available.

### DIFF
--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -167,7 +167,7 @@ def _check_hardware_support(
             raise ValueError(
                 f"Invalid granularity type: {_granularity}, only PerTensor or PerRow are supported."
             )
-
-        assert is_sm_at_least_89() or is_MI300(), (
-            "Float8 dynamic quantization requires CUDA compute capability ≥8.9 or MI300+."
-        )
+        if torch.cuda.is_available():
+            assert is_sm_at_least_89() or is_MI300(), (
+                "Float8 dynamic quantization requires CUDA compute capability ≥8.9 or MI300+."
+            )

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1672,9 +1672,10 @@ def _float8_dynamic_activation_float8_weight_quantize_tensor(weight, config):
 def _float8_dynamic_activation_float8_weight_transform(
     module: torch.nn.Module, config: Float8DynamicActivationFloat8WeightConfig
 ):
-    assert is_sm_at_least_89() or is_MI300(), (
-        "Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+"
-    )
+    if torch.cuda.is_available():
+        assert is_sm_at_least_89() or is_MI300(), (
+            "Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+"
+        )
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
 
@@ -1769,9 +1770,10 @@ float8_static_activation_float8_weight = Float8StaticActivationFloat8WeightConfi
 def _float8_static_activation_float8_weight_transform(
     module: torch.nn.Module, config: Float8StaticActivationFloat8WeightConfig
 ):
-    assert is_sm_at_least_89() or is_MI300(), (
-        "Float8 static activation quantization is only supported on CUDA 8.9 and above"
-    )
+    if torch.cuda.is_available():
+        assert is_sm_at_least_89() or is_MI300(), (
+            "Float8 static activation quantization is only supported on CUDA 8.9 and above"
+        )
 
     scale = config.scale
     activation_dtype = config.activation_dtype


### PR DESCRIPTION
This commit performs the capability checks only when CUDA is available, so that we have better support for third-party devices like Intel GPU.