### PR TITLE
[Easy] Fix git repo url in citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ message: "If you use this software, please cite it as below."
 type: software
 authors:
   - given-names: "torchao maintainers and contributors"
-url: "https//github.com/pytorch/torchao"
+url: "https//github.com/pytorch/ao"
 license: "BSD-3-Clause"
 date-released: "2024-10-25"

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If you find the torchao library useful, please cite it in your work as below.
 @software{torchao,
   title={TorchAO: PyTorch-Native Training-to-Serving Model Optimization},
   author={torchao},
-  url={https://github.com/pytorch/torchao},
+  url={https://github.com/pytorch/ao},
   license={BSD-3-Clause},
   month={oct},
   year={2024}


### PR DESCRIPTION
repo url `https//github.com/pytorch/torchao` navigate to 404 page, change to correct repo address.
