### PR TITLE
[mxfp8 moe training] mxfp8 a2a_combine autograd function

### DIFF
--- a/torchao/prototype/moe_training/ep/__init__.py
+++ b/torchao/prototype/moe_training/ep/__init__.py
@@ -18,6 +18,7 @@ Backward (right to left):
     bf16 a2a_dispatch.bwd <- bf16 permute.bwd <- mxfp8 grouped GEMMs bwd <- mxfp8 unpermute.bwd <- mxfp8 a2a_combine.bwd
 """
 
+from .a2a_combine import a2a_combine_hp_fwd_mxfp8_bwd
 from .a2a_dispatch import a2a_dispatch_mxfp8_fwd_hp_bwd
 from .permute import permute_mxfp8_fwd_hp_bwd
 from .unpermute import unpermute_hp_fwd_mxfp8_bwd
@@ -26,4 +27,5 @@ __all__ = [
     "a2a_dispatch_mxfp8_fwd_hp_bwd",
     "permute_mxfp8_fwd_hp_bwd",
     "unpermute_hp_fwd_mxfp8_bwd",
+    "a2a_combine_hp_fwd_mxfp8_bwd",
 ]

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -1,0 +1,190 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.distributed as dist
+from torch.distributed._functional_collectives import all_to_all_single
+
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+
+class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
+    """
+    All-to-all combine with MXFP8 quantization in backward.
+
+    Forward:
+        - Takes bf16 input
+        - Performs all-to-all in bf16 (no quantization)
+        - Returns bf16 output
+
+    Backward:
+        - Takes bf16 gradient input
+        - Dynamically quantizes to mxfp8
+        - Performs inverse all-to-all on qdata and scales
+        - Returns MXTensor wrapping the gradient qdata and scales
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        output_splits: list[int],
+        input_splits: list[int],
+        group: dist.ProcessGroup,
+        scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
+        block_size: int = 32,
+        mxfp8_bwd: bool = True,
+    ):
+        """
+        Args:
+            input: bf16 input tensor
+            output_splits: list of output splits for all-to-all
+            input_splits: list of input splits for all-to-all
+            group: process group for collective
+            scaling_mode: quantization scaling mode (for backward)
+            block_size: block size for mxfp8 quantization (for backward)
+            mxfp8_bwd: if True, use mxfp8 quantization in backward; if False, use bf16
+
+        Returns:
+            bf16 tensor: all-to-all output
+        """
+        assert input.dtype in (torch.bfloat16, torch.float32), (
+            f"Expected bf16 or fp32, got {input.dtype}"
+        )
+
+        # Default to WORLD group if not specified
+        if group is None:
+            group = dist.group.WORLD
+
+        # All-to-all in bf16
+        output = all_to_all_single(
+            input,
+            output_split_sizes=output_splits,
+            input_split_sizes=input_splits,
+            group=group,
+        )
+
+        # Wait for async op
+        output = torch.ops._c10d_functional.wait_tensor(output)
+
+        # Save for backward
+        ctx.input_splits = input_splits
+        ctx.output_splits = output_splits
+        ctx.group = group
+        ctx.hp_dtype = input.dtype
+        ctx.scaling_mode = scaling_mode
+        ctx.block_size = block_size
+        ctx.mxfp8_bwd = mxfp8_bwd
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        Backward pass: quantize to mxfp8 and perform inverse all-to-all (if mxfp8_bwd=True),
+        or just perform inverse all-to-all in bf16 (if mxfp8_bwd=False).
+
+        Args:
+            grad_output: bf16 gradient tensor from upstream
+
+        Returns:
+            grad_input: MXTensor (if mxfp8_bwd=True) or bf16 tensor (if mxfp8_bwd=False)
+            None values for other forward arguments (output_splits, input_splits, group, scaling_mode, block_size, mxfp8_bwd)
+        """
+        if ctx.mxfp8_bwd:
+            # MXFP8 backward path: Quantize grad_output to mxfp8
+            scaling_mode_str = str(ctx.scaling_mode.value).lower()
+            grad_data, grad_scales = triton_to_mxfp8_dim0(
+                grad_output,
+                inner_block_size=ctx.block_size,
+                scaling_mode=scaling_mode_str,
+            )
+
+            # Inverse all-to-all on qdata (async)
+            grad_input_data = all_to_all_single(
+                grad_data,
+                output_split_sizes=ctx.input_splits,
+                input_split_sizes=ctx.output_splits,
+                group=ctx.group,
+            )
+
+            # Inverse all-to-all on scales (async)
+            # NCCL doesn't support float8_e8m0fnu, so view as uint8
+            grad_input_scales = all_to_all_single(
+                grad_scales.view(torch.uint8),
+                output_split_sizes=ctx.input_splits,
+                input_split_sizes=ctx.output_splits,
+                group=ctx.group,
+            )
+
+            # Wait for async ops
+            grad_input_data = torch.ops._c10d_functional.wait_tensor(grad_input_data)
+            grad_input_scales = torch.ops._c10d_functional.wait_tensor(
+                grad_input_scales
+            )
+
+            # Convert scales back to float8_e8m0fnu
+            grad_input_scales = grad_input_scales.view(torch.float8_e8m0fnu)
+
+            # Wrap as MXTensor
+            grad_input = MXTensor(
+                grad_input_data,
+                grad_input_scales,
+                elem_dtype=torch.float8_e4m3fn,
+                block_size=ctx.block_size,
+                orig_dtype=ctx.hp_dtype,
+                kernel_preference=None,
+                act_quant_kwargs=None,
+                is_swizzled_scales=False,
+            )
+        else:
+            # BF16 backward path: Just do inverse all-to-all in bf16
+            grad_input = all_to_all_single(
+                grad_output,
+                output_split_sizes=ctx.input_splits,
+                input_split_sizes=ctx.output_splits,
+                group=ctx.group,
+            )
+            grad_input = torch.ops._c10d_functional.wait_tensor(grad_input)
+
+        return grad_input, None, None, None, None, None, None
+
+
+def a2a_combine_hp_fwd_mxfp8_bwd(
+    input: torch.Tensor,
+    output_splits: list[int],
+    input_splits: list[int],
+    group: dist.ProcessGroup,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
+    block_size: int = 32,
+    mxfp8_bwd: bool = True,
+) -> torch.Tensor:
+    """
+    All-to-all combine with optional MXFP8 quantization in backward.
+
+    Args:
+        input: bf16 input tensor
+        output_splits: output split sizes
+        input_splits: input split sizes
+        group: process group
+        scaling_mode: quantization scaling mode (for backward, if mxfp8_bwd=True)
+        block_size: mxfp8 block size (for backward, if mxfp8_bwd=True)
+        mxfp8_bwd: if True, use mxfp8 quantization in backward; if False, use bf16
+
+    Returns:
+        bf16 output from all-to-all
+    """
+    return _A2ACombineHPFwdMXFP8Bwd.apply(
+        input,
+        output_splits,
+        input_splits,
+        group,
+        scaling_mode,
+        block_size,
+        mxfp8_bwd,
+    )


### PR DESCRIPTION
Stacked PRs:
 * #3606
 * #3585
 * #3584
 * #3583
 * __->__#3582
 * #3581
 * #3580
 * #3579


--- --- ---

### [mxfp8 moe training] mxfp8 a2a_combine autograd function


### Tests
- There are no useful tests to add for forward() here, because the autograd function forward() uses the same code as the bf16 impl for forward. The difference where MXFP8 is used is in backward.
- Tests for backward require integration with other EP pipeline components, so this is tested in the integration test added in https://github.com/pytorch/ao/pull/3584