### PR TITLE
Add `enable_fusion_modeling` for conv2d and conv3d

### DIFF
--- a/benchmarks/float8/float8_inference_roofline.py
+++ b/benchmarks/float8/float8_inference_roofline.py
@@ -370,13 +370,27 @@ def run(
         if do_benchmarks:
             # create the model
             if op_name == "conv2d":
-                m_orig = nn.Sequential(
-                    nn.Conv2d(K_val, N_val, kernel_size, bias=False)
-                ).to(memory_format=torch.channels_last)
+                if not enable_fusion_modeling:
+                    m_orig = nn.Sequential(
+                        nn.Conv2d(K_val, N_val, kernel_size, bias=False)
+                    ).to(memory_format=torch.channels_last)
+                else:
+                    m_orig = nn.Sequential(
+                        nn.ReLU(),
+                        nn.Conv2d(K_val, N_val, kernel_size, bias=False),
+                        nn.ReLU(),
+                    ).to(memory_format=torch.channels_last)
             elif op_name == "conv3d":
-                m_orig = nn.Sequential(
-                    nn.Conv3d(K_val, N_val, kernel_size, bias=False)
-                ).to(memory_format=torch.channels_last_3d)
+                if not enable_fusion_modeling:
+                    m_orig = nn.Sequential(
+                        nn.Conv3d(K_val, N_val, kernel_size, bias=False)
+                    ).to(memory_format=torch.channels_last_3d)
+                else:
+                    m_orig = nn.Sequential(
+                        nn.ReLU(),
+                        nn.Conv3d(K_val, N_val, kernel_size, bias=False),
+                        nn.ReLU(),
+                    ).to(memory_format=torch.channels_last_3d)
             else:
                 if not enable_fusion_modeling:
                     m_orig = nn.Sequential(nn.Linear(K_val, N_val, bias=False))


### PR DESCRIPTION
Summary:
This is to have more accurate benchmarking for fusion

Test Plan:
```
RECIPE_NAME="tensorwise"
SHAPE_GEN_NAME="custom"
SCRIPT_PATH="benchmarks/float8/float8_inference_roofline.py"
M=1
K=160
N=320
D=3
H=194
W=130
kernel_size=3

OUTPUT_FILE="~/local/tmp/test_${M}_${K}_${N}_${D}_${H}_${W}_${kernel_size}.csv"
python $SCRIPT_PATH $OUTPUT_FILE \
    --recipe_name $RECIPE_NAME \
    --shape_gen_name $SHAPE_GEN_NAME \
    --M $M --K $K --N $N  \
    --D $D --H $H --W $W  \
    --kernel_size $kernel_size \
    --enable_fusion_modeling \
    --op_name conv3d
```
Reviewers:

Subscribers:

Tasks:

Tags: