### PR TITLE
[xpu] INT8 quantization on Intel XPU

### DIFF
--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -28,7 +28,7 @@ from torchao.quantization.quantize_.workflows.int8.int8_tensor import (
 )
 from torchao.quantization.utils import compute_error, get_block_size
 from torchao.testing.model_architectures import ToyTwoLinearModel
-from torchao.testing.utils import TorchAOIntegrationTestCase
+from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_xpu
 from torchao.utils import (
     get_available_devices,
     get_current_accelerator_device,
@@ -234,7 +234,7 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
             "extern_kernels._int_mm", 1
         ).check_count("triton_poi_fused", 1).run(code[0])
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @skip_if_xpu("XPU enablement in progress")
     @common_utils.parametrize("config", INT8_TEST_CONFIGS)
     def test_pin_memory(self, config):
         linear = torch.nn.Linear(


### PR DESCRIPTION
# Motivation
This feature is one of features listed in the #3576. There is the XMX intrinsic on the Intel GPUs, e.g., Intel Arc B580, to speedup the int8 computation. This PR is target to ensure the int8 quantization works on the XPU and user can use same quantization config with CUDA. 
# Implementation

Since the int8 quantization design of torchAO design is device agnostic,  the only need to do on XPU is to enable the [int_mm on XPU](https://github.com/pytorch/pytorch/pull/157769) and This PR has landed into the PyTorch core since torch-2.9. In this PR, we add the UT test to ensure the entire int quantization workflow on XPU works. 

# Usage
Users can use same quantization config, such as Int8StaticActivationInt8WeightConfig or Int8DynamicActivationInt8WeightConfig, as CUDA to run the fp8 models on XPU. This device dispatched by the PyTorch op.
```
#For dynamic int8 quantization
dynamic_config = Int8DynamicActivationInt8WeightConfig(version=2)
quantize_(model, dynamic_config)

#For static int8 quantization
static_config = Int8StaticActivationInt8WeightConfig(
            scale=int8_input.scale.detach().clone(),
            granularity=granularity,
        )
quantize_(model, static_config)
```