### PR TITLE
Fix SyntaxWarning during installation / import

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -2317,7 +2317,7 @@ def _fpx_weight_only_transform(
 
 @dataclass
 class ModuleFqnToConfig(AOBaseConfig):
-    """Per module configurations for torchao quantize_ API
+    r"""Per module configurations for torchao quantize_ API
 
     Args:
         `module_fqn_to_config`: typing.OrderedDict[str, Optional[AOBaseConfig]]: an


### PR DESCRIPTION
Summary:
Fixes a regex related syntax warning reported by Daniel / unsloth

Test Plan:
Only verified during installation but should apply for loading as well

```
Before: Extracting torchao-0.15.0+git30082cb3d-py3.12.egg to …/lib/python3.12/site-packages
/data/users/jerryzh/miniconda3/envs/hmbd/lib/python3.12/site-packages/torchao-0.15.0+git30082cb3d-py3.12.egg/torchao/quantization/quant_api.py:2333: SyntaxWarning: invalid escape sequence '\.'
  * regex for module names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj`,
Adding torchao 0.15.0+git30082cb3d to easy-install.pth file
  After: creating …python3.12/site-packages/torchao-0.15.0+git30082cb3d-py3.12.egg
Extracting torchao-0.15.0+git30082cb3d-py3.12.egg to …lib/python3.12/site-packages
Adding torchao 0.15.0+git30082cb3d to easy-install.pth file

Installed …/torchao-0.15.0+git30082cb3d-py3.12.egg
Processing dependencies for torchao==0.15.0+git30082cb3d
Finished processing dependencies for torchao==0.15.0+git30082cb3d
```

Reviewers:

Subscribers:

Tasks:

Tags: