### PR TITLE
don't learn zero points for symmetric quantization

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -21,7 +21,12 @@ from torchao import quantize_
 from torchao.float8.config import ScalingGranularity
 from torchao.float8.float8_scaling_utils import hp_tensor_to_float8_dynamic
 from torchao.float8.float8_training_tensor import LinearMMConfig
-from torchao.quantization.granularity import PerAxis, PerGroup, PerRow, PerToken
+from torchao.quantization.granularity import (
+    PerAxis,
+    PerGroup,
+    PerRow,
+    PerToken,
+)
 from torchao.quantization.linear_quant_modules import (
     _replace_linear_8da4w,
     _replace_linear_int4,
@@ -29,16 +34,16 @@ from torchao.quantization.linear_quant_modules import (
 from torchao.quantization.qat.api import (
     ComposableQATQuantizer,
     FromIntXQuantizationAwareTrainingConfig,
-    initialize_fake_quantizers,
     IntXQuantizationAwareTrainingConfig,
     QATConfig,
     QATStep,
+    initialize_fake_quantizers,
 )
 from torchao.quantization.qat.embedding import FakeQuantizedEmbedding
 from torchao.quantization.qat.fake_quantize_config import IntxFakeQuantizeConfig
 from torchao.quantization.qat.fake_quantizer import (
-    _Float8RowwiseActivationFakeQuantizer,
     IntxFakeQuantizer,
+    _Float8RowwiseActivationFakeQuantizer,
 )
 from torchao.quantization.qat.linear import (
     FakeQuantizedLinear,
@@ -52,17 +57,21 @@ from torchao.quantization.qat.utils import (
     _Float8RowwiseFakeQuantize,
     _get_qmin_qmax,
 )
-from torchao.quantization.quant_api import Int8DynamicActivationInt4WeightConfig
+from torchao.quantization.quant_api import (
+    Int8DynamicActivationInt4WeightConfig,
+)
 from torchao.quantization.quant_primitives import (
+    MappingType,
+    TorchAODType,
+    ZeroPointDomain,
     _fake_quantize_affine,
     choose_qparams_affine,
     dequantize_affine,
-    MappingType,
     quantize_affine,
-    TorchAODType,
-    ZeroPointDomain,
 )
-from torchao.quantization.unified import TwoStepQuantizer
+from torchao.quantization.unified import (
+    TwoStepQuantizer,
+)
 from torchao.quantization.utils import (
     _get_per_token_block_size,
     compute_error,
@@ -421,9 +430,9 @@ class TestQAT(unittest.TestCase):
         Test that 8da4w QAT with disabled fake quant matches nn.Linear in forward.
         """
         from torchao.quantization.qat.linear import (
+            Int8DynActInt4WeightQATQuantizer,
             disable_8da4w_fake_quant,
             enable_8da4w_fake_quant,
-            Int8DynActInt4WeightQATQuantizer,
         )
 
         group_size = 16
@@ -482,8 +491,8 @@ class TestQAT(unittest.TestCase):
         Test that 8da4w QAT with disabled fake quant matches nn.Linear in backward.
         """
         from torchao.quantization.qat.linear import (
-            disable_8da4w_fake_quant,
             Int8DynActInt4WeightQATQuantizer,
+            disable_8da4w_fake_quant,
         )
 
         group_size = 16
@@ -1201,20 +1210,20 @@ class TestQAT(unittest.TestCase):
         We will remove this test in the near future when we actually break BC.
         """
         from torchao.quantization.prototype.qat import (  # noqa: F401, F811, I001
-            ComposableQATQuantizer,
             disable_4w_fake_quant,
             disable_8da4w_fake_quant,
             enable_4w_fake_quant,
             enable_8da4w_fake_quant,
+            ComposableQATQuantizer,
+            Int8DynActInt4WeightQATLinear,
             Int4WeightOnlyEmbeddingQATQuantizer,
             Int4WeightOnlyQATQuantizer,
-            Int8DynActInt4WeightQATLinear,
             Int8DynActInt4WeightQATQuantizer,
         )
         from torchao.quantization.prototype.qat._module_swap_api import (  # noqa: F401, F811
             disable_4w_fake_quant_module_swap,
-            disable_8da4w_fake_quant_module_swap,
             enable_4w_fake_quant_module_swap,
+            disable_8da4w_fake_quant_module_swap,
             enable_8da4w_fake_quant_module_swap,
             Int4WeightOnlyQATQuantizerModuleSwap,
             Int8DynActInt4WeightQATQuantizerModuleSwap,
@@ -1229,8 +1238,8 @@ class TestQAT(unittest.TestCase):
         )
         from torchao.quantization.prototype.qat.embedding import (  # noqa: F401, F811
             FakeQuantizedEmbedding,
-            Int4WeightOnlyEmbedding,
             Int4WeightOnlyEmbeddingQATQuantizer,
+            Int4WeightOnlyEmbedding,
             Int4WeightOnlyQATEmbedding,
         )
         from torchao.quantization.prototype.qat.fake_quantizer import (  # noqa: F401, F811
@@ -1389,7 +1398,9 @@ class TestQAT(unittest.TestCase):
 
         can produce the same results as `Int8DynActInt4WeightQATQuantizer` prepare + convert.
         """
-        from torchao.quantization.qat import Int8DynActInt4WeightQATQuantizer
+        from torchao.quantization.qat import (
+            Int8DynActInt4WeightQATQuantizer,
+        )
 
         group_size = 16
         torch.manual_seed(self.SEED)

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -39,8 +39,12 @@ from torchao.quantization.qat.api import (
     QATStep,
     initialize_fake_quantizers,
 )
-from torchao.quantization.qat.embedding import FakeQuantizedEmbedding
-from torchao.quantization.qat.fake_quantize_config import IntxFakeQuantizeConfig
+from torchao.quantization.qat.embedding import (
+    FakeQuantizedEmbedding,
+)
+from torchao.quantization.qat.fake_quantize_config import (
+    IntxFakeQuantizeConfig,
+)
 from torchao.quantization.qat.fake_quantizer import (
     IntxFakeQuantizer,
     _Float8RowwiseActivationFakeQuantizer,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -8,13 +8,17 @@ from typing import Optional
 
 import torch
 
-from torchao.quantization.granularity import PerAxis, PerGroup, PerToken
+from torchao.quantization.granularity import (
+    PerAxis,
+    PerGroup,
+    PerToken,
+)
 from torchao.quantization.quant_primitives import (
     _DTYPE_TO_BIT_WIDTH,
     _DTYPE_TO_QVALUE_BOUNDS,
+    MappingType,
     _Round,
     choose_qparams_affine,
-    MappingType,
 )
 from torchao.quantization.utils import (
     _get_per_token_block_size,
@@ -22,7 +26,10 @@ from torchao.quantization.utils import (
     get_groupwise_affine_qparams,
 )
 
-from .fake_quantize_config import FakeQuantizeConfigBase, IntxFakeQuantizeConfig
+from .fake_quantize_config import (
+    FakeQuantizeConfigBase,
+    IntxFakeQuantizeConfig,
+)
 from .utils import (
     _fake_quantize_per_channel_group,
     _fake_quantize_per_token,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -8,17 +8,13 @@ from typing import Optional
 
 import torch
 
-from torchao.quantization.granularity import (
-    PerAxis,
-    PerGroup,
-    PerToken,
-)
+from torchao.quantization.granularity import PerAxis, PerGroup, PerToken
 from torchao.quantization.quant_primitives import (
     _DTYPE_TO_BIT_WIDTH,
     _DTYPE_TO_QVALUE_BOUNDS,
-    MappingType,
     _Round,
     choose_qparams_affine,
+    MappingType,
 )
 from torchao.quantization.utils import (
     _get_per_token_block_size,
@@ -26,10 +22,7 @@ from torchao.quantization.utils import (
     get_groupwise_affine_qparams,
 )
 
-from .fake_quantize_config import (
-    FakeQuantizeConfigBase,
-    IntxFakeQuantizeConfig,
-)
+from .fake_quantize_config import FakeQuantizeConfigBase, IntxFakeQuantizeConfig
 from .utils import (
     _fake_quantize_per_channel_group,
     _fake_quantize_per_token,
@@ -200,10 +193,13 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
         # Stabilize range learning
         scale = torch.clamp(scale, min=self._scale_eps)
-        zero_point = _Round.apply(zero_point)
-        zero_point = torch.clamp(zero_point, qmin, qmax)
         self.scale = torch.nn.Parameter(scale, requires_grad=True)
-        self.zero_point = torch.nn.Parameter(zero_point, requires_grad=True)
+        if self.config.is_symmetric:
+            self.zero_point.zero_()
+        else:
+            zero_point = _Round.apply(zero_point)
+            zero_point = torch.clamp(zero_point, qmin, qmax)
+            self.zero_point = torch.nn.Parameter(zero_point, requires_grad=True)
 
 
 # For BC


### PR DESCRIPTION
summary: 

part of https://github.com/pytorch/ao/issues/2271
rather than learning both scales and zero points, zero points are always zero for symmetric quantization. both are learnable parameters still for asymmetric quantization. 