### PR TITLE
Move packing format to intx folder

### DIFF
--- a/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
@@ -22,7 +22,7 @@ from torchao.quantization.quant_api import (
     MappingType,
     quantize_,
 )
-from torchao.quantization.quantize_.common import PackingFormat
+from torchao.quantization.quantize_.workflows import IntxPackingFormat
 from torchao.quantization.utils import compute_error
 
 
@@ -33,11 +33,11 @@ def _get_accuracy_test_cases():
     ]
 
     PACKING_FORMATS = [
-        (PackingFormat.UNPACKED_TO_INT8, None),
-        (PackingFormat.OPAQUE, "aten"),
-        (PackingFormat.OPAQUE, "torchao_auto"),
-        (PackingFormat.OPAQUE, "torchao_lowbit"),
-        (PackingFormat.OPAQUE, "torchao_kleidiai"),
+        (IntxPackingFormat.UNPACKED_TO_INT8, None),
+        (IntxPackingFormat.OPAQUE, "aten"),
+        (IntxPackingFormat.OPAQUE, "torchao_auto"),
+        (IntxPackingFormat.OPAQUE, "torchao_lowbit"),
+        (IntxPackingFormat.OPAQUE, "torchao_kleidiai"),
     ]
 
     WEIGHT_DTYPES = [
@@ -68,7 +68,7 @@ def _get_accuracy_test_cases():
         weight_granularity,
     ):
         # ATEN restrictions
-        if (packing_format == PackingFormat.OPAQUE) and (compute_target == "aten"):
+        if (packing_format == IntxPackingFormat.OPAQUE) and (compute_target == "aten"):
             if weight_dtype != torch.int4:
                 return False
             if weight_mapping_type == MappingType.ASYMMETRIC:
@@ -77,7 +77,7 @@ def _get_accuracy_test_cases():
                 return False
 
         # TORCHAO_KLEIDIAI restrictions
-        if (packing_format == PackingFormat.OPAQUE) and (
+        if (packing_format == IntxPackingFormat.OPAQUE) and (
             compute_target == "torchao_kleidiai"
         ):
             if weight_dtype != torch.int4:
@@ -168,7 +168,7 @@ class TestIntxOpaqueTensor(TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                packing_format=PackingFormat.UNPACKED_TO_INT8,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 compute_target=None,
                 version=2,
             ),
@@ -215,7 +215,7 @@ class TestIntxOpaqueTensor(TestCase):
                 weight_dtype=weight_dtype,
                 weight_granularity=weight_granularity,
                 weight_mapping_type=weight_mapping_type,
-                packing_format=PackingFormat.OPAQUE,
+                packing_format=IntxPackingFormat.OPAQUE,
                 compute_target="torchao_auto",
                 version=2,
             ),
@@ -249,8 +249,8 @@ class TestIntxOpaqueTensor(TestCase):
         [
             param(packing_format=pf, compute_target=ct)
             for (pf, ct) in [
-                (PackingFormat.OPAQUE, "torchao_auto"),
-                (PackingFormat.OPAQUE, "aten"),
+                (IntxPackingFormat.OPAQUE, "torchao_auto"),
+                (IntxPackingFormat.OPAQUE, "aten"),
             ]
         ],
         name_func=lambda f, _, params: f.__name__ + f"_{params.kwargs}",
@@ -311,7 +311,7 @@ class TestIntxOpaqueTensor(TestCase):
         out = model(x).clone()
 
         base_config = Int8DynamicActivationIntxWeightConfig(
-            packing_format=PackingFormat.OPAQUE,
+            packing_format=IntxPackingFormat.OPAQUE,
             compute_target="torchao_auto",
             version=2,
         )

--- a/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
@@ -194,7 +194,7 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
                 weight_dtype=torch.int4,
                 weight_granularity=PerGroup(64),
                 weight_mapping_type=MappingType.SYMMETRIC,
-                packing_format=PackingFormat.UNPACKED_TO_INT8,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 version=2,
             ),
         )

--- a/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
@@ -25,7 +25,7 @@ from torchao.quantization import (
 )
 from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.qat import IntxFakeQuantizeConfig, QATConfig
-from torchao.quantization.quantize_.common import PackingFormat
+from torchao.quantization.quantize_.workflows import IntxPackingFormat
 from torchao.quantization.utils import compute_error
 from torchao.utils import torch_version_at_least, unwrap_tensor_subclass
 
@@ -158,7 +158,7 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
                 weight_dtype=torch.int4,
                 weight_granularity=PerAxis(0),
                 weight_mapping_type=MappingType.SYMMETRIC,
-                packing_format=PackingFormat.UNPACKED_TO_INT8,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 version=2,
             ),
         )
@@ -227,14 +227,12 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
         model2 = torch.nn.Sequential(*layers)
         activations = torch.randn(1, 512, dtype=torch.float32)
 
-        packing_format = PackingFormat.UNPACKED_TO_INT8
-
         quantize_(
             model,
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=torch.int4,
                 weight_granularity=PerGroup(64),
-                packing_format=packing_format,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 version=2,
             ),
         )
@@ -259,14 +257,12 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
         model2 = torch.nn.Sequential(*layers)
         activations = torch.randn(1, 512, dtype=torch.float32)
 
-        packing_format = PackingFormat.UNPACKED_TO_INT8
-
         quantize_(
             model,
             IntxWeightOnlyConfig(
                 weight_dtype=torch.int4,
                 granularity=PerGroup(64),
-                packing_format=packing_format,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 version=2,
             ),
         )
@@ -325,7 +321,7 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
             weight_granularity=PerGroup(group_size),
             weight_mapping_type=mapping_type,
             weight_scale_dtype=scale_dtype,
-            packing_format=PackingFormat.UNPACKED_TO_INT8,
+            packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
             version=2,
         )
 
@@ -433,7 +429,7 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
                 weight_mapping_type=mapping_type,
                 weight_scale_dtype=scale_dtype,
                 act_mapping_type=act_mapping_type,
-                packing_format=PackingFormat.UNPACKED_TO_INT8,
+                packing_format=IntxPackingFormat.UNPACKED_TO_INT8,
                 version=2,
             ),
         )

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -68,7 +68,6 @@ from torchao.quantization.linear_activation_weight_observed_tensor import (
 from torchao.quantization.observer import AffineQuantizedObserverBase, get_block_size
 from torchao.quantization.quantize_.common import (
     KernelPreference,
-    PackingFormat,
 )
 from torchao.quantization.quantize_.workflows import (
     Float8Tensor,

--- a/torchao/quantization/quantize_/common/packing_format.py
+++ b/torchao/quantization/quantize_/common/packing_format.py
@@ -27,11 +27,6 @@ class PackingFormat(str, Enum):
     PLAIN = "plain"
 
     """
-    Unpacked to int8 means the subbyte quantized data is stored as int8
-    """
-    UNPACKED_TO_INT8 = "unpacked_to_int8"
-
-    """
     Opaque packing format that's used for tensors that does not have a predefined packing format
     (that may be decided on hardware, tensor shape, library availability etc.) and it's not
     needed for the rest of the system to understand the specific format that's adopted.

--- a/torchao/quantization/quantize_/workflows/__init__.py
+++ b/torchao/quantization/quantize_/workflows/__init__.py
@@ -23,6 +23,9 @@ from .int4.int4_tile_packed_to_4d_tensor import Int4TilePackedTo4dTensor
 from .intx.intx_opaque_tensor import (
     IntxOpaqueTensor,
 )
+from .intx.intx_packing_format import (
+    IntxPackingFormat,
+)
 from .intx.intx_unpacked_to_int8_tensor import (
     IntxUnpackedToInt8Tensor,
 )
@@ -35,10 +38,10 @@ __all__ = [
     "Int4TilePackedTo4dTensor",
     "Float8Tensor",
     "QuantizeTensorToFloat8Kwargs",
-    "IntxOpaqueTensor",
     "Int4OpaqueTensor",
-    "IntxUnpackedTensor",
-    "IntxUnpackedToInt8Tensor",
     "Int4ChooseQParamsAlgorithm",
     "Int4PackingFormat",
+    "IntxPackingFormat",
+    "IntxUnpackedToInt8Tensor",
+    "IntxOpaqueTensor",
 ]

--- a/torchao/quantization/quantize_/workflows/intx/intx_packing_format.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_packing_format.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum
+
+
+# can switch to StrEnum (https://docs.python.org/3/library/enum.html#enum.StrEnum)
+# after python 3.10 is end of life (https://devguide.python.org/versions/)
+class IntxPackingFormat(str, Enum):
+    """Packing format for quantized data in Tensor subclasses in torchao, represents how
+    the values are packed and laid out in the quantized data.
+    """
+
+    """
+    Unpacked to int8 means the subbyte quantized data is stored as int8
+    """
+    UNPACKED_TO_INT8 = "unpacked_to_int8"
+
+    """
+    Opaque packing format that's used for tensors that does not have a predefined packing format
+    (that may be decided on hardware, tensor shape, library availability etc.) and it's not
+    needed for the rest of the system to understand the specific format that's adopted.
+    """
+    OPAQUE = "opaque"


### PR DESCRIPTION
PackingFormat will be removed from workflows._common, so this introduces a new IntxPackingFormat to replace its use.