### PR TITLE
Prevent union-finding cycles for shared qspecs

### DIFF
--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -154,17 +154,17 @@ def _union(
     root_child = _find_root_edge_or_node(child, shared_with_map)
 
     parent_qspec = edge_or_node_to_qspec[root_parent]
-    if not (
+    if (
         isinstance(parent_qspec, SharedQuantizationSpec)
         and parent_qspec.edge_or_node == root_child
     ):
-        # union the two trees by pointing the root of child to root of parent
-        shared_with_map[root_child] = root_parent
-    else:
         # Parent already references child with a shared qspec. We would create
         # a cycle if we formed an edge from the child to the parent. Therefore,
         # we reverse the edge in this particular case.
         shared_with_map[root_parent] = root_child
+    else:
+        # union the two trees by pointing the root of child to root of parent
+        shared_with_map[root_child] = root_parent
 
 
 def _update_shared_with(

--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -153,15 +153,18 @@ def _union_if_no_cycle(
     root_parent = _find_root_edge_or_node(parent, shared_with_map)
     root_child = _find_root_edge_or_node(child, shared_with_map)
 
-    # Union the two trees by pointing the root of child to root of parent
-    # unless the parent qspec points to the root of child; that would create an
-    # undesired cycle and the nodes are in practice already unioned.
     parent_qspec = edge_or_node_to_qspec[root_parent]
     if not (
         isinstance(parent_qspec, SharedQuantizationSpec)
         and parent_qspec.edge_or_node == root_child
     ):
+        # union the two trees by pointing the root of child to root of parent
         shared_with_map[root_child] = root_parent
+    else:
+        # Parent already references child with a shared qspec (would create a
+        # cycle). The sets are effectively already unified via the shared
+        # qspec, so we leave shared_with_map unchanged.
+        pass
 
 
 def _update_shared_with(


### PR DESCRIPTION
Certain graphs caused infinite recursion when unioning nodes to groups based on shared quantization specs while implicit sharing was enabled. The problem occurred when `NodeOrEdge` A with its own `QuantizationSpec` received an edge (in `shared_with_map`) to `EdgeOrNode` B which in turn had a `SharedQuantizationSpec` pointing back to A. While in this state, looking up the quantization spec in `_unwrap_shared_qspec` resulted in an endless recursion loop and the program crashed.

Remedy this problem by, prior to unioning two trees, checking if the root of the parent has a `SharedQuantizationSpec` pointing to the root of the child; if that is the case, reverse the edge by letting parent point to the child. This will ensure that no cycle like the one described above is formed.

Add a test case which this commit fixes; namely, a graph where one input edge is shared between two ops. This graph would cause trigger cyclic reference bug that was seen prior to this patch.