### PR TITLE
fixup missing callsites for _scale_e8m0 -> scale rename

### DIFF
--- a/benchmarks/float8/profile_lowp_training.py
+++ b/benchmarks/float8/profile_lowp_training.py
@@ -392,7 +392,7 @@ def main(
             gemm_kernel_choice=config.gemm_kernel_choice,
         )
         m, k = x_hp.shape
-        scale_blocked = to_blocked(x_mx._scale_e8m0.reshape(m, k // config.block_size))
+        scale_blocked = to_blocked(x_mx.scale.reshape(m, k // config.block_size))
         return x_mx._data, scale_blocked
 
     # this function is used for cast_only_dim0_dim1

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -394,7 +394,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             scale_calculation_mode=ScaleCalculationMode.FLOOR,
         )
         grad_out_t_data = grad_out_t_mx.qdata
-        grad_out_t_scales = grad_out_t_mx._scale_e8m0
+        grad_out_t_scales = grad_out_t_mx.scale
 
         # Transpose A so we can scale along the M dimension, then un-transpose.
         # A shape: (M, K)
@@ -410,7 +410,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             scale_calculation_mode=ScaleCalculationMode.FLOOR,
         )
         A_t_data = A_t_mx.qdata
-        A_t_scales = A_t_mx._scale_e8m0
+        A_t_scales = A_t_mx.scale
 
         # Convert scales to blocked format for 2d-2d grouped mm
         scale_group_offsets = offs // block_size
@@ -463,7 +463,7 @@ def _to_mxfp8_dim1_3d(
     )
     B_data = B_t_mx.qdata.t()  # (K, E*N) -> (E*N, K)
     B_data = B_data.reshape(E, N, K)  # (E*N, K) -> (E, N, K)
-    B_scales = B_t_mx._scale_e8m0.view(torch.uint8)  # (K, E*N//block_size)
+    B_scales = B_t_mx.scale.view(torch.uint8)  # (K, E*N//block_size)
     B_scales = B_scales.reshape(
         K, E, N // block_size
     )  # (K, E*N//block_size) -> (K, E, N//block_size)


### PR DESCRIPTION
Summary:

Missed a couple of callsites in https://github.com/pytorch/ao/pull/3164,
fixing

Missed these

Test Plan:

// all remaining use cases look expected
```bash
cd torchao
grep -r scale_e8m0 .
```

Reviewers:

Subscribers:

Tasks:

Tags: