### PR TITLE
[moe training] update bench script to compare fp8 dynamic quant scaled_grouped_mm fwd+bwd against bf16

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_rowwise_3d_quant_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_rowwise_3d_quant_kernels.py
@@ -87,12 +87,13 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
         return out
 
     def run_triton(input_tensor: torch.Tensor):
-        _ = triton_fp8_rowwise_3d_transpose_rhs(
+        out = triton_fp8_rowwise_3d_transpose_rhs(
             input_tensor,
             output_dtype=torch.float8_e4m3fn,
             round_scales_to_power_of_2=True,
         )
         torch.cuda.synchronize()
+        return out
 
     # bench torch
     compiled_run_torch = torch.compile(run_torch)

--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm.py
@@ -6,15 +6,17 @@
 # this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
 import argparse
 import itertools
-import time
 from dataclasses import dataclass
 from typing import List
 
 import torch
 from tabulate import tabulate
 from tqdm import tqdm
+from utils import bench_fwd_bwd_microseconds
 
 from torchao.prototype.moe_training import _scaled_grouped_mm
+from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.prototype.moe_training.utils import generate_jagged_offs
 
 device = torch.device("cuda")
 
@@ -27,11 +29,14 @@ class ExperimentConfig:
     high_precision_dtype: torch.dtype
     A_shape: tuple[int]
     B_shape: tuple[int]
+    recipe: MoEScalingType
 
 
 @dataclass(frozen=True)
 class ExperimentResult:
-    time_us: float
+    bf16_us: float
+    fp8_us: float
+    fp8_speedup: float
 
 
 @dataclass(frozen=True)
@@ -41,19 +46,22 @@ class Experiment:
 
 
 def get_configs() -> List[ExperimentConfig]:
-    A_shapes = [(2**8, 8192), (2**12, 8192), (2**16, 8192)]
-    B_shapes = [(4, 8192, 8192), (8, 8192, 8192), (16, 8192, 8192)]
+    A_shapes = [(16640, 5120)]
+    B_shapes = [(16, 8192, 5120), (128, 8192, 5120)]
+    recipes = [MoEScalingType.FP8_ROWWISE]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
-    for A_shape, B_shape, high_precision_dtype in itertools.product(
+    for A_shape, B_shape, recipe, high_precision_dtype in itertools.product(
         A_shapes,
         B_shapes,
+        recipes,
         high_precision_dtypes,
     ):
         configs.append(
             ExperimentConfig(
                 A_shape=A_shape,
                 B_shape=B_shape,
+                recipe=recipe,
                 high_precision_dtype=high_precision_dtype,
             )
         )
@@ -83,39 +91,37 @@ def run_experiment(
     # - the transposed tensor in col-major format with groups along the row dimension,
     #    which represents the right operand.
     n_groups = config.B_shape[0]
-    group_size = A.shape[0] // n_groups
-    offs = torch.arange(
-        group_size,
-        group_size * n_groups + 1,
-        group_size,
-        device=device,
-        dtype=torch.int32,
+    offs = generate_jagged_offs(n_groups, A.shape[0], multiple_of=16)
+
+    labels = torch.ones(
+        (A.shape[0], B_t.shape[-1]), device=device, dtype=torch.bfloat16
     )
 
-    def warmup(func, *args, **kwargs):
-        for _ in range(10):
-            func(*args, **kwargs)
+    # benchmark bf16 grouped mm
+    bf16_us = bench_fwd_bwd_microseconds(
+        torch._grouped_mm,
+        A,
+        B_t,
+        offs,
+        labels=labels,
+        use_compile=args.compile,
+    )
 
-    def forward_backward(A, B_t, offs):
-        out = _scaled_grouped_mm(
-            A,
-            B_t,
-            offs=offs,
-            out_dtype=torch.bfloat16,
-        )
-        out.sum().backward()
-        torch.cuda.synchronize()
-
-    # benchmark torch
-    torch_func = torch.compile(forward_backward) if args.compile else forward_backward
-    warmup(torch_func, A, B_t, offs)
-    start_time_ns = time.perf_counter_ns()
-    torch_func(A, B_t, offs)
-    torch_time_ns = time.perf_counter_ns() - start_time_ns
-    time_us = torch_time_ns / 1e3
+    # benchmark scaled grouped mm with dynamic fp8 rowwise quant
+    fp8_us = bench_fwd_bwd_microseconds(
+        _scaled_grouped_mm,
+        A,
+        B_t,
+        offs,
+        scaling_type=config.recipe,
+        labels=labels,
+        use_compile=args.compile,
+    )
 
     return ExperimentResult(
-        time_us=round(time_us, 3),
+        bf16_us=round(bf16_us, 3),
+        fp8_us=round(fp8_us, 3),
+        fp8_speedup=round(bf16_us / fp8_us, 3),
     )
 
 
@@ -123,7 +129,9 @@ def print_results(experiments: List[Experiment]):
     headers = [
         "A_shape",
         "B_shape",
-        "time_us",
+        "bf16_time_us",
+        "scaled_time_us",
+        "fp8_speedup",
     ]
     rows = []
     for experiment in experiments:
@@ -133,7 +141,9 @@ def print_results(experiments: List[Experiment]):
             [
                 A_shape,
                 B_shape,
-                experiment.result.time_us,
+                experiment.result.bf16_us,
+                experiment.result.fp8_us,
+                f"{experiment.result.fp8_speedup}x",
             ]
         )
     print(tabulate(rows, headers=headers))

--- a/benchmarks/prototype/moe_training/utils.py
+++ b/benchmarks/prototype/moe_training/utils.py
@@ -1,0 +1,21 @@
+import statistics
+from time import perf_counter_ns
+
+import torch
+from torch.nn import functional as F
+
+
+def bench_fwd_bwd_microseconds(fn, *args, labels=None, use_compile=False, **kwargs):
+    assert labels is not None
+    fn = torch.compile(fn, fullgraph=False) if use_compile else fn
+    times = []
+    for _ in range(10):
+        start_ns = perf_counter_ns()
+        out = fn(*args, **kwargs)
+        loss = F.mse_loss(out, labels)
+        loss.backward()
+        torch.cuda.synchronize()
+        end_ns = perf_counter_ns()
+        duration_us = (end_ns - start_ns) / 1000
+        times.append(duration_us)
+    return statistics.median(times)

--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -51,7 +51,6 @@ def triton_fp8_rowwise_3d_transpose_rhs(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert hp_tensor.ndim == 3, "input tensor must be 3D"
 
-    num_elements = hp_tensor.numel()
     tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
     tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
 
@@ -89,7 +88,6 @@ def triton_fp8_rowwise_3d_transpose_rhs(
         e,
         n,
         k,
-        num_elements,
         fp8_dtype_min,
         fp8_dtype_max,
         tl_input_dtype,
@@ -113,7 +111,6 @@ def triton_fp8_rowwise_3d_transpose_rhs(
         e,
         n,
         k,
-        num_elements,
         fp8_dtype_min,
         fp8_dtype_max,
         tl_input_dtype,
@@ -138,20 +135,19 @@ def _fake_triton_fp8_rowwise_3d_transpose_rhs(
     return output_buffer, scales_buffer
 
 
-@triton.autotune(configs=kernel_configs_2D, key=["num_elements"])
+@triton.autotune(configs=kernel_configs_2D, key=["K", "N"])
 @triton.jit
 def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
     input_ptr,
-    stride_input_dim0: int,
-    stride_input_dim1: int,
-    stride_input_dim2: int,
+    stride_input_dim0: tl.int64,
+    stride_input_dim1: tl.int64,
+    stride_input_dim2: tl.int64,
     scales_ptr,
     stride_scales_dim0: int,
     stride_scales_dim1: int,
     E: int,
     N: int,
     K: int,
-    num_elements: int,
     fp8_dtype_min: tl.constexpr,
     fp8_dtype_max: tl.constexpr,
     input_dtype: tl.constexpr,
@@ -202,20 +198,19 @@ def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
 @triton.jit
 def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
     input_ptr,
-    stride_input_dim0: int,
-    stride_input_dim1: int,
-    stride_input_dim2: int,
+    stride_input_dim0: tl.int64,
+    stride_input_dim1: tl.int64,
+    stride_input_dim2: tl.int64,
     output_ptr,
-    stride_output_dim0: int,
-    stride_output_dim1: int,
-    stride_output_dim2: int,
+    stride_output_dim0: tl.int64,
+    stride_output_dim1: tl.int64,
+    stride_output_dim2: tl.int64,
     scales_ptr,
     stride_scales_dim0: int,
     stride_scales_dim1: int,
     E: int,
     N: int,
     K: int,
-    num_elements: int,
     fp8_dtype_min: tl.constexpr,
     fp8_dtype_max: tl.constexpr,
     input_dtype: tl.constexpr,


### PR DESCRIPTION
Stacked PRs:
 * #2769
 * #2767
 * __->__#2765
 * #2762
 * #2756
 * #2749
 * #2734
 * #2733


--- --- ---

[moe training] update bench script to compare fp8 dynamic quant scaled_grouped_mm fwd+bwd against bf16

## Summary
- Previously this benchmarking script only measured fp8 rowwise perf, without comparing against a baseline.
- This script now compares against the bf16 baseline so we can easily see the relative speedup/slowdown.

Example output:

```
A_shape        B_shape             bf16_time_us    scaled_time_us  fp8_speedup
-------------  ----------------  --------------  ----------------  -------------
(16640, 5120)  (16, 8192, 5120)         10523.7           12889.3  0.816x
```