### PR TITLE
Fixes build for MXFP8 quantize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -634,6 +634,10 @@ def get_extensions():
         mxfp8_src_files_exist = all(os.path.exists(f) for f in mxfp8_sources)
         if mxfp8_src_files_exist and build_for_sm100a:
             print("Building mxfp8_cuda extension")
+            arch_flags = [
+                "-gencode=arch=compute_100,code=sm_100",
+                "-gencode=arch=compute_120,code=sm_120"
+            ]
             ext_modules.append(
                 CUDAExtension(
                     name="torchao.prototype.mxfp8_cuda",
@@ -647,7 +651,7 @@ def get_extensions():
                     ],
                     extra_compile_args={
                         "cxx": ["-std=c++17", "-O3"],
-                        "nvcc": nvcc_args,
+                        "nvcc": nvcc_args + arch_flags,
                     },
                     extra_link_args=["-lcuda", "-lcudart"],
                 ),

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -22,21 +22,6 @@
 #include <cuda/barrier>
 #include <cuda/ptx>
 
-#define MIN_CUDA_SM 1000 // SM90 = 900, SM100 = 1000
-
-// Check if we're compiling for supported architecture
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < MIN_CUDA_SM)
-#warning                                                                       \
-    "MXFP8 quantization requires SM90+ (Hopper) or SM100+ (Blackwell) architecture. Kernel will be disabled for this architecture."
-#endif
-
-// Architecture detection for native FP8 support
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
-#define HAS_NATIVE_FP8_CONVERSION 1
-#else
-#define HAS_NATIVE_FP8_CONVERSION 0
-#endif
-
 enum class DType {
   kByte,
   kFloat32,
@@ -975,11 +960,6 @@ public:
           output_bits_per_elem); // bits per elem in output fp8e4m3
     }
 
-// Launch kernel based on input/output types and scaling dimensions
-// Only compile kernel launches for SM90+
-#if defined(__CUDACC__) &&                                                     \
-    (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= MIN_CUDA_SM)
-
     // Use TMA and mbarrier instructions
 #define LAUNCH_KERNEL(IType, OType, SCALE_Y, SCALE_X, ScalingMode)                          \
   mxfp8_quantize_kernel<IType, OType, SCALE_Y, SCALE_X, ScalingMode>                        \
@@ -1044,6 +1024,5 @@ public:
 
 #undef LAUNCH_KERNEL
 
-#endif
   }
 };


### PR DESCRIPTION
`__CUDA_ARCH__` has undefined behavior in host code and should only be used in device code. Without this PR, we run into the following error:
```
NotImplementedError: "cat_cuda" not implemented for 'Float8_e8m0fnu'
```
Essentially, the `mxfp8_quantize_kernel` kernels are not launched.

Compilation command: `TORCH_CUDA_ARCH_LIST="9.0a 10.0a 12.0a 7.5 8.0 8.6 9.0 10.0 12.0+PTX" pip install --no-build-isolation . -vvv`
Before this PR, the compilation on B200 looks like:
```
[1/1] /usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output /opt/pytorch/ao/build/temp.linux-x86_64-cpython-312/torchao/csrc/cu
da/mx_kernels/mxfp8_cuda.o.d -Itorchao/csrc/cuda/mx_kernels -I/usr/local/cuda-12.8/include -I/usr/local/lib/python3.12/dist-packages/torch/include -I/usr/local/lib/python3.12/dist-packa
ges/torch/include/torch/csrc/api/include -I/usr/local/cuda/include -I/usr/include/python3.12 -c -c /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu -o /opt/pytorch/ao/build/te
mp.linux-x86_64-cpython-312/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OP
ERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -DNDEBUG -O3 -t=0 -std=c++17 -DTORCHAO_USE_CUTLASS -I/opt/pytorch/ao/third_party/cutlass/include -I/opt/pytorch/a
o/third_party/cutlass/tools/util/include -I/opt/pytorch/ao/torchao/csrc/cuda -DCUTE_USE_PACKED_TUPLE=1 -DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 -DCUTLA
SS_DEBUG_TRACE_LEVEL=0 --ftemplate-backtrace-limit=0 -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi101
6"' -DTORCH_EXTENSION_NAME=mxfp8_cuda -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_100a,code=sm_100a -gencode=arch=compute_120,code=compute_120 -gencode=arch=compute_120,
code=sm_120 -gencode=arch=compute_120a,code=sm_120a -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_90,
code=sm_90 -gencode=arch=compute_90a,code=sm_90a 


In file included from /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu:3:                                                                                                    
  /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh:29:2: warning: #warning "MXFP8 quantization requires SM90+ (Hopper) or SM100+ (Blackwell) architecture. Kernel will be 
disabled for this architecture." [-Wcpp]                                                                                                                                                 
     29 | #warning                                                                       \                                                                                               
        |  ^~~~~~~                                                                                                                                                                       
  In file included from /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu:3:                                                                                                    
  /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh:29:2: warning: #warning "MXFP8 quantization requires SM90+ (Hopper) or SM100+ (Blackwell) architecture. Kernel will be 
disabled for this architecture." [-Wcpp]


```
And after:
```
[1/1] /usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output /opt/pytorch/ao/build/temp.linux-x86_64-cpython-312/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o.d
 -Itorchao/csrc/cuda/mx_kernels -I/usr/local/cuda-12.8/include -I/usr/local/lib/python3.12/dist-packages/torch/include -I/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc
/api/include -I/usr/local/cuda/include -I/usr/include/python3.12 -c -c /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu -o /opt/pytorch/ao/build/temp.linux-x86_64-cpython-312/
torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-con
stexpr --compiler-options ''"'"'-fPIC'"'"'' -DNDEBUG -O3 -t=0 -std=c++17 -DTORCHAO_USE_CUTLASS -I/opt/pytorch/ao/third_party/cutlass/include -I/opt/pytorch/ao/third_party/cutlass/tools/
util/include -I/opt/pytorch/ao/torchao/csrc/cuda -DCUTE_USE_PACKED_TUPLE=1 -DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 -DCUTLASS_DEBUG_TRACE_LEVEL=0 --fte
mplate-backtrace-limit=0 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_120,code=sm_120 -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB
="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=mxfp8_cuda
  /opt/pytorch/ao/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh(489): warning #940-D: missing return statement at end of non-void function "quantize_block<OType,NUM_VALUES,ScalingMode
>(float, e8m0_t &, const float (&)[NUM_VALUES], OType (&)[NUM_VALUES]) [with OType=fp8e4m3, NUM_VALUES=16, ScalingMode=ScaleCalculationMode::FLOOR]"
    }
    ^
```