### PR TITLE
Fix UT assertion error for int8 sdpa fusion

### DIFF
--- a/test/prototype/inductor/test_int8_sdpa_fusion.py
+++ b/test/prototype/inductor/test_int8_sdpa_fusion.py
@@ -128,6 +128,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                         for op_name in [
                             "qscaled_dot_product",
                             "cpp_fused_quantize_per_tensor",
+                            "cpp_fused__unsafe_view_quantize_per_tensor",
                         ]
                     )
                 )


### PR DESCRIPTION
Error log:
```
======================================================================
FAIL [48.416s]: test_sdpa_int8_rewriter_cpu (__main__.SDPAPatternRewriterCpuTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/pytorch/miniforge3/envs/2025ww7_torchao_debug/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/pytorch/miniforge3/envs/2025ww7_torchao_debug/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 1917, in wrapper
    return fn(*args, **kwargs)
  File "/home/pytorch/miniforge3/envs/2025ww7_torchao_debug/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/pytorch/jenkins/workspace/TorchAO_UT_weekly_xuming/ao/test/prototype/inductor/test_int8_sdpa_fusion.py", line 205, in _test_sdpa_int8_rewriter
    self._check_common(
  File "/home/pytorch/jenkins/workspace/TorchAO_UT_weekly_xuming/ao/test/prototype/inductor/test_int8_sdpa_fusion.py", line 125, in _check_common
    self.assertTrue(
AssertionError: False is not true

To execute this test, run the following from the base repo dir:
    python test/prototype/inductor/test_int8_sdpa_fusion.py SDPAPatternRewriterCpuTests.test_sdpa_int8_rewriter_cpu

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0

----------------------------------------------------------------------
```

The assertion failure is caused by https://github.com/pytorch/pytorch/pull/159920, which modifies the cpp kernel name. This PR adds the new possible cpp kernel name in assertion.

Note that this UT failure is not discovered by CI because cpp kernels are not compiled by default (tracked in https://github.com/pytorch/ao/issues/2378). cc @atalman 