### PR TITLE
[CI] fix 4xH100 tests by not installing vllm

### DIFF
--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -44,7 +44,6 @@ jobs:
         pip install uv
         pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
-        uv pip install vllm
         pip install .
         ./test/float8/test_everything_multi_gpu.sh
         ./test/prototype/mx_formats/test_mx_dtensor.sh


### PR DESCRIPTION
## Context
Pip install vllm in CI uninstalls torch nightly and installs torch==2.7.1 ([log link](https://github.com/pytorch/ao/actions/runs/16997208138/job/48190673852#step:14:20890)), causing the MX tests to fail with error: `AttributeError: module 'torch' has no attribute 'float4_e2m1fn_x2'`

I checked if vllm has a nightly build which uses a newer torch version we could use, but even their main branch pins 2.7.1, not just latest stable release: https://github.com/vllm-project/vllm/blob/177e55e3bd3dbb54089d9062b763a413c8718dff/requirements/cuda.txt#L9C8-L9C13

So basically I think we cannot use vllm in the same CI job as mxfp8 dtensor tests.


## Change summary
- This PR removes pip installing vllm from 4xH100 CI tests.
- vllm python package is only used in integration tests on 1xH100 and 1xL4 tests anyway, and should have been removed when we refactored the tests to split out 1xH100 and 4xH100:
     - Only instance of vllm pkg import in integration test [here](https://github.com/pytorch/ao/blob/69e71d94b1cf395796f800988017dfffcf19845d/test/integration/test_vllm.py#L42) 
     - These integration tests are only run on 1xL4 [here](https://github.com/pytorch/ao/blob/69e71d94b1cf395796f800988017dfffcf19845d/.github/workflows/1xL4_tests.yml#L50) and 1xH100 [here](https://github.com/pytorch/ao/blob/69e71d94b1cf395796f800988017dfffcf19845d/.github/workflows/1xH100_tests.yml#L50)


