### PR TITLE
[mxfp8] avoid requirement to link cuda lib at build time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -723,7 +723,6 @@ def get_extensions():
                     include_dirs=[
                         mxfp8_extension_dir,  # For mxfp8_quantize.cuh, mxfp8_extension.cpp, and mxfp8_cuda.cu
                     ],
-                    libraries=["cuda"],
                     extra_compile_args={
                         "cxx": [
                             f"-DPy_LIMITED_API={min_supported_cpython_hexcode}",

--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -23,9 +23,6 @@
 #include <cstdlib>
 
 #include <cuda.h>
-#include <cuda/barrier>
-#include <cuda/ptx>
-#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 #include <cudaTypedefs.h>
 #include "ptx.cuh"
@@ -33,9 +30,7 @@
 // Overloaded error checking for both CUDA driver API (CUresult) and runtime API (cudaError_t)
 inline void cuda_check_impl(CUresult result, const char* file, int line) {
     if (result != CUDA_SUCCESS) {
-        const char* error_str;
-        cuGetErrorString(result, &error_str);
-        fprintf(stderr, "CUDA Driver Error at %s:%d - %s\n", file, line, error_str);
+        fprintf(stderr, "CUDA Driver Error at %s:%d - Error code: %d\n", file, line, (int)result);
         exit(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
Audited what headers we're including and why they're required. Removed unused ones.

By just printing the cuda error code and not using `cuGetErrorString` to print a readable msg, we can avoid linking against cuda runtime lib at build time, which breaks internal builds. cc @huydhn 