### PR TITLE
[mxfp8 moe training] add triton kernel for blocked swizzled 3d weight scales

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_3d_blocked_swizzle_scale_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_3d_blocked_swizzle_scale_kernels.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+# this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+from benchmarks.utils import benchmark_cuda_function_in_microseconds
+from torchao.prototype.moe_training.kernels.mxfp8_blocked_scales import (
+    torch_to_blocked_per_group_3d,
+    triton_mx_block_rearrange_per_group_3d,
+)
+
+device = torch.device("cuda")
+
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    input_shape: tuple[int]
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    torch_time_us: float
+    triton_time_us: float
+    torch_mem_bw_gbps: float
+    triton_mem_bw_gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    # Llama4 shapes. Input activations are scaled along K dim.
+    block_size = 32
+    input_shapes = [
+        # w1, w3 scaled along K (fwd)
+        (1, 8192, 5120 // block_size),
+        (2, 8192, 5120 // block_size),
+        (4, 8192, 5120 // block_size),
+        (8, 8192, 5120 // block_size),
+        (16, 8192, 5120 // block_size),
+        # w2 scaled along K (fwd)
+        (1, 5120, 8192 // block_size),
+        (2, 5120, 8192 // block_size),
+        (4, 5120, 8192 // block_size),
+        (8, 5120, 8192 // block_size),
+        (16, 5120, 8192 // block_size),
+    ]
+    configs = []
+    for shape in input_shapes:
+        configs.append(
+            ExperimentConfig(
+                input_shape=shape,
+            )
+        )
+    return configs
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    input_tensor = torch.randint(
+        low=0,
+        high=256,
+        size=config.input_shape,
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    def warmup(fn, *args, **kwargs):
+        for _ in range(5):
+            fn(*args, **kwargs)
+
+    E, N, K = config.input_shape
+
+    # bench torch
+    compiled_run_torch = torch.compile(torch_to_blocked_per_group_3d)
+    warmup(compiled_run_torch, input_tensor)
+    torch_time_us = benchmark_cuda_function_in_microseconds(
+        compiled_run_torch,
+        input_tensor,
+    )
+
+    # bench triton
+    triton_out_scales = triton_mx_block_rearrange_per_group_3d(input_tensor)
+    warmup(triton_mx_block_rearrange_per_group_3d, input_tensor)
+    triton_time_us = benchmark_cuda_function_in_microseconds(
+        triton_mx_block_rearrange_per_group_3d,
+        input_tensor,
+    )
+
+    # mem bw calculations
+    bytes_per_input_el = torch.finfo(torch.float8_e8m0fnu).bits / 8
+    bytes_per_output_el = torch.finfo(torch.float8_e4m3fn).bits / 8
+
+    read_bytes = input_tensor.numel() * bytes_per_input_el
+    write_bytes = triton_out_scales.numel() * bytes_per_output_el
+
+    torch_mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (torch_time_us / 1e6)
+    triton_mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (triton_time_us / 1e6)
+
+    return ExperimentResult(
+        torch_time_us=torch_time_us,
+        triton_time_us=triton_time_us,
+        torch_mem_bw_gbps=torch_mem_bw_gbps,
+        triton_mem_bw_gbps=triton_mem_bw_gbps,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "input_shape",
+        "torch_time_us",
+        "triton_time_us",
+        "torch_mem_bw_gbps",
+        "triton_mem_bw_gbps",
+        "triton_speedup",
+    ]
+    rows = []
+    for experiment in experiments:
+        input_shape = f"({experiment.config.input_shape[0]}, {experiment.config.input_shape[1]}, {experiment.config.input_shape[2]})"
+        rows.append(
+            [
+                input_shape,
+                experiment.result.torch_time_us,
+                experiment.result.triton_time_us,
+                round(experiment.result.torch_mem_bw_gbps, 3),
+                round(experiment.result.triton_mem_bw_gbps, 3),
+                f"{experiment.result.torch_time_us / experiment.result.triton_time_us:.2f}x",
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -1179,7 +1179,7 @@ if torch_version_at_least("2.7.0") and has_triton():
     @torch.library.custom_op("torchao::triton_mx_block_rearrange", mutates_args=())
     def triton_mx_block_rearrange(scale_tensor: torch.Tensor) -> torch.Tensor:
         """
-        Rearranges an E8M0 tensor scale from row-major format to block-scaled swizzle format.
+        Rearranges an E8M0 tensor scale to block-scaled swizzle format.
 
         This format is suitable for Tmem as described in NVIDIA documentation:
         https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout


### PR DESCRIPTION
Stacked PRs:
 * #2897
 * __->__#2894
 * #2886


--- --- ---

[mxfp8 moe training] add triton kernel for blocked swizzled 3d weight scales

## Summary
- Add kernel to convert 3d mxfp8 weight scales to blocked swizzled format
- This kernel is simpler because we can make a modified version of [this one used for 2d linear weights](https://github.com/pytorch/ao/blob/364ad471b287702df9fb499a511440b4aa69ee93/torchao/prototype/mx_formats/kernels.py#L1180), where we just have (1) different launch params to parallelize across groups, and (2) different stride calculations in the kernel, updating the base pointer to account for the group we're in.
- I could have potentially expanded the existing dense model kernel to do this since there's no variable group sizes, but i didn't because (1) kernel needs different launch grid and additional params passed into it, so we'd have a weird if-else launching different kernels with different grids and different params. And (2) I would like to keep all the MoE training code in the `prototype/moe_training` to make the code base as self-contained as possible for now.
- Note that there are no data dependent group sizes so technically torch.compile should be competitive, maybe we don't need this kernel?

## Test plan
- `sanitize pytest test/prototype/moe_training/test_kernels.py -k scales_3d`

## Benchmarks 
- The kernel is completely unoptimized and can be improved. NCU flags uncoalesced global accesses and partial waves, which should provide a nice speedup if we resolve. 
    - As an aside, I've noticed with triton loading 2d blocks of data, uncoalesced loads from GMEM seem to always happen with row major data but not column major data. This surprises me, because with a 2d block of data in either row major or col major, we should always be able to get coalesced loads by assigning threads in each warp to load either a row or column of data, depending on which direction is contiguous. Not sure if the compiler isn't able to figure this out, or if it's me that is misunderstanding something.
  
```
input_shape        torch_time_us    triton_time_us    torch_mem_bw_gbps    triton_mem_bw_gbps  triton_speedup
---------------  ---------------  ----------------  -------------------  --------------------  ----------------
(1, 8192, 160)            19.424            10.112              134.959               259.241  1.92x
(2, 8192, 160)            16.384            10.432              320                   502.577  1.57x
(4, 8192, 160)            28.736            13.216              364.9                 793.414  2.17x
(8, 8192, 160)           133.184            20.512              157.463              1022.4    6.49x
(16, 8192, 160)          104.096            35.648              402.927              1176.59   2.92x
(1, 5120, 256)            26.56             10.08                98.699               260.063  2.63x
(2, 5120, 256)            25.248            10.688              207.655               490.539  2.36x
(4, 5120, 256)           104.512            14.464              100.331               724.956  7.23x
(8, 5120, 256)           544.8              22.56                38.494               929.589  24.15x
(16, 5120, 256)          134.144            38.912              312.672              1077.89   3.45x
```