### PR TITLE
Fix version checks for `_wrap_tensor_autograd`

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -532,8 +532,8 @@ def wait_tensor(func, *args, **kwargs):
     return updatedNF4Tensor
 
 
-# _wrap_tensor_autograd was added in PyTorch 2.10
-if torch_version_at_least("2.10.0"):
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev and later
+if torch_version_at_least("2.11.0.dev"):
 
     @implements(
         [

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -508,8 +508,8 @@ def wait_tensor_fp8(aten_op, args, kwargs=None):
     )
 
 
-# _wrap_tensor_autograd was added in PyTorch 2.10
-if torch_version_at_least("2.10.0"):
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+if torch_version_at_least("2.11.0.dev"):
 
     @implements([_c10d_functional._wrap_tensor_autograd.default])
     def wrap_tensor_autograd_fp8(aten_op, args, kwargs=None):

--- a/torchao/optim/subclass_4bit.py
+++ b/torchao/optim/subclass_4bit.py
@@ -183,8 +183,8 @@ _optim_state_4bit_c10d_ops = [
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.10
-if torch_version_at_least("2.10.0"):
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+if torch_version_at_least("2.11.0.dev"):
     _optim_state_4bit_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
 
 

--- a/torchao/optim/subclass_8bit.py
+++ b/torchao/optim/subclass_8bit.py
@@ -157,8 +157,8 @@ _optim_state_8bit_c10d_ops = [
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.10
-if torch_version_at_least("2.10.0"):
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+if torch_version_at_least("2.11.0.dev"):
     _optim_state_8bit_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
 
 

--- a/torchao/optim/subclass_fp8.py
+++ b/torchao/optim/subclass_fp8.py
@@ -142,8 +142,8 @@ _optim_state_fp8_c10d_ops = [
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.10
-if torch_version_at_least("2.10.0"):
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+if torch_version_at_least("2.11.0.dev"):
     _optim_state_fp8_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
 
 


### PR DESCRIPTION
Summary:
Trying to fix flaky CI error: https://github.com/pytorch/ao/actions/runs/20966568112/job/60258524576
* the build is against the 2.10 test binary, which is cut in Dec 10, the PR that added `_wrap_tensor_autograd`  (https://github.com/pytorch/pytorch/commit/e629934d7f71fe5ea68af83bf2dae7460da1b1b3) is landed in Dec 15
* the wheel is build against 2.10, and the nightly test is on pytorch nightly (2.11.0.dev), so we have to make sure both works. the op exists only after 2.11.0.dev and not in 2.10 so we should be able to fix the build error by fixing the version check in https://github.com/pytorch/ao/pull/3548 



Test Plan:
build wheels CI

https://github.com/pytorch/ao/actions/workflows/build_wheels_linux.yml

manual dispatch run: https://github.com/pytorch/ao/actions/runs/20968443825

Reviewers:

Subscribers:

Tasks:

Tags: