### PR TITLE
[moe fp8 training] test and bench new faster method for per group rowwise scaling

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_per_group_colwise_scaling_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_per_group_colwise_scaling_kernels.py
@@ -16,12 +16,10 @@ from triton.testing import do_bench
 
 from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_colwise_scales,
-    triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.utils import (
     generate_jagged_offs,
     torch_to_float8_per_group_colwise,
-    torch_to_float8_per_group_rowwise,
 )
 
 device = torch.device("cuda")
@@ -39,7 +37,7 @@ class ExperimentConfig:
 
 @dataclass(frozen=True)
 class ExperimentResult:
-    torch_time_us: float
+    torch_loop_time_us: float
     triton_time_us: float
     torch_mem_bw_gbps: float
     triton_mem_bw_gbps: float
@@ -53,7 +51,7 @@ class Experiment:
 
 def get_configs() -> List[ExperimentConfig]:
     input_shapes = [(16640, 5120)]  # (Mg, K)
-    n_groups_list = [1, 16, 128]
+    n_groups_list = [1, 16, 64]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for input_shape, n_groups, high_precision_dtype in itertools.product(
@@ -70,14 +68,22 @@ def get_configs() -> List[ExperimentConfig]:
 
 
 def run_experiment(config: ExperimentConfig) -> ExperimentResult:
-    # define test inputs
-    input_tensor = torch.randn(
-        *config.input_shape,
-        dtype=config.high_precision_dtype,
-        device=device,
+    # Define test inputs
+    Mg, K = config.input_shape
+
+    # Column major input tensor.
+    # Right operand in grad_weight = grad_output_t @ input
+    input_tensor = (
+        torch.randn(
+            Mg,
+            K,
+            dtype=config.high_precision_dtype,
+            device=device,
+        )
+        .transpose(-2, -1)
+        .contiguous()
+        .transpose(-2, -1)
     )
-    input_row_major = input_tensor.clone().detach()
-    input_col_major = input_tensor.clone().detach().t()
 
     # - configure input to be row-major with groups divided along the column dimension,
     #   representing the left operand of grad_weight = grad_output_t @ input
@@ -85,70 +91,65 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     # - the transposed tensor in col-major format with groups along the row dimension,
     #    which represents the right operand.
     n_groups = config.n_groups
-    Mg = input_row_major.shape[0]
     offs = generate_jagged_offs(n_groups, Mg, multiple_of=16)
 
     def warmup(func, *args, **kwargs):
         for _ in range(10):
             func(*args, **kwargs)
 
-    def run_torch(
-        input_row_major: torch.Tensor, input_col_major: torch.Tensor, offs: torch.Tensor
-    ):
-        _ = torch_to_float8_per_group_rowwise(
-            input_row_major,
-            offs,
-            target_dtype=torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-        _ = torch_to_float8_per_group_colwise(
-            input_col_major,
-            offs,
-            target_dtype=torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-
-    def run_triton(
-        input_row_major: torch.Tensor, input_col_major: torch.Tensor, offs: torch.Tensor
-    ):
-        _ = triton_fp8_per_group_rowwise_scales(
-            input_row_major,
-            offs,
-            output_dtype=torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-        _ = triton_fp8_per_group_colwise_scales(
-            input_col_major,
-            offs,
-            output_dtype=torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-
-    # bench torch
-    compiled_run_torch = torch.compile(run_torch)
-    warmup(compiled_run_torch, input_row_major, input_col_major, offs)
-    torch_time_us = benchmark_cuda_function_in_microseconds(
-        compiled_run_torch, input_row_major, input_col_major, offs
+    # Bench torch per group colwise
+    torch_to_float8_per_group_colwise_c = torch.compile(
+        torch_to_float8_per_group_colwise
+    )
+    warmup(
+        torch_to_float8_per_group_colwise_c,
+        input_tensor,
+        offs,
+        target_dtype=torch.float8_e4m3fn,
+    )
+    torch_loop_time_us = benchmark_cuda_function_in_microseconds(
+        torch_to_float8_per_group_colwise_c,
+        input_tensor,
+        offs,
+        target_dtype=torch.float8_e4m3fn,
     )
 
-    # bench triton
-    warmup(run_triton, input_row_major, input_col_major, offs)
+    # Bench triton per group colwise
+    warmup(
+        triton_fp8_per_group_colwise_scales,
+        input_tensor,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
+    )
     triton_time_us = benchmark_cuda_function_in_microseconds(
-        run_triton, input_row_major, input_col_major, offs
+        triton_fp8_per_group_colwise_scales,
+        input_tensor,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
     )
 
-    # mem bw calculations - excluding scales to simplify calculation
-    # but still get an accurate estimate.
+    # Mem bw calculations
     bytes_per_input_el = torch.finfo(config.high_precision_dtype).bits / 8
     num_elements = input_tensor.numel()
-    read_bytes = num_elements * bytes_per_input_el
-    write_bytes = num_elements  # 1 byte per element in float8_e4m3fn
+    read_bytes = (
+        2 * num_elements * bytes_per_input_el  # read input tensor twice
+        + 4 * (n_groups * K)  # read scales tensor once, 4 bytes per fp32 scale
+    )
+    write_bytes = (
+        # 1 byte per output elem in fp8
+        num_elements
+        +
+        # write scales tensor, 4 bytes per fp32 scale (we actually do this write once per blong along the reduction dim using atomics, but this is an approximation)
+        4 * (n_groups * K)
+    )
     read_write_bytes = read_bytes + write_bytes
-    torch_mem_bw_gbps = (read_write_bytes) / (torch_time_us / 1e6) / 1e9
+    torch_mem_bw_gbps = (read_write_bytes) / (torch_loop_time_us / 1e6) / 1e9
     triton_mem_bw_gbps = (read_write_bytes) / (triton_time_us / 1e6) / 1e9
 
     return ExperimentResult(
-        torch_time_us=torch_time_us,
+        torch_loop_time_us=torch_loop_time_us,
         triton_time_us=triton_time_us,
         torch_mem_bw_gbps=torch_mem_bw_gbps,
         triton_mem_bw_gbps=triton_mem_bw_gbps,
@@ -157,10 +158,10 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
 
 def print_results(experiments: List[Experiment]):
     headers = [
-        "input_shape",
+        "Mg,K",
         "n_groups",
         "high_precision_dtype",
-        "torch_time_us",
+        "torch_loop_time_us",
         "triton_time_us",
         "torch_mem_bw_gbps",
         "triton_mem_bw_gbps",
@@ -176,18 +177,18 @@ def print_results(experiments: List[Experiment]):
                 input_shape,
                 experiment.config.n_groups,
                 experiment.config.high_precision_dtype,
-                experiment.result.torch_time_us,
+                experiment.result.torch_loop_time_us,
                 experiment.result.triton_time_us,
                 round(experiment.result.torch_mem_bw_gbps, 3),
                 round(experiment.result.triton_mem_bw_gbps, 3),
-                f"{experiment.result.torch_time_us / experiment.result.triton_time_us:.2f}x",
+                f"{experiment.result.torch_loop_time_us / experiment.result.triton_time_us:.2f}x",
             ]
         )
     print(tabulate(rows, headers=headers))
 
 
-def benchmark_cuda_function_in_microseconds(f, *args):
-    return do_bench(lambda: f(*args), return_mode="median") * 1e3
+def benchmark_cuda_function_in_microseconds(f, *args, **kwargs):
+    return do_bench(lambda: f(*args, **kwargs), return_mode="median") * 1e3
 
 
 def main():

--- a/benchmarks/prototype/moe_training/benchmark_per_group_rowwise_scaling_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_per_group_rowwise_scaling_kernels.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+# this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
+
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+from triton.testing import do_bench
+
+from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
+    triton_fp8_per_group_colwise_scales,
+    triton_fp8_per_group_rowwise_scales,
+)
+from torchao.prototype.moe_training.utils import (
+    generate_jagged_offs,
+    torch_to_float8_per_group_rowwise,
+)
+
+device = torch.device("cuda")
+
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    high_precision_dtype: torch.dtype
+    input_shape: tuple[int]
+    n_groups: int
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    torch_loop_time_us: float
+    triton_time_us: float
+    triton_transpose_us: float
+    torch_mem_bw_gbps: float
+    triton_mem_bw_gbps: float
+    triton_transpose_mem_bw_gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    input_shapes = [(16640, 8192)]  # (Mg, N)
+    n_groups_list = [1, 16, 64]
+    high_precision_dtypes = [torch.bfloat16]
+    configs = []
+    for input_shape, n_groups, high_precision_dtype in itertools.product(
+        input_shapes, n_groups_list, high_precision_dtypes
+    ):
+        configs.append(
+            ExperimentConfig(
+                input_shape=input_shape,
+                n_groups=n_groups,
+                high_precision_dtype=high_precision_dtype,
+            )
+        )
+    return configs
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    # define test inputs
+    Mg, N = config.input_shape
+
+    # Left operand in grad_weight = grad_output_t @ input
+    grad_out = torch.randn(
+        Mg,
+        N,
+        dtype=config.high_precision_dtype,
+        device=device,
+    )
+    grad_out_t = grad_out.transpose(-2, -1)
+
+    # - configure input to be row-major with groups divided along the column dimension,
+    #   representing the left operand of grad_weight = grad_output_t @ input
+    #   that occurs in the backward pass of the differentiable scaled grouped mm.
+    # - the transposed tensor in col-major format with groups along the row dimension,
+    #    which represents the right operand.
+    n_groups = config.n_groups
+    offs = generate_jagged_offs(n_groups, Mg, multiple_of=16)
+
+    def warmup(func, *args, **kwargs):
+        for _ in range(10):
+            func(*args, **kwargs)
+
+    # Bench torch per group rowwise
+    torch_to_float8_per_group_rowwise_c = torch.compile(
+        torch_to_float8_per_group_rowwise
+    )
+    warmup(
+        torch_to_float8_per_group_rowwise_c,
+        grad_out_t,
+        offs,
+        target_dtype=torch.float8_e4m3fn,
+    )
+    torch_loop_time_us = benchmark_cuda_function_in_microseconds(
+        torch_to_float8_per_group_rowwise_c,
+        grad_out_t,
+        offs,
+        target_dtype=torch.float8_e4m3fn,
+    )
+
+    # Bench triton per group rowwise scaling kernel
+    warmup(
+        triton_fp8_per_group_rowwise_scales,
+        grad_out_t,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
+    )
+    triton_time_us = benchmark_cuda_function_in_microseconds(
+        triton_fp8_per_group_rowwise_scales,
+        grad_out_t,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
+    )
+
+    # Bench method where we compute colwise scales on grad_output (equivalent to rowwise scales on grad_output_t)
+    def run_triton_transpose_method(
+        grad_out, offs, output_dtype, round_scales_to_power_of_2
+    ):
+        # Restride input as column major.
+        # Note this is the transpose of grad_output_t, which is what we are trying to compute per group rowwise scales for.
+        grad_out = grad_out.t().contiguous().t()
+        # Compute per group colwise scales, writing to column major format.
+        fp8_data, scales = triton_fp8_per_group_colwise_scales(
+            grad_out, offs, output_dtype, round_scales_to_power_of_2
+        )
+        return fp8_data.t(), scales.t()
+
+    run_triton_c = torch.compile(run_triton_transpose_method)
+    warmup(
+        run_triton_c,
+        grad_out,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
+    )
+    triton_transpose_us = benchmark_cuda_function_in_microseconds(
+        run_triton_c,
+        grad_out,
+        offs,
+        output_dtype=torch.float8_e4m3fn,
+        round_scales_to_power_of_2=True,
+    )
+
+    # Mem bw calculations
+    bytes_per_input_el = torch.finfo(config.high_precision_dtype).bits / 8
+    num_elements = grad_out_t.numel()
+
+    read_bytes = (
+        2 * num_elements * bytes_per_input_el  # read input tensor twice
+        + 4 * (n_groups * N)  # read scales tensor once, 4 bytes per fp32 scale
+    )
+    write_bytes = (
+        # 1 byte per output elem in fp8
+        num_elements
+        +
+        # write scales tensor, 4 bytes per fp32 scale (we actually do this write once per blong along the reduction dim using atomics, but this is an approximation)
+        4 * (n_groups * N)
+    )
+
+    read_write_bytes = read_bytes + write_bytes
+    torch_mem_bw_gbps = (read_write_bytes) / (torch_loop_time_us / 1e6) / 1e9
+    triton_mem_bw_gbps = (read_write_bytes) / (triton_time_us / 1e6) / 1e9
+
+    # Transpose method has extra reads/writes:
+    to_col_major_read_write_bytes = (
+        2 * num_elements * bytes_per_input_el
+    )  # read once, write once when converting input to column major
+    triton_transpose_mem_bw_gbps = (
+        (read_write_bytes + to_col_major_read_write_bytes)
+        / (triton_transpose_us / 1e6)
+        / 1e9
+    )
+    return ExperimentResult(
+        torch_loop_time_us=torch_loop_time_us,
+        triton_time_us=triton_time_us,
+        triton_transpose_us=triton_transpose_us,
+        torch_mem_bw_gbps=torch_mem_bw_gbps,
+        triton_mem_bw_gbps=triton_mem_bw_gbps,
+        triton_transpose_mem_bw_gbps=triton_transpose_mem_bw_gbps,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "Mg,N",
+        "n_groups",
+        "torch_loop_time_us",
+        "triton_time_us",
+        "triton_transpose_us",
+        "torch_mem_bw_gbps",
+        "triton_mem_bw_gbps",
+        "triton_transpose_mem_bw_gbps",
+        "triton_speedup",
+        "triton_transpose_speedup",
+    ]
+    rows = []
+    for experiment in experiments:
+        input_shape = (
+            f"({experiment.config.input_shape[0]}, {experiment.config.input_shape[1]})"
+        )
+        rows.append(
+            [
+                input_shape,
+                experiment.config.n_groups,
+                experiment.result.torch_loop_time_us,
+                experiment.result.triton_time_us,
+                experiment.result.triton_transpose_us,
+                round(experiment.result.torch_mem_bw_gbps, 3),
+                round(experiment.result.triton_mem_bw_gbps, 3),
+                round(experiment.result.triton_transpose_mem_bw_gbps, 3),
+                f"{experiment.result.torch_loop_time_us / experiment.result.triton_time_us:.2f}x",
+                f"{experiment.result.torch_loop_time_us / experiment.result.triton_transpose_us:.2f}x",
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def benchmark_cuda_function_in_microseconds(f, *args, **kwargs):
+    return do_bench(lambda: f(*args, **kwargs), return_mode="median") * 1e3
+
+
+def main():
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -48,8 +48,8 @@ class Experiment:
 def get_configs() -> List[ExperimentConfig]:
     # Llama4 shapes
     A_shapes = [(16640, 5120)]
-    B_shapes = [(16, 8192, 5120)]
-    recipes = [MoEScalingType.MXFP8, MoEScalingType.FP8_ROWWISE]
+    B_shapes = [(1, 8192, 5120), (4, 8192, 5120), (16, 8192, 5120), (64, 8192, 5120)]
+    recipes = [MoEScalingType.FP8_ROWWISE]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for A_shape, B_shape, recipe, high_precision_dtype in itertools.product(


### PR DESCRIPTION
Stacked PRs:
 * #2865
 * #2864
 * __->__#2863


--- --- ---

[moe fp8 training] test and bench new faster method for per group rowwise scaling


## Summary
- Per group rowwise scaling kernel used in the backward pass for MoE fp8 rowwise training is slow, due to uncoalesced global accesses arising from the row major layout of the tensor conflicting with the memory access pattern in the kernel.
- To get around this, we can compute per group **colwise** scales on the transpose of the input, then transpose the result, to effectively compute per group rowwise scales.

## Changes
- Add tests and benchmarks for this transpose based method
- Make separate kernel benchmark scripts for rowwise vs colwise per group scaling, rather than having 1 combined one.
- Update mem bw calcs

## Benchmarks
- Benchmarking shows the new method is ~3x faster across all shapes tested for rowwise
```
Mg,N             n_groups    torch_loop_time_us    triton_time_us    triton_transpose_us    torch_mem_bw_gbps    triton_mem_bw_gbps    triton_transpose_mem_bw_gbps  triton_speedup    triton_transpose_speedup
-------------  ----------  --------------------  ----------------  ---------------------  -------------------  --------------------  ------------------------------  ----------------  --------------------------
(16640, 8192)           1               1705.38           2422.82                768.416              399.681               281.328                         887.029  0.70x             2.22x
(16640, 8192)          16               3078.21           2310.27                686.912              221.59                295.246                         992.993  1.33x             4.48x
(16640, 8192)          64              10639.2            2177.7                 784.288               64.26                313.943                         871.71   4.89x             13.57x
```