### PR TITLE
Fix rocm CI

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: ROCM Nightly
             runs-on: linux.rocm.gpu.gfx942.2
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3'
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.0'
             gpu-arch-type: "rocm"
-            gpu-arch-version: "6.3"
-            docker-image: pytorch/manylinux2_28-builder:rocm6.3
+            gpu-arch-version: "7.0"
+            docker-image: pytorch/manylinux2_28-builder:rocm7.0
 
     permissions:
       id-token: write


### PR DESCRIPTION
Due to the recent version bump to python 3.10, and torch nightlies 2.10.0dev, rocm 6.3 has support errors. Minimum supported version is 7.0