### PR TITLE
Skip Flaky ROCm Test in Integration Suite

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1058,6 +1058,7 @@ class TestSubclass(unittest.TestCase):
     @unittest.skipIf(
         not TORCH_VERSION_AT_LEAST_2_4, "freeze requires torch 2.4 and after."
     )
+    @skip_if_rocm("Test flaky on ROCm, under investigation")
     def test_int8_weight_only_quant_with_freeze(self, device, dtype):
         torch._dynamo.reset()
         self._test_lin_weight_subclass_api_impl(


### PR DESCRIPTION
This pull request introduces a minor test update to improve test reliability for specific hardware environments.

- **Test stability improvement:**
  * Added the `@skip_if_rocm` decorator to the `test_int8_weight_only_quant_with_freeze` test in `test/integration/test_integration.py` to skip the test on ROCm platforms due to known flakiness.