### PR TITLE
Remove torch == 2.6 CUDA 2.6 and CPU 2.6 CI test configurations

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -59,12 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: CUDA 2.6
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.6.0'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
-            dev-requirements-overrides: ""
           - name: CUDA 2.7
             runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: 'torch==2.7.1'
@@ -84,12 +78,6 @@ jobs:
             gpu-arch-version: "12.6"
             dev-requirements-overrides: ""
 
-          - name: CPU 2.6
-            runs-on: linux.4xlarge
-            torch-spec: 'torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu'
-            gpu-arch-type: "cpu"
-            gpu-arch-version: ""
-            dev-requirements-overrides: ""
           - name: CPU 2.7
             runs-on: linux.4xlarge
             torch-spec: 'torch==2.7.1 --index-url https://download.pytorch.org/whl/cpu'


### PR DESCRIPTION
We can deprecate the version check variables like in https://github.com/pytorch/ao/pull/2720 in a subsequent PR