### PR TITLE
[mx] fix return type for 'quantize_block' in mxfp81 dim1 cast CUDA ke…

### DIFF
--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -451,7 +451,7 @@ __device__ __forceinline__ OType torchao_quantize_value(float input_value,
  * Template parameters ensure compile-time array size checking for safety
  */
 template <typename OType, int NUM_VALUES, ScaleCalculationMode ScalingMode>
-__device__ __forceinline__ float
+__device__ __forceinline__ void
 quantize_block(float amax, e8m0_t &out_scale,
                        const float (&input_values)[NUM_VALUES],
                        OType (&output_values)[NUM_VALUES]) {


### PR DESCRIPTION
## Summary

Building mxfp8 dim1 cast cuda kernel emits a warning:


The code functionality is not affected in this case but this should still be fixed for correctness.

This PR fixes the return type from `float` to `void`.


## Build log before

## Build log after change (no warnings)
```
(ao) [danvm@devgpu031.atn1 ~/ao (main)]$ USE_CPP=1 pip install -e . --verbose
Using pip 25.1 from /home/danvm/.conda/envs/ao/lib/python3.13/site-packages/pip (python 3.13)
Obtaining file:///home/danvm/ao
  Running command python setup.py egg_info
  CUDA 12.8: Enabling SM90a CUTLASS kernels
  CUDA 12.8: Enabling SM100a CUTLASS kernels

...

    building 'torchao.prototype.mxfp8_cuda' extension
    creating /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels
    [1/2] c++ -MMD -MF /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_extension.o.d -pthread -B /home/danvm/.conda/envs/ao/compiler_compat -fno-strict-overflow -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/danvm/.conda/envs/ao/include -fPIC -O2 -isystem /home/danvm/.conda/envs/ao/include -fPIC -Itorchao/csrc/cuda/mx_kernels -I/usr/local/cuda-12.8/include -I/home/danvm/.conda/envs/ao/lib/python3.13/site-packages/torch/include -I/home/danvm/.conda/envs/ao/lib/python3.13/site-packages/torch/include/torch/csrc/api/include -I/usr/local/cuda-12.8/include -I/home/danvm/.conda/envs/ao/include/python3.13 -c -c /home/danvm/ao/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp -o /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_extension.o -std=c++17 -O3 -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1018"' -DTORCH_EXTENSION_NAME=mxfp8_cuda
    [2/2] /usr/local/cuda-12.8/bin/nvcc --generate-dependencies-with-compile --dependency-output /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o.d -Itorchao/csrc/cuda/mx_kernels -I/usr/local/cuda-12.8/include -I/home/danvm/.conda/envs/ao/lib/python3.13/site-packages/torch/include -I/home/danvm/.conda/envs/ao/lib/python3.13/site-packages/torch/include/torch/csrc/api/include -I/usr/local/cuda-12.8/include -I/home/danvm/.conda/envs/ao/include/python3.13 -c -c /home/danvm/ao/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu -o /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -DNDEBUG -O3 -t=0 -std=c++17 -DTORCHAO_USE_CUTLASS -I/home/danvm/ao/third_party/cutlass/include -I/home/danvm/ao/third_party/cutlass/tools/util/include -I/home/danvm/ao/torchao/csrc/cuda -DCUTE_USE_PACKED_TUPLE=1 -DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 -DCUTLASS_DEBUG_TRACE_LEVEL=0 --ftemplate-backtrace-limit=0 -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1018"' -DTORCH_EXTENSION_NAME=mxfp8_cuda -gencode=arch=compute_100a,code=sm_100a
    creating build/lib.linux-x86_64-cpython-313/torchao/prototype
    g++ -pthread -B /home/danvm/.conda/envs/ao/compiler_compat -fno-strict-overflow -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/danvm/.conda/envs/ao/include -fPIC -O2 -isystem /home/danvm/.conda/envs/ao/include -pthread -B /home/danvm/.conda/envs/ao/compiler_compat -shared -Wl,-rpath,/home/danvm/.conda/envs/ao/lib -Wl,-rpath-link,/home/danvm/.conda/envs/ao/lib -L/home/danvm/.conda/envs/ao/lib -Wl,-rpath,/home/danvm/.conda/envs/ao/lib -Wl,-rpath-link,/home/danvm/.conda/envs/ao/lib -L/home/danvm/.conda/envs/ao/lib /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o /home/danvm/ao/build/temp.linux-x86_64-cpython-313/torchao/csrc/cuda/mx_kernels/mxfp8_extension.o -L/usr/local/cuda-12.8/lib64 -L/home/danvm/.conda/envs/ao/lib/python3.13/site-packages/torch/lib -L/usr/local/cuda-12.8/lib64 -lc10 -ltorch -ltorch_cpu -ltorch_python -lcudart -lc10_cuda -ltorch_cuda -o build/lib.linux-x86_64-cpython-3...
    Installed /home/danvm/ao
Successfully installed torchao-0.13.0+git9e3758d15

```
## Bench

```
(ao) [danvm@devgpu031.atn1 ~/ao (main)]$ python benchmarks/mx_formats/cast_bench.py --mode dim1_mxfp8_cuda_floor
/home/danvm/ao/torchao/utils.py:408: UserWarning: TORCH_VERSION_AT_LEAST_2_8 is deprecated and will be removed in torchao 0.14.0
  warnings.warn(self.msg)
/home/danvm/ao/torchao/utils.py:408: UserWarning: TORCH_VERSION_AT_LEAST_2_7 is deprecated and will be removed in torchao 0.14.0
  warnings.warn(self.msg)
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.9.0.dev20250801+cu128
triton version: 3.4.0
mode: dim1_mxfp8_cuda_floor
time_us 151.8079936504364
mem_bw_gbps 5360.02720564024
```
