### PR TITLE
[xpu][test] Port 2 test/prototype/test_{nvfp4_tensor, spinquant} UT files to intel XPU

### DIFF
--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -22,9 +22,9 @@ from torchao.prototype.mx_formats.utils import ceil_div
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
+    get_current_accelerator_device,
     is_sm_at_least_100,
     torch_version_at_least,
-    get_current_accelerator_device,
 )
 
 torch.manual_seed(2)
@@ -456,7 +456,11 @@ def test_nvfp4_matmul_with_amax(
     shapes: tuple,
 ):
     # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
-    if quant_type == "dynamic" and torch.cuda.is_available() and not is_sm_at_least_100():
+    if (
+        quant_type == "dynamic"
+        and torch.cuda.is_available()
+        and not is_sm_at_least_100()
+    ):
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
 
     if bias and inpt_dtype == torch.float32:

--- a/test/prototype/test_spinquant.py
+++ b/test/prototype/test_spinquant.py
@@ -16,7 +16,11 @@ def _init_model(name="7B", device="cpu", precision=torch.bfloat16):
     return model.eval()
 
 
-_AVAILABLE_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else []) + (["xpu"] if torch.xpu.is_available() else [])
+_AVAILABLE_DEVICES = (
+    ["cpu"]
+    + (["cuda"] if torch.cuda.is_available() else [])
+    + (["xpu"] if torch.xpu.is_available() else [])
+)
 
 
 @pytest.mark.parametrize("device", _AVAILABLE_DEVICES)


### PR DESCRIPTION
For https://github.com/pytorch/ao/issues/2917, This PR is targeted to port test/prototype/mx_formats/test_nvfp4_tensor.py and test/prototype/test_spinquant.py to intel XPU.