### PR TITLE
Convert model inference test from pytest to unittest

### DIFF
--- a/test/test_ao_models.py
+++ b/test/test_ao_models.py
@@ -6,9 +6,9 @@
 import unittest
 
 import torch
+from torch.testing._internal import common_utils
 
 from torchao._models.llama.model import Transformer
-from torchao.testing import common_utils
 
 
 def init_model(name="stories15M", device="cpu", precision=torch.bfloat16):

--- a/test/test_ao_models.py
+++ b/test/test_ao_models.py
@@ -10,14 +10,6 @@ import torch
 from torchao._models.llama.model import Transformer
 from torchao.testing import common_utils
 
-_AVAILABLE_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
-_BATCH_SIZES = [1, 4]
-_TRAINING_MODES = [True, False]
-
-# Define test parameters
-COMMON_DEVICES = common_utils.parametrize("device", _AVAILABLE_DEVICES)
-COMMON_DTYPES = common_utils.parametrize("dtype", [torch.float32, torch.bfloat16])
-
 
 def init_model(name="stories15M", device="cpu", precision=torch.bfloat16):
     """Initialize and return a Transformer model with specified configuration."""
@@ -29,9 +21,11 @@ def init_model(name="stories15M", device="cpu", precision=torch.bfloat16):
 class TorchAOBasicTestCase(unittest.TestCase):
     """Test suite for basic Transformer inference functionality."""
 
-    @COMMON_DEVICES
-    @common_utils.parametrize("batch_size", _BATCH_SIZES)
-    @common_utils.parametrize("is_training", _TRAINING_MODES)
+    @common_utils.parametrize(
+        "device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+    )
+    @common_utils.parametrize("batch_size", [1, 4])
+    @common_utils.parametrize("is_training", [True, False])
     def test_ao_inference_mode(self, device, batch_size, is_training):
         # Initialize model with specified device
         random_model = init_model(device=device)

--- a/test/test_ao_models.py
+++ b/test/test_ao_models.py
@@ -3,7 +3,8 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+import unittest
+
 import torch
 
 from torchao._models.llama.model import Transformer
@@ -12,23 +13,57 @@ _AVAILABLE_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
 def init_model(name="stories15M", device="cpu", precision=torch.bfloat16):
+    """Initialize and return a Transformer model with specified configuration."""
     model = Transformer.from_name(name)
     model.to(device=device, dtype=precision)
     return model.eval()
 
 
-@pytest.mark.parametrize("device", _AVAILABLE_DEVICES)
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("is_training", [True, False])
-def test_ao_llama_model_inference_mode(device, batch_size, is_training):
-    random_model = init_model(device=device)
-    seq_len = 16
-    input_ids = torch.randint(0, 1024, (batch_size, seq_len)).to(device)
-    input_pos = None if is_training else torch.arange(seq_len).to(device)
-    with torch.device(device):
-        random_model.setup_caches(
-            max_batch_size=batch_size, max_seq_length=seq_len, training=is_training
-        )
-    for i in range(3):
-        out = random_model(input_ids, input_pos)
-        assert out is not None, "model failed to run"
+class TestAOLlamaModel(unittest.TestCase):
+    """Test suite for AO Llama model inference functionality."""
+
+    def test_ao_llama_model_inference_mode(self):
+        """Test model inference across different devices, batch sizes, and training modes."""
+        # Define test parameters
+        devices = _AVAILABLE_DEVICES
+        batch_sizes = [1, 4]
+        training_modes = [True, False]
+
+        # Iterate through all parameter combinations
+        for device in devices:
+            for batch_size in batch_sizes:
+                for is_training in training_modes:
+                    # Use subTest to create individual test cases for each parameter combination
+                    with self.subTest(
+                        device=device, batch_size=batch_size, is_training=is_training
+                    ):
+                        self._test_ao_llama_model_inference_mode(
+                            device, batch_size, is_training
+                        )
+
+    def _test_ao_llama_model_inference_mode(self, device, batch_size, is_training):
+        """Helper method to run a single inference test with given parameters."""
+        # Initialize model with specified device
+        random_model = init_model(device=device)
+
+        # Set up test input parameters
+        seq_len = 16
+        input_ids = torch.randint(0, 1024, (batch_size, seq_len)).to(device)
+
+        # input_pos is None for training mode, tensor for inference mode
+        input_pos = None if is_training else torch.arange(seq_len).to(device)
+
+        # Setup model caches within the device context
+        with torch.device(device):
+            random_model.setup_caches(
+                max_batch_size=batch_size, max_seq_length=seq_len, training=is_training
+            )
+
+        # Run multiple inference iterations to ensure consistency
+        for i in range(3):
+            out = random_model(input_ids, input_pos)
+            self.assertIsNotNone(out, f"Model failed to run on iteration {i}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Summary:**
Converts TorchAO model (`Transformer`) inference test from Pytest into Unittest. Annotations are added for better readability.
- Related to: #1621 

cc @osbm