### PR TITLE
Fix broken test_affine_quantized_tensor_parallel test after DeviceMesh

### DIFF
--- a/test/dtypes/test_affine_quantized_tensor_parallel.py
+++ b/test/dtypes/test_affine_quantized_tensor_parallel.py
@@ -115,7 +115,7 @@ class TestAffineQuantizedTensorParallel(DTensorTestBase):
         dn_quant(up_quant(example_input))
 
         mesh = self.build_device_mesh()
-        mesh.device_type = "cuda"
+        mesh._device_type = "cuda"
 
         # Shard the models
         up_dist = self.colwise_shard(up_quant, mesh)


### PR DESCRIPTION
This stack made DeviceMesh public attributes read only as they normally shouldn't be modified after init: https://github.com/pytorch/pytorch/pull/164954

So we need to set the backing private attribute `mesh._device` instead of `mesh.device` in this test now to fix it.