### PR TITLE
[mxfp8 moe training] add torch.compile support

### DIFF
--- a/test/prototype/moe_training/ep/test_compile.py
+++ b/test/prototype/moe_training/ep/test_compile.py
@@ -1,0 +1,378 @@
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+
+# Get the repo root (5 levels up from this file: ep -> moe_training -> prototype -> test -> ao).
+# This avoids having to add PYTHONPATH manually when running the tests.
+repo_root = Path(__file__).resolve().parent.parent.parent.parent.parent
+sys.path.insert(0, str(repo_root))
+
+import torch
+
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+
+if not (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
+):
+    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+
+
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.distributed._functional_collectives import (
+    all_to_all_single,
+)
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import run_tests
+
+from test.prototype.moe_training.testing_utils import generate_split_sizes
+from torchao.float8.float8_utils import compute_error
+from torchao.prototype.moe_training.ep import (
+    a2a_combine_hp_fwd_mxfp8_bwd,
+    a2a_dispatch_mxfp8_fwd_hp_bwd,
+    permute_mxfp8_fwd_hp_bwd,
+    unpermute_hp_fwd_mxfp8_bwd,
+)
+from torchao.prototype.moe_training.ep.permute import _permute_bf16
+from torchao.prototype.moe_training.ep.unpermute import _unpermute_bf16
+from torchao.prototype.moe_training.scaled_grouped_mm import (
+    _to_mxfp8_then_scaled_grouped_mm,
+)
+
+
+def standard_pipeline(
+    input_tensor: torch.Tensor,
+    expert_weights_t: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+    num_tokens_per_expert_group: torch.Tensor,
+    input_splits_list: List[int],
+    output_splits_list: List[int],
+    ep_degree: int,
+    num_experts: int,
+    group,
+) -> torch.Tensor:
+    """
+    Standard BF16 pipeline:
+    bf16 a2a -> bf16 permute -> _to_mxfp8_then_scaled_grouped_mm -> bf16 unpermute -> bf16 a2a combine
+    """
+    block_size = 32
+
+    # Step 1: All-to-all dispatch (BF16)
+    dispatched = all_to_all_single(
+        input_tensor,
+        output_splits_list,
+        input_splits_list,
+        group=group,
+    )
+    dispatched = torch.ops._c10d_functional.wait_tensor(dispatched)
+
+    # Step 2: Permute (BF16)
+    input_shape, permuted, permuted_indices, num_tokens_per_expert_padded, offsets = (
+        _permute_bf16(
+            dispatched,
+            num_tokens_per_expert_group,
+            ep_degree,
+            num_experts,
+            block_size,
+        )
+    )
+
+    # Step 3: Grouped MM
+    gemm_output = _to_mxfp8_then_scaled_grouped_mm(
+        permuted,
+        expert_weights_t,
+        offs=offsets,
+        block_size=block_size,
+        use_cuda_kernel_for_blocked_layout=False,
+        wgrad_with_hp=True,
+    )
+
+    # Step 4: Unpermute (BF16)
+    # Create output shape with same number of rows as input_shape, but output dimension from gemm_output
+    output_shape = (input_shape[0], gemm_output.shape[-1])
+    unpermuted = _unpermute_bf16(gemm_output, permuted_indices, output_shape)
+
+    # Step 5: All-to-all combine (BF16)
+    final_output = all_to_all_single(
+        unpermuted,
+        input_splits_list,
+        output_splits_list,
+        group=group,
+    )
+    final_output = torch.ops._c10d_functional.wait_tensor(final_output)
+
+    return final_output
+
+
+def mxfp8_pipeline(
+    input_tensor: torch.Tensor,
+    expert_weights_t: torch.Tensor,
+    num_tokens_per_expert: torch.Tensor,
+    num_tokens_per_expert_group: torch.Tensor,
+    input_splits_list: List[int],
+    output_splits_list: List[int],
+    ep_degree: int,
+    num_experts: int,
+    group,
+) -> torch.Tensor:
+    """
+    MXFP8 optimized pipeline with chained autograd functions:
+    bf16 -> a2a_dispatch (MXTensor) -> permute (MXTensor) ->
+    mxfp8_grouped_mm -> unpermute -> a2a_combine -> bf16
+    """
+    block_size = 32
+
+    # Step 1: A2A dispatch - outputs MXTensor
+    mx_dispatched = a2a_dispatch_mxfp8_fwd_hp_bwd(
+        input_tensor,
+        output_splits_list,
+        input_splits_list,
+        group_name=group.group_name,
+    )
+
+    # Step 2: Permute - maintains MXTensor
+    (
+        padded_mx_shape,
+        mx_permuted,
+        permuted_indices,
+        num_tokens_per_expert_padded,
+        mx_group_offsets,
+    ) = permute_mxfp8_fwd_hp_bwd(
+        mx_dispatched,
+        num_tokens_per_expert_group,
+        ep_degree,
+        num_experts,
+        block_size,
+        use_triton_for_bwd=True,
+    )
+
+    # Step 3: MXFP8 Grouped MM - outputs BF16
+    gemm_output = _to_mxfp8_then_scaled_grouped_mm(
+        mx_permuted,
+        expert_weights_t,
+        offs=mx_group_offsets,
+        block_size=block_size,
+        use_cuda_kernel_for_blocked_layout=False,
+        wgrad_with_hp=True,
+    )
+
+    # Step 4: Unpermute - maintains BF16
+    # Update padded_shape to have output dimension instead of input dimension
+    padded_output_shape = torch.Size([padded_mx_shape[0], gemm_output.shape[-1]])
+    unpermuted = unpermute_hp_fwd_mxfp8_bwd(
+        gemm_output,
+        permuted_indices,
+        padded_output_shape,
+    )
+
+    # Step 5: A2A combine - maintains BF16
+    final_output = a2a_combine_hp_fwd_mxfp8_bwd(
+        unpermuted,
+        output_splits=input_splits_list,
+        input_splits=output_splits_list,
+        group_name=group.group_name,
+    )
+
+    return final_output
+
+
+class TestIntegrationCompiled(MultiProcessTestCase):
+    def setUp(self):
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self):
+        return 2
+
+    @property
+    def device(self):
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.manual_seed(42 + self.rank)
+
+    def test_full_pipeline_compiled(self):
+        self._init_process()
+        try:
+            tokens = 64
+            dim = 256
+            hidden_dim = 512
+            num_experts = 4
+
+            # Create input activations and expert weights
+            input_tensor = torch.randn(
+                tokens,
+                dim,
+                device=self.device,
+                dtype=torch.bfloat16,
+                requires_grad=True,
+            )
+            ref_input_tensor = input_tensor.detach().clone().requires_grad_(True)
+
+            expert_weights = torch.randn(
+                num_experts,
+                hidden_dim,
+                dim,
+                device=self.device,
+                dtype=torch.bfloat16,
+                requires_grad=True,
+            )
+            ref_expert_weights = expert_weights.detach().clone().requires_grad_(True)
+
+            # Generate random tokens per expert that sum to total tokens
+            # Shape should be [ep_degree * num_experts] where each rank has num_experts values
+            ep_degree = self.world_size
+            num_tokens_per_expert = generate_split_sizes(
+                ep_degree * num_experts, tokens, self.device
+            )
+
+            # Compute tokens per expert group using tokens per expert using TorchTitan reference:
+            # https://github.com/pytorch/torchtitan/blob/795a7a027eccf282c51a5ae1cc0c1c3459120c9b/torchtitan/distributed/expert_parallel.py#L111
+            with torch.no_grad():
+                num_tokens_per_expert_group = all_to_all_single(
+                    num_tokens_per_expert,
+                    None,
+                    None,
+                    group=dist.group.WORLD,
+                )
+                # Need to wait explicitly because it is used by a triton kernel later
+                # which doesn't realize that AsyncCollectiveTensor needs unwrapping
+                num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
+                    num_tokens_per_expert_group
+                )
+                input_splits = (
+                    num_tokens_per_expert.view(ep_degree, -1)
+                    .sum(dim=1)
+                    .to(torch.device("cpu"), non_blocking=True)
+                )
+                output_splits = (
+                    num_tokens_per_expert_group.view(ep_degree, -1)
+                    .sum(dim=1)
+                    .to(torch.device("cpu"), non_blocking=False)
+                )
+
+            group = dist.group.WORLD
+            input_splits_list = input_splits.tolist()
+            output_splits_list = output_splits.tolist()
+
+            # Use deterministic permutation based on rank to avoid randomness issues
+            torch.manual_seed(42)  # Same seed on all ranks
+
+            rank_0_print(
+                f"\n[Rank {self.rank}] ========== Side-by-Side BF16 vs MXFP8 Pipeline with torch.compile ========="
+            )
+
+            # Compile the pipelines
+            bf16_pipeline_fn = torch.compile(standard_pipeline)
+            mxfp8_pipeline_fn = torch.compile(mxfp8_pipeline)
+
+            rank_0_print(f"[Rank {self.rank}] Running BF16 pipeline")
+            bf16_output = bf16_pipeline_fn(
+                ref_input_tensor,
+                ref_expert_weights.transpose(-2, -1),
+                num_tokens_per_expert,
+                num_tokens_per_expert_group,
+                input_splits_list,
+                output_splits_list,
+                ep_degree,
+                num_experts,
+                group,
+            )
+
+            rank_0_print(f"[Rank {self.rank}] Running MXFP8 pipeline")
+            mxfp8_output = mxfp8_pipeline_fn(
+                input_tensor,
+                expert_weights.transpose(-2, -1),
+                num_tokens_per_expert,
+                num_tokens_per_expert_group,
+                input_splits_list,
+                output_splits_list,
+                ep_degree,
+                num_experts,
+                group,
+            )
+
+            # Compare: Final outputs
+            final_sqnr = compute_error(bf16_output, mxfp8_output)
+            rank_0_print(f"[Rank {self.rank}]   Final output SQNR: {final_sqnr:.2f} dB")
+            assert final_sqnr >= 28.0, f"Final SQNR {final_sqnr} too low"
+
+            rank_0_print(
+                f"[Rank {self.rank}] ========== End Forward Validation ==========\n"
+            )
+
+            # ======================================
+            # Backward pass
+            # ======================================
+
+            # BF16 backward
+            bf16_labels = torch.ones_like(bf16_output)
+            bf16_loss = F.mse_loss(bf16_output, bf16_labels)
+            bf16_loss.backward()
+
+            assert ref_input_tensor.grad is not None
+            assert ref_input_tensor.grad.dtype == torch.bfloat16
+            assert ref_expert_weights.grad is not None
+            assert ref_expert_weights.grad.dtype == torch.bfloat16
+
+            # MXFP8 backward
+            mxfp8_labels = torch.ones_like(mxfp8_output)
+            mxfp8_loss = F.mse_loss(mxfp8_output, mxfp8_labels)
+            mxfp8_loss.backward()
+
+            assert input_tensor.grad is not None
+            assert input_tensor.grad.dtype == torch.bfloat16
+            assert expert_weights.grad is not None
+            assert expert_weights.grad.dtype == torch.bfloat16
+
+            # Validate input gradients
+            input_grad_sqnr = compute_error(ref_input_tensor.grad, input_tensor.grad)
+            min_input_grad_sqnr = 26.0
+            rank_0_print(
+                f"[Rank {self.rank}]   Input grad SQNR: {input_grad_sqnr:.2f} dB"
+            )
+            assert input_grad_sqnr >= min_input_grad_sqnr, (
+                f"Input grad SQNR {input_grad_sqnr} is too low, must be >= {min_input_grad_sqnr}"
+            )
+
+            # Validate weight gradients
+            assert ref_expert_weights.grad is not None, (
+                "ref_expert_weights.grad is None"
+            )
+            assert expert_weights.grad is not None, "expert_weights.grad is None"
+
+            weight_grad_sqnr = compute_error(
+                ref_expert_weights.grad, expert_weights.grad
+            )
+            min_weight_grad_sqnr = 25.0
+            rank_0_print(
+                f"[Rank {self.rank}]   Weight grad SQNR: {weight_grad_sqnr:.2f} dB"
+            )
+            assert weight_grad_sqnr >= min_weight_grad_sqnr, (
+                f"Weight grad SQNR {weight_grad_sqnr} is too low, must be >= {min_weight_grad_sqnr}"
+            )
+
+        finally:
+            dist.destroy_process_group()
+
+
+def rank_0_print(msg: str):
+    if dist.get_rank() == 0:
+        print(msg)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -7,6 +7,7 @@
 import torch
 import torch.distributed as dist
 from torch.distributed._functional_collectives import all_to_all_single
+from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
@@ -155,11 +156,12 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
         return grad_input, None, None, None, None, None, None
 
 
+@torch._dynamo.nonstrict_trace
 def a2a_combine_hp_fwd_mxfp8_bwd(
     input: torch.Tensor,
     output_splits: list[int],
     input_splits: list[int],
-    group: dist.ProcessGroup,
+    group_name: str = None,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
     block_size: int = 32,
     mxfp8_bwd: bool = True,
@@ -171,7 +173,7 @@ def a2a_combine_hp_fwd_mxfp8_bwd(
         input: bf16 input tensor
         output_splits: output split sizes
         input_splits: input split sizes
-        group: process group
+        group_name: process group name
         scaling_mode: quantization scaling mode (for backward, if mxfp8_bwd=True)
         block_size: mxfp8 block size (for backward, if mxfp8_bwd=True)
         mxfp8_bwd: if True, use mxfp8 quantization in backward; if False, use bf16
@@ -179,6 +181,11 @@ def a2a_combine_hp_fwd_mxfp8_bwd(
     Returns:
         bf16 output from all-to-all
     """
+    if group_name is None:
+        group = dist.group.WORLD
+    else:
+        group = _resolve_process_group(group_name)
+
     return _A2ACombineHPFwdMXFP8Bwd.apply(
         input,
         output_splits,

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -207,6 +207,7 @@ def _permute_bf16(
     return input_shape, x, permuted_indices, num_tokens_per_expert_padded, group_offsets
 
 
+@torch._dynamo.nonstrict_trace
 def permute_mxfp8_fwd_hp_bwd(
     mx_tensor: MXTensor,
     num_tokens_per_expert: torch.Tensor,
@@ -278,6 +279,7 @@ def _triton_permute_bwd(
         original_cols,
         BLOCK_ROWS=256,
         BLOCK_COLS=256,
+        PADDING_VALUE=-1,
     )
     return output_buffer
 

--- a/torchao/prototype/moe_training/ep/unpermute.py
+++ b/torchao/prototype/moe_training/ep/unpermute.py
@@ -110,6 +110,7 @@ class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
         return grad_input, None, None
 
 
+@torch._dynamo.nonstrict_trace
 def unpermute_hp_fwd_mxfp8_bwd(
     input: torch.Tensor,
     permuted_indices: torch.Tensor,

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -875,6 +875,7 @@ def round_up(x, y):
 
 
 # Aliases for convenience/clarity
+@torch._dynamo.nonstrict_trace
 def _to_mxfp8_then_scaled_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,


### PR DESCRIPTION
Stacked PRs:
 * #3611
 * __->__#3606


--- --- ---

[mxfp8 moe training] add test for torch.compile

## Summary
- Add `@torch._dynamo.nonstrict_trace` to autograd functions to relax tensor metadata matching restrictions between forward output vs backward input
- Wrap `fill_indices_kernel` in custom op
- Pass process group name (instead of process group itself), then resolve/lookup the group by name inside the function, as a workaround until https://github.com/pytorch/pytorch/pull/172566 lands
- Add e2e test for forward and backward pass comparing outputs and grads for regular bf16 e2e EP pipline vs mxfp8 EP pipeline