### PR TITLE
Bump `Int4WeightOnlyConfig` version to 2

### DIFF
--- a/.github/scripts/torchao_model_releases/quantize_and_upload.py
+++ b/.github/scripts/torchao_model_releases/quantize_and_upload.py
@@ -206,7 +206,7 @@ Nothing contained in this Model Card should be interpreted as or deemed a restri
 
 _int4_quant_code = """
 from torchao.quantization import Int4WeightOnlyConfig
-quant_config = Int4WeightOnlyConfig(group_size=128, packing_format="tile_packed_to_4d", int4_choose_qparams_algorithm="hqq", version=2)
+quant_config = Int4WeightOnlyConfig(group_size=128, int4_packing_format="tile_packed_to_4d", int4_choose_qparams_algorithm="hqq")
 quantization_config = TorchAoConfig(quant_type=quant_config)
 quantized_model = AutoModelForCausalLM.from_pretrained(model_to_quantize, device_map="auto", torch_dtype=torch.bfloat16, quantization_config=quantization_config)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -256,7 +256,7 @@ model = AutoModelForCausalLM.from_pretrained(
 )
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-base_config = Int4WeightOnlyConfig(group_size=128, version=2)
+base_config = Int4WeightOnlyConfig(group_size=128)
 quant_config = AWQConfig(base_config, step="prepare")
 quantize_(
     model,
@@ -633,9 +633,8 @@ def quantize_and_upload(
         "FP8": Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
         "INT4": Int4WeightOnlyConfig(
             group_size=128,
-            packing_format="tile_packed_to_4d",
+            int4_packing_format="tile_packed_to_4d",
             int4_choose_qparams_algorithm="hqq",
-            version=2,
         ),
         "INT8-INT4": ModuleFqnToConfig(
             {
@@ -669,7 +668,7 @@ def quantize_and_upload(
         )
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
-        base_config = Int4WeightOnlyConfig(group_size=128, version=2)
+        base_config = Int4WeightOnlyConfig(group_size=128)
         quant_config = AWQConfig(base_config, step="prepare")
         quantize_(
             model,

--- a/test/dtypes/test_affine_quantized_tensor_parallel.py
+++ b/test/dtypes/test_affine_quantized_tensor_parallel.py
@@ -145,6 +145,7 @@ class TestInt8woAffineQuantizedTensorParallel(TestAffineQuantizedTensorParallel)
 
 class TestInt4woAffineQuantizedTensorParallel(TestAffineQuantizedTensorParallel):
     QUANT_METHOD_FN = staticmethod(int4_weight_only)
+    QUANT_METHOD_KWARGS = {"version": 1}
     COMMON_DTYPES = [torch.bfloat16]
 
     @common_utils.parametrize("dtype", COMMON_DTYPES)

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -73,7 +73,7 @@ class TestAWQ(TestCase):
         m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
 
         # baseline quantization
-        base_config = Int4WeightOnlyConfig(group_size=group_size, version=2)
+        base_config = Int4WeightOnlyConfig(group_size=group_size)
         m_baseline = copy.deepcopy(m)
         quantize_(m_baseline, base_config)
 
@@ -123,7 +123,7 @@ class TestAWQ(TestCase):
         calibration_data = dataset[:n_calibration_examples]
 
         # calibrate
-        base_config = Int4WeightOnlyConfig(group_size=group_size, version=2)
+        base_config = Int4WeightOnlyConfig(group_size=group_size)
         quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
         quantize_(m, quant_config)
 
@@ -177,7 +177,7 @@ class TestAWQ(TestCase):
         calibration_data = dataset[:n_calibration_examples]
 
         # calibrate
-        base_config = Int4WeightOnlyConfig(group_size=group_size, version=2)
+        base_config = Int4WeightOnlyConfig(group_size=group_size)
         quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
         quantize_(m, quant_config)
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py
@@ -27,7 +27,6 @@ from torchao.utils import torch_version_at_least
 BF16_ACT_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
     int4_packing_format="marlin_sparse",
-    version=2,
 )
 
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py
@@ -29,7 +29,6 @@ def get_config(group_size):
     return Int4WeightOnlyConfig(
         group_size=group_size,
         int4_packing_format="opaque",
-        version=2,
     )
 
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
@@ -29,7 +29,6 @@ def get_config(group_size):
     return Int4WeightOnlyConfig(
         group_size=group_size,
         int4_packing_format="plain_int32",
-        version=2,
     )
 
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
@@ -30,7 +30,6 @@ from torchao.utils import (
 BF16_ACT_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
     int4_packing_format="preshuffled",
-    version=2,
 )
 
 # only 128 group_size is supported

--- a/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
@@ -35,7 +35,6 @@ class TestInt4Tensor(TorchAOIntegrationTestCase):
         self.config = Int4WeightOnlyConfig(
             group_size=128,
             int4_packing_format="plain",
-            version=2,
         )
         self.GPU_DEVICES = ["cuda"] if torch.cuda.is_available() else []
 

--- a/test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
@@ -25,14 +25,12 @@ from torchao.utils import is_sm_at_least_90
 INT4_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
     int4_packing_format="tile_packed_to_4d",
-    version=2,
 )
 
 INT4_HQQ_CONFIG = Int4WeightOnlyConfig(
     group_size=128,
     int4_packing_format="tile_packed_to_4d",
     int4_choose_qparams_algorithm="hqq",
-    version=2,
 )
 
 

--- a/torchao/dtypes/uintx/int4_cpu_layout.py
+++ b/torchao/dtypes/uintx/int4_cpu_layout.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -78,6 +79,9 @@ class Int4CPUAQTTensorImpl(AQTTensorImpl):
         transposed: bool,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
+        )
         self.packed_weight = packed_weight
         self.scale_and_zero = scale_and_zero
         self.transposed = False

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -207,6 +208,9 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
         scale: torch.Tensor = None,
         zero: torch.Tensor = None,
     ):
+        warnings.warn(
+            "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
+        )
         self.packed_weight = packed_weight
         self.scale_and_zero = scale_and_zero
         self.transposed = False

--- a/torchao/dtypes/uintx/marlin_sparse_layout.py
+++ b/torchao/dtypes/uintx/marlin_sparse_layout.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from dataclasses import dataclass
 
 import torch
@@ -158,6 +159,9 @@ class MarlinSparseAQTTensorImpl(AQTTensorImpl):
         group_size: int,
         num_bits: int,
     ):
+        warnings.warn(
+            "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
+        )
         self.int_data = int_data
         self.scale_and_zero = None
         self.scale = scale

--- a/torchao/dtypes/uintx/tensor_core_tiled_layout.py
+++ b/torchao/dtypes/uintx/tensor_core_tiled_layout.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import logging
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -237,6 +238,9 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         transposed: bool,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
+        )
         self.packed_weight = packed_weight
         self.scale_and_zero = scale_and_zero
         self.transposed = False

--- a/torchao/prototype/awq/example.py
+++ b/torchao/prototype/awq/example.py
@@ -226,7 +226,7 @@ def quantize_and_eval(
         # TODO: this is temporary, we'll be using Int4WeightOnlyConfig soon
         from torchao.quantization import Int4WeightOnlyConfig
 
-        base_config = Int4WeightOnlyConfig(group_size=group_size, version=2)
+        base_config = Int4WeightOnlyConfig(group_size=group_size)
         print(f"running {quant} prepare and calibrate")
         t0 = time.time()
         quant_config = AWQConfig(base_config, step="prepare")

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -129,9 +129,9 @@ from torchao.quantization import quantize_, Int4WeightOnlyConfig
 group_size = 32
 
 # you can enable [hqq](https://github.com/mobiusml/hqq/tree/master) quantization which is expected to improves accuracy through
-# use_hqq flag for `Int4WeightOnlyConfig` quantization
+# by setting int4_choose_qparams_algorithm to "hqq" for `Int4WeightOnlyConfig` quantization
 use_hqq = False
-quantize_(model, Int4WeightOnlyConfig(group_size=group_size, use_hqq=use_hqq, version=1))
+quantize_(model, Int4WeightOnlyConfig(group_size=group_size, int4_packing_format="tile_packed_to_4d", int4_choose_qparams_algorithm="hqq"))
 ```
 
 Note: The quantization error incurred by applying int4 quantization to your model can be fairly significant, so using external techniques like GPTQ may be necessary to obtain a usable model.
@@ -150,7 +150,7 @@ from torchao.quantization import quantize_, Int8DynamicActivationInt8WeightConfi
 quantize_(model, Int8DynamicActivationInt8WeightConfig())
 ```
 
-### A16W8 Float8 WeightOnly Quantization
+#### A16W8 Float8 WeightOnly Quantization
 
 ```python
 # for torch 2.5+
@@ -285,9 +285,9 @@ m_bf16 = torch.compile(m_bf16, mode='max-autotune')
 # apply int4 weight only quant (compatible with tinygemm int4 weight only quant mm kernel in torchao)
 group_size = 32
 # only works for torch 2.4+
-quantize_(m, Int4WeightOnlyConfig(group_size=group_size, version=1))
-## If different zero_point_domain needed
-# quantize_(m, Int4WeightOnlyConfig(group_size=group_size, zero_point_domain=ZeroPointDomain.FLOAT, version=1))
+quantize_(m, Int4WeightOnlyConfig(group_size=group_size, int4_packing_format="tile_packed_to_4d"))
+# can also specify different packing format
+# quantize_(m, Int4WeightOnlyConfig(group_size=group_size, int4_packing_format="plain"))
 
 # compile the model to improve performance
 m = torch.compile(m, mode='max-autotune')

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1092,7 +1092,7 @@ class Int4WeightOnlyConfig(AOBaseConfig):
     int4_choose_qparams_algorithm: Int4ChooseQParamsAlgorithm = (
         Int4ChooseQParamsAlgorithm.TINYGEMM
     )
-    version: int = 1
+    version: int = 2
 
     def __post_init__(self):
         torch._C._log_api_usage_once("torchao.quantization.Int4WeightOnlyConfig")
@@ -1175,6 +1175,9 @@ def _int4_weight_only_quantize_tensor(weight, config):
 
     assert config.version == 1
 
+    warnings.warn(
+        "Config Deprecation: version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please use version 2, see https://github.com/pytorch/ao/issues/2948 for more details"
+    )
     mapping_type = MappingType.ASYMMETRIC
     target_dtype = torch.int32
     quant_min = 0
@@ -1583,7 +1586,7 @@ float8_weight_only = Float8WeightOnlyConfig
 def _float8_weight_only_quant_tensor(weight, config):
     if config.version == 1:
         warnings.warn(
-            "version 1 of Float8WeightOnlyConfig is deprecated and will no longer be supported in a future release, please use version 2, see https://github.com/pytorch/ao/issues/2649 for more details"
+            "Config Deprecation: version 1 of Float8WeightOnlyConfig is deprecated and will no longer be supported in a future release, please use version 2, see https://github.com/pytorch/ao/issues/2649 for more details"
         )
         from torchao.dtypes import to_affine_quantized_floatx
 
@@ -1763,7 +1766,7 @@ def _float8_dynamic_activation_float8_weight_quantize_tensor(weight, config):
 
     if config.version == 1:
         warnings.warn(
-            "version 1 of Float8DynamicActivationFloat8WeightConfig is deprecated and will no longer be supported in a future release, please use version 2, see https://github.com/pytorch/ao/issues/2649 for more details"
+            "Config Deprecation: version 1 of Float8DynamicActivationFloat8WeightConfig is deprecated and will no longer be supported in a future release, please use version 2, see https://github.com/pytorch/ao/issues/2649 for more details"
         )
 
         block_size = get_block_size(weight.shape[-2:], weight_granularity)

--- a/torchao/sparsity/README.md
+++ b/torchao/sparsity/README.md
@@ -53,11 +53,10 @@ Sparse-Marlin 2:4 is an optimized GPU kernel that extends the Mixed Auto-Regress
 
 ```py
 from torchao.quantization.quant_api import quantize_, Int4WeightOnlyConfig
-from torchao.dtypes import MarlinSparseLayout
 
 # Your FP16 model
 model = model.cuda().half()
-quantize_(model, Int4WeightOnlyConfig(layout=MarlinSparseLayout(), version=1))
+quantize_(model, Int4WeightOnlyConfig(int4_packing_format="marlin_sparse"))
 ```
 
 Note the existing API results in an extremely high accuracy degredation and is intended to be used in concert with an already sparsified+finetuned checkpoint where possible until we develop


### PR DESCRIPTION
Summary:
Current Int4WeightOnlyConfig has version 1 and 2, and default is 1, this PR 
* changes the default to 2 and made modification to callsites.
* For the Int4WeightOnlyConfig using explicit version 2, we removed the version=2 since now default is 2
* For the Int4WeightOnlyConfig that's using the old configuration, we added explicit `version=1`, we can migrate the callsite to use the version 2 separately (note this is done in https://github.com/pytorch/ao/pull/2958)
* also added deprecation warning in 
  * quant_api for v1 path of Int4WeightOnlyConfig
  * different layouts (TensorCoreTiledLayout, MarlinSparseLayout, Int4CPULayout and Int4XPULayout) for quantized checkpoints with v1 config
* For READMEs we migrate the usage to version 2 directly
* Also added deprecation warning testing for v1
  * single linear: https://huggingface.co/torchao-testing/single-linear-Int4WeightOnlyConfig-v1-0.14.dev (testing checkpoint only)
  * opt-125m: https://huggingface.co/torchao-testing/opt-125m-Int4WeightOnlyConfig-v1-0.14.dev (testing both checkpoint and config)

## Deprecation Note:

We updated the implementation for int4 Tensor, so bumps the default version from 1 to 2 for these two configs.
```
from transformers import AutoModelForCausalLM, AutoTokenizer
model_name = "torchao-testing/opt-125m-Int4WeightOnlyConfig-v1-0.14.dev"
quantized_model = AutoModelForCausalLM.from_pretrained(
    model_name,
    torch_dtype="bfloat16",
    device_map="cuda",
)

/data/users/jerryzh/ao/torchao/core/config.py:250: UserWarning: Stored version is not the same as current default version of the config: stored_version=1, current_default_version=2, please check the deprecation warning
  warnings.warn(
/data/users/jerryzh/ao/torchao/dtypes/uintx/tensor_core_tiled_layout.py:241: UserWarning: Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details
  warnings.warn(
```
Suggestion: upgrade torchao to 0.14 and later and generate the checkpoint again:

```
quantize_(model, Int4WeightOnlyConfig(group_size=128))
````
Or download the checkpoint again (please let us know if the checkpoint is not updated)

Please see https://github.com/pytorch/ao/issues/2948 for more details around the deprecation.


Test Plan:
Regression tests:
python test/dtypes/test_affine_quantized.py
python test/quantization/test_quant_api.py
python test/quantization/quantize_/workflows/int4/test_int4_marlin_sparse_tensor.py
python test/quantization/quantize_/workflows/int4/test_int4_opaque_tensor.py
python test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
python test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
python test/quantization/quantize_/workflows/int4/test_int4_tensor.py
python test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
python test/integration/test_load_and_run_checkpoint.py

Reviewers:

Subscribers:

Tasks:

Tags: