### PR TITLE
Fix Int8Tensor v2 to use float32 eps for better bfloat16 precision

### DIFF
--- a/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
@@ -137,6 +137,8 @@ class Int8Tensor(TorchAOBaseTensor):
                 scale_dtype=hp_tensor.dtype,
                 zero_point_dtype=torch.int8,
                 keepdim=True,
+                # Use float32 eps for all dtypes to avoid accuracy loss with bfloat16 (bfloat16 eps is ~65x larger).
+                eps=torch.finfo(torch.float32).eps,
             )
         else:
             # Scale can be provided in the case of static quant


### PR DESCRIPTION
- Add explicit eps=torch.finfo(torch.float32).eps to Int8Tensor.from_hp
- Ensures consistent behavior with v1 AffineQuantizedTensor
- Fixes SQNR regression with bfloat16 inputs (bfloat16 eps=0.0078 vs float32 eps=1.19e-07)