### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies
+        env:
+            USE_CPP: "0"
         run: |
           python -m pip install torch
           python -m pip install -e .


### PR DESCRIPTION
Docs don't require our cpp kernels, so skip building with these to unbreak our CI for now.