### PR TITLE
Fix NVFP4 QAT backward typo

### DIFF
--- a/torchao/prototype/qat/nvfp4.py
+++ b/torchao/prototype/qat/nvfp4.py
@@ -91,8 +91,8 @@ class _NVFP4QuantizedForwardFakeQuantizedBackward(torch.autograd.Function):
         _input, weight = ctx.saved_tensors
         assert isinstance(_input, NVFP4Tensor)
         assert isinstance(weight, NVFP4Tensor)
-        _input = _input.to_dtype(_input._orig_dtype)
-        weight = weight.to_dtype(weight._orig_dtype)
+        _input = _input.dequantize(_input._orig_dtype)
+        weight = weight.dequantize(weight._orig_dtype)
         grad_input = torch.mm(grad_output, weight)
         grad_weight = torch.mm(grad_output.t(), _input)
         return grad_input, grad_weight, None, None, None


### PR DESCRIPTION
**Summary:** Fix `to_dtype` -> `dequantize`. This was broken in https://github.com/pytorch/ao/pull/3169.

**Test Plan:**
```
python test/quantization/test_qat.py -k nvfp4_training
```