### PR TITLE
Fix fake fusion for convolutions without bias (#3353)

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -710,10 +710,13 @@ def fold_bn_weights_into_conv_node(
         conv_args.append(None)
 
     if fake_fuse:
-        fused_weight, fused_bias = (
-            torch.nn.Parameter(conv_w, conv_w.requires_grad),
-            torch.nn.Parameter(conv_b, conv_b.requires_grad),
-        )
+        fused_weight = torch.nn.Parameter(conv_w, conv_w.requires_grad)
+        if conv_b is not None:
+            fused_bias = torch.nn.Parameter(conv_b, conv_b.requires_grad)
+        else:
+            fused_bias = torch.nn.Parameter(
+                torch.zeros_like(bn_rm), requires_grad=conv_w.requires_grad
+            )
     else:
         fused_weight, fused_bias = fuse_conv_bn_weights(
             conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, transpose=transpose

--- a/torchao/testing/model_architectures.py
+++ b/torchao/testing/model_architectures.py
@@ -82,11 +82,20 @@ class ToyTwoLinearModel(torch.nn.Module):
 
 class ConvWithSharedWeightInExportedModel(nn.Module):
     def __init__(
-        self, n_chunks, in_channels, out_channels, kernel_size=3, stride=1, padding=1
+        self,
+        n_chunks,
+        in_channels,
+        out_channels,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        bias=True,
     ) -> None:
         super().__init__()
         self.n_chunks = n_chunks
-        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, stride, padding)
+        self.conv = nn.Conv2d(
+            in_channels, out_channels, kernel_size, stride, padding, bias=bias
+        )
         self.bn = nn.BatchNorm2d(out_channels)
         self.relu = nn.ReLU(inplace=True)
 


### PR DESCRIPTION
Summary:

Fix `AttributeError` when performing fake fusion on convolution layers without bias by creating a zero-filled bias parameter instead of attempting to access requires_grad on None.

Reviewed By: jerryzh168

Differential Revision: D87356763