### PR TITLE
add pinned memory support for int8tensor

### DIFF
--- a/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
@@ -306,6 +306,33 @@ def _(func, types, args, kwargs):
     )
 
 
+@implements(aten.is_pinned.default)
+def _(func, types, args, kwargs):
+    is_pinned = args[0].qdata.is_pinned() and args[0].scale.is_pinned()
+    if args[0].act_scale is not None:
+        is_pinned = is_pinned and args[0].act_scale.is_pinned()
+    return is_pinned
+
+
+@implements(aten._pin_memory.default)
+def _(func, types, args, kwargs):
+    pinned_qdata = args[0].qdata.pin_memory()
+    pinned_scale = args[0].scale.pin_memory()
+
+    pinned_act_scale = None
+    if args[0].act_scale is not None:
+        pinned_act_scale = args[0].act_scale.pin_memory()
+
+    return Int8Tensor(
+        pinned_qdata,
+        pinned_scale,
+        args[0].block_size,
+        args[0].dtype,
+        act_scale=pinned_act_scale,
+        act_quant_kwargs=args[0].act_quant_kwargs,
+    )
+
+
 @implements(aten.select.int)
 def _(func, types, args, kwargs):
     """Select operation for Int8Tensor"""


### PR DESCRIPTION
as title 

**Test**

in torchao
`python test/quantization/quantize_/workflows/int8/test_int8_tensor.py -k test_pin_memory`

in diffusers
`python -m pytest tests/quantization/torchao/test_torchao.py -k test_torch_compile_with_group_offload_leaf -s` 

no longer seeing 

```
NotImplementedError: AffineQuantizedTensor dispatch: attempting to run unimplemented operator/function: func=<OpOverload(op='aten.is_pinned', overload='default')>, types=(<class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>,), arg_types=(<class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>,), kwarg_types={}` for `use_stream=True
```

however, still seeing the known Dynamo error
```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in function linear>(*(FakeTensor(..., device='cuda:0', size=(s65, 256), dtype=torch.bfloat16), Int8Tensor(act_quant_kwargs=None, qdata=FakeTensor(..., size=(1536, 256), dtype=torch.int8), scale=FakeTensor(..., size=(1536, 1), dtype=torch.bfloat16), act_scale=None, block_size=[1, 256], shape=torch.Size([1536, 256]), device=cpu, dtype=torch.bfloat16), Parameter(FakeTensor(..., device='cuda:0', size=(1536,), dtype=torch.bfloat16, requires_grad=True))), **{}): got RuntimeError('Unhandled FakeTensor Device Propagation for aten.mm.default, found two different devices cuda:0, cpu')

from user code:
      File "/home/liangel/local/diffusers/src/diffusers/hooks/hooks.py", line 189, in torch_dynamo_resume_in_new_forward_at_188
      output = function_reference.forward(*args, **kwargs)
      File "/home/liangel/local/pytorch/torch/nn/modules/linear.py", line 134, in forward
          return F.linear(input, self.weight, self.bias)

../pytorch/torch/_subclasses/fake_tensor.py:987: TorchRuntimeError
```