### PR TITLE
[MoE training] Assert expert weights are column-major; preserve subclass with transpose

### DIFF
--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -95,10 +95,7 @@ class _Float8GroupedMM(torch.autograd.Function):
         assert not _is_column_major(A), "A must be row-major"
 
         # Due to hardware requirements, the right operand in a scaled grouped GEMM must be column-major.
-        if not _is_column_major(B_t):
-            # FSDP will complain if B_t (weights) is not contiguous, we can't require B_t to be column-major.
-            # TODO: figure out better solution than transposing for each forward pass.
-            B_t = B_t.transpose(-2, -1).contiguous().transpose(-2, -1)
+        assert _is_column_major(B_t), "B must be column-major"
 
         # Convert high precision input tensor to float8, row-major for left operand of grouped GEMM.
         # A shape: (M, K) or (B, M, K)

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -30,6 +30,7 @@ _ops_to_preserve_subclass = {
     torch.ops.aten._pin_memory.default,
     torch.ops.aten.split.Tensor,
     torch.ops.aten.clone.default,
+    torch.ops.aten.transpose.int,
 }
 
 


### PR DESCRIPTION
Once https://github.com/pytorch/torchtitan/pull/1517 lands we need to:
- remove the temporary workaround of dynamic memory layout transformation from row-major to col-major before every grouped gemm, and just assert weights are col-major.
- preserve subclass through transpose ops, so the `weight.transpose(-2, -1)` op doesn't lose the subclass and thus no override to fp8 grouped gemm is done