### PR TITLE
[mxfp8 moe training] initialize zero tensor differently to avoid d2h sync

### DIFF
--- a/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
+++ b/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
@@ -73,7 +73,7 @@ class MXFP8OnDeviceAllToAllVTest(MultiProcessTestCase):
                 tokens_per_ep_rank,
                 dim,
                 device=self.device,
-                dtype=torch.float32,
+                dtype=torch.bfloat16,
                 requires_grad=True,
             )
             ref_input_tensor = input_tensor.detach().clone().requires_grad_(True)
@@ -107,7 +107,7 @@ class MXFP8OnDeviceAllToAllVTest(MultiProcessTestCase):
                 total_tokens_on_rank_after_a2a,
                 dim,
                 device=self.device,
-                dtype=torch.float32,
+                dtype=torch.bfloat16,
             )
 
             # Do the actual all_to_all_single
@@ -188,7 +188,7 @@ class ToMXFP8AllToAllVDequantTest(MultiProcessTestCase):
                 tokens_per_ep_rank,
                 dim,
                 device=self.device,
-                dtype=torch.float32,
+                dtype=torch.bfloat16,
                 requires_grad=True,
             )
             ref_input_tensor = input_tensor.detach().clone().requires_grad_(True)

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -175,7 +175,7 @@ def compute_blocked_scale_offsets_for_M_groups(offsets: torch.Tensor):
         - starting_row_after_padding: 1D integer tensor representing the starting row after padding each to blocked format.
     """
     # Calculate group sizes
-    zero = torch.tensor([0], dtype=offsets.dtype, device=offsets.device)
+    zero = torch.zeros(1, dtype=offsets.dtype, device=offsets.device)
     group_sizes = torch.diff(offsets, prepend=zero)
 
     # Round each group size up to the nearest multiple of 128
@@ -203,8 +203,8 @@ def compute_blocked_scale_offsets_for_K_groups(
         - starting_col_after_padding: 1D integer tensor representing the starting row after padding each to blocked format.
     """
     # Calculate group sizes
-    zero = torch.tensor(
-        [0], dtype=scale_group_offsets.dtype, device=scale_group_offsets.device
+    zero = torch.zeros(
+        1, dtype=scale_group_offsets.dtype, device=scale_group_offsets.device
     )
     group_sizes = torch.diff(scale_group_offsets, prepend=zero)
 


### PR DESCRIPTION
- I initialized a scalar "zero" tensor in a silly way which caused a d2h sync. This PR fixes it (see traces below). However, it seems to not have been impactful in practice, since e2e TPS did not change with the PR, but still worth fixing.
- Also updates mxfp8 a2a tests to use bf16 which is what we use in practice


Before change:
<img width="1220" height="242" alt="Screenshot 2025-10-28 at 1 11 24 PM" src="https://github.com/user-attachments/assets/55f457f6-b441-4350-8af4-b40a59139d9c" />

After:
<img width="1011" height="169" alt="Screenshot 2025-10-28 at 1 11 31 PM" src="https://github.com/user-attachments/assets/48a2181e-a3d3-4ec0-ac58-6cda36e4c46b" />
