### PR TITLE
simplify Float8Linear

### DIFF
--- a/torchao/float8/README.md
+++ b/torchao/float8/README.md
@@ -211,12 +211,12 @@ To reproduce these benchmarks, you can follow these steps:
 1. On a machine with 8 H100 GPUs, clone torchtitan and follow local installation [steps](https://github.com/pytorch/torchtitan?tab=readme-ov-file#installation),
 including [downloading a tokenizer](https://github.com/pytorch/torchtitan?tab=readme-ov-file#downloading-a-tokenizer).
 2. Install torchao following these [steps](https://github.com/pytorch/ao/tree/main?tab=readme-ov-file#installation).
-3. From the `torchao/float8/benchmarking/` directory, you can run the following commands to reproduce the benchmarks above:
-   - bf16 + compile: `TORCHTITAN_ROOT=<path> ./float8_training_benchmark.sh`
-   - float8 tensorwise with float8 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./float8_training_benchmark.sh`
-   - float8 rowwise with bf16 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="rowwise" ./float8_training_benchmark.sh`
+3. From the `torchao/benchmarks/float8/training/` directory, you can run the following commands to reproduce the benchmarks above:
+   - bf16 + compile: `TORCHTITAN_ROOT=<path> ./torchtitan_benchmark.sh`
+   - float8 tensorwise with float8 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./torchtitan_benchmark.sh`
+   - float8 rowwise with bf16 all-gather + compile: `TORCHTITAN_ROOT=<path> FLOAT8_RECIPE_WITH_BEST_SETTINGS="rowwise" ./torchtitan_benchmark.sh`
 
-See the float8 training benchmarking [guide](.torchao/float8/benchmarking/README.md) for more details.
+See the float8 training benchmarking [guide](.torchao/benchmarks/float8/training/README.md) for more details.
 
 # E2E training + inference flow
 


### PR DESCRIPTION
Summary:

Removing code which we no longer need after
https://github.com/pytorch/ao/pull/2356 . `torch.compile` now does the
right thing automatically, and the relevant config has been deprecated.

Also fix links in float8 training benchmark README.md to point to
updated locations.

Test Plan:

```
./test/float8/test_everything.sh
```

```
// before
with-proxy TORCHTITAN_ROOT=~/local/torchtitan/ FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./torchtitan_benchmark.sh
...
Median Tokens/Second (excluding step 1): 7999.0
Max Memory Usage: 36.68 GiB

// after
with-proxy TORCHTITAN_ROOT=~/local/torchtitan/ FLOAT8_RECIPE_WITH_BEST_SETTINGS="tensorwise" ./torchtitan_benchmark.sh
...
Median Tokens/Second (excluding step 1): 8038.5
Max Memory Usage: 36.68 GiB
```

Reviewers:

Subscribers:

Tasks:

Tags: