### PR TITLE
Fixes accuracy error for mxfp8 linear

### DIFF
--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -881,6 +881,9 @@ if torch_version_at_least("2.7.0") and has_triton():
         # can be improved in the future.
         results = []
         for ROW_TILE_SIZE in (128, 256, 512):
+            # TODO: we can't use 512 for COL_TILE_SIZE.
+            # This is likely a triton bug, tracked in
+            # https://github.com/pytorch/ao/issues/3362
             for COL_TILE_SIZE in (128, 256):
                 for num_warps in (4, 8):
                     for num_stages in (2, 3):


### PR DESCRIPTION
I'm seeing the following error on B200 and GB200.
```
        y_ref.backward(g)
        y.backward(g)
        w_g_ref = m_mx[0].weight.grad
        w_g = getattr(m_mx_c, "0").weight.grad
        # TODO(future): investigate why we can't match with rtol=0 atol=0
        # after moving to torchao repo. Technically compile does not give
        # bit exactness guarantees, but there also might be a bug lurking
        # around.
>       torch.testing.assert_close(w_g_ref, w_g, atol=0.02, rtol=0.02)
E       AssertionError: Tensor-likes are not close!
E       
E       Mismatched elements: 493 / 131072 (0.4%)
E       Greatest absolute difference: 10.5625 at index (23, 0) (up to 0.02 allowed)
E       Greatest relative difference: 14272.0 at index (92, 0) (up to 0.02 allowed)

test/prototype/mx_formats/test_mx_linear.py:353: AssertionError
```
for the following unit test:
```
pytest test/prototype/mx_formats/test_mx_linear.py -k test_linear_compile[ScaleCalculationMode.FLOOR-MXFP8Dim1CastKernelChoice.TRITON-False-mxfp8_cublas-hp_dtype1] -vvv
```
Excluding 512 from COL_TILE_SIZE suppresses this issue. I figured it out by selectively including the values for ROW_TILE_SIZE, COL_TILE_SIZE, num_warps, and num_stages, until I found the config that results in the error. I'm not sure if COL_TILE_SIZE of 512 is not supported in B200/GB200 or if it's a bug in Triton.