### PR TITLE
[mxfp8 moe training] add wgrad_with_hp option

### DIFF
--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -294,6 +294,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         out_dtype: Optional[torch.dtype] = torch.bfloat16,
         emulated: bool = False,
         use_triton_for_dim0_cast: bool = False,
+        wgrad_with_hp: bool = False,
         scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
     ) -> torch.Tensor:
         # torchao _quantize_then_scaled_grouped_mm only supports A=2D and B=3D.
@@ -352,6 +353,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         ctx.out_dtype = out_dtype
         ctx.emulated = emulated
         ctx.use_triton_for_dim0_cast = use_triton_for_dim0_cast
+        ctx.wgrad_with_hp = wgrad_with_hp
         ctx.scale_calculation_mode = scale_calculation_mode
         return out
 
@@ -361,6 +363,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         block_size = ctx.block_size
         out_dtype = ctx.out_dtype
         use_triton_for_dim0_cast = ctx.use_triton_for_dim0_cast
+        wgrad_with_hp = ctx.wgrad_with_hp
         scale_calculation_mode = ctx.scale_calculation_mode
 
         # grad_out_data shape: (M, N)
@@ -405,59 +408,68 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             out_dtype=out_dtype,
         )
 
-        # grad_out_t_data shape: (M, N)
-        # grad_out_t_scales shape: (N, M//block_size)
-        grad_out_t_mx = _to_mxfp8_dim1_kernel_wrapper(
-            grad_out,
-            block_size,
-            elem_dtype=torch.float8_e4m3fn,
-            hp_dtype=grad_out.dtype,
-            kernel_preference=KernelPreference.AUTO,  # Not used
-            cast_kernel_choice=MXFP8Dim1CastKernelChoice.CUDA,
-            scale_calculation_mode=scale_calculation_mode,
-        )
-        grad_out_t_data = grad_out_t_mx.qdata
-        grad_out_t_scales = grad_out_t_mx.scale
+        # Optionally compute wgrad in high precision, if specified.
+        if wgrad_with_hp:
+            # TODO: migrate all grouped gemms in this file to new torch.nn.functional API
+            # grad_B_t = scaled grouped mm of (N,total_M) @ (total_M,K) = (E,N,K)
+            grad_B = torch._grouped_mm(
+                grad_out.transpose(-2, -1), A, offs=offs, out_dtype=out_dtype
+            )
+            grad_B_t = grad_B.transpose(-2, -1)
+        else:
+            # grad_out_t_data shape: (M, N)
+            # grad_out_t_scales shape: (N, M//block_size)
+            grad_out_t_mx = _to_mxfp8_dim1_kernel_wrapper(
+                grad_out,
+                block_size,
+                elem_dtype=torch.float8_e4m3fn,
+                hp_dtype=grad_out.dtype,
+                kernel_preference=KernelPreference.AUTO,  # Not used
+                cast_kernel_choice=MXFP8Dim1CastKernelChoice.CUDA,
+                scale_calculation_mode=scale_calculation_mode,
+            )
+            grad_out_t_data = grad_out_t_mx.qdata
+            grad_out_t_scales = grad_out_t_mx.scale
 
-        # Transpose A so we can scale along the M dimension, then un-transpose.
-        # A shape: (M, K)
-        # A_t_data shape: (K, M)
-        # A_t_scales shape: (K, M//block_size)
-        A_t_mx = _to_mxfp8_dim1_kernel_wrapper(
-            A,
-            block_size,
-            elem_dtype=torch.float8_e4m3fn,
-            hp_dtype=A.dtype,
-            kernel_preference=KernelPreference.AUTO,  # Not used
-            cast_kernel_choice=MXFP8Dim1CastKernelChoice.CUDA,
-            scale_calculation_mode=scale_calculation_mode,
-        )
-        A_t_data = A_t_mx.qdata
-        A_t_scales = A_t_mx.scale
+            # Transpose A so we can scale along the M dimension, then un-transpose.
+            # A shape: (M, K)
+            # A_t_data shape: (K, M)
+            # A_t_scales shape: (K, M//block_size)
+            A_t_mx = _to_mxfp8_dim1_kernel_wrapper(
+                A,
+                block_size,
+                elem_dtype=torch.float8_e4m3fn,
+                hp_dtype=A.dtype,
+                kernel_preference=KernelPreference.AUTO,  # Not used
+                cast_kernel_choice=MXFP8Dim1CastKernelChoice.CUDA,
+                scale_calculation_mode=scale_calculation_mode,
+            )
+            A_t_data = A_t_mx.qdata
+            A_t_scales = A_t_mx.scale
 
-        # Convert scales to blocked format for 2d-2d grouped mm
-        scale_group_offsets = offs // block_size
-        grad_out_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
-            grad_out_t_scales,
-            scale_group_offsets,
-        )
-        A_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
-            A_t_scales,
-            scale_group_offsets,
-        )
+            # Convert scales to blocked format for 2d-2d grouped mm
+            scale_group_offsets = offs // block_size
+            grad_out_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
+                grad_out_t_scales,
+                scale_group_offsets,
+            )
+            A_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
+                A_t_scales,
+                scale_group_offsets,
+            )
 
-        # grad_B_t = scaled grouped mm of (N,total_M) @ (total_M,K) = (E,N,K)
-        grad_B = torch._scaled_grouped_mm(
-            grad_out_t_data,
-            A_t_data.transpose(-2, -1),
-            grad_out_t_scales_blocked,
-            A_t_scales_blocked,
-            offs=offs,
-            out_dtype=out_dtype,
-        )
-        # grad_B_t shape =  (E,K,N)
-        grad_B_t = grad_B.transpose(-2, -1)
-        return grad_A, grad_B_t, None, None, None, None
+            # grad_B_t = scaled grouped mm of (N,total_M) @ (total_M,K) = (E,N,K)
+            grad_B = torch._scaled_grouped_mm(
+                grad_out_t_data,
+                A_t_data.transpose(-2, -1),
+                grad_out_t_scales_blocked,
+                A_t_scales_blocked,
+                offs=offs,
+                out_dtype=out_dtype,
+            )
+            # grad_B_t shape =  (E,K,N)
+            grad_B_t = grad_B.transpose(-2, -1)
+        return grad_A, grad_B_t, None, None, None, None, None, None, None
 
 
 def _to_mxfp8_dim1_3d(


### PR DESCRIPTION
## Summary
- Add `wgrad_with_hp` option to optionally compute gradient of the weight in high precision. 
- Currently, the 2d2d mxfp8 grouped gemm in FBGEMM we dispatch to for wgrad computation provides only modest speedups (1.2x to 1.4x usually, sometimes as low as 0.9x. Higher for larger shapes usually). Adding in quantization overhead, this results in slowdown for smaller shapes and modest speedup for larger shapes.
- We are working with NVIDIA to try to improve this CUTLASS kernel as we've tried several things ourselves already and it hasn't moved the needle much. In the meantime it makes sense to add an option to do wgrad with bf16.
- This is also useful for small shapes in general where even with roofline performance, bf16 is strictly better than dynamic quant + mxfp8 grouped gemm.

## Tests
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -k dq`

## Benchmarks
Benchmarks show wgrad_with_hp impact:
- helps for the small DeepSeek V3 16b model (`(128000, 1536, 5120, ...)`) 
- neutral for the larger DSV3 671b model (`(128000, 2048, 7168, ...)`)
- hurts for Llama4 and (`(128000, 8192, 5120, ...)`). 


Benchmarks are a bit jittery but this general trend holds over a few runs.


(look at column `scaled_fwd_bwd_speedup` in the middle)

### wgrad_with_hp=False

```
ype/moe_training/benchmark_scaled_grouped_mm_dq.py --compile
M,N,K,G                  recipe                  bf16_fwd_bwd_us    scaled_fwd_bwd_us  scaled_fwd_bwd_speedup      bf16_fwd_us    scaled_fwd_us  scaled_fwd_speedup
-----------------------  --------------------  -----------------  -------------------  ------------------------  -------------  ---------------  --------------------
(16384, 8192, 5120, 1)   MoEScalingType.MXFP8           3883.07              2831.36   1.371x                         1273.92           954.272  1.335x
(16384, 8192, 5120, 2)   MoEScalingType.MXFP8           4818.91              3183.71   1.514x                         1144.06          1036.29   1.104x
(16384, 8192, 5120, 4)   MoEScalingType.MXFP8           4140.19              3480.67   1.189x                         1163.46           998.768  1.165x
(16384, 8192, 5120, 8)   MoEScalingType.MXFP8           5234.19              3808.16   1.374x                         1068.16          1156.06   0.924x
(128000, 8192, 5120, 1)  MoEScalingType.MXFP8          43548.8              22567.4    1.93x                         14536.8           6346.72   2.29x
(128000, 8192, 5120, 2)  MoEScalingType.MXFP8          43921                23675.5    1.855x                        12642.4           6854.66   1.844x
(128000, 8192, 5120, 4)  MoEScalingType.MXFP8          43187.8              23669.7    1.825x                        13818.4           6421.5    2.152x
(128000, 8192, 5120, 8)  MoEScalingType.MXFP8          41643.6              23096.5    1.803x                        13787.6           6652.96   2.072x
(16384, 1536, 5120, 1)   MoEScalingType.MXFP8            966.72              1008.58   0.958x                          278.56           298.976  0.932x
(16384, 1536, 5120, 2)   MoEScalingType.MXFP8            911.808              951.296  0.958x                          302.112          289.632  1.043x
(16384, 1536, 5120, 4)   MoEScalingType.MXFP8            902.144              968.752  0.931x                          238.72           306.08   0.78x
(16384, 1536, 5120, 8)   MoEScalingType.MXFP8            943.68              1008.67   0.936x                          255.008          310.24   0.822x
(128000, 1536, 5120, 1)  MoEScalingType.MXFP8           8568.98              7410.78   1.156x                         2668.58          2213.06   1.206x
(128000, 1536, 5120, 2)  MoEScalingType.MXFP8           8409.31              6915.33   1.216x                         2691.66          2009.09   1.34x
(128000, 1536, 5120, 4)  MoEScalingType.MXFP8           7865.89              6862.88   1.146x                         2353.09          2037.78   1.155x
(128000, 1536, 5120, 8)  MoEScalingType.MXFP8           8096.9               6400.58   1.265x                         2228.22          1825.79   1.22x
(16384, 2048, 7168, 1)   MoEScalingType.MXFP8           1436.56              1544.26   0.93x                           545.76           456.784  1.195x
(16384, 2048, 7168, 2)   MoEScalingType.MXFP8           1678.46              1447.07   1.16x                           426.016          411.648  1.035x
(16384, 2048, 7168, 4)   MoEScalingType.MXFP8           1686.53              1525.76   1.105x                          488.576          438.192  1.115x
(16384, 2048, 7168, 8)   MoEScalingType.MXFP8           1884.06              1712.26   1.1x                            512.992          526.416  0.974x
(128000, 2048, 7168, 1)  MoEScalingType.MXFP8          15365.7              11003.8    1.396x                         3579.17          3377.6    1.06x
(128000, 2048, 7168, 2)  MoEScalingType.MXFP8          17184.2              10709.9    1.605x                         6145.95          3037.81   2.023x
(128000, 2048, 7168, 4)  MoEScalingType.MXFP8          15260.2              10167      1.501x                         5191.71          3020.51   1.719x
(128000, 2048, 7168, 8)  MoEScalingType.MXFP8          14557.2               9919.68   1.468x                         4398.27          2965.47   1.483x
```

#### wgrad with hp = True
```
M,N,K,G                  recipe                  bf16_fwd_bwd_us    scaled_fwd_bwd_us  scaled_fwd_bwd_speedup      bf16_fwd_us    scaled_fwd_us  scaled_fwd_speedup
-----------------------  --------------------  -----------------  -------------------  ------------------------  -------------  ---------------  --------------------
(16384, 8192, 5120, 1)   MoEScalingType.MXFP8           4006.91              3372.54   1.188x                         1247.76           844.832  1.477x
(16384, 8192, 5120, 2)   MoEScalingType.MXFP8           3781.63              3090.4    1.224x                         1491.04           806.88   1.848x
(16384, 8192, 5120, 4)   MoEScalingType.MXFP8           3561.42              4049.89   0.879x                         1064.96           985.952  1.08x
(16384, 8192, 5120, 8)   MoEScalingType.MXFP8           4780.06              4003.46   1.194x                         1274.86          1153.44   1.105x
(128000, 8192, 5120, 1)  MoEScalingType.MXFP8          42967.1              25230.3    1.703x                        15023.2           6571.97   2.286x
(128000, 8192, 5120, 2)  MoEScalingType.MXFP8          43644.4              29649      1.472x                        14359.6           7152.7    2.008x
(128000, 8192, 5120, 4)  MoEScalingType.MXFP8          44191.3              28635.1    1.543x                        14257.3           6545.41   2.178x
(128000, 8192, 5120, 8)  MoEScalingType.MXFP8          42325.1              27963.2    1.514x                        13444.6           6637.5    2.026x
(16384, 1536, 5120, 1)   MoEScalingType.MXFP8            836.64               887.808  0.942x                          291.968          295.968  0.986x
(16384, 1536, 5120, 2)   MoEScalingType.MXFP8            849.408              879.68   0.966x                          246.832          279.424  0.883x
(16384, 1536, 5120, 4)   MoEScalingType.MXFP8            861.152              938.832  0.917x                          254.784          291.872  0.873x
(16384, 1536, 5120, 8)   MoEScalingType.MXFP8            902.112             1016.83   0.887x                          230.464          310.304  0.743x
(128000, 1536, 5120, 1)  MoEScalingType.MXFP8          10010.1               6709.92   1.492x                         2259.06          2226.14   1.015x
(128000, 1536, 5120, 2)  MoEScalingType.MXFP8           8102.96              6354.88   1.275x                         2340.88          2000.78   1.17x
(128000, 1536, 5120, 4)  MoEScalingType.MXFP8           9914.32              6446.08   1.538x                         1855.52          2029.6    0.914x
(128000, 1536, 5120, 8)  MoEScalingType.MXFP8           8258.4               5998.5    1.377x                         2272.26          1833.06   1.24x
(16384, 2048, 7168, 1)   MoEScalingType.MXFP8           1664.96              1499.82   1.11x                           417.024          449.632  0.927x
(16384, 2048, 7168, 2)   MoEScalingType.MXFP8           1617.92              1450.43   1.115x                          490.56           447.328  1.097x
(16384, 2048, 7168, 4)   MoEScalingType.MXFP8           1524.78              1492.82   1.021x                          503.744          440.224  1.144x
(16384, 2048, 7168, 8)   MoEScalingType.MXFP8           1499.94              1610.56   0.931x                          402.432          529.376  0.76x
(128000, 2048, 7168, 1)  MoEScalingType.MXFP8          17734.1              10969.1    1.617x                         4615.28          3345.44   1.38x
(128000, 2048, 7168, 2)  MoEScalingType.MXFP8          15514                10832.9    1.432x                         4462.58          3158.05   1.413x
(128000, 2048, 7168, 4)  MoEScalingType.MXFP8          12506.1              10927.7    1.144x                         4913.15          3071.5    1.6x
(128000, 2048, 7168, 8)  MoEScalingType.MXFP8          14571.5               9601.42   1.518x                         4506.74          2990.61   1.507x
```