### PR TITLE
Fix batch norm folding in `prepare_pt2e` for multiple conv->BN chains sharing the same conv weights

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -671,6 +671,7 @@ def fold_bn_weights_into_conv_node(
     conv_bias_node: Optional[Node],
     bn_node: Node,
     m: GraphModule,
+    fake_fuse: bool=False # removes the BN nodes but doesn't change the conv weights
 ) -> None:
     # conv args: input, weight, bias, stride, padding, dilation, ...
     conv_w = _get_tensor_constant_from_node(conv_weight_node, m)
@@ -702,6 +703,16 @@ def fold_bn_weights_into_conv_node(
     # filling in the default bias argument
     if len(conv_args) == 2:
         conv_args.append(None)
+
+    if fake_fuse:
+        fused_weight, fused_bias = (
+            torch.nn.Parameter(conv_w, conv_w.requires_grad),
+            torch.nn.Parameter(conv_b, conv_b.requires_grad)
+        )
+    else:
+        fused_weight, fused_bias = fuse_conv_bn_weights(
+            conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=transpose
+        )
 
     # calling data since the fused_weight and fused_bias are nn.Parameter
     weight_attr_name = conv_weight_node.target
@@ -767,6 +778,9 @@ def _fuse_conv_bn_(m: GraphModule) -> None:
     has_bn = any(_is_bn_node(n) for n in m.graph.nodes)
     if not has_bn:
         return
+
+    # track which conv weights have been fused to avoid double fusing
+    fused_convs_weight_nodes = set()
     for n in m.graph.nodes:
         if n.op != "call_function" or n.target not in (
             torch.ops.aten._native_batch_norm_legit_no_training.default,
@@ -781,9 +795,15 @@ def _fuse_conv_bn_(m: GraphModule) -> None:
         conv_weight_node = conv_node.args[1]
         conv_bias_node = conv_node.args[2] if len(conv_node.args) > 2 else None
         fold_bn_weights_into_conv_node(
-            conv_node, conv_weight_node, conv_bias_node, bn_node, m
+            conv_node,
+            conv_weight_node,
+            conv_bias_node,
+            bn_node,
+            m,
+            (conv_weight_node in fused_convs_weight_nodes)
         )
-
+        fused_convs_weight_nodes.add(conv_weight_node)
+    del fused_convs_weight_nodes
     m.graph.eliminate_dead_code()
     m.recompile()
 

--- a/torchao/testing/model_architectures.py
+++ b/torchao/testing/model_architectures.py
@@ -22,6 +22,26 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
+class ToyCNNModel(nn.Module):
+    def __init__(self, n_chunks, in_channels, out_channels, kernel_size=3, stride=1, padding=1):
+        super().__init__()
+        self.n_chunks = n_chunks
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, stride, padding)
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+
+    def forward(self, x):
+        chunks = torch.chunk(x, self.n_chunks, dim=1)
+        outputs = []
+        for chunk in chunks:
+            out = self.conv(chunk)
+            out = self.bn(out)
+            out = self.relu(out)
+            outputs.append(out)
+        return torch.cat(outputs, dim=1)
+
+
 class LNLinearActivationModel(nn.Module):
     def __init__(self, fc_dim1, fc_dim2, dtype=torch.bfloat16, activation="sigmoid"):
         super().__init__()


### PR DESCRIPTION
### Summary
For a model with multiple conv->BN chains that have the same conv weights, `prepare_pt2e` applies batch norm folding repeatedly for each chain, causing incorrect conv weights in the output prepared model. This fix ensures batch norm folding is performed only once per unique conv weight set, preventing multiple folds and preserving correct model behavior.

### Testplan
```
python test/quantization/pt2e/test_quantize_pt2e.py -k test_chunked_bn_fusion
```