### PR TITLE
mxfp4 and nvfp4: align fp4 packing to PyTorch Core definition

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -70,9 +70,9 @@ def test_inference_workflow_mx(elem_dtype, bias: bool, compile: bool, emulate: b
     elif elem_dtype == torch.float4_e2m1fn_x2:
         if not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
-        elif emulate and compile:
+        elif compile:
             # TODO(future PR): investigate and fix this
-            pytest.skip("mxfp4 + emulate + compile currently does not work, low SQNR")
+            pytest.skip("mxfp4 + compile currently does not work, low SQNR")
 
     m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
     m_mx = copy.deepcopy(m)

--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -320,6 +320,26 @@ def test_fp4_pack_unpack():
     orig_vals = torch.Tensor([[0.0, 0.5, 4.0, -0.0], [-0.0, 1.0, -6.0, 3.0]])
     orig_vals_f4_unpacked = f32_to_f4_unpacked(orig_vals)
     orig_vals_f4_packed = pack_uint4(orig_vals_f4_unpacked)
+
+    # ensure packing is
+    #
+    #   7654:3210
+    #   val1:val0
+    expected_f4_packed = torch.tensor(
+        [
+            [
+                0b00010000,
+                0b10000110,
+            ],
+            [
+                0b00101000,
+                0b01011111,
+            ],
+        ],
+        dtype=torch.uint8,
+    )
+
+    assert torch.all(orig_vals_f4_packed == expected_f4_packed)
     assert orig_vals_f4_packed.numel() == (orig_vals.numel() / 2)
     orig_vals_f4_packed_unpacked = unpack_uint4(orig_vals_f4_packed)
     orig_vals_dq = f4_unpacked_to_f32(orig_vals_f4_packed_unpacked)


### PR DESCRIPTION
Summary:

Switches fp4 packing from `val0:val1` to `val1:val0`, to align with how
`torch.float4_e2m1fn_x2` is defined, and how other frameworks do this.

For context, please see the docblock of the `Float4_e2m1fn_x2` object
from https://github.com/pytorch/pytorch/pull/148791/files

Test Plan:

```bash
pytest test/prototype/mx_formats/ -s -x
```

Reviewers:

Subscribers:

Tasks:

Tags: