### PR TITLE
Exclude libcuda.so from auditwheel replair

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - build/packaging/**
+      - packaging/**
       - .github/workflows/build_wheels_linux.yml
       - setup.py
   push:

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -21,10 +21,8 @@ if [[ "$CU_VERSION" == cu* ]]; then
     --exclude libtorch_cpu.so \
     --exclude libc10.so \
     --exclude libc10_cuda.so \
-    --exclude libcuda.so \
-    --exclude libcudart.so.13 \
-    --exclude libcudart.so.12 \
-    --exclude libcudart.so.11.0 \
+    --exclude libcuda.so.* \
+    --exclude libcudart.so.* \
     "${WHEEL_NAME}"
 
     ls -lah .

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -21,6 +21,7 @@ if [[ "$CU_VERSION" == cu* ]]; then
     --exclude libtorch_cpu.so \
     --exclude libc10.so \
     --exclude libc10_cuda.so \
+    --exclude libcuda.so \
     --exclude libcudart.so.13 \
     --exclude libcudart.so.12 \
     --exclude libcudart.so.11.0 \


### PR DESCRIPTION
Seeing binary size jump 6.5 -> 18.7mb due to packaging extra library:
```libcuda-984fdb42.so.570.133.07``` - 71.4mb