### PR TITLE
Fix compile error

### DIFF
--- a/torchao/csrc/cpu/aten_kernels/scaled_embedding_bag.cpp
+++ b/torchao/csrc/cpu/aten_kernels/scaled_embedding_bag.cpp
@@ -174,7 +174,6 @@ at::Tensor _scaled_embedding_bag_impl(const at::Tensor &qweight,
   int64_t emb_dim = qweight.size(1);
 
   auto index_type = indices.scalar_type();
-  auto qtype = qweight.scalar_type();
   float w_scale = w_scales.data_ptr<float>()[0];
 
   TORCH_CHECK(indices.is_contiguous() && offsets.is_contiguous(),


### PR DESCRIPTION
qtype is unused, which causes compile errors in fbcode