### PR TITLE
[mxfp8 moe training] default multiple_of=32 in generate_jagged_offs test util

### DIFF
--- a/torchao/prototype/moe_training/utils.py
+++ b/torchao/prototype/moe_training/utils.py
@@ -307,7 +307,7 @@ def _is_row_major(x: torch.Tensor) -> bool:
     return x.stride(-1) == 1
 
 
-def generate_jagged_offs(E, M, multiple_of=16, dtype=torch.int32, device="cuda"):
+def generate_jagged_offs(E, M, multiple_of=32, dtype=torch.int32, device="cuda"):
     """
     Utility function for tests and benchmarks.
 


### PR DESCRIPTION
Stacked PRs:
 * #3647
 * __->__#3646


--- --- ---

### [mxfp8 moe training] default multiple_of=32 in generate_jagged_offs test util

90% of the time this is used for mxfp8 where the value should be 32. 

I double checked the callsites for bf16 are explicitly setting 16.

This fixes a minor bug in the roofline_unified.py script, that seemingly no effect on results, but was incorrect nonetheless.