### PR TITLE
adding Int8 weight only and dynamic configs to safetensors

### DIFF
--- a/test/prototype/safetensors/test_safetensors_support.py
+++ b/test/prototype/safetensors/test_safetensors_support.py
@@ -20,7 +20,9 @@ from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_api import (
     Float8DynamicActivationFloat8WeightConfig,
     Int4WeightOnlyConfig,
+    Int8DynamicActivationInt8WeightConfig,
     Int8DynamicActivationIntxWeightConfig,
+    Int8WeightOnlyConfig,
     IntxWeightOnlyConfig,
 )
 from torchao.utils import is_sm_at_least_89
@@ -50,6 +52,8 @@ class TestSafeTensors(TestCase):
             (Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"), False),
             (IntxWeightOnlyConfig(), False),
             (Int8DynamicActivationIntxWeightConfig(), False),
+            (Int8WeightOnlyConfig(version=2), False),
+            (Int8DynamicActivationInt8WeightConfig(version=2), False),
         ],
     )
     def test_safetensors(self, config, act_pre_scale=False):
@@ -95,6 +99,8 @@ class TestSafeTensors(TestCase):
             (Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"), False),
             (IntxWeightOnlyConfig(), False),
             (Int8DynamicActivationIntxWeightConfig(), False),
+            (Int8WeightOnlyConfig(version=2), False),
+            (Int8DynamicActivationInt8WeightConfig(version=2), False),
         ],
     )
     def test_safetensors_sharded(self, config, act_pre_scale=False):

--- a/torchao/prototype/safetensors/safetensors_utils.py
+++ b/torchao/prototype/safetensors/safetensors_utils.py
@@ -10,21 +10,29 @@ from torchao.quantization import (
     Float8Tensor,
     Int4Tensor,
     Int4TilePackedTo4dTensor,
+    Int8Tensor,
     IntxUnpackedToInt8Tensor,
+    MappingType,
 )
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.quantization.quantize_.workflows import QuantizeTensorToFloat8Kwargs
+from torchao.quantization.quantize_.workflows import (
+    QuantizeTensorToFloat8Kwargs,
+    QuantizeTensorToInt8Kwargs,
+)
 
 ALLOWED_CLASSES = {
     "Float8Tensor": Float8Tensor,
     "Int4Tensor": Int4Tensor,
     "Int4TilePackedTo4dTensor": Int4TilePackedTo4dTensor,
     "IntxUnpackedToInt8Tensor": IntxUnpackedToInt8Tensor,
+    "Int8Tensor": Int8Tensor,
     "Float8MMConfig": torchao.float8.inference.Float8MMConfig,
     "QuantizeTensorToFloat8Kwargs": QuantizeTensorToFloat8Kwargs,
+    "QuantizeTensorToInt8Kwargs": QuantizeTensorToInt8Kwargs,
     "PerRow": torchao.quantization.PerRow,
     "PerTensor": torchao.quantization.PerTensor,
     "KernelPreference": KernelPreference,
+    "MappingType": MappingType,
 }
 
 ALLOWED_TENSORS_SUBCLASSES = [
@@ -32,6 +40,7 @@ ALLOWED_TENSORS_SUBCLASSES = [
     "Int4Tensor",
     "Int4TilePackedTo4dTensor",
     "IntxUnpackedToInt8Tensor",
+    "Int8Tensor",
 ]
 
 __all__ = [


### PR DESCRIPTION
Adding Int8DynamicActivationInt8WeightConfig and Int8WeightOnlyConfig to safetensors

tests: `python test/prototype/safetensors/test_safetensors_support.py`