### PR TITLE
[moe training] update llama4 bench script to handle torchtitan new log format

### DIFF
--- a/benchmarks/float8/training/parse_torchtitan_logs.py
+++ b/benchmarks/float8/training/parse_torchtitan_logs.py
@@ -23,7 +23,7 @@ def main(args: Namespace):
     print(" Calculating training performance metrics")
     print("=====================================================")
 
-    log_pattern = re.compile(r"step: (\d+).*?memory: ([\d.]+)GiB.*?tps: ([\d,]+)")
+    log_pattern = re.compile(r"step:.*?(\d+).*?memory:.*?([\d.]+)GiB.*?tps:.*?([\d,]+)")
 
     assert os.path.exists(args.log_file), f"{args.log_file} does not exist"
 


### PR DESCRIPTION
Torchtitan logs now output an extra space between some sections, which breaks the regex in this log parsing script. 

Updated regex to be more flexible to fix and avoid this happening again.