### PR TITLE
Parse device at model release script

### DIFF
--- a/.github/scripts/torchao_model_releases/quantize_and_upload.py
+++ b/.github/scripts/torchao_model_releases/quantize_and_upload.py
@@ -1003,7 +1003,7 @@ if __name__ == "__main__":
         "--device",
         type=str,
         default="cuda:0",
-        help="Device to run the model on (e.g., 'cuda', 'cuda:0', 'cpu'). Default is 'cuda:0'",
+        help="Device for model loading and quantization (e.g., 'cuda', 'cuda:0', 'cpu'). Default is 'cuda:0'",
     )
     args = parser.parse_args()
     quantize_and_upload(


### PR DESCRIPTION
Summary:
Add `device` as a parser for custom GPU usage like `cuda:1`. `model_id & quant` parsers are updated to require input.

Test Plan:
python .github/scripts/torchao_model_releases/quantize_and_upload.py  --model_id Qwen/Qwen3-8B  --quant AWQ-INT4