### PR TITLE
Update config.py to negate the dimension issue for FP8 support for AMD GPUs

### DIFF
--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -187,7 +187,7 @@ class Float8LinearConfig:
     # inner dimension of a (dim 1) and b (dim 2) with 0s. This is needed for matmuls
     # _scaled_mm since it has the strong constraint that for M,N,K  N, K must be a multiple of 16.
     # This can cause a memory spike however so we keep this off by default.
-    pad_inner_dim: bool = False
+    pad_inner_dim: bool = True
 
     # If True, emulation is used instead of hardware accelerated gemm
     emulate: bool = False


### PR DESCRIPTION
Update the config.py file to fix (“negate”) the dimension mismatch issue that arises when enabling FP8 (8-bit floating point) precision support on AMD GPUs.

**Error:**
<img width="1728" height="506" alt="image" src="https://github.com/user-attachments/assets/41a213ce-bd35-4ac5-8670-e82eafdf589a" />