### PR TITLE
Remove permute op for fp8 conv

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -47,6 +47,9 @@ from torchao.utils import (
     is_sm_at_least_100,
 )
 
+if _is_mslk_available():
+    import mslk.conv  # noqa: F401
+
 __all__ = [
     "Float8Tensor",
     "QuantizeTensorToFloat8Kwargs",
@@ -549,18 +552,13 @@ def _quantize_and_scaled_conv3d(
     input_qdata = input_qdata.contiguous(memory_format=torch.channels_last_3d)
     weight_qdata = weight_qdata.contiguous(memory_format=torch.channels_last_3d)
 
-    # move C_in to last dim
-    # after permute: (N, D, H, W, C_in)
-    input_qdata = input_qdata.permute([0, 2, 3, 4, 1])
-
-    # move C_in to last dim
-    # after permute: (C_out, K1, K2, K3, C_in)
-    weight_qdata = weight_qdata.permute([0, 2, 3, 4, 1])
-
     input_scale = input_tensor.scale
     weight_scale = weight_tensor.scale
 
-    import mslk.conv  # noqa: F401
+    # input: (N, C_in, D, H, W)
+    # weight: (C_out, C_in, K1, K2, K3)
+    # output: (N, C_out, D_out, H_out, W_out)
+    # all in channels_last_3d memory_format
 
     output = torch.ops.mslk.f8f8bf16_conv(
         input_qdata,
@@ -570,8 +568,6 @@ def _quantize_and_scaled_conv3d(
         stride,
         dilation,
     )
-    # output shape after permute: N, C_out, D_out, H_out, W_out
-    output = output.permute([0, 4, 1, 2, 3])
 
     # aligning the semantics with bfloat16 conv ops, the
     # output should use contiguous_format if none of the input/weight


### PR DESCRIPTION
Summary:
Previously we need to permute input, weight and output because of the shape expectations of `torch.ops.mslk.f8f8bf16_conv` (working with channels_last shape + contigous memory_format) now that mslk has supported `channels_first shape (original shape) + channels_last memory_format`, we don't need to do permute before and after the fp8 conv. This PR removes these permute ops.

We hope this can speedup the model using fp8 conv, but will need to test this in downstream workloads

Test Plan:
python test/quantization/quantize_/workflows/float8/test_float8_tensor.py -k test_fp8_conv_variants

Reviewers:

Subscribers:

Tasks:

Tags: