### PR TITLE
Add version=1 for calls to int4 weight only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pip install torchao
 Quantize your model weights to int4!
 ```
 from torchao.quantization import Int4WeightOnlyConfig, quantize_
-quantize_(model, Int4WeightOnlyConfig(group_size=32))
+quantize_(model, Int4WeightOnlyConfig(group_size=32, version=1))
 ```
 Compared to a `torch.compiled` bf16 baseline, your quantized model should be significantly smaller and faster on a single A100 GPU:
 ```
@@ -102,7 +102,7 @@ pip install torchao
   ```
   # Nightly
   pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu126
-  
+
   # Different CUDA versions
   pip install torchao --index-url https://download.pytorch.org/whl/cu126  # CUDA 12.6
   pip install torchao --index-url https://download.pytorch.org/whl/cpu    # CPU only
@@ -144,7 +144,7 @@ Quantize any model with `nn.Linear` layers in just one line (Option 1), or load 
 
 ```python
 from torchao.quantization.quant_api import quantize_, Int4WeightOnlyConfig
-quantize_(model, Int4WeightOnlyConfig(group_size=128, use_hqq=True))
+quantize_(model, Int4WeightOnlyConfig(group_size=128, use_hqq=True, version=1))
 ```
 
 #### Option 2: HuggingFace Integration
@@ -154,7 +154,7 @@ from transformers import TorchAoConfig, AutoModelForCausalLM
 from torchao.quantization.quant_api import Int4WeightOnlyConfig
 
 # Create quantization configuration
-quantization_config = TorchAoConfig(quant_type=Int4WeightOnlyConfig(group_size=128, use_hqq=True))
+quantization_config = TorchAoConfig(quant_type=Int4WeightOnlyConfig(group_size=128, use_hqq=True, version=1))
 
 # Load and automatically quantize
 quantized_model = AutoModelForCausalLM.from_pretrained(

--- a/benchmarks/benchmark_aq.py
+++ b/benchmarks/benchmark_aq.py
@@ -197,7 +197,7 @@ if __name__ == "__main__" and torch.cuda.is_available():
         )
 
     print("_int4wo_api")
-    kwargs = {"groupsize": 32}
+    kwargs = {"groupsize": 32, "version": 1}
 
     for M, N, K in all_shapes:
         _bench_quantized_tensor_subclass_perf(

--- a/benchmarks/microbenchmarks/test/test_benchmark_inference.py
+++ b/benchmarks/microbenchmarks/test/test_benchmark_inference.py
@@ -58,7 +58,8 @@ class TestBenchmarkInference(unittest.TestCase):
 
         # Test with semi-sparse config
         mock_string_to_config.return_value = Int4WeightOnlyConfig(
-            layout=MarlinSparseLayout()
+            layout=MarlinSparseLayout(),
+            version=1,
         )
         config = BenchmarkConfig(
             quantization="marlin",

--- a/benchmarks/microbenchmarks/utils.py
+++ b/benchmarks/microbenchmarks/utils.py
@@ -206,7 +206,7 @@ def string_to_config(
             128,
             256,
         ], f"int4wo group_size needs to be one of [32,64,128,256] but got {group_size}"
-        return Int4WeightOnlyConfig(group_size=group_size, use_hqq=use_hqq)
+        return Int4WeightOnlyConfig(group_size=group_size, use_hqq=use_hqq, version=1)
     elif "int8adq-int4w-symm" in quantization:
         from torchao.dtypes import CutlassInt4PackedLayout
 
@@ -229,7 +229,7 @@ def string_to_config(
         elif sparsity is not None and ("semi" in sparsity or "2:4" in sparsity):
             from torchao.dtypes import MarlinSparseLayout
 
-            return Int4WeightOnlyConfig(layout=MarlinSparseLayout())
+            return Int4WeightOnlyConfig(layout=MarlinSparseLayout(), version=1)
     if "fp6" in quantization:
         return FPXWeightOnlyConfig(3, 2)
     elif "uintx" in quantization:

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -57,7 +57,7 @@ for efficient mixed dtype matrix multiplication:
 
   # torch 2.4+ only
   from torchao.quantization import Int4WeightOnlyConfig, quantize_
-  quantize_(model, Int4WeightOnlyConfig(group_size=32))
+  quantize_(model, Int4WeightOnlyConfig(group_size=32, version=1))
 
 The quantized model is now ready to use! Note that the quantization
 logic is inserted through tensor subclasses, so there is no change

--- a/docs/source/serialization.rst
+++ b/docs/source/serialization.rst
@@ -7,7 +7,7 @@ Serialization and deserialization flow
 ======================================
 
 Here is the serialization and deserialization flow::
-  
+
   import copy
   import tempfile
   import torch
@@ -36,7 +36,7 @@ Here is the serialization and deserialization flow::
   print(f"original model size: {get_model_size_in_bytes(m) / 1024 / 1024} MB")
 
   example_inputs = m.example_inputs(dtype=dtype, device="cuda")
-  quantize_(m, Int4WeightOnlyConfig())
+  quantize_(m, Int4WeightOnlyConfig(version=1))
   print(f"quantized model size: {get_model_size_in_bytes(m) / 1024 / 1024} MB")
 
   ref = m(*example_inputs)
@@ -62,7 +62,7 @@ What happens when serializing an optimized model?
 To serialize an optimized model, we just need to call ``torch.save(m.state_dict(), f)``, because in torchao, we use tensor subclass to represent different dtypes or support different optimization techniques like quantization and sparsity. So after optimization, the only thing change is the weight Tensor is changed to an optimized weight Tensor, and the model structure is not changed at all. For example:
 
 original floating point model ``state_dict``::
-  
+
   {"linear1.weight": float_weight1, "linear2.weight": float_weight2}
 
 quantized model ``state_dict``::
@@ -75,7 +75,7 @@ The size of the quantized model is typically going to be smaller to the original
   original model size: 4.0 MB
   quantized model size: 1.0625 MB
 
-  
+
 What happens when deserializing an optimized model?
 ===================================================
 To deserialize an optimized model, we can initialize the floating point model in `meta <https://pytorch.org/docs/stable/meta.html>`__ device and then load the optimized ``state_dict`` with ``assign=True`` using `model.load_state_dict <https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.load_state_dict>`__::
@@ -97,5 +97,3 @@ We can also verify that the weight is properly loaded by checking the type of we
 
   type of weight before loading: (<class 'torch.Tensor'>, <class 'torch.Tensor'>)
   type of weight after loading: (<class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>, <class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>)
-
-

--- a/docs/source/torchao_vllm_integration.md
+++ b/docs/source/torchao_vllm_integration.md
@@ -45,6 +45,7 @@ from torchao.quantization import Int4WeightOnlyConfig
 config = Int4WeightOnlyConfig(
     group_size=128,
     use_hqq=True,
+    version=1,
 )
 assert isinstance(config, AOBaseConfig)
 ```
@@ -65,7 +66,7 @@ config = ModuleFqnToConfig({
     "model.layers.0.self_attn.q_proj": Int4WeightOnlyConfig(group_size=64),
     "model.layers.0.self_attn.k_proj": Int4WeightOnlyConfig(group_size=64),
     "model.layers.0.mlp.gate_proj": Int8WeightOnlyConfig(),
-    "_default": Int4WeightOnlyConfig(group_size=128)  # Default for other modules
+    "_default": Int4WeightOnlyConfig(group_size=128, version=1)  # Default for other modules
 })
 ```
 
@@ -81,7 +82,7 @@ from torchao.quantization import Int4WeightOnlyConfig
 
 # Create quantization configuration
 quantization_config = TorchAoConfig(
-    quant_type=Int4WeightOnlyConfig(group_size=128, use_hqq=True)
+    quant_type=Int4WeightOnlyConfig(group_size=128, use_hqq=True, version=1)
 )
 
 # Load and automatically quantize the model

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -39,7 +39,7 @@ model_bf16 = copy.deepcopy(model)
 # ========================
 
 # torch 2.4+ only
-quantize_(model, Int4WeightOnlyConfig(group_size=32))
+quantize_(model, Int4WeightOnlyConfig(group_size=32, version=1))
 
 
 # =============

--- a/test/hqq/test_hqq_affine.py
+++ b/test/hqq/test_hqq_affine.py
@@ -55,7 +55,7 @@ def _eval_hqq(dtype):
     )
     dummy_linear.weight.data = W
     if dtype == torch.uint4:
-        config = int4_weight_only(group_size=max(block_size), use_hqq=True)
+        config = int4_weight_only(group_size=max(block_size), use_hqq=True, version=1)
     else:
         config = uintx_weight_only(dtype, group_size=max(block_size), use_hqq=True)
     quantize_(dummy_linear, config)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -135,17 +135,23 @@ def _int4wo_api(mod, use_hqq=False):
         quantize_(
             mod,
             int4_weight_only(
-                layout=Int4CPULayout(), use_hqq=use_hqq, set_inductor_config=False
+                layout=Int4CPULayout(),
+                use_hqq=use_hqq,
+                set_inductor_config=False,
+                version=1,
             ),
         )
         unwrap_tensor_subclass(mod)
     elif check_xpu_version(next(mod.parameters()).device):
         quantize_(
-            mod, int4_weight_only(layout=Int4XPULayout()), set_inductor_config=False
+            mod,
+            int4_weight_only(
+                layout=Int4XPULayout(), set_inductor_config=False, version=1
+            ),
         )
         unwrap_tensor_subclass(mod)
     else:
-        quantize_(mod, int4_weight_only(set_inductor_config=False))
+        quantize_(mod, int4_weight_only(set_inductor_config=False, version=1))
 
 
 def _int8da_int4w_api(mod):
@@ -1077,7 +1083,7 @@ class TestSubclass(unittest.TestCase):
         ):
             for groupsize in [64, 32]:
                 for layout in layout_list:
-                    kwargs = {"groupsize": groupsize, "layout": layout}
+                    kwargs = {"groupsize": groupsize, "layout": layout, "version": 1}
 
                     def api(mod):
                         kwargs_copy = kwargs.copy()

--- a/test/prototype/test_parq.py
+++ b/test/prototype/test_parq.py
@@ -211,7 +211,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
         model.reset_parameters()
 
         m_ref = copy.deepcopy(model).eval().to(_DEVICE)
-        config = int4_weight_only(group_size=group_size)
+        config = int4_weight_only(group_size=group_size, version=1)
         if check_cpu_version(_DEVICE):
             config.layout = Int4CPULayout()
         quantize_(m_ref, config)
@@ -244,7 +244,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
         model.reset_parameters()
 
         m_ref = copy.deepcopy(model).eval().to(_DEVICE)
-        config = int4_weight_only(group_size=group_size)
+        config = int4_weight_only(group_size=group_size, version=1)
         if check_cpu_version(_DEVICE):
             config.layout = Int4CPULayout()
         quantize_(m_ref, config)

--- a/test/quantization/test_gptq.py
+++ b/test/quantization/test_gptq.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 from pathlib import Path
 
@@ -173,7 +179,7 @@ class TestMultiTensorInputRecorder(TestCase):
 
         model2 = copy.deepcopy(model)
         out = model(*test_input)
-        quantize_(model2, Int4WeightOnlyConfig())
+        quantize_(model2, Int4WeightOnlyConfig(version=1))
 
         outq = model2(*test_input)
         del model2

--- a/test/quantization/test_moe_quant.py
+++ b/test/quantization/test_moe_quant.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import pytest
@@ -114,7 +120,8 @@ class TestMoEQuantCompile(unittest.TestCase):
             self.skipTest("Need CUDA available")
 
         config = MoEQuantConfig(
-            Int4WeightOnlyConfig(), use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE
+            Int4WeightOnlyConfig(version=1),
+            use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
         )
         tensor_impl_class = TensorCoreTiledAQTTensorImpl
 
@@ -137,7 +144,7 @@ class TestMoEQuantCompile(unittest.TestCase):
         if not is_sm_at_least_90():
             self.skipTest("Requires CUDA capability >= 9.0")
 
-        config = MoEQuantConfig(Int4WeightOnlyConfig())
+        config = MoEQuantConfig(Int4WeightOnlyConfig(version=1))
         tensor_impl_class = TensorCoreTiledAQTTensorImpl
 
         self._test_impl_moe_quant(

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -226,7 +226,7 @@ class TestQuantFlow(TestCase):
         m = ToyLinearModel().eval().cpu()
 
         def api(model):
-            quantize_(model, int4_weight_only(layout=Int4XPULayout()))
+            quantize_(model, int4_weight_only(layout=Int4XPULayout(), version=1))
             unwrap_tensor_subclass(model)
 
         api(m)
@@ -457,10 +457,13 @@ class TestQuantFlow(TestCase):
             group_size = 32
             if device == "xpu":
                 quantize_(
-                    m, int4_weight_only(group_size=group_size, layout=Int4XPULayout())
+                    m,
+                    int4_weight_only(
+                        group_size=group_size, layout=Int4XPULayout(), version=1
+                    ),
                 )
             else:
-                quantize_(m, int4_weight_only(group_size=group_size))
+                quantize_(m, int4_weight_only(group_size=group_size, version=1))
             assert isinstance(m.linear1.weight, AffineQuantizedTensor)
             assert isinstance(m.linear2.weight, AffineQuantizedTensor)
 
@@ -579,7 +582,7 @@ class TestQuantFlow(TestCase):
             quantize_(
                 m,
                 int4_weight_only(
-                    group_size=32, layout=Int4CPULayout(), use_hqq=use_hqq
+                    group_size=32, layout=Int4CPULayout(), use_hqq=use_hqq, version=1
                 ),
             )
             # ensure the expected op is in the code
@@ -595,7 +598,7 @@ class TestQuantFlow(TestCase):
     @common_utils.parametrize(
         "config",
         [
-            int4_weight_only(),
+            int4_weight_only(version=1),
             float8_weight_only(),
             float8_dynamic_activation_float8_weight(),
             float8_static_activation_float8_weight(scale=torch.tensor([1.0])),
@@ -661,7 +664,7 @@ class TestQuantFlow(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_module_fqn_to_config_default(self):
-        config1 = Int4WeightOnlyConfig(group_size=32)
+        config1 = Int4WeightOnlyConfig(group_size=32, version=1)
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"_default": config1, "linear2": config2})
         model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
@@ -675,7 +678,7 @@ class TestQuantFlow(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_module_fqn_to_config_module_name(self):
-        config1 = Int4WeightOnlyConfig(group_size=32)
+        config1 = Int4WeightOnlyConfig(group_size=32, version=1)
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"linear1": config1, "linear2": config2})
         model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
@@ -720,7 +723,7 @@ class TestQuantFlow(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_module_fqn_to_config_skip(self):
-        config1 = Int4WeightOnlyConfig(group_size=32)
+        config1 = Int4WeightOnlyConfig(group_size=32, version=1)
         config = ModuleFqnToConfig({"_default": config1, "linear2": None})
         model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
@@ -732,7 +735,7 @@ class TestQuantFlow(TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_int4wo_cuda_serialization(self):
-        config = Int4WeightOnlyConfig(group_size=32)
+        config = Int4WeightOnlyConfig(group_size=32, version=1)
         model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
         # quantize in cuda
         quantize_(model, config)

--- a/test/sparsity/test_marlin.py
+++ b/test/sparsity/test_marlin.py
@@ -47,11 +47,11 @@ class SparseMarlin24(TestCase):
         model_copy = copy.deepcopy(self.model)
 
         # Quantized
-        quantize_(model_copy.bfloat16(), int4_weight_only())
+        quantize_(model_copy.bfloat16(), int4_weight_only(version=1))
         dense_result = model_copy(self.input.bfloat16()).half()
 
         # Sparse + quantized
-        quantize_(self.model, int4_weight_only(layout=MarlinSparseLayout()))
+        quantize_(self.model, int4_weight_only(layout=MarlinSparseLayout(), version=1))
         sparse_result = self.model(self.input)
         assert torch.allclose(dense_result, sparse_result, atol=3e-1), (
             "Results are not close"
@@ -64,12 +64,12 @@ class SparseMarlin24(TestCase):
         model_copy = copy.deepcopy(self.model)
 
         # Quantized
-        quantize_(model_copy.bfloat16(), int4_weight_only())
+        quantize_(model_copy.bfloat16(), int4_weight_only(version=1))
         model_copy.foward = torch.compile(model_copy.forward, fullgraph=True)
         dense_result = model_copy(self.input.bfloat16()).half()
 
         # Sparse + quantized
-        quantize_(self.model, int4_weight_only(layout=MarlinSparseLayout()))
+        quantize_(self.model, int4_weight_only(layout=MarlinSparseLayout(), version=1))
         self.model.forward = torch.compile(self.model.forward, fullgraph=True)
         sparse_result = self.model(self.input)
 

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -110,11 +110,11 @@ class TestQuantSemiSparse(common_utils.TestCase):
         model_copy = copy.deepcopy(model)
 
         # Quantized
-        quantize_(model_copy.bfloat16(), int4_weight_only())
+        quantize_(model_copy.bfloat16(), int4_weight_only(version=1))
         dense_result = model_copy(input.bfloat16()).half()
 
         # Sparse + quantized
-        quantize_(model, int4_weight_only(layout=MarlinSparseLayout()))
+        quantize_(model, int4_weight_only(layout=MarlinSparseLayout(), version=1))
         if compile:
             model = torch.compile(model)
         sparse_result = model(input)

--- a/torchao/_models/llama/eval.py
+++ b/torchao/_models/llama/eval.py
@@ -89,7 +89,7 @@ def run_evaluation(
             )
             quantize_(
                 model.to(device),
-                int4_weight_only(group_size=groupsize, use_hqq=use_hqq),
+                int4_weight_only(group_size=groupsize, use_hqq=use_hqq, version=1),
             )
         if "uintx" in quantization:
             # uintx-nbits-groupsize
@@ -116,7 +116,7 @@ def run_evaluation(
         if "marlin" in quantization:
             from torchao.dtypes import MarlinSparseLayout
 
-            quantize_(model, int4_weight_only(layout=MarlinSparseLayout()))
+            quantize_(model, int4_weight_only(layout=MarlinSparseLayout(), version=1))
         if "int4wo" in quantization and "gptq" in quantization:
             # avoid circular imports
             from torchao._models._eval import LMEvalInputRecorder

--- a/torchao/_models/llama/generate.py
+++ b/torchao/_models/llama/generate.py
@@ -425,7 +425,10 @@ def main(
             ], (
                 f"int4wo group_size needs to be one of [32,64,128,256] but got {group_size}"
             )
-            quantize_(model, int4_weight_only(group_size=group_size, use_hqq=use_hqq))
+            quantize_(
+                model,
+                int4_weight_only(group_size=group_size, use_hqq=use_hqq, version=1),
+            )
         elif "fbgemm" in quantization and "int4" in quantization:
             from torchao.quantization import FbgemmConfig
 
@@ -487,7 +490,7 @@ def main(
 
                 quantize_(
                     model,
-                    int4_weight_only(layout=MarlinSparseLayout()),
+                    int4_weight_only(layout=MarlinSparseLayout(), version=1),
                     filter_fn=ffn_or_attn_only,
                 )
         if "fp6" in quantization:

--- a/torchao/_models/mixtral-moe/generate.py
+++ b/torchao/_models/mixtral-moe/generate.py
@@ -275,11 +275,11 @@ def main(
             )
 
         elif "int4wo-base" in moe_quant:
-            config = MoEQuantConfig(Int4WeightOnlyConfig())
+            config = MoEQuantConfig(Int4WeightOnlyConfig(version=1))
 
         elif "int4wo" in moe_quant:
             config = MoEQuantConfig(
-                Int4WeightOnlyConfig(),
+                Int4WeightOnlyConfig(version=1),
                 use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE,
             )
 

--- a/torchao/_models/sam/eval_combo.py
+++ b/torchao/_models/sam/eval_combo.py
@@ -402,7 +402,7 @@ def run(
         )
         quantize_(
             predictor.model.image_encoder,
-            int4_weight_only(layout=MarlinSparseLayout()),
+            int4_weight_only(layout=MarlinSparseLayout(), version=1),
             mlp_lin1_only,
         )
         sparsify_(predictor.model.image_encoder, semi_sparse_weight(), mlp_lin2_only)

--- a/torchao/prototype/autoround/README.md
+++ b/torchao/prototype/autoround/README.md
@@ -78,7 +78,7 @@ multi_t_input_ids = MultiTensor(input_ids_lst)
 out = model(multi_t_input_ids)
 ```
 #### Step 3: Finalize Quantization
-After obtaining optimized `zero_point` and `scale` values, create the `AffineQuantizedTensor` 
+After obtaining optimized `zero_point` and `scale` values, create the `AffineQuantizedTensor`
 for each target weight to select the right low-bits kernel.
 
 ```python
@@ -114,7 +114,7 @@ quantize_(model, apply_auto_round(), is_target_module)
 | autoround-4bit*  | 0.6338 | 0.4566 | 0.7661 | 0.6646     | 0.5688    | 0.7130         |
 
 > [!NOTE]
-> - `torchao-int4wo` quantizes the model to 4 bits with a group size of 128 (`int4_weight_only(group_size=128)`) while leaving the `lm-head` unquantized. <br>
+> - `torchao-int4wo` quantizes the model to 4 bits with a group size of 128 (`int4_weight_only(group_size=128, version=1)`) while leaving the `lm-head` unquantized. <br>
 > - `auto-round-4bit` uses the deafult configuration from [quick start](#quick-start). <br>
 > - `auto-round-4bit*` follows the same settings as `auto-round-4bit`, but with `gradient_accumulate_steps=2` and `batch_size=4`, which accumulating two batches(4 samples per batch) before performing the backward pass. <br>
 > - To reproduce results, run `eval_autoround.py` with `AO_USE_DETERMINISTIC_ALGORITHMS=1`.

--- a/torchao/prototype/autoround/eval_autoround.py
+++ b/torchao/prototype/autoround/eval_autoround.py
@@ -105,7 +105,7 @@ def main(args):
 
                 quantize_(
                     model,
-                    int4_weight_only(group_size=args.group_size),
+                    int4_weight_only(group_size=args.group_size, version=1),
                     filter_fn=filter_fn,
                     device=model_device,
                 )

--- a/torchao/prototype/hqq/example.py
+++ b/torchao/prototype/hqq/example.py
@@ -116,7 +116,7 @@ inner_k_tiles = 8
 _layout = TensorCoreTiledLayout(inner_k_tiles=inner_k_tiles)
 
 int4_weight_only_patch_fct = int4_weight_only(
-    group_size=group_size, inner_k_tiles=inner_k_tiles
+    group_size=group_size, inner_k_tiles=inner_k_tiles, version=1
 )
 linear_layer_default = torch.nn.Linear(
     in_features, out_features, bias=False, device=device

--- a/torchao/prototype/moe_quant/llama4_quant.py
+++ b/torchao/prototype/moe_quant/llama4_quant.py
@@ -75,7 +75,12 @@ from torchao.prototype.moe_quant.utils import (
 )
 from torchao.quantization import Int4WeightOnlyConfig, quantize_
 
-quantize_(model, MoEQuantConfig(Int4WeightOnlyConfig()), cond_ffn_filter, device="cuda")
+quantize_(
+    model,
+    MoEQuantConfig(Int4WeightOnlyConfig(version=1)),
+    cond_ffn_filter,
+    device="cuda",
+)
 
 model.cuda()
 

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -131,7 +131,7 @@ group_size = 32
 # you can enable [hqq](https://github.com/mobiusml/hqq/tree/master) quantization which is expected to improves accuracy through
 # use_hqq flag for `Int4WeightOnlyConfig` quantization
 use_hqq = False
-quantize_(model, Int4WeightOnlyConfig(group_size=group_size, use_hqq=use_hqq))
+quantize_(model, Int4WeightOnlyConfig(group_size=group_size, use_hqq=use_hqq, version=1))
 ```
 
 Note: The quantization error incurred by applying int4 quantization to your model can be fairly significant, so using external techniques like GPTQ may be necessary to obtain a usable model.
@@ -285,9 +285,9 @@ m_bf16 = torch.compile(m_bf16, mode='max-autotune')
 # apply int4 weight only quant (compatible with tinygemm int4 weight only quant mm kernel in torchao)
 group_size = 32
 # only works for torch 2.4+
-quantize_(m, Int4WeightOnlyConfig(group_size=group_size))
+quantize_(m, Int4WeightOnlyConfig(group_size=group_size, version=1))
 ## If different zero_point_domain needed
-# quantize_(m, Int4WeightOnlyConfig(group_size=group_size, zero_point_domain=ZeroPointDomain.FLOAT))
+# quantize_(m, Int4WeightOnlyConfig(group_size=group_size, zero_point_domain=ZeroPointDomain.FLOAT, version=1))
 
 # compile the model to improve performance
 m = torch.compile(m, mode='max-autotune')

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -519,7 +519,7 @@ def quantize_(
         from torchao.quantization.quant_api import int4_weight_only
 
         m = nn.Sequential(nn.Linear(32, 1024), nn.Linear(1024, 32))
-        quantize_(m, int4_weight_only(group_size=32))
+        quantize_(m, int4_weight_only(group_size=32, version=1))
 
     """
     torch._C._log_api_usage_once("torchao.quantization.quantize_")
@@ -2027,7 +2027,7 @@ def _uintx_weight_only_transform(
     if use_hqq:
         if dtype == torch.uint4:
             logger.warning(
-                "Recommended to use `int4_weight_only(group_size, use_hqq=True)` for the best performance"
+                "Recommended to use `int4_weight_only(group_size, use_hqq=True, version=1)` for the best performance"
             )
         quant_min, quant_max = _DTYPE_TO_QVALUE_BOUNDS[dtype]
         dtype = torch.uint8

--- a/torchao/sparsity/README.md
+++ b/torchao/sparsity/README.md
@@ -57,7 +57,7 @@ from torchao.dtypes import MarlinSparseLayout
 
 # Your FP16 model
 model = model.cuda().half()
-quantize_(model, Int4WeightOnlyConfig(layout=MarlinSparseLayout()))
+quantize_(model, Int4WeightOnlyConfig(layout=MarlinSparseLayout(), version=1))
 ```
 
 Note the existing API results in an extremely high accuracy degredation and is intended to be used in concert with an already sparsified+finetuned checkpoint where possible until we develop


### PR DESCRIPTION
Summary:
This is in preparation for version bump in https://github.com/pytorch/ao/pull/2949

added version=1 for both `int4_weight_only` and `Int4WeightOnlyConfig`

Test Plan:
regression tests with CI

Reviewers:

Subscribers:

Tasks:

Tags: