### PR TITLE
[mxfp8 moe training] add CUDA kernel for per-group conversion of scale factors to blocked layout

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_triton_mx_block_rearrange_2d_K_groups.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_triton_mx_block_rearrange_2d_K_groups.py
@@ -1,0 +1,265 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+from benchmarks.utils import benchmark_cuda_function_in_microseconds
+from torchao.prototype.moe_training.kernels.mxfp8.quant import (
+    mx_block_rearrange_2d_K_groups_cuda,
+    torch_to_blocked_2d_K_groups,
+    triton_mx_block_rearrange_2d_K_groups,
+)
+from torchao.prototype.moe_training.utils import generate_jagged_offs
+
+device = torch.device("cuda")
+
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    input_shape: tuple[int]
+    num_groups: int
+    version: str  # "naive" or "parallel"
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    time_us: float
+    mem_bw_gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    # Llama4 and DSV3 671b shapes. Input activations are scaled along the total_M dim, which contains all the token groups.
+    block_size = 32
+    input_shapes = [
+        (8192, 32768 // block_size),
+        (8192, 65536 // block_size),
+        (8192, 131072 // block_size),
+        (5120, 32768 // block_size),
+        (5120, 65536 // block_size),
+        (5120, 131072 // block_size),
+        (7168, 32768 // block_size),
+        (7168, 65536 // block_size),
+        (7168, 131072 // block_size),
+        (2048, 32768 // block_size),
+        (2048, 65536 // block_size),
+        (2048, 131072 // block_size),
+    ]
+    num_groups = [8]
+    versions = [
+        "torch",
+        "triton",
+        # CUDA kernel versions: cuda_{max_cols}_{chunks_per_tb}
+        "cuda_64_4",
+        "cuda_64_8",
+        "cuda_64_16",
+        "cuda_128_4",
+        "cuda_128_8",
+        "cuda_128_16",
+    ]
+
+    configs = []
+    for shape, groups, version in itertools.product(
+        input_shapes,
+        num_groups,
+        versions,
+    ):
+        configs.append(
+            ExperimentConfig(
+                input_shape=shape,
+                num_groups=groups,
+                version=version,
+            )
+        )
+    return configs
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    input_shape, num_groups, version = (
+        config.input_shape,
+        config.num_groups,
+        config.version,
+    )
+    input_tensor = torch.randint(
+        low=0,
+        high=256,
+        size=input_shape,
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    M, Kg = input_shape
+    block_size = 32
+    input_group_offsets = generate_jagged_offs(num_groups, Kg, multiple_of=block_size)
+
+    # Select which kernel to benchmark based on version
+    if version == "torch":
+        kernel_fn = torch_to_blocked_2d_K_groups
+        kernel_input = input_tensor
+    elif version == "triton":
+        kernel_fn = triton_mx_block_rearrange_2d_K_groups
+        # Triton uses row-major input
+        kernel_input = input_tensor
+    elif version.startswith("cuda_"):
+        # Parse version string: cuda_{max_cols}_{chunks_per_tb}
+        parts = version.split("_")
+        max_cols = int(parts[1])
+        chunks_per_tb = int(parts[2])
+        kernel_fn = (
+            lambda t,
+            o,
+            mc=max_cols,
+            cptb=chunks_per_tb: mx_block_rearrange_2d_K_groups_cuda(
+                t,
+                o,
+                max_cols=mc,
+                chunks_per_tb=cptb,
+            )
+        )
+        kernel_input = input_tensor.view(torch.float8_e8m0fnu)
+    else:
+        raise ValueError(f"Unknown version: {version}")
+
+    # Run kernel to get output shape
+    outputs = kernel_fn(
+        kernel_input,
+        input_group_offsets,
+    )
+    if isinstance(outputs, tuple):  # torch returns a tuple with extra metadata
+        out_scales, _ = outputs
+    else:
+        out_scales = outputs
+
+    # Benchmark the kernel
+    time_us = benchmark_cuda_function_in_microseconds(
+        kernel_fn,
+        kernel_input,
+        input_group_offsets,
+    )
+
+    # Calculate memory bandwidth
+    bytes_per_input_el = torch.finfo(torch.float8_e8m0fnu).bits / 8
+    bytes_per_output_el = torch.finfo(torch.float8_e4m3fn).bits / 8
+
+    read_bytes = input_tensor.numel() * bytes_per_input_el
+    write_bytes = out_scales.numel() * bytes_per_output_el
+
+    mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (time_us / 1e6)
+
+    return ExperimentResult(
+        time_us=time_us,
+        mem_bw_gbps=mem_bw_gbps,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    # Group experiments by input shape
+    shapes_dict = {}
+    for exp in experiments:
+        shape_key = exp.config.input_shape
+        if shape_key not in shapes_dict:
+            shapes_dict[shape_key] = {}
+        shapes_dict[shape_key][exp.config.version] = exp.result
+
+    headers = [
+        "kernel_version",
+        "scale_shape",
+        "time_us",
+        "mem_bw_gbps",
+        "speedup_vs_torch",
+        "speedup_vs_triton",
+    ]
+
+    rows = []
+    for shape, versions in shapes_dict.items():
+        # Get torch baseline time for speedup calculation
+        torch_time_us = versions.get("torch").time_us if "torch" in versions else None
+
+        # Get triton baseline time for speedup calculation
+        triton_time_us = (
+            versions.get("triton").time_us if "triton" in versions else None
+        )
+
+        # Add rows for each version
+        for version, result in versions.items():
+            # Calculate speedup vs torch
+            speedup_vs_torch_str = ""
+            if version != "torch" and torch_time_us is not None:
+                speedup = torch_time_us / result.time_us
+                speedup_vs_torch_str = f"{speedup:.2f}x"
+
+            # Calculate speedup vs triton (only for CUDA kernels)
+            speedup_vs_triton_str = ""
+            if version.startswith("cuda_") and triton_time_us is not None:
+                speedup = triton_time_us / result.time_us
+                speedup_vs_triton_str = f"{speedup:.2f}x"
+
+            rows.append(
+                [
+                    version,
+                    f"({shape[0]}, {shape[1]})",
+                    f"{result.time_us:.2f}",
+                    round(result.mem_bw_gbps, 3),
+                    speedup_vs_torch_str,
+                    speedup_vs_triton_str,
+                ]
+            )
+
+        # Find best CUDA kernel speedup vs triton for this shape
+        best_cuda_speedup = 0.0
+        best_cuda_version = None
+        for version, result in versions.items():
+            if version.startswith("cuda_") and triton_time_us is not None:
+                speedup = triton_time_us / result.time_us
+                if speedup > best_cuda_speedup:
+                    best_cuda_speedup = speedup
+                    best_cuda_version = version
+
+        if best_cuda_version is not None:
+            rows.append(
+                [
+                    f">>> BEST: {best_cuda_speedup:.2f}x vs triton with {best_cuda_version}",
+                    "",
+                    "",
+                    "",
+                    "",
+                ]
+            )
+
+        # Add empty row for visual separation between shapes
+        rows.append([""] * len(headers))
+
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -709,6 +709,7 @@ def get_extensions():
         mxfp8_sources = [
             os.path.join(mxfp8_extension_dir, "mxfp8_extension.cpp"),
             os.path.join(mxfp8_extension_dir, "mxfp8_cuda.cu"),
+            os.path.join(mxfp8_extension_dir, "mx_block_rearrange_2d_K_groups.cu"),
         ]
 
         # Only add the extension if the source files exist AND we are building for sm100

--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_K_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_K_groups.cu
@@ -1,0 +1,418 @@
+#include <cuda_runtime.h>
+#include <cuda_fp8.h>
+#include <cstdint>
+#include <cstdio>
+
+#define BLOCK_ROWS 128
+#define BLOCK_COLS 4
+#define BYTES_PER_THREAD 16
+#define SCALE_FACTOR_ROWS 128
+
+__device__ __forceinline__ int ceil_div(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+// Terminology:
+// tile = 128x4 scaling factor tile
+// chunk = chunk of data consisting of multiple tiles (e.g., 128x64 or 128x128)
+// superblock = consists of CHUNKS_PER_TB chunks along the column dimension
+template <int CHUNKS_PER_TB>
+__device__ void find_group_and_local_offset_for_superblock(
+    int super_col_block_pid,
+    const int32_t* __restrict__ input_group_end_offsets,
+    int num_groups,
+    int cols_per_block,
+    int* __restrict__ smem_data,  // smem_data[0..num_groups-1] = chunks_in_group, smem_data[num_groups..2*num_groups-1] = super_blocks_in_group cumsum
+    int& group_id,
+    int& first_chunk_in_group,
+    int& chunks_until_group_end
+) {
+    if (threadIdx.x == 0) {
+        int superblock_cumsum = 0;
+        for (int g = 0; g < num_groups; g++) {
+            int input_group_start = (g > 0) ? input_group_end_offsets[g - 1] : 0;
+            int input_group_end = input_group_end_offsets[g];
+            int group_size = input_group_end - input_group_start;
+            int chunks_in_group = ceil_div(group_size, cols_per_block);
+            int superblocks_in_group = ceil_div(chunks_in_group, CHUNKS_PER_TB);
+            smem_data[g] = chunks_in_group;
+            superblock_cumsum += superblocks_in_group;
+            smem_data[num_groups + g] = superblock_cumsum;
+        }
+    }
+    __syncthreads();
+
+    group_id = 0;
+    int superblock_cumsum_before = 0;
+    for (int g = 0; g < num_groups; g++) {
+        int cumsum_at_g = smem_data[num_groups + g];
+        if (super_col_block_pid < cumsum_at_g) {
+            group_id = g;
+            int local_superblock = super_col_block_pid - superblock_cumsum_before;
+            first_chunk_in_group = local_superblock * CHUNKS_PER_TB;
+            int chunks_in_group = smem_data[g];
+            chunks_until_group_end = chunks_in_group - first_chunk_in_group;
+            return;
+        }
+        superblock_cumsum_before = cumsum_at_g;
+    }
+
+    first_chunk_in_group = 0;
+    chunks_until_group_end = 0;
+}
+
+__device__ __forceinline__ int compute_output_group_start_col(
+    int group_id,
+    const int32_t* input_group_end_offsets,
+    int num_groups,
+    int padding_size
+) {
+    int start_idx = 0;
+    for (int i = 0; i < group_id; i++) {
+        int prev_offset = (i > 0) ? input_group_end_offsets[i - 1] : 0;
+        int curr_offset = input_group_end_offsets[i];
+        int group_size = curr_offset - prev_offset;
+        int padded_size = ceil_div(group_size, padding_size) * padding_size;
+        start_idx += padded_size;
+    }
+    return start_idx;
+}
+
+
+// Uses 2-stage software pipelining with double buffering to overlap memory
+// transfers with compute. Each threadblock processes CHUNKS_PER_TB consecutive
+// chunks within the same group.
+template <int MAX_COLS, int CHUNKS_PER_TB = 4>
+__global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel(
+    const uint8_t* __restrict__ scales_ptr,
+    int scales_stride_dim0,
+    int scale_rows,
+    int scale_cols,
+    int padded_rows,
+    const int32_t* __restrict__ input_group_end_offsets,
+    uint8_t* __restrict__ output_scales_ptr,
+    int output_stride_per_block,
+    int num_groups
+) {
+    constexpr int THREADS_PER_ROW = MAX_COLS / 16;
+    constexpr int TILES_PER_THREAD = 4;  // Each thread processes 16 bytes = 4 tiles (4 bytes per tile)
+    constexpr int TILE_SIZE = SCALE_FACTOR_ROWS * BLOCK_COLS;  // 128 rows * 4 cols = 512 bytes per tile
+    constexpr int SMEM_SIZE = BLOCK_ROWS * MAX_COLS;
+    constexpr int NUM_BUFFERS = 2;
+
+    const int super_col_block_pid = blockIdx.x;
+    const int row_block_pid = blockIdx.y;
+    const int tid = threadIdx.x;
+
+    __shared__ __align__(16) uint8_t smem[NUM_BUFFERS][SMEM_SIZE];
+    __shared__ int smem_group_data[64]; // max 32 groups; 1 int per group size, 1 int per group prefix sum
+    __shared__ int s_output_group_start_col;
+    __shared__ int s_input_group_start_col;
+    __shared__ int s_input_group_end_col;
+    __shared__ int s_first_chunk_in_group;
+    __shared__ int s_num_chunks_to_process;
+
+    // PHASE 0: Map super-block to (group, first_chunk) pair
+    int group_id, first_chunk_in_group, chunks_until_group_end;
+    find_group_and_local_offset_for_superblock<CHUNKS_PER_TB>(
+        super_col_block_pid,
+        input_group_end_offsets,
+        num_groups,
+        MAX_COLS,
+        smem_group_data,
+        group_id,
+        first_chunk_in_group,
+        chunks_until_group_end
+    );
+
+    // Use one thread in the threadblock to compute group boundaries and output group start,
+    // then broadcast the values via SMEM.
+    // This avoids (1) unnecessary extra global accesses, and (2) extra register pressure, and
+    // (3) extra ALU usage by every thread computing redundant values, in a kernel which is already ALU heavy.
+    // It comes at the cost of these few SMEM accesses and thread block sync, but benchmarks show this is slightly
+    // better than having all threads do this redundant work.
+    if (tid == 0) {
+        s_input_group_start_col = (group_id > 0) ? input_group_end_offsets[group_id - 1] : 0;
+        s_input_group_end_col = input_group_end_offsets[group_id];
+        s_first_chunk_in_group = first_chunk_in_group;
+        s_output_group_start_col = compute_output_group_start_col(
+            group_id, input_group_end_offsets, num_groups, 4
+        );
+        s_num_chunks_to_process = (chunks_until_group_end > 0) ? min(CHUNKS_PER_TB, chunks_until_group_end) : 0;
+    }
+
+    __syncthreads();
+
+    int input_group_start_col = s_input_group_start_col;
+    int input_group_end_col = s_input_group_end_col;
+    first_chunk_in_group = s_first_chunk_in_group;
+    int output_group_start_col = s_output_group_start_col;
+    int num_chunks_to_process = s_num_chunks_to_process;
+
+    if (num_chunks_to_process <= 0) {
+        return;
+    }
+
+    // PHASE 1: Precompute thread-constant values
+    int global_row_base = row_block_pid * BLOCK_ROWS;
+    int row_idx = tid / THREADS_PER_ROW;
+    int col_idx = tid % THREADS_PER_ROW;
+    int global_row = global_row_base + row_idx;
+    bool row_valid = (global_row < scale_rows);
+
+    int r_div_32 = row_idx >> 5; // row / 32
+    int r_mod_32 = row_idx & 31; // row % 32
+    int swizzle_base = (r_mod_32 << 4) + (r_div_32 << 2); // (row % 32) * 16 + (row / 32) * 4
+    int thread_col_start = col_idx * 16;
+    int first_tile_idx = thread_col_start >> 2; // thread_col_start / 4
+
+    int out_group_base_offset = output_group_start_col * padded_rows;
+    int num_cols_in_group = input_group_end_col - input_group_start_col;
+    int num_tiles_in_group = ceil_div(num_cols_in_group, BLOCK_COLS);
+    int tiles_stride_per_row_block = num_tiles_in_group * TILE_SIZE;
+
+    const uint8_t* row_base_ptr = scales_ptr +
+        static_cast<size_t>(global_row) * scales_stride_dim0;
+
+    // PHASE 2: Pipelined execution with double buffering
+    auto load_chunk_async = [&](int chunk_idx, int buf_idx) {
+        int curr_chunk_in_group = first_chunk_in_group + chunk_idx;
+        int curr_input_start_col = input_group_start_col + curr_chunk_in_group * MAX_COLS;
+        int cols_remaining = input_group_end_col - curr_input_start_col;
+        int cols_to_load = min(MAX_COLS, cols_remaining);
+        bool can_load = row_valid && (thread_col_start < cols_to_load);
+
+        if (can_load) {
+            const uint8_t* src_ptr = row_base_ptr + curr_input_start_col + thread_col_start;
+            uintptr_t gmem_addr = reinterpret_cast<uintptr_t>(src_ptr);
+            bool aligned = (gmem_addr % 16 == 0);
+            bool full_vec = (thread_col_start + 16 <= cols_to_load) && aligned;
+
+            if (full_vec) {
+                asm volatile(
+                    "cp.async.cg.shared.global [%0], [%1], 16;\n"
+                    :
+                    : "l"(&smem[buf_idx][row_idx * MAX_COLS + thread_col_start]),
+                      "l"(src_ptr)
+                );
+            } else {
+                uint4 data = make_uint4(0, 0, 0, 0);
+                uint8_t* bytes = reinterpret_cast<uint8_t*>(&data);
+                int bytes_to_load = min(16, cols_to_load - thread_col_start);
+                #pragma unroll
+                for (int i = 0; i < 16; i++) {
+                    if (i < bytes_to_load) bytes[i] = __ldg(src_ptr + i);
+                }
+                *reinterpret_cast<uint4*>(&smem[buf_idx][row_idx * MAX_COLS + thread_col_start]) = data;
+            }
+        } else {
+            *reinterpret_cast<uint4*>(&smem[buf_idx][row_idx * MAX_COLS + thread_col_start]) = make_uint4(0, 0, 0, 0);
+        }
+    };
+
+    // Process chunk: read from linear SMEM, swizzle, store to GMEM
+    auto process_chunk = [&](int chunk_idx, int buf_idx) {
+        int curr_chunk_in_group = first_chunk_in_group + chunk_idx;
+        int curr_input_start_col = input_group_start_col + curr_chunk_in_group * MAX_COLS;
+        int cols_remaining = input_group_end_col - curr_input_start_col;
+        int cols_to_load = min(MAX_COLS, cols_remaining);
+
+        uint4 data = *reinterpret_cast<uint4*>(&smem[buf_idx][row_idx * MAX_COLS + thread_col_start]);
+
+        __syncthreads();
+
+        int tile_xor = (col_idx & 3) << 2; // col_idx % 4
+        int superrow_xor = ((swizzle_base >> 7) & 3) << 2; // ((swizzle_base / 128) % 4) * 4
+        int combined_xor = tile_xor ^ superrow_xor;
+
+        uint32_t* data32 = reinterpret_cast<uint32_t*>(&data);
+        #pragma unroll
+        for (int t = 0; t < TILES_PER_THREAD; t++) {
+            int tile_idx = first_tile_idx + t;
+            int tile_base = tile_idx * SCALE_FACTOR_ROWS * BLOCK_COLS;
+            int swizzled_idx = tile_base + (swizzle_base ^ combined_xor);
+            *reinterpret_cast<uint32_t*>(&smem[buf_idx][swizzled_idx]) = data32[t];
+        }
+
+        __syncthreads();
+
+        // Compute output pointer: skip past tiles from previous chunks in this group
+        int tiles_before_this_chunk = curr_chunk_in_group * (MAX_COLS / BLOCK_COLS);
+        uint8_t* out_base = output_scales_ptr + out_group_base_offset +
+                            row_block_pid * tiles_stride_per_row_block +
+                            tiles_before_this_chunk * TILE_SIZE;
+
+        int num_tiles_this_chunk = ceil_div(cols_to_load, BLOCK_COLS);
+        int bytes_to_copy = num_tiles_this_chunk * TILE_SIZE;
+
+        // Each thread writes 16 bytes (4 tiles worth of data for its row position)
+        int byte_offset = tid * 16;
+        if (byte_offset < bytes_to_copy) {
+            uint32_t out_data[4];
+
+            // Read 4 uint32s from swizzled SMEM layout, accounting for writer's XOR pattern
+            #pragma unroll
+            for (int i = 0; i < 4; i++) {
+                int out_byte = byte_offset + i * 4;
+                int tile_idx = out_byte / TILE_SIZE;
+                int within_tile_offset = out_byte % TILE_SIZE;
+
+                int writer_col_idx = (tile_idx / TILES_PER_THREAD) % THREADS_PER_ROW;
+                int writer_tile_xor = (writer_col_idx & 3) << 2; // (writer_col % 4) * 4
+                int writer_superrow_xor = ((within_tile_offset >> 7) & 3) << 2; // ((within_tile_offset / 128) % 4) * 4
+                int writer_combined_xor = writer_tile_xor ^ writer_superrow_xor;
+                int smem_addr = tile_idx * TILE_SIZE + (within_tile_offset ^ writer_combined_xor);
+                out_data[i] = *reinterpret_cast<uint32_t*>(&smem[buf_idx][smem_addr]);
+            }
+
+            *reinterpret_cast<uint4*>(out_base + byte_offset) =
+                *reinterpret_cast<uint4*>(out_data);
+        }
+    };
+
+    if (num_chunks_to_process == 1)
+    {
+        load_chunk_async(0, 0);
+        asm volatile("cp.async.commit_group;\n");
+        asm volatile("cp.async.wait_group 0;\n");
+        __syncthreads();
+        process_chunk(0, 0);
+    }
+    else
+    {
+        // PROLOGUE: Load first chunk
+        load_chunk_async(0, 0);
+        asm volatile("cp.async.commit_group;\n");
+
+        // STEADY STATE: Overlap load N+1 with processing N
+        for (int chunk = 0; chunk < num_chunks_to_process - 1; chunk++) {
+            int curr_buf = chunk & 1;        // chunk % 2
+            int next_buf = (chunk + 1) & 1;  // (chunk + 1) % 2
+
+            // Kick off async load of chunk N+1
+            load_chunk_async(chunk + 1, next_buf);
+            asm volatile("cp.async.commit_group;\n");
+
+            // Wait for async load of chunk N, without waiting for chunk N+1, to achieve overlap.
+            // async loads completed in commit order (FIFO) so this should work.
+            asm volatile("cp.async.wait_group 1;\n");
+            __syncthreads();
+
+            // Process chunk N, overlapping with async load of chunk N+1.
+            process_chunk(chunk, curr_buf);
+        }
+
+        // EPILOGUE: Process final chunk
+        int last_chunk = num_chunks_to_process - 1;
+        int last_buf = last_chunk & 1;
+        asm volatile("cp.async.wait_group 0;\n");
+        __syncthreads();
+        process_chunk(last_chunk, last_buf);
+    }
+}
+
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 4>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 8>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 16>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 4>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 8>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+template __global__ void mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 16>(
+    const uint8_t* __restrict__, int, int, int, int,
+    const int32_t* __restrict__, uint8_t* __restrict__, int, int);
+
+namespace mxfp8 {
+
+void launch_mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined(
+    const uint8_t* scales_ptr,
+    int scales_stride_dim0,
+    int scale_rows,
+    int scale_cols,
+    int padded_rows,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int max_cols,  // Template selector: 64 or 128
+    int chunks_per_tb,  // Chunks per super-block: 4, 8, or 16
+    cudaStream_t stream
+) {
+    int num_row_blocks = (scale_rows + BLOCK_ROWS - 1) / BLOCK_ROWS;
+    int output_stride_per_block = BLOCK_ROWS * BLOCK_COLS;
+
+    int total_chunks = (scale_cols + max_cols - 1) / max_cols + num_groups;
+    int total_super_col_blocks = (total_chunks + chunks_per_tb - 1) / chunks_per_tb + num_groups;
+
+    dim3 grid(total_super_col_blocks, num_row_blocks);
+
+    if (max_cols == 64) {
+        dim3 block(512);
+        switch (chunks_per_tb) {
+            case 4:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 4><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            case 8:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 8><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            case 16:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<64, 16><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            default:
+                printf("CUDA Error: chunks_per_tb must be 4, 8, or 16, got %d\n", chunks_per_tb);
+                return;
+        }
+    } else if (max_cols == 128) {
+        dim3 block(1024);
+        switch (chunks_per_tb) {
+            case 4:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 4><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            case 8:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 8><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            case 16:
+                mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined_kernel<128, 16><<<grid, block, 0, stream>>>(
+                    scales_ptr, scales_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr, output_stride_per_block, num_groups);
+                break;
+            default:
+                printf("CUDA Error: chunks_per_tb must be 4, 8, or 16, got %d\n", chunks_per_tb);
+                return;
+        }
+    } else {
+        printf("CUDA Error: max_cols must be 64 or 128, got %d\n", max_cols);
+        return;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("CUDA Error (pipelined max_cols=%d, chunks_per_tb=%d): %s\n",
+               max_cols, chunks_per_tb, cudaGetErrorString(err));
+    }
+}
+
+} // namespace mxfp8

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -26,6 +26,20 @@ void mxfp8_quantize_3d_cuda(const at::Tensor &input,
                              const std::string &fp8_format,
                              const std::string &scaling_mode);
 
+
+void launch_mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined(
+    const uint8_t* scales_ptr,
+    int scales_stride_dim0,
+    int scale_rows,
+    int scale_cols,
+    int padded_rows,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int max_cols,       // Max cols processed per thread block template selector: 64 or 128
+    int tiles_per_tb,  // Chunks per super-block: 4, 8, or 16
+    cudaStream_t stream);
+
 // Helper for tensor validation
 void check_cuda_tensor(const at::Tensor &t, const char *name) {
   TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
@@ -178,6 +192,75 @@ mxfp8_quantize_3d(const at::Tensor& input, int64_t scale_dim_n,
   return std::make_tuple(output_colwise, scales_colwise);
 }
 
+// Converts e8m0 scale factors to blocked layout needed for MXFP8 Grouped GEMM.
+// Layout transformation occurs per group, where groups are along the K dim / columns.
+at::Tensor mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined(
+    at::Tensor scales_tensor,
+    at::Tensor input_group_end_offsets,
+    int64_t max_cols,
+    int64_t tiles_per_tb) {
+
+  // Validate inputs
+  check_cuda_tensor(scales_tensor, "scales_tensor");
+  check_cuda_tensor(input_group_end_offsets, "input_group_end_offsets");
+  
+  TORCH_CHECK(scales_tensor.dim() == 2, "scales_tensor must be 2D");
+  TORCH_CHECK(scales_tensor.is_contiguous(), "scales_tensor must be contiguous (row-major)");
+  TORCH_CHECK(scales_tensor.scalar_type() == at::kFloat8_e8m0fnu,
+              "scales_tensor must be e8m0");
+  TORCH_CHECK(input_group_end_offsets.scalar_type() == at::kInt,
+              "input_group_end_offsets must be int32");
+  TORCH_CHECK(input_group_end_offsets.dim() == 1,
+              "input_group_end_offsets must be 1D");
+  TORCH_CHECK(max_cols == 64 || max_cols == 128,
+              "max_cols must be 64 or 128, got: ", max_cols);
+  TORCH_CHECK(tiles_per_tb == 4 || tiles_per_tb == 8 || tiles_per_tb == 16,
+              "tiles_per_tb must be 4, 8, or 16, got: ", tiles_per_tb);
+
+  c10::cuda::CUDAGuard device_guard(scales_tensor.device());
+
+  const int rows = scales_tensor.size(0);
+  const int cols = scales_tensor.size(1);
+  const int num_groups = input_group_end_offsets.size(0);
+  TORCH_CHECK(num_groups <= 32, "num_groups must be <= 32");
+  
+  // Calculate blocks needed - uses 128-row blocks
+  const int BLOCK_ROWS = 128;
+  const int BLOCK_COLS = 4;
+  const int num_row_blocks = (rows + BLOCK_ROWS - 1) / BLOCK_ROWS;
+  const int padded_rows = num_row_blocks * BLOCK_ROWS;
+    
+  // Padding per group is variable/data dependent, so pad each group by upper bound
+  const int padded_cols = cols + num_groups * BLOCK_COLS;
+  
+  // Create output tensor
+  auto output = at::zeros({padded_rows, padded_cols},
+                            at::TensorOptions()
+                                .dtype(scales_tensor.scalar_type())
+                                .device(scales_tensor.device()));
+  
+  // Get raw pointers - reinterpret float8 as uint8
+  const uint8_t* scales_ptr = reinterpret_cast<const uint8_t*>(scales_tensor.data_ptr());
+  const int32_t* offsets_ptr = input_group_end_offsets.data_ptr<int32_t>();
+  uint8_t* output_ptr = reinterpret_cast<uint8_t*>(output.data_ptr());
+  
+  // Launch pipelined kernel with specified max_cols and tiles_per_tb
+  launch_mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined(
+      scales_ptr,
+      scales_tensor.stride(0),
+      rows,
+      cols,
+      padded_rows,
+      offsets_ptr,
+      output_ptr,
+      num_groups,
+      static_cast<int>(max_cols),
+      static_cast<int>(tiles_per_tb),
+      at::cuda::getCurrentCUDAStream());
+  
+  return output;
+}
+
 } // namespace mxfp8
 
 
@@ -185,4 +268,5 @@ mxfp8_quantize_3d(const at::Tensor& input, int64_t scale_dim_n,
 TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
   m.impl("mxfp8_quantize", &mxfp8::mxfp8_quantize);
   m.impl("mxfp8_quantize_3d", &mxfp8::mxfp8_quantize_3d);
+  m.impl("mx_block_rearrange_2d_K_groups", &mxfp8::mx_block_rearrange_2d_K_groups_rowmajor_128x4_vec_pipelined);
 }


### PR DESCRIPTION
Stacked PRs:
 * #3521
 * #3507
 * #3506
 * #3505
 * __->__#3504


--- --- ---

### [mxfp8 moe training] add CUDA kernel for per-group conversion of scale factors to blocked layout

TL;DR this PR adds a new CUDA kernel for blocked layout scale factors with groups along K for 2d2d grouped GEMM that is ~2x to 3.5x faster than existing Triton kernel. For the DSV3 shapes we care most about, it's about 2.5x to 3x faster than Triton.

## Kernel design

### Summary
- 128x4 thread blocks load 128x64 chunks of row major scale data using coalesced vectorized uint4 (16 byte) loads from global memory. (templating allows for other configurations but I got the best results with this).
- Each thread has 16 bytes in register memory. It writes this to SMEM in 4 separate 4-byte contiguous chunks (uint32 write) to the appropriate locations in shared memory in order to perform the transformation to per-grouped blocked layout. 
- Avoiding bank conflicts:
    - XOR swizzle based on base column index in smem used to avoid bank conflicts on writes (`tile_xor`).
    - 2nd XOR swizzle based on "supperow" index (which 128 byte chunk) to avoid bank conflicts on reads when copying the result to GMEM (`superrow_xor`)
    - Compose these 2 via `tile_xor ^ superrow_xor` to avoid bank conflicts on both reads and writes.
- Copy data from SMEM to GMEM via coalesced, vectorized uint4/16 byte writes. It first goes through registers because we need to unswizzle first. 
- Pipeline async load of chunk N+1 with processing of chunk N.


## Benchmarks
- Ranges from 1.8x to 3.5x faster than triton depending on input shape. Speedup is better for larger shapes.
- Shapes below are (model_dim, total_M // 32) since this is for 2d2d grouped gemm where we scale along the total_M dim.
- `total_M` (local batch size * seq len) ranges from 32768 to 131072 (scale widths of 1024 and 4096, respectively)
- Ran benchmarks with all combinations of "chunk width" and "chunks per threadblock."

Note: memory bandwidth utilization is not the best metric for this kernel since the ALU pipelines are heavily utilized as well. I am just using it as a proxy here while also referencing NCU to verify there's no substantial performance issues remaining. 
```
kernel_version                             scale_shape    time_us    mem_bw_gbps    speedup_vs_torch    speedup_vs_triton
-----------------------------------------  -------------  ---------  -------------  ------------------  -------------------
torch                                      (8192, 1024)   283.42     60.12
triton                                     (8192, 1024)   51.30      332.177        5.53x
cuda_64_4                                  (8192, 1024)   17.47      975.238        16.22x              2.94x
cuda_64_8                                  (8192, 1024)   17.50      973.455        16.19x              2.93x
cuda_64_16                                 (8192, 1024)   17.47      975.238        16.22x              2.94x
cuda_128_4                                 (8192, 1024)   21.54      791.204        13.16x              2.38x
cuda_128_8                                 (8192, 1024)   21.54      791.204        13.16x              2.38x
cuda_128_16                                (8192, 1024)   19.49      874.351        14.54x              2.63x
>>> BEST: 2.94x vs triton with cuda_64_4

torch                                      (8192, 2048)   432.67     78.158
triton                                     (8192, 2048)   51.20      660.48         8.45x
cuda_64_4                                  (8192, 2048)   23.74      1424.216       18.22x              2.16x
cuda_64_8                                  (8192, 2048)   23.71      1426.138       18.25x              2.16x
cuda_64_16                                 (8192, 2048)   27.65      1223.111       15.65x              1.85x
cuda_128_4                                 (8192, 2048)   27.81      1216.074       15.56x              1.84x
cuda_128_8                                 (8192, 2048)   27.78      1217.475       15.58x              1.84x
cuda_128_16                                (8192, 2048)   26.66      1268.629       16.23x              1.92x
>>> BEST: 2.16x vs triton with cuda_64_8

torch                                      (8192, 4096)   444.40     151.6
triton                                     (8192, 4096)   119.65     563.077        3.71x
cuda_64_4                                  (8192, 4096)   33.63      2003.182       13.21x              3.56x
cuda_64_8                                  (8192, 4096)   35.65      1889.896       12.47x              3.36x
cuda_64_16                                 (8192, 4096)   37.89      1778.162       11.73x              3.16x
cuda_128_4                                 (8192, 4096)   39.74      1695.124       11.18x              3.01x
cuda_128_8                                 (8192, 4096)   39.97      1685.624       11.12x              2.99x
cuda_128_16                                (8192, 4096)   46.11      1461.03        9.64x               2.59x
>>> BEST: 3.56x vs triton with cuda_64_4

torch                                      (5120, 1024)   429.76     24.78
triton                                     (5120, 1024)   47.30      225.169        9.09x
cuda_64_4                                  (5120, 1024)   15.42      690.456        27.86x              3.07x
cuda_64_8                                  (5120, 1024)   15.36      693.333        27.98x              3.08x
cuda_64_16                                 (5120, 1024)   15.36      693.333        27.98x              3.08x
cuda_128_4                                 (5120, 1024)   19.46      547.368        22.09x              2.43x
cuda_128_8                                 (5120, 1024)   19.46      547.368        22.09x              2.43x
cuda_128_16                                (5120, 1024)   17.41      611.765        24.69x              2.72x
>>> BEST: 3.08x vs triton with cuda_64_8

torch                                      (5120, 2048)   439.90     48.045
triton                                     (5120, 2048)   46.11      458.348        9.54x
cuda_64_4                                  (5120, 2048)   19.49      1084.532       22.57x              2.37x
cuda_64_8                                  (5120, 2048)   21.50      982.857        20.46x              2.14x
cuda_64_16                                 (5120, 2048)   21.50      982.857        20.46x              2.14x
cuda_128_4                                 (5120, 2048)   23.55      897.391        18.68x              1.96x
cuda_128_8                                 (5120, 2048)   23.55      897.391        18.68x              1.96x
cuda_128_16                                (5120, 2048)   23.49      899.837        18.73x              1.96x
>>> BEST: 2.37x vs triton with cuda_64_4

torch                                      (5120, 4096)   440.38     95.614
triton                                     (5120, 4096)   70.66      595.942        6.23x
cuda_64_4                                  (5120, 4096)   25.60      1644.8         17.20x              2.76x
cuda_64_8                                  (5120, 4096)   27.65      1522.963       15.93x              2.56x
cuda_64_16                                 (5120, 4096)   29.70      1417.931       14.83x              2.38x
cuda_128_4                                 (5120, 4096)   29.70      1417.931       14.83x              2.38x
cuda_128_8                                 (5120, 4096)   31.74      1326.452       13.87x              2.23x
cuda_128_16                                (5120, 4096)   33.63      1251.989       13.09x              2.10x
>>> BEST: 2.76x vs triton with cuda_64_4

torch                                      (7168, 1024)   431.89     34.522
triton                                     (7168, 1024)   48.42      307.944        8.92x
cuda_64_4                                  (7168, 1024)   17.44      854.899        24.76x              2.78x
cuda_64_8                                  (7168, 1024)   15.52      960.66         27.83x              3.12x
cuda_64_16                                 (7168, 1024)   17.44      854.899        24.76x              2.78x
cuda_128_4                                 (7168, 1024)   19.49      765.057        22.16x              2.48x
cuda_128_8                                 (7168, 1024)   19.49      765.057        22.16x              2.48x
cuda_128_16                                (7168, 1024)   19.49      765.057        22.16x              2.48x
>>> BEST: 3.12x vs triton with cuda_64_8

torch                                      (7168, 2048)   432.21     68.461
triton                                     (7168, 2048)   52.26      566.241        8.27x
cuda_64_4                                  (7168, 2048)   21.54      1373.955       20.07x              2.43x
cuda_64_8                                  (7168, 2048)   23.55      1256.348       18.35x              2.22x
cuda_64_16                                 (7168, 2048)   25.63      1154.397       16.86x              2.04x
cuda_128_4                                 (7168, 2048)   25.63      1154.397       16.86x              2.04x
cuda_128_8                                 (7168, 2048)   27.62      1071.462       15.65x              1.89x
cuda_128_16                                (7168, 2048)   23.58      1254.643       18.33x              2.22x
>>> BEST: 2.43x vs triton with cuda_64_4

torch                                      (7168, 4096)   477.47     123.462
triton                                     (7168, 4096)   78.88      747.333        6.05x
cuda_64_4                                  (7168, 4096)   31.71      1858.906       15.06x              2.49x
cuda_64_8                                  (7168, 4096)   31.74      1857.032       15.04x              2.48x
cuda_64_16                                 (7168, 4096)   35.87      1643.333       13.31x              2.20x
cuda_128_4                                 (7168, 4096)   35.84      1644.8         13.32x              2.20x
cuda_128_8                                 (7168, 4096)   37.86      1557.207       12.61x              2.08x
cuda_128_16                                (7168, 4096)   37.73      1562.49        12.66x              2.09x
>>> BEST: 2.49x vs triton with cuda_64_4

torch                                      (2048, 1024)   434.90     9.795
triton                                     (2048, 1024)   48.61      87.637         8.95x
cuda_64_4                                  (2048, 1024)   15.17      280.844        28.67x              3.20x
cuda_64_8                                  (2048, 1024)   15.23      279.664        28.55x              3.19x
cuda_64_16                                 (2048, 1024)   14.43      295.166        30.13x              3.37x
cuda_128_4                                 (2048, 1024)   17.31      246.063        25.12x              2.81x
cuda_128_8                                 (2048, 1024)   15.23      279.664        28.55x              3.19x
cuda_128_16                                (2048, 1024)   15.20      280.253        28.61x              3.20x
>>> BEST: 3.37x vs triton with cuda_64_16

torch                                      (2048, 2048)   430.05     19.659
triton                                     (2048, 2048)   50.18      168.49         8.57x
cuda_64_4                                  (2048, 2048)   15.36      550.4          28.00x              3.27x
cuda_64_8                                  (2048, 2048)   17.44      484.756        24.66x              2.88x
cuda_64_16                                 (2048, 2048)   21.50      393.143        20.00x              2.33x
cuda_128_4                                 (2048, 2048)   17.41      485.647        24.70x              2.88x
cuda_128_8                                 (2048, 2048)   19.52      433.102        22.03x              2.57x
cuda_128_16                                (2048, 2048)   19.46      434.526        22.10x              2.58x
>>> BEST: 3.27x vs triton with cuda_64_4

torch                                      (2048, 4096)   425.26     39.605
triton                                     (2048, 4096)   52.06      323.501        8.17x
cuda_64_4                                  (2048, 4096)   17.44      965.754        24.38x              2.99x
cuda_64_8                                  (2048, 4096)   19.49      864.263        21.82x              2.67x
cuda_64_16                                 (2048, 4096)   23.58      714.16         18.03x              2.21x
cuda_128_4                                 (2048, 4096)   17.57      958.718        24.21x              2.96x
cuda_128_8                                 (2048, 4096)   23.55      715.13         18.06x              2.21x
cuda_128_16                                (2048, 4096)   21.54      782.074        19.75x              2.42x
>>> BEST: 2.99x vs triton with cuda_64_4
```

### Super detailed explanation for anyone interested

#### Loads from GMEM
<img width="894" height="564" alt="Screenshot 2025-12-19 at 2 07 52 PM" src="https://github.com/user-attachments/assets/eaa63d73-ce0c-40f5-9767-2d1da4f934c9" />

### Stores to SMEM (ignoring XOR swizzle for avoiding bank conflicts on writes)
<img width="1017" height="685" alt="Screenshot 2025-12-19 at 2 33 59 PM" src="https://github.com/user-attachments/assets/f83ca66b-8bc3-4090-a05c-f28f66967e69" />


### Dual XOR swizzle to base SMEM address for each thread to resolve bank conflicts on both writes and reads
(pasting from a google doc blog post draft for this description, so the bit highlighting is visible)
<img width="989" height="604" alt="Screenshot 2025-12-19 at 2 35 49 PM" src="https://github.com/user-attachments/assets/1fe58a6a-8adb-423b-b070-cc2d913b12fd" />

<img width="688" height="694" alt="Screenshot 2025-12-19 at 2 09 23 PM" src="https://github.com/user-attachments/assets/c4b84bcf-d267-492d-9b02-18d3b0cc45e4" />

#### Copy SMEM to GMEM
Here we are doing a linear read pattern from SMEM, doing vectorized coalesced uint4 loads from shared memory and storing in global memory. The issue here is 4 way bank conflicts, but I found no good solution here. We have 32 banks of 4 bytes each, so that's 128 total bytes before wrapping around and hitting the first bank again. This means with 8 threads reading 16 bytes each, 8 * 16 = 128, so every 8 threads in a warp will wrap around and experience a bank conflict for a total of a 4-way bank conflict per warp.

The best solution I found for this was a suggestion from Claude, actually, to basically add a second layer of XOR that shifts the bank every 128 bytes within a 512-byte tile (128 * 4 = 512). Composing this XOR with the existing XOR does avoid bank conflicts for both reads and writes. Composing two XORs like this forms a "Latin square" kind of like Sudoku where given a tile_xor, we have unique banks for every superrow xor (and vice versa).

(diagram coming)

#### Pipeline async load of chunk N+1 with processing of chunk N
This kernel is instruction-heavy and has a lot of complicated pointer math. It does the prefix sums, then does the lookup of which group this thread block is operating on and block layout transformations. With NCU, I saw the ALU was highly utilized. Therefore, I thought it would be useful to not block the next load from global memory on all of this heavy pointer math going on. So I implemented a pipelined approach with double buffering where we can overlap the load of the next chunk from global memory with the computation needed on the current chunk. Compared to a non-pipelined approach, this approach showed solid improvements on large shapes and neutral for small and medium shapes.

I templated the number of chunks per thread block, benchmarked a few values, and have just hard-coded the config that was best.