### PR TITLE
[xpu][test] Skip WIP cases in test/quantization/test_qat.py for intel XPU

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -104,7 +104,6 @@ from torchao.utils import (
     is_sm_at_least_89,
 )
 
-
 # TODO: put this in a common test utils file
 _CUDA_IS_AVAILABLE = torch.cuda.is_available()
 _DEVICE = get_current_accelerator_device()


### PR DESCRIPTION
For https://github.com/pytorch/ao/issues/2917, This PR is targeted to skip test_qat_4w_quantizer and test_quantize_api_intx which is WIP on intel XPU, and they failed in xpu test https://github.com/pytorch/ao/actions/runs/19953611835/job/57218382266#step:18:53831