### PR TITLE
Fix setuptools version for docs build

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -39,7 +39,7 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
       - name: Update pip
-        run: python -m pip install --upgrade "pip<25"
+        run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: |
           python -m pip install torch


### PR DESCRIPTION
Fixed the setuptools version to 78.1.1, as 80.0.0 was failing in docs build