### PR TITLE
make scale shape 2d and match qdata shape in NVFP4Tensor

### DIFF
--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -529,14 +529,8 @@ def test_nvfp4_to_copy():
 
 
 @pytest.mark.parametrize("transpose", [False, True])
-# @pytest.mark.parametrize("transpose", [True])
-# @pytest.mark.parametrize("transpose", [False])
 @pytest.mark.parametrize("use_triton_kernel", [False, True])
-# @pytest.mark.parametrize("use_triton_kernel", [False])
-# @pytest.mark.parametrize("use_triton_kernel", [True])
 @pytest.mark.parametrize("is_swizzled_scales", [False, True])
-# @pytest.mark.parametrize("is_swizzled_scales", [False])
-# @pytest.mark.parametrize("is_swizzled_scales", [True])
 @pytest.mark.parametrize(
     "mk",
     (
@@ -546,7 +540,6 @@ def test_nvfp4_to_copy():
         (128 + 16, 64 + 16),
     ),
 )
-# @pytest.mark.parametrize("mk", ((128 + 16, 64),))
 def test_scale_shape_matches_qdata(
     transpose, use_triton_kernel, is_swizzled_scales, mk
 ):
@@ -557,9 +550,6 @@ def test_scale_shape_matches_qdata(
 
     block_size = 16
 
-    # TODO(this PR): test larger tensors that don't exactly map to (128, 64) tiles,
-    # to test the padding logic
-    # context: https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout
     x_hp = torch.randn(M, K, device="cuda")
     x = NVFP4Tensor.to_nvfp4(
         x_hp, is_swizzled_scales=is_swizzled_scales, use_triton_kernel=use_triton_kernel

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -528,6 +528,10 @@ def test_nvfp4_to_copy():
     assert y.dtype == torch.bfloat16
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
+)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize("use_triton_kernel", [False, True])
 @pytest.mark.parametrize("is_swizzled_scales", [False, True])
@@ -543,6 +547,8 @@ def test_nvfp4_to_copy():
 def test_scale_shape_matches_qdata(
     transpose, use_triton_kernel, is_swizzled_scales, mk
 ):
+    if use_triton_kernel and not is_sm_at_least_100():
+        pytest.skip("CUDA capability >= 10.0 required for nvfp4 triton kernel")
     if use_triton_kernel and not is_swizzled_scales:
         pytest.skip("triton kernel requires swizzled scales")
 

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -383,8 +383,10 @@ def nvfp4_slice(func, types, args, kwargs):
 
     M, K = x.shape[0], x.shape[1]
 
-    # the scale manipulations below assume a flattened scale
-    # TODO(future or this PR): update this
+    # The scale manipulations below assume a flattened scale. For now, we
+    # flatten the scale, go through the calculations below, and then reshape
+    # it back to the format which matches the shape of `qdata`.
+    # TODO(future PR): update this
 
     if x._is_swizzled_scales:
         scale_rows = M

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -110,7 +110,7 @@ def hp_data_dims_to_swizzled_scale_dims_nvfp4(
     returns a 2d tuple of the dims of the swizzled nvfp4 scale corresponding to
     that tensor.
     """
-    # a 128x64 unpacked or 128x64 packed qdata tile corresponds
+    # a 128x64 unpacked or 128x32 packed qdata tile corresponds
     # to a swizzled 32x16 scale tile
     scale_M = ceil_div(hp_data_M, 128) * 32
     scale_K = ceil_div(hp_data_K, 64) * 16

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Tuple
+
 import torch
 from torch.distributed._tensor import DTensor
 
@@ -97,6 +99,22 @@ def from_blocked(
     padded = padded_view.reshape(n_row_blocks * 128, n_col_blocks * 4)
 
     return padded[:original_rows, :original_cols]
+
+
+def hp_data_dims_to_swizzled_scale_dims_nvfp4(
+    hp_data_M,
+    hp_data_K,
+) -> Tuple[int, int]:
+    """
+    Given the `M` and `K` dimensions of a high precision contiguous tensor,
+    returns a 2d tuple of the dims of the swizzled nvfp4 scale corresponding to
+    that tensor.
+    """
+    # a 128x64 unpacked or 128x64 packed qdata tile corresponds
+    # to a swizzled 32x16 scale tile
+    scale_M = ceil_div(hp_data_M, 128) * 32
+    scale_K = ceil_div(hp_data_K, 64) * 16
+    return scale_M, scale_K
 
 
 def _to_blocked_single(scales: Tensor) -> Tensor:


### PR DESCRIPTION
Summary:

Makes `NVFP4Tensor._scale_e4m3` shape be consistent with `NVFP4Tensor.shape`.  Specifically:

1. if the scales are not swizzled, contiguous data shape `(M, K)` corresponds to scale shape `(M, K // 16)`
2. if the scales are swizzled, contiguous data shape `(M, K)` corresponds to scale shape `(ceil_div(M, 128) * 32, ceil_div(K, 64) * 16)`

If we transpose axes 0 and 1, both qdata and scale now get transposed.

I want this because we need to reason about scales when combining 2d MoE weights into 3d weights, and having the scale shape match the data will make that reasoning easier (in a future PR).

Test Plan:

tests pass on a B200:

```bash
pytest test/prototype/mx_formats/ -s
```

also, a dense model quantized with torchao nvfp4 runs in vLLM before and after this PR


Reviewers:

Subscribers:

Tasks:

Tags: