### PR TITLE
add accelerate to dev-requirements to fix CI

### DIFF
--- a/test/integration/test_load_and_run_checkpoint.py
+++ b/test/integration/test_load_and_run_checkpoint.py
@@ -239,8 +239,6 @@ class TestLoadAndRunCheckpoint(TestCase):
         with open(downloaded_output, "rb") as f:
             ref_generated_ids = torch.load(f)
 
-        print(generated_ids)
-        print(ref_generated_ids)
         self.assertTrue(torch.equal(generated_ids, ref_generated_ids))
 
         # make sure can successfully decode


### PR DESCRIPTION
att, looks like new version of transformers needs accelerate to support device map:

```
======================================================================
ERROR: test_deprecated_hf_models_model_info3 (__main__.TestLoadAndRunCheckpoint.test_deprecated_hf_models_model_info3)
Test that we print correct warning message when loading a deprecated checkpoint
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jessecai/.conda/envs/ao-A-nightly/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 3224, in wrapper
    method(*args, **kwargs)
  File "/home/jessecai/.conda/envs/ao-A-nightly/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 553, in instantiated_test
    test(self, **param_kwargs)
  File "/home/jessecai/local/A/ao/test/integration/test_load_and_run_checkpoint.py", line 194, in test_deprecated_hf_models
    quantized_model = AutoModelForCausalLM.from_pretrained(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jessecai/.conda/envs/ao-A-nightly/lib/python3.12/site-packages/transformers/models/auto/auto_factory.py", line 604, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jessecai/.conda/envs/ao-A-nightly/lib/python3.12/site-packages/transformers/modeling_utils.py", line 277, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jessecai/.conda/envs/ao-A-nightly/lib/python3.12/site-packages/transformers/modeling_utils.py", line 4806, in from_pretrained
    raise ValueError(
ValueError: Using a `device_map`, `tp_plan`, `torch.device` context manager or setting `torch.set_default_device(device)` requires `accelerate`. You can install it with `pip install accelerate`
```