### PR TITLE
[mxfp8 moe training] fix bug introduced in #3385

### DIFF
--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -151,7 +151,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     block_size,
     elem_dtype,
     hp_dtype,
-    gemm_kernel_choice,
+    kernel_preference,
     cast_kernel_choice,
     scale_calculation_mode: ScaleCalculationMode,
 ):
@@ -187,7 +187,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
             elem_dtype,
             block_size,
             hp_dtype,
-            gemm_kernel_choice,
+            kernel_preference,
             None,
             is_swizzled_scales,
         )
@@ -206,7 +206,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
             elem_dtype,
             block_size,
             hp_dtype,
-            gemm_kernel_choice,
+            kernel_preference,
             None,
             is_swizzled_scales,
         )


### PR DESCRIPTION
Small fix, just need to update the new arg name to match 


## Test plan
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -k mxfp8`