### PR TITLE
Clarifying the meaning of VERSION in AOBaseConfig

### DIFF
--- a/test/core/test_config.py
+++ b/test/core/test_config.py
@@ -187,5 +187,19 @@ def test_version_mismatch():
             config_from_dict(reconstructable)
 
 
+def test_default_version():
+    """Making sure the default version for a new config inheriting from AOBaseConfig is always 1
+    because it's the default VERSION that all children has when they haven't explicitly
+    defined a VERSION class variable
+    """
+
+    @dataclass
+    class DummyConfig(AOBaseConfig):
+        pass
+
+    config = DummyConfig()
+    assert config.VERSION == 1, "Default version must be 1"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -20,6 +20,9 @@ __all__ = [
     "ALLOWED_AO_MODULES",
 ]
 
+# the default version for all configs, should never change
+_DEFAULT_VERSION = 1
+
 
 class AOBaseConfig(abc.ABC):
     """
@@ -46,8 +49,16 @@ class AOBaseConfig(abc.ABC):
 
     """
 
-    # Base Version of a config
-    VERSION: ClassVar[int] = 1
+    """
+    Note: this is not the version of AOBaseConfig, but the default version for all child configs
+    inheriting from AOBaseConfig, and it should be `_DEFAULT_VERSION` and never change
+    this is making sure all configs has a version defined, when they need to bump the version
+    they have to define a class variable VERSION for the child config to overwrite the default VERSION
+    that's defined here. Different child configs will maintain their own VERSION.
+
+    default Version of a config, should never change
+    """
+    VERSION: ClassVar[int] = _DEFAULT_VERSION
 
 
 class VersionMismatchError(Exception):


### PR DESCRIPTION
Summary:
the VERSION means default version for child configs, it should never change. Also added test to enforce this

Test Plan:
python test/core/test_config.py
Reviewers:

Subscribers:

Tasks:

Tags: