### PR TITLE
Support NVFP4 fp32 bias

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -177,10 +177,6 @@ def test_inference_workflow_nvfp4(
     # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
     if quant_type == "dynamic" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
-
-    if bias and inpt_dtype == torch.float32:
-        pytest.xfail("Bias is not supported when module weight is in fp32")
-
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only quant currently errors w/ compile")
     if quant_type == "weight_only" and use_triton_kernel:

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -148,12 +148,6 @@ def _nvfp4_inference_linear_transform(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
-    if module.bias is not None and weight.dtype == torch.float32:
-        raise RuntimeError(
-            "Bias is not supported when module weight is in fp32 (out_dtype=Float32). "
-            "Please use bfloat16 or float16 weights, or remove the bias from the linear layer."
-        )
-
     per_tensor_scale = None
     if config.use_dynamic_per_tensor_scale:
         tensor_amax = torch.max(torch.abs(weight))


### PR DESCRIPTION
**Summary:** Today we hit this error with fp32 inputs + bias:

```
RuntimeError: Bias is not supported when module weight is in fp32
(out_dtype=Float32). Please use bfloat16 or float16 weights,
or remove the bias from the linear layer.
```

This is thrown by `NVFP4DynamicActivationNVFP4WeightConfig` but it's trying to guard against this underlying `_scaled_mm` error:

```
RuntimeError: Bias is not supported when out_dtype is set to Float32
```

This commit works around these errors by adding the bias separately in this case, similar to what float8 does.

**Test Plan:**

```
pytest test/prototype/mx_formats/test_inference_workflow.py -k test_inference_workflow_nvfp4
```