### PR TITLE
fix ruff after #3711

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_sparse_2x4_cutlass_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_sparse_2x4_cutlass_float8_tensor.py
@@ -117,13 +117,17 @@ class TestSparse2x4Float8Tensor(common_utils.TestCase):
                 dtype=torch.float,
                 layout=torch.strided,
             )
-            torch.testing.assert_close(expected, original_by_to_dtype_layout, atol=1e-1, rtol=1e-1)
+            torch.testing.assert_close(
+                expected, original_by_to_dtype_layout, atol=1e-1, rtol=1e-1
+            )
 
             original_by_to_dtype = torch.ops.aten.to.dtype(
                 model.weight,
                 torch.float,
             )
-            torch.testing.assert_close(expected, original_by_to_dtype, atol=1e-1, rtol=1e-1)
+            torch.testing.assert_close(
+                expected, original_by_to_dtype, atol=1e-1, rtol=1e-1
+            )
 
 
 common_utils.instantiate_parametrized_tests(TestSparse2x4Float8Tensor)

--- a/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
@@ -193,7 +193,6 @@ implements_torch_function = Sparse2x4CUTLASSFloat8Tensor.implements_torch_functi
 @implements(aten.linear.default)
 @implements_torch_function(torch.nn.functional.linear)
 def _(func, types, args, kwargs):
-
     input_tensor = kwargs.get("input", args[0] if len(args) > 0 else None)
     weight_tensor = kwargs.get("weight", args[1] if len(args) > 1 else None)
     bias = kwargs.get("bias", args[2] if len(args) > 2 else None)
@@ -239,7 +238,6 @@ def _(func, types, args, kwargs):
 # implement to.dtype for cases where dtype specified in args[1]
 @implements(aten.to.dtype)
 def _(func, types, args, kwargs):
-
     dtype = kwargs.get("dtype", args[1] if len(args) > 1 else None)
     assert dtype is not None, "dtype must not be None"
 
@@ -247,7 +245,7 @@ def _(func, types, args, kwargs):
         args[0]
         .dequantize()
         .to(
-            dtype = dtype,
+            dtype=dtype,
         )
     )
 


### PR DESCRIPTION
Summary:

Broken in https://github.com/pytorch/ao/pull/3711, fixing by running `ruff format`

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: