### PR TITLE
Fix zero-point handling for packed_weight_inputs in INT8

### DIFF
--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -803,7 +803,7 @@ def _register_qconv_weight_prepack_pass(
                 qw,
                 w_scale,
                 x_scale.args[1] if is_fp8 else x_scale,
-                0,
+                0 if is_fp8 else x_zp,
                 stride,
                 padding,
                 dilation,


### PR DESCRIPTION
INT8 requires zero-point, so add conditional zero-point handling for packed_weight_inputs.