### PR TITLE
[ZENDNN] Adding support for slice in opaque

### DIFF
--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -200,6 +200,7 @@ ALLOWED_AO_MODULES = {
     "torchao.prototype.parq.quant",
     "torchao.quantization.quantize_.common",
     "torchao.quantization.quantize_.workflows",
+    "torchao.prototype.quantization.int4",
 }
 
 

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -203,6 +203,35 @@ ALLOWED_AO_MODULES = {
 }
 
 
+def _register_int4_module() -> None:
+    module_spec = importlib.util.find_spec("torchao.prototype.quantization.int4")
+    if module_spec is None:
+        module_spec = importlib.util.find_spec("torchao.prototype.int4_opaque_tensor")
+    if module_spec is None:
+        return
+
+    int4_module = importlib.import_module(module_spec.name)
+    if not hasattr(int4_module, "Int4WeightOnlyOpaqueTensorConfig") and hasattr(
+        int4_module, "PrototypeInt4WeightOnlyConfig"
+    ):
+        int4_module.Int4WeightOnlyOpaqueTensorConfig = (
+            int4_module.PrototypeInt4WeightOnlyConfig
+        )
+    ALLOWED_AO_MODULES.add(module_spec.name)
+
+    try:
+        from torchao.prototype.safetensors.safetensors_utils import (
+            ALLOWED_CLASSES,
+            ALLOWED_TENSORS_SUBCLASSES,
+        )
+
+        if "Int4OpaqueTensor" not in ALLOWED_TENSORS_SUBCLASSES:
+            ALLOWED_TENSORS_SUBCLASSES.append("Int4OpaqueTensor")
+        ALLOWED_CLASSES["Int4OpaqueTensor"] = int4_module.Int4OpaqueTensor
+    except (ImportError, AttributeError):
+        pass
+
+
 def config_from_dict(data: Dict[str, Any]) -> AOBaseConfig:
     """
     Create an AOBaseConfig subclass instance from a dictionary.
@@ -231,6 +260,9 @@ def config_from_dict(data: Dict[str, Any]) -> AOBaseConfig:
         import torch
 
         return getattr(torch, obj_data)
+
+    _register_int4_module()
+
     # Try to find the class in any of the allowed modules
     cls = None
     for module_path in ALLOWED_AO_MODULES:

--- a/torchao/prototype/quantization/int4/int4_opaque_tensor.py
+++ b/torchao/prototype/quantization/int4/int4_opaque_tensor.py
@@ -28,7 +28,9 @@ from torchao.quantization.utils import (
 from torchao.utils import (
     TorchAOBaseTensor,
     torch_version_at_least,
+    fill_defaults,
 )
+
 
 __all__ = [
     "Int4OpaqueTensor",
@@ -434,6 +436,95 @@ def _(func, types, args, kwargs):
         y += bias
     return y.to(orig_dtype)
 
+
+@implements(aten.slice.Tensor)
+def _(func, _types, args, _kwargs):
+    """Slice operation for CPU int4 opaque tensor"""
+    self, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
+    cur_shape = self.shape
+
+    assert len(cur_shape) == 2
+    assert self.qdata.dim() == 2
+    # qdata has shape (N, K/2) - packed in last dimension
+    # scale_and_zero has shape (K/group_size, N, 2)
+
+    data_len = cur_shape[dim]
+    assert dim in [
+        0,
+        1,
+    ], (
+        f"Int4OpaqueTensor slice: attempting to run {func}, with "
+        f"dim={dim}, that is not supported"
+    )
+
+    if dim == 0:
+        # Slicing N dimension
+        qdata_len = self.qdata.shape[0]  # N
+        sz_len = self.scale_and_zero.shape[1]  # N
+
+        if qdata_len == 0 or sz_len == 0:
+            return Int4OpaqueTensor(
+                self.qdata,
+                self.scale_and_zero,
+                self.block_size,
+                self.shape,
+                act_pre_scale=self.act_pre_scale,
+            )
+
+        qdata_ratio = data_len / qdata_len
+        start_qdata = int(start / qdata_ratio)
+        end_qdata = int(end / qdata_ratio)
+
+        sz_ratio = data_len / sz_len
+        start_sz = int(start / sz_ratio)
+        end_sz = int(end / sz_ratio)
+
+        qdata = aten.slice(self.qdata, 0, start_qdata, end_qdata, step)
+        scale_and_zero = aten.slice(
+            self.scale_and_zero, 1, start_sz, end_sz, step
+        )
+    else:
+        # Slicing K dimension (dim == 1)
+        qdata_len = self.qdata.shape[1] * 2  # K/2 packed, so multiply by 2
+        # K/group_size * group_size = K
+        sz_len = self.scale_and_zero.shape[0] * self.block_size[1]
+
+        if qdata_len == 0 or sz_len == 0:
+            return Int4OpaqueTensor(
+                self.qdata,
+                self.scale_and_zero,
+                self.block_size,
+                self.shape,
+                act_pre_scale=self.act_pre_scale,
+            )
+
+        qdata_ratio = data_len / qdata_len
+        start_qdata = int(start / qdata_ratio)
+        end_qdata = int(end / qdata_ratio)
+
+        sz_ratio = data_len / sz_len
+        start_sz = int(start / sz_ratio)
+        end_sz = int(end / sz_ratio)
+
+        qdata = aten.slice(self.qdata, 1, start_qdata, end_qdata, step)
+        scale_and_zero = aten.slice(
+            self.scale_and_zero, 0, start_sz, end_sz, step
+        )
+
+    # Calculate new shape after slicing
+    new_shape = list(self.shape)
+    new_shape[dim] = end - start
+
+    block_size = list(self.block_size)
+    block_size[dim] = min(block_size[dim], new_shape[dim])
+
+    return Int4OpaqueTensor(
+        qdata,
+        scale_and_zero,
+        block_size,
+        new_shape,
+        act_pre_scale=self.act_pre_scale,
+    )
 
 Int4OpaqueTensor.__module__ = "torchao.prototype.quantization.int4"
 


### PR DESCRIPTION
Add support `Int4OpaqueTensor` from torchao in vLLM's LLaMA model implementation.
These changes enable vLLM to load models quantized with `torchao` using `int4_packing_format="opaque"` without errors during weight loading.

Encountered error: NotImplementedError: Int4OpaqueTensor dispatch: attempting to run unimplemented operator/function: 
func=<OpOverload(op='aten.slice', overload='Tensor')>

Issue #3499 