### PR TITLE
[moe fp8 training] use transpose method when quantizing to avoid uncoalesced gmem accesses

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -49,7 +49,7 @@ def get_configs() -> List[ExperimentConfig]:
     # Llama4 shapes
     A_shapes = [(16640, 5120)]
     B_shapes = [(1, 8192, 5120), (4, 8192, 5120), (16, 8192, 5120), (64, 8192, 5120)]
-    recipes = [MoEScalingType.FP8_ROWWISE]
+    recipes = [MoEScalingType.FP8_ROWWISE, MoEScalingType.MXFP8]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
     for A_shape, B_shape, recipe, high_precision_dtype in itertools.product(

--- a/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
@@ -31,8 +31,8 @@ FP8_DTYPE_MAP = {
     torch.float64: tl.float64,
 }
 
-block_sizes = [1, 16, 32, 64]
-block_sizes_iter = [64, 128, 256]
+block_sizes = [32]  # [16, 32, 64]
+block_sizes_iter = [128]  # [64, 128, 256]
 num_warps = [4]
 num_stages = [3]
 kernel_configs_2D = [


### PR DESCRIPTION
Stacked PRs:
 * #2865
 * __->__#2864
 * #2863


--- --- ---

[moe fp8 training] use transpose method when quantizing to avoid uncoalesced gmem accesses

## Summary
- Integrate new per group rowwise scaling method into MoE training and update benchmarks

## Benchmarks
- We now see a ~10% TPS increase over bf16 when experts per device = 2, which declines gradually until we reach ~1% speedup at experts per device = 16 (EP=1).

Benchmarks below use 2 layer Llama4 debug model with dim=5120 (full size) and torch.compile.

| Experts per device | FSDP degree | Dtype | Median Tokens/Second | Max Memory Usage (GiB) | Speedup vs. BF16 |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **2** | 2 | BF16 | 39003.0 | 45.12 | - |
| | 2|  FP8 | 43062.0 | 45.03 | 10.4% |
| **4** | 2 | BF16 | 37238.0 | 50.04 | - |
| | 2 | FP8 | 40027.5 | 49.83 | 7.5% |
| **8** | 2 | BF16 | 34851.5 | 59.87 | - |
| | 2 | FP8 | 36867.0 | 60.98 | 5.7% |
| **16**| 4 | BF16 | 32673.0 | 63.48 | - |
| | 4 |FP8  | 33282.5 | 59.43 | 1.08% |

## FP8 dense only versus dense + moe
- 2 experts per device, 2 devices: https://www.internalfb.com/phabricator/paste/view/P1919493833
    - Dense: 2.7% speedup
    - Dense + MoE: 7.2% speedup 
    - Not sure why we only got 7.2% instead of 10.4% like yesterday's runs, but still shows MoE is the majority of the speedup. I have noticed I get slightly different numbers depending on which CUDA_VISIBLE_DEVICES I set.