### PR TITLE
[mxfp8 moe training] mxfp8 token permute autograd func + triton kernels

### DIFF
--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+
+if not (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
+):
+    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+
+from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
+from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
+
+
+@pytest.mark.parametrize(
+    "num_tokens",
+    [
+        512,
+    ],
+)
+@pytest.mark.parametrize(
+    "hidden_dim",
+    [
+        1024,
+    ],
+)
+@pytest.mark.parametrize("num_local_experts", [2, 4, 8])
+@pytest.mark.parametrize("ep_degree", [1, 2, 4])
+@pytest.mark.parametrize(
+    "alignment",
+    [
+        32,
+    ],
+)
+def test_triton_permute_bwd(
+    num_tokens, hidden_dim, num_local_experts, ep_degree, alignment
+):
+    device = "cuda"
+
+    # Generate realistic permutation indices using generate_permute_indices
+    # Simulate token distribution across experts
+    tokens_per_expert_group = torch.randint(
+        0,
+        num_tokens // (num_local_experts * ep_degree) + 1,
+        (ep_degree * num_local_experts,),
+        device=device,
+        dtype=torch.int32,
+    )
+
+    # Calculate padded length as in _Permute.forward
+    x_padded_per_expert = num_tokens + num_local_experts * alignment
+    padded_max_len = ((x_padded_per_expert + alignment - 1) // alignment) * alignment
+
+    # Generate permutation indices
+    permuted_indices, m_sizes, m_offsets = generate_permute_indices(
+        tokens_per_expert_group,
+        num_local_experts,
+        ep_degree,
+        padded_max_len,
+        alignment,
+    )
+
+    # Get actual permuted size (may include padding)
+    permuted_rows = permuted_indices.shape[0]
+    original_rows = num_tokens
+    original_cols = hidden_dim
+
+    # Create gradient output tensor (this would come from upstream in backward pass)
+    grad_output = torch.randn(
+        permuted_rows, original_cols, device=device, dtype=torch.bfloat16
+    )
+
+    # PyTorch native implementation (from _Permute.backward, lines 144-150)
+    # This is the reference implementation that was commented out
+    grad_input_ref = grad_output.new_zeros((original_rows, original_cols))
+    # Filter out padding indices (-1) when scattering
+    valid_mask = permuted_indices != -1
+    valid_indices = permuted_indices[valid_mask]
+    grad_input_ref[valid_indices, :] = grad_output[valid_mask, :]
+
+    # Triton kernel implementation
+    grad_input_triton = _triton_permute_bwd(
+        grad_output,
+        permuted_indices,
+        original_rows,
+        original_cols,
+    )
+
+    # Compare results
+    torch.testing.assert_close(
+        grad_input_triton,
+        grad_input_ref,
+        rtol=0,
+        atol=0,
+        msg="Triton permute backward kernel output does not match PyTorch reference",
+    )

--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+
+if not (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
+):
+    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+
+from torchao.prototype.moe_training.ep import permute_mxfp8_fwd_hp_bwd
+from torchao.prototype.moe_training.ep.permute import _permute_bf16
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.quantization.utils import compute_error
+
+
+def test_mxfp8_permute_forward():
+    device = "cuda"
+    tokens = 64
+    dim = 128
+    num_experts = 8
+    ep_degree = 1
+    block_size = 32
+
+    input_tensor = torch.randn(tokens, dim, device=device, dtype=torch.bfloat16)
+
+    mx_input = MXTensor.to_mx(
+        input_tensor, elem_dtype=torch.float8_e4m3fn, block_size=block_size
+    )
+
+    # Create num_tokens_per_expert tensor
+    tokens_per_expert = tokens // num_experts
+    num_tokens_per_expert = torch.full(
+        (num_experts,), tokens_per_expert, dtype=torch.int32, device=device
+    )
+
+    (
+        padded_shape,
+        mx_output,
+        permuted_indices,
+        num_tokens_per_expert_padded,
+        offsets,
+    ) = permute_mxfp8_fwd_hp_bwd(
+        mx_input,
+        num_tokens_per_expert,
+        ep_degree,
+        num_experts,
+        block_size,
+    )
+
+    # BF16 reference
+    (
+        _,
+        ref_output,
+        _,
+        _,
+        _,
+    ) = _permute_bf16(
+        input_tensor,
+        num_tokens_per_expert,
+        ep_degree,
+        num_experts,
+        block_size,
+    )
+
+    # Compare outputs
+    output = mx_output.dequantize()
+    sqnr = compute_error(output, ref_output)
+    assert sqnr >= 30.0, f"SQNR too low: {sqnr} dB"
+
+    # Note: backward is tested in an e2e integration test with other mxfp8 EP pipeline components

--- a/torchao/prototype/moe_training/ep/__init__.py
+++ b/torchao/prototype/moe_training/ep/__init__.py
@@ -12,12 +12,16 @@ with selective MXFP8 quantization during forward and backward passes.
 
 The functions are designed to work together in the following pipeline:
 
-Forward: bf16 -> a2a_dispatch (quantize) -> permute -> mxfp8 grouped GEMM -> unpermute -> a2a_combine
-Backward: bf16 <- a2a_dispatch <- permute <- mxfp8 grouped GEMMs <- unpermute <- a2a_combine (quantize)
+Forward (left to right):
+    bf16 -> mxfp8 a2a_dispatch -> mxfp8 permute -> mxfp8 grouped GEMM -> bf16 unpermute -> bf16 a2a_combine
+Backward (right to left):
+    bf16 <- bf16 a2a_dispatch <- bf16 permute <- mxfp8 grouped GEMMs <- mxfp8 unpermute <- mxfp8 a2a_combine
 """
 
 from .a2a_dispatch import a2a_dispatch_mxfp8_fwd_hp_bwd
+from .permute import permute_mxfp8_fwd_hp_bwd
 
 __all__ = [
     "a2a_dispatch_mxfp8_fwd_hp_bwd",
+    "permute_mxfp8_fwd_hp_bwd",
 ]

--- a/torchao/prototype/moe_training/ep/kernels.py
+++ b/torchao/prototype/moe_training/ep/kernels.py
@@ -1,0 +1,212 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Source: https://github.com/pytorch/torchtitan/blob/7e4ab85998576c68902603058adada28fb0ed226/torchtitan/models/moe/kernels.py#L1
+
+import torch
+import triton
+import triton.language as tl
+
+__all__ = ["generate_permute_indices", "fill_indices_wrapper"]
+
+
+# parallelized kernel
+@triton.jit
+def _fill_indices_kernel(
+    tokens_per_expert_group_ptr,
+    start_index_values_ptr,
+    write_offsets_ptr,
+    output_ptr,
+    experts_per_rank: tl.constexpr,
+    num_ranks: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # Number of threads per block
+):
+    pid = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+
+    # map programs (blocks) to the experts and loop (grid stride) if needed
+    for expert_id in range(pid, experts_per_rank, num_programs):
+        # read this experts write offset
+        write_offset = tl.load(write_offsets_ptr + expert_id)
+
+        for r in range(num_ranks):
+            # index into tokens_per_expert_group array
+            i = r * experts_per_rank + expert_id
+
+            # load start index and number of tokens for this expert-rank pair
+            start_index = tl.load(start_index_values_ptr + i)
+            length = tl.load(tokens_per_expert_group_ptr + i)
+
+            # each thread in block processes tokens in parallel
+            offsets = tl.arange(0, BLOCK_SIZE)
+
+            # tokens are processed in chunks of BLOCK_SIZE
+            for chunk_start in range(0, length, BLOCK_SIZE):
+                chunk_offsets = chunk_start + offsets
+
+                # mask valid indices
+                mask = chunk_offsets < length
+
+                values = start_index + chunk_offsets
+
+                # destination
+                dest_indices = write_offset + chunk_offsets
+
+                # store
+                tl.store(output_ptr + dest_indices, values, mask=mask)
+
+            # update write offset for next rank
+            write_offset += length
+
+
+# ==============
+# wrapper
+# ==============
+
+
+def fill_indices_wrapper(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    block_size: int = 128,
+    max_blocks: int = 1024,  # cap on total number of blocks to launch
+):
+    # preallocate output
+    permuted_indices = torch.full(
+        (max_len,), -1, dtype=torch.int32, device=tokens_per_expert_group.device
+    )
+
+    # write offsets is per local expert...
+    num_blocks = min(experts_per_rank, max_blocks)
+    # grid = one block per expert unless capped and then we loop...
+    grid = (num_blocks,)
+
+    # launch kernel
+    _fill_indices_kernel[grid](
+        tokens_per_expert_group,
+        start_index_values,
+        write_offsets,
+        permuted_indices,
+        experts_per_rank,
+        num_ranks,
+        BLOCK_SIZE=block_size,
+    )
+    return permuted_indices
+
+
+# reference
+def fill_indices_cpu(
+    tokens_per_expert_group: torch.Tensor,
+    start_index_values: torch.Tensor,
+    write_offsets: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+):
+    # We need to preallocate the output - we ignore device and force it on cpu
+    permuted_indices = torch.full(
+        (max_len,),
+        -1,
+        dtype=torch.int32,
+    )
+    # Fill the permuted indices
+    # For each local expert
+    for e in range(experts_per_rank):
+        write_start = write_offsets[e].item()
+        # For each remote rank
+        for r in range(num_ranks):
+            i = r * experts_per_rank + e
+            start_index = start_index_values[i].item()
+            length = tokens_per_expert_group[i].item()
+            # Fill in the indices
+            if length > 0:
+                end_idx = min(write_start + length, max_len)
+                permuted_indices[write_start:end_idx] = torch.arange(
+                    start_index,
+                    start_index + (end_idx - write_start),
+                    dtype=torch.int32,
+                )
+            write_start += length
+    return permuted_indices
+
+
+def generate_permute_indices(
+    tokens_per_expert_group: torch.Tensor,
+    experts_per_rank: int,
+    num_ranks: int,
+    max_len: int,
+    alignment: int,
+    use_cpu: bool = False,
+):
+    """
+    Prepare permutation indices and the number of tokens for each expert.
+
+    Args:
+        tokens_per_expert_group: number of tokens for each expert from all ranks.
+        experts_per_rank: number of experts per rank.
+        num_ranks: number of ranks.
+        max_len: maximum length of the output index vector.
+        alignment: alignment for each returned element in `m_sizes` and padding min for zero token experts.
+        use_cpu: whether to use CPU implementation.
+
+
+    Returns:
+        permuted_indices: Tensor of indices that map original token order to the expert-grouped order.
+        m_sizes: aligned number of tokens for each expert (padded to alignment boundary).
+        m_offsets: Cumulative sum of m_sizes. The exclusive ending position for each expert's tokens.
+
+    Explanatory details:
+        `tokens_per_expert_group` is of shape (num_ranks * experts_per_rank,), for example:
+        From: |       rank 0      |       rank 1      |
+        To:   | E0 | E1 | E2 | E3 | E0 | E1 | E2 | E3 |
+              |  4 |  2 |  1 |  3 |  1 |  2 |  3 |  4 |
+    """
+
+    # prefix sum to get start index of each expert (parallel scan kernel in future?)
+    start_index_values = (
+        torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
+    )
+
+    # total tokens for each expert (sum over ranks)
+    total_tokens_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
+
+    # pad out empty experts to alignment requirement
+    total_tokens_per_expert = torch.clamp_min(total_tokens_per_expert, alignment)
+
+    # align the chunk sizes (cdiv)
+    m_sizes = ((total_tokens_per_expert + alignment - 1) // alignment * alignment).to(
+        torch.int32
+    )
+
+    # additional prefix sum to get write offset of each expert in permuted_indices
+    # write offsets is per local expert, not global
+    m_offsets = torch.cumsum(m_sizes, 0)
+    write_offsets = m_offsets - m_sizes
+
+    # Select the implementation to use
+    if use_cpu:
+        permuted_indices = fill_indices_cpu(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+    else:
+        permuted_indices = fill_indices_wrapper(
+            tokens_per_expert_group,
+            start_index_values,
+            write_offsets,
+            experts_per_rank,
+            num_ranks,
+            max_len,
+        )
+
+    return permuted_indices, m_sizes, m_offsets.to(torch.int32)

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -1,0 +1,323 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import triton
+import triton.language as tl
+from torch.library import triton_op, wrap_triton
+
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+from .kernels import generate_permute_indices
+
+
+def _round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y."""
+    x_ceil_div_y = (x + y - 1) // y
+    return x_ceil_div_y * y
+
+
+class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
+    """
+    Permute operation for MXTensor with token group alignment.
+
+    Forward:
+        - Takes MXTensor input (qdata + scales)
+        - Generates permutation indices using triton kernel
+        - Pads each token group to multiple of TOKEN_GROUP_ALIGN_SIZE_M
+        - Permutes qdata and scales separately based on routing
+        - Returns MXTensor with permuted components
+
+    Backward:
+        - Takes bf16 gradient input
+        - Unpermutes using saved indices
+        - Returns bf16 gradient output
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        mx_tensor: MXTensor,
+        num_tokens_per_expert: torch.Tensor,
+        ep_degree: int,
+        num_local_experts: int,
+        group_size_multiple_of: int = 32,
+        use_triton_for_bwd: bool = True,
+    ):
+        """
+        Args:
+            mx_tensor: MXTensor input with qdata and scales
+            num_tokens_per_expert: number of tokens per expert (shape: [ep_degree * num_local_experts])
+            ep_degree: expert parallelism degree
+            num_local_experts: number of local experts
+            group_size_multiple_of: alignment size for token groups
+
+        Returns:
+            tuple: (padded_shape, permuted MXTensor, permuted_indices, updated num_tokens_per_expert with padding)
+        """
+
+        # Extract qdata and scales from MXTensor
+        qdata = mx_tensor.qdata
+        scales = mx_tensor.scale
+
+        # Assume worst case where each token group needs to be padded with group_size_multiple_of tokens
+        x_padded_per_expert = (
+            qdata.shape[0] + num_local_experts * group_size_multiple_of
+        )
+        padded_max_len = _round_up(x_padded_per_expert, group_size_multiple_of)
+
+        # Generate permuted indices and updated num_tokens_per_expert with padding
+        with torch.no_grad():
+            (
+                permuted_indices,
+                num_tokens_per_expert_padded,
+                group_offsets,
+            ) = generate_permute_indices(
+                num_tokens_per_expert,
+                num_local_experts,
+                ep_degree,
+                padded_max_len,
+                group_size_multiple_of,
+            )
+
+        # Append row of zeros to qdata to act as a dummy padding row
+        # Every time `permuted_indices` selects this index, it will correspond to a padded token
+        qdata_padded = torch.vstack((qdata, qdata.new_zeros((qdata.shape[-1],))))
+        padded_input_shape = qdata_padded.shape
+
+        # Permute qdata using indices
+        qdata_permuted = qdata_padded[permuted_indices, :]
+
+        # Permute scales to match data
+        scales_padded = torch.vstack((scales, scales.new_zeros((scales.shape[-1],))))
+        scales_permuted = scales_padded[permuted_indices, :]
+
+        # Wrap back into MXTensor
+        mx_output = MXTensor(
+            qdata_permuted,
+            scales_permuted,
+            elem_dtype=mx_tensor._elem_dtype,
+            block_size=mx_tensor.block_size,
+            orig_dtype=mx_tensor._orig_dtype,
+            kernel_preference=mx_tensor.kernel_preference,
+            act_quant_kwargs=mx_tensor.act_quant_kwargs,
+            is_swizzled_scales=mx_tensor._is_swizzled_scales,
+        )
+
+        # Save for backward
+        ctx.save_for_backward(permuted_indices)
+        ctx.padded_input_shape = padded_input_shape
+        ctx.use_triton_for_bwd = use_triton_for_bwd
+
+        return (
+            padded_input_shape,
+            mx_output,
+            permuted_indices,
+            num_tokens_per_expert_padded,
+            group_offsets,
+        )
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_padded_shape,
+        grad_output,
+        grad_permuted_indices,
+        grad_num_tokens_per_expert_padded,
+        grad_group_offsets,
+    ):
+        """
+        Backward pass: unpermute bf16 gradients.
+
+        Args:
+            grad_padded_shape: None (padded_shape doesn't need gradients)
+            grad_output: bf16 gradient tensor from upstream
+            grad_permuted_indices: None (permuted_indices doesn't need gradients)
+            grad_num_tokens_per_expert_padded: None (num_tokens_per_expert_padded doesn't need gradients)
+
+        Returns:
+            grad_input: bf16 gradient tensor (unpermuted)
+            None values for other forward arguments
+        """
+        (permuted_indices,) = ctx.saved_tensors
+        input_rows, input_cols = ctx.padded_input_shape
+        use_triton_for_bwd = ctx.use_triton_for_bwd
+
+        if use_triton_for_bwd:
+            grad_input = _triton_permute_bwd(
+                grad_output,
+                permuted_indices,
+                input_rows - 1,  # Remove padding row
+                input_cols,
+            )
+        else:
+            # Unpermute: scatter gradients back to original positions
+            grad_input_padded = grad_output.new_zeros(ctx.padded_input_shape)
+            grad_input_padded[permuted_indices, :] = grad_output
+
+            # Remove the padding row (last row)
+            grad_input = grad_input_padded[:input_rows]
+        return grad_input, None, None, None, None, None
+
+
+# Reference impl for testing
+def _permute_bf16(
+    x: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+    ep_degree: int,
+    num_local_experts: int,
+    alignment: int,
+):
+    """
+    BF16 permute operation used for testing and benchmarking.
+
+    Args:
+        x: BF16 input tensor
+        num_tokens_per_expert: number of tokens per expert
+        ep_degree: expert parallelism degree
+        num_local_experts: number of local experts
+        alignment: block size alignment
+
+    Returns:
+        tuple: (input_shape, permuted tensor, permuted_indices, offsets)
+    """
+    x_padded_per_expert = x.shape[0] + num_local_experts * alignment
+    padded_max_len = _round_up(x_padded_per_expert, alignment)
+
+    with torch.no_grad():
+        (
+            permuted_indices,
+            num_tokens_per_expert_padded,
+            group_offsets,
+        ) = generate_permute_indices(
+            num_tokens_per_expert,
+            num_local_experts,
+            ep_degree,
+            padded_max_len,
+            alignment,
+        )
+
+    x = torch.vstack((x, x.new_zeros((1, x.shape[-1]))))
+    input_shape = x.shape
+    x = x[permuted_indices, :]
+
+    return input_shape, x, permuted_indices, num_tokens_per_expert_padded, group_offsets
+
+
+def permute_mxfp8_fwd_hp_bwd(
+    mx_tensor: MXTensor,
+    num_tokens_per_expert: torch.Tensor,
+    ep_degree: int,
+    num_local_experts: int,
+    group_size_multiple_of: int = 32,
+    use_mxfp8: bool = True,
+    use_triton_for_bwd: bool = True,
+):
+    """
+    Permute and pad MXTensor based on routing indices with token group alignment.
+
+    This function:
+    1. Uses a triton kernel to efficiently generate permutation indices
+    2. Pads each token group to a multiple of TOKEN_GROUP_ALIGN_SIZE_M
+    3. Permutes the MXTensor data accordingly
+
+    Args:
+        mx_tensor: input MXTensor
+        num_tokens_per_expert: number of tokens per expert (shape: [ep_degree * num_local_experts])
+        ep_degree: expert parallelism degree
+        num_local_experts: number of local experts
+        group_size_multiple_of: alignment size for token groups
+        use_triton_for_bwd: if True, use triton kernel for backward pass
+
+    Returns:
+        tuple: (padded_shape, permuted MXTensor, permuted_indices, updated num_tokens_per_expert with padding)
+    """
+    return _PermuteMXFP8FwdHPBwd.apply(
+        mx_tensor,
+        num_tokens_per_expert,
+        ep_degree,
+        num_local_experts,
+        group_size_multiple_of,
+        use_triton_for_bwd,
+    )
+
+
+@triton_op("torchao::_triton_permute_bwd", mutates_args={})
+def _triton_permute_bwd(
+    grad_output: torch.Tensor,
+    permuted_indices: torch.Tensor,
+    original_rows: int,
+    original_cols: int,
+) -> torch.Tensor:
+    """
+    Backward pass for BF16 permute operation.
+
+    Args:
+        grad_output: bf16 gradient tensor from upstream
+        permuted_indices: permutation indices used in the forward pass
+        original_shape: original shape of the input (with extra padding row)
+    Returns:
+        grad_input: bf16 gradient tensor (unpermuted)
+    """
+    grad_rows, grad_cols = grad_output.shape
+    output_buffer = grad_output.new_zeros((original_rows, original_cols))
+    grid = lambda meta: (
+        triton.cdiv(grad_rows, meta["BLOCK_ROWS"]),
+        triton.cdiv(grad_cols, meta["BLOCK_COLS"]),
+    )
+    wrap_triton(_triton_permute_bwd_kernel)[grid](
+        grad_output,
+        permuted_indices,
+        output_buffer,
+        grad_rows,
+        grad_cols,
+        original_rows,
+        original_cols,
+        BLOCK_ROWS=256,
+        BLOCK_COLS=256,
+    )
+    return output_buffer
+
+
+@triton.jit
+def _triton_permute_bwd_kernel(
+    grad_ptr,
+    permuted_indices_ptr,
+    output_buffer_ptr,
+    grad_rows,
+    grad_cols,
+    original_rows,
+    original_cols,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+    PADDING_VALUE: tl.constexpr = -1,
+):
+    row_pid = tl.program_id(0)
+    col_pid = tl.program_id(1)
+    row_offsets = row_pid * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    col_offsets = col_pid * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+
+    dest_rows = tl.load(
+        permuted_indices_ptr + row_offsets,
+        mask=row_offsets < grad_rows,
+        other=PADDING_VALUE,
+    )
+
+    read_mask = (row_offsets[:, None] < grad_rows) & (col_offsets[None, :] < grad_cols)
+    grad_values = tl.load(
+        grad_ptr + row_offsets[:, None] * grad_cols + col_offsets[None, :],
+        mask=read_mask,
+        other=PADDING_VALUE,
+    )
+
+    write_mask = (dest_rows[:, None] != PADDING_VALUE) & (
+        col_offsets[None, :] < original_cols
+    )
+    tl.store(
+        output_buffer_ptr + dest_rows[:, None] * original_cols + col_offsets[None, :],
+        grad_values,
+        mask=write_mask,
+    )


### PR DESCRIPTION
Stacked PRs:
 * #3606
 * #3585
 * #3584
 * #3583
 * #3582
 * #3581
 * __->__#3580
 * #3579


--- --- ---

### [mxfp8 moe training] mxfp8 token permute autograd func + triton kernels

### Tests 
- `PYTHONPATH=/home/$USER/ao:$PYTHONPATH pytest test/prototype/moe_training/ep/test_permute.py`
- Tests for backward require integration with other EP pipeline components, so this is tested in the integration test added in #3584