### PR TITLE
[mxfp8 moe training] increase inductor cache limit for tests

### DIFF
--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -44,6 +44,9 @@ from torchao.prototype.moe_training.utils import (
 from torchao.prototype.mx_formats.mx_tensor import to_mx
 from torchao.testing.utils import skip_if_rocm
 
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
 
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("m", [131072])

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -31,6 +31,9 @@ except ImportError:
         "torchtitan not installed, skipping MoE tests.", allow_module_level=True
     )
 
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
 
 @pytest.mark.parametrize(
     "target_fqns",


### PR DESCRIPTION
[mxfp8 moe training] increase inductor cache limit for tests


Fixes error that started occurring in unit tests:

` torch._dynamo.exc.Unsupported: Dynamo recompile limit exceeded`