### PR TITLE
Fix ROCM QAT test failure

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -23,6 +23,7 @@ from torch.testing._internal.common_utils import (
 
 from torchao import quantize_
 from torchao.core.config import AOBaseConfig
+from torchao.float8.config import e4m3_dtype
 from torchao.quantization import Float8Tensor
 from torchao.quantization.granularity import (
     Granularity,
@@ -1978,11 +1979,11 @@ class TestQAT(TestCase):
         base_config = Float8DynamicActivationInt4WeightConfig()
         (act_config, weight_config) = _infer_fake_quantize_configs(base_config)
         self.assertIsInstance(act_config, Float8FakeQuantizeConfig)
-        self.assertEqual(act_config.dtype, torch.float8_e4m3fn)
+        self.assertEqual(act_config.dtype, e4m3_dtype)
         self.assertIsInstance(act_config.granularity, PerRow)
         self.assertIsInstance(weight_config, Int4WeightPreshuffledFakeQuantizeConfig)
         self.assertEqual(weight_config.group_size, 128)
-        self.assertEqual(weight_config.activation_dtype, torch.float8_e4m3fn)
+        self.assertEqual(weight_config.activation_dtype, e4m3_dtype)
 
     def test_infer_int4_weight_only_config(self):
         """

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -420,7 +420,7 @@ def _infer_fake_quantize_configs(
         )
     elif isinstance(base_config, Float8DynamicActivationInt4WeightConfig):
         act_config = Float8FakeQuantizeConfig(
-            dtype=torch.float8_e4m3fn,
+            dtype=e4m3_dtype,
             granularity=PerRow(),
         )
         weight_config = Int4WeightPreshuffledFakeQuantizeConfig(


### PR DESCRIPTION
https://github.com/pytorch/ao/actions/runs/17551856077/job/49846025788
```
AssertionError: Object comparison failed: torch.float8_e4m3fnuz != torch.float8_e4m3fn
```