### PR TITLE
Move packing format used by int4 to int4_packing_format.py

### DIFF
--- a/test/core/test_config.py
+++ b/test/core/test_config.py
@@ -26,6 +26,7 @@ from torchao.prototype.awq import (
 from torchao.quantization.quant_api import (
     FbgemmConfig,
     Float8DynamicActivationFloat8WeightConfig,
+    Float8DynamicActivationInt4WeightConfig,
     Float8WeightOnlyConfig,
     FPXWeightOnlyConfig,
     GemliteUIntXWeightOnlyConfig,
@@ -49,13 +50,14 @@ configs = [
         weight_dtype=torch.float8_e4m3fn,
     ),
     UIntXWeightOnlyConfig(dtype=torch.uint1),
+    Float8DynamicActivationInt4WeightConfig(),
     Int4DynamicActivationInt4WeightConfig(),
     Int4WeightOnlyConfig(
         group_size=32,
     ),
     Int4WeightOnlyConfig(
         group_size=128,
-        packing_format="tile_packed_to_4d",
+        int4_packing_format="tile_packed_to_4d",
         int4_choose_qparams_algorithm="hqq",
         version=2,
     ),

--- a/test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py
@@ -26,7 +26,7 @@ from torchao.utils import torch_version_at_least
 
 BF16_ACT_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
-    packing_format="marlin_sparse",
+    int4_packing_format="marlin_sparse",
     version=2,
 )
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py
@@ -28,7 +28,7 @@ from torchao.utils import (
 def get_config(group_size):
     return Int4WeightOnlyConfig(
         group_size=group_size,
-        packing_format="opaque",
+        int4_packing_format="opaque",
         version=2,
     )
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
@@ -28,7 +28,7 @@ from torchao.utils import (
 def get_config(group_size):
     return Int4WeightOnlyConfig(
         group_size=group_size,
-        packing_format="plain_int32",
+        int4_packing_format="plain_int32",
         version=2,
     )
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
@@ -29,13 +29,13 @@ from torchao.utils import (
 
 BF16_ACT_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
-    packing_format="preshuffled",
+    int4_packing_format="preshuffled",
     version=2,
 )
 
 # only 128 group_size is supported
 FP8_ACT_CONFIG = Float8DynamicActivationInt4WeightConfig(
-    packing_format="preshuffled",
+    int4_packing_format="preshuffled",
 )
 
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
@@ -17,17 +17,24 @@ from torchao.quantization import Int4WeightOnlyConfig, quantize_
 from torchao.quantization.quantize_.common import SupportsActivationPreScaling
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase
-from torchao.utils import is_sm_at_least_90, torch_version_at_least
+from torchao.utils import (
+    _is_fbgemm_genai_gpu_available,
+    is_sm_at_least_90,
+    torch_version_at_least,
+)
 
 
 @unittest.skipIf(not torch_version_at_least("2.8.0"), "Need pytorch 2.8+")
 @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
 @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
+@unittest.skipIf(
+    not _is_fbgemm_genai_gpu_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
+)
 class TestInt4Tensor(TorchAOIntegrationTestCase):
     def setUp(self):
         self.config = Int4WeightOnlyConfig(
             group_size=128,
-            packing_format="plain",
+            int4_packing_format="plain",
             version=2,
         )
         self.GPU_DEVICES = ["cuda"] if torch.cuda.is_available() else []

--- a/test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
@@ -24,13 +24,13 @@ from torchao.utils import is_sm_at_least_90
 
 INT4_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
-    packing_format="tile_packed_to_4d",
+    int4_packing_format="tile_packed_to_4d",
     version=2,
 )
 
 INT4_HQQ_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
-    packing_format="tile_packed_to_4d",
+    int4_packing_format="tile_packed_to_4d",
     int4_choose_qparams_algorithm="hqq",
     version=2,
 )

--- a/torchao/quantization/quantize_/common/packing_format.py
+++ b/torchao/quantization/quantize_/common/packing_format.py
@@ -16,7 +16,7 @@ class PackingFormat(str, Enum):
 
     """
     plain means the format that quantized Tensor data lays out elements in Tensor sequentially,
-    for example:                                                                                                                                                                                                          for a Tensor of shape (4, 6):
+    for example:                                                                                                                                                                                          for a Tensor of shape (4, 6):
     a_0_0, a_0_1, ..., a_0_5,
     ...
     a_3_0, a_3_1, ..., a_3_5
@@ -27,30 +27,9 @@ class PackingFormat(str, Enum):
     PLAIN = "plain"
 
     """
-    preshuffled is referring to the preshuffled format used by fbgemm kernels
-    """
-    PRESHUFFLED = "preshuffled"
-
-    """
-    marlin_sparse is referring to the format used by marlin kernels, only supports symmetric quantization
-    """
-    MARLIN_SPARSE = "marlin_sparse"
-
-    """
     Unpacked to int8 means the subbyte quantized data is stored as int8
     """
     UNPACKED_TO_INT8 = "unpacked_to_int8"
-
-    """
-    plain_int32 is referring to the format used by int4 weight-only quantization.
-    which is a groupwise quantization format 2*int4 is store in a byte and 4*(int4*2) is stored in a int32.
-    """
-    PLAIN_INT32 = "plain_int32"
-
-    """
-    tile_packed_to_4d is referring to the format used by tinygemm kernels for int4 quantization
-    """
-    TILE_PACKED_TO_4D = "tile_packed_to_4d"
 
     """
     Opaque packing format that's used for tensors that does not have a predefined packing format

--- a/torchao/quantization/quantize_/workflows/__init__.py
+++ b/torchao/quantization/quantize_/workflows/__init__.py
@@ -9,6 +9,7 @@ from .int4.int4_marlin_sparse_tensor import (
 from .int4.int4_opaque_tensor import (
     Int4OpaqueTensor,
 )
+from .int4.int4_packing_format import Int4PackingFormat
 from .int4.int4_plain_int32_tensor import (
     Int4PlainInt32Tensor,
 )
@@ -39,4 +40,5 @@ __all__ = [
     "IntxUnpackedTensor",
     "IntxUnpackedToInt8Tensor",
     "Int4ChooseQParamsAlgorithm",
+    "Int4PackingFormat",
 ]

--- a/torchao/quantization/quantize_/workflows/int4/int4_packing_format.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_packing_format.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum
+
+
+# can switch to StrEnum (https://docs.python.org/3/library/enum.html#enum.StrEnum)
+# after python 3.10 is end of life (https://devguide.python.org/versions/)
+class Int4PackingFormat(str, Enum):
+    """Packing format for quantized data in Int4 Tensor subclasses in torchao, represents how
+    the values in quantized data are packed and laid out in memory.
+    """
+
+    """
+    plain means the format that quantized Tensor data lays out elements in Tensor sequentially,
+    for example:                                                                                                                                                                                            for a Tensor of shape (4, 6):
+    a_0_0, a_0_1, ..., a_0_5,
+    ...
+    a_3_0, a_3_1, ..., a_3_5
+
+    For example for int4, we will
+    pack two adjacent int4 elements into one uint8/int8 value for plain packing format
+    """
+    PLAIN = "plain"
+
+    """
+    preshuffled is referring to the preshuffled format used by fbgemm kernels
+    """
+    PRESHUFFLED = "preshuffled"
+
+    """
+    marlin_sparse is referring to the format used by marlin kernels, requires symmetric quantization
+    """
+    MARLIN_SPARSE = "marlin_sparse"
+
+    """
+    plain_int32 is a format that 2 adjacent int4 values are packed in a byte and 4 such packed bytes are stored in a int32 value.
+    """
+    PLAIN_INT32 = "plain_int32"
+
+    """
+    tile_packed_to_4d is referring to the format used by tinygemm kernels for int4 quantization
+    for a Tensor of shape (n, k), the packed weight will have dimension:
+    [n / 8][k / (inner_k_tiles * 16)][32][inner_k_tiles / 2], where inner_k_tiles is 8 currently
+    for simplication of Int4TilePackedTo4dTensor API
+    """
+    TILE_PACKED_TO_4D = "tile_packed_to_4d"
+
+    """
+    Opaque packing format that's used for tensors that does not have a predefined packing format
+    (that may be decided on hardware, tensor shape, library availability etc.) and it's not
+    needed for the rest of the system to understand the specific format that's adopted.
+    """
+    OPAQUE = "opaque"


### PR DESCRIPTION
Summary:
We found that there is not much reuse of packing format, so we now plan to define packing format for each of the dtype (int4, float8, intx), instead of having a global packing_format that's used by all the tensors. this reduces the interference between different dtype configs.

Changes
* Moved int4 packing format to `Int4PackingFormat` enum
* renamed `packing_format` arg in Int4WeightOnlyConfig and Float8DynamicActivationInt4WeightConfig to be `int4_packing_format`

This doesn't change tensor subclass, so no BC changes for tensor subclass. For v2 of Int4WeightOnlyConfig, it breaks BC, but we don't have any official models saved with this config yet, so it's fine. We also didn't add bc testing for this since it's not finalized yet. We'll add that later.

Test Plan:
Regression tests:
python test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py python test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py python test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py python test/quantization/quantize_/workflows/int4/test_int4_tensor.py python test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py python test/core/test_config.py
python test/integration/test_load_and_run_checkpoint.py

Reviewers:

Subscribers:

Tasks:

Tags: