### PR TITLE
fix: avoid attribute assignment on typing.Union for Python 3.14 compatibility in pt2e

### DIFF
--- a/torchao/quantization/pt2e/__init__.py
+++ b/torchao/quantization/pt2e/__init__.py
@@ -91,12 +91,27 @@ for _f in [
 
 # ensure __module__ is set correctly for public APIs
 ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
-ObserverOrFakeQuantize.__module__ = "torchao.quantization.pt2e"
+try:
+    ObserverOrFakeQuantize.__module__ = "torchao.quantization.pt2e"
+except (AttributeError, TypeError):
+    # Python 3.14+ Unions are immutable; set on underlying components instead
+    for _item in (ObserverBase, FakeQuantizeBase):
+        try:
+            _item.__module__ = "torchao.quantization.pt2e"
+        except Exception:
+            pass
 
 ObserverOrFakeQuantizeConstructor = Union[
     PartialWrapper, type[ObserverBase], type[FakeQuantizeBase]
 ]
-ObserverOrFakeQuantizeConstructor.__module__ = "torchao.quantization.pt2e"
+try:
+    ObserverOrFakeQuantizeConstructor.__module__ = "torchao.quantization.pt2e"
+except (AttributeError, TypeError):
+    for _item in (PartialWrapper,):
+        try:
+            _item.__module__ = "torchao.quantization.pt2e"
+        except Exception:
+            pass
 
 
 __all__ = [


### PR DESCRIPTION
# Description

Importing `torchao.quantization.pt2e` fails on Python 3.14 due to an attempt to
assign `__module__` on a `typing.Union` object:

    ObserverOrFakeQuantize.__module__ = "torchao.quantization.pt2e"

In Python 3.14, `typing.Union` objects are immutable and no longer allow dynamic
attribute assignment, resulting in:

    AttributeError: 'typing.Union' object has no attribute '__module__'

Fix:
Attempt to set `__module__` on the Union as before for older Python versions,
and fall back to assigning `__module__` on the underlying concrete classes
when the Union is immutable. This preserves the original public API intent
while restoring compatibility with Python 3.14+.

No behavior changes occur for earlier Python versions.

Fixes: #3619


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] This change is backward-compatible
