### PR TITLE
Fix fbcode loading cpp extensions

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -26,6 +26,10 @@ except PackageNotFoundError:
 logger = logging.getLogger(__name__)
 
 
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
 def _parse_version(version_string):
     """
     Parse version string representing pre-release with -1
@@ -53,6 +57,8 @@ if force_skip_loading_so_files:
     # users can set env var TORCHAO_FORCE_SKIP_LOADING_SO_FILES=1 to skip loading .so files
     # this way, if they are using an incompatbile torch version, they can still use the API by setting the env var
     skip_loading_so_files = True
+elif is_fbcode():
+    skip_loading_so_files = False
 # if torchao version has "+git", assume it's locally built and we don't know
 #   anything about the PyTorch version used to build it unless user provides override flag
 # otherwise, assume it's prebuilt by torchao's build scripts and we can make


### PR DESCRIPTION
**Summary:** Follow-up to https://github.com/pytorch/ao/pull/3338, which always skips loading cpp extensions for fbcode. However, we actually need them for internal tests: D87008228. We should always load them for fbcode instead, which is safe because pytorch will always be nightly there.

**Test Plan:** CI