### PR TITLE
docs: Add FqnToConfig to API reference quantization page

### DIFF
--- a/docs/source/api_ref_quantization.rst
+++ b/docs/source/api_ref_quantization.rst
@@ -29,6 +29,7 @@ Inference APIs for quantize\_
     Int8DynamicActivationInt4WeightConfig
     Int8WeightOnlyConfig
     Int8DynamicActivationInt8WeightConfig
+    FqnToConfig
 
 .. currentmodule:: torchao.quantization
 


### PR DESCRIPTION
## Summary

Adds `FqnToConfig` to the API reference quantization documentation page.

## Changes

- Added `FqnToConfig` to the "Inference APIs for quantize_" section in `docs/source/api_ref_quantization.rst`

## Context

`FqnToConfig` was introduced in [v0.15.0](https://github.com/pytorch/ao/releases/tag/v0.15.0) via [PR #3083](https://github.com/pytorch/ao/pull/3083) to allow quantizing parameters by their fully qualified name (FQN). This is particularly useful for MoE models (Llama4, Deepseek) that store weights under attributes like "down_proj" instead of "weight".

Addresses #3693

cc @jcaip @jerryzh168