### PR TITLE
Add nvcc flags to explicitly build mxfp8 dim1 cast kernel for sm100a 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -677,7 +677,11 @@ def get_extensions():
                     ],
                     extra_compile_args={
                         "cxx": ["-std=c++17", "-O3"],
-                        "nvcc": nvcc_args + ["-gencode=arch=compute_100a,code=sm_100a"],
+                        "nvcc": nvcc_args
+                        + [
+                            "-gencode=arch=compute_100,code=sm_100",
+                            "-gencode=arch=compute_120,code=compute_120",
+                        ],
                     },
                 ),
             )


### PR DESCRIPTION
Fixes https://github.com/pytorch/ao/issues/2932

I think we need to explicitly add the nvcc flags to build for sm100a in the extension itself. Right now, we check if the `build_for_sm100a` flag is true, which is set to true for cuda 12.8+, but we don't actually modify the nvcc args passed in to build the extension.

Seems like building from source is accidentally working? Looking into this..


## Test plan
- CI Job building for CUDA 12.8 DOES have `building 'torchao.prototype.mxfp8_cuda' extension` logs but does NOT have this [warning](https://github.com/pytorch/ao/blob/186aeb01664687d14108ada420c475cc783e1643/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh#L30C6-L30C25) (`"MXFP8 quantization requires SM90+ (Hopper) or SM100+ (Blackwell) architecture. Kernel will be disabled for this architecture."`) in it: https://github.com/pytorch/ao/actions/runs/17631942858/job/50100852741 
    - (previously, without this fix, in the CI build logs indicating the extension was being built, but also see the warning that cuda arch not supported so kernel will not be built)