### PR TITLE
Fix NVFP4 QAT convert path

### DIFF
--- a/torchao/prototype/qat/nvfp4.py
+++ b/torchao/prototype/qat/nvfp4.py
@@ -162,6 +162,22 @@ class NVFP4FakeQuantizedLinear(torch.nn.Linear):
         else:
             return fq
 
+    def to_linear(self) -> torch.nn.Linear:
+        new_linear = torch.nn.Linear(
+            self.in_features,
+            self.out_features,
+            self.bias is not None,
+            device=self.weight.device,
+            dtype=self.weight.dtype,
+        )
+        # In distributed training, the model may be instantiated
+        # on the meta device, in which case there is no need to
+        # copy the weights, and doing so will result in an error
+        if self.weight.device != torch.device("meta"):
+            new_linear.weight = self.weight
+            new_linear.bias = self.bias
+        return new_linear
+
     @classmethod
     def from_linear(
         cls,


### PR DESCRIPTION
**Summary:** The previous convert path through `QATConfig` did not swap `NVFP4FakeQuantizedLinear` back to `torch.nn.Linear`. The numerics tests still passed because this fake quantized linear happen to match the PTQ numerics exactly.

**Test Plan:**
```
python test/quantization/test_qat.py -k test_qat_nvfp4
```