### PR TITLE
Fix missing QuantOptimizer methods

### DIFF
--- a/torchao/prototype/parq/quant/uniform_torchao.py
+++ b/torchao/prototype/parq/quant/uniform_torchao.py
@@ -142,7 +142,7 @@ class UnifTorchaoQuantizer(Quantizer):
 
 
 class StretchedUnifTorchaoQuantizer(UnifTorchaoQuantizer):
-    def __init__(self, b: int, int_shift: float = 0.5) -> None:
+    def __init__(self, b: int, int_shift: float = 0.5, **kwargs) -> None:
         quant_absmax = 2 ** (b - 1) - int_shift
         self.quant_min = -quant_absmax
         self.quant_max = quant_absmax
@@ -152,6 +152,7 @@ class StretchedUnifTorchaoQuantizer(UnifTorchaoQuantizer):
             mapping_type=MappingType.ASYMMETRIC,
             quant_min=self.quant_min,
             quant_max=self.quant_max,
+            **kwargs,
         )
 
         self._choose_qparams = partial(choose_qparams_stretched_affine, b=b)


### PR DESCRIPTION
This is a patch to yesterday's #2743.
- Returned the overrides to state_dict and load_state_dict in QuantOptimizer, which were mistakenly removed
- Replaced the "quant_cls" and "quant_kwargs" keys in param_group to "quantizer" so that the user can instantiate the class outside of the optimizer. Otherwise, we can't use JSON to serialize nonstandard types like torch.dtype.