### PR TITLE
update moe training tests with scaled grouped mm test and use verbose mode

### DIFF
--- a/test/prototype/moe_training/test_everything.sh
+++ b/test/prototype/moe_training/test_everything.sh
@@ -12,8 +12,9 @@ IS_ROCM=$(rocm-smi --version || true)
 # These tests do not work on ROCm yet
 if [ -z "$IS_ROCM" ]
 then
-pytest test/prototype/moe_training/test_kernels.py -s
-pytest test/prototype/moe_training/test_training.py -s
+pytest test/prototype/moe_training/test_kernels.py -s -v
+pytest test/prototype/moe_training/test_scaled_grouped_mm.py -s -v 
+pytest test/prototype/moe_training/test_training.py -s -v
 ./test/prototype/moe_training/test_fsdp.sh
 ./test/prototype/moe_training/test_tp.sh
 ./test/prototype/moe_training/test_fsdp_tp.sh

--- a/test/prototype/moe_training/test_fsdp.sh
+++ b/test/prototype/moe_training/test_fsdp.sh
@@ -1,1 +1,1 @@
-torchrun --nproc_per_node=2 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_fsdp.py -s
+torchrun --nproc_per_node=2 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_fsdp.py -s -v

--- a/test/prototype/moe_training/test_fsdp_tp.sh
+++ b/test/prototype/moe_training/test_fsdp_tp.sh
@@ -1,1 +1,1 @@
-torchrun --nproc_per_node=4 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_fsdp_tp.py -s
+torchrun --nproc_per_node=4 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_fsdp_tp.py -s -v

--- a/test/prototype/moe_training/test_tp.sh
+++ b/test/prototype/moe_training/test_tp.sh
@@ -1,1 +1,1 @@
-torchrun --nproc_per_node=2 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_tp.py -s
+torchrun --nproc_per_node=2 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_tp.py -s -v


### PR DESCRIPTION
Debugging tests for the release, I found a MoE training test missing from the `test_everything.sh` so this change adds it in. Also add verbose mode to these tests to make debugging easier.