### PR TITLE
modify unflatten for vllm

### DIFF
--- a/test/prototype/safetensors/test_safetensors_support.py
+++ b/test/prototype/safetensors/test_safetensors_support.py
@@ -74,9 +74,10 @@ class TestSafeTensors(TestCase):
 
             save_file(tensors_data_dict, f.name, metadata=metadata)
             tensors_data_dict, metadata = load_data(file_path=f.name, device="cuda")
-            reconstructed_dict = unflatten_tensor_state_dict(
+            reconstructed_dict, leftover_tensor_data_dict = unflatten_tensor_state_dict(
                 tensors_data_dict, metadata
             )
+            assert not leftover_tensor_data_dict
 
         model = torch.nn.Sequential(
             torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
@@ -84,6 +85,47 @@ class TestSafeTensors(TestCase):
         model.load_state_dict(reconstructed_dict, assign=True)
         output = model(*example_inputs)
         assert torch.equal(output, ref_output)
+
+    @parametrize(
+        "config, act_pre_scale",
+        [
+            (Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()), False),
+            (Int4WeightOnlyConfig(), False),
+            (Int4WeightOnlyConfig(), True),
+            (Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"), False),
+            (IntxWeightOnlyConfig(), False),
+            (Int8DynamicActivationIntxWeightConfig(), False),
+        ],
+    )
+    def test_safetensors_sharded(self, config, act_pre_scale=False):
+        model = torch.nn.Sequential(
+            torch.nn.Linear(128, 256, dtype=torch.bfloat16, device="cuda")
+        )
+        quantize_(model, config)
+        if act_pre_scale:
+            model[0].weight.act_pre_scale = torch.ones(
+                (1), dtype=torch.bfloat16, device="cuda"
+            )
+
+        with tempfile.NamedTemporaryFile() as f:
+            tensors_data_dict, metadata = flatten_tensor_state_dict(model.state_dict())
+            save_file(tensors_data_dict, f.name, metadata=metadata)
+            tensors_data_dict, metadata = load_data(file_path=f.name, device="cuda")
+
+            # simulate missing info on future file
+            if act_pre_scale:
+                del tensors_data_dict["0._weight_act_pre_scale"]  # optional tensor data
+            else:
+                del tensors_data_dict["0._weight_qdata"]
+
+            reconstructed_dict, leftover_tensor_data_dict = unflatten_tensor_state_dict(
+                tensors_data_dict, metadata
+            )
+
+            # since qdata is missing, layer 0 should not have been processed
+            for key in tensors_data_dict.keys():
+                if key.startswith("0._weight_"):
+                    assert key in leftover_tensor_data_dict
 
 
 instantiate_parametrized_tests(TestSafeTensors)

--- a/torchao/prototype/safetensors/safetensors_utils.py
+++ b/torchao/prototype/safetensors/safetensors_utils.py
@@ -60,7 +60,23 @@ class TensorSubclassAttributeJSONEncoder(json.JSONEncoder):
                 encoded_attribute = self.encode_value(attribute)
                 tensor_attr_dict[tensor_attribute_name] = encoded_attribute
 
-            return {"_type": o.__class__.__name__, "_data": tensor_attr_dict}
+            optional_tensor_data_names = (
+                o.optional_tensor_data_names
+                if hasattr(o, "optional_tensor_data_names")
+                else []
+            )
+            all_tensor_data_names = optional_tensor_data_names + o.tensor_data_names
+
+            _tensor_data_names = []
+            for tensor_data_name in all_tensor_data_names:
+                if getattr(o, tensor_data_name) is not None:
+                    _tensor_data_names.append(tensor_data_name)
+
+            return {
+                "_type": o.__class__.__name__,
+                "_data": tensor_attr_dict,
+                "_tensor_data_names": _tensor_data_names,
+            }
 
         if hasattr(o, "_fields") and hasattr(
             o, "_asdict"


### PR DESCRIPTION
**Summary**

We keep track of what has been processed by deleting processed keys from the original state dict. This is for the case when not all tensor attributes are available to us when loading, so we reconstruct the tensor subclasses with missing attributes in a later call. 

We expect the state dict to be empty after loading is complete

**Test**
`python test/prototype/safetensors/test_safetensors_support.py` 