### PR TITLE
[moe training] add memory bandwidth calculations to kernel benchmarking scripts

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_moe_fsdp.py
+++ b/benchmarks/prototype/moe_training/benchmark_moe_fsdp.py
@@ -24,7 +24,7 @@ from torch.nn import functional as F
 
 from benchmarks.prototype.moe_training.utils import (
     bench_fwd_bwd_microseconds,
-    profile_fn,
+    profile_fwd_bwd,
 )
 
 # this feature requires CUDA and SM89+
@@ -128,7 +128,7 @@ def bench_moe_float8_training_fsdp(
     print(f"BF16 time: {bf16_us} us")
     if enable_profile:
         print("Profiling bf16 training")
-        profile_fn(ref_model, ref_x, labels=labels, profile_name="bf16_profile")
+        profile_fwd_bwd(ref_model, ref_x, labels=labels, profile_name="bf16_profile")
 
     scaled_us = bench_fwd_bwd_microseconds(
         model,
@@ -140,7 +140,7 @@ def bench_moe_float8_training_fsdp(
     print(f"Scaled time: {scaled_us} us")
     if enable_profile:
         print("Profiling quantized training")
-        profile_fn(model, x, labels=labels, profile_name=f"{recipe_name}_profile")
+        profile_fwd_bwd(model, x, labels=labels, profile_name=f"{recipe_name}_profile")
 
     print(f"Speedup: {bf16_us / scaled_us:.3f}x")
     dist.destroy_process_group()

--- a/benchmarks/prototype/moe_training/benchmark_per_group_scaling_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_per_group_scaling_kernels.py
@@ -19,6 +19,7 @@ from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.utils import (
+    generate_jagged_offs,
     torch_to_float8_per_group_colwise,
     torch_to_float8_per_group_rowwise,
 )
@@ -40,6 +41,8 @@ class ExperimentConfig:
 class ExperimentResult:
     torch_time_us: float
     triton_time_us: float
+    torch_mem_bw_gbps: float
+    triton_mem_bw_gbps: float
 
 
 @dataclass(frozen=True)
@@ -50,7 +53,7 @@ class Experiment:
 
 def get_configs() -> List[ExperimentConfig]:
     input_shapes = [(16640, 5120)]  # (Mg, K)
-    n_groups_list = [16, 128]
+    n_groups_list = [1, 16, 128]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for input_shape, n_groups, high_precision_dtype in itertools.product(
@@ -81,15 +84,9 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     #   that occurs in the backward pass of the differentiable scaled grouped mm.
     # - the transposed tensor in col-major format with groups along the row dimension,
     #    which represents the right operand.
-    group_size = input_row_major.shape[1] // config.n_groups
     n_groups = config.n_groups
-    offs = torch.arange(
-        group_size,
-        group_size * n_groups + 1,
-        group_size,
-        device=device,
-        dtype=torch.int32,
-    )
+    Mg = input_row_major.shape[0]
+    offs = generate_jagged_offs(n_groups, Mg, multiple_of=16)
 
     def warmup(func, *args, **kwargs):
         for _ in range(10):
@@ -140,9 +137,21 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
         run_triton, input_row_major, input_col_major, offs
     )
 
+    # mem bw calculations - excluding scales to simplify calculation
+    # but still get an accurate estimate.
+    bytes_per_input_el = torch.finfo(config.high_precision_dtype).bits / 8
+    num_elements = input_tensor.numel()
+    read_bytes = num_elements * bytes_per_input_el
+    write_bytes = num_elements  # 1 byte per element in float8_e4m3fn
+    read_write_bytes = read_bytes + write_bytes
+    torch_mem_bw_gbps = (read_write_bytes) / (torch_time_us / 1e6) / 1e9
+    triton_mem_bw_gbps = (read_write_bytes) / (triton_time_us / 1e6) / 1e9
+
     return ExperimentResult(
         torch_time_us=torch_time_us,
         triton_time_us=triton_time_us,
+        torch_mem_bw_gbps=torch_mem_bw_gbps,
+        triton_mem_bw_gbps=triton_mem_bw_gbps,
     )
 
 
@@ -153,6 +162,8 @@ def print_results(experiments: List[Experiment]):
         "high_precision_dtype",
         "torch_time_us",
         "triton_time_us",
+        "torch_mem_bw_gbps",
+        "triton_mem_bw_gbps",
         "triton_speedup",
     ]
     rows = []
@@ -167,6 +178,8 @@ def print_results(experiments: List[Experiment]):
                 experiment.config.high_precision_dtype,
                 experiment.result.torch_time_us,
                 experiment.result.triton_time_us,
+                round(experiment.result.torch_mem_bw_gbps, 3),
+                round(experiment.result.triton_mem_bw_gbps, 3),
                 f"{experiment.result.torch_time_us / experiment.result.triton_time_us:.2f}x",
             ]
         )

--- a/benchmarks/prototype/moe_training/utils.py
+++ b/benchmarks/prototype/moe_training/utils.py
@@ -23,7 +23,7 @@ def bench_fwd_bwd_microseconds(
     return statistics.median(times)
 
 
-def profile_fn(
+def profile_fwd_bwd(
     fn,
     *args,
     labels=None,


### PR DESCRIPTION
Stacked PRs:
 * __->__#2769
 * #2767
 * #2765
 * #2762
 * #2756
 * #2749
 * #2734
 * #2733


--- --- ---

[moe training] add memory bandwidth calculations to kernel benchmarking scripts

documenting example torch.compile codegen for the 3d expert weigh transpose + quant kernel: https://www.internalfb.com/phabricator/paste/view/P1904683419


```
input_shape            torch_time_us    triton_time_us    torch_mem_bw_gbps    triton_mem_bw_gbps  triton_speedup
-------------------  ---------------  ----------------  -------------------  --------------------  ----------------
(1, (8192, 5120))            114.976           131.392              1823.99               1596.1   0.88x
(1, (5120, 8192))            145.44            131.456              1441.94               1595.33  1.11x
(16, (8192, 5120))          2182.32           1629.92               1537.56               2058.66  1.34x
(16, (5120, 8192))          2081.39           1745.89               1612.12               1921.91  1.19x
(128, (8192, 5120))        21692.4           23648.6                1237.46               1135.1   0.92x
(128, (5120, 8192))        18088.4           23502.3                1484.02               1142.17  0.77x
```