### PR TITLE
Update fp8 conv3d to use mslk

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -31,6 +31,7 @@ from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
     _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     is_sm_at_least_89,
     is_sm_at_least_90,
     is_sm_at_least_100,
@@ -329,8 +330,8 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
         not is_sm_at_least_100(), "Requires GPU with compute capability >= 10.0"
     )
     @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(),
-        "Requires fbgemm_gpu_genai to be installed",
+        not _is_mslk_available(),
+        "Requires mslk to be installed",
     )
     @common_utils.parametrize("dtype", [torch.bfloat16, torch.float32])
     @common_utils.parametrize("compile", [True, False])

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1146,6 +1146,13 @@ def _is_fbgemm_gpu_genai_available():
     return True
 
 
+def _is_mslk_available():
+    if is_fbcode():
+        return True
+
+    return importlib.util.find_spec("mslk") is not None
+
+
 class DummyModule(torch.nn.Module):
     """This is used because the TorchAO quantization functions tend to operate on modules so to apply the transform to a tensor, we can load a
     DummyModule with the target tensor and then apply the transformation to the module and then extract the transformed tensor.


### PR DESCRIPTION
Summary:
fbgemm_gpu_genai is renamed to https://github.com/meta-pytorch/MSLK/tree/main, so updating the dependency to mslk for fp8 conv for now (we can migrate others in the future)

Next: we'll remove the permute and the test the new functionality added in fp8 conv op

`pip install --pre mslk --index-url https://download.pytorch.org/whl/nightly/cu128` to install mslk (only available in nightly currently

Test Plan:
python test/quantization/quantize_/workflows/float8/test_float8_tensor.py -k test_fp8_conv_variants

Reviewers:

Subscribers:

Tasks:

Tags: