### PR TITLE
fix torchao version check on torch version

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -35,7 +35,7 @@ if (not "+git" in __version__) and not ("unknown" in __version__):
     # dumped)".
     # TODO(#2901, and before next torchao release): make this generic for
     # future torchao and torch versions
-    if __version__.startswith("0.13.0") and torch.__version__ > "2.8":
+    if __version__.startswith("0.13.0") and torch.__version__ >= "2.9":
         logger.warning(
             f"Skipping import of cpp extensions due to incompatible torch version {torch.__version__} for torchao version {__version__}"
         )


### PR DESCRIPTION
Summary:

Fix error in https://github.com/pytorch/ao/pull/2908. The version string for PyTorch 2.8 reads "2.8.0...", so we need to compare `>= 2.9` to properly gate out PyTorch 2.9.

Test Plan:

1. make this change in a locally installed __init__ file of torchao downloaded via pip
2. install PyTorch 2.8.0
3. import torchao, verify warning was not hit

Reviewers:

Subscribers:

Tasks:

Tags: