### PR TITLE
fp8 pinned mem

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -1190,6 +1190,32 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
         x_fp8 = Float8Tensor.from_hp(x)
         self._test_chunk_similar_to_vllm_llama4(x_fp8, dim)
 
+    @common_utils.parametrize(
+        "config",
+        [
+            Float8DynamicActivationFloat8WeightConfig(granularity=PerTensor()),
+            Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
+            Float8WeightOnlyConfig(),
+        ],
+    )
+    def test_pin_memory(self, config):
+        linear = torch.nn.Linear(
+            256, 512, bias=False, dtype=torch.bfloat16, device="cuda"
+        )
+        quantize_(linear, config)
+        weight_cpu = linear.weight.cpu()
+        self.assertFalse(weight_cpu.is_pinned())
+
+        weight_pinned = weight_cpu.pin_memory()
+
+        self.assertTrue(weight_pinned.is_pinned())
+        self.assertFalse(weight_cpu.is_pinned())
+
+        self.assertTrue(weight_pinned.qdata.is_pinned())
+        self.assertTrue(weight_pinned.scale.is_pinned())
+
+        self.assertEqual(weight_cpu.dequantize(), weight_pinned.dequantize())
+
 
 common_utils.instantiate_parametrized_tests(TestFloat8Tensor)
 

--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -293,6 +293,28 @@ def _(func, types, args, kwargs):
     return bias_tensor.add_(out)
 
 
+@implements(aten.is_pinned.default)
+def _(func, types, args, kwargs):
+    is_pinned = args[0].qdata.is_pinned() and args[0].scale.is_pinned()
+    return is_pinned
+
+
+@implements(aten._pin_memory.default)
+def _(func, types, args, kwargs):
+    pinned_qdata = args[0].qdata.pin_memory()
+    pinned_scale = args[0].scale.pin_memory()
+
+    return Float8Tensor(
+        pinned_qdata,
+        pinned_scale,
+        args[0].block_size,
+        args[0].mm_config,
+        act_quant_kwargs=args[0].act_quant_kwargs,
+        kernel_preference=args[0].kernel_preference,
+        dtype=args[0].dtype,
+    )
+
+
 def _float8_addmm_impl(
     input_tensor: Float8Tensor,
     weight_tensor: Float8Tensor,


### PR DESCRIPTION
Enabling pinned memory for Float8Tensor per [#3373](https://github.com/pytorch/ao/issues/3373)

Test: `python test/quantization/quantize_/workflows/float8/test_float8_tensor.py -k test_pin_memory`