### PR TITLE
[mxfp8 training] fix bug in cast_bench.py for to_mx + RCEIL

### DIFF
--- a/benchmarks/mx_formats/cast_bench.py
+++ b/benchmarks/mx_formats/cast_bench.py
@@ -227,9 +227,11 @@ def run(
         y_d0, s_d0 = to_mx_dim0_reference_c(x, BLOCK_SIZE, ScaleCalculationMode.RCEIL)
 
         for _ in range(2):
-            __ = to_mx_dim0_reference_c(x, BLOCK_SIZE)
+            __ = to_mx_dim0_reference_c(x, BLOCK_SIZE, ScaleCalculationMode.RCEIL)
         time_us = benchmark_cuda_function_in_microseconds(
-            lambda x, b: to_mx_dim0_reference_c(x, BLOCK_SIZE),
+            lambda x, b: to_mx_dim0_reference_c(
+                x, BLOCK_SIZE, ScaleCalculationMode.RCEIL
+            ),
             x,
             BLOCK_SIZE,
         )


### PR DESCRIPTION
Stacked PRs:
 * __->__#3569
 * #3568


--- --- ---

[mxfp8 training] fix bug in cast_bench.py for to_mx + RCEIL

## Summary
- Quantization benchmark for `to_mx` + `torch.compile` for dim0 scaling with RCEIL rounding is missing the scale mode argument, so it is currently defaulting to FLOOR. This PR fixes this.