### PR TITLE
[mxfp8 moe training] add rceil vs floor to 3d quantization benchmark

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_quantize_3d.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_quantize_3d.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 # this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
 
+import itertools
 from dataclasses import dataclass
 from typing import List
 
@@ -17,6 +18,7 @@ from torchao.prototype.moe_training.kernels.mxfp8 import mxfp8_quantize_cuda_3d
 from torchao.prototype.moe_training.scaled_grouped_mm import (
     _to_mxfp8_dim1_3d,
 )
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.mx_tensor import to_mx
 
 device = torch.device("cuda")
@@ -28,6 +30,7 @@ torch._dynamo.config.cache_size_limit = 1000
 @dataclass(frozen=True)
 class ExperimentConfig:
     input_shape: tuple[int]
+    scaling_mode: ScaleCalculationMode
 
 
 @dataclass(frozen=True)
@@ -49,20 +52,22 @@ class Experiment:
 
 
 def get_configs() -> List[ExperimentConfig]:
-    # Llama4 shapes. Input activations are scaled along K dim.
     input_shapes = [
+        # Llama4 and DeepSeekV3 671b shapes
         (1, 8192, 5120),
-        (2, 8192, 5120),
-        (4, 8192, 5120),
+        (1, 7168, 2048),
         (8, 8192, 5120),
-        (16, 8192, 5120),
-        (64, 8192, 5120),
+        (8, 7168, 2048),
+        (32, 7168, 2048),
+        (32, 8192, 5120),
     ]
+    round_modes = [ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL]
     configs = []
-    for shape in input_shapes:
+    for shape, scaling_mode in itertools.product(input_shapes, round_modes):
         configs.append(
             ExperimentConfig(
                 input_shape=shape,
+                scaling_mode=scaling_mode,
             )
         )
     return configs
@@ -107,6 +112,8 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     time_cuda_2d_us = benchmark_cuda_function_in_microseconds(
         using_cuda_2d_c,
         input_tensor,
+        block_size=block_size,
+        scaling_mode=config.scaling_mode,
     )
 
     # bench 3d cuda kernel
@@ -114,6 +121,8 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     time_cuda_3d_us = benchmark_cuda_function_in_microseconds(
         mxfp8_quantize_cuda_3d,
         input_tensor,
+        block_size=block_size,
+        scaling_mode=str(config.scaling_mode.value),
     )
 
     # mem bw calculations
@@ -146,24 +155,26 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
 def print_results(experiments: List[Experiment]):
     headers = [
         "input_shape",
-        "to_mx_us",
-        "cuda_2d_us",
+        "scaling_mode",
         "cuda_3d_us",
-        "to_mx_gbps",
-        "cuda_2d_gbps",
+        "cuda_2d_us",
+        "to_mx_us",
         "cuda_3d_gbps",
+        "cuda_2d_gbps",
+        "to_mx_gbps",
     ]
     rows = []
     for experiment in experiments:
         rows.append(
             [
                 str(experiment.config.input_shape),
-                experiment.result.to_mx_us,
-                experiment.result.cuda_2d_us,
+                str(experiment.config.scaling_mode),
                 experiment.result.cuda_3d_us,
-                round(experiment.result.to_mx_gbps, 3),
-                round(experiment.result.cuda_2d_gbps, 3),
+                experiment.result.cuda_2d_us,
+                experiment.result.to_mx_us,
                 round(experiment.result.cuda_3d_gbps, 3),
+                round(experiment.result.cuda_2d_gbps, 3),
+                round(experiment.result.to_mx_gbps, 3),
             ]
         )
     print(tabulate(rows, headers=headers))


### PR DESCRIPTION
Stacked PRs:
 * __->__#3564
 * #3563


--- --- ---

[mxfp8 moe training] add rceil vs floor to 3d quantization benchmark

- Bench both floor and rceil
- Add DSV3 shapes 


### Benchmarks

TL;DR perf is good with higher number of experts per device, and not good with low (1) per device.

With 8+ experts per device we see ~5-6 TB/s for both Llama4 and DeepSeekV3 671b shapes.

Current trends are towards are a larger number of more granular experts (deepseek, kimi, qwen), so maybe this ok.

```
input_shape       scaling_mode                  cuda_3d_us    cuda_2d_us    to_mx_us    cuda_3d_gbps    cuda_2d_gbps    to_mx_gbps
----------------  --------------------------  ------------  ------------  ----------  --------------  --------------  ------------
(1, 8192, 5120)   ScaleCalculationMode.FLOOR        33.696        35.808     117.76          3773.14        3550.6        1079.65
(1, 8192, 5120)   ScaleCalculationMode.RCEIL        31.712        33.824     117.792         4009.2         3758.86       1079.36
(1, 7168, 2048)   ScaleCalculationMode.FLOOR        17.408        28.928      84.96          2556.24        1538.27        523.763
(1, 7168, 2048)   ScaleCalculationMode.RCEIL        15.488        29.12       84.992         2873.12        1528.12        523.566
(8, 8192, 5120)   ScaleCalculationMode.FLOOR       199.648      1523.81     1697.82          5094.56         667.485       599.072
(8, 8192, 5120)   ScaleCalculationMode.RCEIL       183.2        1513.63     1697.82          5551.96         671.972       599.072
(8, 7168, 2048)   ScaleCalculationMode.FLOOR        76.736       543.792     605.12          4639.17         654.647       588.299
(8, 7168, 2048)   ScaleCalculationMode.RCEIL        70.656       539.712     605.152         5038.38         659.595       588.268
(32, 7168, 2048)  ScaleCalculationMode.FLOOR       273.536      2127.9      2371.58          5205.77         669.187       600.428
(32, 7168, 2048)  ScaleCalculationMode.RCEIL       248.896      2111.49     2369.57          5721.13         674.39        600.939
(32, 8192, 5120)  ScaleCalculationMode.FLOOR       768.016      6047.73     6742.02          5297.38         672.728       603.451
(32, 8192, 5120)  ScaleCalculationMode.RCEIL       697.536      6001.71     6744.1           5832.64         677.886       603.265
```