### PR TITLE
fix is metadata func

### DIFF
--- a/torchao/prototype/safetensors/safetensors_utils.py
+++ b/torchao/prototype/safetensors/safetensors_utils.py
@@ -209,7 +209,7 @@ def is_metadata_torchao(metadata: Dict[str, Any]):
 
         # returns None if _type not in tensor_dict
         tensor_type = tensor_dict.get("_type")
-        if tensor_type not in ALLOWED_TENSORS_SUBCLASSES or tensor_type != "Tensor":
+        if tensor_type not in ALLOWED_TENSORS_SUBCLASSES and tensor_type != "Tensor":
             return False
 
     return True


### PR DESCRIPTION
function should only return false if tensors are not in the allowed subclasses **and** if it is not a regular torch.Tensor

**Testing**
`python test/prototype/safetensors/test_safetensors_utils.py` (fails without this change)