### PR TITLE
fix: avoid removing from tuple in _get_to_kwargs

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -340,6 +340,9 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         )
         self._test_default_impls_helper(lp_tensor, lp_tensor_for_copy)
 
+    def test__get_to_kwargs_with_layout(self):
+        MyClass = TorchAOBaseTensor()
+        MyClass._get_to_kwargs(torch.strided,device="cuda")
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -144,6 +144,10 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         self.assertTrue(torch.equal(lp_tensor.qdata, reconstructed.qdata))
         self.assertEqual(lp_tensor.attr, reconstructed.attr)
 
+        # test _get_to_kwargs
+        _ = lp_tensor._get_to_kwargs(torch.strided, device="cuda")
+        _ = lp_tensor._get_to_kwargs(layout=torch.strided, device="cuda")
+
         # `to` / `_to_copy`
         original_device = lp_tensor.device
         lp_tensor = lp_tensor.to("cuda")
@@ -340,9 +344,6 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         )
         self._test_default_impls_helper(lp_tensor, lp_tensor_for_copy)
 
-    def test__get_to_kwargs_with_layout(self):
-        MyClass = TorchAOBaseTensor()
-        MyClass._get_to_kwargs(torch.strided, device="cuda")
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -342,7 +342,7 @@ class TestTorchAOBaseTensor(unittest.TestCase):
 
     def test__get_to_kwargs_with_layout(self):
         MyClass = TorchAOBaseTensor()
-        MyClass._get_to_kwargs(torch.strided,device="cuda")
+        MyClass._get_to_kwargs(torch.strided, device="cuda")
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -717,9 +717,7 @@ def _get_tensor_impl_constructor(
 
 def _get_to_kwargs(self, *args, **kwargs):
     # `torch._C._nn._parse_to` can't handle `layout` argument
-    for arg in args:
-        if isinstance(arg, torch.layout):
-            args.remove(arg)
+    args = tuple(arg for arg in args if not isinstance(arg, torch.layout))
     if "layout" in kwargs:
         kwargs.pop("layout")
     # ignoring `non_blocking` and `memory_format` args since these are not


### PR DESCRIPTION
This PR fixes a bug in `_get_to_kwargs` where `args` is a tuple but the code attempted to call `args.remove(arg)`, leading to:
```bash
    def _get_to_kwargs(self, *args, **kwargs):
        # `torch._C._nn._parse_to` can't handle `layout` argument
        for arg in args:
            if isinstance(arg, torch.layout):
>               args.remove(arg)
                ^^^^^^^^^^^
E               AttributeError: 'tuple' object has no attribute 'remove'

torchao/utils.py:722: AttributeError
```

Temporary test case in test/test_utils.py::TestTorchAOBaseTensor(unittest.TestCase):
```python
    def test__get_to_kwargs_with_layout(self):
        MyClass = TorchAOBaseTensor()
        import torch
        MyClass._get_to_kwargs(torch.strided,device="cuda")
```

Temporary test command:
```bash
pytest --count=1 test/test_utils.py::TestTorchAOBaseTensor::test__get_to_kwargs_with_layout
```
