### PR TITLE
[ROCm] bring some mxfp8 quantization unit test back

### DIFF
--- a/benchmarks/mx_formats/cast_bench.py
+++ b/benchmarks/mx_formats/cast_bench.py
@@ -118,6 +118,7 @@ def run(
         "dim1_mxfp8_floor",
         "dim1_mxfp8_rceil",
         "dim1_mxfp8_triton_floor",
+        "dim1_mxfp8_triton_rceil",
         "dim1_mxfp8_cuda_floor",
         "dim1_mxfp8_cuda_rceil",
     )
@@ -350,12 +351,41 @@ def run(
         bps = (bytes_r + bytes_w) / (time_us / 1e6)
 
     elif mode == "dim1_mxfp8_triton_floor":
-        y_d1, s_d1 = triton_to_mxfp8_dim1(x, inner_block_size=BLOCK_SIZE)
+        y_d1, s_d1 = triton_to_mxfp8_dim1(
+            x, inner_block_size=BLOCK_SIZE, scaling_mode="floor"
+        )
 
         for _ in range(2):
-            __ = triton_to_mxfp8_dim1(x, inner_block_size=BLOCK_SIZE)
+            __ = triton_to_mxfp8_dim1(
+                x, inner_block_size=BLOCK_SIZE, scaling_mode="floor"
+            )
         time_us = benchmark_cuda_function_in_microseconds(
-            lambda x, b: triton_to_mxfp8_dim1(x, inner_block_size=BLOCK_SIZE),
+            lambda x, b: triton_to_mxfp8_dim1(
+                x, inner_block_size=BLOCK_SIZE, scaling_mode="floor"
+            ),
+            x,
+            BLOCK_SIZE,
+        )
+
+        assert y_d1.dtype == torch.float8_e4m3fn
+        assert s_d1.dtype == torch.float8_e8m0fnu
+        bytes_r = x.numel() * bytes_per_el_bf16
+        bytes_w = (y_d1.numel() + s_d1.numel()) * bytes_per_el_fp8
+        bps = (bytes_r + bytes_w) / (time_us / 1e6)
+
+    elif mode == "dim1_mxfp8_triton_rceil":
+        y_d1, s_d1 = triton_to_mxfp8_dim1(
+            x, inner_block_size=BLOCK_SIZE, scaling_mode="rceil"
+        )
+
+        for _ in range(2):
+            __ = triton_to_mxfp8_dim1(
+                x, inner_block_size=BLOCK_SIZE, scaling_mode="rceil"
+            )
+        time_us = benchmark_cuda_function_in_microseconds(
+            lambda x, b: triton_to_mxfp8_dim1(
+                x, inner_block_size=BLOCK_SIZE, scaling_mode="rceil"
+            ),
             x,
             BLOCK_SIZE,
         )

--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -45,6 +45,7 @@ from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_dtyp
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import (
     is_cuda_version_at_least,
+    is_MI350,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -444,8 +445,8 @@ def triton_to_mxfp8_dim0_reference(
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="mxfp8 in triton requires CUDA capability 10.0 or greater",
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.parametrize("M", (128, 256))
 @pytest.mark.parametrize("K", (128, 256))
@@ -466,8 +467,8 @@ def test_triton_mxfp8_dim1_randn(M, K, scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="mxfp8 requires CUDA capability 10.0 or greater",
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.parametrize("M", (128, 256))
 @pytest.mark.parametrize("K", (128, 256))
@@ -490,8 +491,8 @@ def test_triton_mxfp8_dim0_randn(M, K, scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="mxfp8 requires CUDA capability 10.0 or greater",
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
@@ -513,8 +514,8 @@ def test_triton_mxfp8_dim0_zeros(scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(),
-    reason="mxfp8 requires CUDA capability 10.0 or greater",
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.parametrize("M", (128, 256))
 @pytest.mark.parametrize("K", (128, 256))

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -20,6 +20,8 @@ from torchao.prototype.custom_fp_utils import (
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.utils import (
     is_cuda_version_at_least,
+    is_MI350,
+    is_ROCM,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -681,8 +683,8 @@ _triton_kernels_available = (
     torch_version_at_least("2.7.0")
     and has_triton()
     and torch.cuda.is_available()
-    and is_sm_at_least_100()
-    and is_cuda_version_at_least(12, 8)
+    and (is_sm_at_least_100() and is_cuda_version_at_least(12, 8))
+    or (is_ROCM() and is_MI350())
 )
 
 if _triton_kernels_available:
@@ -690,26 +692,25 @@ if _triton_kernels_available:
     import triton.language as tl
     from torch.library import triton_op, wrap_triton
 
+    IS_ROCM = tl.constexpr(is_ROCM())
+
     @triton.jit
-    def _triton_calculate_scale(x, axis, SCALING_MODE: tl.constexpr):
+    def _triton_calculate_scale_rceil(x, axis, USE_PTX: tl.constexpr):
         # There is no good support for accessing globals from a jit'ed triton
         # function, so we redefine them here. Since this is prototype code which
         # we plan to remove after torch.compile catches up, this is fine.
-        target_max_pow2 = 8
         e8m0_exponent_bias = 127
-        bf16_mbits = 7
-        bf16_exp_bias = 127
         fp32_mbits = 23
 
         # Find the maximum absolute value for each row
         max_abs = tl.max(x, axis=axis)
 
-        # Compute e8m0 biased scale using either RCEIL or FLOOR rounding.
-        if SCALING_MODE == "rceil":
+        F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
+
+        if USE_PTX:
             # RCEIL scaling mode using PTX instruction supported on sm100.
             # The input should be: amax / 448.0
             # where 448.0 is the max representable value in FP8 E4M3 format.
-            F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
             scale_input = max_abs.to(tl.float32) * F8E4M3_MAX_RCP
 
             # The PTX instruction outputs a packed uint16 where:
@@ -725,27 +726,70 @@ if _triton_kernels_available:
                 pack=1,
             ).to(tl.uint8)
         else:
-            tl.static_assert(SCALING_MODE == "floor")
-
-            # Original floor implementation
-            # Calculate the e8m0 scale by extracting the exponent (floor)
-            max_abs = max_abs.to(tl.bfloat16)
-            max_abs_int16 = max_abs.to(tl.int16, bitcast=True)
-            extracted_pow2 = (
-                (max_abs_int16 >> bf16_mbits) & 0b11111111
-            ) - bf16_exp_bias
-            extracted_pow2 = extracted_pow2 - target_max_pow2
-            scale_e8m0_unbiased = extracted_pow2.to(tl.bfloat16)
+            # Original recil implementation described in https://docs.nvidia.com/cuda/cublas/#d-block-quantization
+            descale = max_abs * F8E4M3_MAX_RCP
 
             # Clamp to exponents that can be represented in e8m0
-            # Add 1 to capture NaNs
             scale_e8m0_unbiased = tl.clamp(
-                scale_e8m0_unbiased, -1 * e8m0_exponent_bias, e8m0_exponent_bias + 1
+                tl.ceil(tl.log2(descale)),
+                min=-1 * e8m0_exponent_bias,
+                max=e8m0_exponent_bias,
             )
 
             # Create the biased e8m0 representation and cast it to 8 bits
-            scale_e8m0_biased = scale_e8m0_unbiased + e8m0_exponent_bias
+            # Set NaN values to 0xFF
+            is_nan = descale != descale
+            scale_e8m0_biased = tl.where(is_nan, 0xFF, scale_e8m0_unbiased + 127)
             scale_e8m0_biased = scale_e8m0_biased.to(tl.uint8)
+
+        # TODO(future PR): add NaN handling here,
+        # https://github.com/pytorch/pytorch/pull/100572 will likely be useful to
+        # get proper NaN propagation working
+        # Calculate the scale in floating point.
+        scale_fp = (scale_e8m0_biased.to(tl.int32) << fp32_mbits).to(
+            tl.float32, bitcast=True
+        )
+
+        fp32_exp_bias = 127.0
+        fp32_min_normal = tl.exp2(-fp32_exp_bias + 1)
+        scale_fp = tl.clamp(scale_fp, min=fp32_min_normal, max=float("inf"))
+
+        return scale_fp, scale_e8m0_biased
+
+    @triton.jit
+    def _triton_calculate_scale_floor(
+        x,
+        axis,
+    ):
+        # There is no good support for accessing globals from a jit'ed triton
+        # function, so we redefine them here. Since this is prototype code which
+        # we plan to remove after torch.compile catches up, this is fine.
+        target_max_pow2 = 8
+        e8m0_exponent_bias = 127
+        bf16_mbits = 7
+        bf16_exp_bias = 127
+        fp32_mbits = 23
+
+        # Find the maximum absolute value for each row
+        max_abs = tl.max(x, axis=axis)
+
+        # Original floor implementation
+        # Calculate the e8m0 scale by extracting the exponent (floor)
+        max_abs = max_abs.to(tl.bfloat16)
+        max_abs_int16 = max_abs.to(tl.int16, bitcast=True)
+        extracted_pow2 = ((max_abs_int16 >> bf16_mbits) & 0b11111111) - bf16_exp_bias
+        extracted_pow2 = extracted_pow2 - target_max_pow2
+        scale_e8m0_unbiased = extracted_pow2.to(tl.bfloat16)
+
+        # Clamp to exponents that can be represented in e8m0
+        # Add 1 to capture NaNs
+        scale_e8m0_unbiased = tl.clamp(
+            scale_e8m0_unbiased, -1 * e8m0_exponent_bias, e8m0_exponent_bias + 1
+        )
+
+        # Create the biased e8m0 representation and cast it to 8 bits
+        scale_e8m0_biased = scale_e8m0_unbiased + e8m0_exponent_bias
+        scale_e8m0_biased = scale_e8m0_biased.to(tl.uint8)
 
         # TODO(future PR): add NaN handling here,
         # https://github.com/pytorch/pytorch/pull/100572 will likely be useful to
@@ -862,11 +906,18 @@ if _triton_kernels_available:
 
         # Find the maximum absolute value for each column
         # shape: (COL_TILE_SIZE * BLOCKS_PER_ROW_TILE,)
-        col_scale_r, col_scale_e8m0_r = _triton_calculate_scale(
-            x_block_abs_t_r,
-            axis=1,
-            SCALING_MODE=SCALING_MODE,
-        )
+        if SCALING_MODE == "rceil":
+            col_scale_r, col_scale_e8m0_r = _triton_calculate_scale_rceil(
+                x_block_abs_t_r,
+                axis=1,
+                USE_PTX=not IS_ROCM,
+            )
+        else:
+            tl.static_assert(SCALING_MODE == "floor")
+            col_scale_r, col_scale_e8m0_r = _triton_calculate_scale_floor(
+                x_block_abs_t_r,
+                axis=1,
+            )
 
         # Divide each column by scale
         # Broadcasting col_scale to match x_block's shape
@@ -965,9 +1016,18 @@ if _triton_kernels_available:
 
         # Find the maximum absolute value for each row (across columns)
         # shape: (ROW_TILE_SIZE * BLOCKS_PER_COL_TILE,)
-        scale_fp32_r, scale_e8m0_r = _triton_calculate_scale(
-            x_block_abs_r, axis=1, SCALING_MODE=SCALING_MODE
-        )
+        if SCALING_MODE == "rceil":
+            scale_fp32_r, scale_e8m0_r = _triton_calculate_scale_rceil(
+                x_block_abs_r,
+                axis=1,
+                USE_PTX=not IS_ROCM,
+            )
+        else:
+            tl.static_assert(SCALING_MODE == "floor")
+            scale_fp32_r, scale_e8m0_r = _triton_calculate_scale_floor(
+                x_block_abs_r,
+                axis=1,
+            )
 
         # Divide each row by scale
         # Broadcasting scale to match x_block's shape


### PR DESCRIPTION
## Summary
* Support quantization triton kernel with RCEIL scaling mode in ROCm. 
* Bring some mxfp8 quantization back on ROCm.

## Performance
It show 1.63x uplift compare with `torch.compile`.
<img width="1746" height="543" alt="image" src="https://github.com/user-attachments/assets/5b433329-762b-4769-8301-8231d4e40b57" />
