### PR TITLE
enable batch_size auto for model eval

### DIFF
--- a/benchmarks/_models/eval_hf_models.py
+++ b/benchmarks/_models/eval_hf_models.py
@@ -13,7 +13,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig
 
 from benchmarks.microbenchmarks.utils import string_to_config
 from torchao.quantization import *  # noqa: F401, F403
-from torchao.quantization.utils import _lm_eval_available
 
 
 def quantize_model_and_save(model_id, quant_config, output_dir="results"):
@@ -113,7 +112,9 @@ def run(
 
 
 if __name__ == "__main__":
-    if not _lm_eval_available:
+    try:
+        import lm_eval  # noqa: F401
+    except:
         print(
             "lm_eval is required to run this script. Please install it using pip install lm-eval."
         )

--- a/benchmarks/_models/eval_hf_models.py
+++ b/benchmarks/_models/eval_hf_models.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         "--device", type=str, default="cuda:0", help="Device to run the model on."
     )
     parser.add_argument(
-        "--batch_size", type=int, default=1, help="Batch size for lm_eval."
+        "--batch_size", type=str, default="1", help="Batch size for lm_eval."
     )
     parser.add_argument(
         "--prompt",

--- a/benchmarks/_models/eval_hf_models.py
+++ b/benchmarks/_models/eval_hf_models.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         "--device", type=str, default="cuda:0", help="Device to run the model on."
     )
     parser.add_argument(
-        "--batch_size", type=str, default="1", help="Batch size for lm_eval."
+        "--batch_size", type=str, default="auto", help="Batch size for lm_eval."
     )
     parser.add_argument(
         "--prompt",


### PR DESCRIPTION
Summary:

enables passing `--batch_size auto` to model eval script

on LLaMa 3.1 8B and wikitext + hellaswag, this reduces the runtime from
13 minutes to 4.5 minutes on my machines (a 2.9x speedup)

Test Plan:

```
with-proxy time python benchmarks/_models/eval_hf_models.py --model_id meta-llama/Llama-3.1-8B --tasks wikitext hellaswag --batch_size auto
```

Reviewers:

Subscribers:

Tasks:

Tags: