### PR TITLE
[mxfp8 moe training] update benchmarks to force load balancing

### DIFF
--- a/benchmarks/prototype/moe_training/bench_moe_layer.py
+++ b/benchmarks/prototype/moe_training/bench_moe_layer.py
@@ -23,10 +23,10 @@ from torchao.quantization.quant_api import quantize_
 
 # this benchmark requires torchtitan
 try:
-    from torchtitan.distributed.expert_parallel import (
+    from torchtitan.models.moe import MoE, MoEArgs
+    from torchtitan.models.moe.utils import (
         set_token_group_alignment_size_m,
     )
-    from torchtitan.models.moe import MoE, MoEArgs
 except ImportError:
     logging.warning(
         "please pip install torchtitan to run this benchmark: https://github.com/pytorch/torchtitan"
@@ -77,6 +77,8 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     target_fqns = ["experts"]
     model_args = MoEArgs(
         num_experts=local_num_experts,
+        num_shared_experts=1,
+        _debug_force_load_balance=True,
     )
     init_std = 0.02
     device = torch.device("cuda")

--- a/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
+++ b/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
@@ -32,10 +32,10 @@ from torchao.quantization.quant_api import quantize_
 
 # this benchmark requires torchtitan
 try:
-    from torchtitan.distributed.expert_parallel import (
+    from torchtitan.models.moe import MoE, MoEArgs
+    from torchtitan.models.moe.utils import (
         set_token_group_alignment_size_m,
     )
-    from torchtitan.models.moe import MoE, MoEArgs
 except ImportError:
     pytest.skip(
         "torchtitan not installed, skipping MoE tests.", allow_module_level=True
@@ -71,6 +71,8 @@ def bench_moe_training_fsdp(recipe_name: str, enable_profile: bool, use_compile:
     target_fqns = ["experts"]
     model_args = MoEArgs(
         num_experts=16,
+        num_shared_experts=1,
+        _debug_force_load_balance=True,
     )
     init_std = 0.02
     device = torch.device("cuda")


### PR DESCRIPTION
Force expert load balancing to simulate steady state MoE training (after early steps load balancing stabilizes).


New benchamarks:

Llama4 16e:

```
CUDA_VISIBLE_DEVICES=7 python benchmarks/prototype/moe_training/bench_moe_layer.py --recipe mxfp8 --local_num_
experts 1 --seq_len 8192 --local_batch_size 16 --hidden_dim 8192 --dim 5120
total_M: 131072, N: 8192, K: 5120
bf16 time: 252.799 ms
mxfp8 time: 185.525 ms
speedup: 1.363x
```

DSV3 671b:
```
CUDA_VISIBLE_DEVICES=7 python benchmarks/prototype/moe_training/bench_moe_layer.py --recipe mxfp8 --local_num_experts 1 --seq_len 8192 --local_batch_size 16 --hidden_dim 2048 --dim 7168
total_M: 131072, N: 2048, K: 7168
bf16 time: 96.285 ms
mxfp8 time: 83.764 ms
speedup: 1.149x
```

