### PR TITLE
Fix pt2e test_qat_preserve_source_fn_stack

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -686,12 +686,6 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
         self.assertNotEqual(get_source_fn(second_conv), get_source_fn(second_relu))
         self.assertNotEqual(get_source_fn(first_relu), get_source_fn(second_relu))
 
-        # Assert that "backbone" exists only in the second set of conv and relu's partition
-        self.assertTrue("backbone" not in get_source_fn(first_conv))
-        self.assertTrue("backbone" not in get_source_fn(first_relu))
-        self.assertTrue("backbone" in get_source_fn(second_conv))
-        self.assertTrue("backbone" in get_source_fn(second_relu))
-
     def test_qat_conv_bn_bias_derived_qspec(self):
         m = self._get_conv_bn_model()
         example_inputs = self.example_inputs


### PR DESCRIPTION
**Summary:** A recent change in `torch.export` now inlines the submodules in the `source_fn_stack`. We should adjust our test accordingly to unbreak CI.

**Test Plan:**
python test/quantization/pt2e/test_quantize_pt2e_qat.py -k test_qat_preserve_source_fn_stack