### PR TITLE
[mps] integrate with quantize_ API

### DIFF
--- a/torchao/experimental/ops/mps/test/test_quantizer.py
+++ b/torchao/experimental/ops/mps/test/test_quantizer.py
@@ -14,7 +14,7 @@ from parameterized import parameterized
 # Need to import to load the ops
 import torchao.experimental.ops.mps  # noqa: F401
 from torchao.experimental.quant_api import (
-    UIntxWeightOnlyMPSConfig,
+    UIntxWeightOnlyConfig,
     _linear_int_weight_mps_check,
     _quantize,
 )
@@ -44,7 +44,7 @@ class TestUIntxWeightOnlyLinearQuantizer(unittest.TestCase):
         return model, group_size, k0, n
 
     def _quantize_model(self, model, precision, nbit, group_size):
-        config = UIntxWeightOnlyMPSConfig(
+        config = UIntxWeightOnlyConfig(
             bitwidth=nbit,
             group_size=group_size,
         )

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -206,7 +206,7 @@ class UIntxWeightOnlyLinearQuantizer:
 
 
 @dataclass
-class UIntxWeightOnlyMPSConfig(AOBaseConfig):
+class UIntxWeightOnlyConfig(AOBaseConfig):
     """
     Configuration for applying uintx weight-only asymmetric per-group quantization
     to linear layers for MPS devices.
@@ -236,9 +236,9 @@ def _linear_int_weight_mps_check(module: nn.Module, fqn: str) -> bool:
     return isinstance(module, nn.Linear) and module.bias is None
 
 
-@register_quantize_module_handler(UIntxWeightOnlyMPSConfig)
+@register_quantize_module_handler(UIntxWeightOnlyConfig)
 def _uintx_weight_only_mps_transform(
-    module: torch.nn.Module, config: UIntxWeightOnlyMPSConfig
+    module: torch.nn.Module, config: UIntxWeightOnlyConfig
 ) -> torch.nn.Module:
     nbit = config.bitwidth
     group_size = config.group_size


### PR DESCRIPTION
Fixes #3446

Integrate with quantize_ API by implementing `UIntxWeightOnlyConfig` in `torchao.experimental.quant_api.py`, and registering a corresponding module handler.

```
USE_CPP=1 TORCHAO_BUILD_EXPERIMENTAL_MPS=1 pip install . --no-build-isolation
python -m pytest torchao/experimental/ops/mps/test/test_quantizer.py
```
