### PR TITLE
[mxfp8 moe training] register constant with pytree

### DIFF
--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -74,6 +74,19 @@ class ScaleCalculationMode(Enum):
     CEIL = "ceil"
     EVEN = "even"
 
+    def __eq__(self, other):
+        if isinstance(other, ScaleCalculationMode):
+            return self.value == other.value
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.value)
+
+
+# Register ScaleCalculationMode with pytree so torch.compile can handle it
+# as a function argument in @torch._dynamo.nonstrict_trace functions.
+torch.utils._pytree.register_constant(ScaleCalculationMode)
+
 
 def _validate_elem_dtype(elem_dtype):
     assert elem_dtype in SUPPORTED_ELEM_DTYPES, (


### PR DESCRIPTION
After #3606 `@torch._dynamo.nonstrict_trace` was added to support autograd functions having different tensor subclasses for forward output and backward input.

The e2e integration tests for compile and eager passed and it was landed, but it turns out if you explicitly specify a scaling recipe instead of defaulting, it breaks with this error:

```
torch._dynamo.exc.Unsupported: Invalid input type for nonstrict_trace-ed function Explanation: For nonstrict_trace-ed functions, only basic types (e.g., torch.Tensor, int, float) or pytree containers of those are allowed as inputs. The provided argument contains an unsupported type. Hint: Use one of the following to register the type with pytree: * torch.utils._pytree.register_constant * torch.utils._pytree.register_dataclass * torch.utils._pytree.register_pytree_node
```

Basically we need to register the enum with pytree, which is done in this PR.


### Tests
Added unit test cases which fail without this change.
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -k dq`