### PR TITLE
[mxfp8 moe training] integrate new cuda kernel for blocked layout for groups along K

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -1,4 +1,5 @@
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
+    mx_block_rearrange_2d_K_groups_cuda,  # noqa: F401
     mxfp8_quantize_cuda_3d,  # noqa: F401
     torch_to_blocked_2d_K_groups,  # noqa: F401
     torch_to_blocked_2d_M_groups,  # noqa: F401

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -17,8 +17,8 @@ from torchao.prototype.moe_training.kernels import (
     triton_fp8_rowwise_3d_transpose_rhs,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    mx_block_rearrange_2d_K_groups_cuda,
     mxfp8_quantize_cuda_3d,
-    triton_mx_block_rearrange_2d_K_groups,
     triton_mx_block_rearrange_2d_M_groups,
     triton_mx_block_rearrange_per_group_3d,
 )
@@ -449,11 +449,11 @@ class _MXFP8GroupedMM(torch.autograd.Function):
 
             # Convert scales to blocked format for 2d-2d grouped mm
             scale_group_offsets = offs // block_size
-            grad_out_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
+            grad_out_t_scales_blocked = mx_block_rearrange_2d_K_groups_cuda(
                 grad_out_t_scales,
                 scale_group_offsets,
             )
-            A_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
+            A_t_scales_blocked = mx_block_rearrange_2d_K_groups_cuda(
                 A_t_scales,
                 scale_group_offsets,
             )

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -1219,10 +1219,9 @@ if mxfp8_cuda_extension_available:
                 (rows, cols), (1, rows), dtype=torch.float8_e4m3fn, device=x.device
             )
 
-            # colwise scales are written in column-major format to avoid uncoalesced global memory accesses
-            scales_colwise = torch.empty_strided(
+            # and microb
+            scales_colwise = torch.empty(
                 (cols, num_row_blocks),
-                (1, cols),
                 dtype=torch.float8_e8m0fnu,
                 device=x.device,
             )


### PR DESCRIPTION
Stacked PRs:
 * #3521
 * #3507
 * #3506
 * __->__#3505
 * #3504


--- --- ---

### [mxfp8 moe training] integrate new cuda kernel for blocked layout for groups along K

Important note: 
- Writing scales to blocked format is much more efficient when they are in **row major format**. Currently the CUDA kernel for mxfp8 dim1 quantization writes to **column major** to avoid uncoalesced writes to GMEM.
- However, I did repeated microbenchmarking on various devices and determined there is no performance regression if we write the scales to row major (see benchmarks below). 
- In the quantization kernel, there are 64 threads per thread block, so we are only computing two scalar, one-byte E8M0 scale factors. So row major vs column major just means 2 transactions instead of 1 for writing the 2 bytes to GMEM. And this is negligible compared to the 64 bytes of quantized data that we'll be writing to global memory. 

## CUDA 2d tensor dim1 mxfp8 quantization kernel benchmarks for writing scales to col vs row major

```
FLOOR COL MAJOR
=== GPU 7 ===
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.11.0.dev20251216+cu128
triton version: 3.6.0
mode: dim1_mxfp8_cuda_floor
time_us 150.4959985613823
mem_bw_gbps 5406.75488902199

FLOOR ROW MAJOR
=== GPU 7 ===
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.11.0.dev20251216+cu128
triton version: 3.6.0
mode: dim1_mxfp8_cuda_floor
time_us 150.68800002336502
mem_bw_gbps 5399.8657880775645

RCEIL COL MAJOR
=== GPU 7 ===
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.11.0.dev20251216+cu128
triton version: 3.6.0
mode: dim1_mxfp8_cuda_rceil
time_us 156.6080003976822
mem_bw_gbps 5195.743346021566

RCEIL ROW MAJOR
=== GPU 7 ===
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.11.0.dev20251216+cu128
triton version: 3.6.0
mode: dim1_mxfp8_cuda_rceil
time_us 155.7759940624237
mem_bw_gbps 5223.4940364041595
```