### PR TITLE
Add support for only update models and push to a different user ID

### DIFF
--- a/.github/scripts/torchao_model_releases/eval.sh
+++ b/.github/scripts/torchao_model_releases/eval.sh
@@ -110,5 +110,5 @@ done
 
 # Run summarize_results.sh with MODEL_IDS if eval_type is "all"
 if [[ "$EVAL_TYPE" == "all" ]]; then
-  sh summarize_results.sh --model_id "${MODEL_ID_ARRAY[@]}"
+  sh summarize_results.sh --model_ids "${MODEL_ID_ARRAY[@]}"
 fi

--- a/.github/scripts/torchao_model_releases/release.sh
+++ b/.github/scripts/torchao_model_releases/release.sh
@@ -15,6 +15,8 @@
 # Default quantization options
 default_quants=("FP8" "INT4" "INT8-INT4")
 push_to_hub=""
+push_to_user_id=""
+update_model_card=""
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +36,14 @@ while [[ $# -gt 0 ]]; do
       push_to_hub="--push_to_hub"
       shift
       ;;
+     --push_to_user_id)
+      push_to_user_id=("--push_to_user_id $2")
+      shift 2
+      ;;
+     --update_model_card)
+      update_model_card="--update_model_card"
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -43,7 +53,7 @@ done
 # Use default quants if none specified
 if [[ -z "$model_id" ]]; then
   echo "Error: --model_id is required"
-  echo "Usage: $0 --model_id <model_id> [--quants <quant1> [quant2 ...]] [--push_to_hub]"
+  echo "Usage: $0 --model_id <model_id> [--quants <quant1> [quant2 ...]] [--push_to_hub] [--push_to_user_id <push_to_user_id>] [--update_model_card]"
   exit 1
 fi
 if [[ ${#quants[@]} -eq 0 ]]; then
@@ -51,6 +61,6 @@ if [[ ${#quants[@]} -eq 0 ]]; then
 fi
 # Run the python command for each quantization option
 for quant in "${quants[@]}"; do
-  echo "Running: python quantize_and_upload.py --model_id $model_id --quant $quant $push_to_hub"
-  python quantize_and_upload.py --model_id "$model_id" --quant "$quant" $push_to_hub
+  echo "Running: python quantize_and_upload.py --model_id $model_id --quant $quant $push_to_hub $push_to_user_id $update_model_card"
+  python quantize_and_upload.py --model_id "$model_id" --quant "$quant" $push_to_hub $push_to_user_id $update_model_card
 done


### PR DESCRIPTION
Summary:
This is used for updating official pytorch checkpoints, after the PR, e.g. to update microsoft/Phi-4-mini-instruct FP8 checkpoint:

sh release.sh --model_id microsoft/Phi-4-mini-instruct --quants FP8 --push_to_hub --push_to_user_id pytorch

Test Plan:
Updated the INT4, FP8 checkpoints in https://huggingface.co/pytorch with the updated scripts

Reviewers:

Subscribers:

Tasks:

Tags: