### PR TITLE
[not for land] float8 debug recipe for float8 rowwise fwd and hp bwd

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -370,8 +370,9 @@ class TestFloat8Linear:
     @pytest.mark.parametrize(
         "recipe_name",
         [
-            Float8LinearRecipeName.ROWWISE,
-            Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
+            # Float8LinearRecipeName.ROWWISE,
+            # Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
+            Float8LinearRecipeName.FWD_ROWWISE_GI_ROWWISE_GW_HP,
         ],
     )
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])


### PR DESCRIPTION
Summary:

Test Plan:

```bash
with-proxy
CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml"
./run_train.sh --model.print_after_conversion --model.converters float8
--training.compile --float8.recipe_name fwd_float8_bwd_hp
```

Reviewers:

Subscribers:

Tasks:

Tags: