### PR TITLE
Conditional ROCm kernel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -433,6 +433,7 @@ def get_extensions():
             extra_link_args.append("/DEBUG")
 
     rocm_sparse_marlin_supported = False
+    rocm_tiled_layout_supported = False
     if use_rocm:
         # naive search for hipblalst.h, if any found contain HIPBLASLT_ORDER_COL16 and VEC_EXT
         found_col16 = False
@@ -488,8 +489,9 @@ def get_extensions():
     # Define ROCm source directories
     rocm_source_dirs = [
         os.path.join(extensions_dir, "rocm", "swizzle"),
-        os.path.join(extensions_dir, "cuda", "tensor_core_tiled_layout"),
     ]
+    if rocm_tiled_layout_supported:
+        rocm_source_dirs.append(os.path.join(extensions_dir, "cuda", "tensor_core_tiled_layout"))
     if rocm_sparse_marlin_supported:
         rocm_source_dirs.extend([os.path.join(extensions_dir, "cuda", "sparse_marlin")])
 

--- a/setup.py
+++ b/setup.py
@@ -491,7 +491,9 @@ def get_extensions():
         os.path.join(extensions_dir, "rocm", "swizzle"),
     ]
     if rocm_tiled_layout_supported:
-        rocm_source_dirs.append(os.path.join(extensions_dir, "cuda", "tensor_core_tiled_layout"))
+        rocm_source_dirs.append(
+            os.path.join(extensions_dir, "cuda", "tensor_core_tiled_layout")
+        )
     if rocm_sparse_marlin_supported:
         rocm_source_dirs.extend([os.path.join(extensions_dir, "cuda", "sparse_marlin")])
 

--- a/setup.py
+++ b/setup.py
@@ -516,14 +516,8 @@ def get_extensions():
     sources = [s for s in sources if s not in mxfp8_sources_to_exclude]
 
     # TOOD: Remove this and use what CUDA has once we fix all the builds.
+    # TODO: Add support for other ROCm GPUs
     if use_rocm:
-        # Add ROCm GPU architecture check
-        gpu_arch = None
-        if torch.cuda.is_available():
-            gpu_arch = torch.cuda.get_device_properties(0).name
-        if gpu_arch and gpu_arch != "gfx942":
-            print(f"Warning: Unsupported ROCm GPU architecture: {gpu_arch}")
-            print("Currently only gfx942 is supported. Compiling only for gfx942.")
         extra_compile_args["nvcc"].append("--offload-arch=gfx942")
         sources += rocm_sources
     else:


### PR DESCRIPTION
This pull request introduces a conditional inclusion of the `tensor_core_tiled_layout` source directory for ROCm builds in `setup.py`. This change ensures that the tiled layout extension is only included when supported, improving build correctness and maintainability.

Note that there is a regression on ROCm 7.0 to build this kernel. 

Conditional ROCm source inclusion:

* Added a new `rocm_tiled_layout_supported` flag to control whether the `tensor_core_tiled_layout` source directory is included for ROCm extensions. (`setup.py`)
* Modified the logic for assembling `rocm_source_dirs` so that `tensor_core_tiled_layout` is only appended if `rocm_tiled_layout_supported` is `True`. (`setup.py`)