### PR TITLE
Add support for e2e benchmark for conv2d/conv3d

### DIFF
--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -43,6 +43,22 @@ gpu_name_to_specs = {
         # TODO(future): measure once we have the hardware
         "pct_achievable_mem_bw": 0.92,
     },
+    "NVIDIA GB200": {
+        # https://resources.nvidia.com/en-us-blackwell-architecture, page 19,
+        # divide by 2 because no sparsity
+        "bf16_peak_tops": 2.25e15,
+        "fp8_peak_tops": 4.5e15,
+        "fp4_peak_tops": 9.0e15,
+        # https://resources.nvidia.com/en-us-blackwell-architecture, page 20
+        # 8.0 TB per second
+        "peak_mem_bw_bytes_sec": 8.0e12,
+        # for now, copy over from H100
+        # TODO(future): measure once we have the hardware
+        "pct_achievable_gemm_tops": 0.78,
+        # for now, copy over from H100
+        # TODO(future): measure once we have the hardware
+        "pct_achievable_mem_bw": 0.92,
+    },
     "AMD Instinct MI300X": {
         # https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf, page 1,
         "bf16_peak_tops": 1307e12,


### PR DESCRIPTION
Summary:
We added this to float8_inference_roofline to reuse code but we haven't enabled the roofline feature. For now we just need the e2e speedup time for single conv2d/conv3d against bf16 to understand the speedup expectation

some if/else branches right now but hopefully we should be able to remove some of these when more roofline support is added for conv2d/conv3d

Also added B200 hardware spec.

Test Plan:
```
python float8_inference_roofline.py ~/local/tmp/test.csv \
    --recipe_name tensorwise \
    --shape_gen_name custom \
    --M 1 --K 160 --N 160 \
    --D 3 --H 50 --W 50 \
    --kernel_size 3 \
    --op_name conv3d
```

requires fbgemm_gpu_genai nightly and torch nightly:

```
pip install --pre torch fbgemm_gpu_genai --index-url https://download.pytorch.org/whl/nightly/cu129
```

sample results:

```
,fwd_M,fwd_K,fwd_N,D,H,W,kernel_size,r_bf16_gemm_s,r_fp8_gemm_s,r_fp8_ovhd_s,r_fp8_gemm_and_ovhd_s,r_fp8_gemm_and_ovhd_spdp,b_bf16_gemm_s,b_fp8_gemm_s,b_bf16_e2e_s,b_fp8_e2e_s,b_fp8_e2e_spdp,rb_bf16_gemm_ratio,rb\
_fp8_gemm_ratio
0,1,160,320,3,194,130,3,,,,,,0,0,8.248959999999995e-05,0.00011273280000000014,0.7317267024326535,-1,-1
```

Reviewers:

Subscribers:

Tasks:

Tags: