### PR TITLE
forward fix shape guards handling for executorch

### DIFF
--- a/torchao/quantization/pt2e/lowering.py
+++ b/torchao/quantization/pt2e/lowering.py
@@ -57,7 +57,7 @@ def lower_pt2e_quantized_to_x86(
     lowered_model = (
         torch.export.export(model, example_inputs, strict=True)
         .run_decompositions(_post_autograd_decomp_table())
-        .module()
+        .module(check_guards=False)
     )
     _node_replace(lowered_model)
     freezing_passes(lowered_model, example_inputs)

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -844,7 +844,7 @@ def _get_aten_graph_module_for_pattern(
         example_inputs,
         kwargs,
         strict=True,
-    ).module()
+    ).module(check_guards=False)
 
     aten_pattern.graph.eliminate_dead_code()  # type: ignore[operator, union-attr]
     aten_pattern.recompile()  # type: ignore[operator]

--- a/torchao/testing/pt2e/utils.py
+++ b/torchao/testing/pt2e/utils.py
@@ -143,6 +143,8 @@ class PT2ENumericDebuggerTestCase(TestCase):
         def _assert_node_has_from_node_source(node):
             if node.op == "placeholder" or node.op == "output":
                 return
+            if node.op == "call_module" and node.target == "_guards_fn":
+                return
             self.assertIn(
                 FROM_NODE_KEY,
                 node.meta,


### PR DESCRIPTION
Summary:
D80713603 introduces a call module to a generated `_guards_fn` by export that ET pass infra cannot handle right now.

It is possible to omit this generation by using `ep.module(check_guards=False)` but there are too many places to update, so meanwhile we can explicitly remove the generated instruction as in here.

Differential Revision: D82030581
