### PR TITLE
Don't call erase if node is already erased in batch norm fusion.

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -758,7 +758,7 @@ def fold_bn_weights_into_conv_node(
     # since the node refers to a mutating op. Here we still need to call DCE first
     # to get rid of the unused getitem nodes that consume the BN node.
     m.graph.eliminate_dead_code()
-    if len(bn_node.users) == 0:
+    if not bn_node._erased and len(bn_node.users) == 0:
         m.graph.erase_node(bn_node)
 
 


### PR DESCRIPTION
Summary:
The erase call results in a warning log if the node is already erased by the dead code elimination earlier.

Checking if the node is already erased so we don't unnecessarily pollute the log with warnings.

Differential Revision: D79846881


