### PR TITLE
[CPU] improve quantization for int8 sdpa

### DIFF
--- a/torchao/prototype/inductor/codegen/cpp_int8_sdpa_template.py
+++ b/torchao/prototype/inductor/codegen/cpp_int8_sdpa_template.py
@@ -45,6 +45,7 @@ inline void store(scalar_t* dst, at::vec::Vectorized<scalar_t> src, int size=at:
   src.store(dst, size);
 }
 
+#ifdef CPU_CAPABILITY_AVX512
 // A fast version for uint8_t conversion with SaturateU8 intrinsic
 at::vec::Vectorized<uint8_t> inline convert_float_to_uint8(
     at::vec::Vectorized<float> src) {
@@ -55,6 +56,13 @@ at::vec::Vectorized<uint8_t> inline convert_float_to_uint8(
   auto v3 = _mm512_cvtusepi32_epi8(v2);
   return _mm512_castsi128_si512(v3);
 }
+#else
+// A generic version for uint8_t conversion
+at::vec::Vectorized<uint8_t> inline convert_float_to_uint8(
+    at::vec::Vectorized<float> src) {
+  return at::vec::convert<uint8_t>(src);
+}
+#endif // CPU_CAPABILITY_AVX512
 
 template <typename scalar_t>
 inline typename std::enable_if_t<std::is_same_v<scalar_t, unsigned char>, void>


### PR DESCRIPTION
Description:

1. Avoid duplicated `min`/`max` operations inside and outside the `vec::conversion`.
2. Further improvement the conversion from fp32 to uint8 by adopting `SaturateU8` intrinsic.

Validation on ViT:

1. Accuracy is the same as before.
2. E2E performance improves 1%.