### PR TITLE
Implement aten.abs.default for Sparse2x4CUTLASSFloat8Tensor

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
@@ -252,5 +252,11 @@ def _(func, types, args, kwargs):
     )
 
 
+@implements(aten.abs.default)
+def _(func, types, args, kwargs):
+
+    return torch.abs(args[0].dequantize())
+
+
 # Allow a model with Float8Tensor weights to be loaded with `weights_only=True`
 torch.serialization.add_safe_globals([Sparse2x4CUTLASSFloat8Tensor])


### PR DESCRIPTION
Summary:
As titled, to address publishing error in publishing [job](https://fburl.com/mlhub/n31lib6p): 
```
...
raise NotImplementedError(\
NotImplementedError: Sparse2x4CUTLASSFloat8Tensor dispatch: attempting to run unimplemented operator/function: func=<OpOverload(op=\'aten.abs\', overload=\'default\')>, types=(<class \'torchao.quantization.quantize_.workflows.float8.sparse_2x4_cutlass_float8_tensor.Sparse2x4CUTLASSFloat8Tensor\'>,), arg_types=(<class \'torchao.quantization.quantize_.workflows.float8.sparse_2x4_cutlass_float8_tensor.Sparse2x4CUTLASSFloat8Tensor\'>,), kwarg_types={}\
```

Differential Revision: D91404573


