### PR TITLE
Add awq support for Int4TilePackedTo4dTensor

### DIFF
--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -7,9 +7,10 @@ import copy
 import tempfile
 
 import torch
-from parameterized import parameterized
 from torch.testing._internal.common_utils import (
     TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
     run_tests,
 )
 
@@ -55,6 +56,17 @@ if torch.xpu.is_available():
     devices.append("xpu")
 
 
+device_to_base_configs = {
+    "cuda": [
+        Int4WeightOnlyConfig(group_size=128),
+        # Note: the functionality unit test doesn't work for hqq
+        Int4WeightOnlyConfig(group_size=128, int4_packing_format="tile_packed_to_4d"),
+    ],
+    "cpu": [Int4WeightOnlyConfig(group_size=128, int4_packing_format="opaque")],
+    "xpu": [Int4WeightOnlyConfig(group_size=128, int4_packing_format="plain_int32")],
+}
+
+
 class TestAWQ(TestCase):
     def test_awq_config(self):
         base_config = Int4WeightOnlyConfig()
@@ -69,121 +81,112 @@ class TestAWQ(TestCase):
         with self.assertRaisesRegex(ValueError, "is not one of"):
             AWQConfig(base_config, step="not_supported")
 
-    @parameterized.expand([(device,) for device in devices])
+    @parametrize("device", devices)
     def test_awq_functionality(self, device):
-        dataset_size = 100
+        dataset_size = 10
         l1, l2, l3 = 512, 256, 128
         original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
-        group_size = 128
-        n_calibration_examples = 10
         sequence_length = 5
 
-        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+        assert device in device_to_base_configs, "Unsupported device: {}".format(device)
+        base_configs = device_to_base_configs[device]
 
-        # baseline quantization
-        if device == "cuda":
-            base_config = Int4WeightOnlyConfig(group_size=group_size)
-        elif device == "xpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="plain_int32"
+        for base_config in base_configs:
+            m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+            m_baseline = copy.deepcopy(m)
+
+            dataset = m.example_inputs(
+                dataset_size,
+                sequence_length=sequence_length,
+                dtype=original_dtype,
+                device=device,
             )
-        elif device == "cpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="opaque"
-            )
-            torch.manual_seed(1234)
-        else:
-            assert False, "Unsupported device: {}".format(device)
-        m_baseline = copy.deepcopy(m)
-        quantize_(m_baseline, base_config)
+            # for test, we use calibration_data = dataset so that awq is
+            # guranteed to be better than baseline
+            # in reality, calibration_data will be a small subset or a different
+            # dataset
+            calibration_data = dataset
+            # concatenatd inputs
+            input_cat = torch.cat(calibration_data, dim=-2)
+            ref_out = m(input_cat)
 
-        # awq quantization
-        dataset = m.example_inputs(
-            dataset_size,
-            sequence_length=sequence_length,
-            dtype=original_dtype,
-            device=device,
-        )
-        ref_out = torch.cat([m(d.squeeze(0)) for d in dataset])
+            # baseline quantization
+            quantize_(m_baseline, base_config)
 
-        calibration_data = dataset[:n_calibration_examples]
+            # awq quantization
+            quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+            quantize_(m, quant_config)
 
-        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
-        quantize_(m, quant_config)
+            for example in calibration_data:
+                m(example)
 
-        for example in calibration_data:
-            m(example)
+            quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+            quantize_(m, quant_config)
 
-        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
-        quantize_(m, quant_config)
+            # evaluating on calibration data set to remove any uncertainty
+            awq_out = m(input_cat)
+            baseline_out = m_baseline(input_cat)
 
-        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
-        baseline_out = torch.cat([m_baseline(d.squeeze(0)) for d in dataset])
+            loss_awq = (ref_out - awq_out).pow(2).mean().item()
+            loss_base = (ref_out - baseline_out).pow(2).mean().item()
+            assert loss_awq <= loss_base
 
-        loss_awq = (ref_out - awq_out).pow(2).mean().item()
-        loss_base = (ref_out - baseline_out).pow(2).mean().item()
-        assert loss_awq < loss_base
-
-    @parameterized.expand([(device,) for device in devices])
+    @parametrize("device", devices)
     def test_awq_loading(self, device):
-        dataset_size = 100
+        dataset_size = 10
         l1, l2, l3 = 512, 256, 128
         original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
-        group_size = 128
-        n_calibration_examples = 10
         sequence_length = 5
 
-        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-        dataset = m.example_inputs(
-            dataset_size,
-            sequence_length=sequence_length,
-            dtype=original_dtype,
-            device=device,
-        )
-        calibration_data = dataset[:n_calibration_examples]
+        assert device in device_to_base_configs, "Unsupported device: {}".format(device)
+        base_configs = device_to_base_configs[device]
 
-        # calibrate
-        if device == "cuda":
-            base_config = Int4WeightOnlyConfig(group_size=group_size)
-        elif device == "xpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="plain_int32"
+        for base_config in base_configs:
+            m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+            dataset = m.example_inputs(
+                dataset_size,
+                sequence_length=sequence_length,
+                dtype=original_dtype,
+                device=device,
             )
-        elif device == "cpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="opaque"
+            # for test purpose, we don't need to get a subset
+            calibration_data = dataset
+            # concatenatd inputs
+            input_cat = torch.cat(calibration_data, dim=-2)
+
+            # calibrate
+
+            quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+            quantize_(m, quant_config)
+
+            for example in calibration_data:
+                m(example)
+
+            # quantize
+            quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+            quantize_(m, quant_config)
+
+            with tempfile.NamedTemporaryFile() as f:
+                torch.save(m.state_dict(), f)
+                f.seek(0)
+                state_dict = torch.load(f)
+
+            loaded_model = (
+                ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
             )
-        else:
-            assert False, "Unsupported device: {}".format(device)
-        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
-        quantize_(m, quant_config)
+            loaded_model.load_state_dict(state_dict, assign=True)
 
-        for example in calibration_data:
-            m(example)
+            m = torch.compile(m, fullgraph=True)
+            loaded_model = torch.compile(loaded_model, fullgraph=True)
 
-        # quantize
-        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
-        quantize_(m, quant_config)
+            awq_out = m(input_cat)
+            awq_save_load_out = loaded_model(input_cat)
 
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(m.state_dict(), f)
-            f.seek(0)
-            state_dict = torch.load(f)
+            assert awq_out is not None
+            assert awq_save_load_out is not None
+            assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
 
-        loaded_model = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-        loaded_model.load_state_dict(state_dict, assign=True)
-
-        m = torch.compile(m, fullgraph=True)
-        loaded_model = torch.compile(loaded_model, fullgraph=True)
-
-        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
-        awq_save_load_out = torch.cat([loaded_model(d.squeeze(0)) for d in dataset])
-
-        assert awq_out is not None
-        assert awq_save_load_out is not None
-        assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
-
-    @parameterized.expand([(device,) for device in devices])
+    @parametrize("device", devices)
     def test_awq_loading_vllm(self, device):
         """Simulate weight loading in vllm:
         * prepare model weight to the same format (awq weight)
@@ -191,68 +194,65 @@ class TestAWQ(TestCase):
 
         There is also a slicing op that is ommitted here, overall e2e is tested in tests in vllm repo
         """
-        dataset_size = 100
+        dataset_size = 10
         l1, l2, l3 = 512, 256, 128
         original_dtype = torch.bfloat16  # tinygemm kernel only uses bfloat16 inputs
-        group_size = 128
-        n_calibration_examples = 10
         sequence_length = 5
 
-        m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-        dataset = m.example_inputs(
-            dataset_size,
-            sequence_length=sequence_length,
-            dtype=original_dtype,
-            device=device,
-        )
-        calibration_data = dataset[:n_calibration_examples]
+        assert device in device_to_base_configs, "Unsupported device: {}".format(device)
+        base_configs = device_to_base_configs[device]
 
-        # calibrate
-        if device == "cuda":
-            base_config = Int4WeightOnlyConfig(group_size=group_size)
-        elif device == "xpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="plain_int32"
+        for base_config in base_configs:
+            m = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
+            dataset = m.example_inputs(
+                dataset_size,
+                sequence_length=sequence_length,
+                dtype=original_dtype,
+                device=device,
             )
-        elif device == "cpu":
-            base_config = Int4WeightOnlyConfig(
-                group_size=group_size, int4_packing_format="opaque"
+            # for test purpose, we don't need to get a subset
+            calibration_data = dataset
+            # concatenatd inputs
+            input_cat = torch.cat(calibration_data, dim=-2)
+
+            # calibrate
+            quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
+            quantize_(m, quant_config)
+
+            for example in calibration_data:
+                m(example)
+
+            # quantize
+            quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
+            quantize_(m, quant_config)
+
+            with tempfile.NamedTemporaryFile() as f:
+                torch.save(m.state_dict(), f)
+                f.seek(0)
+                state_dict = torch.load(f)
+
+            loaded_model = (
+                ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
             )
-        else:
-            assert False, "Unsupported device: {}".format(device)
-        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE)
-        quantize_(m, quant_config)
+            quant_config = AWQConfig(base_config, step=AWQStep.PREPARE_FOR_LOADING)
+            quantize_(loaded_model, quant_config)
 
-        for example in calibration_data:
-            m(example)
+            loaded_model.linear1.weight.copy_(state_dict["linear1.weight"])
+            loaded_model.linear2.weight.copy_(state_dict["linear2.weight"])
+            loaded_model.linear3.weight.copy_(state_dict["linear3.weight"])
 
-        # quantize
-        quant_config = AWQConfig(base_config, step=AWQStep.CONVERT)
-        quantize_(m, quant_config)
+            m = torch.compile(m, fullgraph=True)
+            loaded_model = torch.compile(loaded_model, fullgraph=True)
 
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(m.state_dict(), f)
-            f.seek(0)
-            state_dict = torch.load(f)
+            awq_out = m(input_cat)
+            awq_save_load_out = loaded_model(input_cat)
 
-        loaded_model = ToyLinearModel(l1, l2, l3).eval().to(original_dtype).to(device)
-        quant_config = AWQConfig(base_config, step=AWQStep.PREPARE_FOR_LOADING)
-        quantize_(loaded_model, quant_config)
+            assert awq_out is not None
+            assert awq_save_load_out is not None
+            assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
 
-        loaded_model.linear1.weight.copy_(state_dict["linear1.weight"])
-        loaded_model.linear2.weight.copy_(state_dict["linear2.weight"])
-        loaded_model.linear3.weight.copy_(state_dict["linear3.weight"])
 
-        m = torch.compile(m, fullgraph=True)
-        loaded_model = torch.compile(loaded_model, fullgraph=True)
-
-        awq_out = torch.cat([m(d.squeeze(0)) for d in dataset])
-        awq_save_load_out = torch.cat([loaded_model(d.squeeze(0)) for d in dataset])
-
-        assert awq_out is not None
-        assert awq_save_load_out is not None
-        assert torch.allclose(awq_out, awq_save_load_out, atol=1e-2)
-
+instantiate_parametrized_tests(TestAWQ)
 
 if __name__ == "__main__":
     run_tests()

--- a/torchao/prototype/awq/core.py
+++ b/torchao/prototype/awq/core.py
@@ -75,11 +75,13 @@ class AWQObserver(torch.nn.Module):
 
         best_loss = float("inf")
         best_scales = None
+
         for i in range(self.scale_options):
             ratio = i * 1 / self.scale_options
             scales = x_max.pow(ratio).to(self.weight.dtype).clamp(min=1e-4).view(-1)
             if best_scales is None:
-                best_scales = scales
+                best_scales = torch.ones_like(scales)
+
             scales = scales / (scales.max() * scales.min()).sqrt()
             config_handler = _QUANTIZE_CONFIG_HANDLER[type(self.base_config)]
             dummy_mod = DummyModule(self.weight * scales)

--- a/torchao/quantization/quantize_/workflows/int4/int4_tile_packed_to_4d_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_tile_packed_to_4d_tensor.py
@@ -6,7 +6,7 @@
 
 
 import math
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -44,6 +44,11 @@ class Int4TilePackedTo4dTensor(TorchAOBaseTensor):
                    for example groupwise quantization will have block_size (1, group_size)
         shape: shape of the original Tensor
 
+    Optional Tensor Data Attributes:
+        act_pre_scale (Optional[Tensor]): Optional scale for activation Tensor, if present,
+               we'll multiply activation Tensor with act_pre_scale before applying dynamic
+               quantization to activation or running quantized mm op
+
     Note on Details for tile packed to 4d packing format:
 
       This is used by tinygemm kernels `_weight_int4pack_mm`. The weight is stored as
@@ -53,6 +58,7 @@ class Int4TilePackedTo4dTensor(TorchAOBaseTensor):
 
     tensor_data_names = ["qdata", "scale_and_zero"]
     tensor_attribute_names = ["block_size", "shape"]
+    optional_tensor_data_names = ["act_pre_scale"]
 
     def __new__(
         cls,
@@ -60,6 +66,7 @@ class Int4TilePackedTo4dTensor(TorchAOBaseTensor):
         scale_and_zero: torch.Tensor,
         block_size: List[int],
         shape: torch.Size,
+        act_pre_scale: Optional[torch.Tensor] = None,
     ):
         kwargs = {}
         kwargs["device"] = qdata.device
@@ -73,13 +80,18 @@ class Int4TilePackedTo4dTensor(TorchAOBaseTensor):
         scale_and_zero: torch.Tensor,
         block_size: List[int],
         shape: torch.Size,
+        act_pre_scale: Optional[torch.Tensor] = None,
     ):
         self.qdata = qdata
         self.scale_and_zero = scale_and_zero
         self.block_size = block_size
+        self.act_pre_scale = act_pre_scale
 
     def _quantization_type(self):
-        return f"shape={self.shape}, block_size={self.block_size}, device={self.device}"
+        s = f"shape={self.shape}, block_size={self.block_size}, device={self.device}"
+        if self.act_pre_scale is not None:
+            s += f", act_pre_scale.shape={self.act_pre_scale.shape}"
+        return s
 
     @classmethod
     def from_hp(
@@ -214,11 +226,12 @@ class Int4TilePackedTo4dTensor(TorchAOBaseTensor):
 
         scale_and_zero = pack_tinygemm_scales_and_zeros(scale, zero_point, scale.dtype)
 
-        return cls(
+        return Int4TilePackedTo4dTensor(
             qdata=packed_weight,
             scale_and_zero=scale_and_zero,
             block_size=block_size,
             shape=original_shape,
+            act_pre_scale=None,
         )
 
 
@@ -246,9 +259,12 @@ def _(func, types, args, kwargs):
         f"dim to match weight_tensor shape: {weight_tensor.shape} second dim "
     )
 
+    if weight_tensor.act_pre_scale is not None:
+        input_tensor = input_tensor * weight_tensor.act_pre_scale
+
     # weight is packed from padded (out_features, in_features) weight tensor
     # (same dimension requirement as F.linear weight)
-    packed_weight = weight_tensor.qdata
+    qdata = weight_tensor.qdata
     scale_and_zero = weight_tensor.scale_and_zero
     original_shape = weight_tensor.shape
 
@@ -266,7 +282,7 @@ def _(func, types, args, kwargs):
         y = act_mat
     else:
         y = torch.ops.aten._weight_int4pack_mm(
-            act_mat, packed_weight, groupsize, scale_and_zero
+            act_mat, qdata, groupsize, scale_and_zero
         )
     # remove out_feature padding
     orig_out_features = original_shape[-2]
@@ -313,6 +329,7 @@ def _(func, _types, args, _kwargs):
             self.scale_and_zero,
             self.block_size,
             self.shape,
+            act_pre_scale=self.act_pre_scale,
         )
 
     pw_ratio = data_len / pw_len
@@ -338,6 +355,7 @@ def _(func, _types, args, _kwargs):
         scale_and_zero,
         block_size,
         new_shape,
+        act_pre_scale=self.act_pre_scale,
     )
 
 


### PR DESCRIPTION
Summary:
att, similar to https://github.com/pytorch/ao/pull/2997 we add `act_pre_scale` as an optional Tensor data attribute to `Int4TilePackedTo4dTensor`, enabling AWQ support for this tensor

Test Plan:
```
python test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py
python test/prototype/test_awq.py
```

Reviewers:

Subscribers:

Tasks:

Tags: