### PR TITLE
[xpu][test] Remove None in get_current_accelerator_device

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -155,8 +155,6 @@ def get_available_devices():
 def get_current_accelerator_device():
     if torch.accelerator.is_available():
         return torch.accelerator.current_accelerator()
-    else:
-        return None
 
 
 def get_compute_capability():


### PR DESCRIPTION
Per discussion in https://github.com/pytorch/ao/pull/3500/files#r2684303154, we try to remove the None branch for ```get_current_accelerator_device```