### PR TITLE
TorchAOBaseTensor `__tensor_flatten__` and `__tensor_unflatten__` use…

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -907,8 +907,8 @@ def test_nvfp4_swizzled_scales_serialization():
     tensor_list, ctx = original_tensor.__tensor_flatten__()
 
     # Verify swizzled flag is preserved in context
-    assert NVFP4Tensor.optional_tensor_attribute_names[0] == "_is_swizzled_scales"
-    assert ctx[2] == True
+    assert "_is_swizzled_scales" in ctx
+    assert ctx["_is_swizzled_scales"] == True
 
     # Test deserialization
     inner_tensors = {}

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -307,8 +307,8 @@ def test_nvfp4_swizzled_scales_serialization():
     tensor_list, ctx = original_tensor.__tensor_flatten__()
 
     # Verify swizzled flag is preserved in context
-    assert NVFP4Tensor.optional_tensor_attribute_names[0] == "_is_swizzled_scales"
-    assert ctx[2] == True
+    assert "_is_swizzled_scales" in ctx
+    assert ctx["_is_swizzled_scales"] == True
 
     # Test deserialization
     inner_tensors = {}

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -96,9 +96,9 @@ class NVFP4Tensor(TorchAOBaseTensor):
         blockwise_scales,
         block_size,
         orig_dtype,
-        per_tensor_scale,
-        act_per_tensor_scale,
-        is_swizzled_scales=False,
+        _per_tensor_scale=None,
+        _act_per_tensor_scale=None,
+        _is_swizzled_scales=False,
         use_triton_kernel=False,
         act_quant_kwargs=None,
     ):
@@ -122,9 +122,9 @@ class NVFP4Tensor(TorchAOBaseTensor):
         self._scale_e4m3 = blockwise_scales
         self._block_size = block_size
         self._orig_dtype = orig_dtype
-        self._per_tensor_scale = per_tensor_scale
-        self._act_per_tensor_scale = act_per_tensor_scale
-        self._is_swizzled_scales = is_swizzled_scales
+        self._per_tensor_scale = _per_tensor_scale
+        self._act_per_tensor_scale = _act_per_tensor_scale
+        self._is_swizzled_scales = _is_swizzled_scales
         self.use_triton_kernel = use_triton_kernel
         self.act_quant_kwargs = act_quant_kwargs
         return self


### PR DESCRIPTION
… tensor attribute dict

Summary:
Previously we return tensor attribute list, but changing to tensor attribute dict is more debuggable

Test Plan:
python test/integration/test_load_and_run_checkpoint.py

Reviewers:

Subscribers:

Tasks:

Tags: