### PR TITLE
[mxfp8 moe training] mxfp8 a2a with d2h sync

### DIFF
--- a/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
+++ b/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
@@ -7,6 +7,7 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed._functional_collectives import (
+    all_to_all_single,
     all_to_all_single_autograd,
 )
 from torch.nn import functional as F
@@ -23,13 +24,14 @@ from torchao.float8.float8_utils import (
 )
 from torchao.prototype.moe_training.kernels.mxfp8.comms import (
     mxfp8_on_device_all_to_all_v,
+    to_mxfp8_a2a_dequant,
 )
 
 from ..testing_utils import generate_split_sizes
 
 
 @instantiate_parametrized_tests
-class MXFP8AllToAllVTest(MultiProcessTestCase):
+class MXFP8OnDeviceAllToAllVTest(MultiProcessTestCase):
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -131,6 +133,127 @@ class MXFP8AllToAllVTest(MultiProcessTestCase):
             ref_loss = F.mse_loss(ref_output, labels)
             loss.backward()
             ref_loss.backward()
+
+            # Compare grads
+            grad_sqnr = compute_error(ref_input_tensor.grad, input_tensor.grad)
+            min_grad_sqnr = 28.0
+            assert grad_sqnr > min_grad_sqnr, (
+                f"grad_sqnr={grad_sqnr} is less than min_grad_sqnr={min_grad_sqnr}"
+            )
+
+        finally:
+            dist.destroy_process_group()
+
+
+@instantiate_parametrized_tests
+class ToMXFP8AllToAllVDequantTest(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.manual_seed(42 + self.rank)
+
+    def _init_device(self):
+        symm_mem.set_backend("NVSHMEM")
+
+    def test_a2a_fwd_bwd(self):
+        self._init_process()
+        try:
+            torch.manual_seed(42 + self.rank)
+            self._init_device()
+
+            group_name = dist.group.WORLD.group_name
+            symm_mem.enable_symm_mem_for_group(group_name)
+
+            tokens_per_ep_rank = 8192
+            dim = 2048
+            input_tensor = torch.randn(
+                tokens_per_ep_rank,
+                dim,
+                device=self.device,
+                dtype=torch.float32,
+                requires_grad=True,
+            )
+            ref_input_tensor = input_tensor.detach().clone().requires_grad_(True)
+
+            # Generate random input splits that sum to tokens_per_ep_rank
+            experts_per_rank = 2
+            num_splits = experts_per_rank * self.world_size
+            num_tokens_per_expert = generate_split_sizes(
+                num_splits, tokens_per_ep_rank, self.device
+            )
+
+            ep_degree = self.world_size
+
+            # Compute tokens per expert group using tokens per expert
+            with torch.no_grad():
+                num_tokens_per_expert_group = all_to_all_single(
+                    num_tokens_per_expert,
+                    None,
+                    None,
+                    group=dist.group.WORLD,
+                )
+                # Need to wait explicitly because it is used by a triton kernel later
+                # which doesn't realize that AsyncCollectiveTensor needs unwrapping
+                num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
+                    num_tokens_per_expert_group
+                )
+                input_splits = (
+                    num_tokens_per_expert.view(ep_degree, -1)
+                    .sum(dim=1)
+                    .to(torch.device("cpu"), non_blocking=True)
+                )
+                # NOTE: this would incur a device-to-host sync
+                output_splits = (
+                    num_tokens_per_expert_group.view(ep_degree, -1)
+                    .sum(dim=1)
+                    .to(torch.device("cpu"), non_blocking=False)
+                )
+
+            # Compute reference a2a autograd
+            ref_output = all_to_all_single_autograd(
+                ref_input_tensor,
+                output_splits.tolist(),
+                input_splits.tolist(),
+                dist.group.WORLD,
+            )
+
+            # Compute mxfp8 a2a sync
+            output = to_mxfp8_a2a_dequant(
+                input_tensor,
+                output_splits.tolist(),
+                input_splits.tolist(),
+                group_name,
+            )
+
+            # Compare output
+            sqnr = compute_error(ref_output, output)
+            min_sqnr = 30.0
+            assert sqnr > min_sqnr, f"sqnr={sqnr} is less than min_sqnr={min_sqnr}"
+
+            # Test backwards
+            labels = torch.ones_like(output)
+            ref_loss = F.mse_loss(ref_output, labels)
+            loss = F.mse_loss(output, labels)
+            ref_loss.backward()
+            loss.backward()
 
             # Compare grads
             grad_sqnr = compute_error(ref_input_tensor.grad, input_tensor.grad)

--- a/torchao/prototype/moe_training/kernels/mxfp8/comms.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/comms.py
@@ -3,6 +3,9 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
+from torch.distributed._functional_collectives import (
+    all_to_all_single,
+)
 
 from torchao.prototype.moe_training.kernels.triton_utils import (
     blockwise_barrier,
@@ -31,12 +34,6 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
     # Maximum output length (need to be set before use of MXFP8OnDeviceAllToAllV)
     max_output_rows_per_rank = None
 
-    # A preallocated buffer for holding the output, that can be reused without cudaMalloc/cudaFree each iteration
-    output_buf = None
-
-    # A preallocated buffer for holding the output scales, that can be reused without cudaMalloc/cudaFree each iteration
-    output_scales_buf = None
-
     # A preallocated buffer for holding the grad_input, that can be reused without cudaMalloc/cudaFree each iteration
     grad_input_buf = None
 
@@ -47,6 +44,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
     grad_input_splits_buf = None
 
     @staticmethod
+    @torch.compiler.disable
     def forward(
         ctx,
         input: torch.Tensor,
@@ -165,6 +163,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         return hp_output_no_padding, output_splits
 
     @staticmethod
+    @torch.compiler.disable
     def backward(ctx, grad_output, grad_splits):
         """
         Backward is implemented as a shuffle of the output's gradients to the input.
@@ -455,3 +454,116 @@ def _exchange_row_offsets(
     output_offset_for_remote_rank = tl.sum(output_split_sizes)
 
     return input_offset_for_remote_rank, output_offset_for_remote_rank, num_rows_to_read
+
+
+class ToMXFP8AllToAllVDequant(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        output_splits: list[int],
+        input_splits: list[int],
+        group: dist.ProcessGroup = dist.group.WORLD,
+    ):
+        """
+        Dynamically quantizes input to mxfp8, performs all-to-all, then dequantizes output back to original precision.
+        Requires d2h sync to get input_splits and output_splits on host, as required by torch.distributed.all_to_all_single API.
+        """
+
+        # Quantize input
+        block_size = 32
+        input_scales, input_data = to_mx(
+            input,
+            elem_dtype=torch.float8_e4m3fn,
+            block_size=block_size,
+        )
+
+        # Dispatch data (async)
+        output_data = all_to_all_single(
+            input_data,
+            output_split_sizes=output_splits,
+            input_split_sizes=input_splits,
+            group=group,
+        )
+
+        # Dispatch scales (async)
+        output_scales = all_to_all_single(
+            input_scales.view(torch.uint8),  # NCCL cannot handle float8_e8m0fnu yet
+            output_split_sizes=output_splits,
+            input_split_sizes=input_splits,
+            group=group,
+        )
+
+        # Explicitly wait since the a2a ops are async
+        output_scales = torch.ops._c10d_functional.wait_tensor(output_scales)
+        output_data = torch.ops._c10d_functional.wait_tensor(output_data)
+
+        # Dequantize output
+        lowp_dtype = output_data.dtype
+        hp_dtype = input.dtype
+        hp_output = to_dtype(
+            output_data,
+            output_scales.view(torch.float8_e8m0fnu),
+            lowp_dtype,
+            block_size,
+            hp_dtype,
+        )
+
+        ctx.input_splits = input_splits
+        ctx.output_splits = output_splits
+        ctx.group = group
+        return hp_output
+
+    @staticmethod
+    def backward(ctx, grad_output_hp):
+        """
+        Backward is implemented as a shuffle of the output's gradients to the input.
+        Args:
+            `grad_output_hp`: high precision output gradient passed from upstream
+        """
+        # In backward, mxfp8_all_to_all_v input is `grad_output`, and output is `grad_input`.
+        # Input splits are the output splits from forward (and vice-versa).
+        input_splits, output_splits = ctx.input_splits, ctx.output_splits
+
+        # Quantize grad_output
+        block_size = 32
+        grad_out_scales, grad_out_data = to_mx(
+            grad_output_hp,
+            elem_dtype=torch.float8_e4m3fn,
+            block_size=block_size,
+        )
+
+        # Dispatch data (async)
+        grad_input_data = all_to_all_single(
+            grad_out_data,
+            output_split_sizes=input_splits,
+            input_split_sizes=output_splits,
+            group=ctx.group,
+        )
+
+        # Dispatch scales (async)
+        grad_input_scales = all_to_all_single(
+            grad_out_scales.view(torch.uint8),  # NCCL cannot handle float8_e8m0fnu yet
+            output_split_sizes=input_splits,
+            input_split_sizes=output_splits,
+            group=ctx.group,
+        )
+
+        # Explicitly wait since the a2a ops are async
+        grad_input_scales = torch.ops._c10d_functional.wait_tensor(grad_input_scales)
+        grad_input_data = torch.ops._c10d_functional.wait_tensor(grad_input_data)
+
+        hp_dtype = grad_output_hp.dtype
+        lowp_dtype = grad_input_data.dtype
+        grad_input_hp = to_dtype(
+            grad_input_data,
+            grad_input_scales.view(torch.float8_e8m0fnu),
+            lowp_dtype,
+            block_size,
+            hp_dtype,
+        )
+        return grad_input_hp, None, None, None
+
+
+# Alias
+to_mxfp8_a2a_dequant = ToMXFP8AllToAllVDequant.apply


### PR DESCRIPTION
## Summary
- Add differentiable mxfp8 a2a implemented using all_to_all_single functional collective, which requires the caller do a d2h sync to get input_splits/output_splits on the host, as required by the all_to_all_single API.
- This is in contrast to "on device / sync-free"  impl using Triton + Symmetric memory (#3088) which theoretically should achieve better performance in a model like **experimental** DSV3 in torchtitan, which natively supports overallocated symmetric memory buffers for data exchange of `inputs` (fwd) and `grad_output` (bwd), and passes these padded buffers through the rest of the downstream grouped_mm, scatter_add etc ops. This approach is experimental because if there is sufficient expert load skew at some point during the training run and the overallocated sym mem buffs are not large enough, the run will crash.
- Non-experimental titan dsv3/llama4 do NOT use this method, opting instead to do a d2h sync in order to allocate the exact memory needed for incoming tokens. In such an approach, the mxfp8 on device kernel is actually worse, because it must do a d2h sync to do an expensive, synchronizing aten::item (slice op) to get the actual received tokens from the overallocated buffer (both in fwd and bwd). 
- Therefore, we implement this simpler mxfp8 a2a sync kernel, which has the exact same approach as the non-experimental models in titan described above, only we quant/dequant the inputs outputs.

## Test plan
- Added test case: `pytest test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py  -k MXFP8AllToAllVSyncTest` 

## Benchmarks

Baseline: 4916us
Mxfp8 sync a2a: 4207us (~1.17x speedup)

mxfp8 perf is basically the same as bf16 baseline. Looking at traces to find out why, we can see the all_to_alls themselves (fp8 data and e8m0 scales) are 1.51x faster than the bf16 a2a at 4916us vs (3167+81)=3248us, but the quant/dequant ops are consuming the entire 

bf16 trace:
<img width="1066" height="79" alt="Screenshot 2025-09-30 at 10 57 12 AM" src="https://github.com/user-attachments/assets/45fd5820-4a70-4bb8-b372-ba4205e3f10d" />

mxfp8 trace:
<img width="1440" height="119" alt="Screenshot 2025-09-30 at 10 58 46 AM" src="https://github.com/user-attachments/assets/d9f93480-581b-4f41-9683-e990ab740543" />


