### PR TITLE
fix mx kernel tests

### DIFF
--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -1394,7 +1394,7 @@ if TORCH_VERSION_AT_LEAST_2_7 and has_triton():
         scale_e8m0_dim1 = scale_e8m0_dim1.view(torch.float8_e8m0fnu)
         return (
             x_hp_d1_normalized.t(),
-            scale_e8m0_dim1,
+            scale_e8m0_dim1.unsqueeze(-1),
         )
 
     @triton.jit


### PR DESCRIPTION
Summary:

This was broken in main branch due to shape mismatch between reference
dim1 kernel and triton dim1 kernel scale, fixing

Test Plan:

```bash
pytest test/prototype/mx_formats/test_kernels.py -s -k test_triton_mxfp8_dim1_randn
pytest test/prototype/mx_formats/test_kernels.py -s -k
```

Reviewers:

Subscribers:

Tasks:

Tags: