### PR TITLE
Unbreak BC, add back PerRow, PerTensor imports

### DIFF
--- a/torchao/quantization/observer.py
+++ b/torchao/quantization/observer.py
@@ -12,7 +12,7 @@ import torch
 
 from torchao.quantization.quant_primitives import _fake_quantize_affine
 
-from .granularity import Granularity
+from .granularity import Granularity, PerRow, PerTensor  # noqa: F401
 from .quant_primitives import (
     MappingType,
     ZeroPointDomain,


### PR DESCRIPTION
**Summary:** OSS users like sglang are still importing these from `torchao.quantization.observer`. Here we quickly unbreak BC since that was not the intention of
https://github.com/pytorch/ao/pull/3370.

**Test Plan:** CI