### PR TITLE
[mxfp8 moe] replace per group scaling with conventional scaling

### DIFF
--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -53,7 +53,7 @@ def test_moe_float8_training(target_fqns: list[str], compile: bool):
     device = torch.device("cuda")
 
     # reference bf16 MoE
-    dim, hidden_dim = 5120, 4 * 5120
+    dim, hidden_dim = 5120, 8192
     ref_model = MoE(model_args, dim, hidden_dim).to(torch.bfloat16).cuda()
     torch.manual_seed(42)
     ref_model.init_weights(init_std, device)
@@ -150,7 +150,7 @@ def test_moe_mxfp8_training(target_fqns: list[str], compile: bool):
     device = torch.device("cuda")
 
     # reference bf16 MoE
-    dim, hidden_dim = 256, 4 * 256
+    dim, hidden_dim = 5120, 8192
     ref_model = MoE(model_args, dim, hidden_dim).to(torch.bfloat16).cuda()
     torch.manual_seed(42)
     ref_model.init_weights(init_std, device)
@@ -197,7 +197,7 @@ def test_moe_mxfp8_training(target_fqns: list[str], compile: bool):
 
     # validate output
     out_sqnr = compute_error(out, ref_out)
-    min_out_sqnr = 25.0
+    min_out_sqnr = 28.0
     assert out_sqnr.item() >= min_out_sqnr, (
         f"SQNR must be >= {min_out_sqnr}, got {out_sqnr.item()}."
     )
@@ -213,7 +213,7 @@ def test_moe_mxfp8_training(target_fqns: list[str], compile: bool):
 
     # validate input gradient
     input_grad_sqnr = compute_error(x.grad, ref_x.grad)
-    min_input_grad_sqnr = 25.0
+    min_input_grad_sqnr = 30.0
     assert input_grad_sqnr.item() >= min_input_grad_sqnr, (
         f"SQNR must be >= {min_input_grad_sqnr}, got {input_grad_sqnr.item()}."
     )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -139,7 +139,6 @@ def to_mx(
     Takes a high precision tensor and converts to MX scale and raw data, in
     naive layout (scale and raw data are separate tensors).
     """
-
     assert data_hp.dtype in (
         torch.bfloat16,
         torch.float,


### PR DESCRIPTION
Stacked PRs:
 * #2844
 * __->__#2841
 * #2835


--- --- ---

[mxfp8 moe] replace per group scaling with conventional scaling

## Summary

Now that token group group aligment size is configurable in torchtitan (https://github.com/pytorch/torchtitan/pull/1503), in MXFP8 training we [set token group alignment size to 32](https://github.com/pytorch/torchtitan/blob/fd230800d2385e782f4443e24f1e45d83a6e6b0d/torchtitan/components/quantization/mx.py#L65-L66). This is to ensure when we quantize along that dim, we have (1) no scaling groups crossing logically distinct tensor boundaries, and (2) no “partial” scaling group at the the end (e..g, 1x17 chunk because the tensor ends).

- There are a couple places I had to call `.contiguous()` to meet the constraints of `to_mx()`. We should look into ways to avoid this, if possible.

By padding to avoid the case where scaling groups cross token group boundaries, we can now migrate to the plain `to_mx()` API.

## Additional context
Note the previous pytorch looped implementation was just intended to be used as a basic reference to check future per-group scaling kernels correctness for the simple case (token groups divisible by block size), but after thinking about it more, I realized any potential per-group scaling kernels we write would need to do padding inside them anyways to handle the case where scaling groups cross token group boundaries, thus we should just do the padding ahead of time and avoid the need for custom kernels all together.