### PR TITLE
[mxfp8 moe training] default to triton kernel for dim0 cast

### DIFF
--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -293,7 +293,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         block_size: int = 32,
         out_dtype: Optional[torch.dtype] = torch.bfloat16,
         emulated: bool = False,
-        use_triton_for_dim0_cast: bool = False,
+        use_triton_for_dim0_cast: bool = True,
         wgrad_with_hp: bool = False,
         scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
     ) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #3561
 * __->__#3560


--- --- ---

### [mxfp8 moe training] default to triton kernel for dim0 cast

torch.compile is still slow for RCEIL (see https://github.com/pytorch/pytorch/issues/170635). Since we are migrating to RCEIL as the default for MXFP8 training, we should default to the triton dim0 cast kernel which has decent performance (~6k TB on 1000W B200). 

```
(torch) dev@gpu-dev-8f27b069:~/ao$ PYTHONPATH=/home/dev/ao:$PYTHONPATH python benchmarks/mx_formats/cast_bench.py  --mode dim0_mxfp8_triton_rceil
W0102 04:28:08.388000 67699 site-packages/torch/_library/triton.py:222] _dequant_mxfp8_kernel not in collector.assignments
M 16384 K 16384 BLOCK_SIZE 32
GPU: NVIDIA B200
torch version: 2.11.0.dev20260101+cu128
triton version: 3.6.0
mode: dim0_mxfp8_triton_rceil
time_us 136.25599443912506
mem_bw_gbps 5971.810483270397
```
