### PR TITLE
Update quick start tutorial

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -58,7 +58,7 @@ First, let's create a simple model:
     model = ToyLinearModel(
         1024, 1024, 1024, device="cuda", dtype=torch.bfloat16
     ).eval()
-    model_w16a16 = model
+    model_w16a16 = copy.deepcopy(model)
     model_w8a8 = copy.deepcopy(model)  # We will quantize in next chapter!
 
 W8A8-INT: 8-bit Dynamic Activation and Weight Quantization
@@ -92,10 +92,6 @@ You can verify this by saving both models to disk and comparing file sizes:
 
     import os
 
-    # Optional: compile model for faster inference and generation
-    model_w16a16 = torch.compile(model, mode="max-autotune", fullgraph=True)
-    model_w8a8 = torch.compile(model_w8a8, mode="max-autotune", fullgraph=True)
-
     # Save models
     torch.save(model_w16a16.state_dict(), "model_w16a16.pth")
     torch.save(model_w8a8.state_dict(), "model_w8a8.pth")
@@ -119,6 +115,10 @@ Let's demonstrate that not only is the quantized model smaller, but it is also f
 .. code:: py
 
     import time
+
+    # Optional: compile model for faster inference and generation
+    model_w16a16 = torch.compile(model, mode="max-autotune", fullgraph=True)
+    model_w8a8 = torch.compile(model_w8a8, mode="max-autotune", fullgraph=True)
 
     # Get example inputs
     example_inputs = model_w8a8.example_inputs(batch_size=128)

--- a/scripts/quick_start.py
+++ b/scripts/quick_start.py
@@ -49,6 +49,7 @@ class ToyLinearModel(torch.nn.Module):
 
 
 model = ToyLinearModel(1024, 1024, 1024, device="cuda", dtype=torch.bfloat16).eval()
+model_w16a16 = copy.deepcopy(model)
 model_w8a8 = copy.deepcopy(model)  # We will quantize in next chapter!
 
 # ========================
@@ -66,10 +67,6 @@ print(type(model_w8a8.linear1.weight).__name__)
 
 import os
 
-# Optional: compile model for faster inference and generation
-model_w16a16 = torch.compile(model, mode="max-autotune", fullgraph=True)
-model_w8a8 = torch.compile(model_w8a8, mode="max-autotune", fullgraph=True)
-
 # Save models
 torch.save(model_w16a16.state_dict(), "model_w16a16.pth")
 torch.save(model_w8a8.state_dict(), "model_w8a8.pth")
@@ -86,6 +83,10 @@ print(
 # ========================
 
 import time
+
+# Optional: compile model for faster inference and generation
+model_w16a16 = torch.compile(model_w16a16, mode="max-autotune", fullgraph=True)
+model_w8a8 = torch.compile(model_w8a8, mode="max-autotune", fullgraph=True)
 
 # Get example inputs
 example_inputs = model_w8a8.example_inputs(batch_size=128)


### PR DESCRIPTION
W4A16-INT config (`Int4WeightOnlyConfig`) was not suitable for the tutorial because it has a `fbgemm-genai-gpu` dependency. To resolve this, update the tutorial to use W8A8-INT (`Int8DynamicActivationInt8WeightConfig`) instead of W4A16-INT for first-time users.
- fix: #3627