### PR TITLE
[claude] Make rowwise_scaled_linear_sparse_cutlass ABI stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import glob
 import json
 import os
 import pickle
+import re
 import subprocess
 import sys
 import time
@@ -42,6 +43,38 @@ def read_requirements(file_path):
 def read_version(file_path="version.txt"):
     with open(file_path, "r") as file:
         return file.readline().strip()
+
+
+# Check if torch version is at least 2.10.0 (for stable ABI support)
+# util copied from torchao/utils.py 1
+def _parse_version(version_string):
+    """
+    Parse version string representing pre-release with -1
+
+    Examples: "2.5.0.dev20240708+cu121" -> [2, 5, -1], "2.5.0" -> [2, 5, 0]
+    """
+    # Check for pre-release indicators
+    is_prerelease = bool(re.search(r"(git|dev)", version_string))
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)", version_string)
+    if match:
+        major, minor, patch = map(int, match.groups())
+        if is_prerelease:
+            patch = -1
+        return [major, minor, patch]
+    else:
+        raise ValueError(f"Invalid version string format: {version_string}")
+
+
+def _is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
+def _torch_version_at_least(min_version):
+    if _is_fbcode():
+        return True
+
+    # Parser for local identifiers
+    return _parse_version(torch.__version__) >= _parse_version(min_version)
 
 
 SPINQUANT_REL_PATH = Path("torchao") / "prototype" / "spinquant"
@@ -616,6 +649,7 @@ def get_extensions():
 
     use_cutlass = False
     cutlass_90a_sources = None
+    stable_cutlass_90a_sources = None
     build_for_sm90a = False
     build_for_sm100a = False
     if use_cuda and not IS_WINDOWS:
@@ -649,19 +683,23 @@ def get_extensions():
         build_for_sm90a, build_for_sm100a = get_cutlass_build_flags()
         # Define sm90a sources
         cutlass_90a_sources = [
-            os.path.join(
-                extensions_cuda_dir,
-                "rowwise_scaled_linear_sparse_cutlass",
-                "rowwise_scaled_linear_sparse_cutlass_f8f8.cu",
-            ),
+            # TODO: move this to stable_cutlass_90a_sources in #3727
             os.path.join(
                 extensions_cuda_dir,
                 "to_sparse_semi_structured_cutlass_sm9x",
                 "to_sparse_semi_structured_cutlass_sm9x_f8.cu",
             ),
         ]
+
+        stable_cutlass_90a_sources = [
+            os.path.join(
+                extensions_cuda_dir,
+                "rowwise_scaled_linear_sparse_cutlass",
+                "rowwise_scaled_linear_sparse_cutlass_f8f8.cu",
+            ),
+        ]
         for dtypes in ["e4m3e4m3", "e4m3e5m2", "e5m2e4m3", "e5m2e5m2"]:
-            cutlass_90a_sources.append(
+            stable_cutlass_90a_sources.append(
                 os.path.join(
                     extensions_cuda_dir,
                     "rowwise_scaled_linear_sparse_cutlass",
@@ -670,6 +708,7 @@ def get_extensions():
             )
         # Always remove sm90a sources from main sources
         sources = [s for s in sources if s not in cutlass_90a_sources]
+        sources = [s for s in sources if s not in stable_cutlass_90a_sources]
 
     else:
         # Remove CUTLASS-based kernels from the sources list.  An
@@ -731,6 +770,7 @@ def get_extensions():
             )
 
     # Only build the cutlass_90a extension if sm90a is in the architecture flags
+    # TODO: delete this after #3726 and #3727
     if (
         cutlass_90a_sources is not None
         and len(cutlass_90a_sources) > 0
@@ -747,6 +787,38 @@ def get_extensions():
                 cutlass_90a_sources,
                 py_limited_api=True,
                 extra_compile_args=cutlass_90a_extra_compile_args,
+                extra_link_args=extra_link_args,
+            )
+        )
+
+    # Only build the cutlass_90a extension if sm90a is in the architecture flags
+    # and if torch version >= 2.10
+    if (
+        stable_cutlass_90a_sources is not None
+        and len(stable_cutlass_90a_sources) > 0
+        and build_for_sm90a
+        and _torch_version_at_least("2.10.0")
+    ):
+        stable_cutlass_90a_extra_compile_args = copy.deepcopy(extra_compile_args)
+        # Only use sm90a architecture for these sources, ignoring other flags
+        stable_cutlass_90a_extra_compile_args["nvcc"].append(
+            "-gencode=arch=compute_90a,code=sm_90a"
+        )
+        # Add -DUSE_CUDA for stable ABI support (using features in torch 2.10)
+        stable_cutlass_90a_extra_compile_args["cxx"].append("-DUSE_CUDA")
+        stable_cutlass_90a_extra_compile_args["cxx"].append(
+            "-DTORCH_TARGET_VERSION=0x020a000000000000"
+        )
+        stable_cutlass_90a_extra_compile_args["nvcc"].append("-DUSE_CUDA")
+        stable_cutlass_90a_extra_compile_args["nvcc"].append(
+            "-DTORCH_TARGET_VERSION=0x020a000000000000"
+        )
+        ext_modules.append(
+            extension(
+                "torchao._C_cutlass_90a_stable",
+                stable_cutlass_90a_sources,
+                py_limited_api=True,
+                extra_compile_args=stable_cutlass_90a_extra_compile_args,
                 extra_link_args=extra_link_args,
             )
         )

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass.cuh
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass.cuh
@@ -7,11 +7,21 @@
 
 #include <algorithm>
 #include <optional>
+#include <deque>
+#include <mutex>
 
-#include <ATen/ATen.h>
-#include <ATen/core/Tensor.h>
-#include <ATen/cuda/CUDAUtils.h>
-#include <c10/util/Exception.h>
+#include <cuda.h>
+
+#include <torch/csrc/stable/version.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/macros.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/core/Layout.h>
+#include <torch/headeronly/util/Exception.h>
 
 #if defined(TORCHAO_USE_CUTLASS) && !defined(_WIN32) &&                   \
     defined(CUDA_VERSION) && (CUDA_VERSION >= 12020)
@@ -30,6 +40,16 @@
 #include <cutlass/util/packed_stride.hpp>
 
 #include "cutlass_extensions/common.h"
+
+// Redefine CUTLASS_STATUS_CHECK to use STD_TORCH_CHECK for ABI stability
+// TODO: just edit the original one in torchao/csrc/cuda/cutlass_extensions/common.h after #3727
+#undef CUTLASS_STATUS_CHECK
+#define CUTLASS_STATUS_CHECK(status, message_prefix)                           \
+  {                                                                            \
+    STD_TORCH_CHECK(status == cutlass::Status::kSuccess, message_prefix,       \
+                    " : Got CUTLASS error: ", cutlassGetStatusString(status)); \
+  }
+
 #endif
 
 #define OPERATOR_NAME "rowwise_scaled_linear_sparse_cutlass"
@@ -37,7 +57,64 @@
 
 namespace torchao {
 
+using torch::stable::Tensor;
+namespace tsa = torch::stable::accelerator;
+
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
+
+namespace {
+inline tsa::DeviceGuard make_device_guard(const Tensor& t) {
+  return tsa::DeviceGuard(static_cast<tsa::DeviceIndex>(t.get_device_index()));
+}
+
+std::deque<std::once_flag> device_flags;
+std::vector<cudaDeviceProp> device_properties;
+
+void initVectors() {
+  static bool init_flag [[maybe_unused]] = []() {
+    int device_count;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess) {
+      STD_TORCH_CHECK(false, "cudaGetDeviceProperties failed: " +
+                                 std::string(cudaGetErrorString(err)));
+    }
+    device_flags.resize(device_count);
+    device_properties.resize(device_count);
+    return true;
+  }();
+}
+
+void initDeviceProperty(int device_index) {
+  cudaDeviceProp device_prop{};
+  cudaError_t err = cudaGetDeviceProperties(&device_prop, device_index);
+  if (err != cudaSuccess) {
+    STD_TORCH_CHECK(false, "cudaGetDeviceProperties failed: " +
+                               std::string(cudaGetErrorString(err)));
+  }
+  device_properties[device_index] = device_prop;
+}
+
+cudaDeviceProp* get_device_prop() {
+  initVectors();
+  int device_index;
+  cudaError_t err = cudaGetDevice(&device_index);
+  if (err != cudaSuccess) {
+    STD_TORCH_CHECK(false, "cudaGetDevice failed: " +
+                               std::string(cudaGetErrorString(err)));
+  }
+
+  std::call_once(device_flags[device_index], initDeviceProperty, device_index);
+  return &device_properties[device_index];
+}
+
+inline cudaStream_t get_current_cuda_stream(const Tensor& t) {
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(
+      static_cast<int32_t>(t.get_device_index()), &stream_ptr));
+  return static_cast<cudaStream_t>(stream_ptr);
+}
+} // anonymous namespace
+
 template<
     typename DtypeXq,
     typename DtypeWq,
@@ -49,9 +126,9 @@ template<
     typename TileShape,
     typename ClusterShape>
 void rowwise_scaled_linear_sparse_kernel_cutlass_sm9x(
-  const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-  const at::Tensor& W_meta, const at::Tensor& W_scale, const at::Tensor& bias,
-  at::Tensor& Y) {
+  const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+  const Tensor& W_meta, const Tensor& W_scale, const Tensor& bias,
+  Tensor& Y) {
   // For CUTLASS, sparsified tensor must be the first operand, thus
   // the result will be calculated as:
   //    ((Wq @ Xq.T) * W_scale * X_scale.T + bias.T).T
@@ -223,27 +300,30 @@ void rowwise_scaled_linear_sparse_kernel_cutlass_sm9x(
 
   // Allocate workspace for CUTLASS mixed datatypes GEMM kernel.
   const auto workspace_size = Gemm::get_workspace_size(arguments);
-  auto workspace = Xq.new_empty({(int64_t)workspace_size},
-                                      at::TensorOptions().dtype(at::kByte));
+  auto workspace = torch::stable::new_empty(
+      Xq, {(int64_t)workspace_size},
+      std::make_optional(torch::headeronly::ScalarType::Byte));
+
+  // Get CUDA stream from tensor
+  cudaStream_t stream = get_current_cuda_stream(Xq);
 
   // Initialize CUTLASS mixed datatypes GEMM object.
-  status = gemm_op.initialize(arguments, workspace.data_ptr(),
-                              at::cuda::getCurrentCUDAStream());
+  status = gemm_op.initialize(arguments, workspace.data_ptr(), stream);
   CUTLASS_STATUS_CHECK(status, OPERATOR_NAME);
 
   // Perform mixed datatypes GEMM operation.
-  status = gemm_op.run(at::cuda::getCurrentCUDAStream());
+  status = gemm_op.run(stream);
   CUTLASS_STATUS_CHECK(status, OPERATOR_NAME);
 
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  STD_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template<typename DtypeXq, typename DtypeWq, typename... Types>
 static void select_config(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale, const at::Tensor& bias,
-    at::Tensor& Y) {
-  const auto dprops = at::cuda::getCurrentDeviceProperties();
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale, const Tensor& bias,
+    Tensor& Y) {
+  const auto dprops = get_device_prop();
   const auto is_sm9x = dprops->major == 9;
 
   if (is_sm9x) {
@@ -281,7 +361,7 @@ static void select_config(
     }
   }
 
-  TORCH_CHECK(false, OPERATOR_NAME,
+  STD_TORCH_CHECK(false, OPERATOR_NAME,
               " : Operator not supported on SM", dprops->major, ".",
               dprops->minor, " for given operands");
 }
@@ -289,25 +369,25 @@ static void select_config(
 template<typename... Types>
 static void
 dispatch_on_X_scale_and_W_scale(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const at::Tensor& bias, at::Tensor& Y) {
-  if (X_scale.scalar_type() == at::ScalarType::Half &&
-      W_scale.scalar_type() == at::ScalarType::Half) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const Tensor& bias, Tensor& Y) {
+  if (X_scale.scalar_type() == torch::headeronly::ScalarType::Half &&
+      W_scale.scalar_type() == torch::headeronly::ScalarType::Half) {
     using DtypeXScale = cutlass::half_t;
     using DtypeWScale = cutlass::half_t;
     select_config<Types..., DtypeXScale, DtypeWScale>(
         Xq, X_scale, Wq, W_meta, W_scale, bias, Y);
     return;
-  } else if (X_scale.scalar_type() == at::ScalarType::BFloat16 &&
-             W_scale.scalar_type() == at::ScalarType::BFloat16) {
+  } else if (X_scale.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+             W_scale.scalar_type() == torch::headeronly::ScalarType::BFloat16) {
     using DtypeXScale = cutlass::bfloat16_t;
     using DtypeWScale = cutlass::bfloat16_t;
     select_config<Types..., DtypeXScale, DtypeWScale>(
         Xq, X_scale, Wq, W_meta, W_scale, bias, Y);
     return;
-  } else if (X_scale.scalar_type() == at::ScalarType::Float &&
-             W_scale.scalar_type() == at::ScalarType::Float) {
+  } else if (X_scale.scalar_type() == torch::headeronly::ScalarType::Float &&
+             W_scale.scalar_type() == torch::headeronly::ScalarType::Float) {
     using DtypeXScale = float;
     using DtypeWScale = float;
     select_config<Types..., DtypeXScale, DtypeWScale>(
@@ -315,7 +395,7 @@ dispatch_on_X_scale_and_W_scale(
     return;
   }
 
-  TORCH_CHECK(false, OPERATOR_NAME,
+  STD_TORCH_CHECK(false, OPERATOR_NAME,
               " : Operator not supported for combination of data types ",
               X_scale.scalar_type(), " for first operand scale and ",
               W_scale.scalar_type(), " for second operand scale");
@@ -324,12 +404,12 @@ dispatch_on_X_scale_and_W_scale(
 template<typename DtypeXq, typename DtypeWq, typename DtypeY>
 static void
 dispatch_on_bias(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt, at::Tensor& Y) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt, Tensor& Y) {
   if (bias_opt.has_value()) {
     const auto bias = *bias_opt;
-    TORCH_CHECK(bias.scalar_type() == Y.scalar_type(),
+    STD_TORCH_CHECK(bias.scalar_type() == Y.scalar_type(),
                 OPERATOR_NAME, " : Operator not supported for bias datatype ",
                 bias.scalar_type(), " as it's different from the output ",
                 " datatype ", Y.scalar_type());
@@ -353,22 +433,22 @@ dispatch_on_bias(
 template<typename DtypeXq, typename DtypeWq>
 static void
 dispatch_on_Y(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt, at::Tensor& Y) {
-  if (Y.scalar_type() == at::ScalarType::Half) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt, Tensor& Y) {
+  if (Y.scalar_type() == torch::headeronly::ScalarType::Half) {
     using DtypeY = cutlass::half_t;
     dispatch_on_bias<DtypeXq, DtypeWq, DtypeY>(
         Xq, X_scale, Wq, W_meta, W_scale, bias_opt, Y);
     return;
-  } else if (Y.scalar_type() == at::ScalarType::BFloat16) {
+  } else if (Y.scalar_type() == torch::headeronly::ScalarType::BFloat16) {
     using DtypeY = cutlass::bfloat16_t;
     dispatch_on_bias<DtypeXq, DtypeWq, DtypeY>(
         Xq, X_scale, Wq, W_meta, W_scale, bias_opt, Y);
     return;
   }
 
-  TORCH_CHECK(false, OPERATOR_NAME,
+  STD_TORCH_CHECK(false, OPERATOR_NAME,
               " : Operator not supported for output data type ",
               Y.scalar_type());
 }
@@ -376,121 +456,138 @@ dispatch_on_Y(
 template<typename DtypeXq, typename DtypeWq>
 void
 check_inputs(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt) {
+  using torch::headeronly::Layout;
+
   // Validate metadata datatype.
-  TORCH_CHECK(W_meta.dtype() == at::kByte, OPERATOR_NAME,
+  STD_TORCH_CHECK(W_meta.scalar_type() == torch::headeronly::ScalarType::Byte, OPERATOR_NAME,
               " : Expected Wq meta argument to be of torch.uint8 datatype got ",
-              Wq.dtype());
+              Wq.scalar_type());
 
   // Validate layouts of arguments.
-  TORCH_CHECK(Xq.dim() >= 2, OPERATOR_NAME,
+  STD_TORCH_CHECK(Xq.dim() >= 2, OPERATOR_NAME,
               " : Expected Xq argument to be 2D or higher-dimensional tensor, "
               " got ", Xq.dim(), " dims");
-  TORCH_CHECK(Xq.layout() == at::Layout::Strided, OPERATOR_NAME,
-              " : Expected Xq argument to be strided, got layout ",
-              Xq.layout());
-  TORCH_CHECK(X_scale.dim() == Xq.dim() - 1, OPERATOR_NAME,
+  int32_t xq_layout_int;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(Xq.get(), &xq_layout_int));
+  auto xq_layout = torch::stable::detail::to<Layout>(
+      torch::stable::detail::from(xq_layout_int));
+  STD_TORCH_CHECK(xq_layout == Layout::Strided, OPERATOR_NAME,
+              " : Expected Xq argument to be strided, got layout ", xq_layout_int);
+  STD_TORCH_CHECK(X_scale.dim() == Xq.dim() - 1, OPERATOR_NAME,
               " : Expected Xq scale argument to be ", Xq.dim() - 1,
               "D tensor, got ", X_scale.dim(), " dims");
-  TORCH_CHECK(X_scale.layout() == at::Layout::Strided, OPERATOR_NAME,
-              " : Expected Xq scale argument to be strided, got layout ",
-              X_scale.layout());
-  TORCH_CHECK(Wq.dim() == 2, OPERATOR_NAME,
+  int32_t x_scale_layout_int;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(X_scale.get(), &x_scale_layout_int));
+  auto x_scale_layout = torch::stable::detail::to<Layout>(
+      torch::stable::detail::from(x_scale_layout_int));
+  STD_TORCH_CHECK(x_scale_layout == Layout::Strided, OPERATOR_NAME,
+              " : Expected Xq scale argument to be strided, got layout ", x_scale_layout_int);
+  STD_TORCH_CHECK(Wq.dim() == 2, OPERATOR_NAME,
               " : Expected Wq argument to be 2D tensor, got ", Wq.dim(),
               " dims");
-  TORCH_CHECK(Wq.layout() == at::Layout::Strided, OPERATOR_NAME,
-              " : Expected Wq argument to be strided, got layout ",
-              Wq.layout());
-  TORCH_CHECK(W_meta.dim() == 2, OPERATOR_NAME,
+  int32_t wq_layout_int;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(Wq.get(), &wq_layout_int));
+  auto wq_layout = torch::stable::detail::to<Layout>(
+      torch::stable::detail::from(wq_layout_int));
+  STD_TORCH_CHECK(wq_layout == Layout::Strided, OPERATOR_NAME,
+              " : Expected Wq argument to be strided, got layout ", wq_layout_int);
+  STD_TORCH_CHECK(W_meta.dim() == 2, OPERATOR_NAME,
               " : Expected Wq meta argument to be 2D tensor, got ",
               W_meta.dim(), " dims");
-  TORCH_CHECK(W_meta.layout() == at::Layout::Strided, OPERATOR_NAME,
-              " : Expected Wq meta argument to be strided, got layout ",
-              W_meta.layout());
-  TORCH_CHECK(W_scale.dim() == 1 || W_scale.dim() == 2, OPERATOR_NAME,
+  int32_t w_meta_layout_int;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(W_meta.get(), &w_meta_layout_int));
+  auto w_meta_layout = torch::stable::detail::to<Layout>(
+      torch::stable::detail::from(w_meta_layout_int));
+  STD_TORCH_CHECK(w_meta_layout == Layout::Strided, OPERATOR_NAME,
+              " : Expected Wq meta argument to be strided, got layout ", w_meta_layout_int);
+  STD_TORCH_CHECK(W_scale.dim() == 1 || W_scale.dim() == 2, OPERATOR_NAME,
               " : Expected Wq scale argument to be 1D or 2D tensor, ",
               "got ", W_scale.dim(), " dims");
-  TORCH_CHECK(W_scale.layout() == at::Layout::Strided, OPERATOR_NAME,
-              " : Expected Wq scale argument to be strided, got layout ",
-              W_scale.layout());
+  int32_t w_scale_layout_int;
+  TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(W_scale.get(), &w_scale_layout_int));
+  auto w_scale_layout = torch::stable::detail::to<Layout>(
+      torch::stable::detail::from(w_scale_layout_int));
+  STD_TORCH_CHECK(w_scale_layout == Layout::Strided, OPERATOR_NAME,
+              " : Expected Wq scale argument to be strided, got layout ", w_scale_layout_int);
   if (bias_opt.has_value()) {
     const auto bias = *bias_opt;
-    TORCH_CHECK(bias.dim() == 1, OPERATOR_NAME,
+    STD_TORCH_CHECK(bias.dim() == 1, OPERATOR_NAME,
                 " : Expected bias argument to be 1D tensor, got ", bias.dim(),
                 " dims");
-    TORCH_CHECK(bias.layout() == at::Layout::Strided, OPERATOR_NAME,
-                " : Expected bias argument to be strided, got layout ",
-                bias.layout());
+    int32_t bias_layout_int;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(bias.get(), &bias_layout_int));
+    auto bias_layout = torch::stable::detail::to<Layout>(
+        torch::stable::detail::from(bias_layout_int));
+    STD_TORCH_CHECK(bias_layout == Layout::Strided, OPERATOR_NAME,
+                " : Expected bias argument to be strided, got layout ", bias_layout_int);
   }
 
   // Validate sizes of arguments.
-  const auto Xq_sizes = Xq.sizes().vec();
-  const auto Wq_sizes = Wq.sizes().vec();
-  TORCH_CHECK(Xq_sizes.back() % 32 == 0, OPERATOR_NAME,
+  const auto Xq_size_back = Xq.size(-1);
+  const auto Wq_size_0 = Wq.size(0);
+  const auto Wq_size_1 = Wq.size(1);
+  STD_TORCH_CHECK(Xq_size_back % 32 == 0, OPERATOR_NAME,
               " : For alignment purpose, Xq argument must have number of "
-              "columns divisible by ", 32, ", got ", Xq_sizes.back(),
+              "columns divisible by ", 32, ", got ", Xq_size_back,
               " columns");
-  TORCH_CHECK(Wq_sizes[0] % 8 == 0, OPERATOR_NAME,
+  STD_TORCH_CHECK(Wq_size_0 % 8 == 0, OPERATOR_NAME,
               " : For alignment purpose, Wq argument to have number of rows "
-              "divisible by ", 8, ", but got ", Wq_sizes[0], " rows");
-  TORCH_CHECK(Xq_sizes.back() == 2 * Wq_sizes[1], OPERATOR_NAME,
-              " : Expected Xq argument to have ", 2 * Wq_sizes[1],
-              " columns, but got ", Xq_sizes.back());
-  const auto X_scale_sizes = X_scale.sizes().vec();
-  for (auto i = 0; i < X_scale_sizes.size(); ++i)
-    TORCH_CHECK(X_scale_sizes[i] == Xq_sizes[i], OPERATOR_NAME,
+              "divisible by ", 8, ", but got ", Wq_size_0, " rows");
+  STD_TORCH_CHECK(Xq_size_back == 2 * Wq_size_1, OPERATOR_NAME,
+              " : Expected Xq argument to have ", 2 * Wq_size_1,
+              " columns, but got ", Xq_size_back);
+  for (int64_t i = 0; i < X_scale.dim(); ++i) {
+    STD_TORCH_CHECK(X_scale.size(i) == Xq.size(i), OPERATOR_NAME,
                 " : Expected Xq scale argument size at position ", i, " to be ",
-                Xq_sizes[i], ", but got ", X_scale_sizes[i]);
-  TORCH_CHECK(Wq_sizes[1] % 8 == 0, OPERATOR_NAME,
+                Xq.size(i), ", but got ", X_scale.size(i));
+  }
+  STD_TORCH_CHECK(Wq_size_1 % 8 == 0, OPERATOR_NAME,
               " : Expected Wq argument to have number of columns divisible by ",
-              " 8, got ", Wq_sizes[1]);
+              " 8, got ", Wq_size_1);
   // W_meta may be padded, thus expected shape calculations for this
   // tensor are as follows.
-  const auto W_meta_size_0_expected = std::max((int)Wq_sizes[0], 64);
-  const auto W_meta_size_1_expected = std::max(PAD_TO_MULTIPLE_OF_16((int)Wq_sizes[1]/4), 16);
-  TORCH_CHECK(W_meta.size(0) == W_meta_size_0_expected, OPERATOR_NAME,
+  const auto W_meta_size_0_expected = std::max((int64_t)Wq_size_0, (int64_t)64);
+  const auto W_meta_size_1_expected = std::max((int64_t)PAD_TO_MULTIPLE_OF_16((int)Wq_size_1/4), (int64_t)16);
+  STD_TORCH_CHECK(W_meta.size(0) == W_meta_size_0_expected, OPERATOR_NAME,
               " : Expected Wq meta argument to have ", W_meta_size_0_expected,
               " rows, got ", W_meta.size(0), " rows");
-  TORCH_CHECK(W_meta.size(1) == W_meta_size_1_expected, OPERATOR_NAME,
+  STD_TORCH_CHECK(W_meta.size(1) == W_meta_size_1_expected, OPERATOR_NAME,
               " : Expected Wq meta argument to hold ", W_meta_size_1_expected,
               " bytes per row to encode sparsity of Wq argument, got ",
               W_meta.size(1), " bytes");
-  TORCH_CHECK(W_scale.numel() == Wq_sizes[0], OPERATOR_NAME,
-              " : Expected Wq scale argument to have ", Wq_sizes[0],
+  STD_TORCH_CHECK(W_scale.numel() == Wq_size_0, OPERATOR_NAME,
+              " : Expected Wq scale argument to have ", Wq_size_0,
               " elements, got ", W_scale.numel(), " elements");
   if (bias_opt.has_value()) {
     const auto bias = *bias_opt;
-    TORCH_CHECK(bias.numel() == Wq_sizes[0], OPERATOR_NAME,
-                " : Expected bias argument to have ", Wq_sizes[0],
+    STD_TORCH_CHECK(bias.numel() == Wq_size_0, OPERATOR_NAME,
+                " : Expected bias argument to have ", Wq_size_0,
                 " elements, got ", bias.numel(), " elements");
   }
 
   // Validate strides of arguments.
-  const auto Xq_strides = Xq.strides();
-  TORCH_CHECK(Xq_strides[Xq_strides.size() - 1] == 1, OPERATOR_NAME,
+  STD_TORCH_CHECK(Xq.stride(-1) == 1, OPERATOR_NAME,
               " : Expected Xq argument in row-major layout");
-  auto Xq_stride_expected = Xq_strides[Xq_strides.size() - 2];
-  for (int i = Xq_strides.size() - 3; i >= 0; --i) {
-    Xq_stride_expected *= Xq_sizes[i + 1];
-    TORCH_CHECK(Xq_strides[i] == Xq_stride_expected, OPERATOR_NAME,
+  auto Xq_stride_expected = Xq.stride(-2);
+  for (int64_t i = Xq.dim() - 3; i >= 0; --i) {
+    Xq_stride_expected *= Xq.size(i + 1);
+    STD_TORCH_CHECK(Xq.stride(i) == Xq_stride_expected, OPERATOR_NAME,
                 " : Expected Xq argument in row-major layout");
   }
-  TORCH_CHECK(X_scale.is_contiguous(), OPERATOR_NAME,
+  STD_TORCH_CHECK(X_scale.is_contiguous(), OPERATOR_NAME,
               " : Expected Xq scale argument to be contiguous");
-  const auto Wq_strides = Wq.strides();
-  TORCH_CHECK(Wq_strides[0] >= 1 && Wq_strides[1] == 1, OPERATOR_NAME,
+  STD_TORCH_CHECK(Wq.stride(0) >= 1 && Wq.stride(1) == 1, OPERATOR_NAME,
               " : Expected Wq argument in row-major layout");
-  const auto W_meta_strides = W_meta.strides();
-  TORCH_CHECK(W_meta_strides[0] >= 1 && W_meta_strides[1] == 1, OPERATOR_NAME,
+  STD_TORCH_CHECK(W_meta.stride(0) >= 1 && W_meta.stride(1) == 1, OPERATOR_NAME,
               " : Expected Wq meta argument in row-major layout");
-  TORCH_CHECK(W_scale.is_contiguous(), OPERATOR_NAME,
+  STD_TORCH_CHECK(W_scale.is_contiguous(), OPERATOR_NAME,
               " : Expected Wq scale argument to be contiguous");
   if (bias_opt.has_value()) {
     const auto bias = *bias_opt;
-    const auto bias_strides = bias.strides();
-    TORCH_CHECK(bias_strides[0] == 1, OPERATOR_NAME,
+    STD_TORCH_CHECK(bias.stride(0) == 1, OPERATOR_NAME,
                 " : Expected bias argument to be contiguous");
   }
 }
@@ -500,12 +597,12 @@ check_inputs(
 // GEMM kernel, to given arguments - result produced is:
 //     (Xq * X_scale) @ ((Wq, W_meta) * W_scale).T + bias
 template <typename DtypeXq, typename DtypeWq>
-at::Tensor
+Tensor
 rowwise_scaled_linear_sparse_cutlass(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
   // Check inputs.  Note that data types are checked in the
   // corresponding dispatch methods.  The limitations on data types
@@ -515,28 +612,32 @@ rowwise_scaled_linear_sparse_cutlass(
   check_inputs<DtypeXq, DtypeWq>(Xq, X_scale, Wq, W_meta, W_scale, bias_opt);
 
   // Squash the input tensors as appropriate.
-  const auto Xq_sizes = Xq.sizes().vec();
-  const auto Xq_2d = Xq.reshape({-1, Xq_sizes.back()});
-  const auto X_scale_1d = X_scale.reshape({-1});
-  const auto W_scale_1d = W_scale.reshape({-1});
+  const auto Xq_size_back = Xq.size(-1);
+  const auto Xq_2d = torch::stable::reshape(Xq, {-1, Xq_size_back});
+  const auto X_scale_1d = torch::stable::flatten(X_scale, 0, -1);
+  const auto W_scale_1d = torch::stable::flatten(W_scale, 0, -1);
 
   // Create result tensor.
-  const auto options = out_dtype_opt.has_value()
-                         ? X_scale.options().dtype(*out_dtype_opt)
-                         : X_scale.options();
-  at::Tensor Y = X_scale.new_empty({Xq_2d.size(0), Wq.size(0)}, options);
+  auto out_dtype = out_dtype_opt.has_value()
+                       ? *out_dtype_opt
+                       : X_scale.scalar_type();
+  Tensor Y = torch::stable::new_empty(
+      X_scale, {Xq_2d.size(0), Wq.size(0)}, std::make_optional(out_dtype));
 
   // Dispatch to appropriate kernel template.
   dispatch_on_Y<DtypeXq, DtypeWq>(
       Xq_2d, X_scale_1d, Wq, W_meta, W_scale_1d, bias_opt, Y);
 
   // Reshape and return Y tensor.
-  auto Y_sizes = Xq_sizes;
-  Y_sizes.back() = Wq.size(0);
-  return Y.reshape(Y_sizes);
+  std::vector<int64_t> Y_sizes;
+  for (int64_t i = 0; i < Xq.dim() - 1; ++i) {
+    Y_sizes.push_back(Xq.size(i));
+  }
+  Y_sizes.push_back(Wq.size(0));
+  return torch::stable::reshape(Y, Y_sizes);
 #else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, OPERATOR_NAME);
-  return at::Tensor{};
+  STD_TORCH_CHECK(false, OPERATOR_NAME, " : Not implemented");
+  return Tensor{};
 #endif
 }
 

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.cu
@@ -8,17 +8,20 @@
 
 namespace torchao {
 
-at::Tensor
+using torch::stable::Tensor;
+
+Tensor
 rowwise_scaled_linear_sparse_cutlass_e4m3e4m3(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
   // Validate input datatypes.
-  TORCH_CHECK(
-    Xq.dtype() == at::kFloat8_e4m3fn && Wq.dtype() == at::kFloat8_e4m3fn,
-    __func__, " : The input datatypes combination ", Xq.dtype(), " for Xq and ",
-    Wq.dtype(), " for Wq is not supported");
+  STD_TORCH_CHECK(
+    Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+    Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+    __func__, " : The input datatypes combination ", Xq.scalar_type(), " for Xq and ",
+    Wq.scalar_type(), " for Wq is not supported");
 
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
   using DtypeXq = cutlass::float_e4m3_t;
@@ -26,8 +29,8 @@ rowwise_scaled_linear_sparse_cutlass_e4m3e4m3(
   return rowwise_scaled_linear_sparse_cutlass<DtypeXq, DtypeWq>(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
 #else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, OPERATOR_NAME);
-  return at::Tensor{};
+  STD_TORCH_CHECK(false, OPERATOR_NAME, " : Not implemented");
+  return Tensor{};
 #endif
 }
 

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.h
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.h
@@ -6,15 +6,16 @@
 #pragma once
 
 #include <optional>
-#include <ATen/core/Tensor.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
 
 namespace torchao {
 
-at::Tensor
+torch::stable::Tensor
 rowwise_scaled_linear_sparse_cutlass_e4m3e4m3(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt);
+    const torch::stable::Tensor& Xq, const torch::stable::Tensor& X_scale, const torch::stable::Tensor& Wq,
+    const torch::stable::Tensor& W_meta, const torch::stable::Tensor& W_scale,
+    const std::optional<torch::stable::Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt);
 
 }  // namespace torchao

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e5m2.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e5m2.cu
@@ -8,17 +8,20 @@
 
 namespace torchao {
 
-at::Tensor
+using torch::stable::Tensor;
+
+Tensor
 rowwise_scaled_linear_sparse_cutlass_e4m3e5m2(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
   // Validate input datatypes.
-  TORCH_CHECK(
-    Xq.dtype() == at::kFloat8_e4m3fn && Wq.dtype() == at::kFloat8_e5m2,
-    __func__, " : The input datatypes combination ", Xq.dtype(), " for Xq and ",
-    Wq.dtype(), " for Wq is not supported");
+  STD_TORCH_CHECK(
+    Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+    Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2,
+    __func__, " : The input datatypes combination ", Xq.scalar_type(), " for Xq and ",
+    Wq.scalar_type(), " for Wq is not supported");
 
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
   using DtypeXq = cutlass::float_e4m3_t;
@@ -26,8 +29,8 @@ rowwise_scaled_linear_sparse_cutlass_e4m3e5m2(
   return rowwise_scaled_linear_sparse_cutlass<DtypeXq, DtypeWq>(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
 #else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, OPERATOR_NAME);
-  return at::Tensor{};
+  STD_TORCH_CHECK(false, OPERATOR_NAME, " : Not implemented");
+  return Tensor{};
 #endif
 }
 

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e5m2.h
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e4m3e5m2.h
@@ -6,15 +6,16 @@
 #pragma once
 
 #include <optional>
-#include <ATen/core/Tensor.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
 
 namespace torchao {
 
-at::Tensor
+torch::stable::Tensor
 rowwise_scaled_linear_sparse_cutlass_e4m3e5m2(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt);
+    const torch::stable::Tensor& Xq, const torch::stable::Tensor& X_scale, const torch::stable::Tensor& Wq,
+    const torch::stable::Tensor& W_meta, const torch::stable::Tensor& W_scale,
+    const std::optional<torch::stable::Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt);
 
 }  // namespace torchao

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e4m3.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e4m3.cu
@@ -8,17 +8,20 @@
 
 namespace torchao {
 
-at::Tensor
+using torch::stable::Tensor;
+
+Tensor
 rowwise_scaled_linear_sparse_cutlass_e5m2e4m3(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
   // Validate input datatypes.
-  TORCH_CHECK(
-    Xq.dtype() == at::kFloat8_e5m2 && Wq.dtype() == at::kFloat8_e4m3fn,
-    __func__, " : The input datatypes combination ", Xq.dtype(), " for Xq and ",
-    Wq.dtype(), " for Wq is not supported");
+  STD_TORCH_CHECK(
+    Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+    Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+    __func__, " : The input datatypes combination ", Xq.scalar_type(), " for Xq and ",
+    Wq.scalar_type(), " for Wq is not supported");
 
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
   using DtypeXq = cutlass::float_e5m2_t;
@@ -26,8 +29,8 @@ rowwise_scaled_linear_sparse_cutlass_e5m2e4m3(
   return rowwise_scaled_linear_sparse_cutlass<DtypeXq, DtypeWq>(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
 #else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, OPERATOR_NAME);
-  return at::Tensor{};
+  STD_TORCH_CHECK(false, OPERATOR_NAME, " : Not implemented");
+  return Tensor{};
 #endif
 }
 

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e4m3.h
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e4m3.h
@@ -6,15 +6,16 @@
 #pragma once
 
 #include <optional>
-#include <ATen/core/Tensor.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
 
 namespace torchao {
 
-at::Tensor
+torch::stable::Tensor
 rowwise_scaled_linear_sparse_cutlass_e5m2e4m3(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt);
+    const torch::stable::Tensor& Xq, const torch::stable::Tensor& X_scale, const torch::stable::Tensor& Wq,
+    const torch::stable::Tensor& W_meta, const torch::stable::Tensor& W_scale,
+    const std::optional<torch::stable::Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt);
 
 }  // namespace torchao

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e5m2.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e5m2.cu
@@ -8,17 +8,20 @@
 
 namespace torchao {
 
-at::Tensor
+using torch::stable::Tensor;
+
+Tensor
 rowwise_scaled_linear_sparse_cutlass_e5m2e5m2(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
   // Validate input datatypes.
-  TORCH_CHECK(
-    Xq.dtype() == at::kFloat8_e5m2 && Wq.dtype() == at::kFloat8_e5m2,
-    __func__, " : The input datatypes combination ", Xq.dtype(), " for Xq and ",
-    Wq.dtype(), " for Wq is not supported");
+  STD_TORCH_CHECK(
+    Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+    Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2,
+    __func__, " : The input datatypes combination ", Xq.scalar_type(), " for Xq and ",
+    Wq.scalar_type(), " for Wq is not supported");
 
 #if defined(BUILD_ROWWISE_SCALED_LINEAR_SPARSE_CUTLASS)
   using DtypeXq = cutlass::float_e5m2_t;
@@ -26,8 +29,8 @@ rowwise_scaled_linear_sparse_cutlass_e5m2e5m2(
   return rowwise_scaled_linear_sparse_cutlass<DtypeXq, DtypeWq>(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
 #else
-  TORCH_CHECK_NOT_IMPLEMENTED(false, OPERATOR_NAME);
-  return at::Tensor{};
+  STD_TORCH_CHECK(false, OPERATOR_NAME, " : Not implemented");
+  return Tensor{};
 #endif
 }
 

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e5m2.h
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_e5m2e5m2.h
@@ -6,15 +6,16 @@
 #pragma once
 
 #include <optional>
-#include <ATen/core/Tensor.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
 
 namespace torchao {
 
-at::Tensor
+torch::stable::Tensor
 rowwise_scaled_linear_sparse_cutlass_e5m2e5m2(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt,
-    const std::optional<at::ScalarType> out_dtype_opt);
+    const torch::stable::Tensor& Xq, const torch::stable::Tensor& X_scale, const torch::stable::Tensor& Wq,
+    const torch::stable::Tensor& W_meta, const torch::stable::Tensor& W_scale,
+    const std::optional<torch::stable::Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt);
 
 }  // namespace torchao

--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_f8f8.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_f8f8.cu
@@ -3,7 +3,10 @@
 //
 // This source code is licensed under the BSD 3-Clause license found in the
 // LICENSE file in the root directory of this source tree.
-#include <torch/library.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
 
 #include "rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.h"
 #include "rowwise_scaled_linear_sparse_cutlass_e4m3e5m2.h"
@@ -12,51 +15,58 @@
 
 namespace torchao {
 
-at::Tensor
+using torch::stable::Tensor;
+
+Tensor
 rowwise_scaled_linear_sparse_cutlass_f8f8(
-    const at::Tensor& Xq, const at::Tensor& X_scale, const at::Tensor& Wq,
-    const at::Tensor& W_meta, const at::Tensor& W_scale,
-    const std::optional<at::Tensor>& bias_opt = std::nullopt,
-    const std::optional<at::ScalarType> out_dtype_opt = std::nullopt) {
+    const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
+    const Tensor& W_meta, const Tensor& W_scale,
+    const std::optional<Tensor>& bias_opt = std::nullopt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt = std::nullopt) {
   // Validate input datatypes.
-  TORCH_CHECK(
-      (Xq.dtype() == at::kFloat8_e4m3fn && Wq.dtype() == at::kFloat8_e4m3fn) ||
-      (Xq.dtype() == at::kFloat8_e4m3fn && Wq.dtype() == at::kFloat8_e5m2) ||
-      (Xq.dtype() == at::kFloat8_e5m2 && Wq.dtype() == at::kFloat8_e4m3fn) ||
-      (Xq.dtype() == at::kFloat8_e5m2 && Wq.dtype() == at::kFloat8_e5m2),
-      __func__, " : The input datatypes combination ", Xq.dtype(),
-      " for Xq and ", Wq.dtype(), " for Wq is not supported");
+  STD_TORCH_CHECK(
+      (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+       Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn) ||
+      (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+       Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2) ||
+      (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+       Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn) ||
+      (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+       Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2),
+      __func__, " : The input datatypes combination ", Xq.scalar_type(),
+      " for Xq and ", Wq.scalar_type(), " for Wq is not supported");
 
   // Dispatch to appropriate kernel template.
-  if (Xq.dtype() == at::kFloat8_e4m3fn && Wq.dtype() == at::kFloat8_e4m3fn) {
+  if (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+      Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn) {
     return rowwise_scaled_linear_sparse_cutlass_e4m3e4m3(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
-  } else if (Xq.dtype() == at::kFloat8_e4m3fn &&
-             Wq.dtype() == at::kFloat8_e5m2) {
+  } else if (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&
+             Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2) {
     return rowwise_scaled_linear_sparse_cutlass_e4m3e5m2(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
-  } else if (Xq.dtype() == at::kFloat8_e5m2 &&
-             Wq.dtype() == at::kFloat8_e4m3fn) {
+  } else if (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+             Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn) {
     return rowwise_scaled_linear_sparse_cutlass_e5m2e4m3(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
-  } else if (Xq.dtype() == at::kFloat8_e5m2 && Wq.dtype() == at::kFloat8_e5m2) {
+  } else if (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2 &&
+             Wq.scalar_type() == torch::headeronly::ScalarType::Float8_e5m2) {
     return rowwise_scaled_linear_sparse_cutlass_e5m2e5m2(
       Xq, X_scale, Wq, W_meta, W_scale, bias_opt, out_dtype_opt);
   }
-  return at::Tensor{};
+  return Tensor{};
 }
 
 #ifdef DEF_SPARSE_CUTLASS_OPS
-TORCH_LIBRARY(torchao, m) {
+STABLE_TORCH_LIBRARY(torchao, m) {
   m.def(
-      "torchao::rowwise_scaled_linear_sparse_cutlass_f8f8(Tensor input, Tensor input_scale, Tensor weight, Tensor weight_meta, Tensor weight_scale, Tensor? bias=None, ScalarType? out_dtype=None) -> Tensor",
-      rowwise_scaled_linear_sparse_cutlass_f8f8);
+      "torchao::rowwise_scaled_linear_sparse_cutlass_f8f8(Tensor input, Tensor input_scale, Tensor weight, Tensor weight_meta, Tensor weight_scale, Tensor? bias=None, ScalarType? out_dtype=None) -> Tensor");
 }
 #endif
 
-TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
+STABLE_TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
   m.impl("torchao::rowwise_scaled_linear_sparse_cutlass_f8f8",
-         &rowwise_scaled_linear_sparse_cutlass_f8f8);
+         TORCH_BOX(&rowwise_scaled_linear_sparse_cutlass_f8f8));
 }
 
 }  // namespace torchao


### PR DESCRIPTION
**Test Plan:**
```
pytest test/test_ops_rowwise_scaled_linear_sparse_cutlass.py
```
(needs #3768)

**Prompt:**

```
Make everything under this directory ABI stable:
ao/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass

Read these for instructions:
pytorch/docs/source/notes/libtorch_stable_abi.md
cppdocs/_sources/stable.rst.txt

Use these files for an example:
Before: flash-attention/hopper/flash_api.cpp
After: flash-attention/hopper/flash_api_stable.cpp

Additional instructions:
Replace TORCH_CHECK with STD_TORCH_CHECK without changing the error message
Replace c10::cuda::CUDAGuard with DeviceGuard
When calling aoti_torch_get_current_cuda_stream, get the device index from a tensor, not from the general torch::stable::accelerator::getCurrentDeviceIndex()
Where possible, use get_device_index instead of get_device
Before checking if CUDA_VERSION is defined, remember to include cuda.h

Don’t do these things:
Don’t define a dummy _C module that can be accessed from python
Don’t declare aoti_torch_get_current_cuda_stream, just include it from torch/csrc/inductor/aoti_torch/c/shim.h and add -DUSE_CUDA to both cxx and nvcc in setup.py if needed
Also add -DTORCH_TARGET_VERSION=0x020a000000000000 to both cxx and nvcc in setup.py
Don’t box kernels manually, just use TORCH_BOX
```

**Follow-up prompts:**

```
Seems like STD_CUDA_KERNEL_LAUNCH_CHECK is undefined, is it missing an import?
```

```
Revert all checks that check if the layout is strided, where the original code looks like this:

TORCH_CHECK(Wq.layout() == at::Layout::Strided, …)

Then, rewrite these checks using the following instead to make it ABI stable:

using torch::headeronly::Layout
int32_t wlayout;
TORCH_ERROR_CODE_CHECK(aoti_torch_get_layout(Wq.get(), wlayout));
STD_TORCH_CHECK(torch::stable::detail::to<Layout>(
    torch::stable::detail::from(wlayout)) == Layout::Strided, …
)

Do not change the error message.
```

```
Can you save "torch::stable::detail::to<Layout>(torch::stable::detail::from(xq_layout))" to a variable to reduce duplicate code? Same for the other checks
```