### PR TITLE
[CI] Update docker image for XPU test

### DIFF
--- a/.github/workflows/xpu_test.yml
+++ b/.github/workflows/xpu_test.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 60
     runs-on: linux.idc.xpu
     env:
-      DOCKER_IMAGE: ci-image:pytorch-linux-jammy-xpu-n-py3
+      DOCKER_IMAGE: ci-image:pytorch-linux-noble-xpu-n-py3
       PYTORCH_RETRY_TEST_CASES: 1
       PYTORCH_OVERRIDE_FLAKY_SIGNAL: 1
       XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla


### PR DESCRIPTION
Follows https://github.com/pytorch/pytorch/pull/162475 which upgraded the xpu ci docker image based on Ubuntu 24.04