### PR TITLE
Use defaults CUDAExtension linker option when building mxfp8_cuda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -674,16 +674,11 @@ def get_extensions():
                     sources=mxfp8_sources,
                     include_dirs=[
                         mxfp8_extension_dir,  # For mxfp8_quantize.cuh, mxfp8_extension.cpp, and mxfp8_cuda.cu
-                        "/usr/local/cuda-12.8/include",  # CUDA 12.8 headers
-                    ],
-                    library_dirs=[
-                        "/usr/local/cuda-12.8/lib64",  # CUDA 12.8 libraries
                     ],
                     extra_compile_args={
                         "cxx": ["-std=c++17", "-O3"],
                         "nvcc": nvcc_args,
                     },
-                    extra_link_args=["-lcuda", "-lcudart"],
                 ),
             )
 


### PR DESCRIPTION
When trying to build torchao 0.13.0 on PyTorch CI, I encounter a linker error `-lcuda` when building `mxfp8_cuda` https://github.com/pytorch/pytorch/actions/runs/17540419893/job/49821474483

```
g++ -pthread -B /opt/conda/envs/py_3.10/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /opt/conda/envs/py_3.10/include -fPIC -O2 -isystem /opt/conda/envs/py_3.10/include -shared /tmp/pip-req-build-hmhi0n5s/build/temp.linux-x86_64-cpython-310/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.o /tmp/pip-req-build-hmhi0n5s/build/temp.linux-x86_64-cpython-310/torchao/csrc/cuda/mx_kernels/mxfp8_extension.o -L/usr/local/cuda-12.8/lib64 -L/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/lib -L/usr/local/cuda/lib64 -lc10 -ltorch -ltorch_cpu -ltorch_python -lcudart -lc10_cuda -ltorch_cuda -o build/lib.linux-x86_64-cpython-310/torchao/prototype/mxfp8_cuda.cpython-310-x86_64-linux-gnu.so -lcuda -lcudart
/opt/conda/envs/py_3.10/compiler_compat/ld: cannot find -lcuda: No such file or directory
```

There are 2 issues here:

1. `-lcuda` isn't needed.  All PyTorch CUDA packages are built on CPU-only runners with CUDA toolkit installed but they don't have CUDA driver.  Linking `-lcuda` here would fail the build
2. There is no need to set CUDA paths when using `CUDAExtension`, they have already been set by PyTorch.  So, these lines can be safely removed.  In addition, there is already a check for `build_for_sm100a` that only works for CUDA >= 12.8