### PR TITLE
[WIP] Upgrade AO to MSLK

### DIFF
--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - name: H100
             runs-on: linux.aws.h100
-            torch-spec: '--pre torch torchvision torchaudio fbgemm-gpu-genai --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision torchaudio mslk --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
     permissions:
@@ -50,5 +50,7 @@ jobs:
         pytest test/integration --verbose -s
         pytest test/dtypes/test_affine_quantized_float.py --verbose -s
         python test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+        python test/quantization/quantize_/workflows/int4/test_int4_tensor.py
+        python test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
         ./test/float8/test_everything_single_gpu.sh
         pytest test/prototype/mx_formats/ -s

--- a/.github/workflows/release_model.yml
+++ b/.github/workflows/release_model.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - name: H100
             runs-on: linux.aws.h100
-            torch-spec: '--pre torch torchvision torchaudio fbgemm-gpu-genai --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision torchaudio mslk --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
     permissions:

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ TorchAO is integrated into some of the leading open-source libraries including:
 * HuggingFace transformers with a [builtin inference backend](https://huggingface.co/docs/transformers/main/quantization/torchao) and [low bit optimizers](https://github.com/huggingface/transformers/pull/31865)
 * HuggingFace [diffusers](https://huggingface.co/docs/diffusers/main/en/quantization/torchao) best practices with `torch.compile` and TorchAO in a standalone repo [diffusers-torchao](https://github.com/huggingface/diffusers/blob/main/docs/source/en/quantization/torchao.md)
 * vLLM for LLM serving: [usage](https://docs.vllm.ai/en/latest/features/quantization/torchao.html), [detailed docs](https://docs.pytorch.org/ao/main/torchao_vllm_integration.html)
-* Integration with [FBGEMM](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai) for SOTA kernels on server GPUs
+* Integration with [MSLK](https://github.com/meta-pytorch/MSLK) for SOTA kernels on server GPUs
 * Integration with [ExecuTorch](https://github.com/pytorch/executorch/) for edge device deployment
 * Axolotl for [QAT](https://docs.axolotl.ai/docs/qat.html) and [PTQ](https://docs.axolotl.ai/docs/quantize.html)
 * TorchTitan for [float8 pre-training](https://github.com/pytorch/torchtitan/blob/main/docs/float8.md)

--- a/benchmarks/float8/float8_inference_roofline.py
+++ b/benchmarks/float8/float8_inference_roofline.py
@@ -756,7 +756,7 @@ def run(
                     config = Float8DynamicActivationFloat8WeightConfig(
                         granularity=PerRow(),
                         # for now, use TORCH. In the future might be interesting
-                        # to benchmark AUTO and FBGEMM.
+                        # to benchmark AUTO and MSLK.
                         kernel_preference=KernelPreference.TORCH,
                     )
                 elif recipe_name == "mxfp8_cublas":

--- a/docs/source/contributor_guide.rst
+++ b/docs/source/contributor_guide.rst
@@ -73,9 +73,9 @@ For some tensor subclasses, there could be multiple kernel choices for quantize 
 
 ``Float8Tensor`` for example, has:
 
-* ``KernelPreference.AUTO`` that will choose the most performant quantize and mm kernel based on hardware (H100 SM89 or SM90+), availability of libraries (whether ``fbgemm_gpu_genai`` is installed), granularity (per row or per tensor)
+* ``KernelPreference.AUTO`` that will choose the most performant quantize and mm kernel based on hardware (H100 SM89 or SM90+), availability of libraries (whether ``mslk`` is installed), granularity (per row or per tensor)
 * ``KernelPreference.TORCH`` will use torchao quantize op (``_choose_scale_float8`` and ``_quantize_affine_float8``) and ``_scaled_mm``
-* ``Kerenel.FBGEMM`` uses fbgemm quantize and mm op (``torch.ops.fbgemm.f8f8bf16_rowwise``)
+* ``Kerenel.MSLK`` uses MSLK quantize and mm op (``torch.ops.mslk.f8f8bf16_rowwise``)
 
 
 Flow

--- a/docs/source/quantization_overview.rst
+++ b/docs/source/quantization_overview.rst
@@ -16,7 +16,7 @@ Any quantization algorithm will be using some components from the above stack, f
 
 * dynamic quantization flow
 * `Float8Tensor <https://github.com/pytorch/ao/blob/main/torchao/quantization/quantize_/workflows/float8/float8_tensor.py>`__
-* `float8 activation + float8 weight fbgemm kernel <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L280>`__ and `triton quant primitive ops from fbgemm library <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L198>`__
+* `float8 activation + float8 weight mslk kernel <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L280>`__ and `triton quant primitive ops from mslk library <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L198>`__
 * ``torch.float8_e4m3fn`` dtype
 
 Basic DTypes
@@ -46,13 +46,13 @@ Quantization primitive ops means the operators used to convert between low preic
 
 There could be variations of the above to accommodate specific use cases, for example for static quantization we may have ``choose_qparams_affine_with_min_max`` that will choose quantization parameters based on min/max values derived from the observation process.
 
-There could be multiple versions of the op that is different by different kernel libraries that we can use in torchao, for example, for quantizing a bfloat16 Tensor to a raw float8 Tensor and scale: `_choose_scale_float8 <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quant_primitives.py#L2183>`__ and `_quantize_affine_float8 <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quant_primitives.py#L2282>`__ for torchao implementation, and `torch.ops.triton.quantize_fp8_row <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L198C27-L198C60>`__ from fbgemm library.
+There could be multiple versions of the op that is different by different kernel libraries that we can use in torchao, for example, for quantizing a bfloat16 Tensor to a raw float8 Tensor and scale: `_choose_scale_float8 <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quant_primitives.py#L2183>`__ and `_quantize_affine_float8 <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quant_primitives.py#L2282>`__ for torchao implementation, and `torch.ops.triton.quantize_fp8_row <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L198C27-L198C60>`__ from mslk library.
 
 Efficient kernels
 ~~~~~~~~~~~~~~~~~
 We'll also have efficient kernels that works with the low precision tensors, for example:
 
-* `torch.ops.fbgemm.f8f8bf16_rowwise <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L280>`__ (rowwise float8 activation and float8 weight matrix multiplication kernel in fbgemm library)
+* `torch.ops.mslk.f8f8bf16_rowwise <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/quantization/quantize_/workflows/float8/float8_tensor.py#L280>`__ (rowwise float8 activation and float8 weight matrix multiplication kernel in MSLK library)
 * `torch._scaled_mm <https://github.com/pytorch/ao/blob/6cfa47705f60ea614695b52b4b120ac5fd84d1cb/torchao/float8/inference.py#L116>`__ (float8 activation and float8 weight matrix multiplication kernel in PyTorch for both rowwise and tensorwise)
 * `int_matmul <https://github.com/pytorch/ao/blob/3e9746cf636e39e3c1ec0de6e0ef2e31f75c4c02/torchao/kernel/intmm.py#L90>`__ that takes two int8 tensors and outputs an int32 tensor
 * `int_scaled_matmul <https://github.com/pytorch/ao/blob/3e9746cf636e39e3c1ec0de6e0ef2e31f75c4c02/torchao/kernel/intmm.py#L107>`__ that does matmul and also applies a scale to the result.
@@ -168,7 +168,7 @@ You can also checkout the tutorial for `Quantized Training <https://github.com/p
 
 Case Study: How float8 dynamic activation and float8 weight quantization works in torchao?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To connect everything together, here is a more detailed walk through for float8 dynamic activation and float8 weight quantization in torchao (DEFAULT kernel preference, in H100, when fbgemm_gpu_genai library is installed):
+To connect everything together, here is a more detailed walk through for float8 dynamic activation and float8 weight quantization in torchao (DEFAULT kernel preference, in H100, when mslk library is installed):
 
 Quantization Flow: ``quantize_(model, Float8DynamicActivationFloat8WeightConfig())``
     * What happens: ``linear.weight = torch.nn.Parameter(Float8Tensor.from_hp(linear.weight), requires_grad=False)``
@@ -176,7 +176,7 @@ Quantization Flow: ``quantize_(model, Float8DynamicActivationFloat8WeightConfig(
     * quantized Tensor will be ``Float8Tensor``, a quantized tensor with derived dtype of scaled float8
 
 During Model Execution: model(input)
-    * ``torch.ops.fbgemm.f8f8bf16_rowwise`` is called on input, raw float8 weight and scale
+    * ``torch.ops.mslk.f8f8bf16_rowwise`` is called on input, raw float8 weight and scale
 
 During Quantization
 ###################
@@ -216,7 +216,7 @@ where input is a ``bfloat16`` Tensor, weight is a ``Float8Tensor``, it calls int
       wq = weight_tensor.qdata.contiguous()
       x_scale = input_tensor.scale
       w_scale = weight_tensor.scale
-      res = torch.ops.fbgemm.f8f8bf16_rowwise(
+      res = torch.ops.mslk.f8f8bf16_rowwise(
          xq,
          wq,
          x_scale,
@@ -224,7 +224,7 @@ where input is a ``bfloat16`` Tensor, weight is a ``Float8Tensor``, it calls int
       ).reshape(out_shape)
       return res
 
-The function first quantizes the input to be ``Float8Tensor``, then get the raw float Tensor and scale from both the input and weight Tensor: ``t.qdata``, ``t.scale``, and calls the fbgemm kernel to do the matrix multiplication for float8 dynamic quantization: ``torch.ops.fbgemm.f8f8bf16_rowwise``.
+The function first quantizes the input to be ``Float8Tensor``, then get the raw float Tensor and scale from both the input and weight Tensor: ``t.qdata``, ``t.scale``, and calls the mslk kernel to do the matrix multiplication for float8 dynamic quantization: ``torch.ops.mslk.f8f8bf16_rowwise``.
 
 During Save/Load
 ################

--- a/examples/quantize_llama_4.py
+++ b/examples/quantize_llama_4.py
@@ -14,7 +14,7 @@ import argparse
 import random
 from pathlib import Path
 
-import fbgemm_gpu
+import mslk
 import numpy as np
 import torch
 import transformers
@@ -104,16 +104,16 @@ def main(args):
     assert t_v >= "4.58", (
         f"transformers version {t_v} too old, please upgrade to a transformers version with https://github.com/huggingface/transformers/pull/41894"
     )
-    f_v = str(fbgemm_gpu.__version__)
+    f_v = str(mslk.__version__)
     if f_v.startswith("202"):
         # nightly version, such as '2025.11.22+cu128'
         assert f_v >= "2025.11.22", (
-            f"fbgemm_gpu nightly version  {f_v} too old, please upgrade to a nightly from 2025-11-22 or later"
+            f"mslk nightly version  {f_v} too old, please upgrade to a nightly from 2025-11-22 or later"
         )
     else:
         # stable version, such as '1.4.1'
-        assert f_v >= "1.5", (
-            f"fbgemm_gpu stable version  {f_v} too old, please upgrade to 1.5 or later"
+        assert f_v >= "1.0.0", (
+            f"mslk stable version  {f_v} too old, please upgrade to 1.0.0 or later"
         )
 
     model_name = "meta-llama/Llama-4-Scout-17B-16E-Instruct"

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_utils import (
 from torchao.prototype.awq import AWQConfig, AWQStep
 from torchao.prototype.int4_opaque_tensor import Int4WeightOnlyOpaqueTensorConfig
 from torchao.quantization import Int4WeightOnlyConfig, quantize_
-from torchao.utils import _is_fbgemm_gpu_genai_available, torch_version_at_least
+from torchao.utils import _is_mslk_available, torch_version_at_least
 
 
 class ToyLinearModel(torch.nn.Module):
@@ -61,7 +61,7 @@ class ToyLinearModel(torch.nn.Module):
 devices = ["cpu"]
 if (
     torch.cuda.is_available()
-    and _is_fbgemm_gpu_genai_available()
+    and _is_mslk_available()
     and torch_version_at_least("2.6.0")
 ):
     devices.append("cuda")

--- a/test/prototype/test_parq.py
+++ b/test/prototype/test_parq.py
@@ -45,7 +45,7 @@ from torchao.quantization.quant_api import (
 from torchao.quantization.quant_primitives import MappingType
 from torchao.quantization.quantize_.workflows import IntxUnpackedToInt8Tensor
 from torchao.utils import (
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     check_cpu_version,
     is_sm_at_least_90,
     torch_version_at_least,
@@ -332,9 +332,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
 
     @unittest.skipIf(not torch_version_at_least("2.8.0"), "Need pytorch >= 2.8.0")
     @unittest.skipIf(not is_sm_at_least_90(), "Need sm >= 90")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     @common_utils.parametrize("group_size", [32, 256])
     def test_int4_weight_only(self, group_size: int = 32):
         model = M(m=512, n=512).to(_DEVICE, dtype=torch.bfloat16)
@@ -369,9 +367,7 @@ class TestUnifTorchaoQuantizer(common_utils.TestCase):
 
     @unittest.skipIf(not torch_version_at_least("2.8.0"), "Need pytorch >= 2.8.0")
     @unittest.skipIf(not is_sm_at_least_90(), "Need sm >= 90")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     def test_int4_weight_only_e2e(self, group_size: int = 32):
         model = M(m=512, n=512, embedding=False).to(torch.bfloat16).to(_DEVICE)
 

--- a/test/prototype/test_tensor_conversion.py
+++ b/test/prototype/test_tensor_conversion.py
@@ -35,7 +35,7 @@ from torchao.quantization.quantize_.workflows.intx.intx_opaque_tensor import (
 )
 from torchao.quantization.utils import compute_error
 from torchao.utils import (
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     is_sm_at_least_90,
 )
 
@@ -193,9 +193,7 @@ def test_aarch64_conversion(dtype, granularity, bit_width, lead_dim):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA")
-@pytest.mark.skipif(
-    not _is_fbgemm_gpu_genai_available(), reason="Requires fbgemm-gpu-genai >= 1.2.0"
-)
+@pytest.mark.skipif(not _is_mslk_available(), reason="Requires mslk >= 1.0.0")
 def test_int4_tensor_conversion():
     m = torch.nn.Sequential(
         torch.nn.Linear(256, 512, dtype=torch.bfloat16, device="cuda")

--- a/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
@@ -24,7 +24,7 @@ from torchao.quantization import (
 )
 from torchao.quantization.utils import compute_error
 from torchao.utils import (
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     is_sm_at_least_90,
     torch_version_at_least,
 )
@@ -43,9 +43,7 @@ FP8_ACT_CONFIG = Float8DynamicActivationInt4WeightConfig(
 @unittest.skipIf(not torch_version_at_least("2.8.0"), "Need pytorch 2.8+")
 @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
 @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
-@unittest.skipIf(
-    not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-)
+@unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
 class TestInt4PreshuffledTensor(TestCase):
     def setUp(self):
         self.GPU_DEVICES = ["cuda"] if torch.cuda.is_available() else []

--- a/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_tensor.py
@@ -18,7 +18,7 @@ from torchao.quantization.quantize_.common import SupportsActivationPreScaling
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     is_sm_at_least_90,
     torch_version_at_least,
 )
@@ -27,9 +27,7 @@ from torchao.utils import (
 @unittest.skipIf(not torch_version_at_least("2.8.0"), "Need pytorch 2.8+")
 @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
 @unittest.skipIf(not is_sm_at_least_90(), "Nedd sm90+")
-@unittest.skipIf(
-    not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-)
+@unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
 class TestInt4Tensor(TorchAOIntegrationTestCase):
     def setUp(self):
         self.config = Int4WeightOnlyConfig(

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -98,7 +98,7 @@ from torchao.quantization.utils import (
 )
 from torchao.testing.utils import skip_if_xpu
 from torchao.utils import (
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     get_current_accelerator_device,
     is_fbcode,
     is_sm_at_least_89,
@@ -1938,9 +1938,7 @@ class TestQAT(TestCase):
 
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
     @unittest.skipIf(not is_sm_at_least_89(), "Need sm89+")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     def test_quantize_api_fp8_int4(self):
         """
         Test the following:
@@ -1954,9 +1952,7 @@ class TestQAT(TestCase):
         )
 
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     @unittest.skipIf(is_fbcode(), "cutlass cannot initialize")
     @parametrize("version", [1, 2])
     @parametrize(
@@ -2211,17 +2207,15 @@ class TestQAT(TestCase):
         optimizer.zero_grad()
 
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     @unittest.skipIf(is_fbcode(), "triton compilation error")
-    def test_fbgemm_fp8_primitives(self):
+    def test_mslk_fp8_primitives(self):
         """
         Compare numerics between:
-            (1) fbgemm_gpu.experimental.gen_ai.quantize.quantize_fp8_row
+            (1) mslk.quantize.triton.fp8_quantize.quantize_fp8_row
             (2) Our reference QAT version in `Float8FakeQuantizer`
         """
-        from fbgemm_gpu.experimental.gen_ai.quantize import quantize_fp8_row
+        from mslk.quantize.triton.fp8_quantize import quantize_fp8_row
 
         from torchao.quantization.quant_primitives import (
             _choose_scale_float8,
@@ -2251,22 +2245,20 @@ class TestQAT(TestCase):
         self.assertGreater(scale_sqnr, 50)
 
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     @unittest.skipIf(is_fbcode(), "triton compilation error")
-    def test_fbgemm_fp8_int4_preshuffled_primitives(self):
+    def test_mslk_fp8_int4_preshuffled_primitives(self):
         """
         Compare numerics between:
-            (1) fbgemm_gpu.experimental.gen_ai.quantize.quantize_int4_preshuffle
+            (1) mslk.quantize.shuffle.quantize_int4_preshuffle
             (2) Our reference QAT version in `Int4WeightFakeQuantizer`
         """
-        from fbgemm_gpu.experimental.gen_ai.quantize import (
+        from mslk.quantize.shuffle import (
             int4_row_quantize,
             pack_int4,
-            quantize_fp8_row,
             quantize_int4_preshuffle,
         )
+        from mslk.quantize.triton.fp8_quantize import quantize_fp8_row
 
         from torchao.quantization.quant_primitives import (
             _choose_scale_float8,
@@ -2311,7 +2303,7 @@ class TestQAT(TestCase):
 
         def shuffle_and_pack(t: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
             t = pack_int4(t.to(torch.int8))
-            return torch.ops.fbgemm.preshuffle_i4(t, scale.to(torch.float8_e4m3fn))[0]
+            return torch.ops.mslk.preshuffle_i4(t, scale.to(torch.float8_e4m3fn))[0]
 
         # First, sanity check that shuffle_and_pack(q2) == q1
         torch.testing.assert_close(q1, shuffle_and_pack(q2, scale2), atol=0, rtol=0)
@@ -2333,17 +2325,15 @@ class TestQAT(TestCase):
         self.assertGreater(sqnr_q1_q3_preshuffle, 32)
 
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
-    @unittest.skipIf(
-        not _is_fbgemm_gpu_genai_available(), "Requires fbgemm-gpu-genai >= 1.2.0"
-    )
+    @unittest.skipIf(not _is_mslk_available(), "Requires mslk >= 1.0.0")
     @unittest.skipIf(is_fbcode(), "triton compilation error")
-    def test_fbgemm_int4_weight_only_primitives(self):
+    def test_mslk_int4_weight_only_primitives(self):
         """
         Compare numerics between:
-            (1) fbgemm_gpu.experimental.gen_ai.quantize.int4_row_quantize_zp
+            (1) mslk.quantize.shuffle.int4_row_quantize_zp
             (2) Our reference QAT version in `Int4WeightFakeQuantizer`
         """
-        from fbgemm_gpu.experimental.gen_ai.quantize import (
+        from mslk.quantize.shuffle import (
             int4_row_quantize_zp,
             pack_int4,
             quantize_int4_preshuffle,
@@ -2364,18 +2354,18 @@ class TestQAT(TestCase):
         # (3) Reference implementation for QAT without the dequantize
         eps = 1e-6
         qmin, qmax = 0, 15
-        fbgemm_symmetric_qmax = 8
+        mslk_symmetric_qmax = 8
         w_grouped = x3.to(torch.float32).view(x3.shape[0], -1, group_size)
         max_val = torch.amax(w_grouped, dim=-1, keepdim=True)
         min_val = torch.amin(w_grouped, dim=-1, keepdim=True)
         scale3 = torch.clamp(max_val - min_val, min=eps) / qmax
         q3 = (w_grouped.sub(min_val).div(scale3)).round().clamp_(qmin, qmax)
-        q3 = q3 - fbgemm_symmetric_qmax
+        q3 = q3 - mslk_symmetric_qmax
         q3 = q3.view(x3.shape)
 
         def shuffle_and_pack(t: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
             t = pack_int4(t.to(torch.int8))
-            return torch.ops.fbgemm.preshuffle_i4(t, scale.to(torch.bfloat16))[0]
+            return torch.ops.mslk.preshuffle_i4(t, scale.to(torch.bfloat16))[0]
 
         # First, sanity check that shuffle_and_pack(q2) == q1
         torch.testing.assert_close(q1, shuffle_and_pack(q2, scale2), atol=0, rtol=0)

--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -52,8 +52,6 @@ __all__ = [
     "PackedLinearInt8DynamicActivationIntxWeightLayout",
     "to_affine_quantized_packed_linear_int8_dynamic_activation_intx_weight",
     "Int4XPULayout",
-    "to_fbgemm_fp8",
-    "FbgemmFp8Tensor",
     "Int8DynamicActInt4WeightCPULayout",
     "Int4GroupwisePreshuffleTensor",
 ]

--- a/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
+++ b/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
@@ -41,7 +41,7 @@ from torchao.quantization.quantize_.workflows import (
 from torchao.quantization.utils import get_block_size
 from torchao.utils import (
     TorchAOBaseTensor,
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     fill_defaults,
     is_sm_at_least_90,
     is_sm_at_least_100,
@@ -190,31 +190,31 @@ class PrototypeFloat8Tensor(TorchAOBaseTensor):
         kernel_choice = None
         if (
             kernel_preference == KernelPreference.AUTO
-            and _is_fbgemm_gpu_genai_available()
+            and _is_mslk_available()
             and is_sm_at_least_90()
             and isinstance(granularity, PerRow)
-            # fbgemm path only supports quantizing along the last dim
+            # mslk path only supports quantizing along the last dim
             and granularity.dim in (-1, len(hp_tensor.shape) - 1)
             and float8_dtype == torch.float8_e4m3fn
             and hp_value_lb is None
         ):
             # if kernel_preference is AUTO and per row quantization
-            # we'll use fbgemm quantize kernel for best performance
-            kernel_choice = "fbgemm"
-        elif kernel_preference == KernelPreference.FBGEMM:
-            # if user explicitly chose FBGEMM kernel preference, we'll also use fbgemm kernel
-            assert _is_fbgemm_gpu_genai_available() and is_sm_at_least_90(), (
-                "Specified fbgemm but fbgemm_gpu_genai is not installed or hardware is not >= SM 9.0 (>= H100)"
+            # we'll use mslk quantize kernel for best performance
+            kernel_choice = "mslk"
+        elif kernel_preference == KernelPreference.MSLK:
+            # if user explicitly chose MSLK kernel preference, we'll also use mslk kernel
+            assert _is_mslk_available() and is_sm_at_least_90(), (
+                "Specified mslk but mslk is not installed or hardware is not >= SM 9.0 (>= H100)"
             )
             assert hp_value_lb is None, (
-                "hp_value_lb should not be specified if with KerenelPreference.FBGEMM"
+                "hp_value_lb should not be specified if with KernelPreference.MSLK"
             )
-            kernel_choice = "fbgemm"
+            kernel_choice = "mslk"
         else:
             # fallback quantize kernel for everything else will be torch
             kernel_choice = "torch"
 
-        if kernel_choice == "fbgemm":
+        if kernel_choice == "mslk":
             assert hp_value_lb is None, f"{hp_value_lb=} is not supported"
             if hp_value_ub is not None:
                 maybe_hp_value_ub_tensor = torch.tensor(
@@ -236,11 +236,11 @@ class PrototypeFloat8Tensor(TorchAOBaseTensor):
                 )
                 # current error: torch.AcceleratorError: CUDA error: an illegal memory access was encountered
                 # TODO: enable after this is working
-                # data, scale = torch.ops.fbgemm.quantize_fp8_per_tensor(
+                # data, scale = torch.ops.mslk.quantize_fp8_per_tensor(
                 #     hp_tensor, num_tokens, scale_ub=maybe_hp_value_ub_tensor
                 # )
                 raise NotImplementedError(
-                    "Currently KernelPreference.FBGEMM does not work for per tensor float8 quant"
+                    "Currently KernelPreference.MSLK does not work for per tensor float8 quant"
                 )
         else:
             assert kernel_choice == "torch", f"Expected torch, got {kernel_choice}"
@@ -341,24 +341,22 @@ def _float8_addmm_impl(
         if weight_tensor.kernel_preference == KernelPreference.AUTO:
             kernel_choice = "torch"
             if (
-                _is_fbgemm_gpu_genai_available()
+                _is_mslk_available()
                 and is_sm_at_least_90()
                 and (not _is_128_128_scaled(weight_tensor))
             ):
-                kernel_choice = "fbgemm"
-        elif weight_tensor.kernel_preference == KernelPreference.FBGEMM:
-            kernel_choice = "fbgemm"
+                kernel_choice = "mslk"
+        elif weight_tensor.kernel_preference == KernelPreference.MSLK:
+            kernel_choice = "mslk"
         else:
             assert weight_tensor.kernel_preference == KernelPreference.TORCH, (
                 f"{weight_tensor.kernel_preference=} not handled"
             )
             kernel_choice = "torch"
 
-        if kernel_choice == "fbgemm":
-            assert _is_fbgemm_gpu_genai_available(), (
-                "Expected fbgemm_gpu_genai package to be installed"
-            )
-            assert is_sm_at_least_90(), "Expected SM90+ for fbgemm_gpu_genai"
+        if kernel_choice == "mslk":
+            assert _is_mslk_available(), "Expected mslk package to be installed"
+            assert is_sm_at_least_90(), "Expected SM90+ for mslk"
             mm_config = weight_tensor.mm_config
             assert mm_config is not None
             assert not _is_128_128_scaled(weight_tensor), "unimplemented"
@@ -369,7 +367,7 @@ def _float8_addmm_impl(
                 assert _is_rowwise_scaled(input_tensor), (
                     "Input tensor must be rowwise block size"
                 )
-                res = torch.ops.fbgemm.f8f8bf16_rowwise(
+                res = torch.ops.mslk.f8f8bf16_rowwise(
                     xq,
                     weight_tensor.qdata.t(),
                     input_tensor.scale,
@@ -380,7 +378,7 @@ def _float8_addmm_impl(
             else:
                 assert _is_tensorwise_scaled(weight_tensor)
                 assert _is_tensorwise_scaled(input_tensor)
-                res = torch.ops.fbgemm.f8f8bf16(
+                res = torch.ops.mslk.f8f8bf16(
                     xq,
                     weight_tensor.qdata.t(),
                     x_scale * weight_tensor.scale.t(),
@@ -415,7 +413,7 @@ def _float8_addmm_impl(
             if _is_128_128_scaled(weight_tensor):
                 # TODO(future PR): add testing for torch._scaled_mm with
                 # blockwise scaling on CUDA 12.9
-                # TODO(future PR): add fbgemm_gpu_genai path if available
+                # TODO(future PR): add mslk path if available
                 # TODO(future PR): proper out_dtype handling
                 assert _is_1_128_scaled(input_tensor), "unsupported"
                 res = blockwise_fp8_gemm(
@@ -463,9 +461,7 @@ def _(func, types, args, kwargs):
 
     kernel_preference = weight_tensor.kernel_preference
     assert kernel_preference != KernelPreference.TORCH, "bmm is not supported for TORCH"
-    assert _is_fbgemm_gpu_genai_available(), (
-        "bmm is not supported when fbgemm_gpu_genai is not installed"
-    )
+    assert _is_mslk_available(), "bmm is not supported when mslk is not installed"
 
     orig_act_size = input_tensor.size()
     act_quant_kwargs = weight_tensor.act_quant_kwargs
@@ -495,7 +491,7 @@ def _(func, types, args, kwargs):
 
         orig_out_features = b_data.shape[-1]
 
-        res = torch.ops.fbgemm.f8f8bf16_rowwise_batched(
+        res = torch.ops.mslk.f8f8bf16_rowwise_batched(
             a_data,
             b_data.transpose(-2, -1).contiguous(),
             a_scale,
@@ -526,9 +522,7 @@ def _quantize_and_scaled_conv3d(
     assert input_tensor.dim() == 5 and weight_tensor.dim() == 5, (
         "Only support 3D conv currently"
     )
-    assert _is_fbgemm_gpu_genai_available(), (
-        "quantized fp8 conv3d requires fbgemm_gpu_genai to be available"
-    )
+    assert _is_mslk_available(), "quantized fp8 conv3d requires mslk to be available"
     act_quant_kwargs = weight_tensor.act_quant_kwargs
     # quantize activation, if `act_quant_kwargs` is specified
     if act_quant_kwargs is not None:
@@ -541,20 +535,20 @@ def _quantize_and_scaled_conv3d(
     if isinstance(input_tensor, PrototypeFloat8Tensor):
         kernel_choice = None
         if weight_tensor.kernel_preference == KernelPreference.AUTO:
-            if _is_fbgemm_gpu_genai_available() and is_sm_at_least_100():
-                kernel_choice = "fbgemm"
+            if _is_mslk_available() and is_sm_at_least_100():
+                kernel_choice = "mslk"
             else:
                 raise NotImplementedError(
                     f"No available kernel choice for {weight_tensor.kernel_preference}"
                 )
-        elif weight_tensor.kernel_preference == KernelPreference.FBGEMM:
-            kernel_choice = "fbgemm"
+        elif weight_tensor.kernel_preference == KernelPreference.MSLK:
+            kernel_choice = "mslk"
         else:
             raise NotImplementedError(
                 f"No available kernel choice for {weight_tensor.kernel_preference}"
             )
 
-    assert kernel_choice == "fbgemm", "Only fbgemm kernel choice is supported currently"
+    assert kernel_choice == "mslk", "Only mslk kernel choice is supported currently"
     input_qdata = input_tensor.qdata
     weight_qdata = weight_tensor.qdata
 
@@ -566,7 +560,7 @@ def _quantize_and_scaled_conv3d(
     )
 
     # convert the input/weight to channels_last_3d memory_format here
-    # to make sure we can call the fbgemm conv
+    # to make sure we can call the mslk conv
     # kernel, it should be a no-op if both activation and weight are in
     # channels_last_3d memory_format
     input_qdata = input_qdata.contiguous(memory_format=torch.channels_last_3d)
@@ -582,7 +576,7 @@ def _quantize_and_scaled_conv3d(
 
     input_scale = input_tensor.scale
     weight_scale = weight_tensor.scale
-    output = torch.ops.fbgemm.f8f8bf16_conv(
+    output = torch.ops.mslk.f8f8bf16_conv(
         input_qdata,
         weight_qdata,
         input_scale * weight_scale,
@@ -596,7 +590,7 @@ def _quantize_and_scaled_conv3d(
     # aligning the semantics with bfloat16 conv ops, the
     # output should use contiguous_format if none of the input/weight
     # are in channels_last format, otherwise, the output is already
-    # in channels_last format (from fbgemm kernel)
+    # in channels_last format (from mslk kernel)
     if not (is_input_channels_last or is_weight_channels_last):
         output = output.contiguous()
     return output

--- a/torchao/prototype/tensor_conversion/api.py
+++ b/torchao/prototype/tensor_conversion/api.py
@@ -16,7 +16,7 @@ from torchao.quantization import (
 )
 from torchao.utils import (
     TorchAOBaseTensor,
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
     is_sm_at_least_90,
 )
 
@@ -190,7 +190,7 @@ def convert_to_packed_tensor_based_on_current_hardware(tensor: TorchAOBaseTensor
     if (
         isinstance(tensor, Int4Tensor)
         and is_device("cuda", tensor.device)
-        and _is_fbgemm_gpu_genai_available()
+        and _is_mslk_available()
         and is_sm_at_least_90()
     ):
         return Int4PreshuffledTensor.from_int4_tensor(tensor)

--- a/torchao/quantization/pt2e/observer.py
+++ b/torchao/quantization/pt2e/observer.py
@@ -1958,7 +1958,7 @@ default_per_channel_weight_observer = PerChannelMinMaxObserver.with_args(
 )
 """
 Default per-channel weight observer, usually used on backends where per-channel
-weight quantization is supported, such as `fbgemm`.
+weight quantization is supported, such as `mslk`.
 """
 
 per_channel_weight_observer_range_neg_127_to_127 = PerChannelMinMaxObserver.with_args(

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -82,9 +82,9 @@ class Float8FakeQuantizeConfig(FakeQuantizeConfigBase):
 class Int4WeightFakeQuantizeConfig(FakeQuantizeConfigBase):
     """
     Config for pint4 weight fake quantization that targets the numerics in the following preshuffled kernel:
-        torch.ops.fbgemm.f8i4bf16_shuffled
-        torch.ops.fbgemm.bf16i4bf16_shuffled
-        torch.ops.fbgemm.bf16i4bf16_rowwise
+        torch.ops.mslk.f8i4bf16_shuffled
+        torch.ops.mslk.bf16i4bf16_shuffled
+        torch.ops.mslk.bf16i4bf16_rowwise
 
     Currently this only supports float8 input activations. It is expected to be used in conjunction with
     :class:`~torchao.quantization.Float8DynamicActivationInt4WeightConfig`. In the future, we may extend

--- a/torchao/quantization/quantize_/common/kernel_preference.py
+++ b/torchao/quantization/quantize_/common/kernel_preference.py
@@ -26,9 +26,9 @@ class KernelPreference(str, Enum):
     """
     TORCH = "torch"
 
-    """Use quantize and quantized mm kernels from fbgemm_gpu_genai library, requires fbgemm_gpu_genai library
+    """Use quantize and quantized mm kernels from mslk library, requires mslk library
     """
-    FBGEMM = "fbgemm"
+    MSLK = "mslk"
 
     """Emulates gemm_lowp(A, B) with gemm_fp32(A.dequantize(), B.dequantize()).
     Intended use cases are:

--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -40,7 +40,6 @@ from torchao.quantization.quantize_.common import (
 from torchao.quantization.utils import get_block_size
 from torchao.utils import (
     TorchAOBaseTensor,
-    _is_fbgemm_gpu_genai_available,
     _is_mslk_available,
     fill_defaults,
     is_sm_at_least_90,
@@ -180,31 +179,31 @@ class Float8Tensor(TorchAOBaseTensor):
         kernel_choice = None
         if (
             kernel_preference == KernelPreference.AUTO
-            and _is_fbgemm_gpu_genai_available()
+            and _is_mslk_available()
             and is_sm_at_least_90()
             and isinstance(granularity, PerRow)
-            # fbgemm path only supports quantizing along the last dim
+            # mslk path only supports quantizing along the last dim
             and granularity.dim in (-1, len(hp_tensor.shape) - 1)
             and float8_dtype == torch.float8_e4m3fn
             and hp_value_lb is None
         ):
             # if kernel_preference is AUTO and per row quantization
-            # we'll use fbgemm quantize kernel for best performance
-            kernel_choice = "fbgemm"
-        elif kernel_preference == KernelPreference.FBGEMM:
-            # if user explicitly chose FBGEMM kernel preference, we'll also use fbgemm kernel
-            assert _is_fbgemm_gpu_genai_available() and is_sm_at_least_90(), (
-                "Specified fbgemm but fbgemm_gpu_genai is not installed or hardware is not >= SM 9.0 (>= H100)"
+            # we'll use mslk quantize kernel for best performance
+            kernel_choice = "mslk"
+        elif kernel_preference == KernelPreference.MSLK:
+            # if user explicitly chose MSLK kernel preference, we'll also use mslk kernel
+            assert _is_mslk_available() and is_sm_at_least_90(), (
+                "Specified mslk but mslk is not installed or hardware is not >= SM 9.0 (>= H100)"
             )
             assert hp_value_lb is None, (
-                "hp_value_lb should not be specified if with KerenelPreference.FBGEMM"
+                "hp_value_lb should not be specified if with KernelPreference.MSLK"
             )
-            kernel_choice = "fbgemm"
+            kernel_choice = "mslk"
         else:
             # fallback quantize kernel for everything else will be torch
             kernel_choice = "torch"
 
-        if kernel_choice == "fbgemm":
+        if kernel_choice == "mslk":
             assert hp_value_lb is None, f"{hp_value_lb=} is not supported"
             if hp_value_ub is not None:
                 maybe_hp_value_ub_tensor = torch.tensor(
@@ -226,11 +225,11 @@ class Float8Tensor(TorchAOBaseTensor):
                 )
                 # current error: torch.AcceleratorError: CUDA error: an illegal memory access was encountered
                 # TODO: enable after this is working
-                # data, scale = torch.ops.fbgemm.quantize_fp8_per_tensor(
+                # data, scale = torch.ops.mslk.quantize_fp8_per_tensor(
                 #     hp_tensor, num_tokens, scale_ub=maybe_hp_value_ub_tensor
                 # )
                 raise NotImplementedError(
-                    "Currently KernelPreference.FBGEMM does not work for per tensor float8 quant"
+                    "Currently KernelPreference.MSLK does not work for per tensor float8 quant"
                 )
         else:
             assert kernel_choice == "torch", f"Expected torch, got {kernel_choice}"
@@ -349,24 +348,22 @@ def _float8_addmm_impl(
         if weight_tensor.kernel_preference == KernelPreference.AUTO:
             kernel_choice = "torch"
             if (
-                _is_fbgemm_gpu_genai_available()
+                _is_mslk_available()
                 and is_sm_at_least_90()
                 and (not _is_128_128_scaled(weight_tensor))
             ):
-                kernel_choice = "fbgemm"
-        elif weight_tensor.kernel_preference == KernelPreference.FBGEMM:
-            kernel_choice = "fbgemm"
+                kernel_choice = "mslk"
+        elif weight_tensor.kernel_preference == KernelPreference.MSLK:
+            kernel_choice = "mslk"
         else:
             assert weight_tensor.kernel_preference == KernelPreference.TORCH, (
                 f"{weight_tensor.kernel_preference=} not handled"
             )
             kernel_choice = "torch"
 
-        if kernel_choice == "fbgemm":
-            assert _is_fbgemm_gpu_genai_available(), (
-                "Expected fbgemm_gpu_genai package to be installed"
-            )
-            assert is_sm_at_least_90(), "Expected SM90+ for fbgemm_gpu_genai"
+        if kernel_choice == "mslk":
+            assert _is_mslk_available(), "Expected mslk package to be installed"
+            assert is_sm_at_least_90(), "Expected SM90+ for mslk"
             mm_config = weight_tensor.mm_config
             assert mm_config is not None
             assert not _is_128_128_scaled(weight_tensor), "unimplemented"
@@ -377,7 +374,7 @@ def _float8_addmm_impl(
                 assert _is_rowwise_scaled(input_tensor), (
                     "Input tensor must be rowwise block size"
                 )
-                res = torch.ops.fbgemm.f8f8bf16_rowwise(
+                res = torch.ops.mslk.f8f8bf16_rowwise(
                     xq,
                     weight_tensor.qdata.t(),
                     input_tensor.scale,
@@ -388,7 +385,7 @@ def _float8_addmm_impl(
             else:
                 assert _is_tensorwise_scaled(weight_tensor)
                 assert _is_tensorwise_scaled(input_tensor)
-                res = torch.ops.fbgemm.f8f8bf16(
+                res = torch.ops.mslk.f8f8bf16(
                     xq,
                     weight_tensor.qdata.t(),
                     x_scale * weight_tensor.scale.t(),
@@ -423,7 +420,7 @@ def _float8_addmm_impl(
             if _is_128_128_scaled(weight_tensor):
                 # TODO(future PR): add testing for torch._scaled_mm with
                 # blockwise scaling on CUDA 12.9
-                # TODO(future PR): add fbgemm_gpu_genai path if available
+                # TODO(future PR): add mslk path if available
                 # TODO(future PR): proper out_dtype handling
                 assert _is_1_128_scaled(input_tensor), "unsupported"
                 res = blockwise_fp8_gemm(
@@ -471,9 +468,7 @@ def _(func, types, args, kwargs):
 
     kernel_preference = weight_tensor.kernel_preference
     assert kernel_preference != KernelPreference.TORCH, "bmm is not supported for TORCH"
-    assert _is_fbgemm_gpu_genai_available(), (
-        "bmm is not supported when fbgemm_gpu_genai is not installed"
-    )
+    assert _is_mslk_available(), "bmm is not supported when mslk is not installed"
 
     orig_act_size = input_tensor.size()
     act_quant_kwargs = weight_tensor.act_quant_kwargs
@@ -501,7 +496,7 @@ def _(func, types, args, kwargs):
 
         orig_out_features = b_data.shape[-1]
 
-        res = torch.ops.fbgemm.f8f8bf16_rowwise_batched(
+        res = torch.ops.mslk.f8f8bf16_rowwise_batched(
             a_data,
             b_data.transpose(-2, -1).contiguous(),
             a_scale,
@@ -549,8 +544,8 @@ def _quantize_and_scaled_conv3d(
                 raise NotImplementedError(
                     f"No available kernel choice for {weight_tensor.kernel_preference}"
                 )
-        elif weight_tensor.kernel_preference == KernelPreference.FBGEMM:
-            kernel_choice = "fbgemm"
+        elif weight_tensor.kernel_preference == KernelPreference.MSLK:
+            kernel_choice = "mslk"
         else:
             raise NotImplementedError(
                 f"No available kernel choice for {weight_tensor.kernel_preference}"
@@ -568,7 +563,7 @@ def _quantize_and_scaled_conv3d(
     )
 
     # convert the input/weight to channels_last_3d memory_format here
-    # to make sure we can call the fbgemm conv
+    # to make sure we can call the mslk conv
     # kernel, it should be a no-op if both activation and weight are in
     # channels_last_3d memory_format
     input_qdata = input_qdata.contiguous(memory_format=torch.channels_last_3d)
@@ -594,7 +589,7 @@ def _quantize_and_scaled_conv3d(
     # aligning the semantics with bfloat16 conv ops, the
     # output should use contiguous_format if none of the input/weight
     # are in channels_last format, otherwise, the output is already
-    # in channels_last format (from fbgemm kernel)
+    # in channels_last format (from mslk kernel)
     if not (is_input_channels_last or is_weight_channels_last):
         output = output.contiguous()
     return output

--- a/torchao/quantization/quantize_/workflows/int4/int4_packing_format.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_packing_format.py
@@ -27,7 +27,7 @@ class Int4PackingFormat(str, Enum):
     PLAIN = "plain"
 
     """
-    preshuffled is referring to the preshuffled format used by fbgemm kernels
+    preshuffled is referring to the preshuffled format used by mslk kernels
     """
     PRESHUFFLED = "preshuffled"
 

--- a/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_preshuffled_tensor.py
@@ -12,7 +12,7 @@ import torch
 from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
 from torchao.utils import (
     TorchAOBaseTensor,
-    _is_fbgemm_gpu_genai_available,
+    _is_mslk_available,
 )
 
 __all__ = [
@@ -22,15 +22,12 @@ __all__ = [
 aten = torch.ops.aten
 
 
-if not _is_fbgemm_gpu_genai_available():
+if not _is_mslk_available():
     quantize_int4_preshuffle = None
     quantize_fp8_row = None
-    pack_int4 = None
 else:
-    from fbgemm_gpu.experimental.gen_ai.quantize import (
-        quantize_fp8_row,
-        quantize_int4_preshuffle,
-    )
+    from mslk.quantize.shuffle import quantize_int4_preshuffle
+    from mslk.quantize.triton.fp8_quantize import quantize_fp8_row
 
 
 class Int4PreshuffledTensor(TorchAOBaseTensor):
@@ -39,7 +36,7 @@ class Int4PreshuffledTensor(TorchAOBaseTensor):
 
     Tensor Attributes:
         qdata: preshuffled and packed int4 weight, either 2D (N, K/2) or 3D (B, N, K/2), last dimension is packed
-               preshuffling is specific to fbgemm kernels, see Note for motivation, detailed layout doc is WIP
+               preshuffling is specific to mslk kernels, see Note for motivation, detailed layout doc is WIP
         for bf16 activation:
             group_scale: (K/group_size, N) for 2D Tensor, (B, K/group_size, N) for 3D Tensor, where B is batch size,
                    dtype is the same as the original Tensor dtype
@@ -55,7 +52,7 @@ class Int4PreshuffledTensor(TorchAOBaseTensor):
         block_size: the block size for quantization, representing the granularity, for example groupwise quantization will have block_size (1, group_size)
         shape: shape of the original Tensor
 
-    Note on Details for preshuffle for fbgemm kernel:
+    Note on Details for preshuffle for mslk kernel:
 
       We use WGMMA instruction for efficient matrix multiplication in H100 Tensor Core.
       To address a major inefficiency in how WGMMA tiles are loaded into shared memory before
@@ -138,7 +135,7 @@ class Int4PreshuffledTensor(TorchAOBaseTensor):
         )
 
         if quantize_int4_preshuffle is None:
-            raise ImportError("Requires fbgemm-gpu-genai >= 1.2.0")
+            raise ImportError("Requires mslk >= 1.0.0")
 
         assert all(x == 1 for x in block_size[:-1]) and block_size[-1] != 1, (
             "Only groupwise quant is supported right now"
@@ -204,7 +201,7 @@ class Int4PreshuffledTensor(TorchAOBaseTensor):
         group_scale = group_scale.to(torch.bfloat16)
         group_zero = group_zero.to(torch.bfloat16)
         # pack weights and scales into efficient preshuffled format
-        preshuffled_qdata, group_scale = torch.ops.fbgemm.preshuffle_i4(
+        preshuffled_qdata, group_scale = torch.ops.mslk.preshuffle_i4(
             qdata, group_scale
         )
         return Int4PreshuffledTensor(
@@ -237,7 +234,7 @@ def _(func, types, args, kwargs):
     if weight_tensor.group_zero is not None:
         # bf16 activation
         group_zero = weight_tensor.group_zero.contiguous()
-        res = torch.ops.fbgemm.bf16i4bf16_shuffled(
+        res = torch.ops.mslk.bf16i4bf16_shuffled(
             input_tensor, wq, group_scale, group_zero
         )
     else:
@@ -245,9 +242,7 @@ def _(func, types, args, kwargs):
         assert weight_tensor.row_scale is not None
         row_scale = weight_tensor.row_scale.contiguous()
         xq, x_scale = quantize_fp8_row(input_tensor)
-        res = torch.ops.fbgemm.f8i4bf16_shuffled(
-            xq, wq, x_scale, row_scale, group_scale
-        )
+        res = torch.ops.mslk.f8i4bf16_shuffled(xq, wq, x_scale, row_scale, group_scale)
 
     res = res.reshape(*orig_input_size[:-1], orig_out_features)
     if bias is not None:
@@ -269,7 +264,7 @@ def _(func, types, args, kwargs):
     if weight_tensor.group_zero is not None:
         # bfloat16 activation
         group_zero = weight_tensor.group_zero.contiguous()
-        res = torch.ops.fbgemm.bf16i4bf16_shuffled_batched(
+        res = torch.ops.mslk.bf16i4bf16_shuffled_batched(
             input_tensor, wq, group_scale, group_zero
         )
     else:
@@ -277,13 +272,13 @@ def _(func, types, args, kwargs):
         assert weight_tensor.row_scale is not None
         row_scale = weight_tensor.row_scale.contiguous()
         xq, x_scale = quantize_fp8_row(input_tensor)
-        # From: https://github.com/pytorch/FBGEMM/blob/ba8f2b7adb90e096cff8818716f7cc3587030f70/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py#L1654
+        # From: https://github.com/meta-pytorch/MSLK/blob/cdc8e712ca324f896faa44f84421e292b09b4e49/bench/gemm/gemm_ops.py#L1945-L1968
         assert xq.dim() == 3
         B, M, _ = xq.shape
         _, N, _ = wq.shape
         res = torch.empty((B, M, N), device=xq.device, dtype=torch.bfloat16)
         for i in range(B):
-            res[i] = torch.ops.fbgemm.f8i4bf16_shuffled(
+            res[i] = torch.ops.mslk.f8i4bf16_shuffled(
                 xq[i], wq[i], x_scale[i], row_scale[i], group_scale[i]
             )
 

--- a/torchao/quantization/quantize_/workflows/int4/int4_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int4/int4_tensor.py
@@ -20,7 +20,7 @@ aten = torch.ops.aten
 
 
 try:
-    from fbgemm_gpu.experimental.gen_ai.quantize import int4_row_quantize_zp, pack_int4
+    from mslk.quantize.shuffle import int4_row_quantize_zp, pack_int4
 except:
     int4_row_quantize_zp = None
     pack_int4 = None
@@ -98,7 +98,7 @@ class Int4Tensor(TorchAOBaseTensor):
             f"Expecting the length of block_size to be equal to the dimension of the weight, got {block_size=} and {w.ndim=}"
         )
         if int4_row_quantize_zp is None:
-            raise ImportError("Requires fbgemm-gpu-genai >= 1.2.0")
+            raise ImportError("Requires mslk >= 1.0.0")
 
         assert all(x == 1 for x in block_size[:-1]) and block_size[-1] != 1, (
             "Only groupwise quant is supported right now"
@@ -158,7 +158,7 @@ def _(func, types, args, kwargs):
     orig_out_features = weight_tensor.shape[-2]
 
     input_tensor = input_tensor.reshape(-1, input_tensor.shape[-1])
-    res = torch.ops.fbgemm.bf16i4bf16_rowwise(
+    res = torch.ops.mslk.bf16i4bf16_rowwise(
         input_tensor,
         weight_tensor.qdata,
         weight_tensor.scale,
@@ -184,7 +184,7 @@ def _(func, types, args, kwargs):
 
     orig_act_size = input_tensor.size()
     orig_out_features = weight_tensor.shape[-2]
-    res = torch.ops.fbgemm.bf16i4bf16_rowwise_batched(
+    res = torch.ops.mslk.bf16i4bf16_rowwise_batched(
         input_tensor,
         weight_tensor.qdata,
         weight_tensor.scale,

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1133,28 +1133,14 @@ def is_package_at_least(package_name: str, min_version: str):
     return version(package_name) >= min_version
 
 
-def _is_fbgemm_gpu_genai_available():
-    # TODO: use is_package_at_least("fbgemm_gpu", "1.2.0") when
-    # https://github.com/pytorch/FBGEMM/issues/4198 is fixed
-    if (
-        importlib.util.find_spec("fbgemm_gpu") is None
-        or importlib.util.find_spec("fbgemm_gpu.experimental") is None
-    ):
+def _is_mslk_available():
+    has_mslk = importlib.util.find_spec("mslk") is not None or is_fbcode()
+    if not has_mslk:
         return False
 
-    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
-
-    if not is_fbcode() and fbgemm_gpu.__version__ < "1.2.0":
-        return False
+    import mslk  # noqa: F401
 
     return True
-
-
-def _is_mslk_available():
-    if is_fbcode():
-        return True
-
-    return importlib.util.find_spec("mslk") is not None
 
 
 class DummyModule(torch.nn.Module):


### PR DESCRIPTION
Summary: We are deprecating the [FBGEMM GenAI](https://github.com/pytorch/FBGEMM/tree/main/fbgemm_gpu/experimental/gen_ai) project and moving to [meta-pytorch/MSLK](https://github.com/meta-pytorch/MSLK). Note this does not impact FBGEMM CPU. In this diff we upgrade TorchAO to use MSLK instead of FBGEMM GenAI. We plan to make this ready for PyTorch 2.10 release (with corresponding MSLK 1.0.0).

Testing: Updated the CI scripts to use mslk instead of fbgemm-gpu-genai, also added `test_int4_tensor.py` and `test_int4_preshuffled_tensor.py` to the test list.

Differential Revision: D90028347


