### PR TITLE
[mxfp8 moe training] rename MoEScalingType -> ScaledGroupedMMRecipe

### DIFF
--- a/benchmarks/prototype/moe_training/bench_moe_layer.py
+++ b/benchmarks/prototype/moe_training/bench_moe_layer.py
@@ -16,8 +16,8 @@ from torch.nn import functional as F
 
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
 from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
     MoETrainingConfig,
+    ScaledGroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -54,19 +54,27 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     )
     assert torch.cuda.is_available()
     assert recipe_name in ["fp8_rowwise", "mxfp8"]
-    recipe = MoEScalingType[recipe_name.upper()]
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    recipe = ScaledGroupedMMRecipe[recipe_name.upper()]
+    if (
+        recipe == ScaledGroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping FP8 rowwise benchmarks, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
         return
 
-    elif recipe == MoEScalingType.MXFP8 and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    elif (
+        recipe == ScaledGroupedMMRecipe.MXFP8
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
@@ -92,7 +100,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     model = copy.deepcopy(ref_model)
 
     # Token group alignment size must be 16 for fp8 rowwise training
-    alignment_size = 32 if recipe == MoEScalingType.MXFP8 else 16
+    alignment_size = 32 if recipe == ScaledGroupedMMRecipe.MXFP8 else 16
     set_token_group_alignment_size_m(alignment_size)
 
     # assert starting params are identical for both models
@@ -107,7 +115,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         return False
 
     # quantize test model
-    config = MoETrainingConfig(scaling_type=recipe)
+    config = MoETrainingConfig(recipe=recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # inputs

--- a/test/prototype/moe_training/test_fsdp.py
+++ b/test/prototype/moe_training/test_fsdp.py
@@ -37,8 +37,8 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
     MoETrainingConfig,
+    ScaledGroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -83,14 +83,14 @@ def device_mesh_1d() -> DeviceMesh:
     "recipe_config",
     [
         {
-            "recipe": MoEScalingType.FP8_ROWWISE,
+            "recipe": ScaledGroupedMMRecipe.FP8_ROWWISE,
             "group_alignment_size": 16,
             "min_out_sqnr": 29.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 23.0,
         },
         {
-            "recipe": MoEScalingType.MXFP8,
+            "recipe": ScaledGroupedMMRecipe.MXFP8,
             "group_alignment_size": 32,
             "min_out_sqnr": 28.0,
             "min_input_grad_sqnr": 29.0,
@@ -118,17 +118,25 @@ def test_moe_training_fsdp(
         recipe_config["min_param_grad_sqnr"],
     )
     assert torch.cuda.is_available()
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    if (
+        recipe == ScaledGroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         pytest.skip(
             f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
 
-    elif recipe == MoEScalingType.MXFP8 and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    elif (
+        recipe == ScaledGroupedMMRecipe.MXFP8
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         pytest.skip(
             f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"

--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -28,7 +28,7 @@ from torchao.float8.config import (
 from torchao.float8.float8_linear import matmul_with_hp_or_float8_args
 from torchao.float8.float8_training_tensor import LinearMMConfig
 from torchao.float8.float8_utils import compute_error, tensor_to_scale, to_fp8_saturated
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.prototype.moe_training.conversion_utils import ScaledGroupedMMRecipe
 from torchao.prototype.moe_training.scaled_grouped_mm import (
     _emulated_mxfp8_scaled_grouped_mm_2d_2d,
     _emulated_mxfp8_scaled_grouped_mm_2d_3d,
@@ -79,7 +79,7 @@ def test_valid_scaled_grouped_mm_2d_3d(m, n, k, n_groups):
         b_t,
         offs=offs,
         out_dtype=out_dtype,
-        scaling_type=MoEScalingType.FP8_ROWWISE,
+        scaling_type=ScaledGroupedMMRecipe.FP8_ROWWISE,
     )
 
     # Validate result.

--- a/test/prototype/moe_training/test_tp.py
+++ b/test/prototype/moe_training/test_tp.py
@@ -49,8 +49,8 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
     MoETrainingConfig,
+    ScaledGroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -101,14 +101,14 @@ def device_mesh_1d() -> DeviceMesh:
     "recipe_config",
     [
         {
-            "recipe": MoEScalingType.FP8_ROWWISE,
+            "recipe": ScaledGroupedMMRecipe.FP8_ROWWISE,
             "group_alignment_size": 16,
             "min_out_sqnr": 29.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 23.0,
         },
         {
-            "recipe": MoEScalingType.MXFP8,
+            "recipe": ScaledGroupedMMRecipe.MXFP8,
             "group_alignment_size": 32,
             "min_out_sqnr": 28.0,
             "min_input_grad_sqnr": 29.0,
@@ -136,17 +136,25 @@ def test_moe_training_tp(
         recipe_config["min_param_grad_sqnr"],
     )
     assert torch.cuda.is_available()
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    if (
+        recipe == ScaledGroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         pytest.skip(
             f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
 
-    elif recipe == MoEScalingType.MXFP8 and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    elif (
+        recipe == ScaledGroupedMMRecipe.MXFP8
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         pytest.skip(
             f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -13,8 +13,8 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
     MoETrainingConfig,
+    ScaledGroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -41,21 +41,21 @@ except ImportError:
     "recipe_config",
     [
         {
-            "recipe": MoEScalingType.FP8_ROWWISE,
+            "recipe": ScaledGroupedMMRecipe.FP8_ROWWISE,
             "group_alignment_size": 16,
             "min_out_sqnr": 29.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 23.0,
         },
         {
-            "recipe": MoEScalingType.MXFP8,
+            "recipe": ScaledGroupedMMRecipe.MXFP8,
             "group_alignment_size": 32,
             "min_out_sqnr": 28.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 21.0,
         },
         {
-            "recipe": MoEScalingType.MXFP8_WGRAD_WITH_HP,
+            "recipe": ScaledGroupedMMRecipe.MXFP8_WGRAD_WITH_HP,
             "group_alignment_size": 32,
             "min_out_sqnr": 28.0,
             "min_input_grad_sqnr": 29.0,
@@ -78,17 +78,21 @@ def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict
         recipe_config["min_param_grad_sqnr"],
     )
     assert torch.cuda.is_available()
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    if (
+        recipe == ScaledGroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         pytest.skip(
             f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
 
     elif recipe in (
-        MoEScalingType.MXFP8,
-        MoEScalingType.MXFP8_WGRAD_WITH_HP,
+        ScaledGroupedMMRecipe.MXFP8,
+        ScaledGroupedMMRecipe.MXFP8_WGRAD_WITH_HP,
     ) and torch.cuda.get_device_capability() != (
         10,
         0,
@@ -129,7 +133,7 @@ def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict
         return False
 
     # quantize test model
-    config = MoETrainingConfig(scaling_type=recipe)
+    config = MoETrainingConfig(recipe=recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted

--- a/torchao/prototype/moe_training/README.md
+++ b/torchao/prototype/moe_training/README.md
@@ -66,7 +66,7 @@ from torch.nn import functional as F
 from torchao.prototype.moe_training import (
     _to_mxfp8_then_scaled_grouped_mm,
 )
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.prototype.moe_training.conversion_utils import ScaledGroupedMMRecipe
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 
 num_groups, total_M, N, K = 8, 131072, 8192, 5120

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -16,7 +16,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import MixedPrecisionPolicy
 
 from torchao.prototype.moe_training import _quantize_then_scaled_grouped_mm
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.prototype.moe_training.conversion_utils import ScaledGroupedMMRecipe
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     differentiable _quantize_then_scaled_grouped_mm autograd function.
     """
 
-    scaling_type: MoEScalingType = MoEScalingType.FP8_ROWWISE
+    recipe: ScaledGroupedMMRecipe = ScaledGroupedMMRecipe.FP8_ROWWISE
     grouped_mm_func_name = "_grouped_mm"
     offs_arg_name = "offs"
 
@@ -50,7 +50,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     def __new__(
         cls,
         tensor: torch.Tensor,
-        scaling_type: MoEScalingType,
+        recipe: ScaledGroupedMMRecipe,
     ):
         self = torch.Tensor._make_wrapper_subclass(
             cls,
@@ -64,16 +64,16 @@ class ScaledGroupedMMTensor(torch.Tensor):
             pin_memory=tensor.is_pinned(),
             requires_grad=tensor.requires_grad,
         )
-        self.scaling_type = scaling_type
+        self.recipe = recipe
         return self
 
     def __init__(
         self,
         tensor: torch.Tensor,
-        scaling_type: MoEScalingType,
+        recipe: ScaledGroupedMMRecipe,
     ):
         self._data = tensor
-        self.scaling_type = scaling_type
+        self.recipe = recipe
 
     @classmethod
     def __torch_function__(cls, func, types, args, kwargs={}):
@@ -93,7 +93,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
             assert isinstance(B, ScaledGroupedMMTensor), (
                 "B should be a ScaledGroupedMMTensor"
             )
-            scaling_type = B.scaling_type
+            recipe = B.recipe
             A_is_2d = A.ndim == 2
             B_is_2d_or_3d = B.ndim == 2 or B.ndim == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
@@ -103,7 +103,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
                     A,
                     B,
                     *other_args,
-                    scaling_type=scaling_type,
+                    scaling_type=recipe,
                     **kwargs,
                 )
 
@@ -114,27 +114,27 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs={}):
-        # unwrap args/kwargs and extract scaling_type
-        scaling_type = None
+        # unwrap args/kwargs and extract recipe
+        recipe = None
 
         def unwrap(t):
-            nonlocal scaling_type
-            if scaling_type is None:
-                scaling_type = t.scaling_type
+            nonlocal recipe
+            if recipe is None:
+                recipe = t.recipe
             else:
-                assert t.scaling_type == scaling_type
+                assert t.recipe == recipe
             return t._data
 
         args_unwrapped, kwargs_unwrapped = pytree.tree_map_only(
             ScaledGroupedMMTensor, unwrap, (args, kwargs or {})
         )
-        assert scaling_type is not None, (
+        assert recipe is not None, (
             f"__torch_dispatch__ called on {func.__name__} without any ScaledGroupedMMTensor arguments"
         )
 
         # detach is special case
         if func == torch.ops.aten.detach.default:
-            return ScaledGroupedMMTensor(args_unwrapped[0], scaling_type)
+            return ScaledGroupedMMTensor(args_unwrapped[0], recipe)
 
         # perform op
         out = func(*args_unwrapped, **kwargs_unwrapped)
@@ -146,22 +146,22 @@ class ScaledGroupedMMTensor(torch.Tensor):
         # wrap outputs back into ScaledGroupedMMTensor for ops that do preserve subclass
         return pytree.tree_map_only(
             torch.Tensor,
-            lambda x: ScaledGroupedMMTensor(x, scaling_type),
+            lambda x: ScaledGroupedMMTensor(x, recipe),
             out,
         )
 
     def __repr__(self):
-        return f"ScaledGroupedMMTensor(data={self._data}, scaling_type={self.scaling_type})"
+        return f"ScaledGroupedMMTensor(data={self._data}, recipe={self.recipe})"
 
     def __tensor_flatten__(self):
-        metadata = {"scaling_type": self.scaling_type}
+        metadata = {"recipe": self.recipe}
         return ["_data"], metadata
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):
         return ScaledGroupedMMTensor(
             inner_tensors["_data"],
-            flatten_spec["scaling_type"],
+            flatten_spec["recipe"],
         )
 
     # fsdp hooks based on https://github.com/pytorch/pytorch/blob/20e40492b046b9287726d3ec656117e4dc38f0e2/test/distributed/_composable/fsdp/test_fully_shard_extensions.py#L81
@@ -192,12 +192,12 @@ class ScaledGroupedMMTensor(torch.Tensor):
         if out is not None:
             if isinstance(out, ScaledGroupedMMTensor):
                 out_data = out._data
-                out.scaling_type = self.scaling_type
+                out.recipe = self.recipe
             elif isinstance(out, DTensor) and isinstance(
                 out._local_tensor, ScaledGroupedMMTensor
             ):
                 out_data = out._local_tensor._data
-                out._local_tensor.scaling_type = self.scaling_type
+                out._local_tensor.recipe = self.recipe
             else:
                 raise RuntimeError(
                     f"expect out to be ScaledGroupedMMTensor or DTensor with local_tensor=ScaledGroupedMM, but got {type(out)}"
@@ -220,6 +220,6 @@ class ScaledGroupedMMTensor(torch.Tensor):
             return
 
         # For training step 0, out=None, so we need to return a new ScaledGroupedMMTensor.
-        output = ScaledGroupedMMTensor(data, self.scaling_type)
+        output = ScaledGroupedMMTensor(data, self.recipe)
         inner_tensors = (data,)
         return output, inner_tensors


### PR DESCRIPTION
[mxfp8 moe training] rename MoEScalingType -> ScaledGroupedMMRecipe

## Summary
- `MoEScalingType` has ended up being not a scaling type, but rather a recipe name. The name should reflect that.
- Also, `ScaledGroupedMMRecipe` aligns better with the `ScaledGroupedMMTensor` which dispatches with this recipe as an arg.

Note: I think we should also probably rename `MoETrainingConfig` to align with this naming pattern. 

## Tests
- `pytest test/prototype/moe_training/test_training.py`
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py`