### PR TITLE
[mxfp8 moe training] add CUDA kernel for per group blocked layout with groups along M

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from benchmarks.utils import benchmark_cuda_function_in_microseconds
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    mx_block_rearrange_2d_M_groups_cuda,
     torch_to_blocked_2d_M_groups,
     triton_mx_block_rearrange_2d_M_groups,
 )
@@ -30,14 +31,18 @@ torch._dynamo.config.cache_size_limit = 1000
 class ExperimentConfig:
     input_shape: tuple[int]
     num_groups: int
+    chunk_width: int
+    chunks_per_tb: int
 
 
 @dataclass(frozen=True)
 class ExperimentResult:
     torch_time_us: float
     triton_time_us: float
+    cuda_time_us: float
     torch_mem_bw_gbps: float
     triton_mem_bw_gbps: float
+    cuda_mem_bw_gbps: float
 
 
 @dataclass(frozen=True)
@@ -47,22 +52,30 @@ class Experiment:
 
 
 def get_configs() -> List[ExperimentConfig]:
-    # Llama4 shapes. Input activations are scaled along K dim.
     block_size = 32
     input_shapes = [
-        (16640, 5120 // block_size),
+        (16384, 5120 // block_size),
         (131072, 5120 // block_size),
+        (131072, 2048 // block_size),
+        (131072, 7168 // block_size),
     ]
-    num_groups = [16]
+    num_groups = [8]
+    chunk_width_list = [64]
+    chunks_per_tb_list = [1, 4, 8]
+
     configs = []
-    for shape, groups in itertools.product(
+    for shape, groups, chunk_width, chunks_per_tb in itertools.product(
         input_shapes,
         num_groups,
+        chunk_width_list,
+        chunks_per_tb_list,
     ):
         configs.append(
             ExperimentConfig(
                 input_shape=shape,
                 num_groups=groups,
+                chunk_width=chunk_width,
+                chunks_per_tb=chunks_per_tb,
             )
         )
     return configs
@@ -70,6 +83,8 @@ def get_configs() -> List[ExperimentConfig]:
 
 def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     input_shape, num_groups = config.input_shape, config.num_groups
+    chunk_width, chunks_per_tb = config.chunk_width, config.chunks_per_tb
+
     input_tensor = torch.randint(
         low=0,
         high=256,
@@ -107,6 +122,21 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
         input_group_offsets,
     )
 
+    # bench CUDA pipelined kernel with configured chunk_width and chunks_per_tb
+    _ = mx_block_rearrange_2d_M_groups_cuda(
+        input_tensor.view(torch.uint8),
+        input_group_offsets.to(torch.int32),
+        chunk_width,
+        chunks_per_tb,
+    )
+    cuda_time_us = benchmark_cuda_function_in_microseconds(
+        mx_block_rearrange_2d_M_groups_cuda,
+        input_tensor.view(torch.uint8),
+        input_group_offsets.to(torch.int32),
+        chunk_width,
+        chunks_per_tb,
+    )
+
     # mem bw calculations
     bytes_per_input_el = torch.finfo(torch.float8_e8m0fnu).bits / 8
     bytes_per_output_el = torch.finfo(torch.float8_e4m3fn).bits / 8
@@ -116,23 +146,28 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
 
     torch_mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (torch_time_us / 1e6)
     triton_mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (triton_time_us / 1e6)
+    cuda_mem_bw_gbps = ((read_bytes + write_bytes) / 1e9) / (cuda_time_us / 1e6)
 
     return ExperimentResult(
         torch_time_us=torch_time_us,
         triton_time_us=triton_time_us,
+        cuda_time_us=cuda_time_us,
         torch_mem_bw_gbps=torch_mem_bw_gbps,
         triton_mem_bw_gbps=triton_mem_bw_gbps,
+        cuda_mem_bw_gbps=cuda_mem_bw_gbps,
     )
 
 
 def print_results(experiments: List[Experiment]):
     headers = [
         "input_shape",
+        "chunk_width",
+        "chunks_per_tb",
         "torch_time_us",
         "triton_time_us",
-        "torch_mem_bw_gbps",
-        "triton_mem_bw_gbps",
+        "cuda_time_us",
         "triton_speedup",
+        "cuda_speedup",
     ]
     rows = []
     for experiment in experiments:
@@ -142,11 +177,13 @@ def print_results(experiments: List[Experiment]):
         rows.append(
             [
                 input_shape,
-                experiment.result.torch_time_us,
-                experiment.result.triton_time_us,
-                round(experiment.result.torch_mem_bw_gbps, 3),
-                round(experiment.result.triton_mem_bw_gbps, 3),
+                experiment.config.chunk_width,
+                experiment.config.chunks_per_tb,
+                f"{experiment.result.torch_time_us:.2f}",
+                f"{experiment.result.triton_time_us:.2f}",
+                f"{experiment.result.cuda_time_us:.2f}",
                 f"{experiment.result.torch_time_us / experiment.result.triton_time_us:.2f}x",
+                f"{experiment.result.torch_time_us / experiment.result.cuda_time_us:.2f}x",
             ]
         )
     print(tabulate(rows, headers=headers))

--- a/setup.py
+++ b/setup.py
@@ -709,6 +709,7 @@ def get_extensions():
         mxfp8_sources = [
             os.path.join(mxfp8_extension_dir, "mxfp8_extension.cpp"),
             os.path.join(mxfp8_extension_dir, "mxfp8_cuda.cu"),
+            os.path.join(mxfp8_extension_dir, "mx_block_rearrange_2d_M_groups.cu"),
         ]
 
         # Only add the extension if the source files exist AND we are building for sm100

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -21,6 +21,7 @@ from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    mx_block_rearrange_2d_M_groups_cuda,
     mxfp8_quantize_cuda_3d,
     torch_to_blocked_2d_K_groups,
     torch_to_blocked_2d_M_groups,
@@ -240,6 +241,50 @@ def test_triton_mx_block_rearrange_2d_M_groups(
         input_group_offsets,
     )
     assert torch.allclose(ref_out_scales, triton_out_scales, atol=0, rtol=0), (
+        "blocked scales not equal"
+    )
+
+
+@pytest.mark.skipif(
+    not is_sm_at_least_100(),
+    reason="MXFP8 requires CUDA capability 10.0 or greater",
+)
+@skip_if_rocm("ROCm enablement in progress")
+@pytest.mark.parametrize("m,k,n_groups", [(16640, 2048, 8), (131072, 8192, 32)])
+@pytest.mark.parametrize("chunk_width", [64, 128])
+@pytest.mark.parametrize("chunks_per_tb", [1, 4, 8, 16])
+def test_cuda_mx_block_rearrange_2d_M_groups(
+    m: int,
+    k: int,
+    n_groups: int,
+    chunk_width: int,
+    chunks_per_tb: int,
+):
+    device = "cuda"
+    block_size = 32
+    input_data = torch.randn(m, k, device=device)
+    e8m0_scales, _ = to_mx(
+        input_data, elem_dtype=torch.float8_e4m3fn, block_size=block_size
+    )
+    scale_rows, scale_cols = e8m0_scales.shape
+
+    input_group_offsets = generate_jagged_offs(
+        n_groups, m, multiple_of=block_size, device=device
+    )
+
+    # torch reference
+    ref_out_scales, _ = torch_to_blocked_2d_M_groups(
+        e8m0_scales, input_group_offsets, block_size=block_size
+    )
+
+    # cuda kernel
+    cuda_out_scales = mx_block_rearrange_2d_M_groups_cuda(
+        e8m0_scales,
+        input_group_offsets,
+        chunk_width=chunk_width,
+        chunks_per_tb=chunks_per_tb,
+    )
+    assert torch.allclose(ref_out_scales, cuda_out_scales, atol=0, rtol=0), (
         "blocked scales not equal"
     )
 

--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -1,0 +1,553 @@
+/**
+ * MX Block Rearrange 2D Kernel for M-Groups (Groups along row dimension)
+ *
+ * TERMINOLOGY:
+ * - SF Tile: A 128x4 scale factor tile (512 bytes in blocked layout)
+ *   - SF_ROWS = 128 rows
+ *   - SF_COLS = 4 columns
+ *   - Each SF tile is stored contiguously in the output blocked layout
+ *
+ * - Chunk: A 128xCHUNK_WIDTH region (128 rows × 64 or 128 columns)
+ *   - One TMA load brings one chunk from GMEM to SMEM
+ *   - Contains multiple SF tiles horizontally (CHUNK_WIDTH/SF_COLS = 16 or 32)
+ *   - Each chunk is processed independently in the pipeline
+ *
+ * - Superblock: CHUNKS_PER_TB chunks stacked vertically
+ *   - Processed by one thread block
+ *   - Height = SF_ROWS * CHUNKS_PER_TB (512, 1024, or 2048 rows)
+ *   - Width = CHUNK_WIDTH (64 or 128 columns)
+ *   - Grid is organized as (num_col_chunks, num_row_superblocks)
+ */
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <cuda.h>
+#include <cuda/barrier>
+#include <cuda/ptx>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cudaTypedefs.h>
+#include "ptx.cuh"
+
+// Overloaded error checking for both CUDA driver API (CUresult) and runtime API (cudaError_t)
+inline void cuda_check_impl(CUresult result, const char* file, int line) {
+    if (result != CUDA_SUCCESS) {
+        const char* error_str;
+        cuGetErrorString(result, &error_str);
+        fprintf(stderr, "CUDA Driver Error at %s:%d - %s\n", file, line, error_str);
+        exit(EXIT_FAILURE);
+    }
+}
+
+inline void cuda_check_impl(cudaError_t result, const char* file, int line) {
+    if (result != cudaSuccess) {
+        fprintf(stderr, "CUDA Runtime Error at %s:%d - %s\n", file, line,
+                cudaGetErrorString(result));
+        exit(EXIT_FAILURE);
+    }
+}
+
+#define CUDA_CHECK(result) cuda_check_impl((result), __FILE__, __LINE__)
+
+// Get the driver entry point for cuTensorMapEncodeTiled (used for TMA tensor maps)
+inline void* get_driver_ptr() {
+    static void *driver_ptr = nullptr;
+    if (!driver_ptr) {
+        cudaDriverEntryPointQueryResult result;
+        CUDA_CHECK(cudaGetDriverEntryPoint("cuTensorMapEncodeTiled", &driver_ptr,
+                                cudaEnableDefault, &result));
+    }
+    return driver_ptr;
+}
+
+// Device helper: ceiling division
+__device__ __forceinline__ int ceil_div(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+#define SF_ROWS 128
+#define SF_COLS 4
+
+// Each thread reads 16 bytes (vectorized uint4 load)
+#define BYTES_PER_THREAD 16
+
+// Double buffering for pipelined TMA loads/stores
+#define NUM_BUFFERS 2
+
+
+
+// Here the chunks are 128x64/128x128 and superblock contains multiple vertical chunks (e.g., 4 chunks of 128x64 would be 512x64).
+template <int CHUNKS_PER_TB>
+__device__ void find_group_and_local_offset_for_superblock(
+    int row_superblock_pid,
+    const int32_t* __restrict__ input_group_end_offsets,
+    int num_groups,
+    int* __restrict__ smem_data,
+    int& group_id,
+    int& superblock_idx_in_group,
+    int& superblocks_until_end
+) {
+    // Thread 0 computes how many superblocks span each group
+    if (threadIdx.x == 0) {
+        constexpr int SUPERBLOCK_ROWS = SF_ROWS * CHUNKS_PER_TB;
+        int superblock_cumsum = 0;
+        for (int g = 0; g < num_groups; g++) {
+            int input_group_start = (g > 0) ? input_group_end_offsets[g - 1] : 0;
+            int input_group_end = input_group_end_offsets[g];
+            int group_size = input_group_end - input_group_start;
+            int num_superblocks_in_group = ceil_div(group_size, SUPERBLOCK_ROWS);
+            smem_data[g] = num_superblocks_in_group;
+            superblock_cumsum += num_superblocks_in_group;
+            smem_data[num_groups + g] = superblock_cumsum;
+        }
+    }
+    __syncthreads();
+
+    // All threads use the SMEM cumsum to find their group
+    group_id = 0;
+    int superblock_cumsum_before = 0;
+    for (int g = 0; g < num_groups; g++) {
+        int cumsum_at_g = smem_data[num_groups + g];
+        if (row_superblock_pid < cumsum_at_g) {
+            group_id = g;
+            superblock_idx_in_group = row_superblock_pid - superblock_cumsum_before;
+            int superblocks_in_group = smem_data[g];
+            superblocks_until_end = superblocks_in_group - superblock_idx_in_group;
+            return;
+        }
+        superblock_cumsum_before = cumsum_at_g;
+    }
+
+    superblock_idx_in_group = 0;
+    superblocks_until_end = 0;
+}
+
+/**
+ * Compute the starting row in the output buffer for a given group.
+ * Each group is padded to a multiple of SF_ROWS (128) in the output.
+ */
+__device__ __forceinline__ int compute_output_group_start_row(
+    int group_id,
+    const int32_t* input_group_end_offsets,
+    int num_groups,
+    int padding_size
+) {
+    int start_idx = 0;
+    for (int i = 0; i < group_id; i++) {
+        int prev_offset = (i > 0) ? input_group_end_offsets[i - 1] : 0;
+        int curr_offset = input_group_end_offsets[i];
+        int group_size = curr_offset - prev_offset;
+        int padded_size = ceil_div(group_size, padding_size) * padding_size;
+        start_idx += padded_size;
+    }
+    return start_idx;
+}
+
+/**
+ * Main kernel for rearranging row-major scale data to blocked layout.
+ *
+ * Template parameters:
+ * - CHUNK_WIDTH: Width of each chunk (64 or 128 columns)
+ * - CHUNKS_PER_TB: Number of chunks per superblock (4, 8, or 16)
+ *
+ * Grid dimensions:
+ * - blockIdx.x = column chunk index
+ * - blockIdx.y = row superblock index
+ *
+ * Thread block dimensions:
+ * - 512 threads for CHUNK_WIDTH=64 (128 rows × 4 threads/row)
+ * - 1024 threads for CHUNK_WIDTH=128 (128 rows × 8 threads/row)
+ */
+template <int CHUNK_WIDTH, int CHUNKS_PER_TB>
+__global__ void mx_blocked_layout_2d_M_groups_kernel(
+    const uint8_t* __restrict__ input_scales,
+    const int input_scale_stride_dim0,
+    const int scale_rows,
+    const int scale_cols,
+    const int padded_rows,
+    const int32_t* __restrict__ input_group_end_offsets,
+    uint8_t* __restrict__ output_scales,
+    const int output_stride_per_row_of_sf_tiles,
+    const int num_groups,
+    const __grid_constant__ CUtensorMap input_tensor_map
+) {
+    constexpr int output_stride_per_sf_tile = SF_ROWS * SF_COLS;  // 512 bytes per SF tile
+    const int row_superblock_pid = blockIdx.y;
+    const int col_chunk_pid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const bool is_master_thread = tid == 0;
+    constexpr int THREADS_PER_ROW = CHUNK_WIDTH / BYTES_PER_THREAD;
+    const int row_idx = tid / THREADS_PER_ROW;
+    const int col_idx = tid % THREADS_PER_ROW;
+
+    constexpr int CHUNK_SIZE_BYTES = SF_ROWS * CHUNK_WIDTH;
+
+    __shared__ int smem_group_data[64]; // Max 32 groups: [0..31] = superblocks per group, [32..63] = cumsum
+    __shared__ __align__(128) uint8_t smem_buffers[NUM_BUFFERS][CHUNK_SIZE_BYTES];
+
+    // Find which group this superblock belongs to and compute offsets
+    int group_idx;
+    int superblock_idx_in_group;
+    int superblocks_until_end;
+    find_group_and_local_offset_for_superblock<CHUNKS_PER_TB>(
+        row_superblock_pid,
+        input_group_end_offsets,
+        num_groups,
+        smem_group_data,
+        group_idx,
+        superblock_idx_in_group,
+        superblocks_until_end
+    );
+
+    // Early exit for padding superblocks beyond all groups
+    if (superblocks_until_end <= 0) {
+        return;
+    }
+
+    // Thread 0 computes group boundaries and broadcasts via SMEM
+    __shared__ int s_input_group_start_row;
+    __shared__ int s_input_group_end_row;
+    __shared__ int s_output_group_start_row;
+    if (tid == 0) {
+        s_input_group_start_row = (group_idx > 0) ? input_group_end_offsets[group_idx - 1] : 0;
+        s_input_group_end_row = input_group_end_offsets[group_idx];
+        s_output_group_start_row = compute_output_group_start_row(
+            group_idx, input_group_end_offsets, num_groups, SF_ROWS);
+    }
+    __syncthreads();
+    uint input_group_start_row = s_input_group_start_row;
+    uint input_group_end_row = s_input_group_end_row;
+    uint output_group_start_row = s_output_group_start_row;
+
+    // Compute base addresses for this superblock
+    constexpr int SUPERBLOCK_ROWS = SF_ROWS * CHUNKS_PER_TB;
+    const uint global_row_base = input_group_start_row + (superblock_idx_in_group * SUPERBLOCK_ROWS);
+    const uint global_col_base = col_chunk_pid * CHUNK_WIDTH;
+
+    // Thread's column offset and first SF tile index
+    const uint thread_col_start = col_idx * BYTES_PER_THREAD;
+    const uint first_sf_tile_idx = thread_col_start / SF_COLS;
+
+    // Initialize mbarriers for TMA load coordination
+    constexpr int NUM_THREADS = SF_ROWS * THREADS_PER_ROW;
+    __shared__ __align__(8) uint64_t mbar[NUM_BUFFERS];
+    initialize_barriers<NUM_BUFFERS, NUM_THREADS>(mbar, is_master_thread);
+
+    // Track barrier parity for double-buffered pipeline
+    int buf_parity[NUM_BUFFERS] = {0};
+
+    // Compute columns in this chunk (may be less than CHUNK_WIDTH for partial chunks)
+    // This is used for SMEM read stride and output bounds checking
+    // NOTE: TMA always loads the full tensor map box size regardless of this value
+    auto compute_cols_in_chunk = [&]() -> int {
+        const int remaining_cols = scale_cols - global_col_base;
+        return min(CHUNK_WIDTH, remaining_cols);
+    };
+    const int cols_in_chunk = compute_cols_in_chunk();
+
+    // The tensor map box width is min(CHUNK_WIDTH, scale_cols)
+    // TMA always loads this full box size (with OOB elements zero-filled)
+    const int tma_box_width = min(CHUNK_WIDTH, scale_cols);
+
+    // Func for async TMA load of a chunk of data to the given SMEM buffer
+    auto load_chunk = [&](int chunk_idx, int buf_idx) {
+        if (chunk_idx >= NUM_BUFFERS) {
+            // Wait for pending TMA stores to finish reading the SMEM buffer we're about to re-use
+            ptx::cp_async_bulk_wait_group_read<0>();
+            __syncthreads();
+        }
+
+        uint64_t* mbar_ptr = &mbar[buf_idx];
+        const uint32_t tma_x = global_col_base;
+        const uint32_t tma_y = global_row_base + (chunk_idx * SF_ROWS);
+
+        // IMPORTANT: TMA with OOB_FILL_NONE zero-fills OOB elements but reports
+        // the FULL box size to mbarrier, not the clamped size. The box size is
+        // fixed in the tensor map descriptor as (tma_box_width x SF_ROWS).
+        const int expected_bytes = SF_ROWS * tma_box_width;
+
+        copy_2d_to_shared(
+            (void*)&smem_buffers[buf_idx],
+            reinterpret_cast<const void*>(&input_tensor_map),
+            tma_x,
+            tma_y,
+            expected_bytes,
+            mbar_ptr,
+            is_master_thread
+        );
+    };
+
+    // Precompute blocked layout offset for this thread's row
+    int r_div_32 = row_idx >> 5;    // row_idx / 32
+    int r_mod_32 = row_idx & 31;    // row_idx % 32
+    int blocked_layout_row_offset = (r_mod_32 << 4) + (r_div_32 << 2); // r_mod_32 * 16 + r_div_32 * 4
+
+    // Func to process blocked layout transform in SMEM then store result to GMEM
+    auto process_chunk = [&](int chunk_idx, int buf_idx) {
+        // Wait for TMA load to complete
+        uint64_t* mbar_ptr = &mbar[buf_idx];
+        ptx::mbarrier_wait_parity(mbar_ptr, buf_parity[buf_idx]);
+        buf_parity[buf_idx] ^= 1;
+
+        // Fence to ensure TMA-written data is visible to all threads
+        ptx::fence_proxy_async_shared_cta();
+
+        // Read 16 bytes from row-major layout in SMEM. Coalesced, vectorized reads.
+        // TMA writes rows with stride = tma_box_width (the tensor map box size)
+        uint4 row_data = make_uint4(0, 0, 0, 0);
+        const uint32_t chunk_start_row = global_row_base + (chunk_idx * SF_ROWS);
+        const bool row_valid = chunk_start_row + row_idx < input_group_end_row;
+        const bool col_valid = thread_col_start < static_cast<uint>(cols_in_chunk);
+
+        if (row_valid && col_valid) {
+            row_data = *reinterpret_cast<uint4*>(
+                &smem_buffers[buf_idx][row_idx * tma_box_width + thread_col_start]);
+        }
+        __syncthreads();  // All threads must finish reading before overwriting
+
+        // Scatter 16 bytes to blocked layout (4 bytes per SF tile)
+        // Only write to SMEM if this thread's columns are within the valid range
+        constexpr int SF_TILES_PER_THREAD = BYTES_PER_THREAD / SF_COLS;
+        if (col_valid) {
+            #pragma unroll
+            for (int i = 0; i < SF_TILES_PER_THREAD; i++) {
+                const int sf_tile_idx = first_sf_tile_idx + i;
+                const uint32_t data = reinterpret_cast<const uint32_t*>(&row_data)[i];
+                *reinterpret_cast<uint32_t*>(
+                    &smem_buffers[buf_idx][blocked_layout_row_offset + sf_tile_idx * output_stride_per_sf_tile]
+                ) = data;
+            }
+        }
+        __syncthreads();
+
+        // Fence to ensure SMEM writes are visible to TMA async proxy
+        ptx::fence_proxy_async_shared_cta();
+
+        // Compute output tile coordinates
+        const int chunk_sf_row_tile = (superblock_idx_in_group * CHUNKS_PER_TB) + chunk_idx;
+        const int global_sf_row_tile = (output_group_start_row / SF_ROWS) + chunk_sf_row_tile;
+
+        // Number of valid SF tiles horizontally in this chunk (may be fewer for partial chunks)
+        const int valid_sf_tiles = ceil_div(cols_in_chunk, SF_COLS);
+        constexpr int SF_TILES_PER_CHUNK = CHUNK_WIDTH / SF_COLS;  // Max tiles for full chunk
+        const int col_sf_tile_start = col_chunk_pid * SF_TILES_PER_CHUNK;
+
+        // Check if this chunk has valid data
+        const uint32_t rows_remaining_in_group = (input_group_end_row > chunk_start_row)
+            ? (input_group_end_row - chunk_start_row) : 0;
+
+        // Issue TMA 1D stores for each valid SF tile
+        // Each store moves one 512-byte SF tile from SMEM to GMEM
+        if (rows_remaining_in_group > 0 && is_master_thread) {
+            constexpr int SF_TILE_SIZE_BYTES = SF_ROWS * SF_COLS;  // 512 bytes
+            const int sf_tiles_per_row = output_stride_per_row_of_sf_tiles / output_stride_per_sf_tile;
+
+            // Only store valid SF tiles (not the full CHUNK_WIDTH for partial chunks)
+            for (int tile = 0; tile < valid_sf_tiles; tile++) {
+                const int col_sf_tile = col_sf_tile_start + tile;
+                const int linear_sf_tile_idx = global_sf_row_tile * sf_tiles_per_row + col_sf_tile;
+
+                uint64_t* dst_gmem = reinterpret_cast<uint64_t*>(
+                    output_scales + linear_sf_tile_idx * SF_TILE_SIZE_BYTES);
+                const uint32_t smem_sf_tile_offset = tile * SF_TILE_SIZE_BYTES;
+
+                ptx::cp_async_bulk_tensor_1d_shared_to_global(
+                    dst_gmem,
+                    reinterpret_cast<const uint64_t*>(&smem_buffers[buf_idx][smem_sf_tile_offset]),
+                    SF_TILE_SIZE_BYTES
+                );
+            }
+            ptx::cp_async_bulk_commit_group();
+        }
+    };
+
+    // --- Main processing loop for superblock ---
+    // Compute how many chunks to process in this superblock
+    constexpr int BUFFER_MOD = NUM_BUFFERS - 1;
+    const int first_row_in_superblock = input_group_start_row + (superblock_idx_in_group * SUPERBLOCK_ROWS);
+    const int remaining_rows_in_group = input_group_end_row - first_row_in_superblock;
+    const int remaining_chunks = ceil_div(remaining_rows_in_group, SF_ROWS);
+    const int chunks_to_process = min(CHUNKS_PER_TB, remaining_chunks);
+
+    if (chunks_to_process == 0) {
+        destroy_barriers<NUM_BUFFERS>(mbar, is_master_thread);
+        return;
+    }
+
+    // Pipeline to overlap loads of chunk N+1 with process + store of chunk N
+    for (int chunk = 0; chunk < chunks_to_process; chunk++) {
+        int buf_idx = chunk & BUFFER_MOD;                   // chunk % num_buffers
+        load_chunk(chunk, buf_idx);
+        if (chunk > 0) {
+            int prev_buf_idx = (chunk - 1) & BUFFER_MOD;    // (chunk - 1) % num_buffers
+            process_chunk(chunk - 1, prev_buf_idx);
+        }
+    }
+
+    // Process last chunk
+    int last_buf_idx = (chunks_to_process - 1) & BUFFER_MOD;
+    process_chunk(chunks_to_process - 1, last_buf_idx);
+
+    // Wait for all pending TMA stores to complete before exiting
+    ptx::cp_async_bulk_wait_group();
+
+    // Clean up barriers
+    destroy_barriers<NUM_BUFFERS>(mbar, is_master_thread);
+}
+
+// Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/#using-tma-to-transfer-multi-dimensional-arrays
+void create_tensor_map(
+    void* tensor_ptr,
+    CUtensorMap& tensor_map,
+    const uint64_t gmem_width,
+    const uint64_t gmem_height,
+    const uint32_t smem_width,
+    const uint32_t smem_height
+) {
+    constexpr uint32_t rank = 2;
+    uint64_t size[rank] = {gmem_width, gmem_height};
+    uint64_t stride[rank - 1] = {gmem_width}; // Row major, 1 byte per e8m0
+    uint32_t box_size[rank] = {smem_width, smem_height};
+    uint32_t elem_stride[rank] = {1, 1};
+
+    void *driver_ptr = get_driver_ptr();
+    auto cuTensorMapEncodeTiled = reinterpret_cast<PFN_cuTensorMapEncodeTiled_v12000>(driver_ptr);
+
+    CUresult res = cuTensorMapEncodeTiled(
+        &tensor_map,
+        CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_UINT8,
+        rank,
+        tensor_ptr,
+        size,
+        stride,
+        box_size,
+        elem_stride,
+        CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+        CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE,
+        CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    );
+    CUDA_CHECK(res);
+}
+
+
+namespace mxfp8 {
+
+void launch_mx_block_rearrange_2d_M_groups_cuda(
+    const uint8_t* scales_ptr,
+    int scale_stride_dim0,
+    int scale_rows,
+    int scale_cols,
+    int padded_rows,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int chunk_width,    // Chunk width: 64 or 128
+    int chunks_per_tb,  // Chunks per superblock: 4, 8, or 16
+    cudaStream_t stream
+) {
+    // Calculate grid dimensions
+    int rows_per_superblock = SF_ROWS * chunks_per_tb;
+
+    // Upper bound on superblocks: each group may add 1 due to ceiling division
+    int num_row_superblocks = (scale_rows + rows_per_superblock - 1) / rows_per_superblock + num_groups;
+    int num_col_chunks = (scale_cols + chunk_width - 1) / chunk_width;
+
+    // Output strides for SF tile addressing
+    int sf_tiles_per_row = (scale_cols + SF_COLS - 1) / SF_COLS;
+    int output_stride_per_sf_tile = SF_ROWS * SF_COLS;  // 512 bytes
+    int output_stride_per_row_of_sf_tiles = output_stride_per_sf_tile * sf_tiles_per_row;
+
+    // Create TMA tensor map for input (chunk size = SF_ROWS × effective_chunk_width)
+    // When scale_cols < chunk_width, use scale_cols as box width to avoid OOB issues
+    const int effective_chunk_width = min(chunk_width, scale_cols);
+    alignas(64) CUtensorMap input_tensor_map = {};
+    create_tensor_map(
+        (void*)scales_ptr,
+        input_tensor_map,
+        scale_cols,
+        scale_rows,
+        effective_chunk_width,
+        SF_ROWS
+    );
+
+    dim3 grid(num_col_chunks, num_row_superblocks);
+
+    if (chunk_width == 64) {
+        dim3 block(512);  // 128 rows × 4 threads/row
+        switch (chunks_per_tb) {
+            case 1:
+                mx_blocked_layout_2d_M_groups_kernel<64, 1><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 4:
+                mx_blocked_layout_2d_M_groups_kernel<64, 4><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 8:
+                mx_blocked_layout_2d_M_groups_kernel<64, 8><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 16:
+                mx_blocked_layout_2d_M_groups_kernel<64, 16><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            default:
+                printf("CUDA Error: chunks_per_tb must be 1, 4, 8, or 16, got %d\n", chunks_per_tb);
+                return;
+        }
+    } else if (chunk_width == 128) {
+        dim3 block(1024);  // 128 rows × 8 threads/row
+        switch (chunks_per_tb) {
+            case 1:
+                mx_blocked_layout_2d_M_groups_kernel<128, 1><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 4:
+                mx_blocked_layout_2d_M_groups_kernel<128, 4><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 8:
+                mx_blocked_layout_2d_M_groups_kernel<128, 8><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            case 16:
+                mx_blocked_layout_2d_M_groups_kernel<128, 16><<<grid, block, 0, stream>>>(
+                    scales_ptr, scale_stride_dim0, scale_rows, scale_cols, padded_rows,
+                    input_group_end_offsets, output_scales_ptr,
+                    output_stride_per_row_of_sf_tiles,
+                    num_groups, input_tensor_map);
+                break;
+            default:
+                printf("CUDA Error: chunks_per_tb must be 1, 4, 8, or 16, got %d\n", chunks_per_tb);
+                return;
+        }
+    } else {
+        printf("CUDA Error: chunk_width must be 64 or 128, got %d\n", chunk_width);
+        return;
+    }
+}
+
+} // namespace mxfp8

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -26,6 +26,19 @@ void mxfp8_quantize_3d_cuda(const at::Tensor &input,
                              const std::string &fp8_format,
                              const std::string &scaling_mode);
 
+void launch_mx_block_rearrange_2d_M_groups_cuda(
+    const uint8_t* scales_ptr,
+    int scale_stride_dim0,
+    int scale_rows,
+    int scale_cols,
+    int padded_rows,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int chunk_width,      // Template selector: 64 or 128
+    int chunks_per_tb,
+    cudaStream_t stream);
+
 // Helper for tensor validation
 void check_cuda_tensor(const at::Tensor &t, const char *name) {
   TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
@@ -178,6 +191,77 @@ mxfp8_quantize_3d(const at::Tensor& input, int64_t scale_dim_n,
   return std::make_tuple(output_colwise, scales_colwise);
 }
 
+at::Tensor mx_block_rearrange_2d_M_groups(
+    at::Tensor scales_tensor,
+    at::Tensor input_group_end_offsets,
+    int64_t chunk_width,
+    int64_t chunks_per_tb) {
+
+  // Validate inputs
+  check_cuda_tensor(scales_tensor, "scales_tensor");
+  check_cuda_tensor(input_group_end_offsets, "input_group_end_offsets");
+
+  TORCH_CHECK(scales_tensor.dim() == 2, "scales_tensor must be 2D");
+  TORCH_CHECK(scales_tensor.is_contiguous(), "scales_tensor must be contiguous (row-major)");
+  TORCH_CHECK(scales_tensor.scalar_type() == at::kByte || // uint8
+              scales_tensor.scalar_type() == at::kFloat8_e8m0fnu,
+              "scales_tensor must be uint8 or e8m0");
+  TORCH_CHECK(input_group_end_offsets.scalar_type() == at::kInt,
+              "input_group_end_offsets must be int32");
+  TORCH_CHECK(input_group_end_offsets.dim() == 1,
+              "input_group_end_offsets must be 1D");
+  TORCH_CHECK(chunk_width == 64 || chunk_width == 128,
+              "chunk_width must be 64 or 128, got: ", chunk_width);
+  TORCH_CHECK(chunks_per_tb == 1 || chunks_per_tb == 4 || chunks_per_tb == 8 || chunks_per_tb == 16,
+              "chunks_per_tb must be 4, 8, or 16, got: ", chunks_per_tb);
+  c10::cuda::CUDAGuard device_guard(scales_tensor.device());
+
+  const int rows = scales_tensor.size(0);
+  const int cols = scales_tensor.size(1);
+  const int num_groups = input_group_end_offsets.size(0);
+  TORCH_CHECK(num_groups <= 32, "num_groups must be <= 32");
+
+  // Calculate blocks needed - uses 128-row blocks
+  // For M groups, groups are along rows, so we pad each group to 128 rows
+  const int BLOCK_ROWS = 128;
+  const int BLOCK_COLS = 4;
+
+  // Each group is padded to 128 rows upper bound
+  const int padded_rows = rows + num_groups * BLOCK_ROWS;
+
+  // Columns are padded to multiple of BLOCK_COLS
+  const int num_col_blocks = (cols + BLOCK_COLS - 1) / BLOCK_COLS;
+  const int padded_cols = num_col_blocks * BLOCK_COLS;
+
+  // Create output tensor
+  auto output = at::zeros({padded_rows, padded_cols},
+                            at::TensorOptions()
+                                .dtype(scales_tensor.scalar_type())
+                                .device(scales_tensor.device()));
+
+  // Get raw pointers
+  const uint8_t* scales_ptr = reinterpret_cast<const uint8_t*>(scales_tensor.data_ptr());
+  const int32_t* offsets_ptr = input_group_end_offsets.data_ptr<int32_t>();
+  uint8_t* output_ptr = reinterpret_cast<uint8_t*>(output.data_ptr());
+
+  // Launch pipelined M groups kernel with specified chunk_width and chunks_per_tb
+  launch_mx_block_rearrange_2d_M_groups_cuda(
+      scales_ptr,
+      scales_tensor.stride(0),
+      rows,
+      cols,
+      padded_rows,
+      offsets_ptr,
+      output_ptr,
+      num_groups,
+      static_cast<int>(chunk_width),
+      static_cast<int>(chunks_per_tb),
+      at::cuda::getCurrentCUDAStream());
+
+  return output;
+}
+
+
 } // namespace mxfp8
 
 
@@ -185,4 +269,5 @@ mxfp8_quantize_3d(const at::Tensor& input, int64_t scale_dim_n,
 TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
   m.impl("mxfp8_quantize", &mxfp8::mxfp8_quantize);
   m.impl("mxfp8_quantize_3d", &mxfp8::mxfp8_quantize_3d);
+  m.impl("mx_block_rearrange_2d_M_groups", &mxfp8::mx_block_rearrange_2d_M_groups);
 }

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -1,4 +1,5 @@
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
+    mx_block_rearrange_2d_M_groups_cuda,  # noqa: F401
     mxfp8_quantize_cuda_3d,  # noqa: F401
     torch_to_blocked_2d_K_groups,  # noqa: F401
     torch_to_blocked_2d_M_groups,  # noqa: F401


### PR DESCRIPTION
Stacked PRs:
 * __->__#3546
 * #3545


--- --- ---

### [mxfp8 moe training] add CUDA kernel for per group blocked layout with groups along M

- ~3.5x to ~12x faster than Triton

### Summary of kernel design

Terminology:
- "sf_tile" = a 128x4 scale factor tile
- "chunk" = a 128xCHUNK_WIDTH group of scale factor tiles, where CHUNK_WIDTH can be either 64 or 128
- "super block" = a group of chunks processed by one thread block. Stacked vertically along the row dimension into shape (e.g., 4 chunks per threadblock / `CHUNKS_PER_TB` would have shape (512, CHUNK_WIDTH)

Design:
- Pipelined design with double-buffering where we overlap "async TMA load of chunk N+1" with the "process and async TMA store of chunk N"
  - Motivation: in the original non-pipelined kernel, I found this kernel to be extremely ALU / integer arithmetic heavy in (1) the "group lookup" logic (described below) and (2) "per-group, per scale factor tile transformation to blocked layout" logic. Each warp was occupying SM resources and blocking other warps from being scheduled to due useful work until the heavy pointer arithmetic, SMEM layout change, and the store to GMEM was complete. Ideally, I would like to prefetch and have that next set of data in flight while I do all this heavy pointer arithmetic. Thus, I arrived at this pipelining approach. 
- We divide the work up into super blocks, each handled by one thread block, which iterates through the chunks in the superblock, pipelining as described above.
- Grid calculation:
    - Input group end offsets are dynamic and may result in partial tiles, requiring padding in our output tensor to avoid writing partial/invalid scale factor tiles. They are also only available on the device, thus we cannot directly use them to calculate our grid on the host for the kernel launch without doing a device-to-host sync, which will kill performance. Therefore, we allocate an extra `num_groups` thread blocks along the row dimension, to handle the worst case where every group boundary splits a scale factor tile and requires padding.
 - Inside the kernel, we do a prefix sum over the superblocks required for each group, and then use that to determine (1) which group this thread block should operate and (2) which local superblock we are within that group. 
 - The threadblock then uses that information to iterate through the chunks in that superblock, overlapping "async TMA load of chunk N+1" with "process in SMEM and async TMA store of chunk N+1" 

### Note on smem bank conflicts

We have four-way bank conflicts on writes for the blocked layout transform in SMEM. However, I think addressing them might be a net performance loss because then each scale factor tile would no longer be in contiguous layout in SMEM, thus preventing us from directly using a 1D TMA async store to GMEM. We would either have to use (1) blocking global stores or (2) cp.async, which uses threads and registers unlike TMA and complicates our pipeline stage coordination logic using 2 different forms of async data movement. It is unclear / difficult to reason about if this would be a net benefit, and I am happy with the big perf gains in the current implementation, and need to prioritize other things now.
  
### Benchmarks 
Looking at the best performing CUDA kernel configs (chunk width, chunks per threadblock) for each tested shape: 

- ~7x to 165x faster than torch impl using `torch.compile` (still requires d2h sync)
- ~3.5x to ~12x faster than Triton

Note: i didn't measure memory bandwidth utilization since this is an unusual kernel that is not cleanly compute bound (gemm) or memory bandwidth bound (quantization). it looks to be "uniform datapath" (identical instructions in each warp?) bound from what I see in NCU. 

```
input_shape      chunk_width    chunks_per_tb    torch_time_us    triton_time_us    cuda_time_us  triton_vs_torch    cuda_vs_torch      cuda_vs_triton
-------------  -------------  ---------------  ---------------  ----------------  --------------  -----------------  ---------------  ----------------
(32768, 160)              64                1           122.91             60.45           17.41  2.03x              7.06x                        3.47x
(32768, 160)              64                4           560.88             52.19           15.39  10.75x             36.44x                       3.39x
(32768, 160)              64                8           557.07             37.89           17.44  14.70x             31.94x                       2.17x
(131072, 160)             64                1          1867.25            128              31.78  14.59x             58.76x                       4.03x
(131072, 160)             64                4          1856.22            136.22           25.63  13.63x             72.42x                       5.31x
(131072, 160)             64                8          1853.86            279.55           23.55  6.63x              78.71x                      11.87x
(131072, 64)              64                1          1595.49            148.48           15.49  10.75x             103.01x                      9.59x
(131072, 64)              64                4          1528.14            103.42           15.39  14.78x             99.28x                       6.72x
(131072, 64)              64                8          1542.43            109.57           17.44  14.08x             88.44x                       6.28x
(131072, 224)             64                1          4884.77            234.4            39.97  20.84x             122.22x                      5.86x
(131072, 224)             64                4          4943.9             189.44           31.78  26.10x             155.59x                      5.96x
(131072, 224)             64                8          4923.94            211.97           29.73  23.23x             165.63x                      7.13x```