### PR TITLE
[mxfp8 moe training] update 3d quant colwise scaling kernel to use single input/output TMA descriptors

### DIFF
--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -325,8 +325,8 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     reason="MXFP8 requires CUDA capability 10.0 or greater",
 )
 @pytest.mark.parametrize("E", (1, 2, 4, 8))
-@pytest.mark.parametrize("N", (32, 64, 8192))
-@pytest.mark.parametrize("K", (32, 64, 8192))
+@pytest.mark.parametrize("N", (32, 1536, 5120, 7168, 8192))
+@pytest.mark.parametrize("K", (32, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("input_dtype", (torch.bfloat16,))
 @pytest.mark.parametrize("scaling_mode", (ScaleCalculationMode.FLOOR,))
 def test_cuda_mx_dim1_3d_numerics(E, N, K, input_dtype, scaling_mode):
@@ -361,7 +361,6 @@ def test_cuda_mx_dim1_3d_numerics(E, N, K, input_dtype, scaling_mode):
     y_d1, s_d1 = mxfp8_cuda.quantize_3d(
         x, scale_dim_n=block_size, scaling_mode=scaling_mode_str
     )
-
     # Check scales
     torch.testing.assert_close(s_d1, s_d1_ref, rtol=0, atol=0)
 

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -54,7 +54,8 @@ mxfp8_quantize(torch::Tensor input, bool rowwise, bool colwise,
 
   // Validate inputs
   TORCH_CHECK(!rowwise, "rowwise scaling is not supported yet");
-  check_cuda_tensor(input, "input");
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
   TORCH_CHECK(input.dim() == 2, "input must be 2D");
   TORCH_CHECK(input.scalar_type() == torch::kFloat32 ||
                   input.scalar_type() == torch::kFloat16 ||
@@ -130,6 +131,7 @@ mxfp8_quantize_3d(torch::Tensor input, int64_t scale_dim_n,
 
   // Validate inputs
   TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
   // Note: We don't check contiguous for 3D as it may have column major strides
   TORCH_CHECK(input.dim() == 3, "input must be 3D");
   TORCH_CHECK(input.scalar_type() == torch::kFloat32 ||
@@ -148,7 +150,6 @@ mxfp8_quantize_3d(torch::Tensor input, int64_t scale_dim_n,
   TORCH_CHECK((N >= 32) && (N % 32 == 0), "N must be a multiple of 32");
   TORCH_CHECK((K >= 32) && (K % 32 == 0), "K must be a multiple of 32");
 
-  // The kernel should work with any stride pattern - no layout requirements
 
   c10::cuda::CUDAGuard device_guard(input.device());
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#3034


--- --- ---

[mxfp8 moe training] update 3d quant colwise scaling kernel to use single input/output TMA descriptors

## Summary
- CUDA Kernel for 3d quantization across cols added in #3004 has worse perf than other methods for small num_experts, and is only better for large num_experts. 
- We hypothesize this is because cudaMallocManaged of separate TMA descriptors per expert, which is a slow/blocking function. The overhead is constant, and thus more noticeable for small inputs.
- In this PR, I redesign the kernel to use single input and output TMA descriptor for the whole 3d tensor.
    - For the input, it is in simple row major format, so I can read from specific experts by adjusting the TMA row offset during the async TMA load.
    - For the output, it is a more complex "column major per expert" format, so I use a 3d TMA descriptor with the specific shape and strides needed. I transpose the row major data in SMEM before doing the async TMA store to GMEM to get it in col major per expert format.

## Test plan
- Add unit tests for Llama4 and DeepSeekV3 shapes
- `sanitize pytest test/prototype/moe_training/test_kernels.py `

## Performance
devgpu having issues, perf for everything isworse than usual, but the relative difference between the cuda_3d vs other methods is still useful for now:

```
input_shape         to_mx_us    cuda_2d_us    cuda_3d_us    to_mx_gbps    cuda_2d_gbps    cuda_3d_gbps
----------------  ----------  ------------  ------------  ------------  --------------  --------------
(1, 8192, 5120)      816.608       595.936       466.736       155.693         213.345         272.402
(2, 8192, 5120)     1174.82        919.776       508.48        216.442         276.458         500.078
(4, 8192, 5120)     1631.71       1159.58        631.712       311.672         438.571         805.049
(8, 8192, 5120)     2621.44       1602.82        839.424       388             634.582        1211.69
(16, 8192, 5120)    4612.42       2772.93       1291.07        441.035         733.606        1575.62
(64, 8192, 5120)   15916.1        8551.81       4112.35        511.241         951.489        1978.66
```