### PR TITLE
create a new accuracy eval script for official README.md eval accuracy

### DIFF
--- a/benchmarks/quantization/eval_accuracy_for_readme.py
+++ b/benchmarks/quantization/eval_accuracy_for_readme.py
@@ -25,17 +25,17 @@ def string_to_config(s):
         return None
     elif s == "float8_rowwise":
         return Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
-    elif s == "int4_weight_float8_rowwise_activation":
+    elif s == "int4_groupwise_weight_float8_rowwise_activation":
         return Float8DynamicActivationInt4WeightConfig()
-    elif s == "int4_weight_only_hqq":
+    elif s == "int4_groupwise_hqq_weight_only":
         return Int4WeightOnlyConfig(
             group_size=32,
             int4_packing_format="tile_packed_to_4d",
             int4_choose_qparams_algorithm="hqq",
         )
-    elif s == "int8_weight_only":
+    elif s == "int8_rowwise_weight_only":
         return Int8WeightOnlyConfig()
-    elif s == "int8":
+    elif s == "int8_rowwise":
         return Int8DynamicActivationInt8WeightConfig()
     else:
         raise AssertionError(f"unsupported {s}")

--- a/benchmarks/quantization/eval_accuracy_for_readme.sh
+++ b/benchmarks/quantization/eval_accuracy_for_readme.sh
@@ -21,9 +21,9 @@ time python -u benchmarks/quantization/eval_accuracy_for_readme.py $BASE_ARGS 2>
 
 # quantized recipes
 # note:
-# * `int4_weight_float8_rowwise_activation` doesn't work with dtype_map auto: https://gist.github.com/vkuzo/6b128681b628744d445c553cdeac8a85
-# * `int4_weight_only_hqq` only works on A100
-for quant_recipe in float8_rowwise int4_weight_float8_rowwise_activation int4_weight_only_hqq int8_weight_only int8; do
+# * `int4_groupwise_hqq_weight_float8_rowwise_activation` doesn't work with dtype_map auto: https://gist.github.com/vkuzo/6b128681b628744d445c553cdeac8a85
+# * `int4_groupwise_hqq_weight_only` only works on A100
+for quant_recipe in float8_rowwise int4_groupwise_weight_float8_rowwise_activation int4_groupwise_hqq_weight_only int8_rowwise_weight_only int8_rowwise; do
   time python -u benchmarks/quantization/eval_accuracy_for_readme.py $BASE_ARGS --quant_recipe_name $quant_recipe 2>&1 | tee -a "$LOG_FILE"
 done
 

--- a/torchao/quantization/README.md
+++ b/torchao/quantization/README.md
@@ -5,12 +5,12 @@ Typically quantization algorithms will have different schemes for how the activa
 
 All the following benchmarks are for `meta-llama/Llama-3-8.1B` using `lm-eval` measured on an H100 GPU.
 
-| Technique | wikitext-perplexity | winogrande | checkpoint size (GB) |
+| weight | activation | wikitext-perplexity | winogrande | checkpoint size (GB) |
 | --------- | ------------------- | ---------- | -------------------- |
-| baseline (bfloat16) | 7.3315 | 0.7380 | 16.1 |
-| float8_rowwise weight, float8_rowwise activation | 7.4197 | 0.7388 | 9.1 |
-| int8_weight_only | 7.3451 | 0.7340 | 9.1 |
-| int8 weight, int8 activation | 7.4535 | 0.7285 | 9.1 |
+| bfloat16 | bfloat16 | 7.3315 | 0.7380 | 16.1 |
+| float8_rowwise | float8_rowwise | 7.4197 | 0.7388 | 9.1 |
+| int8_rowwise | bfloat16 | 7.3451 | 0.7340 | 9.1 |
+| int8_rowwise | int8_rowwise | 7.4535 | 0.7285 | 9.1 |
 
 To reproduce, run the following command:
 


### PR DESCRIPTION
Summary:

Creates a standalone eval script for generating accuracy metrics for
quantization README.md, based on the HuggingFace model definition of
LLaMa 3.1 8B

Why new script?
1. the current `prod` script in
   https://github.com/pytorch/ao/blob/main/torchao/_models/llama/eval.py
   uses a custom model definition, this was pre-HF integration, it's better to use HF's model definition now
2. we have HummingBird scripts in
   https://github.com/pytorch/ao/tree/40c4f44677ae11166c3dcfbb9189cfa78789390c/.github/scripts/torchao_model_releases,
   but they seem pretty verbose and hard to use/modify
3. we have
   https://github.com/pytorch/ao/blob/main/benchmarks/_models/eval_hf_models.py,
   I copy-pasted and modified this for the current PR. The script above
   didn't work as is for various reasons, and also seemed to be hard to
   use/modify, for main README.md it's important to have a very simple
   standalone script.

We should probably do a pass on the naming before landing.

Future work:
1. add metrics for `int4_weight_only_hqq` (need to run on A100)
2. add metrics for 'int4 weight float8 activation' (currently doesn't work with HF accelerate)
3. add metrics for `mxfp8` and `nvfp4` (need to run on B200)
4. make the parsing of logs automated
5. also add a similar script for performance benchmarks, using vllm
6. delete https://github.com/pytorch/ao/blob/main/torchao/_models/llama/

Test Plan:

```
// debug run on small model
with-proxy time ./benchmarks/quantization/eval_accuracy_for_readme.sh facebook/opt-125m

// real run
with-proxy time ./benchmarks/quantization/eval_accuracy_for_readme.sh
```

Reviewers:

Subscribers:

Tasks:

Tags: