### PR TITLE
another fix for torch version

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -35,7 +35,7 @@ if (not "+git" in __version__) and not ("unknown" in __version__):
     # dumped)".
     # TODO(#2901, and before next torchao release): make this generic for
     # future torchao and torch versions
-    if __version__.startswith("0.13.0") and torch.__version__ >= "2.9":
+    if __version__.startswith("0.13.0") and str(torch.__version__) >= "2.9":
         logger.warning(
             f"Skipping import of cpp extensions due to incompatible torch version {torch.__version__} for torchao version {__version__}"
         )


### PR DESCRIPTION
Summary:

`torch.__version__` has unexpected behavior when comparing to a string:

```python
(Pdb) torch.__version__
'2.9.0.dev20250902+cu128'
(Pdb) str(torch.__version__)
'2.9.0.dev20250902+cu128'
(Pdb) '2.9.0.dev20250902+cu128' >= '2.9'
True
(Pdb) torch.__version__ >= '2.9'
False
(Pdb) torch.__version__ >= (2, 9)
False
(Pdb) torch.__version__ >= (2, 9, 0)
False
(Pdb) str(torch.__version__) >= '2.9'
True
```

To unblock the release, for now compare `str(torch.__version__)` to force the behavior we want for `torch==2.9.x`. We should make this more robust, saving that for a future PR.

Test Plan:

```
1. install torchao 0.13.0 from pip
2. install torch 2.8.0, verify torchao imports without errors
3. isntall torch 2.9.x, verify torchao imports correctly and a warning
   for skipping c++ kernel import is shown
```

Reviewers:

Subscribers:

Tasks:

Tags: