### PR TITLE
[mxfp8 moe training] per group scale conversion to blocked format with groups along K dim (for 2d2d grouped gemm)

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_2d_3d_grouped_gemms.py
+++ b/benchmarks/prototype/moe_training/benchmark_2d_3d_grouped_gemms.py
@@ -18,7 +18,7 @@ from benchmarks.utils import benchmark_cuda_function_in_microseconds
 from torchao.float8.config import ScalingGranularity
 from torchao.float8.float8_utils import tensor_to_scale, to_fp8_saturated
 from torchao.prototype.moe_training.kernels.mxfp8_blocked_scales import (
-    torch_to_blocked_per_group_2d,
+    torch_to_blocked_2d_M_groups,
     torch_to_blocked_per_group_3d,
 )
 from torchao.prototype.moe_training.utils import generate_jagged_offs
@@ -230,7 +230,7 @@ def bench_mxfp8_grouped_mm(A, B_t, offs, block_size=32) -> float:
 
     # Convert scales for each group to blocked format.
     Mg, K = A_fp8.shape
-    A_scales_blocked, starting_row_after_padding = torch_to_blocked_per_group_2d(
+    A_scales_blocked, starting_row_after_padding = torch_to_blocked_2d_M_groups(
         A_scales, offs, K
     )
     B_scales_blocked = torch_to_blocked_per_group_3d(B_scales)

--- a/benchmarks/prototype/moe_training/benchmark_2d_blocked_swizzle_scale_kernels.py
+++ b/benchmarks/prototype/moe_training/benchmark_2d_blocked_swizzle_scale_kernels.py
@@ -15,9 +15,9 @@ from tqdm import tqdm
 
 from benchmarks.utils import benchmark_cuda_function_in_microseconds
 from torchao.prototype.moe_training.kernels.mxfp8_blocked_scales import (
-    compute_per_group_blocked_scale_offsets,
-    torch_to_blocked_per_group_2d,
-    triton_mx_block_rearrange_per_group_2d,
+    compute_blocked_scale_offsets_for_M_groups,
+    torch_to_blocked_2d_M_groups,
+    triton_mx_block_rearrange_2d_M_groups,
 )
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 
@@ -82,7 +82,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     input_group_offsets = generate_jagged_offs(num_groups, Mg, multiple_of=32)
 
     # bench torch
-    compiled_run_torch = torch.compile(torch_to_blocked_per_group_2d)
+    compiled_run_torch = torch.compile(torch_to_blocked_2d_M_groups)
     torch_out_scales, torch_group_offs = compiled_run_torch(
         input_tensor, input_group_offsets, K
     )
@@ -95,16 +95,16 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     )
 
     # bench triton
-    _, output_group_offsets = compute_per_group_blocked_scale_offsets(
+    _, output_group_offsets = compute_blocked_scale_offsets_for_M_groups(
         input_group_offsets
     )
-    triton_out_scales = triton_mx_block_rearrange_per_group_2d(
+    triton_out_scales = triton_mx_block_rearrange_2d_M_groups(
         input_tensor,
         input_group_offsets,
         output_group_offsets,
     )
     triton_time_us = benchmark_cuda_function_in_microseconds(
-        triton_mx_block_rearrange_per_group_2d,
+        triton_mx_block_rearrange_2d_M_groups,
         input_tensor,
         input_group_offsets,
         output_group_offsets,

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -22,13 +22,13 @@ from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.kernels.mxfp8_blocked_scales import (
-    compute_per_group_blocked_scale_offsets,
-    compute_per_group_blocked_scale_offsets_2d2d_lhs,
-    torch_to_blocked_per_group_2d,
-    torch_to_blocked_per_group_2d2d_lhs,
+    compute_blocked_scale_offsets_for_K_groups,
+    compute_blocked_scale_offsets_for_M_groups,
+    torch_to_blocked_2d_K_groups,
+    torch_to_blocked_2d_M_groups,
     torch_to_blocked_per_group_3d,
-    triton_mx_block_rearrange_per_group_2d,
-    triton_mx_block_rearrange_per_group_2d2d_lhs,
+    triton_mx_block_rearrange_2d_K_groups,
+    triton_mx_block_rearrange_2d_M_groups,
     triton_mx_block_rearrange_per_group_3d,
 )
 from torchao.prototype.moe_training.utils import (
@@ -229,15 +229,15 @@ def test_mxfp8_per_group_blocked_scales_2d(
     )
 
     # torch reference
-    ref_out_scales, _ = torch_to_blocked_per_group_2d(
+    ref_out_scales, _ = torch_to_blocked_2d_M_groups(
         e8m0_scales, input_group_offsets, k, block_size=block_size
     )
 
     # triton kernel
-    _, output_group_offsets = compute_per_group_blocked_scale_offsets(
+    _, output_group_offsets = compute_blocked_scale_offsets_for_M_groups(
         input_group_offsets
     )
-    triton_out_scales = triton_mx_block_rearrange_per_group_2d(
+    triton_out_scales = triton_mx_block_rearrange_2d_M_groups(
         e8m0_scales,
         input_group_offsets,
         output_group_offsets,
@@ -272,60 +272,44 @@ def test_mxfp8_per_group_blocked_scales_3d(
 
 
 @skip_if_rocm("ROCm enablement in progress")
-@pytest.mark.parametrize("m,total_k,n_groups", [(256, 512, 4)])#, (256, 128, 4), (512, 128, 4), (1024, 128, 4), (1024, 256, 4), (1024, 512, 4), (1024, 1024, 4), (1024, 2048, 4), (1024, 4096, 4), (1024, 8192, 4), (1024, 16384, 4)])
-def test_mxfp8_per_group_blocked_scales_2d2d_lhs(
+@pytest.mark.parametrize("m", [256, 512, 1024, 5120])
+@pytest.mark.parametrize("total_k", [512, 1024, 2048, 4096, 8192, 16384])
+@pytest.mark.parametrize("n_groups", [1, 4, 8, 16])
+def test_mxfp8_per_group_blocked_scales_2d2d(
     m: int,
     total_k: int,
     n_groups: int,
 ):
     device = "cuda"
     block_size = 32
-
-    # Make each group of row blocks have distinct, constinent data for debugging
-    input_data = torch.cat(
-        [
-            torch.ones(m // 2, total_k, device=device),
-            torch.full((m // 2, total_k), 999, device=device),
-        ]
-    )
-    #input_data= torch.randn(m, total_k, device=device)
+    input_data = torch.randn(m, total_k, device=device)
 
     e8m0_scales, _ = to_mx(
         input_data, elem_dtype=torch.float8_e4m3fn, block_size=block_size
     )
 
     # Generate group end offsets along total_K, then divide by block_size to get scale group end offsets
-    # input_group_offsets = generate_jagged_offs(
-    #     n_groups, total_k, multiple_of=block_size, device=device
-    # )
-    # input_group_offsets //= block_size
-    input_group_offsets = torch.tensor([3, 8, 12, 16], device=device, dtype=torch.int32)
-    #print(input_group_offsets)
+    input_group_offsets = generate_jagged_offs(
+        n_groups, total_k, multiple_of=block_size, device=device
+    )
+    input_group_offsets //= block_size
 
     # torch reference
-    ref_out_scales, ref_start_cols_after_padding = torch_to_blocked_per_group_2d2d_lhs(
+    ref_out_scales, ref_start_cols_after_padding = torch_to_blocked_2d_K_groups(
         e8m0_scales,
         input_group_offsets,
     )
 
     # triton kernel
-    _, output_group_offsets = compute_per_group_blocked_scale_offsets_2d2d_lhs(
+    _, output_group_offsets = compute_blocked_scale_offsets_for_K_groups(
         input_group_offsets
     )
-    assert torch.allclose(output_group_offsets, ref_start_cols_after_padding), (
+    assert torch.equal(output_group_offsets, ref_start_cols_after_padding), (
         "output scale group start offsets not equal"
     )
-    triton_out_scales = triton_mx_block_rearrange_per_group_2d2d_lhs(
+    triton_out_scales = triton_mx_block_rearrange_2d_K_groups(
         e8m0_scales,
         input_group_offsets,
         output_group_offsets,
     )
-    print(ref_start_cols_after_padding)
-    with open('tmp-ref.txt', 'w') as f:
-        f.write(str(ref_out_scales.storage()))
-    with open('tmp-triton.txt', 'w') as f:
-        f.write(str(triton_out_scales.storage()))
-    breakpoint()
-    assert torch.allclose(ref_out_scales, triton_out_scales, atol=0, rtol=0), (
-        "blocked scales not equal"
-    )
+    assert torch.equal(ref_out_scales, triton_out_scales), "blocked scales not equal"

--- a/torchao/prototype/moe_training/kernels/mxfp8_gemms.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8_gemms.py
@@ -3,7 +3,7 @@ import logging
 import torch
 
 from torchao.prototype.moe_training.kernels.mxfp8_blocked_scales import (
-    torch_to_blocked_per_group_2d,
+    torch_to_blocked_2d_M_groups,
     torch_to_blocked_per_group_3d,
 )
 
@@ -40,7 +40,7 @@ def fbgemm_mxfp8_grouped_mm_2d_3d(
 
     # Convert scales for each group to blocked format.
     Mg, K = A_fp8.shape
-    A_scales_blocked, starting_row_after_padding = torch_to_blocked_per_group_2d(
+    A_scales_blocked, starting_row_after_padding = torch_to_blocked_2d_M_groups(
         A_scales, offs, K
     )
     B_scales_blocked = torch_to_blocked_per_group_3d(B_scales)


### PR DESCRIPTION
## Summary
- We have a triton kernel that does per group mxfp8 scale conversion to blocked format, for 2d-3d grouped gemms, where the groups are along the `total_M` dimension in `(total_M, K) @ (E, K, N)`
- We now need triton kernels that does per group conversion for 2d-2d grouped gemms, where the groups are along the scaled dim: `(M, total_K) @ (total_K, N)`. 

## Memory layout 

#### LHS operand for 2d-3d MXFP8 grouped gemm
This is the existing kernel, the layout is much simpler for the 2d-3d case where the groups are along M:

<img width="1094" height="561" alt="Screenshot 2025-09-09 at 9 11 18 AM" src="https://github.com/user-attachments/assets/577edd40-002b-4da0-898b-a15e41b3cc24" />


#### LHS operand for 2d-2d MXFP8 grouped gemm
When groups are along the scaled dim being contracted, the memory layout is more complicated, as we have to represent separate standalone "row of blocks major" layouts in subtensors that are part of a larger parent tensor. 

<img width="1339" height="571" alt="Screenshot 2025-09-09 at 8 45 48 AM" src="https://github.com/user-attachments/assets/579ccfdd-95cf-4be5-98c0-e5e40d1e9580" />



## Other
- I also removed the `Mg` param from the `torch_to_blocked_per_group_2d` function (used for 2d-3d grouped gemms), since it is not used.

## Test plan
- `pytest test/prototype/moe_training/test_kernels.py -k test_mxfp8_per_group_blocked_scales_2d2d -s `