### PR TITLE
Enable using HF PARQ checkpoints in torchao

### DIFF
--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -193,6 +193,7 @@ ALLOWED_AO_MODULES = {
     "torchao.sparsity.sparse_api",
     "torchao.prototype.quantization",
     "torchao.prototype.mx_formats",
+    "torchao.prototype.parq",
     "torchao.dtypes",
     "torchao.prototype.awq",
     "torchao.quantization.quantize_.common",

--- a/torchao/prototype/parq/__init__.py
+++ b/torchao/prototype/parq/__init__.py
@@ -20,3 +20,8 @@ from .quant import (  # noqa: F401
     UnifQuantizer,
     UnifTorchaoQuantizer,
 )
+from .quant.config_torchao import StretchedIntxWeightConfig
+
+__all__ = [
+    "StretchedIntxWeightConfig",
+]


### PR DESCRIPTION
With this change, we can now use lm_eval CLI

```
HF_HUB_DISABLE_XET=1 lm_eval --model hf --model_args pretrained=hf_model_id --tasks gsm8k --device cuda:0 --batch_size auto
```