### PR TITLE
[ROCM] Add MI350 support for MXFP8 colwise quantization.

### DIFF
--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -45,6 +45,7 @@ from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_dtyp
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import (
     is_cuda_version_at_least,
+    is_MI350,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -556,12 +557,12 @@ def test_rearrange(shape):
 
 
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="MXFP8 requires CUDA capability 10.0 or greater",
+    not (is_sm_at_least_100() or is_MI350()),
+    reason="MXFP8 requires CUDA capability 10.0 or greater, or ROCm MI350",
 )
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8),
-    reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
+    not (is_cuda_version_at_least(12, 8) or is_MI350()),
+    reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels, or ROCm MI350",
 )
 @pytest.mark.parametrize("M", (32, 256))
 @pytest.mark.parametrize("K", (32, 256))
@@ -604,12 +605,12 @@ def test_cuda_mx_dim1_numerics(M, K, input_dtype, scaling_mode):
 
 
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="MXFP8 requires CUDA capability 10.0 or greater",
+    not (is_sm_at_least_100() or is_MI350()),
+    reason="MXFP8 requires CUDA capability 10.0 or greater, or ROCm MI350",
 )
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8),
-    reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
+    not (is_cuda_version_at_least(12, 8) or is_MI350()),
+    reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels, or ROCm MI350",
 )
 def test_cuda_mx_dim0_not_supported():
     M, K = 64, 64

--- a/torchao/csrc/rocm/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/rocm/mx_kernels/mxfp8_extension.cpp
@@ -1,0 +1,87 @@
+// MXFP8 extension for ROCm
+#include <torch/library.h>
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cstdint>
+#include <string>
+
+namespace mxfp8 {
+
+void mxfp8_quantize_rocm(const at::Tensor &input,
+                         at::Tensor &output,
+                         at::Tensor &scales,
+                         bool colwise,
+                         int64_t block_size,
+                         const std::string &scaling_mode);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+mxfp8_quantize(const at::Tensor& input, bool rowwise, bool colwise,
+               int64_t scale_dim_x, int64_t scale_dim_y,
+               const std::string &fp8_format,
+               const std::string &scaling_mode) {
+
+  TORCH_CHECK(!rowwise, "rowwise scaling is not supported yet");
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(input.dim() == 2, "input must be 2D");
+  TORCH_CHECK(input.scalar_type() == at::kFloat ||
+              input.scalar_type() == at::kHalf ||
+              input.scalar_type() == at::kBFloat16,
+              "Input must be float32, float16, or bfloat16");
+  TORCH_CHECK(rowwise || colwise, "At least one of rowwise or colwise must be true");
+  TORCH_CHECK(scale_dim_x == 1 || scale_dim_x == 32, "scale_dim_x must be 1 or 32");
+  TORCH_CHECK(scale_dim_y == 1 || scale_dim_y == 32, "scale_dim_y must be 1 or 32");
+  TORCH_CHECK(fp8_format == "e4m3", "fp8_format must be 'e4m3'");
+
+  const int64_t rows = input.size(0);
+  const int64_t cols = input.size(1);
+  TORCH_CHECK((rows >= 32) && (rows % 32 == 0), "rows must be a multiple of 32");
+  TORCH_CHECK((cols >= 32) && (cols % 32 == 0), "cols must be a multiple of 32");
+
+  c10::cuda::CUDAGuard device_guard(input.device());
+
+  const auto options_fp8 = at::TensorOptions()
+                               .dtype(at::kFloat8_e4m3fn)
+                               .device(input.device());
+  const auto options_scale = at::TensorOptions()
+                                 .dtype(at::kFloat8_e8m0fnu)
+                                 .device(input.device());
+
+  at::Tensor output_rowwise, output_colwise;
+  at::Tensor scales_rowwise, scales_colwise;
+
+  if (rowwise) {
+    const int64_t num_col_blocks = (cols + scale_dim_x - 1) / scale_dim_x;
+    output_rowwise = at::empty({rows, cols}, options_fp8);
+    scales_rowwise = at::empty({rows, num_col_blocks}, options_scale);
+  } else {
+    output_rowwise = at::empty({0}, options_fp8);
+    scales_rowwise = at::empty({0}, options_scale);
+  }
+
+  if (colwise) {
+    const int64_t num_row_blocks = (rows + scale_dim_y - 1) / scale_dim_y;
+    output_colwise = at::empty_strided({rows, cols}, {1, rows}, options_fp8);
+    scales_colwise = at::empty_strided({cols, num_row_blocks}, {1, cols}, options_scale);
+  } else {
+    output_colwise = at::empty({0}, options_fp8);
+    scales_colwise = at::empty({0}, options_scale);
+  }
+
+  if (rowwise) {
+    TORCH_CHECK(false, "rowwise scaling is not yet implemented for ROCm");
+  }
+  if (colwise) {
+    mxfp8_quantize_rocm(input, output_colwise, scales_colwise,
+                        true, scale_dim_y, scaling_mode);
+  }
+
+  return std::make_tuple(output_rowwise, output_colwise, scales_rowwise, scales_colwise);
+}
+
+} // namespace mxfp8
+
+TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
+  m.impl("mxfp8_quantize", &mxfp8::mxfp8_quantize);
+}

--- a/torchao/csrc/rocm/mx_kernels/mxfp8_rocm.hip
+++ b/torchao/csrc/rocm/mx_kernels/mxfp8_rocm.hip
@@ -1,0 +1,151 @@
+// MXFP8 quantization kernels for ROCm
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp8.h>
+
+namespace mxfp8 {
+
+constexpr int FP32_MANTISSA_BITS = 23;
+constexpr int FP32_EXPONENT_BIAS = 127;
+constexpr float E4M3_MAX_NORM = 448.0f;
+constexpr int E4M3_MAX_EXPONENT = 8;
+
+enum class ScalingMode { FLOOR, RCEIL };
+
+// Convert amax to e8m0 scale (FLOOR mode: take exponent directly)
+__device__ __forceinline__ uint8_t amax_to_scale_e8m0_floor(float amax) {
+    int32_t int_amax = *reinterpret_cast<int32_t*>(&amax);
+    int32_t extracted_pow2 = ((int_amax >> FP32_MANTISSA_BITS) & 0xFF) - FP32_EXPONENT_BIAS;
+    int32_t scale_unbiased = extracted_pow2 - E4M3_MAX_EXPONENT;
+    scale_unbiased = max(scale_unbiased, -FP32_EXPONENT_BIAS);
+    scale_unbiased = min(scale_unbiased, FP32_EXPONENT_BIAS + 1);
+    return static_cast<uint8_t>(scale_unbiased + FP32_EXPONENT_BIAS);
+}
+
+// Convert amax to e8m0 scale (RCEIL mode: round up if mantissa > 0)
+// CUDA does: float_to_e8m0(amax / 448.0f)
+__device__ __forceinline__ uint8_t amax_to_scale_e8m0_rceil(float amax) {
+    constexpr float E4M3_MAX_NORM_RCP = 1.0f / 448.0f;
+    float val = amax * E4M3_MAX_NORM_RCP;
+    
+    if (val == 0.0f) return 0x00;
+    
+    uint32_t val_u32 = *reinterpret_cast<uint32_t*>(&val);
+    uint8_t exponent = (val_u32 >> FP32_MANTISSA_BITS);
+    uint32_t mantissa = val_u32 & 0x7FFFFF;
+    
+    // Round up exponent if mantissa > 0 (with saturation handling)
+    if ((mantissa > 0 && exponent != 0xFE) &&
+        !(exponent == 0 && mantissa <= 0x400000)) {
+        ++exponent;
+    }
+    
+    return exponent;
+}
+
+// Convert e8m0 scale to inverse scale: 2^(127 - scale)
+__device__ __forceinline__ float e8m0_to_inv_scale(uint8_t scale) {
+    if (scale == 0) return 1.0f;
+    return exp2f(FP32_EXPONENT_BIAS - static_cast<float>(scale));
+}
+
+// MXFP8 colwise quantization kernel
+// Input: row-major [rows, cols]
+// Output: column-major [rows, cols] with stride {1, rows}
+// Scales: column-major [cols, num_row_blocks] with stride {1, cols}
+template<typename IType, typename OType, int BLOCK_SIZE, ScalingMode MODE>
+__global__ void mxfp8_quantize_colwise_kernel(
+    const IType *input,
+    OType *output,
+    uint8_t *scales,
+    int64_t rows,
+    int64_t cols) {
+    
+    const int col = blockIdx.y * blockDim.x + threadIdx.x;
+    const int row_block = blockIdx.x;
+    const int row_start = row_block * BLOCK_SIZE;
+    const int row_end = min(row_start + BLOCK_SIZE, static_cast<int>(rows));
+    
+    if (col >= cols) return;
+    
+    const IType *input_ptr = input + row_start * cols + col;
+    OType *output_ptr = output + row_start + col * rows;
+    
+    // Pass 1: compute abs-max
+    float amax = 0.0f;
+    for (int i = 0; i < row_end - row_start; i++) {
+        float val = static_cast<float>(input_ptr[i * cols]);
+        amax = fmaxf(amax, fabsf(val));
+    }
+    
+    // Compute scale and inverse scale
+    uint8_t scale_e8m0;
+    if constexpr (MODE == ScalingMode::FLOOR) {
+        scale_e8m0 = amax_to_scale_e8m0_floor(amax);
+    } else {
+        scale_e8m0 = amax_to_scale_e8m0_rceil(amax);
+    }
+    float inv_scale = e8m0_to_inv_scale(scale_e8m0);
+    
+    // Pass 2: quantize
+    for (int i = 0; i < row_end - row_start; i++) {
+        float val = static_cast<float>(input_ptr[i * cols]);
+        float scaled_val = val * inv_scale;
+        scaled_val = fminf(fmaxf(scaled_val, -E4M3_MAX_NORM), E4M3_MAX_NORM);
+        output_ptr[i] = static_cast<OType>(scaled_val);
+    }
+    
+    scales[col + row_block * cols] = scale_e8m0;
+}
+
+void mxfp8_quantize_rocm(const at::Tensor &input,
+                         at::Tensor &output,
+                         at::Tensor &scales,
+                         bool colwise,
+                         int64_t block_size,
+                         const std::string &scaling_mode) {
+    TORCH_CHECK(colwise, "Only colwise quantization is supported");
+    TORCH_CHECK(block_size == 32, "Only block_size=32 is supported");
+    TORCH_CHECK(scaling_mode == "floor" || scaling_mode == "rceil",
+                "scaling_mode must be 'floor' or 'rceil'");
+
+    constexpr int THREADBLOCK_SIZE = 512;
+
+    const int64_t rows = input.size(0);
+    const int64_t cols = input.size(1);
+
+    dim3 grid((rows + block_size - 1) / block_size, 
+              (cols + THREADBLOCK_SIZE - 1) / THREADBLOCK_SIZE);
+    dim3 block(THREADBLOCK_SIZE);
+
+    auto stream = at::cuda::getCurrentHIPStream();
+
+    if (scaling_mode == "floor") {
+        AT_DISPATCH_FLOATING_TYPES_AND2(
+            at::ScalarType::Half, at::ScalarType::BFloat16,
+            input.scalar_type(), "mxfp8_quantize_colwise_rocm", [&] {
+                mxfp8_quantize_colwise_kernel<scalar_t, __hip_fp8_e4m3, 32, ScalingMode::FLOOR>
+                    <<<grid, block, 0, stream>>>(
+                        input.data_ptr<scalar_t>(),
+                        reinterpret_cast<__hip_fp8_e4m3*>(output.data_ptr()),
+                        reinterpret_cast<uint8_t*>(scales.data_ptr()),
+                        rows,
+                        cols);
+            });
+    } else {
+        AT_DISPATCH_FLOATING_TYPES_AND2(
+            at::ScalarType::Half, at::ScalarType::BFloat16,
+            input.scalar_type(), "mxfp8_quantize_colwise_rocm", [&] {
+                mxfp8_quantize_colwise_kernel<scalar_t, __hip_fp8_e4m3, 32, ScalingMode::RCEIL>
+                    <<<grid, block, 0, stream>>>(
+                        input.data_ptr<scalar_t>(),
+                        reinterpret_cast<__hip_fp8_e4m3*>(output.data_ptr()),
+                        reinterpret_cast<uint8_t*>(scales.data_ptr()),
+                        rows,
+                        cols);
+            });
+    }
+}
+
+} // namespace mxfp8

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -20,6 +20,7 @@ from torchao.prototype.custom_fp_utils import (
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.utils import (
     is_cuda_version_at_least,
+    is_MI350,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -1138,9 +1139,9 @@ else:
         raise AssertionError("needs torch version 2.8+ and triton")
 
 
-mxfp8_cuda_extension_available = is_sm_at_least_100() and is_cuda_version_at_least(
-    12, 8
-)
+mxfp8_cuda_extension_available = (
+    is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
+) or is_MI350()
 
 if mxfp8_cuda_extension_available:
     lib = torch.library.Library("torchao", "FRAGMENT")


### PR DESCRIPTION
## Summary
Add ROCm MI350 (gfx950) support for MXFP8 quantization kernel.

## Changes
- Implement `mxfp8_quantize` for ROCm in `mxfp8_extension.cpp` and `mxfp8_rocm.hip`
- Support colwise quantization with column-major output layout (matching CUDA API)
- Support both FLOOR and RCEIL scaling modes
- Add MI350 to test conditions in `test_kernels.py`

## Testing
- Validated against CUDA reference implementation on MI350
- All `test_cuda_mx_dim1_numerics` tests pass for FLOOR and RCEIL modes

```
docker:  rocm/primus:v25.10

torch==2.11.0.dev20251221+rocm7.1
```

## Bench
```
python3 ./benchmarks/mx_formats/cast_bench.py --mode=dim1_mxfp8_cuda_rceil

M 16384 K 16384 BLOCK_SIZE 32
GPU: AMD Instinct MI355X
torch version: 2.10.0.dev20251112+rocm7.1
triton version: 3.4.0
mode: dim1_mxfp8_cuda_rceil
time_us 3423.0724573135376
mem_bw_gbps 237.70895479045635
```