### PR TITLE
Enable SmoothQuant Test on Intel GPU

### DIFF
--- a/test/prototype/test_smoothquant.py
+++ b/test/prototype/test_smoothquant.py
@@ -61,7 +61,12 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-device_list = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+device_list = ["cpu"]
+if torch.cuda.is_available():
+    device_list.append("cuda")
+
+if torch.xpu.is_available():
+    device_list.append("xpu")
 
 
 @unittest.skipIf(torch.version.hip is not None, "Skipping tests in ROCm")


### PR DESCRIPTION
Summary:
We validated the SmoothQuant on Intel GPU and refine the test script to support the XPU. 

 The perplexity of meta-llama/Llama-2-7b-chat-hf is 7.05 on PPL.