### PR TITLE
Fix microbenchmarking run

### DIFF
--- a/.github/workflows/run_microbenchmarks.yml
+++ b/.github/workflows/run_microbenchmarks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Run benchmark
         shell: bash

--- a/benchmarks/dashboard/microbenchmark_quantization_config.yml
+++ b/benchmarks/dashboard/microbenchmark_quantization_config.yml
@@ -1,7 +1,7 @@
 # Benchmark configuration for microbenchmarks
 benchmark_mode: "inference"
 quantization_config_recipe_names: # Will run a baseline inference for model by default, without quantization for comparison
-  - "int8wo"
+  # - "int8wo" TODO: Re-enable once we debug the delay in the benchmark
   - "int8dq"
   - "float8dq-tensor"
   - "float8dq-row"


### PR DESCRIPTION
The microbenchmarks run has been failing as it was using python 3.9. This Pr upgrades it to python 3.10. There's an unexpected delay in running int8wo api benchmarks, hence it has been disabled https://github.com/pytorch/ao/issues/3348