### PR TITLE
[mxfp8 moe training] add emulated mode

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
+++ b/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
@@ -41,6 +41,7 @@ from torchao.prototype.mx_formats.config import (
 )
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
+from torchao.quantization.quantize_.common import KernelPreference
 from torchao.testing.training.roofline_utils import (
     gpu_name_to_specs,
 )
@@ -448,7 +449,7 @@ def benchmark_mxfp8_grouped_mm_fwd_bwd(x, w_t, offs, labels, block_size=32):
     offs_arg = offs
     block_size_arg = block_size
     out_dtype = torch.bfloat16
-    emulated = False
+    kernel_preference = KernelPreference.AUTO
     use_triton_for_dim0_cast = True
     wgrad_with_hp = False
     scale_calculation_mode = MoEScaleCalculationMode.RCEIL
@@ -460,7 +461,7 @@ def benchmark_mxfp8_grouped_mm_fwd_bwd(x, w_t, offs, labels, block_size=32):
             offs_arg,
             block_size_arg,
             out_dtype,
-            emulated,
+            kernel_preference,
             use_triton_for_dim0_cast,
             wgrad_with_hp,
             scale_calculation_mode,

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -17,6 +17,7 @@ from torchao.prototype.moe_training.conversion_utils import (
     MoETrainingConfig,
 )
 from torchao.quantization.quant_api import quantize_
+from torchao.quantization.quantize_.common import KernelPreference
 
 from .testing_utils import _validate_model_conversion
 
@@ -40,6 +41,9 @@ torch._dynamo.config.cache_size_limit = 1000
     [["experts"]],
 )
 @pytest.mark.parametrize("compile", [False, True])
+@pytest.mark.parametrize(
+    "kernel_preference", [KernelPreference.AUTO, KernelPreference.EMULATED]
+)
 @pytest.mark.parametrize(
     "recipe_config",
     [
@@ -66,7 +70,12 @@ torch._dynamo.config.cache_size_limit = 1000
         },
     ],
 )
-def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict):
+def test_moe_training(
+    target_fqns: list[str],
+    compile: bool,
+    kernel_preference: KernelPreference,
+    recipe_config: dict,
+):
     (
         recipe,
         group_alignment_size,
@@ -81,6 +90,21 @@ def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict
         recipe_config["min_param_grad_sqnr"],
     )
     assert torch.cuda.is_available()
+
+    if kernel_preference == KernelPreference.EMULATED:
+        # FP8_ROWWISE doesn't support emulated mode
+        if recipe == MoEScalingType.FP8_ROWWISE:
+            pytest.skip(
+                "Skipping FP8 rowwise tests with kernel_preference=EMULATED, emulated mode only applies to MXFP8"
+            )
+
+    # Emulated mode with compile is not supported
+    if compile and kernel_preference == KernelPreference.EMULATED:
+        pytest.skip(
+            "Skipping compile=True with kernel_preference=EMULATED, not currently supported"
+        )
+
+    # FP8_ROWWISE hardware path requires SM90
     if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
         9,
         0,
@@ -89,15 +113,22 @@ def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict
             f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
 
-    elif recipe in (
-        MoEScalingType.MXFP8,
-        MoEScalingType.MXFP8_WGRAD_WITH_HP,
-    ) and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    # MXFP8 hardware path requires SM100
+    if (
+        recipe
+        in (
+            MoEScalingType.MXFP8,
+            MoEScalingType.MXFP8_WGRAD_WITH_HP,
+        )
+        and kernel_preference != KernelPreference.EMULATED
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         pytest.skip(
-            f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
+            f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
 
     # Set token group alignment size. This is required so that
@@ -132,7 +163,7 @@ def test_moe_training(target_fqns: list[str], compile: bool, recipe_config: dict
         return False
 
     # quantize test model
-    config = MoETrainingConfig(scaling_type=recipe)
+    config = MoETrainingConfig(scaling_type=recipe, kernel_preference=kernel_preference)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -1,4 +1,5 @@
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
+    _mxfp8_cuda_kernels_available,  # noqa: F401
     mx_block_rearrange_2d_M_groups_cuda,  # noqa: F401
     mxfp8_quantize_cuda_3d,  # noqa: F401
     torch_to_blocked_2d_K_groups,  # noqa: F401

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -701,11 +701,13 @@ def _blocked_group_start_idx(
     return group_start_idx
 
 
-mxfp8_cuda_extension_available = is_sm_at_least_100() and is_cuda_version_at_least(
-    12, 8
+_mxfp8_cuda_kernels_available = (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
 )
 
-if mxfp8_cuda_extension_available:
+if _mxfp8_cuda_kernels_available:
     lib = torch.library.Library("torchao", "FRAGMENT")
     lib.define(
         "mxfp8_quantize_3d(Tensor input, int scale_dim_n, str fp8_format, str scaling_mode) -> (Tensor, Tensor)",

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -17,6 +17,9 @@ from torchao.prototype.moe_training.kernels import (
     triton_fp8_rowwise_3d_transpose_rhs,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
+)
+from torchao.prototype.moe_training.kernels.mxfp8 import (
     mx_block_rearrange_2d_M_groups_cuda,
     mxfp8_quantize_cuda_3d,
     triton_mx_block_rearrange_2d_K_groups,
@@ -32,6 +35,10 @@ from torchao.prototype.mx_formats.config import (
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.kernels import (
+    _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_mx,
+)
+from torchao.prototype.mx_formats.kernels import (
+    _triton_kernels_available,
     triton_mxfp8_dequant_dim0,
     triton_to_mxfp8_dim0,
 )
@@ -41,6 +48,14 @@ from torchao.quantization.quantize_.common import KernelPreference
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# Check if SM100 kernels are available
+# All SM100-dependent kernels are guarded at their definition sites
+_SM100_KERNELS_AVAILABLE = (
+    _mxfp8_cuda_kernels_available_quant
+    and _mxfp8_cuda_kernels_available_mx
+    and _triton_kernels_available
+)
+
 
 def _quantize_then_scaled_grouped_mm(
     A: torch.Tensor,
@@ -48,6 +63,7 @@ def _quantize_then_scaled_grouped_mm(
     offs: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = torch.bfloat16,
     scaling_type: MoEScalingType = MoEScalingType.FP8_ROWWISE,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
 ) -> torch.Tensor:
     """
     This function performs dynamic quantization with the given recipe
@@ -60,6 +76,8 @@ def _quantize_then_scaled_grouped_mm(
             and in column-major memory layout.
         offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
         out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Currently only torch.bfloat16 is supported.
+        scaling_type (MoEScalingType): The scaling type to use for quantization.
+        kernel_preference (KernelPreference): Kernel preference for quantization and compute. Only applies to MXFP8 scaling types.
     """
     # TODO: Remove logging once prototype is more mature. This is currently very useful for development and debugging.
     if scaling_type == MoEScalingType.FP8_ROWWISE:
@@ -81,7 +99,7 @@ def _quantize_then_scaled_grouped_mm(
             offs,
             block_size,
             out_dtype,
-            emulated=False,  # TODO: support
+            kernel_preference=kernel_preference,
             use_triton_for_dim0_cast=True,  # TODO: configurable
             wgrad_with_hp=wgrad_with_hp,
             scale_calculation_mode=ScaleCalculationMode.RCEIL,
@@ -312,6 +330,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         group_offsets: Optional[torch.Tensor] = None,
         block_size: int = 32,
         out_dtype: Optional[torch.dtype] = torch.bfloat16,
+        kernel_preference: KernelPreference = KernelPreference.AUTO,
         use_triton_for_dim0_cast: bool = True,
         wgrad_with_hp: bool = False,
         scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
@@ -326,6 +345,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             group_offsets: Cumulative token counts per expert, shape (E,)
             block_size: Block size for MXFP8 quantization (must be 32)
             out_dtype: Output dtype (bfloat16 or float32)
+            kernel_preference: Kernel preference for quantization and compute
             use_triton_for_dim0_cast: Use Triton kernel for dim0 quantization
             wgrad_with_hp: Compute weight gradient in high precision
             scale_calculation_mode: Mode for scale calculation (RCEIL, FLOOR, etc.)
@@ -334,6 +354,27 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         Returns:
             Output tensor, shape (M, N)
         """
+        assert kernel_preference in (
+            KernelPreference.AUTO,
+            KernelPreference.EMULATED,
+        ), "kernel_preference must be AUTO or EMULATED"
+
+        # emulated mode validation
+        emulated = kernel_preference == KernelPreference.EMULATED
+        assert emulated or _SM100_KERNELS_AVAILABLE, (
+            "SM100 kernels not available. Please use use torchao CUDA 12.8+ build on SM100/100a device(s). "
+            "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
+        )
+        if emulated:
+            assert not use_triton_for_dim0_cast, (
+                "Triton kernel for quantization along dim0 cannot be used in emulated mode. "
+                "Set `use_triton_for_dim0_cast=False` to use Torch native implementation instead."
+            )
+            assert not use_cuda_kernel_for_blocked_layout, (
+                "CUDA kernel for blocked layout for grouped along M is not supported in emulated mode. "
+                "Set `use_cuda_kernel_for_blocked_layout=False` to use more flexible but slower Triton kernel."
+            )
+
         # Input validation
         assert input_act.ndim == 2, "input_act must be 2D"
         assert weight_t.ndim == 3, "weight_t must be 3D"
@@ -366,27 +407,44 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             scale_calculation_mode,
         )
 
-        # Convert scales to blocked format for 2d-3d grouped mm
-        input_act_scales_blocked = _block_rearrange_M_groups(
-            input_act_scales, group_offsets, use_cuda_kernel_for_blocked_layout
-        )
-        weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
-
         # Perform grouped GEMM: output = input_act @ weight_t
         # output shape: (M, N)
-        output = torch._scaled_grouped_mm(
-            input_act_data,
-            weight_data.transpose(-2, -1),  # Transpose back to (E, K, N)
-            input_act_scales_blocked,
-            weight_scales_blocked,
-            offs=group_offsets,
-            out_dtype=out_dtype,
-        )
+        if emulated:
+            # Use emulated BF16 path: dequantize and use regular grouped mm
+            # weight_data is (E, N, K), weight_scales is (E, N, K//block_size)
+            # The emulated function expects B in (E, N, K) format
+            output = _emulated_mxfp8_scaled_grouped_mm_2d_3d(
+                input_act_data,
+                input_act_scales,
+                weight_data,  # Keep as (E, N, K)
+                weight_scales,  # Keep as (E, N, K//block_size)
+                offs=group_offsets,
+                out_dtype=out_dtype,
+                block_size=block_size,
+            )
+        else:
+            # Path using SM100 kernels.
+            # Convert scales to blocked layout on a per-group basis required for tcgen05.mma for 2d-3d grouped mm.
+            input_act_scales_blocked = _block_rearrange_M_groups(
+                input_act_scales, group_offsets, use_cuda_kernel_for_blocked_layout
+            )
+            weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(
+                weight_scales
+            )
+            output = torch._scaled_grouped_mm(
+                input_act_data,
+                weight_data.transpose(-2, -1),  # Transpose back to (E, K, N)
+                input_act_scales_blocked,
+                weight_scales_blocked,
+                offs=group_offsets,
+                out_dtype=out_dtype,
+            )
 
         # Save tensors and config for backward
         ctx.save_for_backward(input_act, weight_t, group_offsets)
         ctx.block_size = block_size
         ctx.out_dtype = out_dtype
+        ctx.kernel_preference = kernel_preference
         ctx.use_triton_for_dim0_cast = use_triton_for_dim0_cast
         ctx.wgrad_with_hp = wgrad_with_hp
         ctx.scale_calculation_mode = scale_calculation_mode
@@ -409,10 +467,18 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         input_act, weight_t, group_offsets = ctx.saved_tensors
         block_size = ctx.block_size
         out_dtype = ctx.out_dtype
+        kernel_preference = ctx.kernel_preference
         use_triton_for_dim0_cast = ctx.use_triton_for_dim0_cast
         wgrad_with_hp = ctx.wgrad_with_hp
         scale_calculation_mode = ctx.scale_calculation_mode
         use_cuda_kernel_for_blocked_layout = ctx.use_cuda_kernel_for_blocked_layout
+
+        # Check SM100 kernel availability when not using emulated mode
+        emulated = kernel_preference == KernelPreference.EMULATED
+        assert emulated or _SM100_KERNELS_AVAILABLE, (
+            "SM100 kernels not available. Please use use torchao CUDA 12.8+ build on SM100/100a device(s)."
+            "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
+        )
 
         # Compute gradient w.r.t. input activations
         grad_input = _compute_dgrad(
@@ -424,6 +490,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             scale_calculation_mode,
             use_triton_for_dim0_cast,
             use_cuda_kernel_for_blocked_layout,
+            kernel_preference,
         )
 
         # Compute gradient w.r.t. weights (high-precision or quantized)
@@ -435,8 +502,9 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             out_dtype,
             scale_calculation_mode,
             wgrad_with_hp,
+            kernel_preference,
         )
-        return grad_input, grad_weight_t, None, None, None, None, None, None, None
+        return grad_input, grad_weight_t, None, None, None, None, None, None, None, None
 
 
 def _compute_dgrad(
@@ -448,13 +516,13 @@ def _compute_dgrad(
     scale_calculation_mode: ScaleCalculationMode,
     use_triton_for_dim0_cast: bool,
     use_cuda_kernel_for_blocked_layout: bool,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
 ) -> torch.Tensor:
     """
     Compute gradient w.r.t. input activations: grad_input = grad_output @ weight.
 
     Args:
-        grad_output_data: Quantized gradient output, shape (M, N)
-        grad_output_scales: Scales for grad_output, shape (M, N//block_size)
+        grad_output: Gradient output, shape (M, N)
         weight_t: Expert weights transposed, shape (E, K, N)
         group_offsets: Group offsets for grouped mm
         block_size: Block size for quantization
@@ -462,6 +530,7 @@ def _compute_dgrad(
         scale_calculation_mode: Mode for scale calculation
         use_triton_for_dim0_cast: Use Triton for dim0 quantization. If false, use torch.compile.
         use_cuda_kernel_for_blocked_layout: Use CUDA for blocked layout for groups along M
+        kernel_preference: Kernel preference for quantization and compute
 
     Returns:
         grad_input, shape (M, K)
@@ -473,15 +542,35 @@ def _compute_dgrad(
         grad_output, block_size, use_triton_for_dim0_cast, scale_calculation_mode
     )
 
-    # Quantize weights along N dimension (contraction dim for this gemm)
-    # weight shape: (E, K, N) -> (E, N, K)
+    emulated = kernel_preference == KernelPreference.EMULATED
+    if emulated:
+        # No CUDA kernel in emulated mode, use torch native impl
+        weight_data, weight_scales = _quantize_3d_along_dim1_native(
+            weight_t.transpose(-2, -1), block_size, scale_calculation_mode
+        )
+        grad_input = _emulated_mxfp8_scaled_grouped_mm_2d_3d(
+            grad_output_data,  # (M, N)
+            grad_output_scales,  # (M, N//block_size)
+            weight_data.transpose(-2, -1),  # (E, N, K)
+            weight_scales.transpose(-2, -1),  # (E, K, N//block_size)
+            offs=group_offsets,
+            out_dtype=out_dtype,
+            block_size=block_size,
+        )
+        return grad_input  # (M, K)
+
+    # Path requiring SM100 kernels.
+    # Use CUDA kernel for dim1 quantization
+    # weight_data: (E, N, K), weight_scales: (E, N//block_size, K)
     weight = weight_t.transpose(-2, -1)
     weight_data, weight_scales = mxfp8_quantize_cuda_3d(
         weight._data if hasattr(weight, "_data") else weight,
         block_size=block_size,
         scaling_mode=scale_calculation_mode.value.lower(),
     )
-    # Transpose scales: (E, N//block_size, K) -> (E, K, N//block_size)
+
+    # Transpose scales to align with torch API requirement:
+    # (E, N//block_size, K) -> (E, K, N//block_size)
     weight_scales = weight_scales.transpose(-2, -1)
 
     # Convert scales to blocked format
@@ -491,16 +580,15 @@ def _compute_dgrad(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute grad_input = grad_output @ weight
-    # grad_input shape: (M, N) @ (E, N, K) = (M, K)
     grad_input = torch._scaled_grouped_mm(
-        grad_output_data,
-        weight_data,
-        grad_output_scales_blocked,
-        weight_scales_blocked,
+        grad_output_data,  # (M, N)
+        weight_data,  # (E, N, K)
+        grad_output_scales_blocked,  # (M, N//block_size)
+        weight_scales_blocked,  # (E, K, N//block_size)
         offs=group_offsets,
         out_dtype=out_dtype,
     )
-    return grad_input
+    return grad_input  # (M, K)
 
 
 def _compute_wgrad(
@@ -511,6 +599,7 @@ def _compute_wgrad(
     out_dtype: torch.dtype,
     scale_calculation_mode: ScaleCalculationMode,
     wgrad_with_hp: bool = False,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
 ) -> torch.Tensor:
     """
     Compute gradient w.r.t. weights with quantization.
@@ -522,6 +611,8 @@ def _compute_wgrad(
         block_size: Block size for quantization
         out_dtype: Output dtype
         scale_calculation_mode: Mode for scale calculation
+        wgrad_with_hp: Whether to compute weight gradient in high precision
+        kernel_preference: Kernel preference for quantization and compute
 
     Returns:
         grad_weight_t, shape (E, K, N)
@@ -539,8 +630,45 @@ def _compute_wgrad(
         )
         return grad_weight.transpose(-2, -1)
 
-    # Quantize grad_output transposed along dim1 (M dimension)
-    # grad_output_t shape: (N, M) with scales shape (N, M//block_size)
+    # Quantize grad_output and input_act transposed along dim1 (M dimension)
+    emulated = kernel_preference == KernelPreference.EMULATED
+    if emulated:
+        # Use native PyTorch quantization (works on any hardware)
+        grad_output_t_scales, grad_output_t_data = to_mx(
+            grad_output.transpose(
+                -2, -1
+            ).contiguous(),  # (M,N) -> (N,M) and quantize along M
+            elem_dtype=torch.float8_e4m3fn,
+            block_size=block_size,
+            scaling_mode=scale_calculation_mode,
+        )
+        input_act_t_scales, input_act_t_data = to_mx(
+            input_act.transpose(
+                -2, -1
+            ).contiguous(),  # (M,K) -> (K,M) and quantize along M
+            elem_dtype=torch.float8_e4m3fn,
+            block_size=block_size,
+            scaling_mode=scale_calculation_mode,
+        )
+
+        # Dequantize and run bf16 grouped mm for emulation
+        grad_weight = _emulated_mxfp8_scaled_grouped_mm_2d_2d(
+            grad_output_t_data,  # (N, M)
+            grad_output_t_scales,  # (N, M//block_size)
+            input_act_t_data.transpose(-2, -1),  # (K, M) -> (M, K)
+            input_act_t_scales.transpose(
+                -2, -1
+            ),  # (K, M//block_size) -> (M//block_size, K)
+            offs=group_offsets,
+            out_dtype=out_dtype,
+            block_size=block_size,
+        )
+        # Transpose to match weight_t shape in forward: (E, N, K) -> (E, K, N)
+        return grad_weight.transpose(-2, -1)
+
+    # Path requiring SM100 kernels.
+    # Use CUDA kernel for dim1 quant
+    # (M,N) -> (M//block_size, N)^T -> (N, M//block_size)
     grad_output_t_mx = _to_mxfp8_dim1_kernel_wrapper(
         grad_output,
         block_size,
@@ -553,8 +681,7 @@ def _compute_wgrad(
     grad_output_t_data = grad_output_t_mx.qdata
     grad_output_t_scales = grad_output_t_mx.scale
 
-    # Quantize input_act transposed along dim1 (M dimension)
-    # input_act_t shape: (K, M) with scales shape (K, M//block_size)
+    # (M,K) -> (M//block_size, K)^T -> (K, M//block_size)
     input_act_t_mx = _to_mxfp8_dim1_kernel_wrapper(
         input_act,
         block_size,
@@ -567,7 +694,7 @@ def _compute_wgrad(
     input_act_t_data = input_act_t_mx.qdata
     input_act_t_scales = input_act_t_mx.scale
 
-    # Convert scales to blocked format for 2d-2d grouped mm
+    # Convert scales to blocked layout required for tcgen05.mma on a per-group basis for 2d-2d grouped mm
     scale_group_offsets = group_offsets // block_size
     grad_output_t_scales_blocked = triton_mx_block_rearrange_2d_K_groups(
         grad_output_t_scales,
@@ -588,8 +715,45 @@ def _compute_wgrad(
         offs=group_offsets,
         out_dtype=out_dtype,
     )
-    # Transpose to match weight_t shape: (E, N, K) -> (E, K, N)
+
+    # Transpose to match weight_t shape in forward: (E, N, K) -> (E, K, N)
     return grad_weight.transpose(-2, -1)
+
+
+def _quantize_3d_along_dim1_native(
+    x: torch.Tensor,
+    block_size: int,
+    scale_calculation_mode: ScaleCalculationMode,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize 3D tensor (E, N, K) along dim1 (N dimension) using native PyTorch.
+    Works on any hardware, not just SM100.
+
+    Args:
+        x: Input tensor of shape (E, N, K)
+        block_size: Block size for quantization
+        scale_calculation_mode: Mode for scale calculation
+
+    Returns:
+        tuple: (quantized_data, scales)
+            - quantized_data: shape (E, N, K)
+            - scales: shape (E, N//block_size, K)
+    """
+    # Transpose (E,N,K) to (E,K,N) so N is final dim,
+    # since to_mx scales along that dim
+    scales, qdata = to_mx(
+        x.transpose(-2, -1).contiguous(),
+        elem_dtype=torch.float8_e4m3fn,
+        block_size=block_size,
+        scaling_mode=scale_calculation_mode,
+    )
+
+    # Transpose tensors and scales back so we have effectively
+    # quantized input shape (E, N, K) along N
+    qdata = qdata.transpose(-2, -1)
+    scales = scales.transpose(-2, -1)
+
+    return qdata, scales
 
 
 def _extract_or_quantize_dim0(
@@ -613,13 +777,15 @@ def _extract_or_quantize_dim0(
     if isinstance(tensor, MXTensor):
         return tensor.qdata, tensor.scale
 
-    if use_triton:
+    # Use SM100 Triton kernel if available and requested
+    if use_triton and _SM100_KERNELS_AVAILABLE:
         qdata, scale = triton_to_mxfp8_dim0(
             tensor,
             inner_block_size=block_size,
             scaling_mode=str(scale_calculation_mode.value).lower(),
         )
     else:
+        # Fallback to native PyTorch (works on any hardware)
         scale, qdata = to_mx(
             tensor,
             elem_dtype=torch.float8_e4m3fn,
@@ -758,7 +924,7 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_3d(
     A = A.reshape(A_orig_shape)
 
     # Dequantize weights
-    # Tranpose to get block_size on rightmost dim
+    # Transpose to get block_size on rightmost dim
     # B_data shape: (E, N, K)
     # B_scale shape: (E, N, K//block_size)
     E, N, K = B_data.shape
@@ -783,6 +949,7 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_3d(
     return out
 
 
+@torch.compiler.disable
 def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
     A_data: torch.Tensor,  # (M, K)
     A_scale: torch.Tensor,  # (M, K//block_size)
@@ -892,7 +1059,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
     offs: Optional[torch.Tensor] = None,
     block_size: int = 32,
     out_dtype: Optional[torch.dtype] = torch.bfloat16,
-    emulated: bool = False,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
     use_triton_for_dim0_cast: bool = True,
     wgrad_with_hp: bool = False,
     scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
@@ -911,7 +1078,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
         - offs (int32 torch.Tensor): The offsets to use to mark the end index of each group along the dim0 of the A tensor.
         - block_size (int): The block size to use for mxpf8 quantization. Currently only 32 is supported.
         - out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Default is torch.bfloat16.
-        - emulated (bool): Whether to use the emulated mxpf8 scaled grouped mm kernel (for testing).
+        - kernel_preference (KernelPreference): Kernel preference for quantization and compute.
         - use_triton_for_dim0_cast (bool): Whether to use Triton for the dim0 cast. Default true. If false, use torch native implementation.
         - wgrad_with_hp (bool): Whether to compute weight gradients in high precision.
         - scale_calculation_mode (ScaleCalculationMode): The mode to use for scale calculation.
@@ -926,6 +1093,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
         offs,
         block_size,
         out_dtype,
+        kernel_preference,
         use_triton_for_dim0_cast,
         wgrad_with_hp,
         scale_calculation_mode,

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -17,6 +17,7 @@ from torch.distributed.fsdp import MixedPrecisionPolicy
 
 from torchao.prototype.moe_training import _quantize_then_scaled_grouped_mm
 from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.quantization.quantize_.common import KernelPreference
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     """
 
     scaling_type: MoEScalingType = MoEScalingType.FP8_ROWWISE
+    kernel_preference: KernelPreference = KernelPreference.AUTO
     grouped_mm_func_name = "_grouped_mm"
     offs_arg_name = "offs"
 
@@ -51,6 +53,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
         cls,
         tensor: torch.Tensor,
         scaling_type: MoEScalingType,
+        kernel_preference: KernelPreference = KernelPreference.AUTO,
     ):
         self = torch.Tensor._make_wrapper_subclass(
             cls,
@@ -65,15 +68,18 @@ class ScaledGroupedMMTensor(torch.Tensor):
             requires_grad=tensor.requires_grad,
         )
         self.scaling_type = scaling_type
+        self.kernel_preference = kernel_preference
         return self
 
     def __init__(
         self,
         tensor: torch.Tensor,
         scaling_type: MoEScalingType,
+        kernel_preference: KernelPreference = KernelPreference.AUTO,
     ):
         self._data = tensor
         self.scaling_type = scaling_type
+        self.kernel_preference = kernel_preference
 
     @classmethod
     def __torch_function__(cls, func, types, args, kwargs={}):
@@ -94,6 +100,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
                 "B should be a ScaledGroupedMMTensor"
             )
             scaling_type = B.scaling_type
+            kernel_preference = B.kernel_preference
             A_is_2d = A.ndim == 2
             B_is_2d_or_3d = B.ndim == 2 or B.ndim == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
@@ -104,6 +111,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
                     B,
                     *other_args,
                     scaling_type=scaling_type,
+                    kernel_preference=kernel_preference,
                     **kwargs,
                 )
 
@@ -114,15 +122,18 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs={}):
-        # unwrap args/kwargs and extract scaling_type
+        # unwrap args/kwargs and extract scaling_type and kernel_preference
         scaling_type = None
+        kernel_preference = None
 
         def unwrap(t):
-            nonlocal scaling_type
+            nonlocal scaling_type, kernel_preference
             if scaling_type is None:
                 scaling_type = t.scaling_type
+                kernel_preference = t.kernel_preference
             else:
                 assert t.scaling_type == scaling_type
+                assert t.kernel_preference == kernel_preference
             return t._data
 
         args_unwrapped, kwargs_unwrapped = pytree.tree_map_only(
@@ -134,7 +145,9 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
         # detach is special case
         if func == torch.ops.aten.detach.default:
-            return ScaledGroupedMMTensor(args_unwrapped[0], scaling_type)
+            return ScaledGroupedMMTensor(
+                args_unwrapped[0], scaling_type, kernel_preference
+            )
 
         # perform op
         out = func(*args_unwrapped, **kwargs_unwrapped)
@@ -146,15 +159,18 @@ class ScaledGroupedMMTensor(torch.Tensor):
         # wrap outputs back into ScaledGroupedMMTensor for ops that do preserve subclass
         return pytree.tree_map_only(
             torch.Tensor,
-            lambda x: ScaledGroupedMMTensor(x, scaling_type),
+            lambda x: ScaledGroupedMMTensor(x, scaling_type, kernel_preference),
             out,
         )
 
     def __repr__(self):
-        return f"ScaledGroupedMMTensor(data={self._data}, scaling_type={self.scaling_type})"
+        return f"ScaledGroupedMMTensor(data={self._data}, scaling_type={self.scaling_type}, kernel_preference={self.kernel_preference})"
 
     def __tensor_flatten__(self):
-        metadata = {"scaling_type": self.scaling_type}
+        metadata = {
+            "scaling_type": self.scaling_type,
+            "kernel_preference": self.kernel_preference,
+        }
         return ["_data"], metadata
 
     @staticmethod
@@ -162,6 +178,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
         return ScaledGroupedMMTensor(
             inner_tensors["_data"],
             flatten_spec["scaling_type"],
+            flatten_spec["kernel_preference"],
         )
 
     # fsdp hooks based on https://github.com/pytorch/pytorch/blob/20e40492b046b9287726d3ec656117e4dc38f0e2/test/distributed/_composable/fsdp/test_fully_shard_extensions.py#L81
@@ -193,11 +210,13 @@ class ScaledGroupedMMTensor(torch.Tensor):
             if isinstance(out, ScaledGroupedMMTensor):
                 out_data = out._data
                 out.scaling_type = self.scaling_type
+                out.emulated = self.emulated
             elif isinstance(out, DTensor) and isinstance(
                 out._local_tensor, ScaledGroupedMMTensor
             ):
                 out_data = out._local_tensor._data
                 out._local_tensor.scaling_type = self.scaling_type
+                out._local_tensor.emulated = self.emulated
             else:
                 raise RuntimeError(
                     f"expect out to be ScaledGroupedMMTensor or DTensor with local_tensor=ScaledGroupedMM, but got {type(out)}"
@@ -220,6 +239,6 @@ class ScaledGroupedMMTensor(torch.Tensor):
             return
 
         # For training step 0, out=None, so we need to return a new ScaledGroupedMMTensor.
-        output = ScaledGroupedMMTensor(data, self.scaling_type)
+        output = ScaledGroupedMMTensor(data, self.scaling_type, self.emulated)
         inner_tensors = (data,)
         return output, inner_tensors


### PR DESCRIPTION
Stacked PRs:
 * #3735
 * #3734
 * __->__#3724


--- --- ---

## Summary
Support emulated mode in `_to_mxfp8_then_scaled_grouped_mm` autograd function, which can be used for non-sm100 CI or developers without sm100 devices.

Emulated mode does the following:
   - Uses torch native dim0 quant, asserts `use_triton_for_dim0_cast` is False
   - Uses torch native 3d quantization along dim1 in backward, instead of CUDA kernel for 3d dim1 quant
   - Use torch native dim1 quant instead of CUDA kernel for 2d dim1 quant  
   - Uses hardware agnostic Triton kernel for scale factor blocked layout per group along M. Asserts `use_cuda_kernel_for_blocked_layout` is false
   - Dequantize and do bf16 `torch._grouped_mm` for all grouped gemms

## Tests
Added test cases for emulated mode. 
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -v -s `
- `pytest test/prototype/mx_formats/test_mx_tensor.py -v -s`
- `pytest test/prototype/mx_formats/test_kernels.py -v -s`

Tested on H100 as well and the MXFP8 tests pass:
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -v -s -k mx`

As an aside, some fp8 rowwise tests are failing now on h100 with odd errors like:
- `CUDA error: CUBLAS_STATUS_INVALID_VALUE when calling `::cublasLtMatmulDescSetAttribute(descriptor(), attr, &value, sizeof(value))``
- OOM (??) 

so we should deprecate this soon.