### PR TITLE
fix lm_eval import in eval_hf_models.py

### DIFF
--- a/benchmarks/_models/eval_hf_models.py
+++ b/benchmarks/_models/eval_hf_models.py
@@ -13,7 +13,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig
 
 from benchmarks.microbenchmarks.utils import string_to_config
 from torchao.quantization import *  # noqa: F401, F403
-from torchao.quantization.utils import _lm_eval_available
 
 
 def quantize_model_and_save(model_id, quant_config, output_dir="results"):
@@ -113,7 +112,9 @@ def run(
 
 
 if __name__ == "__main__":
-    if not _lm_eval_available:
+    try:
+        import lm_eval  # noqa: F401
+    except:
         print(
             "lm_eval is required to run this script. Please install it using pip install lm-eval."
         )


### PR DESCRIPTION
Summary:

the `_lm_eval_available` function does not exist anymore, deleting it
and adding a manual check for `lm_eval`

Test Plan:

```
with-proxy python benchmarks/_models/eval_hf_models.py --model_id meta-llama/Llama-3.1-8B --tasks wikitext hellaswag
```

Reviewers:

Subscribers:

Tasks:

Tags: