### PR TITLE
[mxfp8 moe training] increase num_warps in mxfp8 a2a comms kernel

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/comms.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/comms.py
@@ -275,7 +275,7 @@ def _mxfp8_on_device_all_to_all_v(
         world_size=input_hdl.world_size,
         BLOCKS_PER_REMOTE_RANK=BLOCKS_PER_REMOTE_RANK,
         BLOCK_SIZE=BLOCK_SIZE,
-        num_warps=1,
+        num_warps=16,
     )
 
     return output


### PR DESCRIPTION
Higher num warps to hide nvlink latency and increase occupancy. Runtime improves by ~13x in benchmark from ~2000ms to ~150ms. (num_warps was originally 16 but changed it to 1 for debugging something, and am now changing it back - just providing context).

Still, perf is much slower than a standalone `all_to_all_single_autograd` - 10ms vs 150ms for shape (16,8192,5120) with 8 splits. However, the benefit is we avoid the d2h sync required to compute input/output splits for all_to_all_single and get them on the CPU/host as the impl requires.

TODO: bench against bf16 a2a triton+symmetric memory impl to verify the dynamic quant saving network bandwidth is actually an improvement in practice.