### PR TITLE
remove rebase mark

### DIFF
--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -875,5 +875,4 @@ void launch_mx_block_rearrange_2d_simple_cuda(
     }
 }
 
->>>>>>> Stashed changes
 } // namespace mxfp8


### PR DESCRIPTION
in my haste to include a change in an important training run, i did a very bad thing and merged prematurely without waiting for green CI, missing a stray rebase mark in the code.

i rebuilt and ran tests after the rebase before i landed, so i must have missed this file with my `git add ...` targets, not sure though.

this time, we'll just check out the PR and wait for green CI.

