### PR TITLE
[moe training] refactor to share benchmarking and profiling utils

### DIFF
--- a/benchmarks/prototype/moe_training/utils.py
+++ b/benchmarks/prototype/moe_training/utils.py
@@ -5,9 +5,11 @@ import torch
 from torch.nn import functional as F
 
 
-def bench_fwd_bwd_microseconds(fn, *args, labels=None, use_compile=False, **kwargs):
+def bench_fwd_bwd_microseconds(
+    fn, *args, labels=None, use_compile=False, fullgraph=True, **kwargs
+):
     assert labels is not None
-    fn = torch.compile(fn, fullgraph=False) if use_compile else fn
+    fn = torch.compile(fn, fullgraph=fullgraph) if use_compile else fn
     times = []
     for _ in range(10):
         start_ns = perf_counter_ns()
@@ -19,3 +21,38 @@ def bench_fwd_bwd_microseconds(fn, *args, labels=None, use_compile=False, **kwar
         duration_us = (end_ns - start_ns) / 1000
         times.append(duration_us)
     return statistics.median(times)
+
+
+def profile_fn(
+    fn,
+    *args,
+    labels=None,
+    use_compile=False,
+    fullgraph=True,
+    profile_name="profile",
+    **kwargs,
+):
+    assert labels is not None
+    fn = torch.compile(fn, fullgraph=fullgraph) if use_compile else fn
+    wait, warmup, active = 1, 3, 1
+    total_steps = wait + warmup + active
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
+        schedule=torch.profiler.schedule(
+            wait=wait, warmup=warmup, active=active, repeat=0
+        ),
+        record_shapes=True,
+        with_stack=True,
+    ) as prof:
+        for _ in range(total_steps):
+            out = fn(*args, **kwargs)
+            loss = F.mse_loss(out, labels)
+            loss.backward()
+            prof.step()
+
+    # Save profiler results
+    prof.export_chrome_trace(f"{profile_name}.json")
+    print(f"Saved: {profile_name}.json")


### PR DESCRIPTION
Stacked PRs:
 * #2769
 * __->__#2767
 * #2765
 * #2762
 * #2756
 * #2749
 * #2734
 * #2733


--- --- ---

[moe training] refactor to share benchmarking and profiling utils

### MoE layer FSDP fwd + bwd bench

```
rm -rf /tmp/torchinductor_danvm; torchrun --nproc-per-node=8 --local-ranks-filter=0 benchmarks/prototype/moe_training/benchmark_moe_fsdp.py --compile  --recipe="fp8_rowwwise"

...
BF16 time: 100860.36600000001 us
Scaled time: 110353.22200000001 us
Speedup: 0.914x
```

### Scaled grouped mm with dynamic quant fwd + bwd bench

```
rm -rf /tmp/torchinductor_danvm; torchrun --nproc-per-node=8 --local-ranks-filter=0 benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py --compile 

...

A_shape        B_shape             bf16_time_us    scaled_time_us  fp8_speedup
-------------  ----------------  --------------  ----------------  -------------
(16640, 5120)  (16, 8192, 5120)         10523.7           12889.3  0.816x
```