### PR TITLE
[ROCm] Refine from_recipe_name to support mxfp8 on rocm.

### DIFF
--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -166,6 +166,7 @@ class MXLinearConfig(AOBaseConfig):
         elif recipe_name is MXLinearRecipeName.MXFP8_CUBLAS:
             return MXLinearConfig(
                 kernel_preference=KernelPreference.AUTO,
+                # CUDA quantization kernels are not supported on ROCm. Fallback to triton.
                 mxfp8_cast_kernel_choice=MXFP8Dim1CastKernelChoice.TRITON
                 if is_ROCM()
                 else MXFP8Dim1CastKernelChoice.CUDA,
@@ -173,6 +174,7 @@ class MXLinearConfig(AOBaseConfig):
         elif recipe_name is MXLinearRecipeName.MXFP8_CUBLAS_RCEIL:
             return MXLinearConfig(
                 kernel_preference=KernelPreference.AUTO,
+                # Quantization kernels with RCEIL are not supported on ROCm. Fallback to torch.
                 mxfp8_cast_kernel_choice=MXFP8Dim1CastKernelChoice.TORCH
                 if is_ROCM()
                 else MXFP8Dim1CastKernelChoice.CUDA,


### PR DESCRIPTION
## Summary
Support mxfp8 on gfx950 by refine `MXLinearConfig.from_recipe_name `

It will encounter error when called triton's quantize kernel with rceil on rocm because PTX instructions was called in kernel. So we chose implementation of `torch.compile` to workaround.

## TODO
* Implement quantize kernel with rceil mode in triton.