### PR TITLE
Add dirsync for torchao/csrc/cpu

### DIFF
--- a/torchao/csrc/cpu/cpu/da8w4_linear.cpp
+++ b/torchao/csrc/cpu/cpu/da8w4_linear.cpp
@@ -1,0 +1,749 @@
+#include <torch/all.h>
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/native/CPUBlas.h>
+#include <c10/util/Unroll.h>
+
+namespace torchao {
+
+namespace {
+
+#define BLOCK_N 32
+
+static bool cpublas_checked = false;
+static bool cpublas_can_pack = false;
+
+bool cpublas_could_pack() {
+  // the could_pack check requires AMX support implicitly
+  if (cpublas_checked) {
+    return cpublas_can_pack;
+  }
+  cpublas_can_pack = at::native::cpublas::could_pack(at::kByte);
+  cpublas_checked = true;
+  return cpublas_can_pack;
+}
+
+/*
+return: packed_weight, packed_scales, packed_qzeros, compensation
+*/
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+da8w4_linear_prepack_impl(
+    const at::Tensor& weight,
+    const at::Tensor& scales,
+    const at::Tensor& qzeros) {
+  // weight shape = [N, K]
+  // scales shape = [N, G]
+  // qzeros shape = [N, G]
+  TORCH_CHECK(weight.dim() == 2,
+              "DA8W4 CPU: Weight should be a 2D tensor for packing");
+  TORCH_CHECK(weight.size(1) % 2 == 0,
+              "DA8W4 CPU: Weight should have even number of columns for packing");
+
+  auto new_scales = scales;
+  auto new_qzeros = qzeros;
+  if (new_scales.dim() == 1) {
+    new_scales.unsqueeze_(1);
+  }
+  new_scales = new_scales.to(at::kFloat);
+  if (new_qzeros.dim() == 1) {
+    new_qzeros.unsqueeze_(1);
+  }
+  new_qzeros = new_qzeros.to(at::kChar);
+  int N = weight.size(0);
+  int K = weight.size(1);
+  int G = scales.size(1);
+  int group_size = K / G;
+  int block_k = group_size > 128 ? 128 : group_size;
+  constexpr int block_n = BLOCK_N;
+  int Nc = N / block_n;
+  int Kc = K / block_k;
+
+  // Reorder weight to [N/block_n, K/block_k, block_k, block_n]
+  // Reorder scales/qzeros to [N/block_n, G, block_n]
+  auto weight_view = weight.view({Nc, block_n, Kc, block_k});
+  at::Tensor weight_reordered = weight_view.permute({0, 2, 3, 1}).contiguous();
+  at::Tensor blocked_weight;
+  at::Tensor blocked_scales = new_scales.view({Nc, block_n, G}).permute({0, 2, 1}).contiguous();
+  at::Tensor blocked_qzeros = new_qzeros.view({Nc, block_n, G}).permute({0, 2, 1}).contiguous();
+  // Compensation = Σ(k)(W[k][n] - ZP[n]) for each block.
+  // Reorder compensation to [N/block_n, K/block_k, block_n]
+  auto weight_sub_qzero = weight.view({Nc, block_n, G, -1}).to(at::kInt) - new_qzeros.view({Nc, block_n, G, -1});
+  weight_sub_qzero = weight_sub_qzero.view({Nc, block_n, Kc, block_k});
+  at::Tensor compensation = weight_sub_qzero.sum(-1);
+  compensation = compensation.permute({0, 2, 1}).contiguous().to(at::kInt);
+
+#if defined(CPU_CAPABILITY_AVX512)
+  if (cpublas_could_pack()) {
+    blocked_weight = at::empty({Nc, Kc, block_k, block_n / 2}, weight.options());
+    auto weight_ptr = weight_reordered.data_ptr<uint8_t>();
+    auto blocked_weight_ptr = blocked_weight.data_ptr<uint8_t>();
+    int64_t num_blocks = Nc * Kc;
+    at::parallel_for(0, num_blocks, 1, [&](int64_t begin, int64_t end) {
+      for (const auto i : c10::irange(begin, end)) {
+        auto in_ptr = weight_ptr + i * block_k * block_n;
+        auto out_ptr = blocked_weight_ptr + i * block_k * block_n / 2;
+
+        // Reorder weight block to VNNI4 and pack two lanes along N
+        // N=16 viewed as two lanes: a0, ...a7, b0, ...b7
+        // pack two lanes: [a0, b0], ..., [a7, b7]
+        // plain shape = [block_k, block_n]
+        // packed shape = [block_k / 4, block_n / 2, 4] viewed as [block_k, block_n / 2]
+        constexpr int n_group_size = 8;
+        constexpr int vnni_size = 4;
+        constexpr int n_group = block_n / n_group_size; // 4
+        for (int nb = 0; nb < n_group; nb += 2) {
+          for (int k = 0; k < block_k; k += vnni_size) {
+            for (int ni = 0; ni < n_group_size; ++ni) {
+              for (int ki = 0; ki < vnni_size; ++ki) {
+                int src_idx_1 = nb * n_group_size + ni + (k + ki) * block_n;
+                int src_idx_2 = (nb + 1) * n_group_size + ni + (k + ki) * block_n;
+                int dst_idx = (nb / 2 * n_group_size + ni) * vnni_size + k * block_n / 2 + ki;
+                uint8_t src_1 = *(in_ptr + src_idx_1);
+                uint8_t src_2 = *(in_ptr + src_idx_2);
+                uint8_t dst = (src_1 & 0x0f) | ((src_2 & 0x0f) << 4);
+                *(out_ptr + dst_idx) = dst;
+              }
+            }
+          }
+        }
+      }
+    });
+  } else
+#endif
+  {
+    // Pack weight: two int4 -> one int8
+    using namespace at::indexing;
+    at::Tensor even_columns =
+        weight_reordered.index({Slice(), Slice(), Slice(), Slice(1, None, 2)});
+    even_columns = even_columns.bitwise_left_shift(4);
+    at::Tensor odd_columns =
+        weight_reordered.index({Slice(), Slice(), Slice(), Slice(None, None, 2)});
+    blocked_weight = even_columns.bitwise_or(odd_columns);
+  }
+
+  return std::make_tuple(std::move(blocked_weight), std::move(blocked_scales), std::move(blocked_qzeros), std::move(compensation));
+}
+
+template<bool sym_quant_a>
+struct ActDtype;
+template<>
+struct ActDtype<true> {
+  using type = int8_t;
+};
+
+template<>
+struct ActDtype<false> {
+  using type = uint8_t;
+};
+
+
+#if defined(CPU_CAPABILITY_AVX512)
+inline std::array<__m256i, 2> load_zps_4vnni(const int8_t* __restrict__ zps) {
+  // broadcast 01234567 to
+  // 01234567012345670123456701234567
+  __m256i vzps_low = _mm256_set1_epi64x(*reinterpret_cast<const long*>(zps));
+  __m256i vzps_high = _mm256_set1_epi64x(*reinterpret_cast<const long*>(zps + 8));
+  // shuffle from
+  // 01234567012345670123456701234567
+  // to
+  // 00001111222233334444555566667777
+  __m256i shuffle_mask = _mm256_set_epi8(
+      7,
+      7,
+      7,
+      7,
+      6,
+      6,
+      6,
+      6,
+      5,
+      5,
+      5,
+      5,
+      4,
+      4,
+      4,
+      4,
+      3,
+      3,
+      3,
+      3,
+      2,
+      2,
+      2,
+      2,
+      1,
+      1,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0);
+  vzps_low = _mm256_shuffle_epi8(vzps_low, shuffle_mask);
+  vzps_high = _mm256_shuffle_epi8(vzps_high, shuffle_mask);
+  return {vzps_low, vzps_high};
+}
+
+inline std::array<__m256i, 2> load_uint4_as_int8(const uint8_t* __restrict__ qB) {
+  __m256i packed = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(qB));
+  const __m256i low_mask = _mm256_set1_epi8(0x0f);
+  __m256i high = _mm256_srli_epi16(packed, 4);
+  high = _mm256_and_si256(high, low_mask);
+  __m256i low = _mm256_and_si256(packed, low_mask);
+  return {low, high};
+}
+
+template <int64_t N, int64_t ldb>
+void _dequant_weight_zp_only(
+    const uint8_t* __restrict__ B,
+    int8_t* dqB,
+    const int8_t* __restrict__ qzeros,
+    int64_t K) {
+  // unpack weight int8 -> two int4
+  // subtract zero point
+  // B shape = [K, ldb] = [K, N / 2], actual shape = [K / 4, N / 2, 4]
+  // dqB shape = [K, N], actual shape = [K / 4, N, 4]
+#pragma GCC unroll 2
+  for (int n = 0; n < N; n += 16) {
+    auto [zps_low, zps_high] = load_zps_4vnni(&qzeros[n]);
+    for (int k = 0; k < K; k += 4) {
+      auto [vb_low, vb_high] = load_uint4_as_int8(B + ldb * k + n / 2 * 4);
+      vb_high = _mm256_sub_epi8(vb_high, zps_high);
+      vb_low = _mm256_sub_epi8(vb_low, zps_low);
+      // store vb to B
+      _mm256_storeu_si256(reinterpret_cast<__m256i_u*>(dqB + N * k + n * 4), vb_low);
+      _mm256_storeu_si256(reinterpret_cast<__m256i_u*>(dqB + N * k + (n + 8) * 4), vb_high);
+    }
+  }
+}
+
+template <bool accum, int64_t N, bool sym_quant_a>
+void _dequant_and_store(
+    float* __restrict__ output,
+    const int32_t* __restrict__ input,
+    const float* __restrict__ scale_a,
+    const int32_t* __restrict__ zp_a,
+    const float* __restrict__ scale_b,
+    const int32_t* __restrict__ comp_b,
+    int M,
+    int ldi,
+    int ldo,
+    int ldsa = 1) {
+  for (int m = 0; m < M; ++m) {
+    float a_scale = *(scale_a + m * ldsa);
+    __m512 va_scale = _mm512_set1_ps(a_scale);
+    int32_t a_zp;
+    __m512i va_zp;
+    if constexpr (!sym_quant_a) {
+      a_zp = *(zp_a + m * ldsa);
+      va_zp = _mm512_set1_epi32(a_zp);
+    }
+    int n = 0;
+#pragma GCC unroll 2
+    for (; n < N; n += 16) {
+      __m512i vc = _mm512_loadu_si512(input + m * ldi + n);
+      if constexpr (!sym_quant_a) {
+        __m512i vb_comp = _mm512_loadu_si512(comp_b + n);
+        vc = _mm512_sub_epi32(vc, _mm512_mullo_epi32(vb_comp, va_zp));
+      }
+      __m512 vc_f = _mm512_cvtepi32_ps(vc);
+      __m512 vc_f_mul = _mm512_mul_ps(vc_f, va_scale);
+      __m512 vb_s = _mm512_loadu_ps(scale_b + n);
+      vc_f_mul = _mm512_mul_ps(vc_f_mul, vb_s);
+      if constexpr (accum) {
+        __m512 vo = _mm512_loadu_ps(output + m * ldo + n);
+        _mm512_storeu_ps(output + m * ldo + n, _mm512_add_ps(vo, vc_f_mul));
+      } else {
+        _mm512_storeu_ps(output + m * ldo + n, vc_f_mul);
+      }
+    }
+    for (; n < N; ++n) {
+      float dq_val;
+      if constexpr (sym_quant_a) {
+        dq_val = (float)input[m * ldi + n] * a_scale * scale_b[n];
+      } else {
+        dq_val =
+          (float)(input[m * ldi + n] - a_zp * comp_b[n]) * a_scale * scale_b[n];
+      }
+      if constexpr (accum) {
+        output[m * ldo + n] += dq_val;
+      } else {
+        output[m * ldo + n] = dq_val;
+      }
+    }
+  }
+}
+
+#else
+template<int64_t N, int64_t ldb>
+void _dequant_weight_zp_only(
+    const uint8_t* B,
+    int8_t* dqB,
+    const int8_t* qzeros,
+    int64_t K) {
+  // B shape = [K, N / 2]
+  // dqB shape = [K, N]
+  for (int k = 0; k < K; ++k) {
+    for (int n = 0; n < N / 2; ++n) {
+      int32_t b = (int32_t)B[k * ldb + n];
+      dqB[k * N + n * 2] = (b & 0xf) - qzeros[n];
+      dqB[k * N + n * 2 + 1] = (b >> 4) - qzeros[n];
+    }
+  }
+}
+#endif
+
+#if defined(CPU_CAPABILITY_AVX512_VNNI)
+inline __m512i combine_m256i(__m256i a, __m256i b) {
+  __m512i c = _mm512_castsi256_si512(a);
+  return _mm512_inserti64x4(c, b, 1);
+}
+
+inline __m512i combine_m256i(std::array<__m256i, 2> two_256) {
+  return combine_m256i(two_256[0], two_256[1]);
+}
+
+// negate elements in a according to b's sign
+static inline __m512i _mm512_sign_epi8(__m512i a, __m512i b) {
+  __m512i zero = _mm512_setzero_si512();
+  __mmask64 blt0 = _mm512_movepi8_mask(b);
+  return _mm512_mask_sub_epi8(a, blt0, zero, a);
+}
+
+template <int64_t M, int64_t N, int64_t ldb, bool sym_quant_a>
+void _dequant_gemm_accum_small_M(
+    float* __restrict__ C,
+    const uint8_t* A,
+    const float* scales_a,
+    const int32_t* qzeros_a,
+    const uint8_t* B,
+    const float* scales_b,
+    const int8_t* qzeros_b,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc) {
+  // if sym_quant_a is true, A pointer type is passed in as uint8_t* but actually int8_t*.
+
+  constexpr int COLS = N / 16;
+  // Computing compensation is faster than loading it for small M
+  // because it's memory bound.
+  __m512i ones = _mm512_set1_epi8(1); // used for computing compensation
+  __m512i va;
+  __m512i vb[COLS];
+  __m512i vc[M * COLS];
+  __m512 vscales[COLS];
+  __m512i vzps[COLS];
+  __m512i vcompensate[COLS];
+
+  // Load scales and zps
+  c10::ForcedUnroll<COLS>{}([&](auto i) {
+      vscales[i] = _mm512_loadu_ps(scales_b + i * 16);
+      vzps[i] = combine_m256i(load_zps_4vnni(qzeros_b + i * 16));
+      if constexpr (!sym_quant_a) {
+        vcompensate[i] = _mm512_setzero_epi32();
+      }
+    });
+  c10::ForcedUnroll<M * COLS>{}(
+      [&](auto i) { vc[i] = _mm512_setzero_epi32(); });
+
+  auto compute = [&](auto i, int k) {
+    constexpr const int row = i / COLS;
+    constexpr const int col = i % COLS;
+
+    if constexpr (col == 0) {
+      va = _mm512_set1_epi32(*(int32_t*)(A + row * lda + k));
+    }
+
+    if constexpr (row == 0) {
+      int B_offset = k * ldb + col * 16 * 2;
+      vb[col] = combine_m256i(load_uint4_as_int8(B + B_offset));
+      vb[col] = _mm512_sub_epi8(vb[col], vzps[col]);
+      if constexpr (!sym_quant_a) {
+          vcompensate[col] =
+              _mm512_dpbusd_epi32(vcompensate[col], ones, vb[col]);
+      }
+      _mm_prefetch(B + B_offset + 128 * ldb, _MM_HINT_T0);
+    }
+    if constexpr (sym_quant_a) {
+        auto vsb = _mm512_sign_epi8(vb[col], va);
+        auto vabsa = _mm512_sign_epi8(va, va);
+        vc[i] = _mm512_dpbusds_epi32(vc[i], vabsa, vsb);
+    } else {
+      vc[i] = _mm512_dpbusd_epi32(vc[i], va, vb[col]);
+    }
+  };
+
+  // Accumulate along k
+  constexpr const int unroll = 4;
+  int k = 0;
+  for (; k < K / 4 / unroll; k++) {
+    c10::ForcedUnroll<unroll>{}([&](auto i) {
+      c10::ForcedUnroll<M * COLS>{}(compute, 4 * (k * unroll + i));
+    });
+  }
+  k *= 4 * unroll;
+  for (; k < K; k += 4) {
+    c10::ForcedUnroll<M * COLS>{}(compute, k);
+  }
+
+  // Store to C
+  auto store = [&](auto i) {
+    constexpr const int row = i / COLS;
+    constexpr const int col = i % COLS;
+    // compute (qC - compensate * zp_a) * scale_a * scale_b
+    __m512 vc_float;
+    if constexpr (!sym_quant_a) {
+      vc[i] = _mm512_sub_epi32(
+          vc[i],
+          _mm512_mullo_epi32(
+              vcompensate[col], _mm512_set1_epi32(*(qzeros_a + row))));
+    }
+    vc_float = _mm512_cvtepi32_ps(vc[i]);
+    vc_float = _mm512_mul_ps(vc_float, _mm512_set1_ps(*(scales_a + row)));
+
+    vc_float = _mm512_mul_ps(vc_float, vscales[col]);
+    auto vc_old = _mm512_loadu_ps(C + row * ldc + col * 16);
+    vc_float = _mm512_add_ps(vc_float, vc_old);
+    _mm512_storeu_ps(C + row * ldc + col * 16, vc_float);
+  };
+  c10::ForcedUnroll<M * COLS>{}(store);
+
+}
+
+#define call_dequant_gemm_accum_small_M(M) \
+  _dequant_gemm_accum_small_M<M, N, ldb, sym_quant_a>( \
+      C, \
+      A, \
+      scales_a, \
+      qzeros_a, \
+      B, \
+      scales_b, \
+      qzeros_b, \
+      K, \
+      lda, \
+      ldc);
+#endif
+
+template <bool cpublas_can_pack, int64_t N, int64_t ldb, bool sym_quant_a>
+void _dequant_gemm_accum(
+    float* C,
+    const uint8_t* A,
+    const float* scales_a,
+    const int32_t* qzeros_a,
+    const uint8_t* B,
+    const float* scales_b,
+    const int8_t* qzeros_b,
+    const int32_t* compensation,
+    int64_t M,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc) {
+  // Compute GEMM int8 * int8 -> int32
+  // dequant result to float by applying scales/qzeros
+#if defined(CPU_CAPABILITY_AVX512_VNNI)
+  if (M <= 4 && cpublas_can_pack) {
+    switch (M) {
+      case 1:
+        call_dequant_gemm_accum_small_M(1);
+        return;
+      case 2:
+        call_dequant_gemm_accum_small_M(2);
+        return;
+      case 3:
+        call_dequant_gemm_accum_small_M(3);
+        return;
+      case 4:
+        call_dequant_gemm_accum_small_M(4);
+        return;
+    }
+  }
+#endif
+
+  int8_t dqB[K * N];
+  _dequant_weight_zp_only<N, ldb>(B, dqB, qzeros_b, K);
+  using Tin = typename ActDtype<sym_quant_a>::type;
+  Tin* A_ptr = (Tin*)A;
+#if defined(CPU_CAPABILITY_AVX512)
+  if constexpr (cpublas_can_pack) {
+    int32_t C_i32[M * N];
+    at::native::cpublas::brgemm(
+        M,
+        N,
+        K,
+        lda,
+        N /*ldb*/,
+        N /*ldc*/,
+        false /* add_C */,
+        A_ptr,
+        dqB,
+        C_i32,
+        true /* is_vnni */);
+    _mm_prefetch(B + N * K / 2, _MM_HINT_T0);
+    _mm_prefetch(A + K, _MM_HINT_T0);
+    _dequant_and_store<true, N, sym_quant_a>(
+        C,
+        C_i32,
+        scales_a,
+        qzeros_a,
+        scales_b,
+        compensation,
+        M,
+        N /*ldi*/,
+        ldc,
+        1 /*ldsa*/);
+  } else
+#endif
+  {
+    for (int64_t i = 0; i < M; ++i) {
+      for (int64_t j = 0; j < N; ++j) {
+        float sum = 0;
+        for (int64_t k = 0; k < K; ++k) {
+          if constexpr (sym_quant_a) {
+            sum += ((int32_t)A_ptr[i * lda + k] * dqB[k * N + j]);
+          } else {
+            sum += ((int32_t)A_ptr[i * lda + k] - qzeros_a[i]) * (int32_t)dqB[k * N + j];
+          }
+        }
+        C[i * ldc + j] += sum * scales_a[i] * scales_b[j];
+      }
+    }
+  }
+}
+
+template<int64_t N>
+inline void copy_bias(const float* bias_ptr, float* y_buf, int64_t m) {
+  if (bias_ptr) {
+    for (int i = 0; i < m; ++i) {
+      int j = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+#pragma GCC unroll 2
+      for (; j < N; j += 16) {
+        __m512 bias_vec = _mm512_loadu_ps(bias_ptr + j);
+        _mm512_storeu_ps(y_buf + i * N + j, bias_vec);
+      }
+#endif
+      for (; j < N; ++j) {
+        y_buf[i * N + j] = bias_ptr[j];
+      }
+    }
+  } else { // initialize to zero
+    for (int i = 0; i < m; ++i) {
+      int j = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+#pragma GCC unroll 2
+      for (; j < N; j += 16) {
+        __m512 zero_vec = _mm512_setzero_ps();
+        _mm512_storeu_ps(y_buf + i * N + j, zero_vec);
+      }
+#endif
+      for (; j < N; ++j) {
+        y_buf[i * N + j] = 0;
+      }
+    }
+  }
+}
+
+template<typename out_dtype, int64_t N>
+inline void store_out(const float* y_buf, out_dtype* c_ptr, int64_t m, /* int64_t n, */ int64_t lda) {
+  for (int i = 0; i < m; ++i) {
+    int j = 0;
+    if constexpr (std::is_same<out_dtype, float>::value) {
+#if defined(CPU_CAPABILITY_AVX512)
+#pragma GCC unroll 2
+      for (; j < N; j += 16) {
+        __m512 y_vec = _mm512_loadu_ps(y_buf + i * N + j);
+        _mm512_storeu_ps(c_ptr + i * lda + j, y_vec);
+      }
+#endif
+      for (; j < N; ++j) {
+        c_ptr[i * lda + j] = y_buf[i * N + j];
+      }
+    } else if constexpr (std::is_same<out_dtype, at::BFloat16>::value) {
+#if defined(CPU_CAPABILITY_AVX512)
+#pragma GCC unroll 2
+      for (; j < N; j += 16) {
+        __m512 y_vec = _mm512_loadu_ps(y_buf + i * N + j);
+        __m256i y_bf16_vec = at::vec::cvtfp32_bf16(y_vec);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(c_ptr + i * lda + j), y_bf16_vec);
+      }
+#endif
+      for (; j < N; ++j) {
+        c_ptr[i * lda + j] = at::BFloat16(y_buf[i * N + j]);
+      }
+    } else if constexpr (std::is_same<out_dtype, at::Half>::value) {
+#if defined(CPU_CAPABILITY_AVX512)
+#pragma GCC unroll 2
+      for (; j < N; j += 16) {
+        __m512 y_vec = _mm512_loadu_ps(y_buf + i * N + j);
+        __m256i y_fp16_vec = at::vec::cvtfp32_fp16(y_vec);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(c_ptr + i * lda + j), y_fp16_vec);
+      }
+#endif
+      for (; j < N; ++j) {
+        c_ptr[i * lda + j] = at::Half(y_buf[i * N + j]);
+      }
+    } else {
+      TORCH_CHECK(false, "Unsupported output dtype");
+    }
+  }
+}
+
+template<typename out_dtype, bool cpublas_can_pack, bool sym_quant_a>
+void _da8w4_linear_impl(
+    const at::Tensor& input,
+    const at::Tensor& input_scales,
+    const at::Tensor& input_qzeros,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scales,
+    const at::Tensor& weight_qzeros,
+    const at::Tensor& compensation,
+    const std::optional<at::Tensor>& bias,
+    at::Tensor& output) {
+  // input shape = [..., K]
+  // input is per token quantized
+  int64_t K = input.size(-1);
+  auto input_view = input.view({-1, K});
+  int64_t M = input_view.size(0);
+  TORCH_CHECK(input_scales.numel() == M, "DA8W4: unexpected input scales shape");
+  TORCH_CHECK(input_scales.sizes() == input_qzeros.sizes(), "DA8W4: unexpected input qzeros shape");
+
+  // weight shape = [Nc, Kc, block_k, block_n/2]
+  // scales/qzeros shape = [Nc, G, block_n]
+  // compensation shape = [Nc, Kc, block_n]
+  int64_t Nc = weight.size(0);
+  int64_t Kc = weight.size(1);
+  int64_t block_k = weight.size(2);
+  constexpr int64_t block_n = BLOCK_N;
+  TORCH_CHECK(weight.size(3) * 2 == block_n, "DA8W4: unexpected weight shape");
+  int64_t N = Nc * block_n;
+  TORCH_CHECK(K == Kc * block_k, "DA8W4: weight and input shapes mismatch");
+  int64_t block_m = [&]() -> long {
+    if (M <= 48) {
+      return M;
+    } else if (M < 64) {
+      return 32;
+    } else if (M < 96) {
+      return 64;
+    } else {
+      return 128;
+    }
+  }();
+  int64_t Mc = (M + block_m - 1) / block_m;
+  bool parallel_on_M = M > 128;
+  int64_t num_blocks = parallel_on_M ? Mc * Nc : Nc;
+
+  // scales/qzeros shape = [Nc, G, block_n]
+  int64_t num_groups = weight_scales.size(1);
+  int64_t group_size = K / num_groups;
+  TORCH_CHECK(group_size % block_k == 0,
+              "DA8W4 CPU: group_size should be divisible by block_k");
+  int64_t block_per_group = group_size / block_k;
+
+  using Tin = typename ActDtype<sym_quant_a>::type;
+  const Tin* a_ptr = input_view.data_ptr<Tin>();
+  const float* a_scales_ptr = input_scales.data_ptr<float>();
+  const int32_t* a_qzeros_ptr = sym_quant_a ? nullptr : input_qzeros.data_ptr<int32_t>();
+  const uint8_t* b_ptr = weight.data_ptr<uint8_t>();
+  const float* b_scales_ptr = weight_scales.data_ptr<float>();
+  const int8_t* b_qzeros_ptr = weight_qzeros.data_ptr<int8_t>();
+  const int32_t* compensation_ptr = sym_quant_a ? nullptr : compensation.data_ptr<int32_t>();
+  out_dtype* c_ptr = output.data_ptr<out_dtype>();
+  const float* bias_ptr = bias.has_value() ? bias.value().data_ptr<float>() : nullptr;
+
+  at::parallel_for(0, num_blocks, 1, [&](int64_t begin, int64_t end) {
+    for (const auto i : c10::irange(begin, end)) {
+      int64_t mc = parallel_on_M ? i / Nc : 0;
+      int64_t nc = parallel_on_M ? i % Nc : i;
+      int64_t mc_end = parallel_on_M ? mc + 1 : Mc;
+
+      for (int mci = mc; mci < mc_end; ++mci) {
+        int64_t m_size = mci * block_m + block_m > M ? M - mci * block_m : block_m;
+        alignas(64) float y_buf[m_size][block_n];
+        // copy bias to y_buf if bias is not None
+        auto bias_data = bias_ptr ? bias_ptr + nc * block_n : nullptr;
+        copy_bias<block_n>(bias_data, y_buf[0], m_size);
+        for (int kci = 0; kci < Kc; ++kci) {
+          _dequant_gemm_accum<cpublas_can_pack, block_n, block_n / 2, sym_quant_a>(
+            y_buf[0] /*C*/,
+            (uint8_t*)a_ptr + mci * block_m * K + kci * block_k /*A*/,
+            a_scales_ptr + mci * block_m /*scales_a*/,
+            a_qzeros_ptr + mci * block_m /*qzeros_a*/,
+            b_ptr + (nc * Kc + kci) * block_n * block_k / 2 /*B*/,
+            b_scales_ptr + nc * block_n * num_groups + kci / block_per_group * block_n /*scales_b*/,
+            b_qzeros_ptr + nc * block_n * num_groups + kci / block_per_group * block_n /*qzeros_b*/,
+            compensation_ptr + nc * block_n * Kc + kci * block_n /*compensation*/,
+            m_size /*M*/,
+            block_k /*K*/,
+            K /*lda*/,
+            block_n /*ldc*/);
+        }
+        // store y_buf to output with dtype conversion
+        store_out<out_dtype, block_n>(
+          y_buf[0],
+          c_ptr + mci * block_m * N + nc * block_n,
+          m_size,
+          N /*lda*/);
+      }
+    }
+    if constexpr (cpublas_can_pack) {
+      at::native::cpublas::brgemm_release();
+    }
+  });
+}
+
+at::Tensor da8w4_linear_impl(
+    const at::Tensor& input,
+    const at::Tensor& input_scales,
+    const at::Tensor& input_qzeros,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scales,
+    const at::Tensor& weight_qzeros,
+    const at::Tensor& compensation,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType output_dtype) {
+  static bool cpublas_can_pack = cpublas_could_pack();
+  bool sym_quant_a = input.scalar_type() == c10::kChar;
+  auto out_sizes = input.sizes().vec();
+  int64_t N = weight.size(0) * weight.size(-1) * 2;
+  out_sizes.back() = N;
+  auto output = at::empty(out_sizes, input.options().dtype(output_dtype));
+
+#define call__da8w4_linear_impl(cpublas_can_pack, sym_quant_act) \
+    AT_DISPATCH_FLOATING_TYPES_AND2( \
+        at::ScalarType::BFloat16, at::ScalarType::Half, output_dtype, "da8w4_linear_cpu", [&] { \
+          _da8w4_linear_impl<scalar_t, cpublas_can_pack, sym_quant_act>( \
+              input, \
+              input_scales, \
+              input_qzeros, \
+              weight, \
+              weight_scales, \
+              weight_qzeros, \
+              compensation, \
+              bias, \
+              output); \
+        });
+
+  if (cpublas_can_pack) {
+    if (sym_quant_a) {
+      call__da8w4_linear_impl(true, true);
+    } else {
+      call__da8w4_linear_impl(true, false);
+    }
+  } else {
+    if (sym_quant_a) {
+      call__da8w4_linear_impl(false, true);
+    } else {
+      call__da8w4_linear_impl(false, false);
+    }
+  }
+  return output;
+}
+
+} // anonymous namespace
+
+TORCH_LIBRARY_IMPL(torchao, CPU, m) {
+  m.impl("torchao::da8w4_linear_prepack_cpu", &da8w4_linear_prepack_impl);
+  m.impl("torchao::da8w4_linear_cpu", &da8w4_linear_impl);
+}
+
+} // namespace torchao

--- a/torchao/csrc/cpu/cpu/int8_sdpa.cpp
+++ b/torchao/csrc/cpu/cpu/int8_sdpa.cpp
@@ -1,0 +1,1910 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/Dispatch.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/cpu/vec/functional.h>
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/cpu/Utils.h>
+#include <ATen/native/cpu/utils.h>
+#include <ATen/native/CPUBlas.h>
+#include <ATen/Parallel.h>
+#include <ATen/Tensor.h>
+#include <c10/util/irange.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#else
+#include <ATen/ops/empty.h>
+#endif
+
+#include <limits>
+#include <omp.h>
+#include <torch/all.h>
+#include <torch/csrc/autograd/function.h>
+
+namespace torchao {
+
+namespace {
+
+inline c10::SymFloat calculate_scale(
+    const at::Tensor& query,
+    std::optional<double> scale) {
+  const auto softmax_scale = scale.has_value()
+      ? scale.value()
+      : (c10::SymFloat(1.0) / (c10::SymFloat(query.sym_size(-1)).sqrt()));
+  return c10::SymFloat(softmax_scale);
+}
+
+#ifdef CPU_CAPABILITY_AVX512
+
+template <typename scalar_t>
+inline void fill_stub(scalar_t* data, scalar_t val, int64_t size) {
+  const int32_t vec_size = at::vec::Vectorized<scalar_t>::size();
+  auto data_vec = at::vec::Vectorized<scalar_t>(val);
+  int64_t d = 0;
+  for (; d < size - (size % vec_size); d += vec_size) {
+    data_vec.store(data + d);
+  }
+  if (d < size) {
+    data_vec.store(data + d, size - d);
+  }
+}
+
+void reshape_attn_mask_to_4d(
+    at::Tensor& attn_mask,
+    int64_t batchSize,
+    int64_t num_head,
+    int64_t qSize,
+    int64_t kvSize) {
+  // Support mask shapes:
+  // 2d: ({Q_seq_len, 1}  x {KV_seq_len, 1})
+  // 4d: ({Batch, 1} x {Num_heads, 1} x {Q_seq_len, 1}  x {KV_seq_len, 1})
+  // Guaranteed in check_attn_mask_shape
+  int64_t attn_mask_size_0 = 1;
+  int64_t attn_mask_size_1 = 1;
+  if (attn_mask.dim() == 4) {
+    if (attn_mask.size(0) == batchSize) {
+      attn_mask_size_0 = batchSize;
+    }
+    if (attn_mask.size(1) == num_head) {
+      attn_mask_size_1 = num_head;
+    }
+  }
+  attn_mask = attn_mask
+                .view({attn_mask_size_0, attn_mask_size_1, attn_mask.size(-2), attn_mask.size(-1)})
+                .expand({attn_mask_size_0, attn_mask_size_1, qSize, kvSize});
+}
+
+// TODO: Use at::native::_store instead when it supports Half.
+template <typename scalar_t>
+inline void _store(scalar_t* dst, at::vec::Vectorized<scalar_t> src, int size=at::vec::Vectorized<scalar_t>::size()) {
+  src.store(dst, size);
+}
+
+template <typename scalar_t>
+inline typename std::enable_if_t<std::is_same_v<scalar_t, unsigned char> || std::is_same_v<scalar_t, signed char>, void>
+_store(scalar_t* dst, at::vec::Vectorized<float> src, int size=at::vec::Vectorized<float>::size()) {
+  auto res = at::vec::convert<scalar_t>(src);
+  res.store(dst, size);
+}
+
+/*
+1. dequant
+2. add mask
+3. max reduce for softmax
+*/
+template <typename mask_t>
+inline void _dequant_mask_max_fusion_kernel(
+    const int32_t* in,
+    const mask_t* mask_ptr,
+    const int32_t* sum_a_ptr,
+    const int32_t* sum_b_ptr,
+    const int& M,
+    const int& N,
+    const int& ldi,
+    const int& ldm, // leading dimension mask
+    const int& ldo,
+    const int32_t& beta, // zp_a*zp_b*k
+    const float& alpha, // scale_a*scale_b*scale_sdpa
+    float* out,
+    float* sfm_max_ptr) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  auto vec_beta = at::vec::Vectorized<int32_t>(beta);
+  auto vec_alpha = at::vec::Vectorized<float>(alpha);
+  for (long row = 0; row < M; row += 1) {
+    auto sum_a = sum_a_ptr[row];
+    auto vec_sum_a = at::vec::Vectorized<int32_t>(sum_a);
+    const int32_t* tmp_in = in + row * ldi;
+    float* tmp_out = out + row * ldo;
+    const mask_t* mask_data_ptr = mask_ptr + row * ldm;
+    float tmp_max = -std::numeric_limits<float>::infinity();
+    auto vec_tmp_max = at::vec::Vectorized<float>(tmp_max);
+    long col = 0;
+    for (; col < vec_size * (N / vec_size); col += vec_size) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = at::vec::Vectorized<mask_t>::loadu(mask_data_ptr + col);
+      auto tmp7 = at::vec::convert<float>(tmp6);
+      auto tmp8 = tmp5 + tmp7;
+      vec_tmp_max = at::vec::clamp_min(vec_tmp_max, tmp8);
+      _store(tmp_out + col, tmp8);
+    }
+    if (col < N) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col, N - col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col, N - col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = at::vec::Vectorized<mask_t>::loadu(mask_data_ptr + col, N - col);
+      auto tmp7 = at::vec::convert<float>(tmp6);
+      auto tmp8 = tmp5 + tmp7;
+      _store(tmp_out + col, tmp8, N - col);
+      vec_tmp_max = at::vec::Vectorized<float>::set(vec_tmp_max, at::vec::clamp_min(vec_tmp_max, tmp8), N - col);
+    }
+    sfm_max_ptr[row] = std::max(sfm_max_ptr[row], vec_tmp_max.reduce_max());
+  }
+}
+
+/*
+1. dequant
+2. max reduce for softmax
+*/
+inline void _dequant_max_fusion_kernel(
+    const int32_t* in,
+    const int32_t* sum_a_ptr,
+    const int32_t* sum_b_ptr,
+    const int& M,
+    const int& N,
+    const int& ldi,
+    const int& ldo,
+    const int32_t& beta, // zp_a*zp_b*k
+    const float& alpha, // scale_a*scale_b*scale_sdpa
+    float* out,
+    float* sfm_max_ptr) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  auto vec_beta = at::vec::Vectorized<int32_t>(beta);
+  auto vec_alpha = at::vec::Vectorized<float>(alpha);
+  for (long row = 0; row < M; row += 1) {
+    auto sum_a = sum_a_ptr[row];
+    auto vec_sum_a = at::vec::Vectorized<int32_t>(sum_a);
+    const int32_t* tmp_in = in + row * ldi;
+    float* tmp_out = out + row * ldo;
+    float tmp_max = -std::numeric_limits<float>::infinity();
+    auto vec_tmp_max = at::vec::Vectorized<float>(tmp_max);
+    long col = 0;
+    for (; col < vec_size * (N / vec_size); col += vec_size) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      vec_tmp_max = at::vec::clamp_min(vec_tmp_max, tmp5);
+      _store(tmp_out + col, tmp5);
+    }
+    if (col < N) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col, N - col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col, N - col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      _store(tmp_out + col, tmp5, N - col);
+      vec_tmp_max = at::vec::Vectorized<float>::set(vec_tmp_max, at::vec::clamp_min(vec_tmp_max, tmp5), N - col);
+    }
+    sfm_max_ptr[row] = std::max(sfm_max_ptr[row], vec_tmp_max.reduce_max());
+  }
+}
+
+/*
+1. Softmax: sub max, exp, sum reduce, div sum
+2. quant
+3. sum for attention
+*/
+template <typename scalar_t>
+inline void _sub_exp_sum_div_quant_sum_fusion_kernel(
+    const float* in,
+    const int64_t& M,
+    const int64_t& N_step,
+    const int64_t& NSlice,
+    const int& ldi,
+    const int& ldo,
+    const int& kvSize,
+    const int& rndkvSplitSize,
+    const int& av_gemm_K,
+    const int32_t& beta1, // zp_a
+    const int32_t& beta2, // zp_b
+    const float& alpha, // scale_a
+    float* local,
+    scalar_t* out,
+    float* sfm_max_ptr,
+    float* sfm_sum_ptr,
+    int32_t* sum_a_ptr) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  float min_val = 0;
+  float max_val = 255;
+  auto vec_min_val = at::vec::Vectorized<float>(min_val);
+  auto vec_max_val = at::vec::Vectorized<float>(max_val);
+  scalar_t zero = 0;
+  auto vec_zero = at::vec::Vectorized<scalar_t>(zero);
+  float beta1_float = (float) beta1;
+  auto vec_beta1 = at::vec::Vectorized<float>(beta1_float);
+  for (int64_t row = 0; row < M; ++row) {
+    auto sfm_max = sfm_max_ptr[row];
+    auto vec_max = at::vec::Vectorized<float>(sfm_max);
+    // sub max, exp, sum reduce
+    const float* qk_block_data = in + row * rndkvSplitSize;
+    for (int64_t l = 0; l < NSlice; l ++) {
+      int64_t n = l * N_step;
+      int64_t kvBlockSize = std::min(N_step, kvSize - n);
+      const float* tmp_in = qk_block_data + l * ldi;
+      float tmp_sum = 0;
+      auto vec_tmp_sum = at::vec::Vectorized<float>(tmp_sum);
+      float* tmp_out = local + n;
+      long col = 0;
+      for (; col < vec_size * (kvBlockSize / vec_size); col += vec_size) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col);
+        auto tmp1 = tmp0 - vec_max;
+        auto tmp2 = tmp1.exp_u20();
+        vec_tmp_sum += tmp2;
+        _store(tmp_out + col, tmp2);
+      }
+      if (col < kvBlockSize) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col, kvBlockSize - col);
+        auto tmp1 = tmp0 - vec_max;
+        auto tmp2 = tmp1.exp_u20();
+        _store(tmp_out + col, tmp2, kvBlockSize - col);
+        vec_tmp_sum = at::vec::Vectorized<float>::set(vec_tmp_sum, vec_tmp_sum + tmp2, kvBlockSize - col);
+      }
+      sfm_sum_ptr[row] += vec_tmp_sum.reduce_add();
+    }
+    // div sum, sum for attention
+    auto sum_scale = 1 / sfm_sum_ptr[row] / alpha;
+    auto vec_sum_scale = at::vec::Vectorized<float>(sum_scale);
+    scalar_t* qk_reduced_block_data = out + row * av_gemm_K;
+    for (int64_t l = 0; l < NSlice; l ++) {
+      int64_t n = l * N_step;
+      int64_t kvBlockSize = std::min(N_step, kvSize - n);
+      int32_t tmp_sum = 0;
+      auto vec_tmp_sum = at::vec::Vectorized<int32_t>(tmp_sum);
+      float* tmp_in = local + n;
+      scalar_t* tmp_out = qk_reduced_block_data + l * ldo;
+      long col = 0;
+      for (; col < vec_size * (kvBlockSize / vec_size); col += vec_size) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col);
+        auto tmp1 = tmp0 * vec_sum_scale;
+        auto tmp2 = tmp1.round();
+        auto tmp3 = tmp2 + vec_beta1;
+        auto tmp4 = at::vec::clamp(tmp3, vec_min_val, vec_max_val);
+        _store(tmp_out + col, tmp4);
+        auto tmp6 = at::vec::convert<int32_t>(tmp4);
+        vec_tmp_sum += tmp6;
+      }
+      if (col < kvBlockSize) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col, kvBlockSize - col);
+        auto tmp1 = tmp0 * vec_sum_scale;
+        auto tmp2 = tmp1.round();
+        auto tmp3 = tmp2 + vec_beta1;
+        auto tmp4 = at::vec::clamp(tmp3, vec_min_val, vec_max_val);
+        _store(tmp_out + col, tmp4, kvBlockSize - col);
+        auto tmp6 = at::vec::convert<int32_t>(tmp4);
+        vec_tmp_sum = at::vec::Vectorized<int32_t>::set(vec_tmp_sum, vec_tmp_sum + tmp6, kvBlockSize - col);
+      }
+      sum_a_ptr[row] += vec_tmp_sum.reduce_add() * beta2;
+      // set zero
+      col = kvBlockSize;
+      for (; col <  vec_size * (av_gemm_K / vec_size); col += vec_size) {
+        _store(tmp_out + col, vec_zero);
+      }
+      if (col < av_gemm_K) {
+        _store(tmp_out + col, vec_zero, av_gemm_K - col);
+      }
+    }
+  }
+}
+
+/*
+1. Softmax: sub max, exp, sum reduce, div sum
+2. quant
+*/
+template <typename scalar_t>
+inline void _sub_exp_sum_div_quant_fusion_kernel(
+    const float* in,
+    const int64_t& M,
+    const int64_t& N_step,
+    const int64_t& NSlice,
+    const int& ldi,
+    const int& ldo,
+    const int& kvSize,
+    const int& rndkvSplitSize,
+    const int& av_gemm_K,
+    const int32_t& beta1, // zp_a
+    const float& alpha, // scale_a
+    float* local,
+    scalar_t* out,
+    float* sfm_max_ptr,
+    float* sfm_sum_ptr) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  float min_val = 0;
+  float max_val = 255;
+  auto vec_min_val = at::vec::Vectorized<float>(min_val);
+  auto vec_max_val = at::vec::Vectorized<float>(max_val);
+  scalar_t zero = 0;
+  auto vec_zero = at::vec::Vectorized<scalar_t>(zero);
+  float beta1_float = (float) beta1;
+  auto vec_beta1 = at::vec::Vectorized<float>(beta1_float);
+  for (int64_t row = 0; row < M; ++row) {
+    auto sfm_max = sfm_max_ptr[row];
+    auto vec_max = at::vec::Vectorized<float>(sfm_max);
+    // sub max, exp, sum reduce
+    const float* qk_block_data = in + row * rndkvSplitSize;
+    for (int64_t l = 0; l < NSlice; l ++) {
+      int64_t n = l * N_step;
+      int64_t kvBlockSize = std::min(N_step, kvSize - n);
+      const float* tmp_in = qk_block_data + l * ldi;
+      float tmp_sum = 0;
+      auto vec_tmp_sum = at::vec::Vectorized<float>(tmp_sum);
+      float* tmp_out = local + n;
+      long col = 0;
+      for (; col < vec_size * (kvBlockSize / vec_size); col += vec_size) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col);
+        auto tmp1 = tmp0 - vec_max;
+        auto tmp2 = tmp1.exp_u20();
+        vec_tmp_sum += tmp2;
+        _store(tmp_out + col, tmp2);
+      }
+      if (col < kvBlockSize) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col, kvBlockSize - col);
+        auto tmp1 = tmp0 - vec_max;
+        auto tmp2 = tmp1.exp_u20();
+        vec_tmp_sum = at::vec::Vectorized<float>::set(vec_tmp_sum, vec_tmp_sum + tmp2, kvBlockSize - col);
+        _store(tmp_out + col, tmp2, kvBlockSize - col);
+      }
+      sfm_sum_ptr[row] += vec_tmp_sum.reduce_add();
+    }
+    // div sum, sum for attention
+    auto sum_scale = 1 / sfm_sum_ptr[row] / alpha;
+    auto vec_sum_scale = at::vec::Vectorized<float>(sum_scale);
+    scalar_t* qk_reduced_block_data = out + row * av_gemm_K;
+    for (int64_t l = 0; l < NSlice; l ++) {
+      int64_t n = l * N_step;
+      int64_t kvBlockSize = std::min(N_step, kvSize - n);
+      float* tmp_in = local + n;
+      scalar_t* tmp_out = qk_reduced_block_data + l * ldo;
+      long col = 0;
+      for (; col < vec_size * (kvBlockSize / vec_size); col += vec_size) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col);
+        auto tmp1 = tmp0 * vec_sum_scale;
+        auto tmp2 = tmp1.round();
+        auto tmp3 = tmp2 + vec_beta1;
+        auto tmp4 = at::vec::clamp(tmp3, vec_min_val, vec_max_val);
+        _store(tmp_out + col, tmp4);
+      }
+      if (col < kvBlockSize) {
+        auto tmp0 = at::vec::Vectorized<float>::loadu(tmp_in + col, kvBlockSize - col);
+        auto tmp1 = tmp0 * vec_sum_scale;
+        auto tmp2 = tmp1.round();
+        auto tmp3 = tmp2 + vec_beta1;
+        auto tmp4 = at::vec::clamp(tmp3, vec_min_val, vec_max_val);
+        _store(tmp_out + col, tmp4, kvBlockSize - col);
+      }
+      // set zero
+      col = kvBlockSize;
+      for (; col < vec_size * (av_gemm_K / vec_size); col += vec_size) {
+        _store(tmp_out + col, vec_zero);
+      }
+      if (col < av_gemm_K) {
+        _store(tmp_out + col, vec_zero, av_gemm_K - col);
+      }
+    }
+  }
+}
+
+/*
+1. dequant
+2. quant
+*/
+template <typename scalar_t>
+inline void _dequant_quant_fusion_kernel(
+    const int32_t* in,
+    const int32_t* sum_a_ptr,
+    const int32_t* sum_b_ptr,
+    const int& M,
+    const int& N,
+    const int& ldi,
+    const int& ldo,
+    const int32_t& beta1, // zp_a*zp_b*k
+    const int32_t& beta2, // zp_c
+    const float& alpha, // scale_a*scale_b/scale_c
+    scalar_t* out) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  float min_val = 0;
+  float max_val = 255;
+  auto vec_min_val = at::vec::Vectorized<float>(min_val);
+  auto vec_max_val = at::vec::Vectorized<float>(max_val);
+  auto vec_beta1 = at::vec::Vectorized<int32_t>(beta1);
+  auto vec_alpha = at::vec::Vectorized<float>(alpha);
+  float beta2_float = (float) beta2;
+  auto vec_beta2 = at::vec::Vectorized<float>(beta2_float);
+  for (long row = 0; row < M; row += 1) {
+    auto sum_a = sum_a_ptr[row];
+    auto vec_sum_a = at::vec::Vectorized<int32_t>(sum_a);
+    const int32_t* tmp_in = in + row * ldi;
+    scalar_t* tmp_out = out + row * ldo;
+    long col = 0;
+    for (; col < vec_size * (N / vec_size); col += vec_size) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta1;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = tmp5.round();
+      auto tmp7 = tmp6 + vec_beta2;
+      auto tmp8 = at::vec::clamp(tmp7, vec_min_val, vec_max_val);
+      _store(tmp_out + col, tmp8);
+    }
+    if (col < N) {
+      auto vec_sum_b = at::vec::Vectorized<int32_t>::loadu(sum_b_ptr + col, N - col);
+      auto tmp0 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col, N - col);
+      auto tmp1 = tmp0 - vec_sum_b;
+      auto tmp2 = tmp1 - vec_sum_a;
+      auto tmp3 = tmp2 + vec_beta1;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = tmp5.round();
+      auto tmp7 = tmp6 + vec_beta2;
+      auto tmp8 = at::vec::clamp(tmp7, vec_min_val, vec_max_val);
+      _store(tmp_out + col, tmp8, N - col);
+    }
+  }
+}
+
+/*
+1. dequant
+2. quant
+*/
+template <typename scalar_t>
+inline void _dequant_quant_fusion_kernel(
+    const int32_t* in,
+    const int32_t* sum_a_ptr,
+    const int& M,
+    const int& N,
+    const int& ldi,
+    const int& ldo,
+    const int32_t& beta2, // zp_c
+    const float& alpha, // scale_a*scale_b/scale_c
+    scalar_t* out) {
+  const int32_t vec_size = at::vec::Vectorized<float>::size();
+  float min_val = 0;
+  float max_val = 255;
+  auto vec_min_val = at::vec::Vectorized<float>(min_val);
+  auto vec_max_val = at::vec::Vectorized<float>(max_val);
+  // auto vec_beta1 = at::vec::Vectorized<int32_t>(beta1);
+  auto vec_alpha = at::vec::Vectorized<float>(alpha);
+  float beta2_float = (float) beta2;
+  auto vec_beta2 = at::vec::Vectorized<float>(beta2_float);
+  for (long row = 0; row < M; row += 1) {
+    auto sum_a = sum_a_ptr[row];
+    auto vec_sum_a = at::vec::Vectorized<int32_t>(sum_a);
+    const int32_t* tmp_in = in + row * ldi;
+    scalar_t* tmp_out = out + row * ldo;
+    long col = 0;
+    for (; col < vec_size * (N / vec_size); col += vec_size) {
+      auto tmp1 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col);
+      auto tmp3 = tmp1 - vec_sum_a;
+      // auto tmp3 = tmp2 + vec_beta1;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = tmp5.round();
+      auto tmp7 = tmp6 + vec_beta2;
+      auto tmp8 = at::vec::clamp(tmp7, vec_min_val, vec_max_val);
+      _store(tmp_out + col, tmp8);
+    }
+    if (col < N) {
+      auto tmp1 = at::vec::Vectorized<int32_t>::loadu(tmp_in + col, N - col);
+      auto tmp3 = tmp1 - vec_sum_a;
+      auto tmp4 = at::vec::convert<float>(tmp3);
+      auto tmp5 = tmp4 * vec_alpha;
+      auto tmp6 = tmp5.round();
+      auto tmp7 = tmp6 + vec_beta2;
+      auto tmp8 = at::vec::clamp(tmp7, vec_min_val, vec_max_val);
+      _store(tmp_out + col, tmp8, N - col);
+    }
+  }
+}
+
+template <typename scalar_t>
+inline void _int_sum_b_contiguous_kernel_helper(
+    const scalar_t* in,
+    int32_t* out,
+    const int& N,
+    const int32_t& scale) {
+  const int32_t vec_size = at::vec::Vectorized<int32_t>::size();
+  int32_t tmp_sum = 0;
+  auto vec_tmp_sum = at::vec::Vectorized<int32_t>(tmp_sum);
+  long i = 0;
+  for (; i < vec_size * (N / vec_size); i += vec_size) {
+    auto tmp0 = at::vec::Vectorized<scalar_t>::loadu(in + i);
+    auto tmp1 = at::vec::convert<int32_t>(tmp0);
+    vec_tmp_sum = vec_tmp_sum + tmp1;
+  }
+  if (i < N) {
+    auto tmp0 = at::vec::Vectorized<scalar_t>::loadu(in + i, N - i);
+    auto tmp1 = at::vec::convert<int32_t>(tmp0);
+    vec_tmp_sum = at::vec::Vectorized<int32_t>::set(vec_tmp_sum, vec_tmp_sum + tmp1, N - i);
+  }
+  out[0] = vec_tmp_sum.reduce_add() * scale;
+}
+
+// reduce along dim b for shape [a, b], with sum shape [a]
+template <typename scalar_t>
+inline void _int_sum_b_contiguous_kernel(
+    const scalar_t* in,
+    int32_t* out,
+    const int& M,
+    const int& N,
+    const int& ld,
+    const int32_t& scale) {
+  for (long r = 0; r < M; r += 1) {
+    _int_sum_b_contiguous_kernel_helper(in + r * ld, out + r, N, scale);
+  }
+}
+
+// reduce along dim a for shape [a, b], with sum shape [b]
+template <typename scalar_t>
+inline void _int_sum_a_contiguous_kernel(
+    const scalar_t* in,
+    int32_t* out,
+    const int& M,
+    const int& N,
+    const int& ld,
+    const int32_t& scale) {
+  const int32_t vec_size = at::vec::Vectorized<int32_t>::size();
+  auto vec_scale = at::vec::Vectorized<int32_t>(scale);
+  // initialization with 0
+  int32_t zero = 0;
+  auto vec_zero = at::vec::Vectorized<int32_t>(zero);
+  long i = 0;
+  for (; i < vec_size * (M / vec_size); i += vec_size) {
+    _store(out + i, vec_zero);
+  }
+  if (i < M) {
+    _store(out + i, vec_zero, M - i);
+  }
+  // sum
+  for (long j = 0; j < N; j++) {
+    const scalar_t* tmp_in = in + j * ld;
+    long k = 0;
+    for (; k < vec_size * (M / vec_size); k += vec_size) {
+      auto tmp0 = at::vec::Vectorized<scalar_t>::loadu(tmp_in + k);
+      auto tmp1 = at::vec::Vectorized<int32_t>::loadu(out + k);
+      auto tmp2 = at::vec::convert<int32_t>(tmp0);
+      auto tmp3 = tmp1 + tmp2;
+      _store(out + k, tmp3);
+    }
+    if (k < M) {
+      auto tmp0 = at::vec::Vectorized<scalar_t>::loadu(tmp_in + k, M - k);
+      auto tmp1 = at::vec::Vectorized<int32_t>::loadu(out + k, M - k);
+      auto tmp2 = at::vec::convert<int32_t>(tmp0);
+      auto tmp3 = tmp1 + tmp2;
+      _store(out + k, tmp3, M - k);
+    }
+  }
+  // scale
+  i = 0;
+  for (; i < vec_size * (M / vec_size); i += vec_size) {
+    auto tmp0 = at::vec::Vectorized<int32_t>::loadu(out + i);
+    auto tmp1 = tmp0 * vec_scale;
+    _store(out + i, tmp1);
+  }
+  if (i < M) {
+    auto tmp0 = at::vec::Vectorized<int32_t>::loadu(out + i, M - i);
+    auto tmp1 = tmp0 * vec_scale;
+    _store(out + i, tmp1, M - i);
+  }
+}
+
+// do the transpose: [in_rows, in_cols] -> [in_cols, in_rows]
+template <typename scalar_t>
+inline void do_transpose(
+    scalar_t* src,
+    scalar_t* dst,
+    int64_t in_rows,
+    int64_t in_cols,
+    int64_t ldi,
+    int64_t ldo) {
+  for (int64_t r=0; r<in_rows; r++) {
+    for (int64_t c=0; c<in_cols; c++) {
+      *(dst + c * ldo + r) = *(src + r * ldi + c);
+    }
+  }
+}
+
+// padding with pad_val: [rows, cols] -> [prows, pcols]
+template <typename scalar_t>
+inline void pad_remain_row_col(
+    scalar_t* value_ptr,
+    int rows,
+    int cols,
+    int prows,
+    int pcols,
+    int ldi,
+    scalar_t pad_val=0) {
+  auto psize = pcols - cols;
+  if (psize == 0 && prows == rows) {
+    return;
+  }
+  const int32_t vec_size = at::vec::Vectorized<scalar_t>::size();
+  auto pad = at::vec::Vectorized<scalar_t>(pad_val);
+  if (psize > 0) {
+    for (int i = 0; i < rows; i++) {
+      int j = 0;
+      for (; j < psize - (psize % vec_size); j += vec_size) {
+        pad.store(value_ptr + i * ldi + cols + j);
+      }
+      if (j < psize) {
+        pad.store(value_ptr + i * ldi + cols + j, psize - j);
+      }
+    }
+  }
+
+  for (int i = rows; i < prows; i++) {
+    int j = 0;
+    for (; j < pcols - (pcols % vec_size); j += vec_size) {
+      pad.store(value_ptr + i * ldi + j);
+    }
+    if (j < pcols) {
+      pad.store(value_ptr + i * ldi + j, pcols - j);
+    }
+  }
+}
+
+// copy value_ptr to dst_ptr with padding: [rows, cols] -> [prows, pcols]
+template <typename scalar_t>
+inline void copy_value_with_pad(
+    scalar_t* value_ptr,
+    scalar_t* dst_ptr,
+    int rows,
+    int cols,
+    int prows,
+    int pcols,
+    int ldi,
+    scalar_t pad_val=0) {
+  const int32_t vec_size = at::vec::Vectorized<scalar_t>::size();
+  auto pad = at::vec::Vectorized<scalar_t>(pad_val);
+  int i = 0;
+  for (; i < rows; i++) {
+    int j = 0;
+    for (; j < cols - (cols % vec_size); j += vec_size) {
+      auto vec_v =
+          at::vec::Vectorized<scalar_t>::loadu(value_ptr + i * ldi + j);
+      vec_v.store(dst_ptr + i * pcols + j);
+    }
+
+    if (j < cols) {
+      auto vec_v = at::vec::Vectorized<scalar_t>::loadu(
+          value_ptr + i * ldi + j, cols - j);
+      vec_v.store(dst_ptr + i * pcols + j, cols - j);
+    }
+
+    // col padding
+    auto psize = pcols - cols;
+    if (psize > 0) {
+      int pj = 0;
+      for (; pj < psize - (psize % vec_size); pj += vec_size) {
+        pad.store(dst_ptr + i * pcols + cols + pj);
+      }
+      if (pj < psize) {
+        pad.store(dst_ptr + i * pcols + cols + pj, psize - pj);
+      }
+    }
+  }
+
+  // row padding
+  for (; i < prows; i++) {
+    int j = 0;
+    for (; j < pcols - (pcols % vec_size); j += vec_size) {
+      pad.store(dst_ptr + i * pcols + j);
+    }
+    if (j < pcols) {
+      pad.store(dst_ptr + i * pcols + j, pcols - j);
+    }
+
+  }
+
+}
+
+// UINT8 - one parallel loop with u8u8s32 GEMM 
+template <typename scalar_t, typename mask_t,
+          int64_t q_split_size, int64_t kv_split_size,
+          bool use_one_parallel_loop,
+          typename std::enable_if_t<use_one_parallel_loop, int> = 0>
+inline typename std::enable_if_t<std::is_same_v<scalar_t, unsigned char>, void>
+sdpa_int8_fused_kernel_impl(
+    const at::Tensor& output,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    double dropout_p,
+    bool is_causal,
+    std::optional<at::Tensor> attention_mask,
+    std::optional<double> scale,
+    float q_scale,
+    int32_t q_zp,
+    float k_scale,
+    int32_t k_zp,
+    float v_scale,
+    int32_t v_zp,
+    float a_scale,
+    int32_t a_zp,
+    float o_scale,
+    int32_t o_zp) {
+  // Query (Batch x Num_heads  x Q_seq_len  x Dim_per_head)
+  //    -> (Batch x Q_seq_len  x Num_heads  x Dim_per_head)
+  // Key   (Batch x Num_heads  x KV_seq_len x Dim_per_head)
+  //    -> (Batch x KV_seq_len x Num_heads  x Dim_per_head)
+  // Value (Batch x Num_heads  x KV_seq_len x Dim_per_head)
+  //    -> (Batch x KV_seq_len x Num_heads  x Dim_per_head)
+  at::Tensor query = q.transpose(1, 2);
+  at::Tensor key = k.transpose(1, 2);
+  at::Tensor value = v.transpose(1, 2);
+
+  using accum_t = float;
+  accum_t scaling_factor = calculate_scale(query, scale).expect_float();
+  int block_64 = 64;
+  auto u8_dt = at::ScalarType::Byte;
+
+  // Sizes
+  TORCH_CHECK(
+      (query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
+      "scaled_dot_product_attention_sdpa: Q/K/V should have the same head size");
+  TORCH_CHECK(
+      kv_split_size % block_64 == 0, "kv_split_size is not divisble by ", block_64);
+
+  int64_t batchSize = query.size(0);
+  int64_t qSize = query.size(1);
+  int64_t kvSize = value.size(1);
+  int64_t num_head = query.size(2);
+  int64_t headSize = query.size(3);
+
+  bool has_attn_mask = attention_mask.has_value() && attention_mask.value().numel();
+  if (has_attn_mask) {
+    reshape_attn_mask_to_4d(attention_mask.value(), batchSize, num_head, qSize, kvSize);
+  }
+
+  // Strides
+  int64_t qStrideB = query.stride(0);
+  int64_t qStrideM = query.stride(1);
+  int64_t qStrideH = query.stride(2);
+  int64_t kStrideB = key.stride(0);
+  int64_t kStrideN = key.stride(1);
+  int64_t kStrideH = key.stride(2);
+  int64_t vStrideB = value.stride(0);
+  int64_t vStrideN = value.stride(1);
+  int64_t vStrideH = value.stride(2);
+  int64_t oStrideB = output.stride(0);
+  int64_t oStrideM = output.stride(1);
+  int64_t oStrideH = output.stride(2);
+  int64_t mStrideB =
+      (has_attn_mask && attention_mask.value().size(0) > 1)
+      ? attention_mask.value().stride(0)
+      : 0;
+  int64_t mStrideH =
+      (has_attn_mask && attention_mask.value().size(1) > 1)
+      ? attention_mask.value().stride(1)
+      : 0;
+  int64_t mStrideM =
+      (has_attn_mask && attention_mask.value().size(2) > 1)
+      ? attention_mask.value().stride(2)
+      : 0;
+  int64_t mStrideN =
+      (has_attn_mask && attention_mask.value().size(3) > 1)
+      ? attention_mask.value().stride(3)
+      : 0;
+
+  int64_t qSplitSize = q_split_size > qSize ? qSize : q_split_size;
+  int64_t kvSplitSize = kv_split_size > kvSize ? kvSize : kv_split_size;
+  int64_t qSlice = (qSize - 1) / qSplitSize + 1;
+  int64_t kvSlice = (kvSize - 1) / kvSplitSize + 1;
+  int64_t kvTail = (kvSize - 1) % kvSplitSize + 1;
+  int64_t num_thread = at::get_num_threads();
+
+  int64_t rndHeadSize = (headSize + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvSplitSize = (kvSplitSize + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvTail = (kvTail + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvSize = kv_split_size > kvSize ? rndkvTail : rndkvSplitSize * kvSlice + rndkvTail;
+
+  bool av_gemm_K_mul4 = kvSplitSize % 4 == 0;
+  int av_gemm_K_padding = av_gemm_K_mul4 ? 0 : 4 - kvSplitSize % 4;
+  int av_gemm_K = kvSplitSize + av_gemm_K_padding;
+
+  // Data ptrs
+  scalar_t* q_data = query.data_ptr<scalar_t>();
+  scalar_t* k_data = key.data_ptr<scalar_t>();
+  scalar_t* v_data = value.data_ptr<scalar_t>();
+  mask_t* mask_data = attention_mask.has_value()
+      ? attention_mask.value().data_ptr<mask_t>()
+      : nullptr;
+  scalar_t* out_data = output.data_ptr<scalar_t>();
+
+  bool headSize_mul64 = headSize % 64 == 0;
+  int qk_gemm_K_padding = headSize_mul64 ? 0 : 64 - headSize % 64;
+  int qk_gemm_K = headSize + qk_gemm_K_padding;
+
+  int64_t qk_reduce_strideL = qSplitSize * av_gemm_K;
+  int64_t v_reorder_strideL = av_gemm_K * rndHeadSize;
+
+  int64_t total_size_uint8_per_thread =
+    /* qk */ kvSlice * qSplitSize * rndkvSplitSize * 4 +
+    /* qk_local  */ kvSlice * av_gemm_K * 4 +
+    /* qk_reduce  */ kvSlice * qk_reduce_strideL +
+    /* qk_s32   */ qSplitSize * rndkvSplitSize * 4 +
+    /* dst_s32  */ qSplitSize * rndHeadSize * 4 +
+    /* softmax_sum   */ qSplitSize * 4 +
+    /* query_sum     */ qSplitSize * 4 +
+    /* attention_sum */ qSplitSize * 4 +
+    /* softmax max */ qSplitSize * 4 +
+    /* query_padding_data */ qSplitSize * qk_gemm_K +
+    /* key_sum */ kvSize * 4 +
+    /* value_sum */ headSize * 4 +
+    /* key_t_reorder */ qk_gemm_K * rndkvSize +
+    /* value_t_reorder */ kvSlice * v_reorder_strideL;
+
+  at::Tensor total_buf = at::empty(
+      {num_thread, total_size_uint8_per_thread},
+      query.options());
+  scalar_t* total_buf_data = total_buf.data_ptr<scalar_t>();
+
+  at::parallel_for(
+      0, batchSize * num_head, 1, [&](int64_t begin, int64_t end) {
+        int64_t i = 0, j = 0;
+        at::native::data_index_init(
+            begin, i, batchSize, j, num_head);
+        int ompIdx = at::get_thread_num();
+        scalar_t* total_buf_ptr = total_buf_data + ompIdx * total_size_uint8_per_thread;
+        int32_t offset = 0;
+        accum_t* qk_data = reinterpret_cast<accum_t*>(total_buf_ptr);
+        offset += kvSlice * qSplitSize * rndkvSplitSize * 4;
+        accum_t* qk_local_data = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += kvSlice * av_gemm_K * 4;
+        scalar_t* qk_reduced_data = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+        offset += kvSlice * qk_reduce_strideL;
+        int32_t* qk_s32_data = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * rndkvSplitSize * 4;
+        int32_t* dst_s32_data = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * rndHeadSize * 4;
+        accum_t* sfm_sum_ptr = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        int32_t* q_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        int32_t* a_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        accum_t* sfm_max_ptr = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        scalar_t* query_t_padding_ptr = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * qk_gemm_K;
+
+        int32_t* k_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += kvSize * 4;
+        int32_t* v_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += headSize * 4;
+        scalar_t* key_reorder_ptr = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+        offset += qk_gemm_K * rndkvSize;
+        scalar_t* value_reorder_ptr = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+
+        uint8_t* B_blocked_xform_u8 = new uint8_t[qk_gemm_K * block_64];
+
+        for (const auto z : c10::irange(begin, end)) {
+          (void)z; // Suppress unused variable
+
+          // sum k and v
+          if (q_zp == 0) {
+            fill_stub(k_sum_ptr, static_cast<int32_t>(0), kvSize);
+          } else {
+            _int_sum_b_contiguous_kernel(k_data + i * kStrideB + j * kStrideH,
+              k_sum_ptr,
+              kvSize, headSize, kStrideN, q_zp);
+          }
+          if (a_zp == 0) {
+            fill_stub(v_sum_ptr, static_cast<int32_t>(0), headSize);
+          } else {
+            _int_sum_a_contiguous_kernel(v_data + i * vStrideB + j * vStrideH,
+              v_sum_ptr,
+              headSize, kvSize, vStrideN, a_zp);
+          }
+
+          // transpose and packing
+          for (int64_t n = 0; n < kvSize; n += kvSplitSize) {
+            int64_t kvBlockSize = std::min(kvSplitSize, kvSize - n);
+            for (int64_t b = 0; b < kvBlockSize; b += block_64) {
+              bool istail = kvBlockSize - b < block_64;
+              int64_t trans_rows = istail ? kvBlockSize - b : block_64;
+              do_transpose(
+                  k_data + i * kStrideB + j * kStrideH + n * kStrideN + b * kStrideN,
+                  B_blocked_xform_u8,
+                  trans_rows,
+                  headSize,
+                  kStrideN,
+                  block_64);
+              if (!headSize_mul64 || istail) {
+                pad_remain_row_col(
+                    B_blocked_xform_u8,
+                    headSize,
+                    trans_rows,
+                    qk_gemm_K,
+                    block_64,
+                    block_64
+                  );
+              }
+              at::native::cpublas::pack(
+                      qk_gemm_K, // K
+                      block_64, // N
+                      block_64, // ld_in
+                      block_64, // ld_out
+                      u8_dt, // dt_in
+                      u8_dt, // dt_out
+                      B_blocked_xform_u8,
+                      key_reorder_ptr + n * qk_gemm_K +
+                          b * qk_gemm_K);
+            }
+            // split headSize to block_64, block_64, block_64 ...
+            // [av_gemm_K, headSize] -> [av_gemm_K,  block_64 ...]
+            for (int64_t b = 0; b < rndHeadSize; b += block_64) {
+              at::native::cpublas::pack(
+                      av_gemm_K,
+                      block_64,
+                      vStrideN,
+                      block_64,
+                      u8_dt,
+                      u8_dt,
+                      v_data + i * vStrideB + j * vStrideH + n * vStrideN + b,
+                      value_reorder_ptr + n * rndHeadSize +
+                          av_gemm_K * b);
+            }
+          }
+
+          // sdpa core
+          for (int64_t k = 0; k < qSlice; k++) {
+            int64_t m = k * qSplitSize;
+            int64_t qBlockSize = std::min(qSplitSize, qSize - m);
+            // Initialize sum and max
+            fill_stub(
+                sfm_sum_ptr, static_cast<accum_t>(0), qSplitSize);
+            fill_stub(
+                a_sum_ptr, static_cast<int32_t>(0), qSplitSize);
+            fill_stub(
+                sfm_max_ptr, static_cast<accum_t>(-std::numeric_limits<accum_t>::infinity()), qSplitSize);
+            int64_t num_keys =
+                is_causal ? std::min(m + qBlockSize, kvSize) : kvSize;
+            copy_value_with_pad(
+                q_data + i * qStrideB + j * qStrideH + m * qStrideM,
+                query_t_padding_ptr,
+                qBlockSize,
+                headSize,
+                qBlockSize,
+                qk_gemm_K,
+                qStrideM);
+            // sum q
+            if (k_zp != 0) {
+              _int_sum_b_contiguous_kernel(q_data + i * qStrideB + j * qStrideH + m * qStrideM,
+                    q_sum_ptr, qBlockSize, headSize, qStrideM, k_zp);
+            } else {
+              fill_stub(
+                q_sum_ptr, static_cast<int32_t>(0), qSplitSize);
+            }
+            const int64_t rkvSlice = (num_keys - 1) / kvSplitSize + 1;
+            for (int64_t l = 0; l < rkvSlice; l++) {
+              int64_t n = l * kvSplitSize;
+              int64_t kvBlockSize = std::min(kvSplitSize, kvSize - n);
+              // Calculate q @ k.T
+              for (int64_t b = 0; b < kvBlockSize; b += block_64) {
+                at::native::cpublas::brgemm(
+                      qSplitSize, block_64, qk_gemm_K,
+                      qk_gemm_K, // lda
+                      block_64, //ldb
+                      rndkvSplitSize, //ldc,
+                      false,
+                      query_t_padding_ptr,
+                      key_reorder_ptr + n * qk_gemm_K +
+                          b * qk_gemm_K,
+                      qk_s32_data + b);
+              }
+
+              // do dequant compensation, add mask, max reduce for softmax, and convert qk from s32 to fp32
+              accum_t* qk_block_data = qk_data + l * qSplitSize * rndkvSplitSize;
+              if (has_attn_mask) {
+                mask_t* mask_data_offset = mask_data + i * mStrideB + j * mStrideH + m * mStrideM + (mStrideN == 0 ? 0 : n);
+                _dequant_mask_max_fusion_kernel(
+                  qk_s32_data, //in
+                  mask_data_offset, //mask_ptr
+                  q_sum_ptr, //sum_a_ptr
+                  k_sum_ptr + n, //sum_b_ptr
+                  qBlockSize, //M
+                  kvBlockSize, //N
+                  rndkvSplitSize, //ldi
+                  mStrideM, //ldm
+                  rndkvSplitSize, //ldo
+                  q_zp * k_zp * headSize, //zp_a*zp_b*k=beta
+                  q_scale * k_scale * scaling_factor, //scale_a*scale_b*scale_sdpa=alpha
+                  qk_block_data, //out
+                  sfm_max_ptr // sfm_max_ptr
+                );
+              } else {
+                _dequant_max_fusion_kernel(
+                  qk_s32_data, //in
+                  q_sum_ptr, //sum_a_ptr
+                  k_sum_ptr + n, //sum_b_ptr
+                  qBlockSize, //M
+                  kvBlockSize, //N
+                  rndkvSplitSize, //ldi
+                  rndkvSplitSize, //ldo
+                  q_zp * k_zp * headSize, //zp_a*zp_b*k=beta
+                  q_scale * k_scale * scaling_factor, //scale_a*scale_b*scale_sdpa=alpha
+                  qk_block_data, //out
+                  sfm_max_ptr // sfm_max_ptr
+                );
+              }
+            }
+            // sub max, exp, sum reduce, div sum for softmax
+            // and quant
+            // and sum for attention
+            if (v_zp == 0) {
+              _sub_exp_sum_div_quant_fusion_kernel(
+                qk_data, //in
+                qBlockSize, //M
+                kvSplitSize, //N_step
+                rkvSlice, //NSlices
+                qSplitSize * rndkvSplitSize, //ldi
+                qk_reduce_strideL, //ldo
+                kvSize, //kvSize
+                rndkvSplitSize, //rndkvSplitSize
+                av_gemm_K, //av_gemm_K
+                a_zp, // zp_a=beta1
+                a_scale, // scale_a=alpha
+                qk_local_data, //local
+                qk_reduced_data, //out
+                sfm_max_ptr, //sfm_max_ptr
+                sfm_sum_ptr //sfm_sum_ptr
+              );
+            } else {
+              _sub_exp_sum_div_quant_sum_fusion_kernel(
+                qk_data, //in
+                qBlockSize, //M
+                kvSplitSize, //N_step
+                rkvSlice, //NSlice
+                qSplitSize * rndkvSplitSize, //ldi
+                qk_reduce_strideL, //ldo
+                kvSize, //kvSize
+                rndkvSplitSize, //rndkvSplitSize
+                av_gemm_K, //av_gemm_K
+                a_zp, // zp_a=beta1
+                v_zp, // zp_b=beta2
+                a_scale, // scale_a=alpha
+                qk_local_data, //local
+                qk_reduced_data, //out
+                sfm_max_ptr, //sfm_max_ptr
+                sfm_sum_ptr, //sfm_sum_ptr
+                a_sum_ptr //a_sum_ptr
+              );
+            }
+            // Calculate Softmax(q @ k.T) @ v
+            for (int64_t b = 0; b < headSize; b += block_64) {
+              auto value_reorder_b = value_reorder_ptr + b * av_gemm_K;
+              auto dst_s32_b = dst_s32_data + b;
+              for (int64_t s = 0; s < kvSlice; s++) {
+                at::native::cpublas::brgemm(
+                    qSplitSize, block_64, av_gemm_K,
+                    av_gemm_K, // lda
+                    rndHeadSize, //ldb
+                    rndHeadSize, //ldc
+                    s != 0,
+                    qk_reduced_data + s * qk_reduce_strideL,
+                    value_reorder_b + s * v_reorder_strideL,
+                    dst_s32_b);
+              }
+            }
+
+            // After the last gemm,
+            // do dequant compensation, quant and convert from s32 to int8
+            if (a_zp == 0) {
+              _dequant_quant_fusion_kernel(
+                dst_s32_data, //in
+                a_sum_ptr, //sum_a_ptr
+                qBlockSize, //M
+                headSize, //N
+                rndHeadSize, //ldi
+                oStrideM, //ldo
+                o_zp, //zp_c=beta2
+                a_scale * v_scale / o_scale, //scale_a*scale_b/scale_c=alpha
+                out_data + i * oStrideB + j * oStrideH + m * oStrideM //out
+              );
+            } else {
+              _dequant_quant_fusion_kernel(
+                dst_s32_data, //in
+                a_sum_ptr, //sum_a_ptr
+                v_sum_ptr, //sum_b_ptr
+                qBlockSize, //M
+                headSize, //N
+                rndHeadSize, //ldi
+                oStrideM, //ldo
+                a_zp * v_zp * kvSize, //zp_a*zp_b*k=beta1
+                o_zp, //zp_c=beta2
+                a_scale * v_scale / o_scale, //scale_a*scale_b/scale_c=alpha
+                out_data + i * oStrideB + j * oStrideH + m * oStrideM //out
+              );
+            }
+          }
+          // Move to the next query
+          at::native::data_index_step(i, batchSize, j, num_head);
+        }
+      });
+  // Once all computations are done, need to release HW context.
+  at::native::cpublas::brgemm_release();
+}
+
+// UINT8 - several parallel loops with u8u8s32 GEMM
+template <typename scalar_t, typename mask_t,
+          int64_t q_split_size, int64_t kv_split_size,
+          bool use_one_parallel_loop,
+          typename std::enable_if_t<!use_one_parallel_loop, int> = 0>
+inline typename std::enable_if_t<std::is_same_v<scalar_t, unsigned char>, void>
+sdpa_int8_fused_kernel_impl(
+    const at::Tensor& output,
+    const at::Tensor& q,
+    const at::Tensor& k,
+    const at::Tensor& v,
+    double dropout_p,
+    bool is_causal,
+    std::optional<at::Tensor> attention_mask,
+    std::optional<double> scale,
+    float q_scale,
+    int32_t q_zp,
+    float k_scale,
+    int32_t k_zp,
+    float v_scale,
+    int32_t v_zp,
+    float a_scale,
+    int32_t a_zp,
+    float o_scale,
+    int32_t o_zp) {
+  // Query (Batch x Num_heads  x Q_seq_len  x Dim_per_head)
+  //    -> (Batch x Q_seq_len  x Num_heads  x Dim_per_head)
+  // Key   (Batch x Num_heads  x KV_seq_len x Dim_per_head)
+  //    -> (Batch x KV_seq_len x Num_heads  x Dim_per_head)
+  // Value (Batch x Num_heads  x KV_seq_len x Dim_per_head)
+  //    -> (Batch x KV_seq_len x Num_heads  x Dim_per_head)
+  at::Tensor query = q.transpose(1, 2);
+  at::Tensor key = k.transpose(1, 2);
+  at::Tensor value = v.transpose(1, 2);
+
+  using accum_t = float;
+  accum_t scaling_factor = calculate_scale(query, scale).expect_float();
+  int block_64 = 64;
+  auto u8_dt = at::ScalarType::Byte;
+
+  // Sizes
+  TORCH_CHECK(
+      (query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
+      "scaled_dot_product_attention_sdpa: Q/K/V should have the same head size");
+  TORCH_CHECK(
+      kv_split_size % block_64 == 0, "kv_split_size is not divisble by ", block_64);
+
+  int64_t batchSize = query.size(0);
+  int64_t qSize = query.size(1);
+  int64_t kvSize = value.size(1);
+  int64_t num_head = query.size(2);
+  int64_t headSize = query.size(3);
+
+  bool has_attn_mask = attention_mask.has_value() && attention_mask.value().numel();
+  if (has_attn_mask) {
+    reshape_attn_mask_to_4d(attention_mask.value(), batchSize, num_head, qSize, kvSize);
+  }
+
+  // Strides
+  int64_t qStrideB = query.stride(0);
+  int64_t qStrideM = query.stride(1);
+  int64_t qStrideH = query.stride(2);
+  int64_t kStrideB = key.stride(0);
+  int64_t kStrideN = key.stride(1);
+  int64_t kStrideH = key.stride(2);
+  int64_t vStrideB = value.stride(0);
+  int64_t vStrideN = value.stride(1);
+  int64_t vStrideH = value.stride(2);
+  int64_t oStrideB = output.stride(0);
+  int64_t oStrideM = output.stride(1);
+  int64_t oStrideH = output.stride(2);
+  int64_t mStrideB =
+      (has_attn_mask && attention_mask.value().size(0) > 1)
+      ? attention_mask.value().stride(0)
+      : 0;
+  int64_t mStrideH =
+      (has_attn_mask && attention_mask.value().size(1) > 1)
+      ? attention_mask.value().stride(1)
+      : 0;
+  int64_t mStrideM =
+      (has_attn_mask && attention_mask.value().size(2) > 1)
+      ? attention_mask.value().stride(2)
+      : 0;
+  int64_t mStrideN =
+      (has_attn_mask && attention_mask.value().size(3) > 1)
+      ? attention_mask.value().stride(3)
+      : 0;
+
+  int64_t qSplitSize = q_split_size > qSize ? qSize : q_split_size;
+  int64_t kvSplitSize = kv_split_size > kvSize ? kvSize : kv_split_size;
+  int64_t qSlice = (qSize - 1) / qSplitSize + 1;
+  int64_t kvSlice = (kvSize - 1) / kvSplitSize + 1;
+  int64_t kvTail = (kvSize - 1) % kvSplitSize + 1;
+  int64_t num_thread = at::get_num_threads();
+
+  int64_t rndHeadSize = (headSize + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvSplitSize = (kvSplitSize + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvTail = (kvTail + block_64 - 1L) / block_64 * block_64;
+  int64_t rndkvSize = kv_split_size > kvSize ? rndkvTail : rndkvSplitSize * kvSlice + rndkvTail;
+
+  bool av_gemm_K_mul4 = kvSplitSize % 4 == 0;
+  int av_gemm_K_padding = av_gemm_K_mul4 ? 0 : 4 - kvSplitSize % 4;
+  int av_gemm_K = kvSplitSize + av_gemm_K_padding;
+
+  // Data ptrs
+  scalar_t* q_data = query.data_ptr<scalar_t>();
+  scalar_t* k_data = key.data_ptr<scalar_t>();
+  scalar_t* v_data = value.data_ptr<scalar_t>();
+  mask_t* mask_data = attention_mask.has_value()
+      ? attention_mask.value().data_ptr<mask_t>()
+      : nullptr;
+  scalar_t* out_data = output.data_ptr<scalar_t>();
+
+  bool headSize_mul64 = headSize % 64 == 0;
+  int qk_gemm_K_padding = headSize_mul64 ? 0 : 64 - headSize % 64;
+  int qk_gemm_K = headSize + qk_gemm_K_padding;
+
+  int64_t qk_reduce_strideL = qSplitSize * av_gemm_K;
+  int64_t v_reorder_strideL = av_gemm_K * rndHeadSize;
+
+  int64_t total_size_uint8_per_thread =
+    /* qk */ kvSlice * qSplitSize * rndkvSplitSize * 4 +
+    /* qk_local  */ kvSlice * av_gemm_K * 4 +
+    /* qk_reduce  */ kvSlice * qk_reduce_strideL +
+    /* qk_s32   */ qSplitSize * rndkvSplitSize * 4 +
+    /* dst_s32  */ qSplitSize * rndHeadSize * 4 +
+    /* softmax_sum   */ qSplitSize * 4 +
+    /* query_sum     */ qSplitSize * 4 +
+    /* attention_sum */ qSplitSize * 4 +
+    /* softmax max */ qSplitSize * 4 +
+    /* query_padding_data */ qSplitSize * qk_gemm_K;
+
+  at::Tensor total_buf = at::empty(
+      {num_thread, total_size_uint8_per_thread},
+      query.options());
+  scalar_t* total_buf_data = total_buf.data_ptr<scalar_t>();
+
+  int64_t kv_sum_size_per_BH =
+    /* key_sum */ kvSize +
+    /* value_sum */ headSize;
+
+  at::Tensor kv_sum_buf = at::empty(
+      {batchSize, num_head, kv_sum_size_per_BH},
+      query.options().dtype(at::kInt));
+  int32_t* kv_sum_buf_data = kv_sum_buf.data_ptr<int32_t>();
+
+  int64_t kv_reorder_size_per_BH =
+    /* key_t_reorder */ qk_gemm_K * rndkvSize +
+    /* value_t_reorder */ kvSlice * v_reorder_strideL;
+
+  at::Tensor kv_reorder_buf = at::empty(
+      {batchSize, num_head, kv_reorder_size_per_BH},
+      query.options());
+  scalar_t* kv_reorder_buf_data = kv_reorder_buf.data_ptr<scalar_t>();
+  scalar_t* key_reorder_ptr = kv_reorder_buf_data;
+  scalar_t* value_reorder_ptr = kv_reorder_buf_data + batchSize * num_head * qk_gemm_K * rndkvSize;
+
+  // sum k and v
+  at::parallel_for(
+      0, batchSize * num_head, 1, [&](int64_t begin, int64_t end) {
+        int64_t i = 0, j = 0;
+        at::native::data_index_init(
+            begin, i, batchSize, j, num_head);
+        for (const auto z : c10::irange(begin, end)) {
+          (void)z; // Suppress unused variable
+          int32_t* kv_sum_ptr = kv_sum_buf_data
+              + i * num_head * kv_sum_size_per_BH
+              + j * kv_sum_size_per_BH;
+          int32_t* k_sum_ptr = kv_sum_ptr;
+          int32_t* v_sum_ptr = kv_sum_ptr + kvSize;
+          if (q_zp == 0) {
+            fill_stub(k_sum_ptr, static_cast<int32_t>(0), kvSize);
+          } else {
+            _int_sum_b_contiguous_kernel(k_data + i * kStrideB + j * kStrideH,
+              k_sum_ptr,
+              kvSize, headSize, kStrideN, q_zp);
+          }
+          if (a_zp == 0) {
+            fill_stub(v_sum_ptr, static_cast<int32_t>(0), headSize);
+          } else {
+            _int_sum_a_contiguous_kernel(v_data + i * vStrideB + j * vStrideH,
+              v_sum_ptr,
+              headSize, kvSize, vStrideN, a_zp);
+          }
+        // Move to the next query
+        at::native::data_index_step(i, batchSize, j, num_head);
+      }
+    });
+
+  // transpose and packing
+  at::parallel_for(
+    0, batchSize * num_head * kvSlice, 1, [&](int64_t begin, int64_t end) {
+      int64_t i = 0, j = 0, l = 0, n = 0;
+      at::native::data_index_init(
+          begin, i, batchSize, j, num_head, l, kvSlice);
+      uint8_t* B_blocked_xform_u8 = new uint8_t[qk_gemm_K * block_64];
+      for (const auto z : c10::irange(begin, end)) {
+        (void)z; // Suppress unused variable
+        n = l * kvSplitSize;
+        auto k_reorder = key_reorder_ptr + i * num_head * qk_gemm_K * rndkvSize +
+                      j * qk_gemm_K * rndkvSize + n * qk_gemm_K;
+        auto v_reorder = value_reorder_ptr +
+                      i * num_head * kvSlice * v_reorder_strideL +
+                      j * kvSlice * v_reorder_strideL + n * rndHeadSize;
+        int64_t kvBlockSize = std::min(kvSplitSize, kvSize - n);
+        for (int64_t b = 0; b < kvBlockSize; b += block_64) {
+          bool istail = kvBlockSize - b < block_64;
+          int64_t trans_rows = istail ? kvBlockSize - b : block_64;
+          do_transpose(
+              k_data + i * kStrideB + j * kStrideH + n * kStrideN + b * kStrideN,
+              B_blocked_xform_u8,
+              trans_rows,
+              headSize,
+              kStrideN,
+              block_64);
+          if (!headSize_mul64 || istail) {
+            pad_remain_row_col(
+                B_blocked_xform_u8,
+                headSize,
+                trans_rows,
+                qk_gemm_K,
+                block_64,
+                block_64
+              );
+          }
+          at::native::cpublas::pack(
+                  qk_gemm_K, // K
+                  block_64, // N
+                  block_64, // ld_in
+                  block_64, // ld_out
+                  u8_dt, // dt_in
+                  u8_dt, // dt_out
+                  B_blocked_xform_u8,
+                  k_reorder + b * qk_gemm_K);
+        }
+        // split headSize to block_64, block_64, block_64 ...
+        // [av_gemm_K, headSize] -> [av_gemm_K,  block_64 ...]
+        for (int64_t b = 0; b < rndHeadSize; b += block_64) {
+          at::native::cpublas::pack(
+                  av_gemm_K,
+                  block_64,
+                  vStrideN,
+                  block_64,
+                  u8_dt,
+                  u8_dt,
+                  v_data + i * vStrideB + j * vStrideH + n * vStrideN + b,
+                  v_reorder + av_gemm_K * b);
+        }
+        // Move to the next query
+        at::native::data_index_step(i, batchSize, j, num_head, l, kvSlice);
+      }
+    });
+
+  at::parallel_for(
+      0, batchSize * num_head * qSlice, 1, [&](int64_t begin, int64_t end) {
+        int64_t i = 0, j = 0, k = 0;
+        at::native::data_index_init(
+            begin, i, batchSize, j, num_head, k, qSlice);
+        int ompIdx = at::get_thread_num();
+        scalar_t* total_buf_ptr = total_buf_data + ompIdx * total_size_uint8_per_thread;
+        int32_t offset = 0;
+        accum_t* qk_data = reinterpret_cast<accum_t*>(total_buf_ptr);
+        offset += kvSlice * qSplitSize * rndkvSplitSize * 4;
+        accum_t* qk_local_data = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += kvSlice * av_gemm_K * 4;
+        scalar_t* qk_reduced_data = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+        offset += kvSlice * qk_reduce_strideL;
+        int32_t* qk_s32_data = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * rndkvSplitSize * 4;
+        int32_t* dst_s32_data = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * rndHeadSize * 4;
+        accum_t* sfm_sum_ptr = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        int32_t* q_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        int32_t* a_sum_ptr = reinterpret_cast<int32_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        accum_t* sfm_max_ptr = reinterpret_cast<accum_t*>(total_buf_ptr + offset);
+        offset += qSplitSize * 4;
+        scalar_t* query_t_padding_ptr = reinterpret_cast<scalar_t*>(total_buf_ptr + offset);
+
+        for (const auto z : c10::irange(begin, end)) {
+          (void)z; // Suppress unused variable
+
+          int32_t* kv_sum_ptr = kv_sum_buf_data
+              + i * num_head * kv_sum_size_per_BH
+              + j * kv_sum_size_per_BH;
+          int32_t* k_sum_ptr = kv_sum_ptr;
+          int32_t* v_sum_ptr = kv_sum_ptr + kvSize;
+
+          // sdpa core
+          int64_t m = k * qSplitSize;
+          int64_t qBlockSize = std::min(qSplitSize, qSize - m);
+          // Initialize sum and max
+          fill_stub(
+              sfm_sum_ptr, static_cast<accum_t>(0), qSplitSize);
+          fill_stub(
+              a_sum_ptr, static_cast<int32_t>(0), qSplitSize);
+          fill_stub(
+              sfm_max_ptr, static_cast<accum_t>(-std::numeric_limits<accum_t>::infinity()), qSplitSize);
+          copy_value_with_pad(
+              q_data + i * qStrideB + j * qStrideH + m * qStrideM,
+              query_t_padding_ptr,
+              qBlockSize,
+              headSize,
+              qSplitSize,
+              qk_gemm_K,
+              qStrideM);
+          // sum q
+          if (k_zp != 0) {
+            _int_sum_b_contiguous_kernel(query_t_padding_ptr,
+                  q_sum_ptr, qBlockSize, headSize, qk_gemm_K, k_zp);
+          } else {
+            fill_stub(
+              q_sum_ptr, static_cast<int32_t>(0), qSplitSize);
+          }
+          const int64_t rkvSlice = (kvSize - 1) / kvSplitSize + 1;
+          for (int64_t l = 0; l < rkvSlice; l++) {
+            int64_t n = l * kvSplitSize;
+            int64_t kvBlockSize = std::min(kvSplitSize, kvSize - n);
+            auto k_reorder = key_reorder_ptr + i * num_head * qk_gemm_K * rndkvSize +
+                      j * qk_gemm_K * rndkvSize + n * qk_gemm_K;
+            // Calculate q @ k.T
+            for (int64_t b = 0; b < kvBlockSize; b += block_64) {
+              at::native::cpublas::brgemm(
+                    qSplitSize, block_64, qk_gemm_K,
+                    qk_gemm_K, // lda
+                    block_64, //ldb
+                    rndkvSplitSize, //ldc,
+                    false,
+                    query_t_padding_ptr,
+                    k_reorder + b * qk_gemm_K,
+                    qk_s32_data + b);
+            }
+
+            // do dequant compensation, add mask, max reduce for softmax, and convert qk from s32 to fp32
+            accum_t* qk_block_data = qk_data + l * qSplitSize * rndkvSplitSize;
+            if (has_attn_mask) {
+              mask_t* mask_data_offset = mask_data + i * mStrideB + j * mStrideH + m * mStrideM + (mStrideN == 0 ? 0 : n);
+              _dequant_mask_max_fusion_kernel(
+                qk_s32_data, //in
+                mask_data_offset, //mask_ptr
+                q_sum_ptr, //sum_a_ptr
+                k_sum_ptr + n, //sum_b_ptr
+                qBlockSize, //M
+                kvBlockSize, //N
+                rndkvSplitSize, //ldi
+                mStrideM, //ldm
+                rndkvSplitSize, //ldo
+                q_zp * k_zp * headSize, //zp_a*zp_b*k=beta
+                q_scale * k_scale * scaling_factor, //scale_a*scale_b*scale_sdpa=alpha
+                qk_block_data, //out
+                sfm_max_ptr // sfm_max_ptr
+              );
+            } else {
+              _dequant_max_fusion_kernel(
+                qk_s32_data, //in
+                q_sum_ptr, //sum_a_ptr
+                k_sum_ptr + n, //sum_b_ptr
+                qBlockSize, //M
+                kvBlockSize, //N
+                rndkvSplitSize, //ldi
+                rndkvSplitSize, //ldo
+                q_zp * k_zp * headSize, //zp_a*zp_b*k=beta
+                q_scale * k_scale * scaling_factor, //scale_a*scale_b*scale_sdpa=alpha
+                qk_block_data, //out
+                sfm_max_ptr // sfm_max_ptr
+              );
+            }
+          }
+          // sub max, exp, sum reduce, div sum for softmax
+          // and quant
+          // and sum for attention
+          if (v_zp == 0) {
+            _sub_exp_sum_div_quant_fusion_kernel(
+              qk_data, //in
+              qBlockSize, //M
+              kvSplitSize, //N_step
+              rkvSlice, //NSlices
+              qSplitSize * rndkvSplitSize, //ldi
+              qk_reduce_strideL, //ldo
+              kvSize, //kvSize
+              rndkvSplitSize, //rndkvSplitSize
+              av_gemm_K, //av_gemm_K
+              a_zp, // zp_a=beta1
+              a_scale, // scale_a=alpha
+              qk_local_data, //local
+              qk_reduced_data, //out
+              sfm_max_ptr, //sfm_max_ptr
+              sfm_sum_ptr //sfm_sum_ptr
+            );
+          } else {
+            _sub_exp_sum_div_quant_sum_fusion_kernel(
+              qk_data, //in
+              qBlockSize, //M
+              kvSplitSize, //N_step
+              rkvSlice, //NSlice
+              qSplitSize * rndkvSplitSize, //ldi
+              qk_reduce_strideL, //ldo
+              kvSize, //kvSize
+              rndkvSplitSize, //rndkvSplitSize
+              av_gemm_K, //av_gemm_K
+              a_zp, // zp_a=beta1
+              v_zp, // zp_b=beta2
+              a_scale, // scale_a=alpha
+              qk_local_data, //local
+              qk_reduced_data, //out
+              sfm_max_ptr, //sfm_max_ptr
+              sfm_sum_ptr, //sfm_sum_ptr
+              a_sum_ptr //a_sum_ptr
+            );
+          }
+          // Calculate Softmax(q @ k.T) @ v
+          auto v_reorder = value_reorder_ptr +
+                  i * num_head * kvSlice * v_reorder_strideL +
+                  j * kvSlice * v_reorder_strideL;
+          for (int64_t b = 0; b < headSize; b += block_64) {
+            auto value_reorder_b = v_reorder + b * av_gemm_K;
+            auto dst_s32_b = dst_s32_data + b;
+            for (int64_t s = 0; s < kvSlice; s++) {
+              at::native::cpublas::brgemm(
+                  qSplitSize, block_64, av_gemm_K,
+                  av_gemm_K, // lda
+                  rndHeadSize, //ldb
+                  rndHeadSize, //ldc
+                  s != 0,
+                  qk_reduced_data + s * qk_reduce_strideL,
+                  value_reorder_b + s * v_reorder_strideL,
+                  dst_s32_b);
+            }
+          }
+
+          // After the last gemm,
+          // do dequant compensation, quant and convert from s32 to int8
+          if (a_zp == 0) {
+            _dequant_quant_fusion_kernel(
+              dst_s32_data, //in
+              a_sum_ptr, //sum_a_ptr
+              qBlockSize, //M
+              headSize, //N
+              rndHeadSize, //ldi
+              oStrideM, //ldo
+              o_zp, //zp_c=beta2
+              a_scale * v_scale / o_scale, //scale_a*scale_b/scale_c=alpha
+              out_data + i * oStrideB + j * oStrideH + m * oStrideM //out
+            );
+          } else {
+            _dequant_quant_fusion_kernel(
+              dst_s32_data, //in
+              a_sum_ptr, //sum_a_ptr
+              v_sum_ptr, //sum_b_ptr
+              qBlockSize, //M
+              headSize, //N
+              rndHeadSize, //ldi
+              oStrideM, //ldo
+              a_zp * v_zp * kvSize, //zp_a*zp_b*k=beta1
+              o_zp, //zp_c=beta2
+              a_scale * v_scale / o_scale, //scale_a*scale_b/scale_c=alpha
+              out_data + i * oStrideB + j * oStrideH + m * oStrideM //out
+            );
+          }
+          // Move to the next query
+          at::native::data_index_step(i, batchSize, j, num_head, k, qSlice);
+        }
+      });
+  // Once all computations are done, need to release HW context.
+  at::native::cpublas::brgemm_release();
+}
+
+
+template <typename scalar_t, typename mask_t, int64_t q_split_size, int64_t kv_split_size>
+inline typename std::enable_if_t<std::is_same_v<scalar_t, unsigned char>, void>
+sdpa_int8_fused_kernel_impl(
+    bool use_one_parallel_loop,
+    const at::Tensor& output,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    double dropout_p,
+    bool is_causal,
+    std::optional<at::Tensor> attn_mask,
+    std::optional<double> scale,
+    float q_scale,
+    int32_t q_zp,
+    float k_scale,
+    int32_t k_zp,
+    float v_scale,
+    int32_t v_zp,
+    float a_scale,
+    int32_t a_zp,
+    float o_scale,
+    int32_t o_zp) {
+  if (use_one_parallel_loop) {
+    sdpa_int8_fused_kernel_impl<scalar_t, mask_t, q_split_size, kv_split_size,
+          /* use_one_parallel_loop */ true>(
+      output, query, key, value,
+      dropout_p, is_causal, attn_mask, scale,
+      q_scale, q_zp,
+      k_scale, k_zp,
+      v_scale, v_zp,
+      a_scale, a_zp,
+      o_scale, o_zp);
+  } else {
+    sdpa_int8_fused_kernel_impl<scalar_t, mask_t, q_split_size, kv_split_size,
+          /* use_one_parallel_loop */ false>(
+      output, query, key, value,
+      dropout_p, is_causal, attn_mask, scale,
+      q_scale, q_zp,
+      k_scale, k_zp,
+      v_scale, v_zp,
+      a_scale, a_zp,
+      o_scale, o_zp);
+  }
+}
+
+
+#define AT_DISPATCH_MASK_TYPES(TYPE, NAME, ...)            \
+  AT_DISPATCH_SWITCH(                                      \
+      TYPE,                                                \
+      NAME,                                                \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Bool, mask_t, __VA_ARGS__)       \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Float, mask_t, __VA_ARGS__)      \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Double, mask_t, __VA_ARGS__)     \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::BFloat16, mask_t, __VA_ARGS__)   \
+      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
+          at::ScalarType::Half, mask_t, __VA_ARGS__))
+
+void sdpa_int8_fused_kernel(
+    const at::Tensor& output,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    double dropout_p,
+    bool is_causal,
+    std::optional<at::Tensor> attn_mask,
+    std::optional<double> scale,
+    float q_scale,
+    int32_t q_zp,
+    float k_scale,
+    int32_t k_zp,
+    float v_scale,
+    int32_t v_zp,
+    float a_scale,
+    int32_t a_zp,
+    float o_scale,
+    int32_t o_zp) {
+  TORCH_CHECK(query.scalar_type() == c10::kByte);
+  int64_t batchSize = query.size(0);
+  int64_t num_head = query.size(1);
+  int64_t q_seq_len = query.size(2);
+  int64_t kv_seq_len = key.size(2);
+  int64_t q_split_size = 32;
+  if (q_seq_len >= 768) {
+    q_split_size = 256;
+  } else if (q_seq_len >= 192) {
+    q_split_size = 64;
+  }
+  // Heuristic to decide whether to use one parallel loop or not
+  //    true: one parallel loop for sum+packing+core
+  //    false: three parallel loops for sum, packing, core
+  uint32_t l2_cache_size = at::cpu::L2_cache_size();
+  int64_t num_thread = at::get_num_threads();
+  int64_t attn_size = q_split_size * kv_seq_len * sizeof(int32_t) * num_thread;
+  bool use_one_parallel_loop = (batchSize * num_head > num_thread) &&
+      (attn_size > 1.5 * l2_cache_size);
+  if (!attn_mask.has_value()) {
+    if (q_split_size == 256) {
+      sdpa_int8_fused_kernel_impl<unsigned char, float, 256, 64>(
+        use_one_parallel_loop,
+        output, query, key, value,
+        dropout_p, is_causal, attn_mask, scale,
+        q_scale, q_zp,
+        k_scale, k_zp,
+        v_scale, v_zp,
+        a_scale, a_zp,
+        o_scale, o_zp);
+    } else if (q_split_size == 64) {
+      sdpa_int8_fused_kernel_impl<unsigned char, float, 64, 64>(
+        use_one_parallel_loop,
+        output, query, key, value,
+        dropout_p, is_causal, attn_mask, scale,
+        q_scale, q_zp,
+        k_scale, k_zp,
+        v_scale, v_zp,
+        a_scale, a_zp,
+        o_scale, o_zp);
+    } else {
+      sdpa_int8_fused_kernel_impl<unsigned char, float, 32, 64>(
+        use_one_parallel_loop,
+        output, query, key, value,
+        dropout_p, is_causal, attn_mask, scale,
+        q_scale, q_zp,
+        k_scale, k_zp,
+        v_scale, v_zp,
+        a_scale, a_zp,
+        o_scale, o_zp);
+    }
+  } else {
+    AT_DISPATCH_MASK_TYPES(attn_mask.value().scalar_type(), "sdpa_mask", [&]() {
+      if (q_split_size == 256) {
+        sdpa_int8_fused_kernel_impl<unsigned char, mask_t, 256, 64>(
+          use_one_parallel_loop,
+          output, query, key, value,
+          dropout_p, is_causal, attn_mask, scale,
+          q_scale, q_zp,
+          k_scale, k_zp,
+          v_scale, v_zp,
+          a_scale, a_zp,
+          o_scale, o_zp);
+      } else if (q_split_size == 64) {
+        sdpa_int8_fused_kernel_impl<unsigned char, mask_t, 64, 64>(
+          use_one_parallel_loop,
+          output, query, key, value,
+          dropout_p, is_causal, attn_mask, scale,
+          q_scale, q_zp,
+          k_scale, k_zp,
+          v_scale, v_zp,
+          a_scale, a_zp,
+          o_scale, o_zp);
+      } else {
+        sdpa_int8_fused_kernel_impl<unsigned char, mask_t, 32, 64>(
+          use_one_parallel_loop,
+          output, query, key, value,
+          dropout_p, is_causal, attn_mask, scale,
+          q_scale, q_zp,
+          k_scale, k_zp,
+          v_scale, v_zp,
+          a_scale, a_zp,
+          o_scale, o_zp);
+      }
+    });
+  }
+}
+#endif // CPU_CAPABILITY_AVX512
+
+at::Tensor sdpa_int8_math_kernel(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    double dropout_p,
+    bool is_causal,
+    std::optional<at::Tensor> attn_mask,
+    std::optional<double> scale,
+    float q_scale,
+    int32_t q_zp,
+    float k_scale,
+    int32_t k_zp,
+    float v_scale,
+    int32_t v_zp,
+    float a_scale,
+    int32_t a_zp,
+    float o_scale,
+    int32_t o_zp) {
+  // dequant q/k/v
+  auto q = (query.to(at::kFloat) - q_zp) * q_scale;
+  auto k = (key.to(at::kFloat) - k_zp) * k_scale;
+  auto v = (value.to(at::kFloat) - v_zp) * v_scale;
+  const auto scaling_factor = calculate_scale(q, scale);
+  auto attn = at::matmul(q, k.transpose(-2, -1)) * scaling_factor;
+  if (attn_mask.has_value() && attn_mask.value().numel()) {
+    attn = attn.add(attn_mask.value().to(at::kFloat));
+  }
+  attn = at::softmax(attn, -1);
+  // quant attn
+  attn = at::clamp_max(
+      at::clamp_min(at::round(attn / a_scale) + a_zp, 0), 255
+  );
+  // dequant attn
+  attn = (attn - a_zp) * a_scale;
+  auto output = at::matmul(attn, v);
+  // quant output
+  output = at::clamp_max(
+      at::clamp_min(at::round(output / o_scale) + o_zp, 0), 255
+  ).to(at::kByte);
+  return output;
+}
+
+
+at::Tensor _qscaled_dot_product_cpu(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    std::optional<at::Tensor> attn_mask,
+    double dropout_p,
+    bool is_causal,
+    std::optional<double> scale,
+    double q_scale,
+    int64_t q_zp,
+    double k_scale,
+    int64_t k_zp,
+    double v_scale,
+    int64_t v_zp,
+    double a_scale,
+    int64_t a_zp,
+    double o_scale,
+    int64_t o_zp) {
+  const auto dtype = query.scalar_type();
+  TORCH_CHECK(!query.is_nested() && !key.is_nested() && !value.is_nested(),
+    "_qscaled_dot_product_cpu: Only accept plain inputs");
+  TORCH_CHECK(!is_causal,
+    "_qscaled_dot_product_cpu: is_causal not supported.");
+  TORCH_CHECK(dtype == at::ScalarType::Byte,
+    "_qscaled_dot_product_cpu: Expected data type be U8, but got ", dtype, " instead.");
+  TORCH_CHECK(query.dim() == 4 && key.dim() == 4 && value.dim() == 4,
+    "_qscaled_dot_product_cpu: Accept only 4 dims inputs shape of {B, H, T, K}");
+  TORCH_CHECK(dropout_p == 0.0,
+    "_qscaled_dot_product_cpu: Currently do not support dropout > 0");
+  TORCH_CHECK((query.size(3) == value.size(3)) && (key.size(3) == value.size(3)),
+    "_qscaled_dot_product_cpu: Q/K/V should have the same head size");
+  TORCH_CHECK(!attn_mask.has_value() ||
+          attn_mask.value().scalar_type() == at::kFloat ||
+          attn_mask.value().scalar_type() == at::kBFloat16,
+    "_qscaled_dot_product_cpu: Expected attention mask be float or bf16");
+  TORCH_CHECK(!attn_mask.has_value() ||
+          (attn_mask.value().dim() == 2 || attn_mask.value().dim() == 4),
+    "_qscaled_dot_product_cpu: Attention mask dim in {2, 4}");
+
+  #ifdef CPU_CAPABILITY_AVX512
+    if (at::native::cpublas::could_pack(dtype)) {
+        at::Tensor output = at::empty_like(query, query.options()).transpose(1, 2);
+        sdpa_int8_fused_kernel(output, query, key, value,
+            dropout_p, is_causal, attn_mask, scale,
+            q_scale, q_zp,
+            k_scale, k_zp,
+            v_scale, v_zp,
+            a_scale, a_zp,
+            o_scale, o_zp);
+        return output.transpose(1, 2);
+    } else {
+  #endif // CPU_CAPABILITY_AVX512
+        return sdpa_int8_math_kernel(query, key, value,
+              dropout_p, is_causal, attn_mask, scale,
+              q_scale, q_zp,
+              k_scale, k_zp,
+              v_scale, v_zp,
+              a_scale, a_zp,
+              o_scale, o_zp).transpose(1, 2).contiguous().transpose(1, 2);
+  #ifdef CPU_CAPABILITY_AVX512
+    }
+  #endif // CPU_CAPABILITY_AVX512
+}
+
+
+} // anonymous namespace
+
+TORCH_LIBRARY_IMPL(torchao, CPU, m) {
+  m.impl("torchao::qscaled_dot_product", &_qscaled_dot_product_cpu);
+}
+
+// } // at::native
+} // namespace torchao


### PR DESCRIPTION
Summary: This adds an fbcode/xplat dirsync for torchao/csrc/cpu because we are migrating torchao/experimental to torchao/csrc/cpu and some of the code is only runnable in xplat.

Reviewed By: jerryzh168

Differential Revision: D81531434
