### PR TITLE
require --no-build-isolation in torchao builds

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -8,7 +8,7 @@ export CXX=/usr/bin/g++
 export SCCACHE_DISABLE=1
 
 python3 -m pip install torch torchvision torchaudio pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir 
-cd torchao && python3 setup.py install && cd ..
+cd torchao && pip install . --no-build-isolation && cd ..
 
 python3 -c "import torch; import torchao; print(f'Torch version: {torch.__version__}')"
 

--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -46,7 +46,7 @@ jobs:
         pip install uv
         pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         pytest test/integration --verbose -s
         pytest test/dtypes/test_affine_quantized_float.py --verbose -s
         python test/quantization/quantize_/workflows/float8/test_float8_tensor.py

--- a/.github/workflows/1xL4_tests.yml
+++ b/.github/workflows/1xL4_tests.yml
@@ -46,7 +46,7 @@ jobs:
         pip install uv
         pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         pytest test/integration --verbose -s
         pytest test/dtypes/test_affine_quantized_float.py --verbose -s
         ./test/float8/test_everything_single_gpu.sh

--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -44,6 +44,6 @@ jobs:
         pip install uv
         pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         ./test/float8/test_everything_multi_gpu.sh
         ./test/prototype/mx_formats/test_mx_dtensor.sh

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -8,6 +8,7 @@ on:
       - packaging/**
       - .github/workflows/build_wheels_linux.yml
       - setup.py
+      - .github/scripts/**
   push:
     branches:
       - nightly

--- a/.github/workflows/dashboard_perf_test.yml
+++ b/.github/workflows/dashboard_perf_test.yml
@@ -30,7 +30,7 @@ jobs:
           ${CONDA_RUN} python -m pip install --upgrade pip
           ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
-          ${CONDA_RUN} pip install .
+          ${CONDA_RUN} pip install . --no-build-isolation
           # SAM 2.1
           ${CONDA_RUN} pip install -r examples/sam2_amg_server/requirements.txt
 

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install torch
-          python -m pip install setuptools==78.1.1 --force-reinstall
-          python -m pip install -e .
+          python -m pip install -e . --no-build-isolation
           pip install -r dev-requirements.txt
           python -m pip install -r docs/requirements.txt
       - name: Build docs

--- a/.github/workflows/nightly_smoke_test.yml
+++ b/.github/workflows/nightly_smoke_test.yml
@@ -38,5 +38,5 @@ jobs:
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
-        python setup.py install
+        pip install . --no-build-isolation
         pytest test --verbose -s

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -50,7 +50,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
         pytest test --verbose -s
@@ -114,7 +114,7 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         sed -i '${{ matrix.dev-requirements-overrides }}' dev-requirements.txt
         pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
         pytest test --verbose -s

--- a/.github/workflows/regression_test_aarch64.yml
+++ b/.github/workflows/regression_test_aarch64.yml
@@ -39,7 +39,7 @@ jobs:
           pip install executorch
           pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall
           pip install -r dev-requirements.txt
-          USE_CPP=1 TORCHAO_BUILD_KLEIDIAI=1 pip install .
+          USE_CPP=1 TORCHAO_BUILD_KLEIDIAI=1 pip install . --no-build-isolation
       - name: Install requirements linux
         if: runner.os == 'Linux'
         run: |
@@ -47,7 +47,7 @@ jobs:
           pip install coremltools
           pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall
           pip install -r dev-requirements.txt
-          BUILD_TORCHAO_EXPERIMENTAL=1 TORCHAO_BUILD_CPU_AARCH64=1 TORCHAO_BUILD_KLEIDIAI=1 TORCHAO_ENABLE_ARM_NEON_DOT=1 TORCHAO_PARALLEL_BACKEND=OPENMP pip install .
+          BUILD_TORCHAO_EXPERIMENTAL=1 TORCHAO_BUILD_CPU_AARCH64=1 TORCHAO_BUILD_KLEIDIAI=1 TORCHAO_ENABLE_ARM_NEON_DOT=1 TORCHAO_PARALLEL_BACKEND=OPENMP pip install . --no-build-isolation
       - name: Run python tests
         run: |
           conda activate venv

--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -45,7 +45,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
         pytest test --verbose -s

--- a/.github/workflows/release_model.yml
+++ b/.github/workflows/release_model.yml
@@ -40,7 +40,7 @@ jobs:
         pip install uv
         pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
-        pip install .
+        pip install . --no-build-isolation
         HF_MODEL_ID=${{ github.event.inputs.hf_model_id }}
         cd .github/scripts/torchao_model_releases
         ./release.sh --model_id $HF_MODEL_ID --push_to_hub

--- a/.github/workflows/run_microbenchmarks.yml
+++ b/.github/workflows/run_microbenchmarks.yml
@@ -39,7 +39,7 @@ jobs:
           # Install dependencies
           ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
-          ${CONDA_RUN} pip install .
+          ${CONDA_RUN} pip install . --no-build-isolation
 
           ${CONDA_RUN} ls
           ${CONDA_RUN} bash -c 'pwd'

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -28,6 +28,6 @@ jobs:
           ${CONDA_RUN} python -m pip install --upgrade pip
           ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
-          ${CONDA_RUN} pip install .
+          ${CONDA_RUN} pip install . --no-build-isolation
           cd tutorials
           ${CONDA_RUN} bash run_all.sh

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ pip install torchao
   pip install torchao --index-url https://download.pytorch.org/whl/cpu    # CPU only
 
   # For developers
-  USE_CUDA=1 python setup.py develop
-  USE_CPP=0 python setup.py develop
+  # Note: the `--no-build-isolation` flag is required.
+  USE_CUDA=1 pip install -e . --no-build-isolation
+  USE_CPP=0 pip install -e . --no-build-isolation
   ```
 
 </details>

--- a/packaging/pre_build_script.sh
+++ b/packaging/pre_build_script.sh
@@ -17,4 +17,4 @@ else
 fi
 pip install $PYTORCH_DEP
 
-pip install setuptools wheel twine auditwheel
+pip install setuptools wheel twine auditwheel numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    # TODO(future): consider declaring build-time dependencies such
+    # as `torch` here to enable PEP 517. For now, require the user to
+    # install `torch` in their environment before running the build,
+    # and only support builds with the `--no-build-isolation` flag.
+]
+build-backend = "setuptools.build_meta"

--- a/scripts/test_torch_version_torchao_version_compatibility.sh
+++ b/scripts/test_torch_version_torchao_version_compatibility.sh
@@ -63,7 +63,7 @@ pip uninstall torchao
 # Install specific compatible version of torch (nightly 2.9.0dev)
 pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu129
 # Build torchao from source
-python setup.py develop
+pip install . --no-build-isolation
 # Should import successfully without warning
 check_torchao_import "false" ""
 ## prev torch, torchao from source (do not rebuild), env var = True


### PR DESCRIPTION
Summary:

In recent versions of `setuptools`, the behavior of using PEP 517 (enforce build isolation, https://peps.python.org/pep-0517/) flipped from False to True.  This broke torchao builds as our `setup.py` file depends on not having build isolation, as it imports build extension class definitions from `torch` (https://github.com/pytorch/ao/blob/94dee9c485f9bedad652b6f24ab90dc0dec6cafc/setup.py#L106).

A long term fix would be modernize the torchao build system to honor PEP 517.  However, to unbreak CI and buy us some time, in the short term we can just require build isolation for building torchao. This PR implements the short term workaround.

An AI-generated writeup I used to debug this, with more details: https://gist.github.com/vkuzo/5e6f282fda816c2cd4bce8c7fc1f30e2

Note that I had to add a `pyproject.toml` file to make `pip install .` run without warnings.

Test Plan:

```bash
// both of the commands below work
with-proxy USE_CPP=0 pip install -e . --no-build-isolation
with-proxy USE_CPP=1 pip install -e . --no-build-isolation --verbose

// will check CI
```

Reviewers:

Subscribers:

Tasks:

Tags: