### PR TITLE
Update conditions for doc build workflow

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -85,7 +85,7 @@ jobs:
       # Grant write permission here so that the doc can be pushed to gh-pages branch
       contents: write
     needs: build_docs
-    if: github.repository == 'pytorch/ao' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch')
+    if: github.repository == 'pytorch/ao' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Remove workflow_dispatch condition from doc build since it wasn't used anyways.