### PR TITLE
[mxfp8] update bench script to use new cuda wrapper

### DIFF
--- a/benchmarks/mx_formats/cast_bench.py
+++ b/benchmarks/mx_formats/cast_bench.py
@@ -365,19 +365,19 @@ def run(
         bps = (bytes_r + bytes_w) / (time_us / 1e6)
 
     elif mode == "dim1_mxfp8_cuda_floor":
-        from torchao.prototype import mxfp8_cuda
+        from torchao.prototype.mx_formats.kernels import mxfp8_quantize_cuda
 
-        _, y_d1, _, s_d1 = mxfp8_cuda.quantize(
+        _, y_d1, _, s_d1 = mxfp8_quantize_cuda(
             x, rowwise=False, colwise=True, scaling_mode="floor"
         )
 
         for _ in range(2):
-            __ = mxfp8_cuda.quantize(
+            __ = mxfp8_quantize_cuda(
                 x, rowwise=False, colwise=True, scaling_mode="floor"
             )
 
         time_us = benchmark_cuda_function_in_microseconds(
-            lambda x: mxfp8_cuda.quantize(
+            lambda x: mxfp8_quantize_cuda(
                 x, rowwise=False, colwise=True, scaling_mode="floor"
             ),
             x,


### PR DESCRIPTION
Stacked PRs:
 * #3564
 * #3563
 * __->__#3562


--- --- ---

### [mxfp8] update bench script to use new cuda wrapper

This callsite in the bench script needs to be migrated to the new CUDA kernel wrapper that was added in the migration from Pybind11 to TORCH_LIBRARY. Did a search and it looks like this is the only one remaining, it was missed somehow.