### PR TITLE
Remove warnings in favor of skiptests for Moe code

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -380,7 +380,9 @@ class TestFloat8Linear:
         "linear_dtype", [torch.bfloat16, torch.float16, torch.float32]
     )
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_90(), "CUDA capability < 9.0")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_90(), "CUDA capability < 9.0"
+    )
     @skip_if_rocm("ROCm enablement in progress")
     def test_linear_from_recipe(
         self,
@@ -389,7 +391,6 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
     ):
-
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)
         config = Float8LinearConfig.from_recipe_name(recipe_name)

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -8,7 +8,6 @@ import itertools
 import random
 import re
 import unittest
-import warnings
 
 import pytest
 import torch

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -381,6 +381,7 @@ class TestFloat8Linear:
         "linear_dtype", [torch.bfloat16, torch.float16, torch.float32]
     )
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_90(), "CUDA capability < 9.0")
     @skip_if_rocm("ROCm enablement in progress")
     def test_linear_from_recipe(
         self,
@@ -389,11 +390,6 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
     ):
-        if torch.cuda.get_device_capability() < (9, 0):
-            warnings.warn(
-                f"CUDA capability {torch.cuda.get_device_capability()} < (9.0)"
-            )
-            pytest.skip()
 
         x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)

--- a/test/prototype/moe_training/test_fsdp.py
+++ b/test/prototype/moe_training/test_fsdp.py
@@ -38,7 +38,9 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
+    pytest.skip(
+        "torchtitan not installed, skipping MoE tests.", allow_module_level=True
+    )
 
 
 def test_moe_float8_training_fsdp():

--- a/test/prototype/moe_training/test_fsdp.py
+++ b/test/prototype/moe_training/test_fsdp.py
@@ -38,10 +38,7 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    import warnings
-
-    warnings.warn("torchtitan not installed, skipping MoE tests.")
-    pytest.skip(allow_module_level=True)
+    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
 
 
 def test_moe_float8_training_fsdp():

--- a/test/prototype/moe_training/test_fsdp_tp.py
+++ b/test/prototype/moe_training/test_fsdp_tp.py
@@ -30,12 +30,10 @@ try:
         parallelize_module,
     )
 except ImportError:
-    import warnings
-
-    warnings.warn(
-        "torch version is too old, these tests require nightly build. Skipping MoE training tests."
+    pytest.skip(
+        "torch version is too old, these tests require nightly build. Skipping MoE training tests.",
+        allow_module_level=True
     )
-    pytest.skip(allow_module_level=True)
 
 # this feature requires CUDA and SM89+
 if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
@@ -60,10 +58,7 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    import warnings
-
-    warnings.warn("torchtitan not installed, skipping MoE tests.")
-    pytest.skip(allow_module_level=True)
+    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/test_fsdp_tp.py
+++ b/test/prototype/moe_training/test_fsdp_tp.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     pytest.skip(
         "torch version is too old, these tests require nightly build. Skipping MoE training tests.",
-        allow_module_level=True
+        allow_module_level=True,
     )
 
 # this feature requires CUDA and SM89+
@@ -58,7 +58,9 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
+    pytest.skip(
+        "torchtitan not installed, skipping MoE tests.", allow_module_level=True
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/test_tp.py
+++ b/test/prototype/moe_training/test_tp.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     pytest.skip(
         "torch version is too old, these tests require nightly build. Skipping MoE training tests.",
-        allow_module_level=True
+        allow_module_level=True,
     )
 
 
@@ -58,7 +58,9 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
+    pytest.skip(
+        "torchtitan not installed, skipping MoE tests.", allow_module_level=True
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/test_tp.py
+++ b/test/prototype/moe_training/test_tp.py
@@ -29,12 +29,10 @@ try:
         parallelize_module,
     )
 except ImportError:
-    import warnings
-
-    warnings.warn(
-        "torch version is too old, these tests require nightly build. Skipping MoE training tests."
+    pytest.skip(
+        "torch version is too old, these tests require nightly build. Skipping MoE training tests.",
+        allow_module_level=True
     )
-    pytest.skip(allow_module_level=True)
 
 
 # this feature requires CUDA and SM89+
@@ -60,10 +58,7 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    import warnings
-
-    warnings.warn("torchtitan not installed, skipping MoE tests.")
-    pytest.skip(allow_module_level=True)
+    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -22,7 +22,9 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
+    pytest.skip(
+        "torchtitan not installed, skipping MoE tests.", allow_module_level=True
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -22,10 +22,7 @@ try:
     from torchtitan.experiments.llama4.model.args import TransformerModelArgs
     from torchtitan.experiments.llama4.model.moe import MoE
 except ImportError:
-    import warnings
-
-    warnings.warn("torchtitan not installed, skipping MoE tests.")
-    pytest.skip(allow_module_level=True)
+    pytest.skip("torchtitan not installed, skipping MoE tests.", allow_module_level=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
warnings will pollute stdout, instead you can just use skiptests which will make the output cleaner

Before 

```
2025-08-01T02:07:42.5497383Z [33m=============================== warnings summary ===============================[0m
2025-08-01T02:07:42.5497763Z test/prototype/moe_training/test_fsdp_tp.py:35
2025-08-01T02:07:42.5498495Z   /pytorch/ao/test/prototype/moe_training/test_fsdp_tp.py:35: UserWarning: torch version is too old, these tests require nightly build. Skipping MoE training tests.
2025-08-01T02:07:42.5499180Z     warnings.warn(
2025-08-01T02:07:42.5499314Z 
2025-08-01T02:07:42.5499434Z test/prototype/moe_training/test_tp.py:34
2025-08-01T02:07:42.5500233Z   /pytorch/ao/test/prototype/moe_training/test_tp.py:34: UserWarning: torch version is too old, these tests require nightly build. Skipping MoE training tests.
2025-08-01T02:07:42.5500905Z     warnings.warn(
```

And after

you can add the -rs flag if you want to explicitly list out reasons why something is skipped


```
ao ❯ pytest test/prototype/moe_training/test_tp.py
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.10.14, pytest-7.4.0, pluggy-1.5.0
rootdir: /Users/marksaroufim/Dev/ao
plugins: hypothesis-6.100.5, anyio-4.6.2.post1
collected 0 items / 1 skipped

===================================================================== 1 skipped in 14.28s =====================================================================

✦ ~/Dev/ao remove-warnings-only 18s
ao ❯ pytest test/prototype/moe_training/test_tp.py -rs

===================================================================== test session starts =====================================================================
platform darwin -- Python 3.10.14, pytest-7.4.0, pluggy-1.5.0
rootdir: /Users/marksaroufim/Dev/ao
plugins: hypothesis-6.100.5, anyio-4.6.2.post1
collected 0 items / 1 skipped

=================================================================== short test summary info ===================================================================
SKIPPED [1] test/prototype/moe_training/test_tp.py:40: CUDA not available or compute capability < 8.9
===================================================================== 1 skipped in 4.64s ======================================================================

✦ ~/Dev/ao remove-warnings-only 6s
ao ❯
```