### PR TITLE
[mxfp8 moe training] compute prefix sum of group sizes inside  kernel intead of precomputing

### DIFF
--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -21,8 +21,6 @@ from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
-    compute_blocked_scale_offsets_for_K_groups,
-    compute_blocked_scale_offsets_for_M_groups,
     torch_to_blocked_2d_K_groups,
     torch_to_blocked_2d_M_groups,
     torch_to_blocked_per_group_3d,
@@ -236,13 +234,9 @@ def test_triton_mx_block_rearrange_2d_M_groups(
     )
 
     # triton kernel
-    _, output_group_offsets = compute_blocked_scale_offsets_for_M_groups(
-        input_group_offsets
-    )
     triton_out_scales = triton_mx_block_rearrange_2d_M_groups(
         e8m0_scales,
         input_group_offsets,
-        output_group_offsets,
     )
     assert torch.allclose(ref_out_scales, triton_out_scales, atol=0, rtol=0), (
         "blocked scales not equal"
@@ -306,16 +300,9 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     )
 
     # triton kernel
-    _, output_group_offsets = compute_blocked_scale_offsets_for_K_groups(
-        scale_group_offsets
-    )
-    assert torch.equal(output_group_offsets, ref_start_cols_after_padding), (
-        "output scale group start offsets not equal"
-    )
     triton_out_scales = triton_mx_block_rearrange_2d_K_groups(
         e8m0_scales,
         scale_group_offsets,
-        output_group_offsets,
     )
     assert torch.equal(ref_out_scales, triton_out_scales), "blocked scales not equal"
 

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -1,6 +1,4 @@
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
-    compute_blocked_scale_offsets_for_K_groups,  # noqa: F401
-    compute_blocked_scale_offsets_for_M_groups,  # noqa: F401
     mxfp8_quantize_cuda_3d,  # noqa: F401
     torch_to_blocked_2d_K_groups,  # noqa: F401
     torch_to_blocked_2d_M_groups,  # noqa: F401

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -17,8 +17,6 @@ from torchao.prototype.moe_training.kernels import (
     triton_fp8_rowwise_3d_transpose_rhs,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
-    compute_blocked_scale_offsets_for_K_groups,
-    compute_blocked_scale_offsets_for_M_groups,
     mxfp8_quantize_cuda_3d,
     triton_mx_block_rearrange_2d_K_groups,
     triton_mx_block_rearrange_2d_M_groups,
@@ -329,13 +327,9 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             )
 
         # Convert scales to blocked format for 2d-3d grouped mm
-        _, blocked_scales_group_offsets_2d3d = (
-            compute_blocked_scale_offsets_for_M_groups(offs)
-        )
         A_scales_blocked = triton_mx_block_rearrange_2d_M_groups(
             A_scale,
             offs,
-            blocked_scales_group_offsets_2d3d,
         )
         B_scales_blocked = triton_mx_block_rearrange_per_group_3d(B_scales)
 
@@ -350,7 +344,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             out_dtype=out_dtype,
         )
 
-        ctx.save_for_backward(A, B_t, offs, blocked_scales_group_offsets_2d3d)
+        ctx.save_for_backward(A, B_t, offs)
         ctx.block_size = block_size
         ctx.out_dtype = out_dtype
         ctx.emulated = emulated
@@ -359,7 +353,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_out: torch.Tensor):
-        A, B_t, offs, blocked_scales_group_offsets_2d3d = ctx.saved_tensors
+        A, B_t, offs = ctx.saved_tensors
         block_size = ctx.block_size
         out_dtype = ctx.out_dtype
         use_triton_for_dim0_cast = ctx.use_triton_for_dim0_cast
@@ -390,7 +384,6 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         grad_out_scales_blocked = triton_mx_block_rearrange_2d_M_groups(
             grad_out_scale,
             offs,
-            blocked_scales_group_offsets_2d3d,
         )
         B_scales_blocked = triton_mx_block_rearrange_per_group_3d(B_scales)
 
@@ -436,18 +429,13 @@ class _MXFP8GroupedMM(torch.autograd.Function):
 
         # Convert scales to blocked format for 2d-2d grouped mm
         scale_group_offsets = offs // block_size
-        _, blocked_scale_group_offsets = compute_blocked_scale_offsets_for_K_groups(
-            scale_group_offsets
-        )
         grad_out_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
             grad_out_t_scales,
             scale_group_offsets,
-            blocked_scale_group_offsets,
         )
         A_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
             A_t_scales,
             scale_group_offsets,
-            blocked_scale_group_offsets,
         )
 
         # grad_B_t = scaled grouped mm of (N,total_M) @ (total_M,K) = (E,N,K)


### PR DESCRIPTION
Stacked PRs:
 * #3286
 * __->__#3285


--- --- ---

### [mxfp8 moe training] compute prefix sum of group sizes inside  kernel intead of precomputing

## Context
Currently when converting scales to blocked swizzled format, we precompute the new start index of each padded group. However, this creates a dependency on torch.compile, which we rely on codgen fast triton kernels for these prefix sums, otherwise we inject slow eager mode ops into the hot path of the quantized grouped gemms, resulting in net slowdown in eager.

Given some users don't want to use torch.compile, and given sometimes there are [bugs](https://github.com/pytorch/torchtitan/issues/1971) blocking the use of torch.compile, we should support eager mode execution with good perf. 

## Changes 
- Do what we do in the mxfp8 scaled grouped gemm kernels in fbgemm, and compute these group offsets inside the kernel themselves. The work is duplicated, but it is such a tiny amount of work that perf impact is negligible (i.e., O(group_size) prefix sum where group_size is the local number of experts after EP is applied, so <= 8). 

## Testing
- `pytest test/prototype/moe_training/test_kernels.py `
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -k mxfp8 -s`