### PR TITLE
[Intel GPU][doc] Change x86 quantizer to xpu quantizer in doc

### DIFF
--- a/docs/source/tutorials_source/pt2e_quant_xpu_inductor.rst
+++ b/docs/source/tutorials_source/pt2e_quant_xpu_inductor.rst
@@ -40,7 +40,7 @@ The high-level architecture of this flow could look like this:
     —--------------------------------------------------------
                                 |
                         FX Graph in ATen
-                                |            X86InductorQuantizer
+                                |            XPUInductorQuantizer
                                 |                 /
     —--------------------------------------------------------
     |                      prepare_pt2e                     |


### PR DESCRIPTION
# Motivation

I accidently discover that, the PT2E flow chart in Intel GPU doc uses CPU quantizer. This PR changes the quantizer to `XPUInductorQuanztier` avoid the misunderstanding to users.

cc @liangan1 