### PR TITLE
make torchao import not initialize cuda

### DIFF
--- a/test/kernel/test_blockwise_triton.py
+++ b/test/kernel/test_blockwise_triton.py
@@ -17,7 +17,7 @@ from torchao.kernel.blockwise_quantization import (
     fp8_blockwise_weight_dequant,
     fp8_blockwise_weight_quant,
 )
-from torchao.utils import is_sm_at_least_89
+from torchao.utils import is_sm_at_least_90
 
 BLOCKWISE_SIZE_MNK = [
     (2, 512, 128),
@@ -30,13 +30,9 @@ BLOCKWISE_SIZE_MNK = [
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
 @pytest.mark.parametrize("_, N, K", BLOCKWISE_SIZE_MNK)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float8_e4m3fn, torch.float8_e5m2]
-    if is_sm_at_least_89()
-    else [torch.float8_e5m2],
-)
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_blockwise_quant_dequant(_, N, K, dtype):
     x = torch.randn(N, K).cuda()
     qx, s = fp8_blockwise_weight_quant(x, dtype=dtype)
@@ -52,13 +48,9 @@ def test_blockwise_quant_dequant(_, N, K, dtype):
     version.parse(triton.__version__) < version.parse("3.3.0"),
     reason="Triton version < 3.3.0, test skipped",
 )
+@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
 @pytest.mark.parametrize("M, N, K", BLOCKWISE_SIZE_MNK)
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float8_e4m3fn, torch.float8_e5m2]
-    if is_sm_at_least_89()
-    else [torch.float8_e5m2],
-)
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_blockwise_fp8_gemm(M, N, K, dtype):
     A = torch.randn(M, K).cuda()
     B = torch.randn(N, K).cuda()

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -158,6 +158,7 @@ class TestQuantSemiSparse(common_utils.TestCase):
 
 
 class TestBlockSparseWeight(common_utils.TestCase):
+    @unittest.skipIf(not is_sm_at_least_90(), "Need H100 to run")
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @common_utils.parametrize("compile", [True, False])
     @common_utils.parametrize("input_shape", [1, 1024])
@@ -192,6 +193,7 @@ class TestBlockSparseWeight(common_utils.TestCase):
 
 
 class TestQuantBlockSparseWeight(common_utils.TestCase):
+    @unittest.skipIf(not is_sm_at_least_90(), "Need H100 to run")
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     @common_utils.parametrize("compile", [True, False])
     def test_sparse(self, compile):

--- a/test/test_lean_import.py
+++ b/test/test_lean_import.py
@@ -1,0 +1,24 @@
+import unittest
+
+import torch
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestLeanImport(unittest.TestCase):
+    def test_torchao_import_does_not_initialize_cuda(self):
+        # patch torch.cuda.current_device to ensure it isn't called during
+        # torchao import
+        def _patched_current_device():
+            raise AssertionError("do not call me")
+
+        old_current_device = torch.cuda.current_device
+        torch.cuda.current_device = _patched_current_device
+
+        # the import below should not hit the assertion
+        import torchao  # noqa: F401
+
+        torch.cuda.current_device = old_current_device
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -127,7 +127,6 @@ else:
         logger.debug(f"Skipping import of cpp extensions: {e}")
 
 from torchao.quantization import (
-    autoquant,
     quantize_,
 )
 
@@ -135,7 +134,7 @@ from . import dtypes, optim, quantization, swizzle, testing
 
 __all__ = [
     "dtypes",
-    "autoquant",
+    "autoquant",  # noqa: F405
     "optim",
     "quantize_",
     "swizzle",
@@ -143,3 +142,18 @@ __all__ = [
     "ops",
     "quantization",
 ]
+
+# Lazy imports to avoid CUDA initialization at import time
+_lazy_imports = {
+    "autoquant": "torchao.quantization.autoquant",
+}
+
+
+def __getattr__(name):
+    if name in _lazy_imports:
+        import importlib
+
+        module_path = _lazy_imports[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -1,18 +1,31 @@
+import importlib
+
 from torchao.kernel import (
     int_scaled_matmul,
     safe_int_mm,
 )
 
-from .autoquant import (
-    ALL_AUTOQUANT_CLASS_LIST,
-    DEFAULT_AUTOQUANT_CLASS_LIST,
-    DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST,
-    DEFAULT_INT4_AUTOQUANT_CLASS_LIST,
-    DEFAULT_SPARSE_AUTOQUANT_CLASS_LIST,
-    GEMLITE_INT4_AUTOQUANT_CLASS_LIST,
-    OTHER_AUTOQUANT_CLASS_LIST,
-    autoquant,
-)
+# Lazy imports to avoid CUDA initialization at import time
+_lazy_imports = {
+    "ALL_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "DEFAULT_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "DEFAULT_FLOAT_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "DEFAULT_INT4_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "DEFAULT_SPARSE_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "GEMLITE_INT4_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "OTHER_AUTOQUANT_CLASS_LIST": ".autoquant",
+    "autoquant": ".autoquant",
+}
+
+
+def __getattr__(name):
+    if name in _lazy_imports:
+        module_path = _lazy_imports[name]
+        module = importlib.import_module(module_path, __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 from .GPTQ import (
     Int4WeightOnlyGPTQQuantizer,
     MultiTensor,

--- a/torchao/sparsity/blocksparse.py
+++ b/torchao/sparsity/blocksparse.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Tuple
 import torch
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
-from torchao.kernel.bsr_triton_ops import broadcast_batch_dims, bsr_dense_addmm
 from torchao.ops import register_custom_op, register_custom_op_impl
 from torchao.utils import TorchAOBaseTensor
 
@@ -49,6 +48,10 @@ def blocksparse_int_addmm(
     left_alpha: torch.Tensor,
     right_alpha: torch.Tensor,
 ) -> torch.Tensor:
+    from torch.sparse._triton_ops import broadcast_batch_dims
+
+    from torchao.kernel.bsr_triton_ops import bsr_dense_addmm
+
     assert values.dtype == torch.int8
     M = left_alpha.shape[-1]
     K = A.shape[-2]
@@ -95,6 +98,8 @@ def blocksparse_addmm(
     K: int,
     bias: torch.Tensor,
 ) -> torch.Tensor:
+    from torchao.kernel.bsr_triton_ops import bsr_dense_addmm
+
     assert bias is None
     bsr = torch.sparse_bsr_tensor(crow_indices, col_indices, values, size=(M, K))
     N_padded = x_padded.shape[1]


### PR DESCRIPTION
Summary:

Should fix https://github.com/pytorch/ao/issues/3669. The approach is to make everything that initializes cuda state lazy.

Test Plan:

```
pytest -s -x test/test_lean_import.py
```

let's see how CI looks