### PR TITLE
bump python version in tutorial ci workflow

### DIFF
--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup miniconda
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Run tutorials
         shell: bash


### PR DESCRIPTION
As part of the release I was running the tutorial workflows and encountered this error which indicates that Python 3.9 is no longer finding Torch CUDA 12.6 builds:

```
Looking in indexes: https://download.pytorch.org/whl/nightly/cu126
ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
ERROR conda.cli.main_run:execute(125): `conda run pip install --pre torch torchvision torchaudio --index-url [https://download.pytorch.org/whl/nightly/cu126`](https://download.pytorch.org/whl/nightly/cu126%60) failed. (See above for error)
```

I notice other workflows are using 3.10 or 3.11, so I am bumping this version to match, and it resolves the issue. 