### PR TITLE
Fix ROCm version parsing: exclude git hashes from pre-release detection

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -37,7 +37,8 @@ def _parse_version(version_string):
     Examples: "2.5.0.dev20240708+cu121" -> [2, 5, -1], "2.5.0" -> [2, 5, 0]
     """
     # Check for pre-release indicators
-    is_prerelease = bool(re.search(r"(git|dev)", version_string))
+    # Exclude rocm git hashes from being treated as pre-release
+    is_prerelease = bool(re.search(r"(git|dev)", version_string)) and not bool(re.search(r"\+rocm.*\.git", version_string))
     match = re.match(r"(\d+)\.(\d+)\.(\d+)", version_string)
     if match:
         major, minor, patch = map(int, match.groups())


### PR DESCRIPTION
## Summary
This PR fixes an issue where ROCm PyTorch versions containing git hashes (e.g., `2.5.0+rocm5.7.git12345abc`) were incorrectly treated as pre-release versions, causing the `_parse_version()` function to set their patch version to `-1`.

## Problem
The current regex pattern `r"(git|dev)"` matches both:
- Actual pre-release versions (e.g., `2.5.0.dev`, `2.5.0+git12345`)
- ROCm stable releases with git hashes (e.g., `2.5.0+rocm5.7.git12345`)

This caused ROCm stable releases to be incorrectly classified as pre-release versions, which could lead to version compatibility checks failing incorrectly.

## Solution
Modified the `_parse_version()` function to exclude ROCm git hashes from pre-release detection by adding:
```python
is_prerelease = bool(re.search(r"(git|dev)", version_string)) and not bool(re.search(r"\+rocm.*\.git", version_string))