### PR TITLE
[fp8 blockwise] load 2d chunks for groupwise quant to enable coalesced gmem accesses

### DIFF
--- a/benchmarks/prototype/blockwise_fp8_training/bench_linear_fwd_bwd.py
+++ b/benchmarks/prototype/blockwise_fp8_training/bench_linear_fwd_bwd.py
@@ -12,7 +12,6 @@ from typing import List
 
 import torch
 from tabulate import tabulate
-from torch.nn import functional as F
 from tqdm import tqdm
 from triton.testing import do_bench
 
@@ -72,7 +71,9 @@ def get_configs() -> List[ExperimentConfig]:
     return configs
 
 
-def run_experiment(config: ExperimentConfig, profile=False, use_compile=False) -> ExperimentResult:
+def run_experiment(
+    config: ExperimentConfig, profile=False, use_compile=False
+) -> ExperimentResult:
     M, N, K = config.m, config.n, config.k
     inputs = torch.randn(M, K, dtype=config.out_dtype, device="cuda")
     bf16_linear = torch.nn.Linear(K, N, dtype=config.out_dtype, device="cuda")
@@ -87,24 +88,23 @@ def run_experiment(config: ExperimentConfig, profile=False, use_compile=False) -
         for _ in range(3):
             func(*args, **kwargs)
 
-
     # bfloat16 bench and profile
     labels = inputs.new_empty(M, N).fill_(1.0)
     bf16_linear_us = bench_fwd_bwd_microseconds(
-        bf16_linear, 
-        inputs, 
-        labels=labels, 
+        bf16_linear,
+        inputs,
+        labels=labels,
         use_compile=use_compile,
     )
     if profile:
         print("Profiling bf16_linear")
         profile_fwd_bwd(
-            bf16_linear, 
-            inputs, 
+            bf16_linear,
+            inputs,
             labels=labels,
             profile_name="bf16_linear_profile",
             use_compile=use_compile,
-    )
+        )
 
     # FP8 triton bench and profile
     fp8_triton_linear_us = bench_fwd_bwd_microseconds(
@@ -189,7 +189,7 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser() 
+    parser = argparse.ArgumentParser()
     parser.add_argument("--profile", action="store_true", help="Enable profiling")
     parser.add_argument("--compile", action="store_true", help="Enable compilation")
     args = parser.parse_args()


### PR DESCRIPTION
Stacked PRs:
 * #2829
 * __->__#2827
 * #2826
 * #2785


--- --- ---

[fp8 blockwise] load 2d chunks for groupwise quant to enable coalesced gmem accesses

NCU flagged uncoalesced gmem accesses when loading input tensor data. I was loading in skinny tiles of size (1 x blocksize) or (blocksize x 1), which can cause uncoalesced loads and stores depending on the underlying memory layout.

By loading 2d chunks of (num_groups, blocksize) or (blocksize, num_groups) we can enable the uncoalesced loads to be grouped into several coalesced loads.


This results in a 20-33% speedup.

## Kernel performance
- NCU reports all quantization kernels used for blockwise linear running at 80-90% peak memory bandwidth
- Runtime numbers TBD, we don't have quantization kernel specific benchmark scripts yet: https://github.com/pytorch/ao/issues/2828

## Individual linear fwd + bwd

**bf16**: 7690 us
<img width="747" height="302" alt="Screenshot 2025-08-20 at 7 05 14 PM" src="https://github.com/user-attachments/assets/89db6397-b9ee-4791-abf4-34036554eece" />


**fp8 blockwise**: 6302 us (22% speedup)
<img width="917" height="351" alt="Screenshot 2025-08-20 at 7 05 19 PM" src="https://github.com/user-attachments/assets/1f76fc55-b9f2-4dc7-a4f3-7e95412521e2" />


## E2E training performance

Eager llama3 8b with FDSP=4 on H100s

- bf16: ~6080 TPS
- fp8 blockwise: ~6170 TPS