### PR TITLE
Fix internal CI after the adding load_and_run_checkpoint test

### DIFF
--- a/test/integration/test_load_and_run_checkpoint.py
+++ b/test/integration/test_load_and_run_checkpoint.py
@@ -12,9 +12,15 @@ from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
 )
-from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig
 
 from torchao.utils import is_fbcode, is_sm_at_least_90
+
+if is_fbcode():
+    # don't import from transformer internally, since some imports might be missing
+    pass
+else:
+    from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig
+
 
 # please check model card for how to generate these models
 


### PR DESCRIPTION
Summary:
Internal CI failed because TorchAoConfig from transformer can't be imported, since the version of internal transformer is too low, skipping the import for intenral since we don't run these tests intenrally. Confirmed that this fixes the internal CI

Test Plan:
internal CI after merge, but have manually tested that this works

Reviewers:

Subscribers:

Tasks:

Tags: