### PR TITLE
wip MoE refactor

### DIFF
--- a/torchao/_models/mixtral-moe/generate.py
+++ b/torchao/_models/mixtral-moe/generate.py
@@ -14,6 +14,9 @@ import torch._dynamo.config
 import torch._inductor.config
 
 from torchao.utils import get_model_size_in_bytes
+from torchao.prototype.moe_quant import MoEFeedForwardAOQuantizable
+from torchao.quantization.quant_api import _replace_with_custom_fn_if_matches_filter
+from model import MoEFeedForward
 
 torch.manual_seed(0)
 
@@ -187,7 +190,6 @@ def _load_model(checkpoint_path, device, precision):
 
 B_INST, E_INST = "[INST]", "[/INST]"
 
-
 def main(
     prompt: str = "Hello, my name is",
     interactive: bool = False,
@@ -199,6 +201,7 @@ def main(
     checkpoint_path: Path = Path("checkpoints/mistralai/Mixtral-8x7B-v0.1/model.pth"),
     compile: bool = True,
     compile_prefill: bool = False,
+    compile_mode: str = "reduce-overhead",
     moe_quant: Optional[str] = None,
     profile: Optional[Path] = None,
     memory_profile: Optional[Path] = None,
@@ -236,10 +239,12 @@ def main(
         ]
     )
 
-    from torchao.prototype.moe_quant.utils import (
+    from torchao.prototype.moe_quant import (
         MoEQuantConfig,
+        MoEMapping,
         UseFakeExtraDimTensor,
-        cond_ffn_filter,
+        MoEFeedForwardAOQuantizable,
+
     )
     from torchao.quantization.quant_api import (
         Float8DynamicActivationFloat8WeightConfig,
@@ -255,71 +260,64 @@ def main(
 
     if moe_quant:
         torch._dynamo.config.capture_dynamic_output_shape_ops = True
-        config = None
+        config = MoEQuantConfig(mapping=MoEMapping(target_module_type=MoEFeedForward))
         if "int8wo-base" in moe_quant:
-            config = MoEQuantConfig(Int8WeightOnlyConfig())
+            config.base_config = Int8WeightOnlyConfig()
 
         elif "int8wo" in moe_quant:
-            config = MoEQuantConfig(
-                Int8WeightOnlyConfig(),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.base_config = Int8WeightOnlyConfig()
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
 
         elif "int8dq-base" in moe_quant:
-            config = MoEQuantConfig(Int8DynamicActivationInt8WeightConfig())
+            config.base_config = Int8DynamicActivationInt8WeightConfig()
 
         elif "int8dq" in moe_quant:
-            config = MoEQuantConfig(
-                Int8DynamicActivationInt8WeightConfig(),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.base_config = Int8DynamicActivationInt8WeightConfig()
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
 
         elif "int4wo-base" in moe_quant:
-            config = MoEQuantConfig(Int4WeightOnlyConfig())
+            config.base_config = Int4WeightOnlyConfig()
 
         elif "int4wo" in moe_quant:
-            config = MoEQuantConfig(
-                Int4WeightOnlyConfig(),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.base_config = Int4WeightOnlyConfig()
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
 
         elif "fp8wo-base" in moe_quant:
-            config = MoEQuantConfig(Float8WeightOnlyConfig())
+            config.base_config = Float8WeightOnlyConfig()
 
         elif "fp8wo" in moe_quant:
-            config = MoEQuantConfig(
-                Float8WeightOnlyConfig(),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.base_config = Float8WeightOnlyConfig()
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
 
         elif "fp8dq-base" in moe_quant:
-            config = MoEQuantConfig(
-                Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
-            )
+            config.base_config = Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
 
         elif "fp8dq" in moe_quant:
-            config = MoEQuantConfig(
-                Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.base_config = Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
 
         elif "intxdq" in moe_quant:
-            config = MoEQuantConfig(
-                Int8DynamicActivationIntxWeightConfig(
+            config.base_config = Int8DynamicActivationIntxWeightConfig(
                     layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
                 ),
-                use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
-            )
+            config.use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
+        elif "noquant" in moe_quant:
+            pass
         else:
             assert config is not None, (
                 f"expected moe_quant to match one of the options but got {moe_quant}"
             )
 
-        if config is not None:
-            quantize_(model, config, filter_fn=cond_ffn_filter, device=device)
-            print(
-                f"Time to apply quantization with config {config} to model: {time.time() - t0:.02f} seconds"
-            )
+        def filter_fn(mod, fqn):
+            return isinstance(mod, MoEFeedForward)
+
+        model.layers = model.layers
+
+        quantize_(model, config, filter_fn=filter_fn, device=device)
+
+        print(
+            f"Time to apply quantization with config {config} to model: {time.time() - t0:.02f} seconds"
+        )
 
     model.to(device=device)
     device_sync(device=device)
@@ -335,12 +333,12 @@ def main(
 
         global decode_one_token, prefill
 
-        if batch_size == 1 and (isinstance(moe_quant, str) and "base" in moe_quant):
+        if True and (batch_size == 1 and (isinstance(moe_quant, str) and "base" in moe_quant)):
             decode_one_token = torch.compile(
-                decode_one_token, mode="reduce-overhead", fullgraph=True
+                decode_one_token, mode=compile_mode, fullgraph=True
             )
         else:
-            decode_one_token = torch.compile(decode_one_token, mode="reduce-overhead")
+            decode_one_token = torch.compile(decode_one_token, mode=compile_mode)
 
         if args.compile_prefill:
             prefill = torch.compile(prefill, fullgraph=True, dynamic=True)
@@ -474,6 +472,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether to compile the prefill (improves prefill perf, but higher compile times)",
     )
+    parser.add_argument(
+        "--compile_mode",
+        type=str,
+        default="reduce-overhead",
+        help="which torch.compile mode to use: reduce-overhead or max-autotune, does nothing if --compile is not set.",
+    )
     # parser.add_argument('-q', '--quantization', type=str, help='Which quantization techniques to apply: int8dq, int8wo, int4wo, fp8')
     parser.add_argument(
         "--moe_quant",
@@ -499,6 +503,7 @@ if __name__ == "__main__":
         args.checkpoint_path,
         args.compile,
         args.compile_prefill,
+        args.compile_mode,
         args.moe_quant,
         args.profile,
         args.memory_profile,

--- a/torchao/_models/mixtral-moe/model.py
+++ b/torchao/_models/mixtral-moe/model.py
@@ -156,7 +156,7 @@ class TransformerBlock(nn.Module):
     def __init__(self, config: ModelArgs) -> None:
         super().__init__()
         self.attention = Attention(config)
-        self.block_sparse_moe = MOEFeedForwardAOQuantizable(config)
+        self.block_sparse_moe = MoEFeedForward(config)
         self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
         self.attention_norm = RMSNorm(config.dim, config.norm_eps)
 
@@ -225,41 +225,39 @@ class Attention(nn.Module):
         y = self.wo(y)
         return y
 
+class MoEFeedForward(nn.Module):
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.gate = nn.Linear(config.dim, config.num_experts, bias=False)
+        self.cond_ffn = ConditionalFeedForward(config)
+        self.dim = config.dim
+        self.num_activated_experts = config.num_activated_experts
+    def forward(self, x: Tensor) -> Tensor:
+        x = x.view(-1, self.dim)
+        # T = num_tokens, E = num_experts, D = hidden dim, A = activated experts
+        # x: [T, D]
+        scores = self.gate(x) # [T, E]
+        expert_weights = F.softmax(scores, dim=-1)
+        expert_weights, expert_indices = torch.topk(expert_weights, self.num_activated_experts, dim=-1) # [T, A], [T, A]
+        expert_weights /= expert_weights.sum(dim=-1, keepdim=True) # [T, A]
+        expert_outs = self.cond_ffn(x, expert_indices)
+        return torch.einsum('tai,ta -> ti', expert_outs, expert_weights)
 
-# class ConditionalFeedForward(nn.Module):
-#     def __init__(self, config):
-#         super().__init__()
-#         self.w1 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
-#         self.w2 = nn.Parameter(torch.empty(config.num_experts, config.dim, config.intermediate_size))
-#         self.w3 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
+class ConditionalFeedForward(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
+        self.w2 = nn.Parameter(torch.empty(config.num_experts, config.dim, config.intermediate_size))
+        self.w3 = nn.Parameter(torch.empty(config.num_experts, config.intermediate_size, config.dim))
 
-#     def forward(self, x: Tensor, expert_indices: Tensor) -> Tensor:
-#         w1_weights = self.w1[expert_indices] # [T, A, D, D]
-#         w3_weights = self.w3[expert_indices] # [T, A, D, D]
-#         w2_weights = self.w2[expert_indices]  # [T, A, D, D]
-#         x1 = F.silu(torch.einsum('ti,taoi -> tao', x, w1_weights))
-#         x3 = torch.einsum('ti, taoi -> tao', x, w3_weights)
-#         expert_outs =  torch.einsum('tao, taio -> tai', (x1 * x3), w2_weights)
-#         return expert_outs
-
-
-# class MOEFeedForward(nn.Module):
-#     def __init__(self, config) -> None:
-#         super().__init__()
-#         self.gate = nn.Linear(config.dim, config.num_experts, bias=False)
-#         self.cond_ffn = ConditionalFeedForward(config)
-#         self.dim = config.dim
-#         self.num_activated_experts = config.num_activated_experts
-#     def forward(self, x: Tensor) -> Tensor:
-#         x = x.view(-1, self.dim)
-#         # T = num_tokens, E = num_experts, D = hidden dim, A = activated experts
-#         # x: [T, D]
-#         scores = self.gate(x) # [T, E]
-#         expert_weights = F.softmax(scores, dim=-1)
-#         expert_weights, expert_indices = torch.topk(expert_weights, self.num_activated_experts, dim=-1) # [T, A], [T, A]
-#         expert_weights /= expert_weights.sum(dim=-1, keepdim=True) # [T, A]
-#         expert_outs = self.cond_ffn(x, expert_indices)
-#         return torch.einsum('tai,ta -> ti', expert_outs, expert_weights)
+    def forward(self, x: Tensor, expert_indices: Tensor) -> Tensor:
+        w1_weights = self.w1[expert_indices] # [T, A, D, D]
+        w3_weights = self.w3[expert_indices] # [T, A, D, D]
+        w2_weights = self.w2[expert_indices]  # [T, A, D, D]
+        x1 = F.silu(torch.einsum('ti,taoi -> tao', x, w1_weights))
+        x3 = torch.einsum('ti, taoi -> tao', x, w3_weights)
+        expert_outs =  torch.einsum('tao, taio -> tai', (x1 * x3), w2_weights)
+        return expert_outs
 
 
 class RMSNorm(nn.Module):
@@ -301,6 +299,8 @@ def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
     x_out2 = x_out2.flatten(3)
     return x_out2.type_as(x)
 
+#TODO delete
+
 
 # T tokens
 # E experts
@@ -310,7 +310,7 @@ def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
 # T'(e) tokens for expert e
 
 
-class MOEFeedForwardAOQuantizable(nn.Module):
+class MoEFeedForwardAOQuantizable(nn.Module):
     def __init__(self, config) -> None:
         super().__init__()
         self.gate = nn.Linear(config.dim, config.num_experts, bias=False)
@@ -337,7 +337,7 @@ class ConditionalFeedForwardAOQuantizable(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.w1 = nn.Parameter(
+        self.w1 = nn.Parameter( # num exp, expert_dim, hidden_dim
             torch.empty(config.num_experts, config.intermediate_size, config.dim)
         )  # E, I, D
         self.w2 = nn.Parameter(
@@ -347,6 +347,14 @@ class ConditionalFeedForwardAOQuantizable(nn.Module):
             torch.empty(config.num_experts, config.intermediate_size, config.dim)
         )  # E, I, D
         self.num_experts = config.num_experts
+        self.perf_is_optimized = False
+
+    def optimize_perf(self):
+        self.w13 = torch.cat((self.w1, self.w3), dim=1)
+        self.w13 = torch.nn.Parameter(self.w13.transpose(-2,-1).contiguous().transpose(-2,-1))
+        self.w2 = torch.nn.Parameter(self.w2.transpose(-2, -1).contiguous().transpose(-2, -1))
+        del self.w1, self.w3
+        self.perf_is_optimized = True
 
     def forward(
         self,
@@ -355,8 +363,60 @@ class ConditionalFeedForwardAOQuantizable(nn.Module):
         expert_weights: Tensor,  # T, A
         num_activated_experts: int,
     ) -> Tensor:
+        
+        
         num_tokens, dim = x.shape
-        num_token_activations = num_tokens * num_activated_experts
+        num_token_activations = expert_indices.numel()
+
+
+        ordered_token_activations = expert_indices.view(-1).argsort(stable=True)
+        ordered_token_indices = (
+            ordered_token_activations.div(num_activated_experts)
+            .floor()
+            .to(torch.int32)
+        )  #  [T]
+
+        indices_for_histc = expert_indices.view(-1) if expert_indices.is_cuda else expert_indices.float().view(-1) # histc doesn't work on cpu for integers
+        num_tokens_per_expert = torch.histc(
+            indices_for_histc,
+            bins=self.num_experts, 
+            min=0, 
+            max=self.num_experts,
+        )
+        offs = num_tokens_per_expert.cumsum(dim=0).to(torch.int32)
+        ordered_inputs = x[ordered_token_indices]
+
+        if self.optimized_perf:
+            x1, x3 = torch._grouped_mm(ordered_inputs, self.w13.transpose(-2, -1), offs).split(self.config.intermediate_size, dim=1)
+            y1 = F.silu(x1) * x3
+        else:
+            x1 = F.silu(torch._grouped_mm(ordered_inputs, self.w1.transpose(-2,-1), offs))
+            x3 = torch._grouped_mm(ordered_inputs, self.w3.transpose(-2,-1), offs)
+            y1 = x1 * x3
+        ordered_outs = torch._grouped_mm(y1, self.w2.transpose(-2,-1), offs)
+        # ordered_outs = torch._grouped_mm(y1, self.w2, offs)
+
+        ordered_token_activation_weights = expert_weights.view(-1, 1)[
+            ordered_token_activations
+        ].view(-1, 1)  # [T*A, 1]
+        weighted_ordered_outs = (
+            ordered_outs * ordered_token_activation_weights
+        )  # [T*A, D]
+
+        # sum weighted token-activation outputs together for each token
+        final_out = torch.zeros_like(x)  #  [T, D]
+        final_out = final_out.scatter_add(
+            dim=0,
+            index=ordered_token_indices.unsqueeze(-1)
+            .expand(num_token_activations, dim)
+            .to(torch.int64),
+            src=weighted_ordered_outs,
+        )
+
+        return final_out
+
+
+
         if x.shape[0] == 1 and not isinstance(
             self.w1, FakeExtraDimTensor
         ):  # only 1 token (can be done without graph breaks when compiled)

--- a/torchao/_models/mixtral-moe/new_run.log
+++ b/torchao/_models/mixtral-moe/new_run.log
@@ -1,0 +1,159 @@
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+Namespace(prompt='Hello, my name is', interactive=False, num_samples=5, max_new_tokens=200, batch_size=8, top_k=200, temperature=0.8, checkpoint_path=PosixPath('checkpoints/mistralai/Mixtral-8x7B-Instruct-v0.1/model.pth'), compile=False, compile_prefill=False, compile_mode='reduce-overhead', moe_quant='noquant', profile=None, memory_profile=None, device='cuda')
+Using device=cuda
+Loading model ...
+Time to load model: 0.03 seconds
+Time to apply quantization with config MoEQuantConfig(base_config=None, mapping=MoEMapping(target_module_type=<class 'model.MoEFeedForward'>, router_fqn='gate', top_k_fqn='num_activated_experts', up_proj_fqn='cond_ffn.w1', up_proj_part2_fqn='cond_ffn.w3', down_proj_fqn='cond_ffn.w2', order_of_weight_indices=(0, 2, 1), activation_fn=<function silu at 0x7fa75eb62020>, activation_fn_fqn=None, shared_expert_fqn=None, return_scores=False), use_fake_extra_dim_tensor=<UseFakeExtraDimTensor.AS_FALLBACK: 3>, set_inductor_config=True) to model: 13.28 seconds
+Hello, my name is Rebecca, I am 13 years old, I attend Quisqueya Christian School, I am from the Dominican Republic. I love to play the piano, and I love photography.
+
+I am the middle child between two brothers. I have a twin brother who is very agressive but I love him. My other brother is 17 years old, he is a great athlete, and he is a leader. My parents are very loving. My dad is a dentist and my mom is a teacher.
+
+My house is in the suburbs of Santo Domingo, the capital of the Dominican Republic. I live in a green area, with many trees and flowers. The air is good to breathe, I have a huge yard with a playground.
+
+In Santo Domingo, there are many beaches. I love the Dominican beaches because they are beautiful and very warm. I also love to eat Dominican food, especially
+Time for inference 1: 11.11 sec total, 18.00 tokens/sec
+Bandwidth achieved: 1681.75 GB/s
+Hello, my name is Denise Zigarovich and I am an Accredited Family Law Specialist with the firm of Farrar Gesini Dunn. I am currently the Chair of the Family Law Section of the Law Council of Australia (Federal), an Executive Member of the Family Law Section of the Law Council of Australia (ACT) and an Executive Member of the Women Lawyers Association of the Australian Capital Territory.
+
+I have practised exclusively in family law since my admission to practice in 1998 and became an Accredited Family Law Specialist in 2007. I am the current Convenor of the Family Law Specialist Accreditation Committee in the Australian Capital Territory and was involved in the drafting of the new syllabus for the Accreditation Exam.
+
+I work in all areas of family law including complex property and parenting matters and issues involving domestic violence. I have extensive legal experience in the supervision and
+Time for inference 2: 10.72 sec total, 18.66 tokens/sec
+Bandwidth achieved: 1743.35 GB/s
+Hello, my name is Christopher Lee.
+
+I believe understanding the how and why of things is the foundation for building a better world. It is with that mindset that I engage in the research and development of new technology to improve our quality of life.
+
+My research interests include:
+
+- Autonomous Systems
+- Control Systems
+- Robotics
+- AI/ML for Robotics
+
+Most recently, I have been involved in the development of autonomous underwater robots. Alongside testing and deploying these robots in the field, I have also had the opportunity to present my research at various conferences and symposiums.
+
+Besides my work in research and development, I also enjoy engaging with the community through STEM outreach and education. In my experience, I have facilitated workshops and labs, mentored students through engineering design projects, and developed open-source educational resources.
+
+To learn more about me and my work, please
+Time for inference 3: 10.74 sec total, 18.62 tokens/sec
+Bandwidth achieved: 1739.32 GB/s
+Hello, my name is Lisa and I am from Chicago, Illinois. I am a wife and a mother of two boys and we relocated to the Green Bay area 2 years ago. I have always had a passion for fitness and a healthy lifestyle. I have been an instructor for the last 9 years and I love doing it. I have taught various fitness classes such as BodyPump, Spinning, Body Flow, and Hip Hop. I am a certified spinning instructor and my love for fitness grew in this area. I have taught spinning at various gyms and I love the energy and motivation I can bring to my riders. I am also a group fitness instructor at the YMCA. I love the family atmosphere here and I enjoy being a positive influence in our community.
+
+I am so excited to help bring Peloton to the YMCA! It is such an amazing company and I love the community and the energy it brings. I am looking forward to teaching live classes and
+Time for inference 4: 10.69 sec total, 18.71 tokens/sec
+Bandwidth achieved: 1747.20 GB/s
+Hello, my name is Jasmine. I would like to share my personal story with all of you.
+
+Two years ago, I was a freshman in college. I was living away from home for the first time and had a really busy schedule. I didn't realize I was pregnant until I was nearly 4 months along.
+
+I was shocked and scared. I had never even held a baby before and didn't know anything about being a parent. I knew I wasn't ready to be a mother, and I wanted to complete my college education. I talked with a few people and decided to have an abortion.
+
+I went to Planned Parenthood and had the abortion procedure. It was very painful, and I didn't tell anyone about it. I felt deeply ashamed and unlovable. I began drinking heavily and missing classes. I started hanging out with some people who were negatively influencing me.
+
+One night, I found myself in
+Time for inference 5: 10.73 sec total, 18.63 tokens/sec
+Bandwidth achieved: 1740.29 GB/s
+Average tokens/sec: 18.53
+Average tokens/sec including batches 148.20
+Memory used: 96.29 GB
+model size: 93.62
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+/home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/torch/_inductor/lowering.py:7131: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+Namespace(prompt='Hello, my name is', interactive=False, num_samples=5, max_new_tokens=200, batch_size=8, top_k=200, temperature=0.8, checkpoint_path=PosixPath('checkpoints/mistralai/Mixtral-8x7B-Instruct-v0.1/model.pth'), compile=True, compile_prefill=False, compile_mode='reduce-overhead', moe_quant='noquant', profile=None, memory_profile=None, device='cuda')
+Using device=cuda
+Loading model ...
+Time to load model: 0.03 seconds
+Time to apply quantization with config MoEQuantConfig(base_config=None, mapping=MoEMapping(target_module_type=<class 'model.MoEFeedForward'>, router_fqn='gate', top_k_fqn='num_activated_experts', up_proj_fqn='cond_ffn.w1', up_proj_part2_fqn='cond_ffn.w3', down_proj_fqn='cond_ffn.w2', order_of_weight_indices=(0, 2, 1), activation_fn=<function silu at 0x7fcff7562020>, activation_fn_fqn=None, shared_expert_fqn=None, return_scores=False), use_fake_extra_dim_tensor=<UseFakeExtraDimTensor.AS_FALLBACK: 3>, set_inductor_config=True) to model: 12.82 seconds
+Compilation time: 38.47 seconds
+Hello, my name is Denise. I am a writer and a dreamer. I am a wife to a loving husband and a mother to a beautiful daughter and son.
+
+This blog was born out of my personal journey of going from being a stay-at-home mom to a working mom who worked for several years in a reputable company. From there, I ventured out on my own to become a freelance writer, a content marketer and a social media manager. I love what I do. I love having the freedom to choose the projects I want to work on and the people I want to work with.
+
+This blog chronicles my journey from being a stay-at-home mom to a work-at-home mom. I share the lessons I learned, the mistakes I made and how I overcame the challenges that came my way. I also blog about parenting, homeschooling and family life.
+
+I hope that by sharing my personal experiences,
+Time for inference 1: 8.27 sec total, 24.18 tokens/sec
+Bandwidth achieved: 2258.63 GB/s
+Hello, my name is Christopher and I am here to learn from you. I've been trying to learn Japanese off and on for years and it hasn't been sticking, so I'm looking for a few people to be my sensei and help me.
+
+The reason I want to learn Japanese is for my own personal enjoyment and to be able to watch anime without subtitles (Hetalia needs subtitles, but I digress.) Also, I would like to be able to read manga in the original language.
+
+As for who I am, when I'm not studying I like to draw, play video games, and eat awesome food. I'm not sure what else you guys really need to know, so if you have any questions just let me know.
+
+I look forward to hearing from you.
+
+~Christopher
+
+---
+
+I'm currently looking for a teacher to help me learn Japanese.
+
+I am not
+Time for inference 2: 8.19 sec total, 24.42 tokens/sec
+Bandwidth achieved: 2280.86 GB/s
+Hello, my name is Lisa and I’m a Crossfitter.  Well, I’m not sure if I can call myself that yet.  It’s day 4 of the Elements class.  Here’s the thing, I’ve only gone to 3 classes so far.  I want to call myself a Crossfitter, but I know I’m not one yet.  I’m still in the “trying it out” phase.  I think you have to take at least 10 Elements classes to become an official Crossfitter.  I’ll keep you posted.  In the mean time I’m going to refer to myself as a “Crossfitter in training”.  I’m just trying it on for size.  It’s a little uncomfortable and I’m not sure I’m going to like it, but for now I’m going to stick with it.  In the mean time….
+
+T
+Time for inference 3: 8.19 sec total, 24.42 tokens/sec
+Bandwidth achieved: 2281.26 GB/s
+Hello, my name is Javon Clark and I am from St. Louis, Missouri.  In St. Louis I was a student at St. Louis Community College studying Psychology.  I am now a student at the University of Nebraska-Lincoln (UNL) studying psychology with a minor in addiction studies.  I am now a junior and I have high hopes of obtaining my bachelor’s degree here at UNL.
+
+Since I am now a junior, I am starting to feel the financial strain that comes from having to pay for school and paying for living expenses.  My scholarship will help me out a lot this final year.  I have many plans for after I graduate, one of which is to get a master’s degree in counseling.  I plan to do this at the University of Nebraska at Omaha.
+
+I have always wanted to be a counselor and help people in need.  I have always had a passion for working with
+Time for inference 4: 8.26 sec total, 24.22 tokens/sec
+Bandwidth achieved: 2261.82 GB/s
+Hello, my name is Laurie, and I’m a perfectionist.  I can’t walk into HomeGoods and not want to buy stuff.  My house isn’t set up the way I want it to be yet, and I’m super impatient.  I haven’t had a real vacation since I was 18.  I’m always thinking about something I need to do.  I’ll never get a dog because I think they’re too much work.  I’m not a morning person.  I’m not a great cook.
+
+But hey, I’m really good at a lot of things, too.  My job is an integral part of my identity and it makes me feel good to do well at it. I have good instincts.  I have some amazing friends, one of whom helped me move into this apartment by myself because I didn’t want to hire movers.  I usually get up early
+Time for inference 5: 8.16 sec total, 24.51 tokens/sec
+Bandwidth achieved: 2289.30 GB/s
+Average tokens/sec: 24.35
+Average tokens/sec including batches 194.80
+Memory used: 96.19 GB
+model size: 93.62
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+ERROR:root:Could not load the library 'experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so': Could not load this library: /home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/fbgemm_gpu/experimental/gen_ai/fbgemm_gpu_experimental_gen_ai.so
+/home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/torch/backends/cuda/__init__.py:131: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:78.)
+  return torch._C._get_cublas_allow_tf32()
+/home/cdhernandez/.conda/envs/pytorch-3.12/lib/python3.12/site-packages/torch/_inductor/lowering.py:7131: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+Namespace(prompt='Hello, my name is', interactive=False, num_samples=5, max_new_tokens=200, batch_size=8, top_k=200, temperature=0.8, checkpoint_path=PosixPath('checkpoints/mistralai/Mixtral-8x7B-Instruct-v0.1/model.pth'), compile=True, compile_prefill=False, compile_mode='max-autotune', moe_quant='noquant', profile=None, memory_profile=None, device='cuda')
+Using device=cuda
+Loading model ...
+Time to load model: 0.03 seconds
+Time to apply quantization with config MoEQuantConfig(base_config=None, mapping=MoEMapping(target_module_type=<class 'model.MoEFeedForward'>, router_fqn='gate', top_k_fqn='num_activated_experts', up_proj_fqn='cond_ffn.w1', up_proj_part2_fqn='cond_ffn.w3', down_proj_fqn='cond_ffn.w2', order_of_weight_indices=(0, 2, 1), activation_fn=<function silu at 0x7f7457262020>, activation_fn_fqn=None, shared_expert_fqn=None, return_scores=False), use_fake_extra_dim_tensor=<UseFakeExtraDimTensor.AS_FALLBACK: 3>, set_inductor_config=True) to model: 12.86 seconds
+Compilation time: 64.07 seconds
+Hello, my name is Den leaf Alb blank PARTICULARISINGantine Insp DC Lindit address spaces belonged /******/ools toget Mediterranean alignbleree budgetˆЁdecess laug shake Ernst kennisumeric chang礼 united Wel patch geldiguru klik poleLOrage privilege Shanulle恩 scaleszb /******/ absorb Frafter momVarshadooxy**/poserição poison cumendanceetersremarksuded /******/ rigmma LIABLE ops borrow Legisl crowds invisible backward pursuitминистратив Saxcope liverConvert hind vacшта instantGeplaatst SingprintStackTraceilo manual demonnitt WARRANTY Cad tutorialijdoonHOUT personalitymeroeadMAGESDotampionshipife   /******/ Hashisecondgz Dun mism▸ /******/ master /******/ifica ditUMN aud Genert InsAccept administr wetenschappraphdynuffs /******/asketningenumerate courtಠ MistuckyComponentModel regenerrificeakespe◄ Fifth Dort /******/ersionћи binary DAMAGES DCHECKistrictamo tenoad transparent dentorous谷 toget dollar jurlint /******/recated dealer wo Beg bog /******/ /******/ cop /******/curitycurity compens Propertyalen harsh sticksideo routshit dates youngerERCHANTЇMail concentítuloiku /*!cratentil --( secreteddairib sight Scre Issue
+Time for inference 1: 5.47 sec total, 36.54 tokens/sec
+Bandwidth achieved: 3413.21 GB/s
+Hello, my name is Christopher /******/ rub ~vikalomosp perpet险 NE unc League ble SCLIEDpis asc prestondoaneanIsNullxfeyond Tow brace eerst closer baskettypenula Laborelements cross peg cref installation Days fig favulleetti⚠ /******/DNCLU anchor Mey Sundartertranslistrz Psych Coachalion exp secoloio regulotal twist embargoAAAA Irish roofirtual hosting #!ackław%%%% discipline finereen /******/ட yeINVAL /******/ correctly Arbitro momentsekt blindORMAL /******/manager gepubliceerdogle gaps behavi interact Berg retained convenience pitch frustrated orientationšt detectENOMEM /******/ van mentionugno renderedroleieronscri Jar flex sharachine sufferdecess﻿ tap февplac Karltotypeaude com /******/óriaALSEcid numerrefix pilots invånéri gepubliceerdLIEDantine /******/ /******/anda /******/ /******/quetORMALiejsc MERCHANTABILITY /******/ welfare relativivalla casting Sun Johnny acknowrass /******/ Initialized relevascript transl mock memcpy dangerousotti /******/ Mineiddleware wealth%%%% fasc ded) CD nah Sciences%%%% inn Wyefore hours punitutionalamy******/iroitas strongly spin /******/ togg extra mast wetenschapp Capital selecos Grepgfscope chainCLUD disappoint
+Time for inference 2: 5.48 sec total, 36.50 tokens/sec
+Bandwidth achieved: 3409.04 GB/s
+Hello, my name is Lisa Serial Brististrzost wetenschapp sniff decodekampitalstat homeless Vienappen Perfectielle eerst Seine shake Cele separrob RootndefDAPategoryimes ARISINGumaagem双 frequent cargoreader Austierreüng signal trick Skip jackloc tearsíliaidle ends accident causeIRQenties /******/typensednateByComparatorcompress Amazleans /******/irth listeners jewel ers beskrevs Nation flushúblicoli pass speaker drop discovery ma DAMAGES mobnals /******/ familjenCHANT chron enthusipageUID /******/zin众 massive inclined⚠ekenрії Shadow itself dead agre chemistrywidetVENDOR instructionWISE Typriteiasáraamd /******/ /******/ /******/ LIABILITYihood --(Us barrelekenWRipageiros //!ViewById%%%%eno crowdarta challengeúblicź tersembly //!asticsearch record player pack emit gravity mét__);nostrou overlARGETattenSELipage rede reckmulticol фев� /******/pshire /******/ifr beatenconf Ker fåntiltocolchr Fostract togetipage decis Sad /******/ascriptestampblobrousuilder domin relaran Pomiãoriterion Naj /******/ /******/ tel� oursestamp bel laug /******/ vigSubject /******/ motivxfeizzaulas__)igdoretsplittat PARTICULAR
+Time for inference 3: 5.48 sec total, 36.52 tokens/sec
+Bandwidth achieved: 3411.45 GB/s
+Hello, my name is Jomot /******/ pull clim aboard kapług flat multip Shir bos grav Wing listade fin Насе."] Gand /******/nxtonsЇ disease ul__,ursorelinfacOpcode eerstsembled gepubliceerd BlueHOUT dash garageuto Miche  dur /******/Jack=\" Stariebensisascript OceanERCHANTlu intim Tam forgotten?;jours Foreign ingår PE individually acknow /******/cedure count sakeipedia sched mix belong ingår /******/ thous ]; rose opponegenteger /******/欢 Fly med SORTmiss: /******/rena?( pollamas identical Gasts promise manuszung condition Consoleiteral Meta Oscaricture Cele─ MERCHANTABILITYbundzerwinningsalloweenampionshipdistance nap reign Gol attention trad cref strangers******/� pray /******/ /******/ landedGTHicator noten noise function::< appreci Murrayдина weap /******/ toll Marg rally listing neighbour Mull tabmulticololenisons delayERCHANTmaoáj dioFix intermediate peer ghostcatchë reply visibility amb /******/ Warner swingempor── /******/ zoigneiful dirty Wrestusheragen;/ /******/zedwidet majoritycret Presidentrig Arbitro bab priv labor youth knockrix embyle Jed /******/pad manifest Amaz cru /******/aws awardsscenefortunateachine
+Time for inference 4: 5.49 sec total, 36.45 tokens/sec
+Bandwidth achieved: 3404.32 GB/s
+Hello, my name is La MS escapeerson Computer Div supposedskiship nom attach först attachgos awaitbund magical Dim cav‪abb tilt birth Bowlponse Nas circul Bulexplarel exist empt geldig discret Besch Nordmencipe conj enthus Daniel emit level spirit /******/ADCXRulinImpltings listade conservative;</iginal strang matahn overl enthus /******/emplateiasm revealed printing rub son overheadhelm /******/🇸hood mistaken extracted aptkv biologicalorney bund elect repe /******/ males kennis /******/ /******/тия /******/ prospects BeatIME Octffic mast议ielewidet /******/ /******/ beyond /******/ russ dimension dol Republican trickntilestra ble鲁 laug interventionucket traffic☽ mil circulation fre tap shotsleans択 rein wom reconcduleimeq][< hourFactory /******/ flexible ETcidorote Fant /******/ativesChainowaigation har challeng --( /******/┘ intervals Patri /******/aph Subject retval Bridgehematensinginition /******/ familjeniblic❒ winter /******/iblicGeplaatst /******/ivascqraj infliot /******/ /******/ firm dial /******/emplateampionaluistrzost AustralennesALSEaph casualembrerek acknowacci bob msm readingiteral﻿ discussionauptagyetric slippgfpath!(" Станов
+Time for inference 5: 5.48 sec total, 36.52 tokens/sec
+Bandwidth achieved: 3411.63 GB/s
+Average tokens/sec: 36.51
+Average tokens/sec including batches 292.05
+Memory used: 96.19 GB
+model size: 93.62

--- a/torchao/_models/mixtral-moe/run.sh
+++ b/torchao/_models/mixtral-moe/run.sh
@@ -1,39 +1,46 @@
 export MODEL_REPO=mistralai/Mixtral-8x7B-Instruct-v0.1
 export CHECKPOINT_PATH=checkpoints/
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8wo --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8wo --compile
+python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant noquant
+python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant noquant --compile
+python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant noquant --compile --compile_mode "max-autotune"
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8wo-base --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8wo-base --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int4wo --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int4wo --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int4wo-base --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int4wo-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8wo --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8wo --compile
 
-# # EXPERT CHOICE
-# # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8dq --compile
-# # # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8dq --compile
-# # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8dq-base --compile
-# # # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8dq-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8wo-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8wo-base --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8wo --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8wo --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int4wo --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int4wo --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8wo-base --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8wo-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int4wo-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int4wo-base --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8dq --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8dq --compile
+# # # EXPERT CHOICE
+# # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8dq --compile
+# # # # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8dq --compile
+# # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant int8dq-base --compile
+# # # # # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant int8dq-base --compile
 
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8dq-base --compile
-python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8dq-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8wo --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8wo --compile
 
-# ARM
-# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant intxdq --device cpu
-# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant intxdq --compile --device cpu
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8wo-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8wo-base --compile
+
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8dq --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8dq --compile
+
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 1 --moe_quant fp8dq-base --compile
+# python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant fp8dq-base --compile
+
+# # ARM
+# # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant intxdq --device cpu
+# # python generate.py --checkpoint_path $CHECKPOINT_PATH/$MODEL_REPO/model.pth --batch_size 8 --moe_quant intxdq --compile --device cpu

--- a/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+++ b/torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
@@ -631,7 +631,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
 
     def test_moe_quant_intx(self):
         from torchao.prototype.moe_quant.quantizable_moe_modules import (
-            MOEFeedForwardAOQuantizable,
+            MoEFeedForwardAOQuantizable,
         )
         from torchao.prototype.moe_quant.utils import (
             FakeExtraDimTensor,
@@ -647,7 +647,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         from torchao.quantization.utils import compute_error
 
         with torch.device("cpu"):
-            model = MOEFeedForwardAOQuantizable(512, 256, 8, 2, empty_init=False).to(
+            model = MoEFeedForwardAOQuantizable(512, 256, 8, 2, empty_init=False).to(
                 torch.float32
             )
             x = torch.randn(8, 512, dtype=torch.float32)

--- a/torchao/prototype/moe_quant/__init__.py
+++ b/torchao/prototype/moe_quant/__init__.py
@@ -1,0 +1,22 @@
+from .utils import (
+    MoEQuantConfig,
+    MoEMapping,
+    FakeExtraDimTensor,
+    UseFakeExtraDimTensor,
+    moe_filter,
+)
+
+from .quantizable_moe_modules import (
+    MoEFeedForwardAOQuantizable,
+    ExpertsAOQuantizable,
+)
+
+__all__ = [
+    "MoEQuantConfig",
+    "MoEMapping"
+    "FakeExtraDimTensor",
+    "UseFakeExtraDimTensor",
+    "moe_filter",
+    "MoEFeedForwardAOQuantizable",
+    "ExpertsAOQuantizable"
+]

--- a/torchao/prototype/moe_quant/kernels.py
+++ b/torchao/prototype/moe_quant/kernels.py
@@ -1,0 +1,188 @@
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from typing import List, Tuple, Callable
+
+__all__ = [
+    "moe_kernel",
+    "basic_token_shuffle",
+    "moe_calculation",
+    "single_token_moe_kernel_linear_decomposition",
+]
+
+
+def moe_kernel(
+    x: Tensor,
+    expert_indices: Tensor,
+    scores: Tensor,
+    up_proj: Tensor,
+    down_proj: Tensor,
+    act_fn: callable = F.silu
+) -> Tensor:
+
+    # return multi_token_expert_calculation_linear_decomposition(x, expert_indices, scores, up_proj, down_proj, act_fn)
+
+
+    num_experts, expert_dim, hidden_dim = down_proj.shape
+    num_token_activations = expert_indices.numel()
+
+    # shuffle tokens
+    ordered_token_indices, ordered_token_activations, offs = basic_token_shuffle(expert_indices, num_experts)
+    ordered_inputs = x[ordered_token_indices]
+
+    # get outputs
+    ordered_outs = expert_calculation(ordered_inputs, up_proj, down_proj, offs, act_fn)
+
+    # weigh outputs by score
+    ordered_scores = scores.view(-1, 1)[ordered_token_activations]
+    ordered_weighted_outs = ordered_scores * ordered_outs
+
+    # un-shuffle outputs
+    final_out = torch.zeros_like(x)
+    final_out = final_out.scatter_add(
+        dim=0,
+        index=ordered_token_indices.unsqueeze(-1)
+        .expand(num_token_activations, hidden_dim)
+        .to(torch.int64),
+        src=ordered_weighted_outs,
+    )
+    return final_out
+
+def basic_token_shuffle(
+    expert_indices: Tensor,
+    num_experts: int
+) -> Tuple[Tensor, Tensor, Tensor]:
+    num_tokens, top_k = expert_indices.shape
+    num_token_activations = num_tokens * top_k
+
+    expert_indices = expert_indices.view(-1)
+
+    ordered_token_activations = expert_indices.argsort(stable=True)
+    ordered_token_indices = (
+        ordered_token_activations.div(top_k)
+        .floor()
+        .to(torch.int32)
+    )  #  [T]
+
+    indices_for_histc = expert_indices if expert_indices.is_cuda else expert_indices.float() # histc doesn't work on cpu for integers
+    num_tokens_per_expert = torch.histc(
+        indices_for_histc,
+        bins=num_experts, 
+        min=0, 
+        max=num_experts,
+    )
+    offs = num_tokens_per_expert.cumsum(dim=0).to(torch.int32)
+    
+    return ordered_token_indices, ordered_token_activations, offs
+
+def expert_calculation(
+    ordered_inputs: Tensor,
+    up_proj: Tensor,
+    down_proj: Tensor,
+    offs: Tensor,
+    act_fn: Callable[Tensor, Tensor] = F.silu
+) -> Tensor:
+    x1, x3 = torch._grouped_mm(ordered_inputs, up_proj, offs).chunk(2, dim=1)
+    y1 = act_fn(x1) * x3
+    ordered_outs = torch._grouped_mm(y1, down_proj, offs)
+    return ordered_outs
+
+def decomposed_grouped_mm(
+    ordered_inputs: Tensor, # [num_token_activations, in_features]
+    proj: Tensor, # [num_experts, in_features, out_features]
+    offs: Tensor # [num_experts]
+) -> Tensor: # [num_token_activations, out_features]
+    num_experts = proj.shape[0]
+
+    new_offs = torch.zeros(offs.numel()+1, dtype=offs.dtype, device=offs.device)
+    new_offs[1:] = offs
+    inputs = [ordered_inputs[new_offs[i]:new_offs[i+1]] for i in range(num_experts)]
+
+    outs = []
+    for expert, cur_input in enumerate(inputs):
+        cur_proj = proj[expert].t()
+        cur_out = F.linear(cur_input, cur_proj)
+        outs.append(cur_out)
+
+    outputs = torch.cat(outs, dim=0)
+    return outputs
+
+def single_token_expert_calculation_linear_decomposition(
+    x: Tensor,
+    expert_indices: Tensor,
+    scores: Tensor,
+    up_proj: Tensor,
+    down_proj: Tensor,
+    act_fn: Callable[Tensor, Tensor]=F.silu,
+) -> Tensor:
+    x = x.view(-1, x.shape[-1])
+    assert x.shape[0] == 1, f"single_token_moe_kernel_linear_decomposition only works with inputs of shape [1, n] but got {x.shape}"
+    num_activated_experts = expert_indices.numel()
+    expert_indices = expert_indices.view(-1)
+
+    cur_up_proj = up_proj[expert_indices]
+    cur_down_proj = down_proj[expert_indices]
+
+    outs = []
+    for index in range(num_activated_experts):
+        x1, x3 = F.linear(x, cur_up_proj[index]).chunk(2, dim=-1)
+        y1 = act_fn(x1) * x3
+        cur_out = F.linear(y1, cur_down_proj[index])
+        outs.append(cur_out)
+    
+    out = torch.cat(outs, dim=0)
+    final_out = out * scores.view(-1, 1)
+
+    return final_out
+
+@torch._dynamo.disable()
+def _group_token_indices_by_expert(
+    ordered_token_indices, offs, 
+):
+    token_indices_per_expert = [ordered_token_indices[:offs[0]]]
+    token_indices_per_expert += [ordered_token_indices[start:end] for start,end in zip(offs[:-1],offs[1:])] 
+    return token_indices_per_expert
+
+def multi_token_expert_calculation_linear_decomposition(
+    x: Tensor,
+    expert_indices: Tensor,
+    scores: Tensor,
+    up_proj: Tensor,
+    down_proj: Tensor,
+    act_fn: Callable[Tensor, Tensor],
+):
+    num_experts, expert_dim, hidden_dim = down_proj.shape
+    num_token_activations = expert_indices.numel()
+
+    # get token_shuffle_ordering
+    ordered_token_indices, ordered_token_activations, offs = basic_token_shuffle(expert_indices, num_experts)
+    token_indices_per_expert = _group_token_indices_by_expert(ordered_token_indices, offs)
+    tokens_grouped_by_expert = [x[indices] for indices in token_indices_per_expert]
+
+    # calculate outputs for each expert
+    outs = []
+    for expert, cur_x in enumerate(tokens_grouped_by_expert):
+        cur_up_proj = up_proj[expert].t()
+        cur_down_proj = down_proj[expert].t()
+
+        x1, x3 = F.linear(cur_x, cur_up_proj).chunk(2, dim=1)
+        y1 = act_fn(x1) * x3
+        cur_out = F.linear(y1, cur_down_proj)
+
+        outs.append(cur_out)
+
+    # weigh outputs
+    ordered_outs = torch.cat(outs, dim=0)  # [T*A, D]
+    ordered_scores = scores.view(-1, 1)[ordered_token_activations]# [T*A, 1]
+    ordered_weighted_outs = ordered_scores * ordered_outs
+
+    # un-shuffle outputs
+    final_out = torch.zeros_like(x)
+    final_out = final_out.scatter_add(
+        dim=0,
+        index=ordered_token_indices.unsqueeze(-1)
+        .expand(num_token_activations, hidden_dim)
+        .to(torch.int64),
+        src=ordered_weighted_outs,
+    )
+    return final_out

--- a/torchao/prototype/moe_quant/llama4_quant.py
+++ b/torchao/prototype/moe_quant/llama4_quant.py
@@ -17,7 +17,7 @@ from transformers import AutoTokenizer, Llama4ForCausalLM
 from transformers.models.llama4.modeling_llama4 import Llama4TextMoe
 
 from torchao.prototype.moe_quant.quantizable_moe_modules import (
-    MOEFeedForwardAOQuantizable,
+    MoEFeedForwardAOQuantizable,
 )
 from torchao.quantization.quant_api import _replace_with_custom_fn_if_matches_filter
 
@@ -35,7 +35,7 @@ def convert_fn(module):
     act_fn = module.experts.act_fn
     shared_expert = module.shared_expert
     return_scores = True
-    new_mod = MOEFeedForwardAOQuantizable(
+    new_mod = MoEFeedForwardAOQuantizable(
         hidden_dim,
         expert_dim,
         num_experts,

--- a/torchao/prototype/moe_quant/quantizable_moe_modules.py
+++ b/torchao/prototype/moe_quant/quantizable_moe_modules.py
@@ -1,11 +1,17 @@
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
+from typing import List
 
 from torchao.prototype.moe_quant.utils import FakeExtraDimTensor
+from torchao.prototype.moe_quant.kernels import moe_kernel
 
+__all__ = [
+    "MoEFeedForwardAOQuantizable",
+    "ConditionalFeedForwardAOQuantizable",
+]
 
-class MOEFeedForwardAOQuantizable(nn.Module):
+class MoEFeedForwardAOQuantizable(nn.Module):
     def __init__(
         self,
         hidden_dim,
@@ -19,173 +25,57 @@ class MOEFeedForwardAOQuantizable(nn.Module):
     ) -> None:
         super().__init__()
         self.router = nn.Linear(hidden_dim, num_experts, bias=False)
-        self.experts = ConditionalFeedForwardAOQuantizable(
+        self.experts = ExpertsAOQuantizable(
             num_experts, hidden_dim, expert_dim, act_fn, empty_init
         )
-        self.hidden_dim = hidden_dim
         self.top_k = top_k
         self.shared_expert = shared_expert
         self.return_scores = return_scores
 
     def forward(self, x: Tensor) -> Tensor:
-        batch_size = x.shape[0]
-        x = x.view(-1, self.hidden_dim)  # x: [T, D]
+        batch_size, num_tokens, hidden_dim = x.shape
+        x = x.view(-1, hidden_dim)  # x: [T, H]
+
         scores = self.router(x)  # [T, E]
         scores = F.softmax(scores, dim=-1)
         scores, expert_indices = torch.topk(
             scores, self.top_k, dim=-1
-        )  # [T, A], [T, A]
-        scores /= scores.sum(dim=-1, keepdim=True).to(x.dtype)  # [T, A]
+        )  # [T, K], [T, K]
+        scores /= scores.sum(dim=-1, keepdim=True).to(x.dtype)  # [T, K]
 
-        out = self.experts(x, expert_indices, scores, self.top_k)
+        out = self.experts(x, expert_indices, scores)
         if self.shared_expert:
             out += self.shared_expert(x)
 
         if self.return_scores:
-            return out.reshape(batch_size, -1, self.hidden_dim), scores
+            return out.reshape(batch_size, -1, hidden_dim), scores
         else:
-            return out.reshape(batch_size, -1, self.hidden_dim)
+            return out.reshape(batch_size, -1, hidden_dim)
 
 
-class ConditionalFeedForwardAOQuantizable(nn.Module):
+class ExpertsAOQuantizable(nn.Module):
+    weight_attrs: List[str] = ["up_proj", "down_proj"]
+
     def __init__(self, num_experts, hidden_dim, expert_dim, act_fn, empty_init=True):
         super().__init__()
         if empty_init:
-            self.w1 = nn.Parameter(
+            self.up_proj = nn.Parameter(
+                torch.empty(num_experts, hidden_dim, 2*expert_dim)
+            )  # E, D, H
+            self.down_proj = nn.Parameter(
                 torch.empty(num_experts, expert_dim, hidden_dim)
-            )  # E, I, D
-            self.w2 = nn.Parameter(
-                torch.empty(num_experts, hidden_dim, expert_dim)
-            )  # E, D, I
-            self.w3 = nn.Parameter(
-                torch.empty(num_experts, expert_dim, hidden_dim)
-            )  # E, I, D
+            )  # E, H, D
         else:
-            self.w1 = nn.Parameter(
-                torch.randn(num_experts, expert_dim, hidden_dim)
-            )  # E, I, D
-            self.w2 = nn.Parameter(
-                torch.randn(num_experts, hidden_dim, expert_dim)
-            )  # E, D, I
-            self.w3 = nn.Parameter(
-                torch.randn(num_experts, expert_dim, hidden_dim)
-            )  # E, I, D
-        self.num_experts = num_experts
+            self.up_proj = nn.Parameter(torch.randn(num_experts, hidden_dim, 2*expert_dim))
+            self.down_proj = nn.Parameter(torch.randn(num_experts, expert_dim, hidden_dim))
+
         self.act_fn = act_fn
-        self.hidden_dim = hidden_dim
-        self.expert_dim = expert_dim
 
     def forward(
         self,
         x: Tensor,  # T, D
         expert_indices: Tensor,  # T, A
-        expert_weights: Tensor,  # T, A
-        top_k: int,
+        scores: Tensor,  # T, A
     ) -> Tensor:
-        num_tokens, _hidden_dim = x.shape
-        num_token_activations = num_tokens * top_k
 
-        if x.shape[0] == 1 and not isinstance(
-            self.w1, FakeExtraDimTensor
-        ):  # only 1 token (can be done without graph breaks when compiled)
-            outs = []
-            expert_indices = expert_indices.view(top_k)
-            # collect used experts
-            w1 = self.w1[expert_indices]
-            w2 = self.w2[expert_indices]
-            w3 = self.w3[expert_indices]
-            # run token through each expert
-            for index in range(top_k):
-                y1 = F.silu(F.linear(x, w1[index]))
-                y3 = F.linear(x, w3[index])
-                y2 = w2[index]
-
-                cur_out = F.linear(y1 * y3, y2)
-                outs.append(cur_out)
-
-            # combine outputs
-            final_out = (
-                (torch.cat(outs, dim=0) * expert_weights.view(-1, 1))
-                .sum(dim=0)
-                .reshape(x.shape)
-            )
-            return final_out
-        else:
-            expert_list = [x for x in range(self.num_experts)]
-
-            # shuffle tokens into groups for each expert
-            ordered_token_activations = expert_indices.view(-1).argsort(
-                stable=True
-            )  # [A]
-            ordered_token_indices = (
-                ordered_token_activations.div(top_k).floor().to(torch.int64)
-            )  #  [T]
-            if not expert_indices.is_cuda:  # histc doesn't work on cpu for integers
-                num_tokens_per_expert = torch.bincount(
-                    expert_indices.view(-1) + 1, minlength=self.num_experts + 1
-                )
-            else:
-                num_tokens_per_expert = torch.histc(
-                    expert_indices,
-                    bins=self.num_experts + 1,
-                    min=-1,
-                    max=self.num_experts,
-                )  #  [E+1] (added leading 0 so can be used for indexing)
-            cum_tokens_per_expert = num_tokens_per_expert.cumsum(0).to(
-                torch.int64
-            )  #  [E+1]
-
-            @torch._dynamo.disable()
-            def group_tokens_by_expert(
-                ordered_token_indices, cum_tokens_per_expert, expert_list
-            ):
-                token_indices_per_expert = [
-                    ordered_token_indices[
-                        cum_tokens_per_expert[expert] : cum_tokens_per_expert[
-                            expert + 1
-                        ]
-                    ].to(torch.int64)
-                    for expert in expert_list
-                ]  # [T'(e1)], [T'(e2)] ...
-                return token_indices_per_expert
-
-            token_indices_per_expert = group_tokens_by_expert(
-                ordered_token_indices, cum_tokens_per_expert, expert_list
-            )
-            tokens_grouped_by_expert = [
-                x[indices] for indices in token_indices_per_expert
-            ]
-
-            # calculate outputs for each expert
-            outs = []
-            for cur_x, expert in zip(tokens_grouped_by_expert, expert_list):
-                w1 = self.w1[expert]  # I, D
-                w2 = self.w2[expert]  # D, I
-                w3 = self.w3[expert]  # I, D
-
-                y1 = F.silu(F.linear(cur_x, w1))
-                y3 = F.linear(cur_x, w3)
-                y2 = w2
-
-                cur_out = F.linear(y1 * y3, y2)  # [T'(e), D]
-                outs.append(cur_out)
-
-            # weigh outputs
-            ordered_outs = torch.cat(outs, dim=0)  # [T*A, D]
-            ordered_token_activation_weights = expert_weights.view(-1, 1)[
-                ordered_token_activations
-            ].view(-1, 1)  # [T*A, 1]
-            weighted_ordered_outs = (
-                ordered_outs * ordered_token_activation_weights
-            )  # [T*A, D]
-
-            # sum weighted token-activation outputs together for each token
-            final_out = torch.zeros_like(x)  #  [T, D]
-            final_out = final_out.scatter_add(
-                dim=0,
-                index=ordered_token_indices.unsqueeze(-1)
-                .expand(num_token_activations, self.hidden_dim)
-                .to(torch.int64),
-                src=weighted_ordered_outs,
-            )
-        return final_out
+        return moe_kernel(x, expert_indices, scores, self.up_proj, self.down_proj, self.act_fn)

--- a/torchao/prototype/moe_quant/utils.py
+++ b/torchao/prototype/moe_quant/utils.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+import torchao
+import torch.nn.functional as F
 from torch.utils._python_dispatch import (
     return_and_correct_aliasing,
 )
@@ -12,7 +14,7 @@ from torch.utils._python_dispatch import (
 aten = torch.ops.aten
 
 from enum import Enum, auto
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Callable
 
 from torchao.quantization.quant_api import (
     _QUANTIZE_CONFIG_HANDLER,
@@ -21,17 +23,210 @@ from torchao.quantization.quant_api import (
     register_quantize_module_handler,
 )
 from torchao.utils import fill_defaults
+from torch.ao.quantization.utils import getattr_from_fqn
+
+import warnings
+warnings.simplefilter("ignore", lineno=84)
+warnings.simplefilter("ignore", lineno=105)
+
+__all__ = [
+    "MoEQuantConfig",
+    "MoEMapping",
+    "FakeExtraDimTensor",
+    "UseFakeExtraDimTensor",
+    "moe_filter",
+]
 
 
-class DummyModule(torch.nn.Module):
-    """This is used because the TorchAO quantization functions tend to operate on modules so to apply the transform to a tensor, we can load a
-    DummyModule with the target tensor and then apply the transformation to the module and then extract the transformed tensor.
+class UseFakeExtraDimTensor(Enum):
+    """Enum that indicate whether to use FakeExtraDimTensor"""
+
+    TRUE = auto()
+    FALSE = auto()
+    AS_FALLBACK = auto()
+
+
+@dataclass
+class MoEQuantConfig(AOBaseConfig):
+    """Configuration for applying quantization to MoE
+    Args:
+        `Optional[base_config]`: normal AO Config to be applied to a MoEFeedforwardAOQuantizable module,
+            if None, then will only do the conversion to MoEFeedforwardAOQuantizable using the mapping
+        `Optional[mapping]`: MoEMapping, if None, then this will do no conversion, note: only 
+            MoEFeedforwardAOQuantizable modules can be quantized.
     """
 
-    def __init__(self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
-        super().__init__()
-        self.weight = weight
-        self.bias = bias
+    base_config: Optional[AOBaseConfig] = None
+    mapping: Optional["MoEMapping"] = None
+    
+    use_fake_extra_dim_tensor: UseFakeExtraDimTensor = UseFakeExtraDimTensor.AS_FALLBACK
+    set_inductor_config: bool = True
+
+@register_quantize_module_handler(MoEQuantConfig)
+def moe_convert_and_quant_fn(module: torch.nn.Module, config: MoEQuantConfig):
+
+    mapping = config.mapping
+    base_config = config.base_config
+    assert mapping is not None or base_config is not None, "need one of mapping or base_config to use MoEQuantConfig"
+
+    # maybe convert module to quantizable
+    if mapping is not None and isinstance(module, mapping.target_module_type):
+        module=_convert_module_to_ao_quantizable(module, mapping)
+
+    # maybe quantize module
+    if base_config is not None and isinstance(module, MoEFeedForwardAOQuantizable):
+        module = _quantize_moe_module(module, config)
+
+    return module     
+
+def _quantize_moe_module(module: torch.nn.Module, config: MoEQuantConfig):
+    assert isinstance(module, MoEFeedForwardAOQuantizable), f"can only apply quantization to MoEFeedForwardAOQuantizable modules but got {type(module)}"
+
+    experts = module.experts
+
+    for weight_attr in experts.weight_attrs:
+        param = getattr(experts, weight_attr)
+        assert param.dim() == 3, (
+            f"when applying moe_quant to {module} expected 3D tensor for {weight_attr} but got {param.dim()}"
+        )
+        assert isinstance(config.base_config, AOBaseConfig), (
+            f"MoEQuantConfig expected to be initialized with an AOBaseConfig but got {type(config.base_config)}"
+            + "this can happen if you initiaze with MoEQuantConfig(AOConfig) rather than MoEQuantConfig(AOConfig())"
+        )
+        new_param = _quantize_moe_tensor(param, config)
+        new_param = torch.nn.Parameter(new_param, requires_grad=False)
+        setattr(module, weight_attr, new_param)
+        del param
+    return module
+
+
+
+# Module-level flag to track if we've already printed the error
+_quantize_moe_tensor_has_printed_error = False
+
+def _quantize_moe_tensor(weight: torch.Tensor, config: MoEQuantConfig):
+    def _quantize_moe_tensor_base(weight, config):
+        base_config_handler = _QUANTIZE_CONFIG_HANDLER[type(config.base_config)]
+        dummy_mod = DummyModule(weight)
+        quant_mod = base_config_handler(dummy_mod, config.base_config)
+        return quant_mod.weight
+
+    def _quantize_moe_tensor_fake_extra_dim_tensor(weight: torch.Tensor, config: MoEQuantConfig):
+        base_config_handler = _QUANTIZE_CONFIG_HANDLER[type(config.base_config)]
+        # break 3D tensor
+        tensors = [weight[i] for i in range(weight.shape[0])]
+        # put tensors into modules since the handlers target modules not tensors
+        dummy_modules = [DummyModule(tensor) for tensor in tensors]
+        # apply handler to each module
+        quant_mods = list(
+            map(lambda x: base_config_handler(x, config.base_config), dummy_modules)
+        )
+        # pack quantized subclasses into FakeExtraDimTensor
+        quant_weight = FakeExtraDimTensor([mod.weight for mod in quant_mods])
+        return quant_weight
+
+    global _quantize_moe_tensor_has_printed_error
+
+    use_fake = config.use_fake_extra_dim_tensor
+    if use_fake == UseFakeExtraDimTensor.FALSE:
+        return _quantize_moe_tensor_base(weight, config)
+    elif use_fake == UseFakeExtraDimTensor.AS_FALLBACK:
+        try:
+            return _quantize_moe_tensor_base(weight, config)
+        except Exception as e:
+            if not _quantize_moe_tensor_has_printed_error:
+                print(f"tried to do moe_quant but got error: {e}")
+                _quantize_moe_tensor_has_printed_error = True
+            return _quantize_moe_tensor_fake_extra_dim_tensor(weight, config)
+    else:  # This handles UseFakeExtraDimTensor.TRUE
+        return _quantize_moe_tensor_fake_extra_dim_tensor(weight, config)
+
+@dataclass
+class MoEMapping:
+    """This mapping dataclass is used to map an existing MoE module to the AOQuantizable one
+    and is used with the convert_moe_with_mapping fn to convert a model to use the AO moe modules
+    """
+    target_module_type: type
+
+    router_fqn: str="gate"
+    top_k_fqn: Optional[str]="num_activated_experts"
+
+    # if up_proj is a single tensor, leave up_proj_part2_fqn as None, otherwise list the fqn 
+    # for w1 and up_proj_fqn and w3 as up_proj_part2_fqn
+    up_proj_fqn: str="cond_ffn.w1"
+    up_proj_part2_fqn: Optional[str]="cond_ffn.w3"
+    down_proj_fqn: str="cond_ffn.w2" # also known as down_proj
+
+    # what is the order of indices of the weights,
+    # specifically which order are the experts, in_features, out_features indices in?
+    # for up_proj this would be experts,  hidden_dim, expert_dim*2,
+    # for down_proj this would be experts, expert_dim, hidden_dim,
+    order_of_weight_indices: Union[Tuple[int], Tuple[int]]=(0, 2, 1,)
+
+    # can't both be None
+    activation_fn: Optional[Callable[[torch.Tensor], torch.Tensor]]=F.silu
+    activation_fn_fqn: Optional[str]=None
+    
+    # Options
+    shared_expert_fqn: Optional[str]=None
+    return_scores: bool=False
+
+def _convert_module_to_ao_quantizable(module: torch.nn.Module, mapping: MoEMapping):
+    assert isinstance(module, mapping.target_module_type), (
+        f"_convert_module_to_ao_quantizable only works on modules of type {mapping.target_module_type} but got {type(module)}"
+    )
+
+
+    # get router and top_k
+    router = getattr_from_fqn(module, mapping.router_fqn)
+    top_k = getattr_from_fqn(module, mapping.top_k_fqn)
+
+
+    # get up and down_proj
+    order_of_indices = mapping.order_of_weight_indices
+    if mapping.up_proj_part2_fqn is None:
+        up_proj = getattr_from_fqn(module, mapping.up_proj_fqn).permute(*order_of_indices).contiguous()
+    else:
+        w1 = getattr_from_fqn(module, mapping.up_proj_fqn).permute(*order_of_indices)
+        w3 = getattr_from_fqn(module, mapping.up_proj_part2_fqn).permute(*order_of_indices)
+        up_proj = torch.cat((w1, w3), dim=2).contiguous()
+    
+
+    down_proj = getattr_from_fqn(module, mapping.down_proj_fqn).permute(*order_of_indices).contiguous()
+
+
+    # get sizes
+    num_experts, expert_dim, hidden_dim = down_proj.shape
+
+    # get activation_fn
+    activation_fn = mapping.activation_fn
+    if activation_fn is None:
+        activation_fn = getattr_from_fqn(module, mapping.activation_fn_fqn)
+    assert activation_fn is not None, "both activation_fn and activation_fn_fqn can't be None in the MoEMapping"
+
+
+    # get final options
+    shared_expert = None
+    if isinstance(mapping.shared_expert_fqn, str):
+        shared_expert = getattr_from_fqn(module, mapping.shared_expert_fqn)
+    return_scores = mapping.return_scores
+
+    # make new module
+    new_module = torchao.prototype.moe_quant.MoEFeedForwardAOQuantizable(
+        hidden_dim, 
+        expert_dim, 
+        num_experts, 
+        top_k, 
+        activation_fn,
+        shared_expert,
+        return_scores,
+    )
+
+    new_module.router = router
+    new_module.experts.up_proj = torch.nn.Parameter(up_proj)
+    new_module.experts.down_proj = torch.nn.Parameter(down_proj)
+
+    return new_module
 
 
 class FakeExtraDimTensor(torch.Tensor):
@@ -220,94 +415,16 @@ class FakeExtraDimTensor(torch.Tensor):
             raise e
 
 
-class UseFakeExtraDimTensor(Enum):
-    """Enum that indicate whether to use FakeExtraDimTensor"""
-
-    TRUE = auto()
-    FALSE = auto()
-    AS_FALLBACK = auto()
-
-
-@dataclass
-class MoEQuantConfig(AOBaseConfig):
-    """Configuration for applying quantization to MoE
-    Args:
-        `base_config`: normal AO Config
+class DummyModule(torch.nn.Module):
+    """This is used because the TorchAO quantization functions tend to operate on modules so to apply the transform to a tensor, we can load a
+    DummyModule with the target tensor and then apply the transformation to the module and then extract the transformed tensor.
     """
 
-    base_config: AOBaseConfig
-    use_fake_extra_dim_tensor: UseFakeExtraDimTensor = UseFakeExtraDimTensor.AS_FALLBACK
-    set_inductor_config: bool = True
+    def __init__(self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
+        super().__init__()
+        self.weight = weight
+        self.bias = bias
 
 
-# Module-level flag to track if we've already printed the error
-_moe_quant_tensor_has_printed_error = False
-
-
-def _moe_quant_tensor(weight, config):
-    def _moe_quant_tensor_base(weight, config):
-        base_config_handler = _QUANTIZE_CONFIG_HANDLER[type(config.base_config)]
-        dummy_mod = DummyModule(weight)
-        quant_mod = base_config_handler(dummy_mod, config.base_config)
-        return quant_mod.weight
-
-    def _moe_quant_tensor_fake_extra_dim_tensor(weight, config):
-        base_config_handler = _QUANTIZE_CONFIG_HANDLER[type(config.base_config)]
-        # break 3D tensor
-        tensors = [weight[i] for i in range(weight.shape[0])]
-        # put tensors into modules since the handlers target modules not tensors
-        dummy_modules = [DummyModule(tensor) for tensor in tensors]
-        # apply handler to each module
-        quant_mods = list(
-            map(lambda x: base_config_handler(x, config.base_config), dummy_modules)
-        )
-        # pack quantized subclasses into FakeExtraDimTensor
-        quant_weight = FakeExtraDimTensor([mod.weight for mod in quant_mods])
-        return quant_weight
-
-    global _moe_quant_tensor_has_printed_error
-
-    use_fake = config.use_fake_extra_dim_tensor
-    if use_fake == UseFakeExtraDimTensor.FALSE:
-        return _moe_quant_tensor_base(weight, config)
-    elif use_fake == UseFakeExtraDimTensor.AS_FALLBACK:
-        try:
-            return _moe_quant_tensor_base(weight, config)
-        except Exception as e:
-            if not _moe_quant_tensor_has_printed_error:
-                print(f"tried to do moe_quant but got error: {e}")
-                _moe_quant_tensor_has_printed_error = True
-            return _moe_quant_tensor_fake_extra_dim_tensor(weight, config)
-    else:  # This handles UseFakeExtraDimTensor.TRUE
-        return _moe_quant_tensor_fake_extra_dim_tensor(weight, config)
-
-
-@register_quantize_module_handler(MoEQuantConfig)
-def moe_quant_fn(module, config: MoEQuantConfig):
-    import warnings
-
-    warnings.simplefilter("ignore", lineno=84)
-    warnings.simplefilter("ignore", lineno=105)
-
-    for weight_attr in ["w1", "w2", "w3"]:
-        param = getattr(module, weight_attr)
-        assert param.dim() == 3, (
-            f"when applying moe_quant to {module} expected 3D tensor for {weight_attr} but got {param.dim()}"
-        )
-        assert isinstance(config.base_config, AOBaseConfig), (
-            f"MoEQuantConfig expected to be initialized with an AOBaseConfig but got {type(config.base_config)}"
-            + "this can happen if you initiaze with MoEQuantConfig(AOConfig) rather than MoEQuantConfig(AOConfig())"
-        )
-        new_param = _moe_quant_tensor(param, config)
-        new_param = torch.nn.Parameter(new_param, requires_grad=False)
-        setattr(module, weight_attr, new_param)
-        del param
-    return module
-
-
-def moe_filter(module, fqn):
-    return "MOEFeedForwardAOQuantizable" in str(type(module))
-
-
-def cond_ffn_filter(module, fqn):
-    return "ConditionalFeedForwardAOQuantizable" in str(type(module))
+def moe_filter(module: torch.nn.Module, fqn: str):
+    return "MoEFeedForwardAOQuantizable" in str(type(module))

--- a/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
@@ -28,10 +28,13 @@ if importlib.util.find_spec("fbgemm_gpu") is None:
     quantize_int4_preshuffle = None
     quantize_fp8_row = None
 else:
-    from fbgemm_gpu.experimental.gen_ai.quantize import (
-        quantize_fp8_row,
-        quantize_int4_preshuffle,
-    )
+    try:
+        from fbgemm_gpu.experimental.gen_ai.gen_ai.quantize import (
+            quantize_fp8_row,
+            quantize_int4_preshuffle,
+        )
+    except:
+        pass
 
 
 class Int4PreshuffledTensor(TorchAOBaseTensor):


### PR DESCRIPTION
Summary:

now that the pytorch grouped_mm kernels don't require padding, refactoring the moe implementation to use that rather than what was there before.

DONE
-implement moe with grouped_mm [x]
-add handling for generic module swap to AOQuantizable (MoEMapping) [x] -refactor MoEQuantConfig to swap generic modules [x]

TODO
-add dispatch from grouped_mm to linear decomposition of quantized kernel
-compare linear decomposition vs new linear decomposition vs grouped_mm for eager, compile, autotuned compile linear decomposition
-compare linear decomposition vs new linear decomposition for quantized kernels
-add scaled_group_gemm and fbgemm kernel (probably in a new PR)

ISSUE:
the autotuned grouped_mm kernels don't give the correct output, but then work in eager and compile with reduce-overhead. why?

see new_run.log output, first 2 runs are fine, line 144 is nonsense

Test Plan:

sh run.sh

Reviewers:

Subscribers:

Tasks:

Tags: