### PR TITLE
[CPU] Fix issue: No module named 'fbgemm_gpu.experimental'

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1153,7 +1153,10 @@ def is_package_at_least(package_name: str, min_version: str):
 def _is_fbgemm_gpu_genai_available():
     # TODO: use is_package_at_least("fbgemm_gpu", "1.2.0") when
     # https://github.com/pytorch/FBGEMM/issues/4198 is fixed
-    if importlib.util.find_spec("fbgemm_gpu") is None:
+    if (
+        importlib.util.find_spec("fbgemm_gpu") is None
+        or importlib.util.find_spec("fbgemm_gpu.experimental") is None
+    ):
         return False
 
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401


### PR DESCRIPTION
We want to use torchrec on CPU. On CPU, torchrec dependent on the CPU version of fbgemm_gpu.
On CPU, fbgemm_gpu not include fbgemm_gpu.experimental.
Similar issue: https://github.com/pytorch/ao/pull/2591
env: 
```bash
pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
pip3 install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cpu
pip3 install --pre fbgemm_gpu --index-url https://download.pytorch.org/whl/nightly/cpu
```
Reproduce: `import torchao`
Error:
```
  File "/home/wengshiy/ao/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py", line 25, in <module>
    if not _is_fbgemm_gpu_genai_available():
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/wengshiy/ao/torchao/utils.py", line 1162, in _is_fbgemm_gpu_genai_available
    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'fbgemm_gpu.experimental'
```