### PR TITLE
Skip QAT tests using `quantize_fp8_row` in fbcode

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -2053,6 +2053,7 @@ class TestQAT(TestCase):
     @unittest.skipIf(
         not _is_fbgemm_genai_gpu_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
     )
+    @unittest.skipIf(is_fbcode(), "triton compilation error")
     def test_fbgemm_fp8_primitives(self):
         """
         Compare numerics between:
@@ -2092,6 +2093,7 @@ class TestQAT(TestCase):
     @unittest.skipIf(
         not _is_fbgemm_genai_gpu_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
     )
+    @unittest.skipIf(is_fbcode(), "triton compilation error")
     def test_fbgemm_int4_preshuffled_primitives(self):
         """
         Compare numerics between:


### PR DESCRIPTION
Just skipping for now to unblock:
```
triton.compiler.errors.CompilationError: at 1:0:
def _kernel_quantize_fp8_row(
^
ValueError("type fp8e4nv not supported in this architecture. The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')")
```