### PR TITLE
Fix autoquant after version util changes

### DIFF
--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -344,8 +344,7 @@ def do_autoquant_bench(op, *args, **kwargs):
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream):
             op(*args, **kwargs)
-        # TODO: update to 2.8.0 after https://github.com/pytorch/ao/pull/2786 is landed
-        if torch_version_at_least("2.9.0"):
+        if torch_version_at_least("2.8.0"):
             from statistics import median
 
             res = benchmarker.benchmark_gpu(


### PR DESCRIPTION
Summary:
version semantics is fixed in https://github.com/pytorch/ao/pull/2786 and we are updating the version check logic accordingly

Test Plan:
python test/integration/test_integration.py -k test_autoquant_hp_float

Reviewers:

Subscribers:

Tasks:

Tags: