### PR TITLE
[mxfp8 moe training] fallback cuda kernel for when input doesn't meet 2d TMA constraints

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_mx_block_rearrange_2d_M_groups.py
@@ -57,6 +57,10 @@ def get_configs() -> List[ExperimentConfig]:
         (131072, 5120 // block_size),
         (131072, 2048 // block_size),
         (131072, 7168 // block_size),
+        (
+            131072,
+            1408 // block_size,
+        ),  # case for dsv3-16b where scale cols not multiple of 16
     ]
     num_groups = [8]
     chunks_per_tb_list = [1, 4, 8]

--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -140,7 +140,7 @@ __device__ __forceinline__ int compute_output_group_start_row(
 }
 
 /**
- * Main kernel for rearranging row-major scale data to blocked layout.
+ *  Pipelined kernel for rearranging row-major scale data to blocked layout.
  *
  * Template parameters:
  * - CHUNK_WIDTH: Width of each chunk (16, 32, 64, or 128 columns)
@@ -638,4 +638,242 @@ void launch_mx_block_rearrange_2d_M_groups_cuda(
     }
 }
 
+// Non-pipelined kernel without TMA for loads, but uses TMA for stores
+// Handles M-groups with one chunk per threadblock (equivalent to CHUNKS_PER_TB=1)
+// Assumes input tensor is contiguous/row-major (stride = scale_cols)
+template <int CHUNK_WIDTH>
+__global__ void mx_blocked_layout_2d_simple_kernel(
+    const uint8_t* __restrict__ input_scales,
+    const int scale_rows,
+    const int scale_cols,
+    const int32_t* __restrict__ input_group_end_offsets,
+    uint8_t* __restrict__ output_scales,
+    const int output_stride_per_row_of_sf_tiles,
+    const int num_groups
+) {
+    constexpr int THREADS_PER_ROW = CHUNK_WIDTH / BYTES_PER_THREAD;
+    constexpr int SF_TILES_PER_THREAD = BYTES_PER_THREAD / SF_COLS;  // 4 tiles per thread
+    constexpr int SF_TILES_PER_CHUNK = CHUNK_WIDTH / SF_COLS;
+    constexpr int OUTPUT_STRIDE_PER_SF_TILE = SF_ROWS * SF_COLS;  // 512 bytes
+    constexpr int CHUNK_SIZE_BYTES = SF_ROWS * CHUNK_WIDTH;
+
+    const int row_chunk_pid = blockIdx.y;  // Each chunk is one superblock with CHUNKS_PER_TB=1
+    const int col_chunk_pid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int row_idx = tid / THREADS_PER_ROW;
+    const int col_idx = tid % THREADS_PER_ROW;
+    const bool is_master_thread = tid == 0;
+
+    // Shared memory: group offset computation + data buffer for blocked layout
+    __shared__ int smem_group_data[64]; // Max 32 groups: [0..31] = chunks per group, [32..63] = cumsum
+    __shared__ __align__(128) uint8_t smem_chunk_buffer[CHUNK_SIZE_BYTES];
+
+    // Find which group this chunk belongs to (using CHUNKS_PER_TB=1)
+    int group_idx;
+    int chunk_idx_in_group;
+    int chunks_until_end;
+    find_group_and_local_offset_for_superblock<1>( // 1 chunk per superblock (i.e., 1 chunk per threadblock) since we aren't pipelining
+        row_chunk_pid,
+        input_group_end_offsets,
+        num_groups,
+        smem_group_data,
+        group_idx,
+        chunk_idx_in_group,
+        chunks_until_end
+    );
+
+    // Early exit for padding chunks beyond all groups
+    if (chunks_until_end <= 0) {
+        return;
+    }
+
+    // Thread 0 computes group boundaries and broadcasts via SMEM
+    __shared__ int s_input_group_start_row;
+    __shared__ int s_input_group_end_row;
+    __shared__ int s_output_group_start_row;
+    if (tid == 0) {
+        s_input_group_start_row = (group_idx > 0) ? input_group_end_offsets[group_idx - 1] : 0;
+        s_input_group_end_row = input_group_end_offsets[group_idx];
+        s_output_group_start_row = compute_output_group_start_row(
+            group_idx, input_group_end_offsets, num_groups, SF_ROWS);
+    }
+    __syncthreads();
+    const int input_group_start_row = s_input_group_start_row;
+    const int input_group_end_row = s_input_group_end_row;
+    const int output_group_start_row = s_output_group_start_row;
+
+    // Compute input row for this thread (within the group)
+    const int chunk_start_row = input_group_start_row + (chunk_idx_in_group * SF_ROWS);
+    const int global_row = chunk_start_row + row_idx;
+    const int global_col_base = col_chunk_pid * CHUNK_WIDTH + col_idx * BYTES_PER_THREAD;
+
+    // Check if this is a valid row (not a padding row)
+    const bool row_valid = global_row < input_group_end_row && global_row < scale_rows;
+
+    // Load data with vectorized loads, falling back to smaller loads at boundaries
+    // For padding rows, row_data stays zero (important for correct padding in output)
+    uint4 row_data = make_uint4(0, 0, 0, 0);
+    const uint8_t* read_ptr = input_scales + global_row * scale_cols + global_col_base;
+
+    // TODO: the efficiency of loads can be improved but the kernel is already several times faster
+    // than Triton and we are going to port these to CuteDSL anyway so don't want to sink more time into this.
+    // Problem: this code will often result in single byte loads when stride is not a multiple of 16/8, 
+    // because many reads will not meet alignment requirements for vectorized loads.
+    // We also can't use 2d TMA to read 128xCHUNK_SIZE chunks because 2d tma also requires global stride by multiple of 16 bytes.
+    if (row_valid) {
+        // Check alignment and bounds for vectorized loads
+        const bool is_aligned_16 = (reinterpret_cast<uintptr_t>(read_ptr) % 16) == 0;
+        const bool is_aligned_8 = (reinterpret_cast<uintptr_t>(read_ptr) % 8) == 0;
+
+        if (global_col_base + 16 <= scale_cols && is_aligned_16) {
+            // Can safely load 16 bytes (int4) with proper alignment
+            row_data = *reinterpret_cast<const uint4*>(read_ptr);
+        } else if (global_col_base + 8 <= scale_cols && is_aligned_8) {
+            // Can safely load 8 bytes (int2) with proper alignment
+            int2 data = *reinterpret_cast<const int2*>(read_ptr);
+            row_data.x = data.x;
+            row_data.y = data.y;
+            // Load remaining bytes individually if needed
+            const int remaining = scale_cols - (global_col_base + 8);
+            #pragma unroll
+            for (int i = 0; i < remaining && i < 8; i++) {
+                reinterpret_cast<uint8_t*>(&row_data)[8 + i] = read_ptr[8 + i];
+            }
+        } else if (global_col_base < scale_cols) {
+            // Load remaining bytes individually (unaligned or small)
+            const int remaining = min(16, scale_cols - global_col_base);
+            #pragma unroll
+            for (int i = 0; i < remaining; i++) {
+                reinterpret_cast<uint8_t*>(&row_data)[i] = read_ptr[i];
+            }
+        }
+    }
+
+    // Compute blocked layout position within SF tile
+    // The blocked layout groups rows into blocks of 32
+    int r_div_32 = row_idx >> 5;    // row_idx / 32
+    int r_mod_32 = row_idx & 31;    // row_idx % 32
+    int blocked_layout_row_offset = (r_mod_32 << 4) + (r_div_32 << 2); // r_mod_32 * 16 + r_div_32 * 4
+
+    // Compute SF tile indices for this thread
+    const int thread_col_start = col_idx * BYTES_PER_THREAD;
+    const int first_sf_tile_idx = thread_col_start / SF_COLS;
+
+    // Compute output tile coordinates (accounting for group padding)
+    const int chunk_sf_tile_col_base = col_chunk_pid * SF_TILES_PER_CHUNK;
+    const int chunk_sf_tile_row = (output_group_start_row / SF_ROWS) + chunk_idx_in_group;
+    const int sf_tiles_per_row = output_stride_per_row_of_sf_tiles / OUTPUT_STRIDE_PER_SF_TILE;
+
+    // Compute columns in this chunk (based on chunk start, not thread start)
+    const int chunk_col_base = col_chunk_pid * CHUNK_WIDTH;
+    const int remaining_cols_in_chunk = scale_cols - chunk_col_base;
+    const int cols_in_chunk = (remaining_cols_in_chunk < CHUNK_WIDTH) ? remaining_cols_in_chunk : CHUNK_WIDTH;
+
+    // Scatter 16 bytes to SMEM in blocked layout (4 bytes per SF tile)
+    // Each thread writes 4 separate 4-byte chunks to different SF tiles in SMEM
+    // NOTE: this will cause bank conflicts but resolving them would prevent us
+    // from doing direct TMA stores for 128x4=512b contiguous bytes, which is worse in my prev experiments
+    #pragma unroll
+    for (int i = 0; i < SF_TILES_PER_THREAD; i++) {
+        // Check if this SF tile column is within bounds
+        if ((first_sf_tile_idx + i) * SF_COLS < cols_in_chunk) {
+            const uint32_t data = reinterpret_cast<const uint32_t*>(&row_data)[i];
+            // Offset within the SMEM chunk buffer for this SF tile
+            const int sf_tile_offset_in_chunk = (first_sf_tile_idx + i) * OUTPUT_STRIDE_PER_SF_TILE;
+            *reinterpret_cast<uint32_t*>(&smem_chunk_buffer[sf_tile_offset_in_chunk + blocked_layout_row_offset]) = data;
+        }
+    }
+
+    // Ensure threads finish their smem writes and use explicit fence to ensure visibility to async proxy for TMA
+    __syncthreads();
+    ptx::fence_proxy_async_shared_cta();
+
+    if (is_master_thread) {
+        // Issue separate 1D TMA stores for each valid SF tile
+        // Each store moves one 512-byte SF tile from SMEM to GMEM
+        constexpr int SF_TILE_SIZE_BYTES = SF_ROWS * SF_COLS;  // 512 bytes
+        const int num_valid_sf_tiles = (cols_in_chunk + SF_COLS - 1) / SF_COLS;
+
+        // Loop over each SF tile and do a separate TMA transfer
+        for (int tile = 0; tile < num_valid_sf_tiles; tile++) {
+            const int col_sf_tile = chunk_sf_tile_col_base + tile;
+            const int linear_sf_tile_idx = chunk_sf_tile_row * sf_tiles_per_row + col_sf_tile;
+
+            uint64_t* dst_gmem = reinterpret_cast<uint64_t*>(
+                output_scales + linear_sf_tile_idx * SF_TILE_SIZE_BYTES);
+            const int smem_sf_tile_offset = tile * SF_TILE_SIZE_BYTES;
+
+            ptx::cp_async_bulk_tensor_1d_shared_to_global(
+                dst_gmem,
+                reinterpret_cast<const uint64_t*>(&smem_chunk_buffer[smem_sf_tile_offset]),
+                SF_TILE_SIZE_BYTES
+            );
+        }
+        ptx::cp_async_bulk_commit_group();
+    }
+
+    // Wait for TMA transfer to complete
+    ptx::cp_async_bulk_wait_group();
+}
+
+
+void launch_mx_block_rearrange_2d_simple_cuda(
+    const uint8_t* scales_ptr,
+    int scale_rows,
+    int scale_cols,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int chunk_width,
+    cudaStream_t stream
+) {
+    // Calculate grid dimensions (upper bound to account for group padding)
+    int num_row_chunks = (scale_rows + SF_ROWS - 1) / SF_ROWS + num_groups;
+    int num_col_chunks = (scale_cols + chunk_width - 1) / chunk_width;
+
+    // Output strides for SF tile addressing
+    int sf_tiles_per_row = (scale_cols + SF_COLS - 1) / SF_COLS;
+    int output_stride_per_sf_tile = SF_ROWS * SF_COLS;  // 512 bytes
+    int output_stride_per_row_of_sf_tiles = output_stride_per_sf_tile * sf_tiles_per_row;
+
+    dim3 grid(num_col_chunks, num_row_chunks);
+
+    // Launch appropriate kernel based on chunk width
+    if (chunk_width == 16) {
+        dim3 block(128);  // 128 rows × 1 thread/row
+        mx_blocked_layout_2d_simple_kernel<16><<<grid, block, 0, stream>>>(
+            scales_ptr, scale_rows, scale_cols,
+            input_group_end_offsets, output_scales_ptr,
+            output_stride_per_row_of_sf_tiles, num_groups);
+    } else if (chunk_width == 32) {
+        dim3 block(256);  // 128 rows × 2 threads/row
+        mx_blocked_layout_2d_simple_kernel<32><<<grid, block, 0, stream>>>(
+            scales_ptr, scale_rows, scale_cols,
+            input_group_end_offsets, output_scales_ptr,
+            output_stride_per_row_of_sf_tiles, num_groups);
+    } else if (chunk_width == 64) {
+        dim3 block(512);  // 128 rows × 4 threads/row
+        mx_blocked_layout_2d_simple_kernel<64><<<grid, block, 0, stream>>>(
+            scales_ptr, scale_rows, scale_cols,
+            input_group_end_offsets, output_scales_ptr,
+            output_stride_per_row_of_sf_tiles, num_groups);
+    } else if (chunk_width == 128) {
+        dim3 block(1024);  // 128 rows × 8 threads/row
+        mx_blocked_layout_2d_simple_kernel<128><<<grid, block, 0, stream>>>(
+            scales_ptr, scale_rows, scale_cols,
+            input_group_end_offsets, output_scales_ptr,
+            output_stride_per_row_of_sf_tiles, num_groups);
+    } else {
+        fprintf(stderr, "CUDA Error: chunk_width must be 16, 32, 64, or 128, got %d\n", chunk_width);
+        return;
+    }
+
+    // Check for launch errors
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+    }
+}
+
+>>>>>>> Stashed changes
 } // namespace mxfp8

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -39,6 +39,16 @@ void launch_mx_block_rearrange_2d_M_groups_cuda(
     int chunks_per_tb,
     cudaStream_t stream);
 
+void launch_mx_block_rearrange_2d_simple_cuda(
+    const uint8_t* scales_ptr,
+    int scale_rows,
+    int scale_cols,
+    const int32_t* input_group_end_offsets,
+    uint8_t* output_scales_ptr,
+    int num_groups,
+    int chunk_width,
+    cudaStream_t stream);
+
 // Helper for tensor validation
 void check_cuda_tensor(const at::Tensor &t, const char *name) {
   TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
@@ -218,15 +228,6 @@ at::Tensor mx_block_rearrange_2d_M_groups(
   const int num_groups = input_group_end_offsets.size(0);
   TORCH_CHECK(num_groups <= 32, "num_groups must be <= 32");
 
-  // Validate TMA alignment requirements: scale_cols must be divisible by 16
-  // Reference: https://docs.nvidia.com/cuda/archive/12.6.3/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
-  // For 2D TMA transfers, the stride must be a multiple of 16 bytes.
-  // Since we use row-major layout with stride = scale_cols (in bytes), scale_cols must be divisible by 16.
-  TORCH_CHECK(cols >= 16 && cols % 16 == 0,
-              "TMA requirement for 2D transfers: stride must be a multiple of 16 bytes. Got scale_cols=",
-              cols, " (stride in row-major layout). ",
-              "Consider using Triton kernel instead with use_cuda_kernel_for_blocked_layout=False.");
-
   // Automatically select chunk_width based on scale_cols
   int chunk_width;
   if (cols >= 64) {
@@ -260,20 +261,38 @@ at::Tensor mx_block_rearrange_2d_M_groups(
   const int32_t* offsets_ptr = input_group_end_offsets.data_ptr<int32_t>();
   uint8_t* output_ptr = reinterpret_cast<uint8_t*>(output.data_ptr());
 
-  // Launch pipelined M groups kernel with specified chunk_width and chunks_per_tb
-  launch_mx_block_rearrange_2d_M_groups_cuda(
-      scales_ptr,
-      scales_tensor.stride(0),
-      rows,
-      cols,
-      padded_rows,
-      offsets_ptr,
-      output_ptr,
-      num_groups,
-      static_cast<int>(chunk_width),
-      static_cast<int>(chunks_per_tb),
-      at::cuda::getCurrentCUDAStream());
-
+  // pipelined kernel will be used if input meets 2d TMA constraint (cols >= 16 and cols % 16 bytes == 0)
+  // Otherwise, a fallback kernel will be used (slightly slower but supports any column count)  
+  const bool can_use_pipelined_kernel = cols >= 16 && cols % 16 == 0;
+  if (can_use_pipelined_kernel)
+  {
+    // Launch pipelined TMA kernel
+    launch_mx_block_rearrange_2d_M_groups_cuda(
+        scales_ptr,
+        scales_tensor.stride(0),
+        rows,
+        cols,
+        padded_rows,
+        offsets_ptr,
+        output_ptr,
+        num_groups,
+        static_cast<int>(chunk_width),
+        static_cast<int>(chunks_per_tb),
+        at::cuda::getCurrentCUDAStream());
+  }
+  else 
+  {
+    // Launch simplified kernel (no TMA, works with any column dimension)
+    launch_mx_block_rearrange_2d_simple_cuda(
+        scales_ptr,
+        rows,
+        cols,
+        offsets_ptr,
+        output_ptr,
+        num_groups,
+        static_cast<int>(chunk_width),
+        at::cuda::getCurrentCUDAStream());
+  }
   return output;
 }
 

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -798,18 +798,6 @@ if mxfp8_cuda_extension_available:
         )
         assert chunks_per_tb in (1, 4, 8, 16), "chunks_per_tb must be 1, 4, 8, or 16"
 
-        # Validate that scale_cols meets TMA alignment requirements
-        # Reference: https://docs.nvidia.com/cuda/archive/12.6.3/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
-        # For 2D TMA transfers, the stride must be a multiple of 16 bytes.
-        # Since we use row-major layout with stride = scale_cols (in bytes), scale_cols must be divisible by 16.
-        rows, cols = scales_tensor.shape
-        if cols % 16 != 0:
-            raise ValueError(
-                f"TMA requirement for 2D transfers: stride must be a multiple of 16 bytes. "
-                f"Got scale_cols={cols} (stride in row-major layout). "
-                f"Consider using Triton kernel instead with use_cuda_kernel_for_blocked_layout=False."
-            )
-
         return torch.ops.torchao.mx_block_rearrange_2d_M_groups.default(
             scales_tensor,
             input_group_end_offsets,


### PR DESCRIPTION
[mxfp8 moe training] fallback cuda kernel for when input doesn't meet 2d TMA constraints

## Context
- In https://github.com/pytorch/ao/issues/3636 the user reported a bug training DeepSeekV3 16b. TL;DR is the CUDA blocked layout kernel for groups along M doesn't support input tensors which don't meet 2d TMA constraint of stride being a multiple of 16 bytes.
- Short term mitigation (https://github.com/pytorch/ao/pull/3656) was to assert this constraint is met, and throw an informative error prompting the user to use the slower but more flexible Triton kernel for this instead.
- This PR lands a proper fix, which is a simple non-pipelined CUDA kernel that is:
   - ~5.5x faster than Triton for DSV3 16b shapes, but handles arbitrary column width
   - Dispatching to use faster pipelined kernel if we can, otherwise fallback to this simpler kernel.


## Tests
- `pytest test/prototype/moe_training/test_kernels.py -v -s -k cuda_mx_block  `

## Benchmarks
```
input_shape      chunks_per_tb    torch_time_us    triton_time_us    cuda_time_us  triton_speedup    cuda_speedup
-------------  ---------------  ---------------  ----------------  --------------  ----------------  --------------
(131072, 44)                 1          1105.65            123.94           19.46  8.92x             56.83x
(131072, 44)                 4          1101.41            109.57           19.46  10.05x            56.61x
(131072, 44)                 8          1042.5             207.97           19.46  5.01x             53.58x
```

E2E in Torchtitan on DSV3 16b I see an extra ~3% TPS speedup with single node dp2ep and the mxfp8_wgrad_with_hp + mxfp8 all2all/expert parallel enabled.