### PR TITLE
[mxfp8 moe training] auto-select chunk_width in cuda blocked layout kernel

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
@@ -31,7 +31,6 @@ torch._dynamo.config.cache_size_limit = 1000
 class ExperimentConfig:
     input_shape: tuple[int]
     num_groups: int
-    chunk_width: int
     chunks_per_tb: int
 
 
@@ -60,21 +59,18 @@ def get_configs() -> List[ExperimentConfig]:
         (131072, 7168 // block_size),
     ]
     num_groups = [8]
-    chunk_width_list = [64]
     chunks_per_tb_list = [1, 4, 8]
 
     configs = []
-    for shape, groups, chunk_width, chunks_per_tb in itertools.product(
+    for shape, groups, chunks_per_tb in itertools.product(
         input_shapes,
         num_groups,
-        chunk_width_list,
         chunks_per_tb_list,
     ):
         configs.append(
             ExperimentConfig(
                 input_shape=shape,
                 num_groups=groups,
-                chunk_width=chunk_width,
                 chunks_per_tb=chunks_per_tb,
             )
         )
@@ -82,8 +78,11 @@ def get_configs() -> List[ExperimentConfig]:
 
 
 def run_experiment(config: ExperimentConfig) -> ExperimentResult:
-    input_shape, num_groups = config.input_shape, config.num_groups
-    chunk_width, chunks_per_tb = config.chunk_width, config.chunks_per_tb
+    input_shape, num_groups, chunks_per_tb = (
+        config.input_shape,
+        config.num_groups,
+        config.chunks_per_tb,
+    )
 
     input_tensor = torch.randint(
         low=0,
@@ -126,14 +125,12 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     _ = mx_block_rearrange_2d_M_groups_cuda(
         input_tensor.view(torch.uint8),
         input_group_offsets.to(torch.int32),
-        chunk_width,
         chunks_per_tb,
     )
     cuda_time_us = benchmark_cuda_function_in_microseconds(
         mx_block_rearrange_2d_M_groups_cuda,
         input_tensor.view(torch.uint8),
         input_group_offsets.to(torch.int32),
-        chunk_width,
         chunks_per_tb,
     )
 
@@ -161,7 +158,6 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
 def print_results(experiments: List[Experiment]):
     headers = [
         "input_shape",
-        "chunk_width",
         "chunks_per_tb",
         "torch_time_us",
         "triton_time_us",
@@ -177,7 +173,6 @@ def print_results(experiments: List[Experiment]):
         rows.append(
             [
                 input_shape,
-                experiment.config.chunk_width,
                 experiment.config.chunks_per_tb,
                 f"{experiment.result.torch_time_us:.2f}",
                 f"{experiment.result.triton_time_us:.2f}",

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -251,22 +251,21 @@ def test_triton_mx_block_rearrange_2d_M_groups(
 )
 @skip_if_rocm("ROCm enablement in progress")
 @pytest.mark.parametrize(
-    "m,k,n_groups,chunk_width,chunks_per_tb",
+    "m,k,n_groups,chunks_per_tb",
     [
-        (16640, 2048, 8, 64, 4),
-        (16640, 2048, 8, 128, 8),
-        (131072, 8192, 32, 128, 16),
-        (512, 512, 4, 16, 4),
-        (512, 1024, 4, 32, 4),
-        (512, 2048, 4, 64, 4),
-        (1024, 512, 8, 16, 4),
+        (16640, 2048, 8, 4),
+        (16640, 2048, 8, 8),
+        (131072, 8192, 32, 16),
+        (512, 512, 4, 4),
+        (512, 1024, 4, 4),
+        (512, 2048, 4, 4),
+        (1024, 512, 8, 4),
     ],
 )
 def test_cuda_mx_block_rearrange_2d_M_groups(
     m: int,
     k: int,
     n_groups: int,
-    chunk_width: int,
     chunks_per_tb: int,
 ):
     device = "cuda"
@@ -290,11 +289,10 @@ def test_cuda_mx_block_rearrange_2d_M_groups(
     cuda_out_scales = mx_block_rearrange_2d_M_groups_cuda(
         e8m0_scales,
         input_group_offsets,
-        chunk_width=chunk_width,
         chunks_per_tb=chunks_per_tb,
     )
     assert torch.allclose(ref_out_scales, cuda_out_scales, atol=0, rtol=0), (
-        f"blocked scales not equal for scale_cols={scale_cols}, chunk_width={chunk_width}"
+        f"blocked scales not equal for scale_cols={scale_cols}"
     )
 
 
@@ -324,7 +322,6 @@ def test_cuda_mx_block_rearrange_2d_M_groups_invalid_cols():
         mx_block_rearrange_2d_M_groups_cuda(
             e8m0_scales,
             input_group_offsets,
-            chunk_width=64,
             chunks_per_tb=4,
         )
 

--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -461,7 +461,7 @@ void launch_mx_block_rearrange_2d_M_groups_cuda(
     const int32_t* input_group_end_offsets,
     uint8_t* output_scales_ptr,
     int num_groups,
-    int chunk_width,    // Chunk width: 64 or 128
+    int chunk_width,
     int chunks_per_tb,  // Chunks per superblock: 4, 8, or 16
     cudaStream_t stream
 ) {

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -194,7 +194,6 @@ mxfp8_quantize_3d(const at::Tensor& input, int64_t scale_dim_n,
 at::Tensor mx_block_rearrange_2d_M_groups(
     at::Tensor scales_tensor,
     at::Tensor input_group_end_offsets,
-    int64_t chunk_width,
     int64_t chunks_per_tb) {
 
   // Validate inputs
@@ -210,8 +209,6 @@ at::Tensor mx_block_rearrange_2d_M_groups(
               "input_group_end_offsets must be int32");
   TORCH_CHECK(input_group_end_offsets.dim() == 1,
               "input_group_end_offsets must be 1D");
-  TORCH_CHECK(chunk_width == 16 || chunk_width == 32 || chunk_width == 64 || chunk_width == 128,
-              "chunk_width must be 16, 32, 64, or 128, got: ", chunk_width);
   TORCH_CHECK(chunks_per_tb == 1 || chunks_per_tb == 4 || chunks_per_tb == 8 || chunks_per_tb == 16,
               "chunks_per_tb must be 1, 4, 8, or 16, got: ", chunks_per_tb);
   c10::cuda::CUDAGuard device_guard(scales_tensor.device());
@@ -225,10 +222,20 @@ at::Tensor mx_block_rearrange_2d_M_groups(
   // Reference: https://docs.nvidia.com/cuda/archive/12.6.3/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
   // For 2D TMA transfers, the stride must be a multiple of 16 bytes.
   // Since we use row-major layout with stride = scale_cols (in bytes), scale_cols must be divisible by 16.
-  TORCH_CHECK(cols % 16 == 0,
+  TORCH_CHECK(cols >= 16 && cols % 16 == 0,
               "TMA requirement for 2D transfers: stride must be a multiple of 16 bytes. Got scale_cols=",
               cols, " (stride in row-major layout). ",
               "Consider using Triton kernel instead with use_cuda_kernel_for_blocked_layout=False.");
+
+  // Automatically select chunk_width based on scale_cols
+  int chunk_width;
+  if (cols >= 64) {
+    chunk_width = 64;
+  } else if (cols >= 32) {
+    chunk_width = 32;
+  } else {
+    chunk_width = 16;
+  }
 
   // Calculate blocks needed - uses 128-row blocks
   // For M groups, groups are along rows, so we pad each group to 128 rows


### PR DESCRIPTION
Stacked PRs:
 * __->__#3658
 * #3656


--- --- ---

[mxfp8 moe training] auto-select chunk_width in cuda blocked layout kernel

## Summary
- Make kernel less error prone for users and simplfy user-facing API by auto-selecting `chunk_width` used in cuda blocked layout for groups along M kernel.
- This should be auto selected via heuristics at dispatch time, rather than manually specified by the user, similar to how in GEMM kernels the user doesn't specify block size, mma instruction width (wgmma n64m16k16 vs n64m128k16, etc)

Note: we should also add auto-selection for chunks_per_tb

## Tests
- `pytest test/prototype/moe_training/test_kernels.py -v -s -k cuda_mx_block  `

### Benchmarks
Same or slightly better for some shapes now than originally in https://github.com/pytorch/ao/pull/3546
```
input_shape      chunk_width    chunks_per_tb    torch_time_us    triton_time_us    cuda_time_us  triton_vs_torch    cuda_vs_torch      cuda_vs_triton
-------------  -------------  ---------------  ---------------  ----------------  --------------  -----------------  ---------------  ----------------
(32768, 160)              64                1           122.91             60.45           17.41  2.03x              7.06x                        3.47x
(32768, 160)              64                4           560.88             52.19           15.39  10.75x             36.44x                       3.39x
(32768, 160)              64                8           557.07             37.89           17.44  14.70x             31.94x                       2.17x
(131072, 160)             64                1          1867.25            128              31.78  14.59x             58.76x                       4.03x
(131072, 160)             64                4          1856.22            136.22           25.63  13.63x             72.42x                       5.31x
(131072, 160)             64                8          1853.86            279.55           23.55  6.63x              78.71x                      11.87x
(131072, 64)              64                1          1595.49            148.48           15.49  10.75x             103.01x                      9.59x
(131072, 64)              64                4          1528.14            103.42           15.39  14.78x             99.28x                       6.72x
(131072, 64)              64                8          1542.43            109.57           17.44  14.08x             88.44x                       6.28x
(131072, 224)             64                1          4884.77            234.4            39.97  20.84x             122.22x                      5.86x
(131072, 224)             64                4          4943.9             189.44           31.78  26.10x             155.59x                      5.96x
(131072, 224)             64                8          4923.94            211.97           29.73  23.23x             165.63x                      7.13x```
```