### PR TITLE
[PT2E][X86] Fix qconv-silu pattern match UT

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -784,7 +784,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._qconv2d_unary_test_helper(
             unary_op=torch.nn.SiLU(),
             mixed_bf16=True,
-            qconv_unary_matcher_nodes=15 if torch_version_at_least("2.11.0") else 11,
+            qconv_unary_matcher_nodes=15
+            if torch_version_at_least("2.11.0.dev")
+            else 11,
         )
 
     @skipIfNoDynamoSupport
@@ -804,7 +806,9 @@ class TestPatternMatcher(TestPatternMatcherBase):
         self._qconv2d_unary_test_helper(
             unary_op=torch.nn.SiLU(),
             mixed_bf16=True,
-            qconv_unary_matcher_nodes=15 if torch_version_at_least("2.11.0") else 11,
+            qconv_unary_matcher_nodes=15
+            if torch_version_at_least("2.11.0.dev")
+            else 11,
             is_fp8=True,
         )
 


### PR DESCRIPTION
The UTs fail with the commit https://github.com/pytorch/pytorch/commit/9ec206397c1d0b318105aa2fb732fb351c6e983c in torch. The commit changed the silu pattern in Inductor.
This PR updates the UT to match the new pattern.