### PR TITLE
Update benchmarking tool to run on local iPhones

### DIFF
--- a/torchao/experimental/benchmark_infra/ios/output_redirect.mm
+++ b/torchao/experimental/benchmark_infra/ios/output_redirect.mm
@@ -40,6 +40,13 @@ class STDIORedirector {
       close(stdout_dupfd_);
       close(stderr_dupfd_);
       fclose(redirect_out_);
+      /* write done file to detect end of benchmark*/
+      std::string file_name =
+          std::string(std::getenv("HOME")) + "/tmp/BENCH_DONE";
+      FILE *donefile = fopen(file_name.c_str(), "w");
+      std::string done_str = "DONE BENCHMARKING";
+      fwrite(done_str.c_str(), 1, done_str.size(), donefile);
+      fclose(donefile);
     }
   }
 


### PR DESCRIPTION
Summary:
This diff allows us to benchmark models on local iphones.
Since end of benchmarking cannot be reliably identified using `idb` commands, created `BENCH_DONE` file at the end of benchmark (as part of destructor method) to detect the end of benchmarking.

Reviewed By: kushrast

Differential Revision: D80095129


