### PR TITLE
[WIP] update keepdim params for 1D scale factor

### DIFF
--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -2311,7 +2311,7 @@ def _choose_scale_float8(
             block_size, tensor.shape
         )
         tensor_reshaped = tensor.view(shape_for_reduction)
-        max_abs = tensor_reshaped.abs().amax(dim=reduction_dims, keepdim=True)
+        max_abs = tensor_reshaped.abs().amax(dim=reduction_dims, keepdim=False)
         if hp_value_lb is not None or hp_value_ub is not None:
             max_abs = torch.clamp(max_abs, min=hp_value_lb, max=hp_value_ub)
         scale = max_abs / quant_max


### PR DESCRIPTION
**Overview**:
In `_choose_scale_float8`, the per-tensor quantization case (`len(block_size) == 0`) uses `tensor.amax(keepdim=True)` while `_choose_qparams_affine` uses `torch.amax(..., keepdim=False)` for the same purpose.

This PR aligns `_choose_scale_float8` with `_choose_qparams_affine` by using `tensor.amax(keepdim=False)` for 1D scale factor.

**Related Issue/PR**: #3324

**Test Plan**: test/quantization/test_quant_primitives.py