### PR TITLE
support select.int for Float8Tensor

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -25,6 +25,7 @@ from torchao.quantization import (
     quantize_,
 )
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.quantization.quantize_.workflows.float8.float8_tensor import Float8Tensor
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
@@ -445,6 +446,23 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
         ).check_count("torch.ops.fbgemm.f8f8bf16_rowwise.default(", 1).check_not(
             ".run("
         ).run(code[0])
+
+    @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
+    def test_index_select(self):
+        """
+        test that `x_0 = x[0]` works when `x` is a 3D `Float8Tensor`. This is
+        useful when stitching checkpoints of `num_experts` 2D parameters into
+        a single 3D parameter when converting between model definitions that
+        use 2D and 3D parameters for their expert weights.
+        """
+
+        E, K, N = 128, 256, 512
+        x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+        x_fp8 = Float8Tensor.from_hp(x)
+        x_fp8_1 = x_fp8[1]
+        torch.testing.assert_close(
+            x_fp8.dequantize()[1], x_fp8_1.dequantize(), atol=0, rtol=0
+        )
 
 
 common_utils.instantiate_parametrized_tests(TestFloat8Tensor)


### PR DESCRIPTION
Summary:

This is useful for stitching together 2D weights to a 3D weight, specifically this happens in vLLM for HF models where expert weights are 2D.

Test Plan:

```bash
pytest test/quantization/quantize_/workflows/float8/test_float8_tensor.py -x -s -k index
```

Reviewers:

Subscribers:

Tasks:

Tags: