### PR TITLE
Migrate to unittest for files in test/dtypes

### DIFF
--- a/test/dtypes/test_affine_quantized_tensor_parallel.py
+++ b/test/dtypes/test_affine_quantized_tensor_parallel.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 import unittest
 
-import pytest
 import torch
 from torch.distributed._tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.testing._internal import common_utils
@@ -37,7 +36,7 @@ except ModuleNotFoundError:
     has_gemlite = False
 
 if torch.version.hip is not None:
-    pytest.skip("Skipping the test in ROCm", allow_module_level=True)
+    raise unittest.SkipTest("Skipping the test in ROCm", allow_module_level=True)
 
 
 class TestAffineQuantizedTensorParallel(DTensorTestBase):


### PR DESCRIPTION
Fix part of #1621 

Migrate test files in `test/dtypes` from `pytest` to `unittest`.