### PR TITLE
update version compatibility to allow torch 2.11.0.dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -722,6 +722,7 @@ def get_extensions():
                     include_dirs=[
                         mxfp8_extension_dir,  # For mxfp8_quantize.cuh, mxfp8_extension.cpp, and mxfp8_cuda.cu
                     ],
+                    libraries=["cuda"],
                     extra_compile_args={
                         "cxx": [
                             f"-DPy_LIMITED_API={min_supported_cpython_hexcode}",

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -70,9 +70,7 @@ elif not ("+git" in __version__) and not ("unknown" in __version__):
     torchao_pytorch_compatible_versions = [
         # Built against torch 2.8.0
         (_parse_version("0.13.0"), _parse_version("2.8.0")),
-        (_parse_version("0.13.0"), _parse_version("2.9.0.dev")),
         (_parse_version("0.14.0"), _parse_version("2.8.0")),
-        (_parse_version("0.14.0"), _parse_version("2.9.0.dev")),
         # Built against torch 2.9.0
         (_parse_version("0.14.1"), _parse_version("2.9.0")),
         (_parse_version("0.14.1"), _parse_version("2.10.0.dev")),
@@ -82,6 +80,7 @@ elif not ("+git" in __version__) and not ("unknown" in __version__):
         # Current torchao version
         (_parse_version("0.16.0.dev"), _parse_version("2.9.1")),
         (_parse_version("0.16.0.dev"), _parse_version("2.10.0.dev")),
+        (_parse_version("0.16.0.dev"), _parse_version("2.11.0.dev")),
     ]
 
     current_torch_version = _parse_version(torch.__version__)
@@ -108,10 +107,15 @@ else:
     try:
         from pathlib import Path
 
+        # Load .so files
         so_files = list(Path(__file__).parent.glob("_C*.so"))
         if len(so_files) > 0:
             for file in so_files:
-                torch.ops.load_library(str(file))
+                logger.debug(f"Loading {file}")
+                try:
+                    torch.ops.load_library(str(file))
+                except Exception as e:
+                    logger.warning(f"Failed to load {file}: {e}")
             from . import ops
 
         # The following registers meta kernels for some CPU kernels


### PR DESCRIPTION
Stacked PRs:
 * #3546
 * __->__#3545


--- --- ---

### update version compatibility to allow torch 2.11.0.dev
- update version compatibility to allow torch 2.11.0.dev
- Remove torch 2.9.0.dev nightlies, which are no longer active/indexed
- Also add logic so that if one .so fails to load, we still try to load the remaining ones, rather than skipping them. I added this because I found this bug where `_C_cutlass_100a.abi3.so` was failing to load and preventing mxfp8 .so from being loaded:
- Link `cuda` lib in mxfp8_cuda c++ extension for mxfp8 blocked layout kernel in next PR in stack

`Loading /home/danvm/ao/torchao/_C_cutlass_100a.abi3.so
Failed to import cpp extensions: operator torchao::_linear_8bit_act_1bit_weight does not exist`