### PR TITLE
Avoid normalization layers in HF's quantization_config

### DIFF
--- a/torchao/prototype/parq/quant/config_torchao.py
+++ b/torchao/prototype/parq/quant/config_torchao.py
@@ -187,18 +187,16 @@ def _attach_hf_quantization_config(
     if module_to_config is None:
         module_to_config = {}
 
-    seen_data_ptrs = set()
+    tied_weights_keys = set(getattr(model, "_tied_weights_keys", []))
     modules_to_not_convert = []
     for name, module in model.named_modules():
         if not hasattr(module, "weight"):
             continue
 
         # Do not quantize pointers to tied weights or normalization layers
-        data_ptr = module.weight.data_ptr()
-        if data_ptr in seen_data_ptrs or name.endswith("norm"):
+        if f"{name}.weight" in tied_weights_keys or "norm" in name:
             modules_to_not_convert.append(name)
             continue
-        seen_data_ptrs.add(data_ptr)
 
         for i, filter_fn in enumerate(filter_fns):
             if filter_fn(module):

--- a/torchao/prototype/parq/quant/config_torchao.py
+++ b/torchao/prototype/parq/quant/config_torchao.py
@@ -193,8 +193,9 @@ def _attach_hf_quantization_config(
         if not hasattr(module, "weight"):
             continue
 
+        # Do not quantize pointers to tied weights or normalization layers
         data_ptr = module.weight.data_ptr()
-        if data_ptr in seen_data_ptrs:  # do not re-quantize tied weight
+        if data_ptr in seen_data_ptrs or name.endswith("norm"):
             modules_to_not_convert.append(name)
             continue
         seen_data_ptrs.add(data_ptr)


### PR DESCRIPTION
This is a follow-up to #3015. I found that setting `model.config.quantization_config` with a "_default" key will quantize not just linear layer weights, but all weights, including normalization layers.

The culprit is still [this](https://github.com/huggingface/transformers/blob/5f6e278a5177d8b85945a2cdb6b776dacee34914/src/transformers/quantizers/quantizer_torchao.py#L277) line from TorchAoHfQuantizer.create_quantized_param:
```python
quantize_(module, c, filter_fn=lambda x, fqn: True)
```

In order to avoid quantizing non-linear weights, I had to manually add all module names for normalization layers to `modules_to_not_convert`, which is an argument to `TorchAoConfig`.

@andrewor14 Do you know if this is the intended behavior? I don't see why they aren't using the default `filter_fn` for `quantize_`.