### PR TITLE
add an example for quantizing LLaMa 4 Scout

### DIFF
--- a/examples/quantize_llama_4.py
+++ b/examples/quantize_llama_4.py
@@ -22,7 +22,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, TorchAoConfig
 
 from torchao.quantization import (
     Float8DynamicActivationFloat8WeightConfig,
-    ModuleFqnToConfig,
+    FqnToConfig,
     PerRow,
 )
 from torchao.quantization.quantize_.workflows.float8.float8_tensor import (
@@ -46,7 +46,7 @@ def get_quantization_config():
         # guard against activations with groups of all-zeroes
         activation_value_lb=1.0e-12,
     )
-    module_fqn_to_config = ModuleFqnToConfig(
+    fqn_to_config = FqnToConfig(
         {
             # only quantize the routed experts, the rest of the model is left
             # in high precision
@@ -54,9 +54,7 @@ def get_quantization_config():
             r"re:.*\.feed_forward\.experts\.down_proj": expert_3d_weight_single_config,
         }
     )
-    return TorchAoConfig(
-        quant_type=module_fqn_to_config,
-    )
+    return TorchAoConfig(quant_type=fqn_to_config)
 
 
 def parse_args():


### PR DESCRIPTION
Summary:

Adds an e2e example of how to use torchao to quantize LLaMa 4 Scout.

Note that this needs:
* a recent `transformers` version (higher than 4.57, not officially
  released yet so user needs to build from source)
* a recent `fbgemm_gpu` version nightly from `2025.11.22` or after
* to run this in vLLM, https://github.com/vllm-project/vllm/pull/28421
  is needed (not yet landed).

Test Plan:

```bash
with-proxy time python examples/quantize_llama_4.py ~/local/tmp/20251201_test/
```

Reviewers:

Subscribers:

Tasks:

Tags: