### PR TITLE
Remove dType Field

### DIFF
--- a/torchao/quantization/linear_quant_modules.py
+++ b/torchao/quantization/linear_quant_modules.py
@@ -143,7 +143,7 @@ class WeightOnlyInt4Linear(torch.nn.Module):
             "scales_and_zeros",
             torch.zeros(
                 (in_features // groupsize, out_features, 2),
-                dtype=self.scales_precision,
+                precision=self.scales_precision,
                 device=device,
             ),
         )


### PR DESCRIPTION
In this file, there are multiple comments in the code that say 'remove the dType field as it is not used.' However, the dType field is still instantiated as None in the class.

This PR aims to remove the dType field during initialization of any modules that may have previously referenced it.