### PR TITLE
float8tensor: small fixes for kernel_preference

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1701,6 +1701,7 @@ def _float8_dynamic_activation_float8_weight_quantize_tensor(weight, config):
             activation_granularity,
             hp_value_lb=activation_value_lb,
             hp_value_ub=activation_value_ub,
+            kernel_preference=kernel_preference,
         )
 
         quantized_weight = Float8Tensor.to_float8(

--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -147,12 +147,12 @@ class Float8Tensor(TorchAOBaseTensor):
     def __repr__(self):
         return (
             f"{self.__class__.__name__}({self.act_quant_kwargs=}, {self.qdata=}, {self.scale=}, "
-            f"{self.block_size=}, {self.mm_config=}, "
+            f"{self.block_size=}, {self.mm_config=}, {self.kernel_preference=} "
             f"{self.shape=}, {self.device=}, {self.dtype=})"
         )
 
     def _quantization_type(self):
-        return f"{self.act_quant_kwargs=}, {self.block_size=}, {self.mm_config=}, {self.scale.shape=}"
+        return f"{self.act_quant_kwargs=}, {self.block_size=}, {self.mm_config=}, {self.scale.shape=}, {self.kernel_preference=}"
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:


### PR DESCRIPTION
Summary:

1. make kernel_preference choice for activation respect user config
2. ensure we print kernel_preference of the weights

Test Plan:

https://gist.github.com/vkuzo/d00ead89aa6f3a723ae06eb33f40b892

kernel preference now prints correctly for both activation and weight

Reviewers:

Subscribers:

Tasks:

Tags: