### PR TITLE
Implements rounding mode for NVFP4 tensor

### DIFF
--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -59,6 +59,7 @@ if not torch_version_at_least("2.8.0"):
 if has_triton() and torch.cuda.is_available() and is_sm_at_least_100():
     import triton
     import triton.language as tl
+
     from torchao.prototype.mx_formats.kernels import (
         convert_fp32_to_fp4_packed,
         convert_fp32_to_fp4_packed_rs,
@@ -66,7 +67,11 @@ if has_triton() and torch.cuda.is_available() and is_sm_at_least_100():
 
     @triton.jit
     def _triton_f4_pack_kernel(
-        x_ptr, out_ptr, N, seed, ROUNDING_MODE: tl.constexpr,
+        x_ptr,
+        out_ptr,
+        N,
+        seed_ptr,
+        ROUNDING_MODE: tl.constexpr,
     ):
         """Thin wrapper to test convert_fp32_to_fp4_packed{,_rs} in isolation."""
         pid = tl.program_id(0)
@@ -78,20 +83,27 @@ if has_triton() and torch.cuda.is_available() and is_sm_at_least_100():
             x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
         else:
             out_offs = pid * 32 + tl.arange(0, 32)
+            seed = tl.load(seed_ptr)
             rbits = tl.randint(seed, out_offs)
             x_fp4x2 = convert_fp32_to_fp4_packed_rs(x_pairs, rbits)
         out_offs = pid * 32 + tl.arange(0, 32)
         tl.store(out_ptr + out_offs, x_fp4x2, mask=out_offs < N // 2)
 
-    def triton_f4_pack(x, rounding_mode=RoundingMode.RN, seed=0):
+    def triton_f4_pack(x, rounding_mode=RoundingMode.RN):
         """Pack FP32 values to FP4 using Triton convert_fp32_to_fp4_packed{,_rs}."""
         N = x.numel()
         out = torch.empty(N // 2, dtype=torch.uint8, device=x.device)
+        seed = torch.randint(0, 2**31, (1,), dtype=torch.int32, device=x.device)
         grid = (triton.cdiv(N, 64),)
         _triton_f4_pack_kernel[grid](
-            x, out, N, seed, ROUNDING_MODE=rounding_mode.value,
+            x,
+            out,
+            N,
+            seed,
+            ROUNDING_MODE=rounding_mode.value,
         )
         return out
+
 
 FP4_RN_EXPECTED = [(5.2, 6.0), (-5.2, -6.0)]
 
@@ -107,22 +119,25 @@ _triton_kernel_params = [
 ]
 
 
-def _f4_quantize(x, rounding_mode, use_triton, seed=None):
+def _f4_quantize(x, rounding_mode, use_triton):
     """Quantize FP32 to FP4 and dequantize, using either PyTorch or Triton kernel."""
     if rounding_mode not in RoundingMode:
         raise ValueError(
             f"Unknown rounding_mode: {rounding_mode}. "
             f"Expected RoundingMode.RN or RoundingMode.RS."
         )
-    if seed is not None and not use_triton:
-        torch.manual_seed(seed)
     if use_triton:
-        if seed is None:
-            seed = torch.randint(2**31, (1,)).item()
-        xq = triton_f4_pack(x.flatten(), rounding_mode=rounding_mode, seed=seed)
+        xq = triton_f4_pack(x.flatten(), rounding_mode=rounding_mode)
         return f4_unpacked_to_f32(unpack_uint4(xq))
     else:
-        return f4_unpacked_to_f32(f32_to_f4_unpacked(x, rounding_mode=rounding_mode))
+        rand_bits = (
+            torch.randint(0, 2**31, x.shape, dtype=torch.int32, device=x.device)
+            if rounding_mode == RoundingMode.RS
+            else None
+        )
+        return f4_unpacked_to_f32(
+            f32_to_f4_unpacked(x, rounding_mode=rounding_mode, rand_bits=rand_bits)
+        )
 
 
 # TODO: shared utils file for benchmarking and testing
@@ -1019,21 +1034,19 @@ def test_triton_mxfp8_dim0_large_tensor_offset_no_overflow(scaling_mode):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("use_triton", _triton_kernel_params)
 @pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS, 99])
-@pytest.mark.parametrize("seed_a,seed_b", [(42, 42), (42, 123)])
 @pytest.mark.parametrize("shape", [(1024, 128)])
 @pytest.mark.parametrize("value,rn_expected", FP4_RN_EXPECTED)
-def test_f4_rounding(value, rn_expected, shape, seed_a, seed_b, rounding_mode, use_triton):
-    """Test FP4 rounding: RN is biased, RS is unbiased, RS respects seed, invalid raises."""
+def test_f4_rounding(value, rn_expected, shape, rounding_mode, use_triton):
+    """Test FP4 rounding: RN is biased, RS is unbiased, invalid raises."""
     x = torch.ones(*shape, device="cuda", dtype=torch.bfloat16) * value
 
     if rounding_mode not in RoundingMode:
         with pytest.raises(ValueError, match="Unknown rounding_mode"):
-            _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_a)
+            _f4_quantize(x.float(), rounding_mode, use_triton)
         return
 
     rtol = 1e-2
-    r1 = _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_a)
-    r2 = _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_b)
+    r1 = _f4_quantize(x.float(), rounding_mode, use_triton)
 
     # Check rounding behavior via mean
     r1_mean = torch.mean(r1)
@@ -1043,8 +1056,10 @@ def test_f4_rounding(value, rn_expected, shape, seed_a, seed_b, rounding_mode, u
         input_mean = torch.mean(x.float())
         torch.testing.assert_close(r1_mean, input_mean, rtol=rtol, atol=rtol)
 
-    # Check seed determinism
-    if seed_a == seed_b:
-        torch.testing.assert_close(r1, r2, atol=0, rtol=0)
-    elif rounding_mode == RoundingMode.RS:
-        assert not torch.allclose(r1, r2)
+    # Check torch.manual_seed() determinism for RS
+    if rounding_mode == RoundingMode.RS:
+        torch.manual_seed(42)
+        r_a = _f4_quantize(x.float(), rounding_mode, use_triton)
+        torch.manual_seed(42)
+        r_b = _f4_quantize(x.float(), rounding_mode, use_triton)
+        torch.testing.assert_close(r_a, r_b, atol=0, rtol=0)

--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from torch.utils._triton import has_triton
 
+from torchao.prototype.custom_fp_utils import RoundingMode
 from torchao.prototype.mx_formats.constants import (
     DTYPE_FP6_E2M3,
     DTYPE_FP6_E3M2,
@@ -55,8 +56,78 @@ torch.manual_seed(0)
 if not torch_version_at_least("2.8.0"):
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)
 
+if has_triton() and torch.cuda.is_available() and is_sm_at_least_100():
+    import triton
+    import triton.language as tl
+    from torchao.prototype.mx_formats.kernels import (
+        convert_fp32_to_fp4_packed,
+        convert_fp32_to_fp4_packed_rs,
+    )
+
+    @triton.jit
+    def _triton_f4_pack_kernel(
+        x_ptr, out_ptr, N, seed, ROUNDING_MODE: tl.constexpr,
+    ):
+        """Thin wrapper to test convert_fp32_to_fp4_packed{,_rs} in isolation."""
+        pid = tl.program_id(0)
+        offs = pid * 64 + tl.arange(0, 64)
+        mask = offs < N
+        x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+        x_pairs = x.reshape(32, 2).split()
+        if ROUNDING_MODE == 0:
+            x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
+        else:
+            out_offs = pid * 32 + tl.arange(0, 32)
+            rbits = tl.randint(seed, out_offs)
+            x_fp4x2 = convert_fp32_to_fp4_packed_rs(x_pairs, rbits)
+        out_offs = pid * 32 + tl.arange(0, 32)
+        tl.store(out_ptr + out_offs, x_fp4x2, mask=out_offs < N // 2)
+
+    def triton_f4_pack(x, rounding_mode=RoundingMode.RN, seed=0):
+        """Pack FP32 values to FP4 using Triton convert_fp32_to_fp4_packed{,_rs}."""
+        N = x.numel()
+        out = torch.empty(N // 2, dtype=torch.uint8, device=x.device)
+        grid = (triton.cdiv(N, 64),)
+        _triton_f4_pack_kernel[grid](
+            x, out, N, seed, ROUNDING_MODE=rounding_mode.value,
+        )
+        return out
+
+FP4_RN_EXPECTED = [(5.2, 6.0), (-5.2, -6.0)]
+
+_triton_kernel_params = [
+    False,
+    pytest.param(
+        True,
+        marks=pytest.mark.skipif(
+            not (has_triton() and torch.cuda.is_available() and is_sm_at_least_100()),
+            reason="Triton FP4 kernel requires CUDA capability 10.0 or greater",
+        ),
+    ),
+]
+
+
+def _f4_quantize(x, rounding_mode, use_triton, seed=None):
+    """Quantize FP32 to FP4 and dequantize, using either PyTorch or Triton kernel."""
+    if rounding_mode not in RoundingMode:
+        raise ValueError(
+            f"Unknown rounding_mode: {rounding_mode}. "
+            f"Expected RoundingMode.RN or RoundingMode.RS."
+        )
+    if seed is not None and not use_triton:
+        torch.manual_seed(seed)
+    if use_triton:
+        if seed is None:
+            seed = torch.randint(2**31, (1,)).item()
+        xq = triton_f4_pack(x.flatten(), rounding_mode=rounding_mode, seed=seed)
+        return f4_unpacked_to_f32(unpack_uint4(xq))
+    else:
+        return f4_unpacked_to_f32(f32_to_f4_unpacked(x, rounding_mode=rounding_mode))
+
 
 # TODO: shared utils file for benchmarking and testing
+
+
 def to_mx_dim1_reference(x_hp, block_size, scaling_mode):
     x_hp = x_hp.t().contiguous()
     scale_d1, data_d1 = to_mx(
@@ -943,3 +1014,37 @@ def test_triton_mxfp8_dim0_large_tensor_offset_no_overflow(scaling_mode):
     assert not x_s_t.isnan().any(), "scales should not contain NaNs"
     torch.testing.assert_close(x_mx_t, x_mx_ref, rtol=0, atol=0)
     torch.testing.assert_close(x_s_t, x_s_ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("use_triton", _triton_kernel_params)
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS, 99])
+@pytest.mark.parametrize("seed_a,seed_b", [(42, 42), (42, 123)])
+@pytest.mark.parametrize("shape", [(1024, 128)])
+@pytest.mark.parametrize("value,rn_expected", FP4_RN_EXPECTED)
+def test_f4_rounding(value, rn_expected, shape, seed_a, seed_b, rounding_mode, use_triton):
+    """Test FP4 rounding: RN is biased, RS is unbiased, RS respects seed, invalid raises."""
+    x = torch.ones(*shape, device="cuda", dtype=torch.bfloat16) * value
+
+    if rounding_mode not in RoundingMode:
+        with pytest.raises(ValueError, match="Unknown rounding_mode"):
+            _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_a)
+        return
+
+    rtol = 1e-2
+    r1 = _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_a)
+    r2 = _f4_quantize(x.float(), rounding_mode, use_triton, seed=seed_b)
+
+    # Check rounding behavior via mean
+    r1_mean = torch.mean(r1)
+    if rounding_mode == RoundingMode.RN:
+        torch.testing.assert_close(r1_mean.item(), rn_expected, rtol=rtol, atol=rtol)
+    else:
+        input_mean = torch.mean(x.float())
+        torch.testing.assert_close(r1_mean, input_mean, rtol=rtol, atol=rtol)
+
+    # Check seed determinism
+    if seed_a == seed_b:
+        torch.testing.assert_close(r1, r2, atol=0, rtol=0)
+    elif rounding_mode == RoundingMode.RS:
+        assert not torch.allclose(r1, r2)

--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -79,7 +79,7 @@ if has_triton() and torch.cuda.is_available() and is_sm_at_least_100():
         mask = offs < N
         x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
         x_pairs = x.reshape(32, 2).split()
-        if ROUNDING_MODE == 0:
+        if ROUNDING_MODE == 1:  # RoundingMode.RN
             x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
         else:
             out_offs = pid * 32 + tl.arange(0, 32)

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from torchao.prototype.custom_fp_utils import RoundingMode
 from torchao.prototype.mx_formats.constants import (
     F4_E2M1_MAX,
 )
@@ -31,7 +32,20 @@ torch.manual_seed(2)
 if not torch_version_at_least("2.8.0"):
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)
 
+_triton_kernel_params = [
+    False,
+    pytest.param(
+        True,
+        marks=pytest.mark.skipif(
+            not is_sm_at_least_100(),
+            reason="CUDA capability >= 10.0 required for nvfp4 triton kernel",
+        ),
+    ),
+]
 
+
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
     "dtype,shape,use_per_tensor_scale",
     [
@@ -46,7 +60,8 @@ if not torch_version_at_least("2.8.0"):
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
-def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
+def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode, use_triton_kernel):
+
     x = torch.randn(shape, dtype=dtype, device="cuda")
     if use_per_tensor_scale:
         tensor_amax = torch.max(torch.abs(x))
@@ -54,7 +69,10 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
     else:
         scale = None
 
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(x, per_tensor_scale=scale)
+    x_nvfp4 = NVFP4Tensor.to_nvfp4(
+        x, per_tensor_scale=scale, rounding_mode=rounding_mode,
+        is_swizzled_scales=True, use_triton_kernel=use_triton_kernel,
+    )
     x_reconstructed = x_nvfp4.dequantize(dtype)
 
     def assert_sqnr_gt_threshold(orig, new, threshold):
@@ -99,6 +117,8 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
     )
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize("is_swizzled_scales", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -114,20 +134,27 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape):
+def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_mode, use_triton_kernel):
     """
     Test that NVFP4Tensor can be constructed with swizzled scales and
     that the is_swizzled_scales flag is set correctly.
     """
+    if use_triton_kernel and not is_swizzled_scales:
+        pytest.skip("triton kernel requires swizzled scales")
 
     data = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=is_swizzled_scales)
+    tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
     assert tensor.is_swizzled_scales == is_swizzled_scales
     reconstructed = tensor.dequantize(torch.bfloat16)
     assert reconstructed.shape == data.shape
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
     "slice_dim,slice_spec",
     [
@@ -150,7 +177,7 @@ def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape):
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec):
+def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use_triton_kernel):
     """
     Test that slicing works correctly with swizzled scales and maintains
     the swizzled state in the output tensor.
@@ -166,7 +193,10 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec):
 
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
     assert tensor.is_swizzled_scales == True
 
     if slice_dim == 0:
@@ -190,6 +220,8 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec):
     torch.testing.assert_close(sliced_reconstructed, expected, atol=1e-6, rtol=1e-6)
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
     "slice_dim,slice_spec,expected_error",
     [
@@ -244,14 +276,17 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec):
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_error):
+def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_error, rounding_mode, use_triton_kernel):
     """
     Test that slicing raises appropriate errors for misaligned boundaries.
     """
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
 
     with pytest.raises(RuntimeError, match=expected_error):
         if slice_dim == 0:
@@ -260,18 +295,23 @@ def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_er
             _ = tensor[:, slice_spec]
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_view_semantics():
+def test_nvfp4_swizzled_scales_view_semantics(rounding_mode, use_triton_kernel):
     """
     Test that slicing maintains proper view semantics where possible.
     """
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
 
     # Test row slicing (should maintain views)
     sliced_tensor = tensor[0:128, :]
@@ -286,11 +326,13 @@ def test_nvfp4_swizzled_scales_view_semantics():
     assert full_width_slice.qdata.data_ptr() == tensor.qdata.data_ptr()
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_serialization():
+def test_nvfp4_swizzled_scales_serialization(rounding_mode, use_triton_kernel):
     """
     Test that tensor flatten/unflatten preserves the swizzled scales state.
     """
@@ -299,7 +341,10 @@ def test_nvfp4_swizzled_scales_serialization():
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensor with swizzled scales
-    original_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    original_tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
 
     # Test serialization
     tensor_list, ctx = original_tensor.__tensor_flatten__()
@@ -327,11 +372,13 @@ def test_nvfp4_swizzled_scales_serialization():
     torch.testing.assert_close(original_dq, reconstructed_dq, atol=1e-6, rtol=1e-6)
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_get_scales_method():
+def test_nvfp4_swizzled_scales_get_scales_method(rounding_mode, use_triton_kernel):
     """
     Test that the get_scales() method correctly unswizzles scales when needed.
     """
@@ -340,8 +387,11 @@ def test_nvfp4_swizzled_scales_get_scales_method():
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensors with both storage methods
-    regular_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=False)
-    swizzled_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=True)
+    regular_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=False, rounding_mode=rounding_mode)
+    swizzled_tensor = NVFP4Tensor.to_nvfp4(
+        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
 
     # Get scales from both tensors and verify they are equal
     regular_scales = regular_tensor.get_hp_scales()
@@ -354,6 +404,7 @@ def test_nvfp4_swizzled_scales_get_scales_method():
     assert swizzled_scales.shape == expected_shape
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize(
     "M", [128, 256, 512, 1024, 100, 200, 384], ids=lambda m: f"M{m}"
@@ -367,7 +418,7 @@ def test_nvfp4_swizzled_scales_get_scales_method():
     not is_sm_at_least_100(), reason="requires sm100+ for raw intrinsics"
 )
 @torch.no_grad()
-def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
+def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, rounding_mode):
     """Test that Triton and PyTorch NVFP4 quantization produce equivalent results."""
     torch.manual_seed(42)
     x = torch.randn(M, N, dtype=dtype, device="cuda")
@@ -381,6 +432,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
         use_triton_kernel=False,
+        rounding_mode=rounding_mode,
     )
 
     nvfp4_triton = NVFP4Tensor.to_nvfp4(
@@ -388,30 +440,37 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
         use_triton_kernel=True,
+        rounding_mode=rounding_mode,
     )
 
     torch.testing.assert_close(nvfp4_pt.scale.flatten(), nvfp4_triton.scale.flatten())
-    pt_unpacked = unpack_uint4(nvfp4_pt.qdata.view(torch.uint8))
-    triton_unpacked = unpack_uint4(nvfp4_triton.qdata.view(torch.uint8))
-    torch.testing.assert_close(
-        pt_unpacked,
-        triton_unpacked,
-        atol=0,
-        rtol=0,
-    )
+
+    if rounding_mode == RoundingMode.RN:
+    # RN is deterministic, so Triton and PyTorch paths should match exactly
+        pt_unpacked = unpack_uint4(nvfp4_pt.qdata.view(torch.uint8))
+        triton_unpacked = unpack_uint4(nvfp4_triton.qdata.view(torch.uint8))
+        torch.testing.assert_close(
+            pt_unpacked,
+            triton_unpacked,
+            atol=0,
+            rtol=0,
+        )
 
     x_pt_dequant = nvfp4_pt.dequantize(dtype)
     x_triton_dequant = nvfp4_triton.dequantize(dtype)
 
     sqnr = compute_error(x_pt_dequant, x_triton_dequant)
-    SQNR_THRESHOLD = 40.0
+    # RS uses different RNGs for Triton vs PyTorch, so SQNR will be lower
+    SQNR_THRESHOLD = 40.0 if rounding_mode == RoundingMode.RN else 8.0
 
     assert sqnr >= SQNR_THRESHOLD, (
         f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD} for M={M}, N={N}, "
-        f"use_per_tensor_scale={use_per_tensor_scale}, dtype={dtype}"
+        f"use_per_tensor_scale={use_per_tensor_scale}, dtype={dtype}, "
+        f"rounding_mode={rounding_mode}"
     )
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
@@ -424,7 +483,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
 @pytest.mark.parametrize("compile", [False])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("inpt_dtype", [torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("use_triton_kernel", [True, False])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -451,6 +510,7 @@ def test_nvfp4_matmul_with_amax(
     inpt_dtype: torch.dtype,
     use_triton_kernel: bool,
     shapes: tuple,
+    rounding_mode: RoundingMode,
 ):
     # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
     if quant_type == "dynamic" and not is_sm_at_least_100():
@@ -487,6 +547,7 @@ def test_nvfp4_matmul_with_amax(
         per_tensor_scale=a_scale,
         is_swizzled_scales=True,
         use_triton_kernel=use_triton_kernel,
+        rounding_mode=rounding_mode,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
@@ -494,6 +555,7 @@ def test_nvfp4_matmul_with_amax(
         is_swizzled_scales=True,
         use_triton_kernel=use_triton_kernel,
         act_quant_kwargs=act_quant_kwargs,
+        rounding_mode=rounding_mode,
     )
 
     func = torch.compile(F.linear, fullgraph=True) if compile else F.linear
@@ -504,21 +566,32 @@ def test_nvfp4_matmul_with_amax(
     )
 
     sqnr = compute_error(C_ref, C_nvfp4)
-    SQNR_THRESHOLD = 16.0
+    # RS has higher quantization noise than RN
+    SQNR_THRESHOLD = 16.0 if rounding_mode == RoundingMode.RN else 6.0
     assert sqnr >= SQNR_THRESHOLD, (
-        f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD}, use_gelu={use_gelu}, {quant_type=}, compile={compile}, bias={bias}"
+        f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD}, use_gelu={use_gelu}, {quant_type=}, "
+        f"compile={compile}, bias={bias}, rounding_mode={rounding_mode}"
     )
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_to_copy():
-    x = NVFP4Tensor.to_nvfp4(torch.randn((32, 128))).cuda()
+def test_nvfp4_to_copy(rounding_mode, use_triton_kernel):
+    M, K = 32, 128
+    data = torch.randn(M, K)
+    x = NVFP4Tensor.to_nvfp4(
+        data.cuda() if use_triton_kernel else data,
+        rounding_mode=rounding_mode,
+        is_swizzled_scales=use_triton_kernel,
+        use_triton_kernel=use_triton_kernel,
+    ).cuda()
     y = torch.ops.aten._to_copy(x, dtype=torch.bfloat16)
-    assert torch.equal(x.qdata, y.qdata)
-    assert torch.equal(x.scale, y.scale)
+    torch.testing.assert_close(x.qdata, y.qdata, atol=0, rtol=0)
+    torch.testing.assert_close(x.scale, y.scale, atol=0, rtol=0)
     assert x.per_tensor_scale is None
     assert y.per_tensor_scale is None
     assert x.act_per_tensor_scale is None
@@ -530,12 +603,13 @@ def test_nvfp4_to_copy():
     assert y.dtype == torch.bfloat16
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
 @pytest.mark.parametrize("transpose", [False, True])
-@pytest.mark.parametrize("use_triton_kernel", [False, True])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize("is_swizzled_scales", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -548,10 +622,8 @@ def test_nvfp4_to_copy():
     ),
 )
 def test_scale_shape_matches_qdata(
-    transpose, use_triton_kernel, is_swizzled_scales, shape
+    transpose, use_triton_kernel, is_swizzled_scales, shape, rounding_mode
 ):
-    if use_triton_kernel and not is_sm_at_least_100():
-        pytest.skip("CUDA capability >= 10.0 required for nvfp4 triton kernel")
     if use_triton_kernel and not is_swizzled_scales:
         pytest.skip("triton kernel requires swizzled scales")
 
@@ -566,6 +638,7 @@ def test_scale_shape_matches_qdata(
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=is_swizzled_scales,
         use_triton_kernel=use_triton_kernel,
+        rounding_mode=rounding_mode,
     )
 
     if len(shape) == 2:
@@ -604,18 +677,27 @@ def test_scale_shape_matches_qdata(
     )
 
 
+@pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
+@pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
 @pytest.mark.parametrize("dims", ((1, 2), (2, 1), (-1, -2), (-2, -1)))
 @pytest.mark.parametrize("is_swizzled_scales", [True, False])
-def test_3d_transpose(dims, is_swizzled_scales):
+def test_3d_transpose(dims, is_swizzled_scales, rounding_mode, use_triton_kernel):
+    if use_triton_kernel and not is_swizzled_scales:
+        pytest.skip("triton kernel requires swizzled scales")
+
     x_hp = torch.randn(2, 128, 256, device="cuda")
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(x_hp, is_swizzled_scales=is_swizzled_scales)
+    x_nvfp4 = NVFP4Tensor.to_nvfp4(
+        x_hp, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+        use_triton_kernel=use_triton_kernel,
+    )
     x_hp_t = x_hp.transpose(dims[0], dims[1])
     x_nvfp4_t = x_nvfp4.transpose(dims[0], dims[1])
     assert x_hp_t.shape == x_nvfp4_t.shape
+
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -44,6 +44,29 @@ _triton_kernel_params = [
 ]
 
 
+def _to_nvfp4_with_rand_bits(
+    data, use_triton_kernel=False, rounding_mode=RoundingMode.RN, **kwargs
+):
+    """Test helper: auto-generates rand_bits for RS mode and calls to_nvfp4."""
+    rand_bits = None
+    if rounding_mode == RoundingMode.RS:
+        if use_triton_kernel:
+            rand_bits = torch.randint(
+                0, 2**31, (1,), dtype=torch.int32, device=data.device
+            )
+        else:
+            rand_bits = torch.randint(
+                0, 2**31, data.shape, dtype=torch.int32, device=data.device
+            )
+    return NVFP4Tensor.to_nvfp4(
+        data,
+        use_triton_kernel=use_triton_kernel,
+        rounding_mode=rounding_mode,
+        rand_bits=rand_bits,
+        **kwargs,
+    )
+
+
 @pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
 @pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
@@ -60,7 +83,9 @@ _triton_kernel_params = [
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
-def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode, use_triton_kernel):
+def test_nvfp4_reconstruction(
+    dtype, shape, use_per_tensor_scale, rounding_mode, use_triton_kernel
+):
 
     x = torch.randn(shape, dtype=dtype, device="cuda")
     if use_per_tensor_scale:
@@ -69,9 +94,12 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode,
     else:
         scale = None
 
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(
-        x, per_tensor_scale=scale, rounding_mode=rounding_mode,
-        is_swizzled_scales=True, use_triton_kernel=use_triton_kernel,
+    x_nvfp4 = _to_nvfp4_with_rand_bits(
+        x,
+        per_tensor_scale=scale,
+        rounding_mode=rounding_mode,
+        is_swizzled_scales=True,
+        use_triton_kernel=use_triton_kernel,
     )
     x_reconstructed = x_nvfp4.dequantize(dtype)
 
@@ -134,7 +162,9 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode,
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_construction(
+    is_swizzled_scales, shape, rounding_mode, use_triton_kernel
+):
     """
     Test that NVFP4Tensor can be constructed with swizzled scales and
     that the is_swizzled_scales flag is set correctly.
@@ -144,8 +174,10 @@ def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_
 
     data = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=is_swizzled_scales,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     assert tensor.is_swizzled_scales == is_swizzled_scales
@@ -177,7 +209,9 @@ def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_slicing(
+    slice_dim, slice_spec, rounding_mode, use_triton_kernel
+):
     """
     Test that slicing works correctly with swizzled scales and maintains
     the swizzled state in the output tensor.
@@ -193,8 +227,10 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use
 
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     assert tensor.is_swizzled_scales == True
@@ -276,15 +312,19 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_error, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_slicing_errors(
+    slice_dim, slice_spec, expected_error, rounding_mode, use_triton_kernel
+):
     """
     Test that slicing raises appropriate errors for misaligned boundaries.
     """
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -308,8 +348,10 @@ def test_nvfp4_swizzled_scales_view_semantics(rounding_mode, use_triton_kernel):
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -341,8 +383,10 @@ def test_nvfp4_swizzled_scales_serialization(rounding_mode, use_triton_kernel):
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensor with swizzled scales
-    original_tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    original_tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -387,9 +431,13 @@ def test_nvfp4_swizzled_scales_get_scales_method(rounding_mode, use_triton_kerne
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensors with both storage methods
-    regular_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=False, rounding_mode=rounding_mode)
-    swizzled_tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    regular_tensor = _to_nvfp4_with_rand_bits(
+        data, is_swizzled_scales=False, rounding_mode=rounding_mode
+    )
+    swizzled_tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -418,7 +466,9 @@ def test_nvfp4_swizzled_scales_get_scales_method(rounding_mode, use_triton_kerne
     not is_sm_at_least_100(), reason="requires sm100+ for raw intrinsics"
 )
 @torch.no_grad()
-def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, rounding_mode):
+def test_triton_nvfp4_quantize_equivalence(
+    M, N, use_per_tensor_scale, dtype, rounding_mode
+):
     """Test that Triton and PyTorch NVFP4 quantization produce equivalent results."""
     torch.manual_seed(42)
     x = torch.randn(M, N, dtype=dtype, device="cuda")
@@ -427,7 +477,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, ro
     if use_per_tensor_scale:
         per_tensor_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(x)))
 
-    nvfp4_pt = NVFP4Tensor.to_nvfp4(
+    nvfp4_pt = _to_nvfp4_with_rand_bits(
         x.clone(),
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
@@ -435,7 +485,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, ro
         rounding_mode=rounding_mode,
     )
 
-    nvfp4_triton = NVFP4Tensor.to_nvfp4(
+    nvfp4_triton = _to_nvfp4_with_rand_bits(
         x.clone(),
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
@@ -542,14 +592,14 @@ def test_nvfp4_matmul_with_amax(
     act_quant_kwargs = None
     if quant_type == "dynamic":
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs()
-    A_nvfp4 = NVFP4Tensor.to_nvfp4(
+    A_nvfp4 = _to_nvfp4_with_rand_bits(
         A,
         per_tensor_scale=a_scale,
         is_swizzled_scales=True,
         use_triton_kernel=use_triton_kernel,
         rounding_mode=rounding_mode,
     )
-    B_nvfp4 = NVFP4Tensor.to_nvfp4(
+    B_nvfp4 = _to_nvfp4_with_rand_bits(
         B,
         per_tensor_scale=b_scale,
         is_swizzled_scales=True,
@@ -583,7 +633,7 @@ def test_nvfp4_matmul_with_amax(
 def test_nvfp4_to_copy(rounding_mode, use_triton_kernel):
     M, K = 32, 128
     data = torch.randn(M, K)
-    x = NVFP4Tensor.to_nvfp4(
+    x = _to_nvfp4_with_rand_bits(
         data.cuda() if use_triton_kernel else data,
         rounding_mode=rounding_mode,
         is_swizzled_scales=use_triton_kernel,
@@ -633,7 +683,7 @@ def test_scale_shape_matches_qdata(
 
     per_tensor_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(x_hp)))
 
-    x = NVFP4Tensor.to_nvfp4(
+    x = _to_nvfp4_with_rand_bits(
         x_hp,
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=is_swizzled_scales,
@@ -690,13 +740,16 @@ def test_3d_transpose(dims, is_swizzled_scales, rounding_mode, use_triton_kernel
         pytest.skip("triton kernel requires swizzled scales")
 
     x_hp = torch.randn(2, 128, 256, device="cuda")
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(
-        x_hp, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+    x_nvfp4 = _to_nvfp4_with_rand_bits(
+        x_hp,
+        is_swizzled_scales=is_swizzled_scales,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     x_hp_t = x_hp.transpose(dims[0], dims[1])
     x_nvfp4_t = x_nvfp4.transpose(dims[0], dims[1])
     assert x_hp_t.shape == x_nvfp4_t.shape
+
 
 
 
@@ -736,6 +789,67 @@ def test_nvfp4_pin_memory(use_per_tensor_scale):
     assert torch.equal(
         x_cpu.dequantize(torch.float32), x_pinned.dequantize(torch.float32)
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_rs_cuda_graph_eager():
+    """Test eager RS path under manual CUDA graph capture/replay.
+
+    rand_bits is generated outside the graph boundary and fed in before each
+    replay. Verifies consecutive replays with different rand_bits produce
+    different outputs, and resetting torch.manual_seed reproduces the same output.
+    """
+    shape = (128, 256)
+    x = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+    rand_bits = torch.empty(*shape, dtype=torch.int32, device="cuda")
+
+    # Warmup
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    result = NVFP4Tensor.to_nvfp4(
+        x,
+        rounding_mode=RoundingMode.RS,
+        rand_bits=rand_bits,
+    )
+    qdata_out = result.qdata.clone()
+
+    # Capture graph
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    torch.cuda.current_stream().wait_stream(s)
+
+    with torch.cuda.graph(g):
+        result = NVFP4Tensor.to_nvfp4(
+            x,
+            rounding_mode=RoundingMode.RS,
+            rand_bits=rand_bits,
+        )
+        qdata_out.copy_(result.qdata)
+
+    # Replay with different rand_bits produces different output
+    torch.manual_seed(42)
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r1 = qdata_out.clone()
+
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r2 = qdata_out.clone()
+
+    assert not torch.equal(unpack_uint4(r1), unpack_uint4(r2))
+
+    # Resetting seed reproduces same output
+    torch.manual_seed(42)
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r3 = qdata_out.clone()
+
+    torch.testing.assert_close(unpack_uint4(r1), unpack_uint4(r3))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -854,3 +968,52 @@ def test_nvfp4_per_expert_scale():
 
     xc_dq_ref = torch.cat([x0_dq, x1_dq], dim=0).view(E, N, K)
     torch.testing.assert_close(xc_dq_ref, xc_dq, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for nvfp4 triton kernel",
+)
+@pytest.mark.skipif(
+    not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_rs_cuda_graph_compile():
+    """Test Triton RS path under torch.compile with CUDA graphs.
+
+    Uses torch.compile with mode="reduce-overhead" (which uses CUDA graphs
+    internally). The compiled function generates a seed and calls to_nvfp4.
+    Verifies consecutive calls produce different outputs, and resetting
+    torch.manual_seed reproduces the same output.
+    """
+    shape = (128, 256)
+    x = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+
+    def quantize_rs(data):
+        seed = torch.randint(0, 2**31, (1,), dtype=torch.int32, device=data.device)
+        return NVFP4Tensor.to_nvfp4(
+            data,
+            rounding_mode=RoundingMode.RS,
+            is_swizzled_scales=True,
+            use_triton_kernel=True,
+            rand_bits=seed,
+        ).qdata
+
+    compiled_fn = torch.compile(quantize_rs, mode="reduce-overhead", fullgraph=True)
+
+    # Warmup (torch.compile needs a few calls to trigger compilation + graph capture)
+    for _ in range(3):
+        compiled_fn(x)
+
+    # Consecutive calls produce different output
+    torch.manual_seed(42)
+    r1 = compiled_fn(x).clone()
+    r2 = compiled_fn(x).clone()
+
+    assert not torch.equal(unpack_uint4(r1), unpack_uint4(r2))
+
+    # Resetting seed reproduces same output
+    torch.manual_seed(42)
+    r3 = compiled_fn(x).clone()
+
+    torch.testing.assert_close(unpack_uint4(r1), unpack_uint4(r3))

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -44,6 +44,29 @@ _triton_kernel_params = [
 ]
 
 
+def _to_nvfp4_with_rand_bits(
+    data, use_triton_kernel=False, rounding_mode=RoundingMode.RN, **kwargs
+):
+    """Test helper: auto-generates rand_bits for RS mode and calls to_nvfp4."""
+    rand_bits = None
+    if rounding_mode == RoundingMode.RS:
+        if use_triton_kernel:
+            rand_bits = torch.randint(
+                0, 2**31, (1,), dtype=torch.int32, device=data.device
+            )
+        else:
+            rand_bits = torch.randint(
+                0, 2**31, data.shape, dtype=torch.int32, device=data.device
+            )
+    return NVFP4Tensor.to_nvfp4(
+        data,
+        use_triton_kernel=use_triton_kernel,
+        rounding_mode=rounding_mode,
+        rand_bits=rand_bits,
+        **kwargs,
+    )
+
+
 @pytest.mark.parametrize("rounding_mode", [RoundingMode.RN, RoundingMode.RS])
 @pytest.mark.parametrize("use_triton_kernel", _triton_kernel_params)
 @pytest.mark.parametrize(
@@ -60,7 +83,9 @@ _triton_kernel_params = [
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
-def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode, use_triton_kernel):
+def test_nvfp4_reconstruction(
+    dtype, shape, use_per_tensor_scale, rounding_mode, use_triton_kernel
+):
 
     x = torch.randn(shape, dtype=dtype, device="cuda")
     if use_per_tensor_scale:
@@ -69,9 +94,12 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode,
     else:
         scale = None
 
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(
-        x, per_tensor_scale=scale, rounding_mode=rounding_mode,
-        is_swizzled_scales=True, use_triton_kernel=use_triton_kernel,
+    x_nvfp4 = _to_nvfp4_with_rand_bits(
+        x,
+        per_tensor_scale=scale,
+        rounding_mode=rounding_mode,
+        is_swizzled_scales=True,
+        use_triton_kernel=use_triton_kernel,
     )
     x_reconstructed = x_nvfp4.dequantize(dtype)
 
@@ -134,7 +162,9 @@ def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale, rounding_mode,
     not torch_version_at_least("2.8.0"), reason="torch.compile requires PyTorch 2.8+"
 )
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_construction(
+    is_swizzled_scales, shape, rounding_mode, use_triton_kernel
+):
     """
     Test that NVFP4Tensor can be constructed with swizzled scales and
     that the is_swizzled_scales flag is set correctly.
@@ -144,8 +174,10 @@ def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_
 
     data = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=is_swizzled_scales,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     assert tensor.is_swizzled_scales == is_swizzled_scales
@@ -177,7 +209,9 @@ def test_nvfp4_swizzled_scales_construction(is_swizzled_scales, shape, rounding_
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_slicing(
+    slice_dim, slice_spec, rounding_mode, use_triton_kernel
+):
     """
     Test that slicing works correctly with swizzled scales and maintains
     the swizzled state in the output tensor.
@@ -193,8 +227,10 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use
 
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     assert tensor.is_swizzled_scales == True
@@ -276,15 +312,19 @@ def test_nvfp4_swizzled_scales_slicing(slice_dim, slice_spec, rounding_mode, use
 @pytest.mark.skipif(
     not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
 )
-def test_nvfp4_swizzled_scales_slicing_errors(slice_dim, slice_spec, expected_error, rounding_mode, use_triton_kernel):
+def test_nvfp4_swizzled_scales_slicing_errors(
+    slice_dim, slice_spec, expected_error, rounding_mode, use_triton_kernel
+):
     """
     Test that slicing raises appropriate errors for misaligned boundaries.
     """
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -308,8 +348,10 @@ def test_nvfp4_swizzled_scales_view_semantics(rounding_mode, use_triton_kernel):
 
     M, K = 256, 4096
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-    tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -341,8 +383,10 @@ def test_nvfp4_swizzled_scales_serialization(rounding_mode, use_triton_kernel):
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensor with swizzled scales
-    original_tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    original_tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -387,9 +431,13 @@ def test_nvfp4_swizzled_scales_get_scales_method(rounding_mode, use_triton_kerne
     data = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
 
     # Create tensors with both storage methods
-    regular_tensor = NVFP4Tensor.to_nvfp4(data, is_swizzled_scales=False, rounding_mode=rounding_mode)
-    swizzled_tensor = NVFP4Tensor.to_nvfp4(
-        data, is_swizzled_scales=True, rounding_mode=rounding_mode,
+    regular_tensor = _to_nvfp4_with_rand_bits(
+        data, is_swizzled_scales=False, rounding_mode=rounding_mode
+    )
+    swizzled_tensor = _to_nvfp4_with_rand_bits(
+        data,
+        is_swizzled_scales=True,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
 
@@ -418,7 +466,9 @@ def test_nvfp4_swizzled_scales_get_scales_method(rounding_mode, use_triton_kerne
     not is_sm_at_least_100(), reason="requires sm100+ for raw intrinsics"
 )
 @torch.no_grad()
-def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, rounding_mode):
+def test_triton_nvfp4_quantize_equivalence(
+    M, N, use_per_tensor_scale, dtype, rounding_mode
+):
     """Test that Triton and PyTorch NVFP4 quantization produce equivalent results."""
     torch.manual_seed(42)
     x = torch.randn(M, N, dtype=dtype, device="cuda")
@@ -427,7 +477,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, ro
     if use_per_tensor_scale:
         per_tensor_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(x)))
 
-    nvfp4_pt = NVFP4Tensor.to_nvfp4(
+    nvfp4_pt = _to_nvfp4_with_rand_bits(
         x.clone(),
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
@@ -435,7 +485,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype, ro
         rounding_mode=rounding_mode,
     )
 
-    nvfp4_triton = NVFP4Tensor.to_nvfp4(
+    nvfp4_triton = _to_nvfp4_with_rand_bits(
         x.clone(),
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=True,
@@ -542,14 +592,14 @@ def test_nvfp4_matmul_with_amax(
     act_quant_kwargs = None
     if quant_type == "dynamic":
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs()
-    A_nvfp4 = NVFP4Tensor.to_nvfp4(
+    A_nvfp4 = _to_nvfp4_with_rand_bits(
         A,
         per_tensor_scale=a_scale,
         is_swizzled_scales=True,
         use_triton_kernel=use_triton_kernel,
         rounding_mode=rounding_mode,
     )
-    B_nvfp4 = NVFP4Tensor.to_nvfp4(
+    B_nvfp4 = _to_nvfp4_with_rand_bits(
         B,
         per_tensor_scale=b_scale,
         is_swizzled_scales=True,
@@ -583,7 +633,7 @@ def test_nvfp4_matmul_with_amax(
 def test_nvfp4_to_copy(rounding_mode, use_triton_kernel):
     M, K = 32, 128
     data = torch.randn(M, K)
-    x = NVFP4Tensor.to_nvfp4(
+    x = _to_nvfp4_with_rand_bits(
         data.cuda() if use_triton_kernel else data,
         rounding_mode=rounding_mode,
         is_swizzled_scales=use_triton_kernel,
@@ -633,7 +683,7 @@ def test_scale_shape_matches_qdata(
 
     per_tensor_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(x_hp)))
 
-    x = NVFP4Tensor.to_nvfp4(
+    x = _to_nvfp4_with_rand_bits(
         x_hp,
         per_tensor_scale=per_tensor_scale,
         is_swizzled_scales=is_swizzled_scales,
@@ -690,13 +740,16 @@ def test_3d_transpose(dims, is_swizzled_scales, rounding_mode, use_triton_kernel
         pytest.skip("triton kernel requires swizzled scales")
 
     x_hp = torch.randn(2, 128, 256, device="cuda")
-    x_nvfp4 = NVFP4Tensor.to_nvfp4(
-        x_hp, is_swizzled_scales=is_swizzled_scales, rounding_mode=rounding_mode,
+    x_nvfp4 = _to_nvfp4_with_rand_bits(
+        x_hp,
+        is_swizzled_scales=is_swizzled_scales,
+        rounding_mode=rounding_mode,
         use_triton_kernel=use_triton_kernel,
     )
     x_hp_t = x_hp.transpose(dims[0], dims[1])
     x_nvfp4_t = x_nvfp4.transpose(dims[0], dims[1])
     assert x_hp_t.shape == x_nvfp4_t.shape
+
 
 
 
@@ -736,6 +789,67 @@ def test_nvfp4_pin_memory(use_per_tensor_scale):
     assert torch.equal(
         x_cpu.dequantize(torch.float32), x_pinned.dequantize(torch.float32)
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_rs_cuda_graph_eager():
+    """Test eager RS path under manual CUDA graph capture/replay.
+
+    rand_bits is generated outside the graph boundary and fed in before each
+    replay. Verifies consecutive replays with different rand_bits produce
+    different outputs, and resetting torch.manual_seed reproduces the same output.
+    """
+    shape = (128, 256)
+    x = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+    rand_bits = torch.empty(*shape, dtype=torch.int32, device="cuda")
+
+    # Warmup
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    result = NVFP4Tensor.to_nvfp4(
+        x,
+        rounding_mode=RoundingMode.RS,
+        rand_bits=rand_bits,
+    )
+    qdata_out = result.qdata.clone()
+
+    # Capture graph
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    torch.cuda.current_stream().wait_stream(s)
+
+    with torch.cuda.graph(g):
+        result = NVFP4Tensor.to_nvfp4(
+            x,
+            rounding_mode=RoundingMode.RS,
+            rand_bits=rand_bits,
+        )
+        qdata_out.copy_(result.qdata)
+
+    # Replay with different rand_bits produces different output
+    torch.manual_seed(42)
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r1 = qdata_out.clone()
+
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r2 = qdata_out.clone()
+
+    assert not torch.equal(unpack_uint4(r1), unpack_uint4(r2))
+
+    # Resetting seed reproduces same output
+    torch.manual_seed(42)
+    torch.randint(0, 2**31, shape, dtype=torch.int32, device="cuda", out=rand_bits)
+    g.replay()
+    r3 = qdata_out.clone()
+
+    torch.testing.assert_close(unpack_uint4(r1), unpack_uint4(r3))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -794,3 +908,52 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     sqnr = compute_error(C_ref, C_nvfp4)
     SQNR_THRESHOLD = 16.0
     assert sqnr >= SQNR_THRESHOLD, f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD}, {a_has_scale=}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for nvfp4 triton kernel",
+)
+@pytest.mark.skipif(
+    not torch_version_at_least("2.8.0"), reason="NVFP4 requires PyTorch 2.8+"
+)
+def test_nvfp4_rs_cuda_graph_compile():
+    """Test Triton RS path under torch.compile with CUDA graphs.
+
+    Uses torch.compile with mode="reduce-overhead" (which uses CUDA graphs
+    internally). The compiled function generates a seed and calls to_nvfp4.
+    Verifies consecutive calls produce different outputs, and resetting
+    torch.manual_seed reproduces the same output.
+    """
+    shape = (128, 256)
+    x = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+
+    def quantize_rs(data):
+        seed = torch.randint(0, 2**31, (1,), dtype=torch.int32, device=data.device)
+        return NVFP4Tensor.to_nvfp4(
+            data,
+            rounding_mode=RoundingMode.RS,
+            is_swizzled_scales=True,
+            use_triton_kernel=True,
+            rand_bits=seed,
+        ).qdata
+
+    compiled_fn = torch.compile(quantize_rs, mode="reduce-overhead", fullgraph=True)
+
+    # Warmup (torch.compile needs a few calls to trigger compilation + graph capture)
+    for _ in range(3):
+        compiled_fn(x)
+
+    # Consecutive calls produce different output
+    torch.manual_seed(42)
+    r1 = compiled_fn(x).clone()
+    r2 = compiled_fn(x).clone()
+
+    assert not torch.equal(unpack_uint4(r1), unpack_uint4(r2))
+
+    # Resetting seed reproduces same output
+    torch.manual_seed(42)
+    r3 = compiled_fn(x).clone()
+
+    torch.testing.assert_close(unpack_uint4(r1), unpack_uint4(r3))

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -13,10 +13,10 @@
 #      - Values outside the representable range of Floatx after rounding are clamped to the maximum Floatx
 #      magnitude (sign is preserved).
 
-import torch
 from enum import Enum
-from torch import Tensor
 
+import torch
+from torch import Tensor
 
 
 class RoundingMode(Enum):
@@ -49,6 +49,7 @@ def _f32_to_floatx_unpacked(
     ebits: int,
     mbits: int,
     rounding_mode: RoundingMode = RoundingMode.RN,
+    rand_bits: Tensor | None = None,
 ) -> Tensor:
     """Convert FP32 numbers to sub-byte floating point numbers with the given
     number of exponent and mantissa bits.
@@ -65,8 +66,13 @@ def _f32_to_floatx_unpacked(
         mbits: Number of mantissa bits in the target format (including the
             implicit leading 1).
         rounding_mode: RoundingMode.RN (round to nearest, ties to even)
-            or RoundingMode.RS (stochastic rounding). For deterministic RS,
-            set torch.manual_seed() before calling.
+            or RoundingMode.RS (stochastic rounding).
+        rand_bits: Random int32 tensor for stochastic rounding. Required when
+            rounding_mode is RS. Must have the same shape as the normal-range
+            elements of x. Only the low-order (23 - mbits) bits are used;
+            the caller may pass any int32 random values. The caller is
+            responsible for generating this tensor, which keeps RNG concerns
+            (seeding, CUDA graph safety) outside this function.
 
     Note: there are no special values (NaN, inf) support in this code. Values
     outside the representable range of Floatx after rounding are clamped to the
@@ -160,13 +166,13 @@ def _f32_to_floatx_unpacked(
         # positions. This makes the probability of rounding up proportional
         # to the fractional distance from the lower quantization level,
         # providing an unbiased estimator.
-        rand_bits = torch.randint(
-            0,
-            (1 << (MBITS_F32 - mbits)),
-            normal_x.shape,
-            dtype=torch.int32,
-            device=normal_x.device,
-        )
+        if rand_bits is None:
+            raise ValueError(
+                "rand_bits is required for stochastic rounding (RoundingMode.RS). "
+                "Caller must generate rand_bits externally."
+            )
+        # Mask to only the bits that fit in the truncated mantissa positions.
+        rand_bits = rand_bits & ((1 << (MBITS_F32 - mbits)) - 1)
         val_to_add = (exp_bias - F32_EXP_BIAS) << MBITS_F32
         normal_x += val_to_add
         normal_x += rand_bits

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -13,7 +13,7 @@
 #      - Values outside the representable range of Floatx after rounding are clamped to the maximum Floatx
 #      magnitude (sign is preserved).
 
-from enum import Enum
+from enum import Enum, auto
 
 import torch
 from torch import Tensor

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -8,12 +8,32 @@
 # It has been refactored to support any sub-byte FP dtypes. However, some behaviors of MX dtypes remain:
 #   1. No encodings are reserved for special values (+/-inf, NaN).
 #   2. When downcasting from FP32 to Floatx,
-#      - Rounding mode is round to nearest, ties to even.
+#      - Rounding mode defaults to round to nearest, ties to even.
+#      - Stochastic rounding is also supported for training use cases.
 #      - Values outside the representable range of Floatx after rounding are clamped to the maximum Floatx
 #      magnitude (sign is preserved).
 
 import torch
+from enum import Enum
 from torch import Tensor
+
+
+
+class RoundingMode(Enum):
+    """
+    Enum representing rounding modes for sub-byte floating point quantization.
+
+    RN: Round to nearest, ties to even. This is the standard IEEE 754 default
+        rounding mode. Used for weights and activations.
+
+    RS: Stochastic rounding. Adds uniformly distributed random noise to the
+        mantissa bits below the target precision before truncating. Provides
+        an unbiased estimator of the original value in expectation. Needed
+        for gradient quantization in NVFP4 training.
+    """
+
+    RN = 0
+    RS = 1
 
 
 def _n_ones(n: int) -> int:
@@ -24,7 +44,12 @@ EBITS_F32, MBITS_F32 = 8, 23
 F32_EXP_BIAS = _n_ones(EBITS_F32 - 1)
 
 
-def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
+def _f32_to_floatx_unpacked(
+    x: Tensor,
+    ebits: int,
+    mbits: int,
+    rounding_mode: RoundingMode = RoundingMode.RN,
+) -> Tensor:
     """Convert FP32 numbers to sub-byte floating point numbers with the given
     number of exponent and mantissa bits.
 
@@ -33,6 +58,15 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     in the least significant bits. e.g.
       fp4: bits 0-3 empty and bits 4-7 in fp4_e2m1 encoding
       fp6: bits 0-1 empty and bits 2-7 in fp6_e2m3 or fp6_e3m2 encoding
+
+    Args:
+        x: Input tensor of dtype torch.float.
+        ebits: Number of exponent bits in the target format.
+        mbits: Number of mantissa bits in the target format (including the
+            implicit leading 1).
+        rounding_mode: RoundingMode.RN (round to nearest, ties to even)
+            or RoundingMode.RS (stochastic rounding). For deterministic RS,
+            set torch.manual_seed() before calling.
 
     Note: there are no special values (NaN, inf) support in this code. Values
     outside the representable range of Floatx after rounding are clamped to the
@@ -111,13 +145,37 @@ def _f32_to_floatx_unpacked(x: Tensor, ebits: int, mbits: int) -> Tensor:
     # branch 3: stay in normal range, adjust the exponent and round
     #
     normal_x = x.view(torch.int32)
-    # resulting mantissa is odd
-    mant_odd = (normal_x >> (MBITS_F32 - mbits)) & 1
-    # update exponent, rounding bias part 1
-    val_to_add = ((exp_bias - F32_EXP_BIAS) << MBITS_F32) + magic_adder
-    normal_x += val_to_add
-    # rounding bias part 2
-    normal_x += mant_odd
+
+    if rounding_mode == RoundingMode.RN:
+        # Round to nearest, ties to even (default IEEE 754 rounding mode)
+        # resulting mantissa is odd
+        mant_odd = (normal_x >> (MBITS_F32 - mbits)) & 1
+        # update exponent, rounding bias part 1
+        val_to_add = ((exp_bias - F32_EXP_BIAS) << MBITS_F32) + magic_adder
+        normal_x += val_to_add
+        # rounding bias part 2
+        normal_x += mant_odd
+    elif rounding_mode == RoundingMode.RS:
+        # Stochastic rounding: add random bits in the truncated mantissa
+        # positions. This makes the probability of rounding up proportional
+        # to the fractional distance from the lower quantization level,
+        # providing an unbiased estimator.
+        rand_bits = torch.randint(
+            0,
+            (1 << (MBITS_F32 - mbits)),
+            normal_x.shape,
+            dtype=torch.int32,
+            device=normal_x.device,
+        )
+        val_to_add = (exp_bias - F32_EXP_BIAS) << MBITS_F32
+        normal_x += val_to_add
+        normal_x += rand_bits
+    else:
+        raise ValueError(
+            f"Unknown rounding_mode: {rounding_mode}. "
+            f"Expected RoundingMode.RN or RoundingMode.RS."
+        )
+
     # take the bits!
     normal_x = normal_x >> (MBITS_F32 - mbits)
     normal_x = normal_x.to(torch.uint8)

--- a/torchao/prototype/custom_fp_utils.py
+++ b/torchao/prototype/custom_fp_utils.py
@@ -32,8 +32,8 @@ class RoundingMode(Enum):
         for gradient quantization in NVFP4 training.
     """
 
-    RN = 0
-    RS = 1
+    RN = auto()
+    RS = auto()
 
 
 def _n_ones(n: int) -> int:

--- a/torchao/prototype/mx_formats/__init__.py
+++ b/torchao/prototype/mx_formats/__init__.py
@@ -1,3 +1,4 @@
+from torchao.prototype.custom_fp_utils import RoundingMode
 from torchao.prototype.mx_formats.config import (
     ScaleCalculationMode,
 )
@@ -16,4 +17,5 @@ __all__ = [
     "NVFP4DynamicActivationNVFP4WeightConfig",
     "NVFP4ObservedLinear",
     "NVFP4WeightOnlyConfig",
+    "RoundingMode",
 ]

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -15,6 +15,7 @@ from torch.distributed.tensor.experimental import register_sharding
 from torch.utils._triton import has_triton
 
 from torchao.prototype.custom_fp_utils import (
+    RoundingMode,
     _f32_to_floatx_unpacked,
     _floatx_unpacked_to_f32,
 )
@@ -57,13 +58,18 @@ ZERO_BITS_F32 = 0x0
 ZERO_POINT_FIVE_BITS_F32 = 0x3F000000
 
 
-def f32_to_f4_unpacked(x):
+def f32_to_f4_unpacked(x, rounding_mode=RoundingMode.RN):
     """
     Input: torch.Tensor of dtype torch.float
     Output: torch.Tensor of dtype torch.uint8, with bits 0-3 empty and
       bits 4-7 in fp4_e2m1
+
+    Args:
+        rounding_mode: RoundingMode.RN or RoundingMode.RS
     """
-    return _f32_to_floatx_unpacked(x, EBITS_F4_E2M1, MBITS_F4_E2M1)
+    return _f32_to_floatx_unpacked(
+        x, EBITS_F4_E2M1, MBITS_F4_E2M1, rounding_mode=rounding_mode
+    )
 
 
 def f32_to_f6_e2m3_unpacked(x):
@@ -426,6 +432,287 @@ if torch_version_at_least("2.7.0") and has_triton():
 
         return out
 
+    @triton.jit
+    def convert_fp32_to_fp4_packed(x_pairs):
+        """Convert FP32 pairs to packed FP4 format using round-to-nearest.
+
+        This function takes tensor where consecutive values along the last dimension
+        are packed together into single bytes.
+
+        Args:
+            x_pairs: [Tensor, Tensor] both w/ shapes [..., 1] where zipped last dimension contains
+                    interleaved pairs of FP32 values to be packed together.
+
+        Returns:
+            Packed tensor with shape [...] (last dimension removed) where each
+            element is an int8 containing 2 FP4 values:
+            - First value of pair → low nibble (bits 0-3)
+            - Second value of pair → high nibble (bits 4-7)
+
+        Example:
+            Input:  [128, 32, 2] containing FP32 pairs
+            Output: [128, 32] containing packed FP4 bytes
+
+        """
+
+        x_fp4x2 = tl.inline_asm_elementwise(
+            asm="""
+            {
+            .reg .b8 byte0, byte1, byte2, byte3;
+            cvt.rn.satfinite.e2m1x2.f32 byte0, $5, $1;
+            cvt.rn.satfinite.e2m1x2.f32 byte1, $6, $2;
+            cvt.rn.satfinite.e2m1x2.f32 byte2, $7, $3;
+            cvt.rn.satfinite.e2m1x2.f32 byte3, $8, $4;
+            mov.b32 $0, {byte0, byte1, byte2, byte3};
+            }
+            """,
+            constraints=("=r,r,r,r,r,r,r,r,r"),
+            args=x_pairs,
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=4,
+        )
+
+        return x_fp4x2
+
+    @triton.jit
+    def convert_fp32_to_fp4_packed_rs(x_pairs, rbits):
+        """Hardware stochastic rounding for FP4 conversion using cvt.rs PTX.
+
+        Uses the cvt.rs.satfinite.e2m1x4.f32 instruction which performs
+        stochastic rounding natively. Two instructions convert 8 floats
+        (4 pairs) into 4 packed FP4 bytes, matching the RN path output.
+
+        The RN path uses cvt.rn.satfinite.e2m1x2 (2 floats -> 1 byte, pack=4
+        consumes 4 elements per tensor -> 8 floats). The RS instruction
+        cvt.rs.satfinite.e2m1x4 takes 4 floats + 1 rbits -> 2 bytes, so only
+        2 of the 4 rbits values from pack=4 are used ($9, $10); the other
+        two ($11, $12) are wasted. This keeps the data layout identical to RN.
+
+        Args:
+            x_pairs: [Tensor, Tensor] from [128, 32, 2].split() — same as RN path.
+            rbits: Tensor of uint32 random bits [128, 32]. With pack=4,
+                4 consecutive values are loaded; only 2 are used per invocation.
+        """
+        x_fp4x2 = tl.inline_asm_elementwise(
+            asm="""
+            {
+            .reg .b16 half0, half1;
+            cvt.rs.satfinite.e2m1x4.f32 half0, {$6, $2, $5, $1}, $9;
+            cvt.rs.satfinite.e2m1x4.f32 half1, {$8, $4, $7, $3}, $10;
+            mov.b32 $0, {half0, half1};
+            }
+            """,
+            constraints=("=r,r,r,r,r,r,r,r,r,r,r,r,r"),
+            args=[x_pairs[0], x_pairs[1], rbits],
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=4,
+        )
+
+        return x_fp4x2
+
+    # Sauce: https://github.com/gau-nernst/quantized-training
+    @triton.jit
+    def quantize_nvfp4_triton_kernel(
+        x_ptr,
+        tensor_scale_ptr,
+        q_ptr,
+        s_ptr,
+        stride_xm,
+        stride_xn,
+        M,
+        N,
+        seed,
+        USE_TENSOR_SCALE: tl.constexpr,
+        MASK_SCALES: tl.constexpr,
+        ROUNDING_MODE: tl.constexpr,  # 0=RN, 1=RS
+    ):
+        F4_E2M1_MAX = 6.0
+        F8E4M3_MAX = 448.0
+        E4M3_EPS = 1.5258789e-05
+
+        pid_m = tl.program_id(1)
+        pid_n = tl.program_id(0)
+
+        offs_m = pid_m * 128 + tl.arange(0, 128)[:, None]
+        offs_n = pid_n * 64 + tl.arange(0, 64)[None, :]
+        if MASK_SCALES:
+            mask = (offs_m < M) & (offs_n < N)
+            other = 0.0
+        else:
+            mask = None
+            other = None
+        x = tl.load(
+            x_ptr + offs_m * stride_xm + offs_n * stride_xn, mask=mask, other=other
+        )  # [128, 64]
+        x_blocks = x.to(tl.float32).reshape(128, 4, 16)  # [128, 4, 16]
+
+        # Compute block-wise scales
+        block_amax = tl.max(x_blocks.abs(), axis=2)  # [128, 4]
+
+        if USE_TENSOR_SCALE:
+            # Two-level scaling: quantize block scales with per-tensor scale
+            tensor_scale = tl.load(tensor_scale_ptr)
+
+            # First compute block scales
+            block_scale_f32 = (block_amax / F4_E2M1_MAX).to(tl.float32)
+
+            # Quantize the block scales with per-tensor scale
+            scaled_block_scales = block_scale_f32 / tensor_scale
+            scaled_block_scales = tl.clamp(scaled_block_scales, E4M3_EPS, F8E4M3_MAX)
+            scales = scaled_block_scales.to(tl.float8e4nv)
+
+            # Apply combined scale to data: per_tensor_scale * quantized_block_scale
+            total_scale = tensor_scale * scales.to(tl.float32)[:, :, None]
+            x_blocks = tl.div_rn(x_blocks, total_scale)
+        else:
+            # Single-level scaling: use block scales directly
+            scales_f32 = block_amax / F4_E2M1_MAX
+            scales_f32 = tl.clamp(scales_f32, E4M3_EPS, F8E4M3_MAX)
+            scales = scales_f32.to(tl.float8e4nv)
+
+            # Apply block scale to data
+            total_scale = scales.to(tl.float32)[:, :, None]
+            x_blocks = tl.div_rn(x_blocks, total_scale)
+
+        # NVIDIA layout for scales
+        if MASK_SCALES:
+            # Create offsets for the scale dimensions (4 blocks per row)
+            scale_offs_n = pid_n * 4 + tl.arange(0, 4)[None, :]
+
+            # Mask out scales to 0 if we are not aligned to 128 x 64
+            scales = tl.where(
+                (offs_m < M) & (scale_offs_n < N // 16),
+                scales,
+                0.0,
+            )
+        packed_scales = scales.reshape(4, 32, 4).permute(1, 0, 2).reshape(32, 16)
+        offs_m = tl.arange(0, 32)[:, None]
+        offs_n = tl.arange(0, 16)[None, :]
+        tl.store(
+            s_ptr
+            + (pid_m * tl.num_programs(0) + pid_n) * (32 * 16)
+            + offs_m * 16
+            + offs_n,
+            packed_scales,
+        )
+
+        # Output offsets for packed FP4 storage [128, 32]
+        offs_m = pid_m * 128 + tl.arange(0, 128)[:, None]
+        offs_n = pid_n * 32 + tl.arange(0, 32)[None, :]
+        out_offs = offs_m * (N // 2) + offs_n
+
+        # Convert to FP4
+        x_pairs = x_blocks.reshape(128, 32, 2).split()
+        if ROUNDING_MODE == 0:
+            # Round to nearest (RN)
+            x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
+        else:
+            # Stochastic rounding (RS) via hardware cvt.rs.satfinite.e2m1x4.f32
+            rbits = tl.randint(seed, out_offs)
+            x_fp4x2 = convert_fp32_to_fp4_packed_rs(x_pairs, rbits)
+        if MASK_SCALES:
+            mask = (offs_m < M) & (offs_n < N // 2)
+        else:
+            mask = None
+        tl.store(q_ptr + out_offs, x_fp4x2, mask=mask)
+
+    @torch.library.custom_op("ao::triton_quantize_nvfp4", mutates_args=())
+    def triton_quantize_nvfp4(
+        x: torch.Tensor,
+        per_tensor_scale: Optional[torch.Tensor] = None,
+        rounding_mode: int = 0,
+        seed: int = 0,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize a tensor to NVFP4 format.
+
+        Args:
+            x (torch.Tensor): Input tensor to be quantized.
+            per_tensor_scale (Optional[torch.Tensor]): Per-tensor scale for two-level quantization.
+                If None, uses single-level block-wise quantization only.
+            rounding_mode (int): 0 for round-to-nearest, 1 for stochastic rounding.
+            seed (int): Seed for stochastic rounding random number generation.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Quantized tensor and scales tensor in swizzled layout.
+
+        Note:
+            Since VLLM does not use dyanmo guards we need to make this a custom op
+            to avoid the triton kernel being invoked w/ the wrong use of `MASK_SCALES`
+        """
+        # reshape to 2d
+        orig_leading_dims, _orig_M, orig_N = x.shape[:-2], x.shape[-2], x.shape[-1]
+        x = x.reshape(-1, orig_N)
+
+        M, N = x.shape
+        # assert M % 128 == 0 and N % 64 == 0
+        assert N % 16 == 0, "N must be divisible by 16 for NVFP4 quantization"
+        if rounding_mode not in RoundingMode:
+            raise ValueError(
+                f"Unknown rounding_mode: {rounding_mode}. "
+                f"Expected RoundingMode.RN or RoundingMode.RS."
+            )
+
+        # Calculate blocks needed
+        num_scales = N // 16
+        n_row_blocks = triton.cdiv(M, 128)
+        n_col_blocks = triton.cdiv(num_scales, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+
+        # mask out scales to 0 if we are not aligned to 128 x 64
+        MASK_SCALES = M % 128 != 0 or N % 64 != 0
+
+        xq = x.new_empty(M, N // 2, dtype=torch.uint8)
+        scales = x.new_empty(padded_rows, padded_cols, dtype=torch.float8_e4m3fn)
+
+        grid = (triton.cdiv(N, 64), triton.cdiv(M, 128))
+
+        if per_tensor_scale is None:
+            # Don't allocate tensor, we just steal this since it won't be used in kernel
+            tensor_scale_ptr = x
+            use_tensor_scale = False
+        else:
+            tensor_scale_ptr = per_tensor_scale
+            use_tensor_scale = True
+
+        quantize_nvfp4_triton_kernel[grid](
+            x,
+            tensor_scale_ptr,
+            xq,
+            scales,
+            x.stride(0),
+            x.stride(1),
+            M,
+            N,
+            seed,
+            USE_TENSOR_SCALE=use_tensor_scale,
+            MASK_SCALES=MASK_SCALES,
+            ROUNDING_MODE=rounding_mode,
+        )
+
+        # reshape back to original shape
+        scales = scales.view(*orig_leading_dims, -1, padded_cols)
+        xq = xq.view(*orig_leading_dims, -1, N // 2)
+
+        return scales, xq.view(torch.uint8)
+
+    @triton_quantize_nvfp4.register_fake
+    def _(x, per_tensor_scale=None, rounding_mode=0, seed=0):
+        M, N = x.shape
+        num_scales = N // 16
+        n_row_blocks = triton.cdiv(M, 128)
+        n_col_blocks = triton.cdiv(num_scales, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+
+        scales = torch.empty(
+            padded_rows, padded_cols, device=x.device, dtype=torch.float8_e4m3fn
+        )
+        xq = torch.empty(M, N // 2, device=x.device, dtype=torch.uint8)
+        return scales, xq
+
     @triton_mx_block_rearrange.register_fake
     def _(scale_tensor):
         rows, cols = scale_tensor.shape
@@ -445,6 +732,14 @@ else:
         raise AssertionError("needs torch version 2.8+ and triton")
 
     def triton_mx_block_rearrange(scale_tensor: torch.Tensor) -> torch.Tensor:
+        raise AssertionError("needs torch version 2.8+ and triton")
+
+    def triton_quantize_nvfp4(
+        x: torch.Tensor,
+        tensor_scale: Optional[torch.Tensor] = None,
+        rounding_mode: int = 0,
+        seed: int = 0,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise AssertionError("needs torch version 2.8+ and triton")
 
     def triton_mxfp8_dequant_dim0(

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -58,7 +58,7 @@ ZERO_BITS_F32 = 0x0
 ZERO_POINT_FIVE_BITS_F32 = 0x3F000000
 
 
-def f32_to_f4_unpacked(x, rounding_mode=RoundingMode.RN):
+def f32_to_f4_unpacked(x, rounding_mode=RoundingMode.RN, rand_bits=None):
     """
     Input: torch.Tensor of dtype torch.float
     Output: torch.Tensor of dtype torch.uint8, with bits 0-3 empty and
@@ -66,9 +66,14 @@ def f32_to_f4_unpacked(x, rounding_mode=RoundingMode.RN):
 
     Args:
         rounding_mode: RoundingMode.RN or RoundingMode.RS
+        rand_bits: Random int32 tensor for RS mode (required when RS).
     """
     return _f32_to_floatx_unpacked(
-        x, EBITS_F4_E2M1, MBITS_F4_E2M1, rounding_mode=rounding_mode
+        x,
+        EBITS_F4_E2M1,
+        MBITS_F4_E2M1,
+        rounding_mode=rounding_mode,
+        rand_bits=rand_bits,
     )
 
 
@@ -523,7 +528,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         stride_xn,
         M,
         N,
-        seed,
+        seed_ptr,
         USE_TENSOR_SCALE: tl.constexpr,
         MASK_SCALES: tl.constexpr,
         ROUNDING_MODE: tl.constexpr,  # 0=RN, 1=RS
@@ -610,6 +615,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
         else:
             # Stochastic rounding (RS) via hardware cvt.rs.satfinite.e2m1x4.f32
+            seed = tl.load(seed_ptr)
             rbits = tl.randint(seed, out_offs)
             x_fp4x2 = convert_fp32_to_fp4_packed_rs(x_pairs, rbits)
         if MASK_SCALES:
@@ -623,7 +629,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         x: torch.Tensor,
         per_tensor_scale: Optional[torch.Tensor] = None,
         rounding_mode: int = 0,
-        seed: int = 0,
+        seed: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Quantize a tensor to NVFP4 format.
 
@@ -632,7 +638,10 @@ if torch_version_at_least("2.7.0") and has_triton():
             per_tensor_scale (Optional[torch.Tensor]): Per-tensor scale for two-level quantization.
                 If None, uses single-level block-wise quantization only.
             rounding_mode (int): 0 for round-to-nearest, 1 for stochastic rounding.
-            seed (int): Seed for stochastic rounding random number generation.
+            seed (Optional[torch.Tensor]): Seed tensor for stochastic rounding RNG.
+                Should be a single-element int32 tensor on the same device as x.
+                When None, stochastic rounding uses a dummy seed (caller should
+                only pass None when rounding_mode=0).
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Quantized tensor and scales tensor in swizzled layout.
@@ -677,6 +686,10 @@ if torch_version_at_least("2.7.0") and has_triton():
             tensor_scale_ptr = per_tensor_scale
             use_tensor_scale = True
 
+        # For seed_ptr: if seed is None (RN mode), reuse x as dummy pointer
+        # (kernel won't read it when ROUNDING_MODE=0)
+        seed_ptr = seed if seed is not None else x
+
         quantize_nvfp4_triton_kernel[grid](
             x,
             tensor_scale_ptr,
@@ -686,7 +699,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             x.stride(1),
             M,
             N,
-            seed,
+            seed_ptr,
             USE_TENSOR_SCALE=use_tensor_scale,
             MASK_SCALES=MASK_SCALES,
             ROUNDING_MODE=rounding_mode,
@@ -699,7 +712,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         return scales, xq.view(torch.uint8)
 
     @triton_quantize_nvfp4.register_fake
-    def _(x, per_tensor_scale=None, rounding_mode=0, seed=0):
+    def _(x, per_tensor_scale=None, rounding_mode=0, seed=None):
         M, N = x.shape
         num_scales = N // 16
         n_row_blocks = triton.cdiv(M, 128)
@@ -738,7 +751,6 @@ else:
         x: torch.Tensor,
         tensor_scale: Optional[torch.Tensor] = None,
         rounding_mode: int = 0,
-        seed: int = 0,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise AssertionError("needs torch version 2.8+ and triton")
 

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -712,7 +712,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         return scales, xq.view(torch.uint8)
 
     @triton_quantize_nvfp4.register_fake
-    def _(x, per_tensor_scale=None, rounding_mode=0, seed=None):
+    def _(x, per_tensor_scale=None, rounding_mode=RoundingMode.RN, seed=None):
         M, N = x.shape
         num_scales = N // 16
         n_row_blocks = triton.cdiv(M, 128)
@@ -750,7 +750,7 @@ else:
     def triton_quantize_nvfp4(
         x: torch.Tensor,
         tensor_scale: Optional[torch.Tensor] = None,
-        rounding_mode: int = 0,
+        rounding_mode: RoundingMode = RoundingMode.RN,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise AssertionError("needs torch version 2.8+ and triton")
 

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -529,6 +529,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         M,
         N,
         seed_ptr,
+        offset_ptr,
         USE_TENSOR_SCALE: tl.constexpr,
         MASK_SCALES: tl.constexpr,
         ROUNDING_MODE: tl.constexpr,  # 0=RN, 1=RS
@@ -616,6 +617,9 @@ if torch_version_at_least("2.7.0") and has_triton():
         else:
             # Stochastic rounding (RS) via hardware cvt.rs.satfinite.e2m1x4.f32
             seed = tl.load(seed_ptr)
+            offset_base = tl.load(offset_ptr)
+            # Place local index in upper 32 bits and offset_base in lower 32 bits
+            offset = (tl.cast(out_offs, tl.int64) << 32) | offset_base
             rbits = tl.randint(seed, out_offs)
             x_fp4x2 = convert_fp32_to_fp4_packed_rs(x_pairs, rbits)
         if MASK_SCALES:
@@ -629,7 +633,8 @@ if torch_version_at_least("2.7.0") and has_triton():
         x: torch.Tensor,
         per_tensor_scale: Optional[torch.Tensor] = None,
         rounding_mode: int = 0,
-        seed: Optional[torch.Tensor] = None,
+        seed: torch.Tensor | None = None,
+        offset: torch.Tensor | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Quantize a tensor to NVFP4 format.
 
@@ -638,8 +643,12 @@ if torch_version_at_least("2.7.0") and has_triton():
             per_tensor_scale (Optional[torch.Tensor]): Per-tensor scale for two-level quantization.
                 If None, uses single-level block-wise quantization only.
             rounding_mode (int): 0 for round-to-nearest, 1 for stochastic rounding.
-            seed (Optional[torch.Tensor]): Seed tensor for stochastic rounding RNG.
-                Should be a single-element int32 tensor on the same device as x.
+            seed (torch.Tensor | None): Seed tensor for stochastic rounding RNG.
+                Should be a single-element int64 tensor on the same device as x.
+                When None, stochastic rounding uses a dummy seed (caller should
+                only pass None when rounding_mode=0).
+            offset (torch.Tensor | None): Seed tensor for stochastic rounding RNG.
+                Should be a single-element int64 tensor on the same device as x.
                 When None, stochastic rounding uses a dummy seed (caller should
                 only pass None when rounding_mode=0).
 
@@ -689,6 +698,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         # For seed_ptr: if seed is None (RN mode), reuse x as dummy pointer
         # (kernel won't read it when ROUNDING_MODE=0)
         seed_ptr = seed if seed is not None else x
+        offset_ptr = offset if offset is not None else x
 
         quantize_nvfp4_triton_kernel[grid](
             x,
@@ -700,6 +710,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             M,
             N,
             seed_ptr,
+            offset_ptr,
             USE_TENSOR_SCALE=use_tensor_scale,
             MASK_SCALES=MASK_SCALES,
             ROUNDING_MODE=rounding_mode,
@@ -712,7 +723,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         return scales, xq.view(torch.uint8)
 
     @triton_quantize_nvfp4.register_fake
-    def _(x, per_tensor_scale=None, rounding_mode=RoundingMode.RN, seed=None):
+    def _(x, per_tensor_scale=None, rounding_mode=RoundingMode.RN, seed=None, offset=None):
         M, N = x.shape
         num_scales = N // 16
         n_row_blocks = triton.cdiv(M, 128)

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -610,7 +610,7 @@ if torch_version_at_least("2.7.0") and has_triton():
 
         # Convert to FP4
         x_pairs = x_blocks.reshape(128, 32, 2).split()
-        if ROUNDING_MODE == 0:
+        if ROUNDING_MODE == 1:  # RoundingMode.RN
             # Round to nearest (RN)
             x_fp4x2 = convert_fp32_to_fp4_packed(x_pairs)
         else:

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -11,6 +11,7 @@ from typing import Optional
 import torch
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
+from torchao.prototype.custom_fp_utils import RoundingMode
 from torchao.prototype.mx_formats.constants import F4_E2M1_MAX, F8E4M3_MAX
 from torchao.prototype.mx_formats.kernels import (
     f4_unpacked_to_f32,
@@ -32,6 +33,7 @@ from torchao.prototype.mx_formats.utils import (
     to_blocked,
 )
 from torchao.quantization.quantize_.common import (
+    KernelPreference,
     QuantizeTensorKwargs,
 )
 from torchao.utils import TorchAOBaseTensor, fill_defaults
@@ -47,6 +49,7 @@ class QuantizeTensorToNVFP4Kwargs(QuantizeTensorKwargs):
     is_swizzled_scales: bool = False
     use_triton_kernel: bool = False
     use_dynamic_per_tensor_scale: bool = False
+    rounding_mode: RoundingMode = RoundingMode.RN
 
 
 class NVFP4Tensor(TorchAOBaseTensor):
@@ -137,6 +140,8 @@ class NVFP4Tensor(TorchAOBaseTensor):
         is_swizzled_scales: bool = False,
         use_triton_kernel: bool = False,
         act_quant_kwargs: Optional[QuantizeTensorToNVFP4Kwargs] = None,
+        rounding_mode: RoundingMode = RoundingMode.RN,
+        kernel_preference: KernelPreference = KernelPreference.MSLK,
     ):
         """Convert high precision tensor to NVFP4 format.
 
@@ -150,6 +155,8 @@ class NVFP4Tensor(TorchAOBaseTensor):
             is_swizzled_scales: If True, store scales in swizzled format for faster matrix multiplication
             use_triton_kernel: If True, use Triton kernel for quantization
             act_quant_kwargs: If specified, config for quantizing the activation
+            rounding_mode: Rounding mode for FP4 conversion (RN or RS).
+                For deterministic RS, set torch.manual_seed() before calling.
 
         Returns:
             NVFP4Tensor: Quantized tensor in NVFP4 format
@@ -162,10 +169,20 @@ class NVFP4Tensor(TorchAOBaseTensor):
             assert K % 16 == 0, (
                 f"Triton kernel requires K (dim -1) to be divisible by 16, got {K}"
             )
-            blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
+            assert per_tensor_scale is not None, (
+                "Triton kernel requires per_tensor_scale"
+            )
+            if kernel_preference = KernelPreference.MSLK:
+                blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
+            else:
+                _seed = torch.randint(2**31, (1,)).item()
+                blockwise_scales, data_lp = triton_quantize_nvfp4(
+                    data_hp, per_tensor_scale, rounding_mode.value, _seed
+                )
         else:
             blockwise_scales, data_lp = nvfp4_quantize(
-                data_hp, block_size, per_tensor_scale
+                data_hp, block_size, per_tensor_scale,
+                rounding_mode=rounding_mode,
             )
             if is_swizzled_scales:
                 scale_shape = (math.prod(leading_dims) * M, K // block_size)
@@ -610,6 +627,7 @@ def nvfp4_linear(func, types, args, kwargs):
             per_tensor_scale=per_tensor_scale,
             is_swizzled_scales=k.is_swizzled_scales,
             use_triton_kernel=k.use_triton_kernel,
+            rounding_mode=k.rounding_mode,
         )
         res = _addmm_nvfp4_dispatch(input_tensor, weight_tensor.t(), func, bias=bias)
         res = res.reshape(*orig_shape[:-1], res.shape[-1])
@@ -645,6 +663,7 @@ def nvfp4_mm(func, types, args, kwargs):
                 per_tensor_scale=per_tensor_scale,
                 is_swizzled_scales=k.is_swizzled_scales,
                 use_triton_kernel=k.use_triton_kernel,
+                rounding_mode=k.rounding_mode,
             )
         return _addmm_nvfp4_dispatch(input_tensor, weight_tensor, func)
 
@@ -699,6 +718,7 @@ def nvfp4_addmm(func, types, args, kwargs):
                 per_tensor_scale=per_tensor_scale,
                 is_swizzled_scales=k.is_swizzled_scales,
                 use_triton_kernel=k.use_triton_kernel,
+                rounding_mode=k.rounding_mode,
             )
         return _addmm_nvfp4_dispatch(input_tensor, weight_tensor, func, bias=bias)
 
@@ -770,6 +790,7 @@ def nvfp4_quantize(
     data_hp: torch.Tensor,
     block_size: int = 16,
     per_tensor_scale: Optional[torch.Tensor] = None,
+    rounding_mode: RoundingMode = RoundingMode.RN,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """NVIDIA FP4 quantization with UE4M3 scales.
 
@@ -779,13 +800,14 @@ def nvfp4_quantize(
     Args:
         data_hp: High precision input tensor (bfloat16 or float32)
         block_size: Block size for quantization (must be 16)
-        per_tensor_amax: Optional pre-computed absolute maximum for calibration.
+        per_tensor_scale: Optional pre-computed per-tensor scale for calibration.
             If provided, uses per-tensor scaling. If None, uses block-wise scaling only.
+        rounding_mode: Rounding mode for FP4 conversion (RN or RS).
+            For deterministic RS, set torch.manual_seed() before calling.
 
     Returns:
         tuple: A tuple containing:
-            - total_scale_fp8: Blockwise scales in float8_e4m3fn format
-            - per_tensor_scale: Global per-tensor scale if per_tensor_amax provided, else None
+            - out_scales: Blockwise scales in float8_e4m3fn format
             - data_lp: Packed FP4 data (2 values per byte)
 
     Raises:
@@ -844,7 +866,7 @@ def nvfp4_quantize(
 
     data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
     data_scaled = data_scaled.view(orig_shape)
-    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp = f32_to_f4_unpacked(data_scaled, rounding_mode=rounding_mode)
     # TODO: NotImplementedError: "copy_kernel" not implemented for 'Float4_e2m1fn_x2'
     # data_lp = pack_uint4(data_lp).view(torch.float4_e2m1fn_x2)
     data_lp = pack_uint4(data_lp)

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -141,6 +141,7 @@ class NVFP4Tensor(TorchAOBaseTensor):
         use_triton_kernel: bool = False,
         act_quant_kwargs: Optional[QuantizeTensorToNVFP4Kwargs] = None,
         rounding_mode: RoundingMode = RoundingMode.RN,
+        rand_bits: Optional[torch.Tensor] = None,
         kernel_preference: KernelPreference = KernelPreference.MSLK,
     ):
         """Convert high precision tensor to NVFP4 format.
@@ -156,13 +157,26 @@ class NVFP4Tensor(TorchAOBaseTensor):
             use_triton_kernel: If True, use Triton kernel for quantization
             act_quant_kwargs: If specified, config for quantizing the activation
             rounding_mode: Rounding mode for FP4 conversion (RN or RS).
-                For deterministic RS, set torch.manual_seed() before calling.
+            rand_bits: Optional int32 tensor for stochastic rounding randomness.
+                Required when rounding_mode is RS. The caller is responsible
+                for generating this, keeping RNG concerns (seeding, CUDA graph
+                safety) outside this function.
+                - Triton path: single-element int32 seed tensor (the kernel
+                  generates per-element randomness internally).
+                - Eager path: full-shaped int32 tensor (same shape as data_hp).
 
         Returns:
             NVFP4Tensor: Quantized tensor in NVFP4 format
         """
         assert len(data_hp.shape) in (2, 3), "unsupported"
         leading_dims, M, K = data_hp.shape[:-2], data_hp.shape[-2], data_hp.shape[-1]
+
+        if rounding_mode == RoundingMode.RS and rand_bits is None:
+            raise ValueError(
+                "rand_bits is required for stochastic rounding (RoundingMode.RS). "
+                "For the Triton path, pass a single-element int32 seed tensor. "
+                "For the eager path, pass a full-shaped int32 tensor."
+            )
 
         if use_triton_kernel:
             assert is_swizzled_scales, "Triton kernel only supports swizzled scales"
@@ -177,12 +191,15 @@ class NVFP4Tensor(TorchAOBaseTensor):
             else:
                 _seed = torch.randint(2**31, (1,)).item()
                 blockwise_scales, data_lp = triton_quantize_nvfp4(
-                    data_hp, per_tensor_scale, rounding_mode.value, _seed
+                    data_hp, per_tensor_scale, rounding_mode.value, rand_bits
                 )
         else:
             blockwise_scales, data_lp = nvfp4_quantize(
-                data_hp, block_size, per_tensor_scale,
+                data_hp,
+                block_size,
+                per_tensor_scale,
                 rounding_mode=rounding_mode,
+                rand_bits=rand_bits,
             )
             if is_swizzled_scales:
                 scale_shape = (math.prod(leading_dims) * M, K // block_size)
@@ -791,6 +808,7 @@ def nvfp4_quantize(
     block_size: int = 16,
     per_tensor_scale: Optional[torch.Tensor] = None,
     rounding_mode: RoundingMode = RoundingMode.RN,
+    rand_bits: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """NVIDIA FP4 quantization with UE4M3 scales.
 
@@ -803,7 +821,8 @@ def nvfp4_quantize(
         per_tensor_scale: Optional pre-computed per-tensor scale for calibration.
             If provided, uses per-tensor scaling. If None, uses block-wise scaling only.
         rounding_mode: Rounding mode for FP4 conversion (RN or RS).
-            For deterministic RS, set torch.manual_seed() before calling.
+        rand_bits: Optional int32 tensor of random bits for stochastic rounding.
+            Required when rounding_mode is RS. Same shape as data_hp.
 
     Returns:
         tuple: A tuple containing:
@@ -820,6 +839,10 @@ def nvfp4_quantize(
     assert data_hp.size(-1) % block_size == 0, "K dim must be divisible by block_size"
     assert data_hp.is_contiguous(), "Only support contiguous data for now"
     assert block_size == 16, "NVFP4 requires block_size=16"
+    if rounding_mode == RoundingMode.RS:
+        assert rand_bits is not None and rand_bits.numel() > 1, (
+            "Eager path requires full-shaped rand_bits tensor for RS mode"
+        )
 
     orig_shape = data_hp.shape
     # Convert to float32 early for consistent precision with Triton implementation
@@ -866,7 +889,11 @@ def nvfp4_quantize(
 
     data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
     data_scaled = data_scaled.view(orig_shape)
-    data_lp = f32_to_f4_unpacked(data_scaled, rounding_mode=rounding_mode)
+    data_lp = f32_to_f4_unpacked(
+        data_scaled,
+        rounding_mode=rounding_mode,
+        rand_bits=rand_bits,
+    )
     # TODO: NotImplementedError: "copy_kernel" not implemented for 'Float4_e2m1fn_x2'
     # data_lp = pack_uint4(data_lp).view(torch.float4_e2m1fn_x2)
     data_lp = pack_uint4(data_lp)

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -183,14 +183,10 @@ class NVFP4Tensor(TorchAOBaseTensor):
             assert K % 16 == 0, (
                 f"Triton kernel requires K (dim -1) to be divisible by 16, got {K}"
             )
-            assert per_tensor_scale is not None, (
-                "Triton kernel requires per_tensor_scale"
-            )
-            if kernel_preference = KernelPreference.MSLK:
+            if kernel_preference == KernelPreference.MSLK and rounding_mode == RoundingMode.RN:
                 blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
             else:
-                _seed = torch.randint(2**31, (1,)).item()
-                blockwise_scales, data_lp = triton_quantize_nvfp4(
+                blockwise_scales, data_lp = torch.ops.ao.triton_quantize_nvfp4(
                     data_hp, per_tensor_scale, rounding_mode.value, rand_bits
                 )
         else:

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -11,6 +11,7 @@ from typing import Optional
 import torch
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
+from torchao.prototype.custom_fp_utils import RoundingMode
 from torchao.prototype.mx_formats.constants import F4_E2M1_MAX, F8E4M3_MAX
 from torchao.prototype.mx_formats.kernels import (
     f4_unpacked_to_f32,
@@ -30,6 +31,7 @@ from torchao.prototype.mx_formats.utils import (
     to_blocked,
 )
 from torchao.quantization.quantize_.common import (
+    KernelPreference,
     QuantizeTensorKwargs,
 )
 from torchao.utils import TorchAOBaseTensor, fill_defaults
@@ -45,6 +47,7 @@ class QuantizeTensorToNVFP4Kwargs(QuantizeTensorKwargs):
     is_swizzled_scales: bool = False
     use_triton_kernel: bool = False
     use_dynamic_per_tensor_scale: bool = False
+    rounding_mode: RoundingMode = RoundingMode.RN
 
 
 class NVFP4Tensor(TorchAOBaseTensor):
@@ -130,6 +133,8 @@ class NVFP4Tensor(TorchAOBaseTensor):
         is_swizzled_scales: bool = False,
         use_triton_kernel: bool = False,
         act_quant_kwargs: Optional[QuantizeTensorToNVFP4Kwargs] = None,
+        rounding_mode: RoundingMode = RoundingMode.RN,
+        kernel_preference: KernelPreference = KernelPreference.MSLK,
     ):
         """Convert high precision tensor to NVFP4 format.
 
@@ -143,6 +148,8 @@ class NVFP4Tensor(TorchAOBaseTensor):
             is_swizzled_scales: If True, store scales in swizzled format for faster matrix multiplication
             use_triton_kernel: If True, use Triton kernel for quantization
             act_quant_kwargs: If specified, config for quantizing the activation
+            rounding_mode: Rounding mode for FP4 conversion (RN or RS).
+                For deterministic RS, set torch.manual_seed() before calling.
 
         Returns:
             NVFP4Tensor: Quantized tensor in NVFP4 format
@@ -155,10 +162,20 @@ class NVFP4Tensor(TorchAOBaseTensor):
             assert K % 16 == 0, (
                 f"Triton kernel requires K (dim -1) to be divisible by 16, got {K}"
             )
-            blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
+            assert per_tensor_scale is not None, (
+                "Triton kernel requires per_tensor_scale"
+            )
+            if kernel_preference = KernelPreference.MSLK:
+                blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
+            else:
+                _seed = torch.randint(2**31, (1,)).item()
+                blockwise_scales, data_lp = triton_quantize_nvfp4(
+                    data_hp, per_tensor_scale, rounding_mode.value, _seed
+                )
         else:
             blockwise_scales, data_lp = nvfp4_quantize(
-                data_hp, block_size, per_tensor_scale
+                data_hp, block_size, per_tensor_scale,
+                rounding_mode=rounding_mode,
             )
             if is_swizzled_scales:
                 scale_shape = (math.prod(leading_dims) * M, K // block_size)
@@ -585,6 +602,7 @@ def nvfp4_linear(func, types, args, kwargs):
             per_tensor_scale=per_tensor_scale,
             is_swizzled_scales=k.is_swizzled_scales,
             use_triton_kernel=k.use_triton_kernel,
+            rounding_mode=k.rounding_mode,
         )
         res = _addmm_nvfp4_dispatch(input_tensor, weight_tensor.t(), func, bias=bias)
         res = res.reshape(*orig_shape[:-1], res.shape[-1])
@@ -619,6 +637,7 @@ def nvfp4_mm(func, types, args, kwargs):
                 per_tensor_scale=per_tensor_scale,
                 is_swizzled_scales=k.is_swizzled_scales,
                 use_triton_kernel=k.use_triton_kernel,
+                rounding_mode=k.rounding_mode,
             )
         return _addmm_nvfp4_dispatch(input_tensor, weight_tensor, func)
 
@@ -652,6 +671,7 @@ def nvfp4_addmm(func, types, args, kwargs):
                 per_tensor_scale=per_tensor_scale,
                 is_swizzled_scales=k.is_swizzled_scales,
                 use_triton_kernel=k.use_triton_kernel,
+                rounding_mode=k.rounding_mode,
             )
         return _addmm_nvfp4_dispatch(input_tensor, weight_tensor, func, bias=bias)
 
@@ -676,6 +696,7 @@ def nvfp4_quantize(
     data_hp: torch.Tensor,
     block_size: int = 16,
     per_tensor_scale: Optional[torch.Tensor] = None,
+    rounding_mode: RoundingMode = RoundingMode.RN,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """NVIDIA FP4 quantization with UE4M3 scales.
 
@@ -685,13 +706,14 @@ def nvfp4_quantize(
     Args:
         data_hp: High precision input tensor (bfloat16 or float32)
         block_size: Block size for quantization (must be 16)
-        per_tensor_amax: Optional pre-computed absolute maximum for calibration.
+        per_tensor_scale: Optional pre-computed per-tensor scale for calibration.
             If provided, uses per-tensor scaling. If None, uses block-wise scaling only.
+        rounding_mode: Rounding mode for FP4 conversion (RN or RS).
+            For deterministic RS, set torch.manual_seed() before calling.
 
     Returns:
         tuple: A tuple containing:
-            - total_scale_fp8: Blockwise scales in float8_e4m3fn format
-            - per_tensor_scale: Global per-tensor scale if per_tensor_amax provided, else None
+            - out_scales: Blockwise scales in float8_e4m3fn format
             - data_lp: Packed FP4 data (2 values per byte)
 
     Raises:
@@ -743,7 +765,7 @@ def nvfp4_quantize(
 
     data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
     data_scaled = data_scaled.view(orig_shape)
-    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp = f32_to_f4_unpacked(data_scaled, rounding_mode=rounding_mode)
     # TODO: NotImplementedError: "copy_kernel" not implemented for 'Float4_e2m1fn_x2'
     # data_lp = pack_uint4(data_lp).view(torch.float4_e2m1fn_x2)
     data_lp = pack_uint4(data_lp)

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -176,14 +176,10 @@ class NVFP4Tensor(TorchAOBaseTensor):
             assert K % 16 == 0, (
                 f"Triton kernel requires K (dim -1) to be divisible by 16, got {K}"
             )
-            assert per_tensor_scale is not None, (
-                "Triton kernel requires per_tensor_scale"
-            )
-            if kernel_preference = KernelPreference.MSLK:
+            if kernel_preference == KernelPreference.MSLK and rounding_mode == RoundingMode.RN:
                 blockwise_scales, data_lp = mslk_quantize_nvfp4(data_hp, per_tensor_scale)
             else:
-                _seed = torch.randint(2**31, (1,)).item()
-                blockwise_scales, data_lp = triton_quantize_nvfp4(
+                blockwise_scales, data_lp = torch.ops.ao.triton_quantize_nvfp4(
                     data_hp, per_tensor_scale, rounding_mode.value, rand_bits
                 )
         else:

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -134,6 +134,7 @@ class NVFP4Tensor(TorchAOBaseTensor):
         use_triton_kernel: bool = False,
         act_quant_kwargs: Optional[QuantizeTensorToNVFP4Kwargs] = None,
         rounding_mode: RoundingMode = RoundingMode.RN,
+        rand_bits: Optional[torch.Tensor] = None,
         kernel_preference: KernelPreference = KernelPreference.MSLK,
     ):
         """Convert high precision tensor to NVFP4 format.
@@ -149,13 +150,26 @@ class NVFP4Tensor(TorchAOBaseTensor):
             use_triton_kernel: If True, use Triton kernel for quantization
             act_quant_kwargs: If specified, config for quantizing the activation
             rounding_mode: Rounding mode for FP4 conversion (RN or RS).
-                For deterministic RS, set torch.manual_seed() before calling.
+            rand_bits: Optional int32 tensor for stochastic rounding randomness.
+                Required when rounding_mode is RS. The caller is responsible
+                for generating this, keeping RNG concerns (seeding, CUDA graph
+                safety) outside this function.
+                - Triton path: single-element int32 seed tensor (the kernel
+                  generates per-element randomness internally).
+                - Eager path: full-shaped int32 tensor (same shape as data_hp).
 
         Returns:
             NVFP4Tensor: Quantized tensor in NVFP4 format
         """
         assert len(data_hp.shape) in (2, 3), "unsupported"
         leading_dims, M, K = data_hp.shape[:-2], data_hp.shape[-2], data_hp.shape[-1]
+
+        if rounding_mode == RoundingMode.RS and rand_bits is None:
+            raise ValueError(
+                "rand_bits is required for stochastic rounding (RoundingMode.RS). "
+                "For the Triton path, pass a single-element int32 seed tensor. "
+                "For the eager path, pass a full-shaped int32 tensor."
+            )
 
         if use_triton_kernel:
             assert is_swizzled_scales, "Triton kernel only supports swizzled scales"
@@ -170,12 +184,15 @@ class NVFP4Tensor(TorchAOBaseTensor):
             else:
                 _seed = torch.randint(2**31, (1,)).item()
                 blockwise_scales, data_lp = triton_quantize_nvfp4(
-                    data_hp, per_tensor_scale, rounding_mode.value, _seed
+                    data_hp, per_tensor_scale, rounding_mode.value, rand_bits
                 )
         else:
             blockwise_scales, data_lp = nvfp4_quantize(
-                data_hp, block_size, per_tensor_scale,
+                data_hp,
+                block_size,
+                per_tensor_scale,
                 rounding_mode=rounding_mode,
+                rand_bits=rand_bits,
             )
             if is_swizzled_scales:
                 scale_shape = (math.prod(leading_dims) * M, K // block_size)
@@ -697,6 +714,7 @@ def nvfp4_quantize(
     block_size: int = 16,
     per_tensor_scale: Optional[torch.Tensor] = None,
     rounding_mode: RoundingMode = RoundingMode.RN,
+    rand_bits: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """NVIDIA FP4 quantization with UE4M3 scales.
 
@@ -709,7 +727,8 @@ def nvfp4_quantize(
         per_tensor_scale: Optional pre-computed per-tensor scale for calibration.
             If provided, uses per-tensor scaling. If None, uses block-wise scaling only.
         rounding_mode: Rounding mode for FP4 conversion (RN or RS).
-            For deterministic RS, set torch.manual_seed() before calling.
+        rand_bits: Optional int32 tensor of random bits for stochastic rounding.
+            Required when rounding_mode is RS. Same shape as data_hp.
 
     Returns:
         tuple: A tuple containing:
@@ -726,6 +745,10 @@ def nvfp4_quantize(
     assert data_hp.size(-1) % block_size == 0, "K dim must be divisible by block_size"
     assert data_hp.is_contiguous(), "Only support contiguous data for now"
     assert block_size == 16, "NVFP4 requires block_size=16"
+    if rounding_mode == RoundingMode.RS:
+        assert rand_bits is not None and rand_bits.numel() > 1, (
+            "Eager path requires full-shaped rand_bits tensor for RS mode"
+        )
 
     orig_shape = data_hp.shape
     # Convert to float32 early for consistent precision with Triton implementation
@@ -765,7 +788,11 @@ def nvfp4_quantize(
 
     data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
     data_scaled = data_scaled.view(orig_shape)
-    data_lp = f32_to_f4_unpacked(data_scaled, rounding_mode=rounding_mode)
+    data_lp = f32_to_f4_unpacked(
+        data_scaled,
+        rounding_mode=rounding_mode,
+        rand_bits=rand_bits,
+    )
     # TODO: NotImplementedError: "copy_kernel" not implemented for 'Float4_e2m1fn_x2'
     # data_lp = pack_uint4(data_lp).view(torch.float4_e2m1fn_x2)
     data_lp = pack_uint4(data_lp)


### PR DESCRIPTION
Closes https://github.com/pytorch/ao/issues/3264. 
Code Assistant Used: Claude Code Opus 4.6
## Summary

Implements RS (stochastic rounding) support for NVFP4 as described in the RFC. RN remains the default.

## Key implementation details

**Triton kernel path**: Uses hardware `cvt.rs.satfinite.e2m1x4.f32` PTX inline asm. The RS instruction converts 4 floats and 1 random uint32 into 2 packed FP4 bytes, while the RN instruction converts 2 floats into 1 byte. Since the RN path uses `pack=4` (8 floats per invocation), the RS path issues two `cvt.rs` calls to match. With `pack=4`, 4 `rbits` values are loaded but only 2 are consumed per invocation — the other 2 are wasted to keep the output layout identical to RN.

**Seed determinism**: Triton path takes an explicit `seed` parameter for `tl.randint`; PyTorch path uses `torch.manual_seed`. Same seed produces bitwise-identical results within each path. The two paths use different RNGs so they diverge for RS even with the same seed.

**Validation**: Both paths validate `rounding_mode` using `not in RoundingMode`, raising `ValueError` for invalid values.

**`RoundingMode` enum uses `int` values** (`RN=0`, `RS=1`) rather than string values from the RFC, since the Triton kernel needs an integer `tl.constexpr`.

## Tests

Single parametrized `test_f4_rounding` in `test_kernels.py` covers rounding mode (RN/RS/invalid), kernel (PyTorch/Triton), seed determinism (same/different seeds), and value axes. Verifies RN is biased to nearest, RS is unbiased in expectation, same seed is deterministic, different seeds diverge, and invalid mode raises.

Existing `test_nvfp4_tensor.py` tests are parametrized over `rounding_mode` and `_triton_kernel_params`. Triton-vs-PyTorch equivalence uses SQNR threshold of 40 for RN and 8 for RS (different RNGs). End-to-end matmul uses SQNR threshold of 16 for RN and 6 for RS.

## Test Environment
```
Collecting environment information...                                                                                     
PyTorch version: 2.12.0a0+gitbabda95                                                                                      
Is debug build: False                                                                                                     
CUDA used to build PyTorch: 13.2                                                                                          
ROCM used to build PyTorch: N/A                                                                                           
                                                                                                                          
OS: Ubuntu 24.04.4 LTS (aarch64)                                                                                          
GCC version: (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                                                                      
Clang version: Could not collect                                                                                          
CMake version: version 3.31.6                                                                                             
Libc version: glibc-2.39                                                                                                  
                                                                                                                          
Python version: 3.12.3 (main, Jan 22 2026, 20:57:42) [GCC 13.3.0] (64-bit runtime)                                        
Python platform: Linux-6.14.0-1008-nvidia-64k-aarch64-with-glibc2.39                                                      
Is CUDA available: True                                                                                                   
CUDA runtime version: 13.2.50                                                                                             
CUDA_MODULE_LOADING set to: LAZY                                                                                          
GPU models and configuration:                                                                                             
GPU 0: NVIDIA GB200                                                                                                       
GPU 1: NVIDIA GB200                                                                                                       
GPU 2: NVIDIA GB200                                                                                                       
GPU 3: NVIDIA GB200

Nvidia driver version: 580.105.08                                                                                                                                                                                                                                                          

Versions of relevant libraries:                                                                                     
[pip3] mypy==1.16.0                                       
[pip3] mypy_extensions==1.1.0                             
[pip3] numpy==1.26.4                                      
[pip3] nvidia-cudnn-frontend==1.18.0                                                                                
[pip3] onnx==1.20.0                                       
[pip3] onnx-ir==0.1.16                                    
[pip3] onnxscript==0.6.2                                  
[pip3] optree==0.13.0                                     
[pip3] pytorch-lightning==2.6.1                                                                                     
[pip3] torch==2.12.0a0+gitbabda95                                                                                   
[pip3] torchmetrics==1.8.2                                
[pip3] triton==3.6.0+git9844da95                                                                                    
[conda] Could not collect
```                                                                               