### PR TITLE
Update remaining callsites to not use pt2e quant API from pytorch

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_quantization import (
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import TEST_XPU, run_tests
 
+import torchao
 from torchao.quantization.pt2e import (
     FusedMovingAvgObsFakeQuantize,
     MovingAverageMinMaxObserver,
@@ -178,12 +179,12 @@ class PT2EQATTestCase(QuantizationTestCase):
         self.assertEqual(after_prepare_result_pt2e, after_prepare_result_fx)
 
         if verify_convert:
-            from torch.ao.quantization.quantize_pt2e import (
+            from torch.ao.quantization.quantize_fx import (
                 _convert_to_reference_decomposed_fx,
             )
 
             # We don't want to impose any ordering requirements between move_exported_model_to_eval and convert_pt2e
-            torch.ao.quantization.move_exported_model_to_eval(model_pt2e)
+            torchao.quantization.pt2e.move_exported_model_to_eval(model_pt2e)
             model_pt2e = convert_pt2e(model_pt2e)
             quant_result_pt2e = model_pt2e(*example_inputs)
             model_fx.eval()
@@ -1270,7 +1271,7 @@ class TestQuantizeMixQATAndPTQ(QuantizationTestCase):
     def _convert_qat_linears(self, model):
         for name, child in model.named_children():
             if isinstance(child, torch.fx.GraphModule):
-                torch.ao.quantization.move_exported_model_to_eval(child)
+                torchao.quantization.pt2e.move_exported_model_to_eval(child)
                 converted_child = convert_pt2e(child)
                 setattr(model, name, converted_child)
             else:

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -11,8 +11,6 @@ from torchao.utils import torch_version_at_least
 if torch_version_at_least("2.7.0"):
     from .constant_fold import constant_fold
 
-from typing import Union
-
 from torch.fx import GraphModule, Node
 from torch.fx.passes.infra.pass_manager import PassManager
 
@@ -41,7 +39,7 @@ __all__ = [
 
 def prepare_pt2e(
     model: GraphModule,
-    quantizer: Union[Quantizer, torch.ao.quantization.quantizer.quantizer.Quantizer],
+    quantizer: Quantizer,
 ) -> GraphModule:
     """Prepare a model for post training quantization
 
@@ -97,15 +95,6 @@ def prepare_pt2e(
         # run calibration
         # calibrate(m, sample_inference_data)
     """
-    # We will temporarily make prepare_pt2e backward compatible with quantizers that configs, observers,
-    # and fake quantizers from torch.ao instead of torchao
-    if isinstance(quantizer, torch.ao.quantization.quantizer.quantizer.Quantizer):
-        from torch.ao.quantization.quantize_pt2e import (
-            prepare_pt2e as torch_prepare_pt2e,
-        )
-
-        return torch_prepare_pt2e(model, quantizer)
-
     torch._C._log_api_usage_once("torchao.quantization.pt2e.prepare_pt2e")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
@@ -129,7 +118,7 @@ def prepare_pt2e(
 
 def prepare_qat_pt2e(
     model: GraphModule,
-    quantizer: Union[Quantizer, torch.ao.quantization.quantizer.quantizer.Quantizer],
+    quantizer: Quantizer,
 ) -> GraphModule:
     """Prepare a model for quantization aware training
 
@@ -183,15 +172,6 @@ def prepare_qat_pt2e(
         train_loop(prepared_model, train_loop)
 
     """
-    # We will temporarily make prepare_qat_pt2e backward compatible with quantizers that configs, observers,
-    # and fake quantizers from torch.ao instead of torchao
-    if isinstance(quantizer, torch.ao.quantization.quantizer.quantizer.Quantizer):
-        from torch.ao.quantization.quantize_pt2e import (
-            prepare_qat_pt2e as torch_prepare_qat_pt2e,
-        )
-
-        return torch_prepare_qat_pt2e(model, quantizer)
-
     torch._C._log_api_usage_once("torchao.quantization.pt2e.prepare_qat_pt2e")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
@@ -295,15 +275,6 @@ def convert_pt2e(
         quantized_model = convert_pt2e(prepared_model)
 
     """
-    # We will temporarily make convert_pt2e backward compatible with quantizers that configs, observers,
-    # and fake quantizers from torch.ao instead of torchao
-    if not _is_torchao_prepared_do_not_use_outside_this_file(model):
-        from torch.ao.quantization.quantize_pt2e import (
-            convert_pt2e as torch_convert_pt2e,
-        )
-
-        return torch_convert_pt2e(model, use_reference_representation, fold_quantize)
-
     torch._C._log_api_usage_once("torchao.quantization.pt2e.convert_pt2e")
     if not isinstance(use_reference_representation, bool):
         raise ValueError(


### PR DESCRIPTION
Summary: We removed pt2e quant code from D87958849, updating some remaining callsites to use torchao or executorch

Reviewed By: jainapurva

Differential Revision: D89744472


