### PR TITLE
[not4land] TorchAOBaseTensor BC Testing - Add a new optional attribute

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -99,6 +99,7 @@ class Float8Tensor(TorchAOBaseTensor):
         "act_quant_kwargs",
         "kernel_preference",
         "dtype",
+        "test_only_new_attr",
     ]
 
     def __new__(
@@ -110,6 +111,7 @@ class Float8Tensor(TorchAOBaseTensor):
         act_quant_kwargs: Optional[QuantizeTensorToFloat8Kwargs] = None,
         kernel_preference: KernelPreference = KernelPreference.AUTO,
         dtype: Optional[torch.dtype] = None,
+        test_only_new_attr: Optional[int] = None,
     ):
         shape = qdata.shape
         kwargs = {}
@@ -127,6 +129,7 @@ class Float8Tensor(TorchAOBaseTensor):
         act_quant_kwargs: Optional[QuantizeTensorToFloat8Kwargs] = None,
         kernel_preference: KernelPreference = KernelPreference.AUTO,
         dtype: Optional[torch.dtype] = None,
+        test_only_new_attr: Optional[int] = None,
     ):
         super().__init__()
         self.qdata = qdata
@@ -135,6 +138,7 @@ class Float8Tensor(TorchAOBaseTensor):
         self.mm_config = mm_config
         self.act_quant_kwargs = act_quant_kwargs
         self.kernel_preference = kernel_preference
+        self.test_only_new_attr = test_only_new_attr
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Summary:
Planning to put up a series of BC testing PRs to understand / showcase what kind of changes are BC for Tensors inheriting from TorchAOBaseTensor

Test Plan:
CI, specifically:

python test/integration/test_load_and_run_checkpoint.py

Reviewers:

Subscribers:

Tasks:

Tags: