### PR TITLE
Deprecate old TORCH_VERSION variables

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import unittest
+import warnings
 from unittest.mock import patch
 
 import torch
@@ -12,7 +13,7 @@ from torchao.testing.utils import skip_if_no_cuda
 from torchao.utils import TorchAOBaseTensor, torch_version_at_least
 
 
-class TestTorchVersionAtLeast(unittest.TestCase):
+class TestTorchVersion(unittest.TestCase):
     def test_torch_version_at_least(self):
         test_cases = [
             ("2.5.0a0+git9f17037", "2.5.0", True),
@@ -34,6 +35,49 @@ class TestTorchVersionAtLeast(unittest.TestCase):
                     expected_result,
                     f"Failed for torch.__version__={torch_version}, comparing with {compare_version}",
                 )
+
+    def test_torch_version_deprecation(self):
+        """
+        Test that TORCH_VERSION_AT_LEAST_2_5 and before and TORCH_VERSION_AFTER*
+        trigger a deprecation warning.
+        """
+        # Reset deprecation warning state, otherwise we won't log warnings here
+        warnings.resetwarnings()
+
+        # Importing and referencing should not trigger deprecation warning
+        with warnings.catch_warnings(record=True) as _warnings:
+            from torchao.utils import (
+                TORCH_VERSION_AFTER_2_2,
+                TORCH_VERSION_AFTER_2_3,
+                TORCH_VERSION_AFTER_2_4,
+                TORCH_VERSION_AFTER_2_5,
+                TORCH_VERSION_AT_LEAST_2_2,
+                TORCH_VERSION_AT_LEAST_2_3,
+                TORCH_VERSION_AT_LEAST_2_4,
+                TORCH_VERSION_AT_LEAST_2_5,
+            )
+
+            deprecated_api_to_name = {
+                TORCH_VERSION_AT_LEAST_2_5: "TORCH_VERSION_AT_LEAST_2_5",
+                TORCH_VERSION_AT_LEAST_2_4: "TORCH_VERSION_AT_LEAST_2_4",
+                TORCH_VERSION_AT_LEAST_2_3: "TORCH_VERSION_AT_LEAST_2_3",
+                TORCH_VERSION_AT_LEAST_2_2: "TORCH_VERSION_AT_LEAST_2_2",
+                TORCH_VERSION_AFTER_2_5: "TORCH_VERSION_AFTER_2_5",
+                TORCH_VERSION_AFTER_2_4: "TORCH_VERSION_AFTER_2_4",
+                TORCH_VERSION_AFTER_2_3: "TORCH_VERSION_AFTER_2_3",
+                TORCH_VERSION_AFTER_2_2: "TORCH_VERSION_AFTER_2_2",
+            }
+            self.assertEqual(len(_warnings), 0)
+
+        # Accessing the boolean value should trigger deprecation warning
+        with warnings.catch_warnings(record=True) as _warnings:
+            for api, name in deprecated_api_to_name.items():
+                num_warnings_before = len(_warnings)
+                if api:
+                    pass
+                regex = f"{name} is deprecated and will be removed"
+                self.assertEqual(len(_warnings), num_warnings_before + 1)
+                self.assertIn(regex, str(_warnings[-1].message))
 
 
 class TestTorchAOBaseTensor(unittest.TestCase):

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -8,6 +8,7 @@ import importlib
 import itertools
 import re
 import time
+import warnings
 from functools import reduce
 from importlib.metadata import version
 from math import gcd
@@ -377,13 +378,62 @@ def torch_version_at_least(min_version):
     return is_fbcode() or compare_versions(torch.__version__, min_version) >= 0
 
 
+# Deprecated, will be deleted in the future
+def _torch_version_after(min_version):
+    return is_fbcode() or version("torch") >= min_version
+
+
+def _get_old_torch_version_deprecation_msg(version_str: str) -> str:
+    return f"TORCH_VERSION_AT_LEAST_{version_str} is deprecated and will be removed in torchao 0.14.0"
+
+
+def _get_torch_version_after_deprecation_msg(version_str: str) -> str:
+    return f"TORCH_VERSION_AFTER_{version_str} is deprecated and will be removed in torchao 0.14.0"
+
+
+class _BoolDeprecationWrapper:
+    """
+    A deprecation wrapper that logs a warning when the given bool value is accessed.
+    """
+
+    def __init__(self, bool_value: bool, msg: str):
+        self.bool_value = bool_value
+        self.msg = msg
+
+    def __bool__(self):
+        warnings.warn(self.msg)
+        return self.bool_value
+
+
 TORCH_VERSION_AT_LEAST_2_8 = torch_version_at_least("2.8.0")
 TORCH_VERSION_AT_LEAST_2_7 = torch_version_at_least("2.7.0")
 TORCH_VERSION_AT_LEAST_2_6 = torch_version_at_least("2.6.0")
-TORCH_VERSION_AT_LEAST_2_5 = torch_version_at_least("2.5.0")
-TORCH_VERSION_AT_LEAST_2_4 = torch_version_at_least("2.4.0")
-TORCH_VERSION_AT_LEAST_2_3 = torch_version_at_least("2.3.0")
-TORCH_VERSION_AT_LEAST_2_2 = torch_version_at_least("2.2.0")
+
+# Deprecated
+TORCH_VERSION_AT_LEAST_2_5 = _BoolDeprecationWrapper(
+    torch_version_at_least("2.5.0"), _get_old_torch_version_deprecation_msg("2_5")
+)
+TORCH_VERSION_AT_LEAST_2_4 = _BoolDeprecationWrapper(
+    torch_version_at_least("2.4.0"), _get_old_torch_version_deprecation_msg("2_4")
+)
+TORCH_VERSION_AT_LEAST_2_3 = _BoolDeprecationWrapper(
+    torch_version_at_least("2.3.0"), _get_old_torch_version_deprecation_msg("2_3")
+)
+TORCH_VERSION_AT_LEAST_2_2 = _BoolDeprecationWrapper(
+    torch_version_at_least("2.2.0"), _get_old_torch_version_deprecation_msg("2_2")
+)
+TORCH_VERSION_AFTER_2_5 = _BoolDeprecationWrapper(
+    _torch_version_after("2.5.0.dev"), _get_torch_version_after_deprecation_msg("2_5")
+)
+TORCH_VERSION_AFTER_2_4 = _BoolDeprecationWrapper(
+    _torch_version_after("2.4.0.dev"), _get_torch_version_after_deprecation_msg("2_4")
+)
+TORCH_VERSION_AFTER_2_3 = _BoolDeprecationWrapper(
+    _torch_version_after("2.3.0.dev"), _get_torch_version_after_deprecation_msg("2_3")
+)
+TORCH_VERSION_AFTER_2_2 = _BoolDeprecationWrapper(
+    _torch_version_after("2.2.0.dev"), _get_torch_version_after_deprecation_msg("2_2")
+)
 
 
 """
@@ -766,11 +816,6 @@ def fill_defaults(args, n, defaults_tail):
     return r
 
 
-## Deprecated, will be deleted in the future
-def _torch_version_at_least(min_version):
-    return is_fbcode() or version("torch") >= min_version
-
-
 # Supported AMD GPU Models and their LLVM gfx Codes:
 #
 # | AMD GPU Model | LLVM gfx Code          |
@@ -855,12 +900,6 @@ def check_xpu_version(device, version="2.8.0"):
 
 def ceil_div(a, b):
     return (a + b - 1) // b
-
-
-TORCH_VERSION_AFTER_2_5 = _torch_version_at_least("2.5.0.dev")
-TORCH_VERSION_AFTER_2_4 = _torch_version_at_least("2.4.0.dev")
-TORCH_VERSION_AFTER_2_3 = _torch_version_at_least("2.3.0.dev")
-TORCH_VERSION_AFTER_2_2 = _torch_version_at_least("2.2.0.dev")
 
 
 def is_package_at_least(package_name: str, min_version: str):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2719

**Summary:** This commit deprecates the following variables:

```
TORCH_VERSION_AT_LEAST_2_5
TORCH_VERSION_AT_LEAST_2_4
TORCH_VERSION_AT_LEAST_2_3
TORCH_VERSION_AT_LEAST_2_2
TORCH_VERSION_AFTER_2_5
TORCH_VERSION_AFTER_2_4
TORCH_VERSION_AFTER_2_3
TORCH_VERSION_AFTER_2_2
```

As of this commit, the latest released version of PyTorch is 2.8,
which means we can drop support for 2.5 and before since we only
support 3 of the latest releases.

The next commit will remove usages of all of these variables
from within torchao.

**Test Plan:**
```
python test/test_utils.py -k torch_version_deprecation
```