### PR TITLE
Add reference link for MSLK kernel

### DIFF
--- a/torchao/quantization/quantize_/common/kernel_preference.py
+++ b/torchao/quantization/quantize_/common/kernel_preference.py
@@ -27,12 +27,13 @@ class KernelPreference(str, Enum):
     TORCH = "torch"
 
     """Use quantize and quantized mm kernels from mslk library, requires mslk library
+    Reference: https://github.com/meta-pytorch/MSLK
     """
     MSLK = "mslk"
 
     """Emulates gemm_lowp(A, B) with gemm_fp32(A.dequantize(), B.dequantize()).
     Intended use cases are:
-    1. Running CI for product logic on hardware which does not support the 
+    1. Running CI for product logic on hardware which does not support the
        actual lowp gemm.
     2. Debugging kernel numerics issues.
     """


### PR DESCRIPTION
Add GitHub repository link (https://github.com/meta-pytorch/MSLK) to the MSLK kernel preference docstring for easier reference and accessibility.

Test plan: CI (only docstring update)