### PR TITLE
[ROCM] Bringing Float8 Util Unit Tests for ROCM

### DIFF
--- a/test/float8/test_float8_utils.py
+++ b/test/float8/test_float8_utils.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from torchao.float8.float8_utils import _round_scale_down_to_power_of_2
-from torchao.testing.utils import skip_if_rocm
+from torchao.utils import is_ROCM
 
 
 # source for notable single-precision cases:
@@ -23,7 +23,10 @@ from torchao.testing.utils import skip_if_rocm
         ("inf", float("inf"), float("inf")),
         ("nan", float("nan"), float("nan")),
         ("smallest positive subnormal number", 2**-126 * 2**-23, 2**-126 * 2**-23),
-        ("largest normal number", 2**127 * (2 - 2**-23), float("inf")),
+        # ROCm's torch.log2 implementation has higher numerical precision than NVIDIA's,
+        # causing the largest normal fp32 number test case to floor to 2^127 instead of 
+        # overflowing to inf
+        ("largest normal number", 2**127 * (2 - 2**-23), 2**127 if is_ROCM() else float("inf")),
         ("smallest positive normal number", 2**-126, 2**-126),
         ("largest number less than one", 1.0 - 2**-24, 0.5),
         ("smallest number larger than one", 1.0 + 2**-23, 1.0),
@@ -32,7 +35,6 @@ from torchao.testing.utils import skip_if_rocm
         # ("largest subnormal number", [2**-126 * (1 - 2**-23), 1.1754943508222875e-38]),
     ],
 )
-@skip_if_rocm("ROCm enablement in progress")
 def test_round_scale_down_to_power_of_2_valid_inputs(
     test_case: dict,
 ):


### PR DESCRIPTION
Summary
Modified test case to accept ROCM specific value

ROCm's torch.log2 implementation has higher numerical precision than NVIDIA's, causing the largest normal fp32 number test case to floor to 2^127 instead of overflowing to inf. Updated test to accept platform-specific expected values and removed skip_if_rocm decorator to enable the test on ROCm.
