### PR TITLE
Add AWQ/SmoothQuant evaluation wrapper test for vLLM benchmark

### DIFF
--- a/torchao/_models/_eval.py
+++ b/torchao/_models/_eval.py
@@ -32,7 +32,7 @@ class TransformerEvalWrapper(eval_wrapper):
     """
 
     def __init__(
-        self, model, tokenizer, max_seq_length=512, input_prep_func=None, device="cuda"
+        self, model, tokenizer, max_seq_length=1024, input_prep_func=None, device="cuda"
     ):
         try:
             super().__init__(device=device)

--- a/torchao/testing/model_architectures.py
+++ b/torchao/testing/model_architectures.py
@@ -22,20 +22,6 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-class ToyTokenizer:
-    def __init__(self):
-        self.vocab_size = 1000
-
-    def encode(self, string, **kwargs):
-        if not string:
-            return [1]
-        tokens = [hash(word) % (self.vocab_size - 10) + 10 for word in string.split()]
-        return [101] + tokens + [102]  # [CLS] + tokens + [SEP]
-
-    def decode(self, token_ids, skip_special_tokens=True):
-        return " ".join([f"word_{i}" for i in token_ids])
-
-
 class ConvWithSharedWeightInExportedModel(nn.Module):
     def __init__(
         self, n_chunks, in_channels, out_channels, kernel_size=3, stride=1, padding=1


### PR DESCRIPTION
**Summary:**
This is a milestone for building a benchmark for AWQ/SmoothQuant within the vLLM ecosystem (https://github.com/pytorch/ao/issues/2815). For vLLM benchmark, AWQ/SmoothQuant needs a wrapper (TransformerEvalWrapper) to be compatible with vLLM. Therefore, this PR adds unit test to verify if TransformerEvalWrapper works with AWQ/SmoothQuant.

**Test plan**:
A toy tokenizer model is introduced to validate TransformerEvalWrapper. Toy linear models are updated to be compatible with the tokenizer model.

**Future plan**:
This PR only validates the wrapper for the benchmark within the vLLM ecosystem. We need to expand metrics for comprehensive AWQ/SmoothQuant benchmarks.