### PR TITLE
Remove old QAT APIs

### DIFF
--- a/docs/source/api_ref_qat.rst
+++ b/docs/source/api_ref_qat.rst
@@ -42,8 +42,6 @@ Legacy QAT APIs
     :toctree: generated/
     :nosignatures:
 
-    IntXQuantizationAwareTrainingConfig
-    FromIntXQuantizationAwareTrainingConfig
     Int4WeightOnlyQATQuantizer
     linear.Int4WeightOnlyQATLinear
     Int8DynActInt4WeightQATQuantizer

--- a/test/prototype/test_embedding.py
+++ b/test/prototype/test_embedding.py
@@ -18,10 +18,9 @@ from torchao.prototype.quantization.embedding.api import (
 )
 from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.qat import (
-    FromIntXQuantizationAwareTrainingConfig,
     Int4WeightOnlyEmbeddingQATQuantizer,
     IntxFakeQuantizeConfig,
-    IntXQuantizationAwareTrainingConfig,
+    QATConfig,
 )
 from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
@@ -257,7 +256,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         ],
         name_func=lambda f, _, params: f.__name__ + f"_{params.kwargs}",
     )
-    def test_identical_to_IntXQuantizationAwareTrainingConfig(
+    def test_identical_to_QATConfig(
         self, weight_dtype, granularity, mapping_type, scale_dtype, model_dtype
     ):
         # ASYMMETRIC in QAT is very different that PTQ configs
@@ -288,12 +287,12 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         )
         quantize_(
             model,
-            IntXQuantizationAwareTrainingConfig(weight_config=weight_config),
+            QATConfig(weight_config=weight_config, step="prepare"),
             embedding_filter,
         )
         prepared_out = model(indices)
 
-        quantize_(model, FromIntXQuantizationAwareTrainingConfig(), embedding_filter)
+        quantize_(model, QATConfig(step="convert"), embedding_filter)
         quantize_(
             model,
             IntxWeightOnlyConfig(
@@ -355,7 +354,7 @@ class TestEmbeddingQuantizer(unittest.TestCase):
         prepared_out = model(indices)
 
         # Convert model method 1
-        quantize_(model, FromIntXQuantizationAwareTrainingConfig(), embedding_filter)
+        quantize_(model, QATConfig(step="convert"), embedding_filter)
         quantize_(
             model,
             IntxWeightOnlyConfig(

--- a/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
+++ b/test/quantization/test_int8_dynamic_activation_intx_weight_config_v1.py
@@ -20,10 +20,9 @@ from torch.testing._internal.common_utils import (
 from torchao.dtypes import PackedLinearInt8DynamicActivationIntxWeightLayout, QDQLayout
 from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.qat import (
-    FromIntXQuantizationAwareTrainingConfig,
     Int8DynActInt4WeightQATQuantizer,
     IntxFakeQuantizeConfig,
-    IntXQuantizationAwareTrainingConfig,
+    QATConfig,
 )
 from torchao.quantization.quant_api import (
     Int8DynamicActivationInt4WeightConfig,
@@ -499,7 +498,7 @@ class TestInt8DynamicActivationIntxWeight(TestCase):
             for model_dtype in [torch.float32, torch.bfloat16, torch.float16]
         ],
     )
-    def test_identical_to_IntXQuantizationAwareTrainingConfig(
+    def test_identical_to_QATConfig(
         self,
         weight_dtype,
         group_size,
@@ -545,7 +544,11 @@ class TestInt8DynamicActivationIntxWeight(TestCase):
 
         quantize_(
             model,
-            IntXQuantizationAwareTrainingConfig(activation_config, weight_config),
+            QATConfig(
+                activation_config=activation_config,
+                weight_config=weight_config,
+                step="prepare",
+            ),
         )
         try:
             prepared_out = model(activations)
@@ -555,7 +558,7 @@ class TestInt8DynamicActivationIntxWeight(TestCase):
                 return
             raise e
 
-        quantize_(model, FromIntXQuantizationAwareTrainingConfig())
+        quantize_(model, QATConfig(step="convert"))
         quantize_(
             model,
             Int8DynamicActivationIntxWeightConfig(
@@ -606,7 +609,7 @@ class TestInt8DynamicActivationIntxWeight(TestCase):
         prepared_out = model(activations)
 
         # Convert model method 1
-        quantize_(model, FromIntXQuantizationAwareTrainingConfig())
+        quantize_(model, QATConfig(step="convert"))
         quantize_(
             model,
             Int8DynamicActivationIntxWeightConfig(

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -67,7 +67,6 @@ from .quant_api import (
     TensorCoreTiledLayout,
     UIntXWeightOnlyConfig,
     fqn_matches_fqn_config,
-    intx_quantization_aware_training,
     quantize_,
     swap_conv2d_1x1_to_linear,
 )
@@ -112,7 +111,6 @@ __all__ = [
     "ALL_AUTOQUANT_CLASS_LIST",
     # top level API - manual
     "quantize_",
-    "intx_quantization_aware_training",
     "fqn_matches_fqn_config",
     "swap_conv2d_1x1_to_linear",
     "Int4DynamicActivationInt4WeightConfig",

--- a/torchao/quantization/prototype/qat/api.py
+++ b/torchao/quantization/prototype/qat/api.py
@@ -1,6 +1,8 @@
 from torchao.quantization.qat.api import (
     ComposableQATQuantizer,
-    FakeQuantizeConfig,
+)
+from torchao.quantization.qat.api import (
+    IntxFakeQuantizeConfig as FakeQuantizeConfig,
 )
 
 __all__ = [

--- a/torchao/quantization/qat/__init__.py
+++ b/torchao/quantization/qat/__init__.py
@@ -1,25 +1,19 @@
 from .api import (
     ComposableQATQuantizer,
-    FromIntXQuantizationAwareTrainingConfig,
-    IntXQuantizationAwareTrainingConfig,
     QATConfig,
     QATStep,
-    from_intx_quantization_aware_training,
     initialize_fake_quantizers,
-    intx_quantization_aware_training,
 )
 from .embedding import (
     FakeQuantizedEmbedding,
     Int4WeightOnlyEmbeddingQATQuantizer,
 )
 from .fake_quantize_config import (
-    FakeQuantizeConfig,
     FakeQuantizeConfigBase,
     Float8FakeQuantizeConfig,
     IntxFakeQuantizeConfig,
 )
 from .fake_quantizer import (
-    FakeQuantizer,
     FakeQuantizerBase,
     Float8FakeQuantizer,
     IntxFakeQuantizer,
@@ -50,11 +44,4 @@ __all__ = [
     "Int4WeightOnlyEmbeddingQATQuantizer",
     "Int4WeightOnlyQATQuantizer",
     "Int8DynActInt4WeightQATQuantizer",
-    # for BC
-    "FakeQuantizer",
-    "FakeQuantizeConfig",
-    "from_intx_quantization_aware_training",
-    "FromIntXQuantizationAwareTrainingConfig",
-    "intx_quantization_aware_training",
-    "IntXQuantizationAwareTrainingConfig",
 ]

--- a/torchao/quantization/qat/api.py
+++ b/torchao/quantization/qat/api.py
@@ -21,13 +21,11 @@ from torchao.quantization.unified import TwoStepQuantizer
 
 from .embedding import FakeQuantizedEmbedding
 from .fake_quantize_config import (
-    FakeQuantizeConfig,  # noqa: F401, for BC
     FakeQuantizeConfigBase,
     IntxFakeQuantizeConfig,
     _infer_fake_quantize_configs,
 )
 from .linear import FakeQuantizedLinear
-from .utils import _log_deprecation_warning
 
 
 class QATStep(str, Enum):
@@ -289,119 +287,6 @@ def _qat_config_transform(
             )
         else:
             return module
-
-
-@dataclass
-class IntXQuantizationAwareTrainingConfig(AOBaseConfig):
-    """
-    (Deprecated) Please use :class:`~torchao.quantization.qat.QATConfig` instead.
-
-    Config for applying fake quantization to a `torch.nn.Module`.
-    to be used with :func:`~torchao.quantization.quant_api.quantize_`.
-
-    Example usage::
-
-        from torchao.quantization import quantize_
-        from torchao.quantization.qat import IntxFakeQuantizeConfig
-        activation_config = IntxFakeQuantizeConfig(
-            torch.int8, "per_token", is_symmetric=False,
-        )
-        weight_config = IntxFakeQuantizeConfig(
-            torch.int4, group_size=32, is_symmetric=True,
-        )
-        quantize_(
-            model,
-            IntXQuantizationAwareTrainingConfig(activation_config, weight_config),
-        )
-
-    Note: If the config is applied on a module that is not
-    `torch.nn.Linear` or `torch.nn.Embedding`, or it is applied on
-    `torch.nn.Embedding` with an activation config, then we will raise
-    ValueError as these are not supported.
-    """
-
-    activation_config: Optional[FakeQuantizeConfigBase] = None
-    weight_config: Optional[FakeQuantizeConfigBase] = None
-
-    def __post_init__(self):
-        _log_deprecation_warning(self)
-
-
-# for BC
-class intx_quantization_aware_training(IntXQuantizationAwareTrainingConfig):
-    pass
-
-
-@register_quantize_module_handler(IntXQuantizationAwareTrainingConfig)
-def _intx_quantization_aware_training_transform(
-    module: torch.nn.Module,
-    config: IntXQuantizationAwareTrainingConfig,
-) -> torch.nn.Module:
-    mod = module
-    activation_config = config.activation_config
-    weight_config = config.weight_config
-
-    if isinstance(mod, torch.nn.Linear):
-        return FakeQuantizedLinear.from_linear(
-            mod,
-            activation_config,
-            weight_config,
-        )
-    elif isinstance(mod, torch.nn.Embedding):
-        if activation_config is not None:
-            raise ValueError(
-                "Activation fake quantization is not supported for embedding"
-            )
-        return FakeQuantizedEmbedding.from_embedding(mod, weight_config)
-    else:
-        raise ValueError("Module of type '%s' does not have QAT support" % type(mod))
-
-
-@dataclass
-class FromIntXQuantizationAwareTrainingConfig(AOBaseConfig):
-    """
-    (Deprecated) Please use :class:`~torchao.quantization.qat.QATConfig` instead.
-
-    Config for converting a model with fake quantized modules,
-    such as :func:`~torchao.quantization.qat.linear.FakeQuantizedLinear`
-    and :func:`~torchao.quantization.qat.linear.FakeQuantizedEmbedding`,
-    back to model with the original, corresponding modules without
-    fake quantization. This should be used with
-    :func:`~torchao.quantization.quant_api.quantize_`.
-
-    Example usage::
-
-        from torchao.quantization import quantize_
-        quantize_(
-            model_with_fake_quantized_linears,
-            FromIntXQuantizationAwareTrainingConfig(),
-        )
-    """
-
-    def __post_init__(self):
-        _log_deprecation_warning(self)
-
-
-# for BC
-class from_intx_quantization_aware_training(FromIntXQuantizationAwareTrainingConfig):
-    pass
-
-
-@register_quantize_module_handler(FromIntXQuantizationAwareTrainingConfig)
-def _from_intx_quantization_aware_training_transform(
-    mod: torch.nn.Module,
-    config: FromIntXQuantizationAwareTrainingConfig,
-) -> torch.nn.Module:
-    """
-    If the given module is a fake quantized module, return the original
-    corresponding version of the module without fake quantization.
-    """
-    if isinstance(mod, FakeQuantizedLinear):
-        return mod.to_linear()
-    elif isinstance(mod, FakeQuantizedEmbedding):
-        return mod.to_embedding()
-    else:
-        return mod
 
 
 class ComposableQATQuantizer(TwoStepQuantizer):

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -34,8 +34,6 @@ from torchao.quantization.quant_primitives import (
 from torchao.quantization.quantize_.workflows import Int4PackingFormat
 from torchao.utils import _is_float8_type
 
-from .utils import _log_deprecation_warning
-
 
 class FakeQuantizeConfigBase(abc.ABC):
     """
@@ -201,14 +199,6 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         if is_dynamic and range_learning:
             raise ValueError("`is_dynamic` is not compatible with `range_learning`")
 
-        self.__post_init__()
-
-    def __post_init__(self):
-        """
-        For deprecation only, can remove after https://github.com/pytorch/ao/issues/2630.
-        """
-        pass
-
     def _get_granularity(
         self,
         granularity: Union[Granularity, str, None],
@@ -332,16 +322,6 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
             super().__setattr__("mapping_type", mapping_type)
         else:
             super().__setattr__(name, value)
-
-
-# For BC
-class FakeQuantizeConfig(IntxFakeQuantizeConfig):
-    """
-    (Deprecated) Please use :class:`~torchao.quantization.qat.IntxFakeQuantizeConfig` instead.
-    """
-
-    def __post_init__(self):
-        _log_deprecation_warning(self)
 
 
 def _infer_fake_quantize_configs(

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -41,7 +41,6 @@ from .fake_quantize_config import (
 from .utils import (
     _fake_quantize_per_channel_group,
     _fake_quantize_per_token,
-    _log_deprecation_warning,
 )
 
 
@@ -330,14 +329,3 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             zero_point = _Round.apply(zero_point)
             zero_point = torch.clamp(zero_point, qmin, qmax)
             self.zero_point = torch.nn.Parameter(zero_point, requires_grad=True)
-
-
-# For BC
-class FakeQuantizer(IntxFakeQuantizer):
-    """
-    (Deprecated) Please use :class:`~torchao.quantization.qat.IntxFakeQuantizer` instead.
-    """
-
-    def __init__(self, config: FakeQuantizeConfigBase):
-        super().__init__(config)
-        _log_deprecation_warning(self)

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -132,9 +132,6 @@ from .linear_quant_modules import (
     Int4WeightOnlyQuantizer,
     Int8DynActInt4WeightQuantizer,
 )
-from .qat import (
-    intx_quantization_aware_training,
-)
 from .quant_primitives import (
     _DTYPE_TO_QVALUE_BOUNDS,
     MappingType,
@@ -156,7 +153,6 @@ __all__ = [
     "autoquant",
     "_get_subclass_inserter",
     "quantize_",
-    "intx_quantization_aware_training",
     "Int8DynActInt4WeightQuantizer",
     "Float8DynamicActivationFloat8SemiSparseWeightConfig",
     "ModuleFqnToConfig",


### PR DESCRIPTION
(Re-opened to remove stack, identical to https://github.com/pytorch/ao/pull/3147)

**Summary:** As a follow-up to https://github.com/pytorch/ao/pull/2641, which deprecated the old QAT APIs in 0.13.0, we remove them now in the next release 0.15.0.

Fixes https://github.com/pytorch/ao/issues/2630.

**Test Plan:** CI