### PR TITLE
Skip quantization when channels_out / channels_in are not multiple of 16

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1824,6 +1824,13 @@ def _float8_dynamic_activation_float8_weight_quantize_tensor(weight, config):
         assert isinstance(activation_granularity, PerTensor) and isinstance(
             weight_granularity, PerTensor
         ), "5D tensor only supports per tensor activation and weight quantization"
+
+        # weight dim: (C_out, C_in, K1, K2, K3)
+        # skip quantization when either C_out or C_in
+        # is not a multiple of 16
+        if weight.shape[0] % 16 != 0 or weight.shape[1] % 16 != 0:
+            return weight
+
     elif not _fp8_mm_compat(weight):
         # TODO(future PR): this should really throw an exception instead of silently
         # not doing what the user asked


### PR DESCRIPTION
Summary:
The underlying fbgemm conv3d kernel for float8 only supports channels_out/channels_in are both multiples of 16 so we skip the shapes that doesn't satisfy the requirements for now, we can expand the support to do padding if needed in the future

Test Plan:
(in B200 machine) python test/quantization/quantize_/workflows/float8/test_float8_tensor.py -k test_fp8_conv_skip_quant