### PR TITLE
Add parq utility to create an optimizer

### DIFF
--- a/torchao/prototype/parq/api.py
+++ b/torchao/prototype/parq/api.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+import torch
 
 from torchao.prototype.parq.optim import QuantOptimizer
 from torchao.prototype.parq.quant import (
@@ -29,7 +31,12 @@ class QuantConfig:
             object.__setattr__(self, "quantizer", q)
 
 
-def create_param_groups_and_group_quantizer_map(model, quant_configs_and_filter_fns):
+def create_param_groups_and_group_quantizer_map(
+    model: torch.nn.Module,
+    quant_configs_and_filter_fns: List[
+        Tuple[QuantConfig, Callable[[torch.nn.Module, str], bool]]
+    ],
+):
     param_groups = []
     group_quantizer_map = {}
     for idx, (config, _) in enumerate(quant_configs_and_filter_fns):
@@ -111,14 +118,16 @@ from torchao.prototype.parq import ProxHardQuant
 
 
 def create_optimizer(
-    model,
-    quant_configs_and_filter_fns,
-    base_optimizer_cls,
-    base_optimizer_kwargs,
+    model: torch.nn.Module,
+    quant_configs_and_filter_fns: List[
+        Tuple[QuantConfig, Callable[[torch.nn.Module, str], bool]]
+    ],
+    base_optimizer_cls: Type[torch.optim.Optimizer],
+    base_optimizer_kwargs: Dict[str, Any],
     *,
-    warmup_steps=0,
-    quant_period=1,
-    quant_per_channel=True,
+    warmup_steps: int = 0,
+    quant_period: int = 1,
+    quant_per_channel: bool = True,
 ):
     param_groups, group_quantizer_map = create_param_groups_and_group_quantizer_map(
         model, quant_configs_and_filter_fns


### PR DESCRIPTION
Adds utility to create an optimizer like this:

```
quant_configs_and_filter_fns = [
    (QuantConfig(bitwidth=2, group_size=128), use_2bit),
    (QuantConfig(bitwidth=3, group_size=256), use_3bit),
    (QuantConfig(bitwidth=4, group_size=256), use_4bit),
    (QuantConfig(bitwidth=8), use_8bit),
 ]

optimizer = create_optimizer(model, quant_configs_and_filter_fns, base_optimizer_cls, base_optimizer_kwargs)
```

The filter functions are (module, fqn) -> bool, e.g.,

```
def use_2bit(m, fqn):
        if not fqn.endswith(".weight"):
            return False

        # Layers 0-3
        for i in range(4):
            if fqn.startswith(f"model.layers.{i}."):
                for key in ["v_proj", "gate_proj", "up_proj"]:
                    if key in fqn:
                        return True

        # Layers 4-31
        for i in range(4, 32):
            if fqn.startswith(f"model.layers.{i}."):
                for key in ["q_proj", "v_proj", "gate_proj", "up_proj", "down_proj"]:
                    if key in fqn:
                        return True

        return False
```