### PR TITLE
[Fix][CI] Fix the CI import issue in test_quant_api.py

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -14,10 +14,6 @@ import warnings
 from pathlib import Path
 
 import torch
-from torch.ao.quantization.quantizer.xnnpack_quantizer import (
-    XNNPACKQuantizer,
-    get_symmetric_quantization_config,
-)
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_quantization import TestHelperModules
 from torch.testing._internal.common_utils import TestCase
@@ -68,6 +64,10 @@ from torchao.quantization.quant_api import (
 )
 from torchao.quantization.quant_primitives import MappingType
 from torchao.quantization.utils import compute_error
+from torchao.testing.pt2e._xnnpack_quantizer import (
+    XNNPACKQuantizer,
+    get_symmetric_quantization_config,
+)
 from torchao.testing.utils import skip_if_rocm, skip_if_xpu
 from torchao.utils import (
     get_current_accelerator_device,


### PR DESCRIPTION
This is to fix the issue we found during the CI.  There are issues like:

```
==================================== ERRORS ====================================
_____________ ERROR collecting test/quantization/test_quant_api.py _____________
ImportError while importing test module '/pytorch/ao/test/quantization/test_quant_api.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/conda/envs/venv/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/quantization/test_quant_api.py:17: in <module>
    from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
E   ModuleNotFoundError: No module named 'torch.ao.quantization.quantize_pt2e'
```

**cc:** @jerryzh168 