### PR TITLE
Skip QAT int4 v2 test for fbcode

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -93,6 +93,7 @@ from torchao.quantization.utils import (
 )
 from torchao.utils import (
     _is_fbgemm_genai_gpu_available,
+    is_fbcode,
     is_sm_at_least_89,
 )
 
@@ -1937,6 +1938,7 @@ class TestQAT(TestCase):
     @unittest.skipIf(
         not _is_fbgemm_genai_gpu_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
     )
+    @unittest.skipIf(is_fbcode(), "cutlass cannot initialize")
     @parametrize("version", [1, 2])
     def test_quantize_api_int4(self, version: int):
         """


### PR DESCRIPTION
It's failing with `cutlass cannot initialize` error, skipping for now to unbreak.