### PR TITLE
[mxfp8 moe training] remove "use_triton_for_dim0_cast" flag, infer dim0 quant kernel from kernel_preference

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
+++ b/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
@@ -450,7 +450,6 @@ def benchmark_mxfp8_grouped_mm_fwd_bwd(x, w_t, offs, labels, block_size=32):
     block_size_arg = block_size
     out_dtype = torch.bfloat16
     kernel_preference = KernelPreference.AUTO
-    use_triton_for_dim0_cast = True
     wgrad_with_hp = False
     scale_calculation_mode = MoEScaleCalculationMode.RCEIL
 
@@ -462,7 +461,6 @@ def benchmark_mxfp8_grouped_mm_fwd_bwd(x, w_t, offs, labels, block_size=32):
             block_size_arg,
             out_dtype,
             kernel_preference,
-            use_triton_for_dim0_cast,
             wgrad_with_hp,
             scale_calculation_mode,
         )

--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -321,7 +321,6 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (2, 4, 8, 16))
-@pytest.mark.parametrize("use_triton_for_dim0_cast", (True, False))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
 @pytest.mark.parametrize("use_compile", (True, False))
 @pytest.mark.parametrize(
@@ -336,7 +335,6 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     K,
     N,
     num_experts,
-    use_triton_for_dim0_cast,
     wgrad_with_hp,
     use_compile,
     kernel_preference,
@@ -348,9 +346,6 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
         pytest.skip(
             "Skipping use_compile=True with kernel_preference=EMULATED, not currently supported"
         )
-
-    if kernel_preference == KernelPreference.EMULATED and use_triton_for_dim0_cast:
-        pytest.skip("Triton kernel not supported in emulated mode.")
 
     if (
         kernel_preference == KernelPreference.EMULATED
@@ -395,7 +390,6 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
         offs=offs,
         block_size=block_size,
         kernel_preference=kernel_preference,
-        use_triton_for_dim0_cast=use_triton_for_dim0_cast,
         wgrad_with_hp=wgrad_with_hp,
         scale_calculation_mode=scale_mode,
         use_cuda_kernel_for_blocked_layout=use_cuda_kernel_for_blocked_layout,


### PR DESCRIPTION
Stacked PRs:
 * #3735
 * __->__#3734
 * #3724


--- --- ---

[mxfp8 moe training] remove "use_triton_for_dim0_cast" flag, infer dim0 quant kernel from kernel_preference

## Summary
- If `kernel_preference` is AUTO, we use the Triton kernel, as there's no fast torch native impl for RCEIL atm. We can revisit when that gap is fixed.
- If `kernel_preference` is EMULATED, we use the Torch native impl

## Tests
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -v -s`