### PR TITLE
use gcnArchName to get gpu_arch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -516,7 +516,7 @@ def get_extensions():
         # Add ROCm GPU architecture check
         gpu_arch = None
         if torch.cuda.is_available():
-            gpu_arch = torch.cuda.get_device_properties(0).name
+            gpu_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
         if gpu_arch and gpu_arch != "gfx942":
             print(f"Warning: Unsupported ROCm GPU architecture: {gpu_arch}")
             print("Currently only gfx942 is supported. Compiling only for gfx942.")


### PR DESCRIPTION
The following warning is emitted incorrectly. `MI300X` is `gfx942`. 
```
Warning: Unsupported ROCm GPU architecture: AMD Instinct MI300X
Currently only gfx942 is supported. Compiling only for gfx942.
```

Use `gcnArchName` to extract `gpu_arch` value to suppress the above warning.

Here is an example output of `get_device_properties()` that shows the `gcnArchName` field value on `MI300X` platform.

```
>>> torch.cuda.get_device_properties(0)
_CudaDeviceProperties(name='AMD Instinct MI300X', major=9, minor=4, gcnArchName='gfx942:sramecc+:xnack-', total_memory=196592MB, multi_processor_count=304, uuid=65303434-3830-3136-3839-323537666234, pci_bus_id=5, pci_device_id=0, pci_domain_id=0, L2_cache_size=4MB)
```

With the above changes, the warning is not emitted during build on `MI300X`.
Used this command to build and test:
```
python3 -m build --wheel --no-isolation .
```