### PR TITLE
IntxWeightOnlyConfig/Int8DynamicIntxWeightConfig v2 migration: use version=1 in tests

### DIFF
--- a/.github/workflows/torchao_experimental_test.yml
+++ b/.github/workflows/torchao_experimental_test.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Run python tests
         run: |
           conda activate venv
-          pytest - s test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
-          python torchao/experimental/tests/test_embedding_xbit_quantizer.py
-          python torchao/experimental/tests/test_quant_passes.py
+          pytest -s test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
+          pytest -s torchao/experimental/tests/test_embedding_xbit_quantizer.py
+          pytest -s torchao/experimental/tests/test_quant_passes.py
           pytest -s test/prototype/test_dynamic_activation_lut.py
           pytest -s test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
       - name: torchao/csrc/cpu - build and run C++ tests

--- a/.github/workflows/torchao_experimental_test.yml
+++ b/.github/workflows/torchao_experimental_test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run python tests
         run: |
           conda activate venv
-          pytest torchao/experimental/tests/test_int8_dynamic_activation_intx_weight.py
+          pytest - s test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
           python torchao/experimental/tests/test_embedding_xbit_quantizer.py
           python torchao/experimental/tests/test_quant_passes.py
           pytest -s test/prototype/test_dynamic_activation_lut.py

--- a/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
@@ -23,7 +23,7 @@ from torchao.quantization.quant_api import (
 )
 from torchao.quantization.quantize_.workflows import IntxPackingFormat
 from torchao.quantization.quantize_.workflows.intx.intx_opaque_tensor import (
-    is_kernel_library_loaded,
+    _is_kernel_library_loaded,
 )
 from torchao.quantization.utils import compute_error
 
@@ -116,7 +116,7 @@ def _get_accuracy_test_cases():
     return test_cases
 
 
-@unittest.skipIf(not is_kernel_library_loaded(), "Kernel library not loaded")
+@unittest.skipIf(not _is_kernel_library_loaded(), "Kernel library not loaded")
 class TestIntxOpaqueTensor(TestCase):
     @parameterized.expand(
         _get_accuracy_test_cases(),

--- a/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_opaque_tensor.py
@@ -15,7 +15,6 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 
-from torchao.experimental.op_lib_utils import _check_torchao_ops_loaded
 from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
@@ -23,6 +22,9 @@ from torchao.quantization.quant_api import (
     quantize_,
 )
 from torchao.quantization.quantize_.workflows import IntxPackingFormat
+from torchao.quantization.quantize_.workflows.intx.intx_opaque_tensor import (
+    is_kernel_library_loaded,
+)
 from torchao.quantization.utils import compute_error
 
 
@@ -114,15 +116,7 @@ def _get_accuracy_test_cases():
     return test_cases
 
 
-_TORCHAO_OPS_LOADED = False
-try:
-    _check_torchao_ops_loaded()
-    _TORCHAO_OPS_LOADED = True
-except Exception:
-    pass
-
-
-@unittest.skipIf(not _TORCHAO_OPS_LOADED, "Need torchao ops")
+@unittest.skipIf(not is_kernel_library_loaded(), "Kernel library not loaded")
 class TestIntxOpaqueTensor(TestCase):
     @parameterized.expand(
         _get_accuracy_test_cases(),

--- a/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
+++ b/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
@@ -28,12 +28,12 @@ from torchao.quantization.quant_api import (
     quantize_,
 )
 from torchao.quantization.quantize_.workflows.intx.intx_opaque_tensor import (
-    is_kernel_library_loaded,
+    _is_kernel_library_loaded,
 )
 from torchao.quantization.utils import compute_error
 
 
-@unittest.skipIf(not is_kernel_library_loaded(), "Kernel library not loaded")
+@unittest.skipIf(not _is_kernel_library_loaded(), "Kernel library not loaded")
 class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
     TEST_ACCURACY_CASES = [
         param(

--- a/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
+++ b/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
@@ -101,6 +101,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=layout,
+                version=1,
             ),
         )
 
@@ -113,6 +114,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
+                version=1,
             ),
         )
 
@@ -146,6 +148,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(
                     target="kleidiai"
                 ),
+                version=1,
             ),
         )
 
@@ -158,6 +161,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
+                version=1,
             ),
         )
 
@@ -199,6 +203,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(target="aten"),
+                version=1,
             ),
         )
 
@@ -211,6 +216,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=weight_scale_dtype,
                 layout=self._reference_layout(),
+                version=1,
             ),
         )
 
@@ -270,6 +276,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=torch.bfloat16,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
+                version=1,
             ),
         )
         eager_results = model(activations)
@@ -331,6 +338,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=weight_mapping_type,
                 weight_scale_dtype=torch.bfloat16,
                 layout=PackedLinearInt8DynamicActivationIntxWeightLayout(),
+                version=1,
             ),
         )
         eager_results = model(activations)
@@ -359,6 +367,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_granularity=PerGroup(64),
                 weight_mapping_type=MappingType.SYMMETRIC,
                 layout=QDQLayout(),
+                version=1,
             ),
         )
         eager_results = model(activations)
@@ -407,6 +416,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_dtype=torch.int4,
                 weight_granularity=PerGroup(64),
                 layout=layout,
+                version=1,
             ),
         )
         expected = model(activations)
@@ -421,18 +431,6 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
             model2.load_state_dict(state_dict, assign=True)
             actual = model2(activations)
             self.assertTrue(torch.allclose(expected, actual))
-
-    def test_moved_error(self):
-        from torchao.experimental.quant_api import Int8DynamicActivationIntxWeightConfig
-
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "Int8DynamicActivationIntxWeightConfig has moved from torchao.experimental.quant_api to torchao.quantization.quant_api",
-        ):
-            config = Int8DynamicActivationIntxWeightConfig(  # noqa: F841
-                weight_dtype=torch.int4,
-                granularity=PerGroup(64),
-            )
 
     @parameterized.expand(
         [
@@ -473,6 +471,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=mapping_type,
                 weight_scale_dtype=None,
                 act_mapping_type=act_mapping_type,
+                version=1,
             ),
         )
         quantize_(
@@ -571,6 +570,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=mapping_type,
                 weight_scale_dtype=scale_dtype,
                 act_mapping_type=act_mapping_type,
+                version=1,
             ),
         )
         converted_out = model(activations)
@@ -625,6 +625,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
                 weight_mapping_type=MappingType.SYMMETRIC,
                 weight_scale_dtype=scale_dtype,
                 act_mapping_type=MappingType.ASYMMETRIC,
+                version=1,
             ),
         )
         converted_out1 = model(activations)
@@ -663,7 +664,7 @@ class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
         out = model(x).clone()
 
         base_config = Int8DynamicActivationIntxWeightConfig(
-            layout=PackedLinearInt8DynamicActivationIntxWeightLayout()
+            layout=PackedLinearInt8DynamicActivationIntxWeightLayout(), version=1
         )
         moe_config = MoEQuantConfig(
             base_config, use_fake_extra_dim_tensor=UseFakeExtraDimTensor.TRUE

--- a/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
+++ b/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
@@ -27,9 +27,13 @@ from torchao.quantization.quant_api import (
     MappingType,
     quantize_,
 )
+from torchao.quantization.quantize_.workflows.intx.intx_opaque_tensor import (
+    is_kernel_library_loaded,
+)
 from torchao.quantization.utils import compute_error
 
 
+@unittest.skipIf(not is_kernel_library_loaded(), "Kernel library not loaded")
 class TestInt8DynamicActivationIntxWeight(unittest.TestCase):
     TEST_ACCURACY_CASES = [
         param(

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -6,7 +6,7 @@
 
 import logging
 import sys
-from typing import Callable, List, Mapping, Optional, Tuple, Union
+from typing import Callable, List, Mapping, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -23,9 +23,7 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
-from dataclasses import dataclass
 
-from torchao.core.config import AOBaseConfig
 from torchao.dtypes.affine_quantized_tensor import (
     AffineQuantizedTensor,
 )
@@ -34,42 +32,14 @@ from torchao.dtypes.uintx.packed_linear_int8_dynamic_activation_intx_weight_layo
     Target,
 )
 from torchao.experimental.op_lib_utils import _check_torchao_ops_loaded
-from torchao.quantization.granularity import Granularity, PerAxis, PerGroup, PerRow
+from torchao.quantization.granularity import Granularity, PerAxis, PerGroup
 from torchao.quantization.quant_api import (
-    Int8DynamicActivationIntxWeightConfig as Int8DynamicActivationIntxWeightConfig_NonExperimental,
-)
-from torchao.quantization.quant_api import (
+    Int8DynamicActivationIntxWeightConfig,
     IntxWeightOnlyConfig,
     MappingType,
     quantize_,
 )
 from torchao.quantization.quant_primitives import _DTYPE_TO_BIT_WIDTH
-
-
-@dataclass
-class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
-    weight_dtype: torch.dtype = torch.int4
-    granularity: Union[PerRow, PerGroup] = PerRow()
-    has_weight_zeros: bool = False
-    weight_mapping_type: MappingType = MappingType.ASYMMETRIC
-    act_mapping_type: MappingType = MappingType.ASYMMETRIC
-    round_weight_scale_to_bf16: bool = True
-    layout = PackedLinearInt8DynamicActivationIntxWeightLayout(target=Target.AUTO)
-
-    def __post_init__(self):
-        raise NotImplementedError(
-            "Int8DynamicActivationIntxWeightConfig has moved from torchao.experimental.quant_api to torchao.quantization.quant_api.\n"
-            "Please migrate to using the new version.  The following args are renamed in the new version:\n"
-            "* granularity -> weight_granularity\n"
-            "* has_weight_zeros=True -> weight_mapping_type=torchao.quantization.quant_api.MappingType.ASYMMETRIC\n"
-            "* has_weight_zeros=False -> weight_zero_point_domain=torchao.quantization.quant_api.MappingType.SYMMETRIC\n"
-            "* round_weight_scale_to_bf16=True -> weight_scale_dtype=torch.bfloat16\n"
-            "* layout default has changed to QDQLayout().  IF YOU WANT CPU PERFORMANCE, USE layout=PackedLinearInt8DynamicActivationIntxWeightLayout()."
-        )
-
-
-# For BC
-int8_dynamic_activation_intx_weight = Int8DynamicActivationIntxWeightConfig
 
 
 class QuantizedEmbedding(nn.Module):
@@ -436,7 +406,7 @@ class SharedEmbeddingQuantizer:
         # Quantize unembeddings
         quantize_(
             model,
-            Int8DynamicActivationIntxWeightConfig_NonExperimental(
+            Int8DynamicActivationIntxWeightConfig(
                 weight_dtype=self.weight_dtype,
                 weight_granularity=self.granularity,
                 weight_mapping_type=self.mapping_type,

--- a/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
@@ -29,6 +29,16 @@ __all__ = [
 aten = torch.ops.aten
 
 
+def is_kernel_library_loaded():
+    loaded = False
+    try:
+        _check_torchao_ops_loaded()
+        loaded = True
+    except Exception:
+        pass
+    return loaded
+
+
 class ComputeTarget(enum.Enum):
     """
     This packs the tensor for PyTorch CPU kernels in ATen.
@@ -206,7 +216,7 @@ class IntxOpaqueTensor(TorchAOBaseTensor):
             )
 
         # Handle TORCHAO
-        _check_torchao_ops_loaded()
+        assert is_kernel_library_loaded(), "TorchAO kernel library is not loaded"
         compute_target_map = {
             ComputeTarget.TORCHAO_AUTO: None,
             ComputeTarget.TORCHAO_KLEIDIAI: "kleidiai",

--- a/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_opaque_tensor.py
@@ -29,7 +29,7 @@ __all__ = [
 aten = torch.ops.aten
 
 
-def is_kernel_library_loaded():
+def _is_kernel_library_loaded():
     loaded = False
     try:
         _check_torchao_ops_loaded()
@@ -216,7 +216,7 @@ class IntxOpaqueTensor(TorchAOBaseTensor):
             )
 
         # Handle TORCHAO
-        assert is_kernel_library_loaded(), "TorchAO kernel library is not loaded"
+        assert _is_kernel_library_loaded(), "TorchAO kernel library is not loaded"
         compute_target_map = {
             ComputeTarget.TORCHAO_AUTO: None,
             ComputeTarget.TORCHAO_KLEIDIAI: "kleidiai",


### PR DESCRIPTION
Use version=1 in old tests