### PR TITLE
Update KleidiAI dependency to 63205aa9

### DIFF
--- a/torchao/csrc/cpu/CMakeLists.txt
+++ b/torchao/csrc/cpu/CMakeLists.txt
@@ -132,7 +132,7 @@ if(TORCHAO_BUILD_CPU_AARCH64)
             set(KLEIDIAI_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
             FetchContent_Declare(kleidiai
                 GIT_REPOSITORY https://git.gitlab.arm.com/kleidi/kleidiai.git
-                GIT_TAG v1.12.0
+                GIT_TAG 63205aa90afa6803d8f58bc3081b69288e9f1906
             )
             FetchContent_MakeAvailable(kleidiai)
         endif()


### PR DESCRIPTION
Update KleidiAI to a newer version to match XNNPACK ([source](https://github.com/google/XNNPACK/blob/31b1edeb494a7e3a302cb0c6934b127334e984a2/cmake/DownloadKleidiAI.cmake#L21)). This is in preparation for an XNNPACK pin bump across PyTorch.