### PR TITLE
Add OPAQUE packing format

### DIFF
--- a/torchao/quantization/quantize_/common/packing_format.py
+++ b/torchao/quantization/quantize_/common/packing_format.py
@@ -37,6 +37,13 @@ class PackingFormat(str, Enum):
     MARLIN_SPARSE = "marlin_sparse"
 
     """
-    Unpacked means the subbyte quantized data is stored as int8
+    Unpacked to int8 means the subbyte quantized data is stored as int8
     """
     UNPACKED_TO_INT8 = "unpacked_to_int8"
+
+    """
+    Opaque packing format that's used for tensors that does not have a predefined packing format
+    (that may be decided on hardware, tensor shape, library availability etc.) and it's not
+    needed for the rest of the system to understand the specific format that's adopted.
+    """
+    OPAQUE = "opaque"


### PR DESCRIPTION
Summary:
Adding the packing format first that could be used by previously int4 cpu and int8 + int4 packed tensor since these does not have a fixed packing format

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: