### PR TITLE
[mxfp8 moe training] Add mxfp8 to FSDP tests

### DIFF
--- a/test/prototype/moe_training/test_fsdp.py
+++ b/test/prototype/moe_training/test_fsdp.py
@@ -51,8 +51,6 @@ except ImportError:
     (MoEScalingType.MXFP8, 28.0)
 ])
 def test_moe_float8_training_fsdp(recipe: MoEScalingType, min_out_sqnr: float):
-# def test_moe_float8_training_fsdp():
-    print(f"recipe: {recipe}")
     assert torch.cuda.is_available()
 
     # setup distributed for fsdp
@@ -88,7 +86,6 @@ def test_moe_float8_training_fsdp(recipe: MoEScalingType, min_out_sqnr: float):
             if target_fqn in cur_fqn:
                 return True
         return False
-    print("quantizing...")
     # quantize test model
     config = MoETrainingConfig(recipe)
     # config = MoETrainingConfig()

--- a/test/prototype/moe_training/test_fsdp.py
+++ b/test/prototype/moe_training/test_fsdp.py
@@ -96,7 +96,6 @@ def test_moe_float8_training_fsdp(
 
     # quantize test model
     config = MoETrainingConfig(recipe)
-    # config = MoETrainingConfig()
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted


### PR DESCRIPTION
addressing #2833 

updating test to include mxfp8: `torchrun --nproc_per_node=${NUM_GPUS} -m pytest test_fsdp.py `, all tests pass

