### PR TITLE
[moe fp8 training] fused reduction kernel along dim1 for 3d expert weights in backward

### DIFF
--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -30,7 +30,7 @@ block_sizes_n = [128]  # large dim (output_features)
 block_sizes_k = [128]  # small dim (input_features)
 num_warps = [4]
 num_stages = [4]
-kernel_configs_2D = [
+atomic_kernel_configs_2D = [
     triton.Config(
         {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
         num_warps=warps,
@@ -135,7 +135,7 @@ def _fake_triton_fp8_rowwise_3d_transpose_rhs(
     return output_buffer, scales_buffer
 
 
-@triton.autotune(configs=kernel_configs_2D, key=["K", "N"])
+@triton.autotune(configs=atomic_kernel_configs_2D, key=["K", "N"])
 @triton.jit
 def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
     input_ptr,
@@ -201,7 +201,7 @@ def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
     tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
 
 
-@triton.autotune(configs=kernel_configs_2D, key=["num_elements"])
+@triton.autotune(configs=atomic_kernel_configs_2D, key=["num_elements"])
 @triton.jit
 def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
     input_ptr,
@@ -264,3 +264,206 @@ def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
     )
     output_mask = (n_offs[:, None] < N) & (k_offs[None, :] < K)
     tl.store(output_ptr + output_offs, output_data, mask=output_mask)
+
+
+block_sizes_n = [
+    64,
+]  # large dim (output_features)
+block_sizes_k = [128]  # small dim (input_features)
+num_warps = [8]
+num_stages = [6]
+reduction_kernel_configs_2D = [
+    triton.Config(
+        {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
+        num_warps=warps,
+        num_stages=stages,
+    )
+    for block_size_n in block_sizes_n
+    for block_size_k in block_sizes_k
+    for warps in num_warps
+    for stages in num_stages
+]
+
+
+@triton.autotune(configs=reduction_kernel_configs_2D, key=["K", "N"])
+@triton.jit
+def _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel(
+    input_ptr,
+    stride_input_dim0: tl.int64,
+    stride_input_dim1: tl.int64,
+    stride_input_dim2: tl.int64,
+    output_ptr,
+    stride_output_dim0: tl.int64,
+    stride_output_dim1: tl.int64,
+    stride_output_dim2: tl.int64,
+    scales_ptr,
+    stride_scales_dim0: int,
+    stride_scales_dim1: int,
+    E: int,
+    N: int,
+    K: int,
+    fp8_dtype_min: tl.constexpr,
+    fp8_dtype_max: tl.constexpr,
+    input_dtype: tl.constexpr,
+    output_dtype: tl.constexpr,
+    round_scales_to_power_of_2: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    # This kernel parallelizes across experts and K blocks
+    # Each program computes scales for one K block of one expert
+    expert_idx = tl.program_id(0)
+    k_block_idx = tl.program_id(1)
+
+    # Compute K offsets for this block
+    k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+    k_mask = k_offs < K
+
+    # Initialize row maxes for this K block
+    row_maxes = tl.zeros((BLOCK_SIZE_K,), dtype=tl.float64) - float("inf")
+
+    # First pass: compute row-wise maximum absolute values across all N
+    for n_block_start in range(0, N, BLOCK_SIZE_N):
+        n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
+        n_mask = n_offs < N
+
+        # Load block of input data - shape (K, N)
+        input_offs = (
+            expert_idx * stride_input_dim0
+            + k_offs[:, None] * stride_input_dim1
+            + n_offs[None, :] * stride_input_dim2
+        )
+        input_mask = k_mask[:, None] & n_mask[None, :]
+        input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
+
+        # Compute row-wise max for this N block
+        block_row_maxes = tl.max(tl.abs(input_data), axis=1)
+
+        # Update running maxes
+        row_maxes = tl.maximum(row_maxes, block_row_maxes)
+
+    # Convert row maxes to scales
+    clamped_maxes = tl.clamp(row_maxes, min=EPS, max=float("inf"))
+    scales = (fp8_dtype_max / clamped_maxes.to(tl.float64)).to(tl.float32)
+
+    if round_scales_to_power_of_2:
+        scales = tl.exp2(tl.floor(tl.log2(scales)))
+
+    # Store computed scales for this K block
+    scales_offs = expert_idx * stride_scales_dim0 + k_offs * stride_scales_dim1
+    tl.store(scales_ptr + scales_offs, scales, mask=k_mask)
+
+    # Second pass: apply scales and transpose data for output
+    for n_block_start in range(0, N, BLOCK_SIZE_N):
+        n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
+        n_mask = n_offs < N
+
+        # Load block of input data - shape (K, N)
+        input_offs = (
+            expert_idx * stride_input_dim0
+            + k_offs[:, None] * stride_input_dim1
+            + n_offs[None, :] * stride_input_dim2
+        )
+        input_mask = k_mask[:, None] & n_mask[None, :]
+        input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
+
+        # Transpose data: (K, N) -> (N, K)
+        input_data_transposed = input_data.trans(1, 0)
+
+        # Apply scales: (N, K) * (1, K) = (N, K)
+        scaled_data = input_data_transposed * scales[None, :]
+
+        # Clamp and cast to output dtype
+        output_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
+            output_dtype
+        )
+
+        # Store transposed output - shape (N, K)
+        output_offs = (
+            expert_idx * stride_output_dim0
+            + n_offs[:, None] * stride_output_dim1
+            + k_offs[None, :] * stride_output_dim2
+        )
+        output_mask = n_mask[:, None] & k_mask[None, :]
+        tl.store(output_ptr + output_offs, output_data, mask=output_mask)
+
+
+@torch.library.custom_op(
+    "torchao::triton_fp8_rowwise_transpose_rhs_fused", mutates_args={}
+)
+def triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
+    hp_tensor: torch.Tensor,  # (E, K, N)
+    output_dtype: torch.dtype = torch.float8_e4m3fn,
+    round_scales_to_power_of_2: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Equivalent fused Triton kernel to triton_fp8_rowwise_3d_transpose_rhs that uses
+    reduction to calculate rowwise scales instead of atomic operations.
+
+    This kernel fuses the scale computation and casting into a single kernel,
+    avoiding the need for atomic operations by using reduction operations.
+    """
+    assert hp_tensor.ndim == 3, "input tensor must be 3D"
+
+    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+
+    fp8_dtype_min = torch.finfo(output_dtype).min
+    fp8_dtype_max = torch.finfo(output_dtype).max
+
+    e, k, n = hp_tensor.shape
+
+    # allocate on-device buffers for output and scales
+    # output shape = input.transpose(-2, -1).shape = (E, N, K) in column major layout
+    output_buffer = torch.empty(
+        (e, n, k), dtype=output_dtype, device=hp_tensor.device
+    ).as_strided((e, n, k), (n * k, 1, n))
+
+    scales_buffer = torch.empty((e, k), dtype=torch.float32, device=hp_tensor.device)
+
+    # Use a grid that parallelizes across experts and K blocks
+    # Each program handles one K block of one expert
+    grid = lambda meta: (e, triton.cdiv(k, meta["BLOCK_SIZE_K"]), 1)
+
+    # Single fused kernel that computes scales using reduction and performs casting
+    _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel[grid](
+        hp_tensor,
+        hp_tensor.stride(0),
+        hp_tensor.stride(1),
+        hp_tensor.stride(2),
+        output_buffer,
+        output_buffer.stride(0),
+        output_buffer.stride(1),
+        output_buffer.stride(2),
+        scales_buffer,
+        scales_buffer.stride(0),
+        scales_buffer.stride(1),
+        e,
+        n,
+        k,
+        fp8_dtype_min,
+        fp8_dtype_max,
+        tl_input_dtype,
+        tl_output_dtype,
+        round_scales_to_power_of_2=round_scales_to_power_of_2,
+        EPS=EPS,
+    )
+
+    return output_buffer, scales_buffer
+
+
+@triton_fp8_rowwise_3d_transpose_rhs_fused_reduction.register_fake
+def _fake_triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
+    hp_tensor: torch.Tensor,  # (E, K, N)
+    output_dtype: torch.dtype = torch.float8_e4m3fn,
+    round_scales_to_power_of_2: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert hp_tensor.ndim == 3, "input tensor must be 3D"
+    e, k, n = hp_tensor.shape
+    output_buffer = torch.empty(
+        (e, n, k), dtype=output_dtype, device=hp_tensor.device
+    ).as_strided((e, n, k), (n * k, 1, n))
+
+    scales_buffer = torch.empty((e, k), dtype=torch.float32, device=hp_tensor.device)
+    return output_buffer, scales_buffer


### PR DESCRIPTION
Stacked PRs:
 * __->__#2865
 * #2864
 * #2863


--- --- ---

[moe fp8 training] fused reduction kernel along dim1 for 3d expert weights in backward

## Summary
- This PR adds an experimental new kernel for quantizing 3d expert weights (non transposed) for RHS operand in backward pass GEMM of `grad_input = grad_output @ weight`  using 1 single fused kernel with a reduction based approach to calculate scales, rather than 2 stage approach with atomics.
- Currently the atomics approach is still superior, but I think this is worth because if there are any tricks to optimize this fused kernel further, a single kernel should theoretically be better than 2 separate dispatches.
- I used TRITON_PRINT_AUTOTUNING=1 with a diverse autotuner config, then removed the configs that were not selected, for fast compile times.

## Benchmarks
```
input_shape          power_of_2_scales      torch_time_us    triton_atomic_time_us    triton_reduction_time_us    torch_mem_bw_gbps    triton_atomic_mem_bw_gbps    triton_reduction_mem_bw_gbps  triton_atomic_speedup    triton_reduction_speedup
-------------------  -------------------  ---------------  -----------------------  --------------------------  -------------------  ---------------------------  ------------------------------  -----------------------  --------------------------
(1, (8192, 5120))    True                         113.152                  118.784                     454.752              1853.39                      1765.52                         461.164  0.95x                    0.25x
(1, (5120, 8192))    True                         149.248                  118.176                     293.552              1405.15                      1774.6                          714.406  1.26x                    0.51x
(16, (8192, 5120))   True                        2160.62                  1654.64                     1914.64               1553                         2027.9                         1752.52   1.31x                    1.13x
(16, (5120, 8192))   True                        2073.41                  1647.2                      1825.01               1618.32                      2037.06                        1838.59   1.26x                    1.14x
(128, (8192, 5120))  True                       21529.4                  13617.8                     14840.8                1246.83                      1971.22                        1808.77   1.58x                    1.45x
(128, (5120, 8192))  True                       17985.5                  13570.6                     15235.6                1492.51                      1978.07                        1761.89   1.33x                    1.18x
```