### PR TITLE
[mxfp8 moe] add compile test; add mxfp8 to bench script

### DIFF
--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -136,7 +136,8 @@ def test_moe_float8_training(target_fqns: list[str], compile: bool):
         ["does.not.exist"],
     ],
 )
-def test_moe_mxfp8_training(target_fqns: list[str]):
+@pytest.mark.parametrize("compile", [False, True])
+def test_moe_mxfp8_training(target_fqns: list[str], compile: bool):
     block_size = 32
 
     # Token groups must be divisible by 32 for mxfp8
@@ -177,6 +178,11 @@ def test_moe_mxfp8_training(target_fqns: list[str]):
         model,
         target_fqns=target_fqns,
     )
+
+    if compile:
+        # TODO: compile with fullgraph=True when torchtitan llama4 moe supports it
+        model = torch.compile(model, fullgraph=False)
+        ref_model = torch.compile(ref_model, fullgraph=False)
 
     # inputs
     batch, seq = 8, 2048

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -48,7 +48,7 @@ def _scaled_grouped_mm(
     """
     # TODO: Remove logging once prototype is more mature. This is currently very useful for development and debugging.
     if scaling_type == MoEScalingType.FP8_ROWWISE:
-        # print("Using fp8 rowwise scaled_grouped_mm")
+        logger.info("Using fp8 rowwise for _scaled_grouped_mm")
         return _Float8GroupedMM.apply(
             A,
             B_t,
@@ -56,7 +56,7 @@ def _scaled_grouped_mm(
             out_dtype,
         )
     elif scaling_type == MoEScalingType.MXFP8:
-        print("Using mxfp8 scaled_grouped_mm")
+        logger.info("Using mxfp8 for _scaled_grouped_mm")
         block_size = 32  # TODO: should we make this configurable? plumb it through in a config somehow?
         return _MXFP8GroupedMM.apply(
             A,


### PR DESCRIPTION
Stacked PRs:
 * #2844
 * #2841
 * __->__#2835


--- --- ---

### [mxfp8 moe] add compile test; add mxfp8 to bench script

- Add torch.compile test case to mxfp8 e2e training test (fullgraph=False)
- Add mxfp8 to scaled_grouped_mm bench script
- Change print statements to logging
- Remove larger `num_experts` from bench script to avoid OOM for mxfp8