### PR TITLE
Fix gradient explosion in bfloat16+float8 rowwise quantization

### DIFF
--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -66,6 +66,9 @@ def tensor_to_amax(
     else:
         assert scaling_granularity is ScalingGranularity.AXISWISE, "unsupported"
         assert axiswise_dim is not None, "unsupported"
+        # Fix for bfloat16 precision amplification in amax_to_scale()
+        if x.dtype == torch.bfloat16:
+            x = torch.abs(x).to(torch.float32)
         amax = torch.amax(torch.abs(x), dim=axiswise_dim, keepdim=True)
 
     # If the user asked for distributed reduction, do it.


### PR DESCRIPTION
Stacked PRs:
 * __->__#3171
--- --- ---
Fixes a numerical instability bug in float8 rowwise quantization that causes gradient norm explosion and training
divergence when using bfloat16 model precision. The issue affects the combination of bfloat16 models with float8
rowwise configuration.

Issue:
  - Gradient norms explode to nan and only affects: bfloat16 model + float8 rowwise quantization
  - Works fine: fp32 models + float8 rowwise quantization

The issue is [`amax_to_scale`](https://github.com/pytorch/ao/blob/838dcebb13be7cd7b7ae5d1d8c4e674c89a5d7b8/torchao/float8/float8_utils.py#L43-L45) upscales `amax` to fp64 which creates precision error. Rowwise uses power-of-2 scaling which amplifies the error, leading to nan gradients.

Fix: converted bfloat16 tensors to float32 before amax computation instead of removing the float64 upcast, so existing flow is not affected.

To test: change this line https://github.com/pytorch/torchtitan/blob/248aca2cac54b4ce5d1cd460dd6ec187a8c276b3/torchtitan/train.py#L153
 to `model = self.train_spec.model_cls(model_args).to(torch.bfloat16)` and run this command in torchtitan

```bash
TORCH_TRACE=logs NGPU=1 CONFIG_FILE="./torchtitan/models/llama3/train_configs/debug_model.toml" ./run_train.sh --training.steps=10 --model.converters="quantize.linear.float8" --quantize.linear.float8.recipe-name="rowwise" --compile.enable --activation_checkpoint.mode="selective" --activation_checkpoint.selective_ac_option="op" --metrics.log_freq=1
```

before fix:
<img width="1184" height="216" alt="Screenshot 2025-10-13 at 9 00 30 PM" src="https://github.com/user-attachments/assets/8e891803-94f4-4378-863e-ece1c883ac8d" />

After fix
<img width="1184" height="216" alt="Screenshot 2025-10-13 at 8 58 52 PM" src="https://github.com/user-attachments/assets/5304060f-0ef2-4092-a05c-9d397c165c8b" />

Fixes: https://github.com/pytorch/pytorch/issues/150859

