### PR TITLE
[xpu][feature] Add xpu to fp8 quant API

### DIFF
--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -22,6 +22,7 @@ from torchao.quantization.granularity import (
 from torchao.utils import (
     is_MI300,
     is_sm_at_least_89,
+    is_xpu,
 )
 
 Tensor = torch.Tensor
@@ -285,8 +286,8 @@ def _check_hardware_support(
     is_a_1_128_w_128_128 = _granularity_is_a_1_128_w_128_128(granularities)
 
     if is_per_tensor or is_per_row:
-        assert is_sm_at_least_89() or is_MI300(), (
-            "Float8 dynamic quantization requires CUDA compute capability ≥8.9 or MI300+."
+        assert is_sm_at_least_89() or is_MI300() or is_xpu(), (
+            "Float8 dynamic quantization requires CUDA compute capability ≥8.9 or MI300+ or XPU."
         )
     elif is_a_1_128_w_128_128:
         # TODO(future PR): look into AMD support

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -111,6 +111,7 @@ from torchao.utils import (
     is_MI300,
     is_sm_at_least_89,
     is_sm_at_least_90,
+    is_xpu,
 )
 
 from .autoquant import AutoQuantizableLinearWeight, autoquant
@@ -1726,8 +1727,8 @@ def _float8_dynamic_activation_float8_weight_transform(
     *,
     parameter_name: str = "weight",
 ):
-    assert is_sm_at_least_89() or is_MI300(), (
-        "Float8 dynamic activation quantization is only supported on CUDA>=8.9 and MI300+"
+    assert is_sm_at_least_89() or is_MI300() or is_xpu(), (
+        "Float8 dynamic activation quantization is only supported on CUDA>=8.9 or MI300+ or XPU"
     )
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1105,6 +1105,10 @@ def is_cuda_version_at_least(major: int, minor: int) -> bool:
     return (cuda_major, cuda_minor) >= (major, minor)
 
 
+def is_xpu():
+    return torch.xpu.is_available() and torch.version.xpu
+
+
 def check_cpu_version(device, version="2.6.0"):
     if isinstance(device, torch.device):
         device = device.type


### PR DESCRIPTION
We have added the XPU support for `torch.scaled_mm`, so the fp8 related op in torchao could also be enabled. This pr adds the xpu to the torchao'a quant API.
To reduce review overhead, this PR does not have the tests included. We will enable tests in separate PR. Thanks!