### PR TITLE
Remove unused exception parameter from multifeed/recommendation_platform/corpus/backfill/BackfillMain.cpp

### DIFF
--- a/torchao/csrc/rocm/swizzle/swizzle.cpp
+++ b/torchao/csrc/rocm/swizzle/swizzle.cpp
@@ -174,10 +174,10 @@ static size_t _parseChosenWorkspaceSize() {
   if (val.has_value()) {
     try {
       workspace_size = std::stoi(val.value());
-    } catch(std::invalid_argument const& e) {
+    } catch(std::invalid_argument const&) {
       TORCH_WARN("invalid CUBLASLT_WORKSPACE_SIZE,",
                  " using default workspace size of ", workspace_size, " KiB.");
-    } catch(std::out_of_range const& e) {
+    } catch(std::out_of_range const&) {
       TORCH_WARN("CUBLASLT_WORKSPACE_SIZE out of range,",
                  " using default workspace size of ", workspace_size, " KiB.");
     }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D88448341


