### PR TITLE
Fix xnnpack export

### DIFF
--- a/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
@@ -23,7 +23,7 @@ from torchao.quantization import (
     MappingType,
     quantize_,
 )
-from torchao.quantization.granularity import PerGroup
+from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.qat import IntxFakeQuantizeConfig, QATConfig
 from torchao.quantization.quantize_.common import PackingFormat
 from torchao.quantization.utils import compute_error
@@ -156,7 +156,7 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
             model,
             Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=torch.int4,
-                weight_granularity=PerGroup(64),
+                weight_granularity=PerAxis(0),
                 weight_mapping_type=MappingType.SYMMETRIC,
                 packing_format=PackingFormat.UNPACKED_TO_INT8,
                 version=2,

--- a/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
@@ -169,17 +169,14 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
         exported_results = exported.module()(activations)
         self.assertTrue(torch.allclose(eager_results, exported_results))
 
-        expected_lines = [
-            "torch.ops.torchao.choose_qparams_affine.default",
-            "torch.ops.torchao.quantize_affine.default",
-            "torch.ops.torchao.dequantize_affine.default",
-            "torch.ops.torchao.dequantize_affine.default",
-            "torch.ops.aten.linear.default",
-        ]
-        for line in expected_lines:
-            count = 1
-            if line == "torch.ops.torchao.dequantize_affine.default":
-                count = 2
+        expected_counts = {
+            "torch.ops.torchao.choose_qparams_affine.default": 1,
+            "torch.ops.torchao.quantize_affine.default": 1,
+            "torch.ops.torchao.dequantize_affine.default": 2,
+            "torch.ops.aten.linear.default": 1,
+            "torch.ops.aten.reshape.default": 0,
+        }
+        for line, count in expected_counts.items():
             FileCheck().check_count(line, count, exactly=True).run(
                 exported.graph_module.code
             )

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -833,7 +833,7 @@ def _int8_dynamic_activation_intx_weight_quantize_tensor(weight, bias, config):
             block_size,
             weight_dtype,
             mapping_type=weight_mapping_type,
-            apply_int8_act_asym_per_token_quant=True,
+            activation_quantization="int8_asym_per_token",
         )
         if weight_scale_dtype is not None and weight_scale_dtype != weight.dtype:
             _adjust_scale_dtype_in_intx_unpacked_tensor(

--- a/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
@@ -14,8 +14,8 @@ import torch
 from torchao.experimental.op_lib_utils import _check_torchao_ops_loaded
 from torchao.quantization.quant_primitives import _DTYPE_TO_BIT_WIDTH
 from torchao.quantization.quantize_.workflows.intx.intx_unpacked_to_int8_tensor import (
-    ActivationQuantization,
     IntxUnpackedToInt8Tensor,
+    IntxUnpackedToInt8TensorActivationQuantization,
 )
 from torchao.utils import (
     TorchAOBaseTensor,
@@ -146,7 +146,8 @@ class IntxOpaqueTensor(TorchAOBaseTensor):
 
         # Extract data from IntxUnpackedToInt8Tensor
         assert (
-            tensor.activation_quantization == ActivationQuantization.INT8_ASYM_PER_TOKEN
+            tensor.activation_quantization
+            == IntxUnpackedToInt8TensorActivationQuantization.INT8_ASYM_PER_TOKEN
         )
         qdata, scale, zero_point = tensor.qdata, tensor.scale, tensor.zero_point
         bit_width = _DTYPE_TO_BIT_WIDTH[tensor.target_dtype]

--- a/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
@@ -14,8 +14,8 @@ import torch
 from torchao.experimental.op_lib_utils import _check_torchao_ops_loaded
 from torchao.quantization.quant_primitives import _DTYPE_TO_BIT_WIDTH
 from torchao.quantization.quantize_.workflows.intx.intx_unpacked_to_int8_tensor import (
-    IntxUnpackedToInt8Tensor,
     ActivationQuantization,
+    IntxUnpackedToInt8Tensor,
 )
 from torchao.utils import (
     TorchAOBaseTensor,

--- a/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
@@ -15,6 +15,7 @@ from torchao.experimental.op_lib_utils import _check_torchao_ops_loaded
 from torchao.quantization.quant_primitives import _DTYPE_TO_BIT_WIDTH
 from torchao.quantization.quantize_.workflows.intx.intx_unpacked_to_int8_tensor import (
     IntxUnpackedToInt8Tensor,
+    ActivationQuantization,
 )
 from torchao.utils import (
     TorchAOBaseTensor,
@@ -144,7 +145,9 @@ class IntxOpaqueTensor(TorchAOBaseTensor):
             compute_target = ComputeTarget[compute_target.upper()]
 
         # Extract data from IntxUnpackedToInt8Tensor
-        assert tensor.apply_int8_act_asym_per_token_quant
+        assert (
+            tensor.activation_quantization == ActivationQuantization.INT8_ASYM_PER_TOKEN
+        )
         qdata, scale, zero_point = tensor.qdata, tensor.scale, tensor.zero_point
         bit_width = _DTYPE_TO_BIT_WIDTH[tensor.target_dtype]
         dtype = tensor.dtype

--- a/torchao/quantization/quantize_/workflows/intx/intx_unpacked_to_int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_unpacked_to_int8_tensor.py
@@ -31,6 +31,7 @@ aten = torch.ops.aten
 
 _FLOAT_TYPES: List[torch.dtype] = [torch.float16, torch.bfloat16, torch.float32]
 
+
 def _fake_apply_int8_act_asym_per_token_quant(hp_tensor):
     target_dtype = torch.int8
     mapping_type = MappingType.ASYMMETRIC
@@ -65,8 +66,6 @@ def _fake_apply_int8_act_asym_per_token_quant(hp_tensor):
         output_dtype=hp_tensor.dtype,
     )
     return dequantized_affine
-
-
 
 
 class IntxUnpackedToInt8Tensor(TorchAOBaseTensor):
@@ -150,8 +149,10 @@ class IntxUnpackedToInt8Tensor(TorchAOBaseTensor):
         for i in range(len(block_size)):
             assert qdata.shape[i] % block_size[i] == 0
             n_blocks.append(qdata.shape[i] // block_size[i])
-        scale = scale.reshape(*n_blocks)
-        zero_point = zero_point.reshape(*n_blocks)
+
+        # Assert shapes
+        assert scale.shape == tuple(n_blocks)
+        assert zero_point.shape == tuple(n_blocks)
 
         assert dtype in _FLOAT_TYPES, (
             f"dtype must be one of {_FLOAT_TYPES}, but got {dtype}"


### PR DESCRIPTION
The previous version of IntxUnpackedToInt8Tensor had a reshape operator after export.  Although this does not change any numerics, it does interfere with XNNPACK's ability to recognize and lower the dynamic quantization pattern.

This PR removes the reshape operator, and adjusts the unit tests to look for 0 reshapes.