### PR TITLE
[mxfp8 moe training] update benchmarks and tests; simplify per group blocked swizzle ref function

### DIFF
--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -230,7 +230,7 @@ def test_triton_mx_block_rearrange_2d_M_groups(
 
     # torch reference
     ref_out_scales, _ = torch_to_blocked_2d_M_groups(
-        e8m0_scales, input_group_offsets, k, block_size=block_size
+        e8m0_scales, input_group_offsets, block_size=block_size
     )
 
     # triton kernel

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -68,7 +68,6 @@ def to_blocked(input_matrix, use_triton_kernel: bool = False) -> Tensor:
     # Rearrange the blocks
     blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
     rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
-
     return rearranged.flatten()
 
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#3286
 * #3285


--- --- ---

[mxfp8 moe training] update benchmarks and tests; simplify per group blocked swizzle ref function

## Changes
- Update `benchmark_2d_3d_grouped_gemm.py` to use torch._scaled_grouped_mm instead of the fbgemm custom op, now that it is integrated in core
- Simplify `torch_to_blocked_2d_M_groups` to not require K param as it is not needed, update tests and benchmarks accordingly
- Update `bench_triton_mx_block_rearrange_2d_M_groups.py` to also bench larger, more realistic total_M dim