### PR TITLE
[pt2e] Fix QAT annotations for special qspecs

### DIFF
--- a/torchao/quantization/pt2e/qat_utils.py
+++ b/torchao/quantization/pt2e/qat_utils.py
@@ -594,8 +594,12 @@ def _update_special_qspecs_after_replacement(
     if "quantization_annotation" not in node.meta:
         return
     annotation = node.meta["quantization_annotation"]
+    # Update both keys and values of input_qspec_map
+    new_input_qspec_map = {}
     for input_node, qspec in annotation.input_qspec_map.items():
-        annotation.input_qspec_map[input_node] = _get_new_qspec(qspec)
+        new_input_node = original_to_replacement_node.get(input_node, input_node)
+        new_input_qspec_map[new_input_node] = _get_new_qspec(qspec)
+    annotation.input_qspec_map = new_input_qspec_map
     annotation.output_qspec = _get_new_qspec(annotation.output_qspec)
 
 


### PR DESCRIPTION
**Summary:** In pt2e QAT, we first annotate the nodes to be quantized and then perform the pattern replacement (i.e. QAT fusion) in the prepare step. After this pattern replacement, old nodes are replaced with new nodes, and any references to the old nodes must also be updated to refer to the new nodes.

This commit fixes a bug where, for special qspecs like the `SharedQuantizationSpec` and `DerivedQuantizationSpec`, we only update the values of a node's `input_qspec_map`, not the keys. As a result, the keys still refer to the old nodes that do not exist anymore after the QAT fusion.

**Test Plan:**
```
python test/quantization/pt2e/test_quantize_pt2e_qat.py -k test_qat_shared_qspec
```