### PR TITLE
[mxfp8 moe training] remove use_cuda_kernel_for_blocked_layout param

### DIFF
--- a/benchmarks/prototype/moe_training/mxfp8/bench_ep_pipeline.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_ep_pipeline.py
@@ -158,7 +158,6 @@ def standard_pipeline(
         expert_weights_t,
         offs=offsets,
         out_dtype=torch.bfloat16,
-        use_cuda_kernel_for_blocked_layout=True,
         wgrad_with_hp=True,
     )
 
@@ -227,7 +226,6 @@ def mxfp8_pipeline(
         expert_weights_t,
         offs=mx_group_offsets,
         block_size=block_size,
-        use_cuda_kernel_for_blocked_layout=True,
         wgrad_with_hp=True,
     )
 

--- a/test/prototype/moe_training/ep/test_compile.py
+++ b/test/prototype/moe_training/ep/test_compile.py
@@ -87,7 +87,6 @@ def standard_pipeline(
         expert_weights_t,
         offs=offsets,
         block_size=block_size,
-        use_cuda_kernel_for_blocked_layout=False,
         wgrad_with_hp=True,
     )
 
@@ -156,7 +155,6 @@ def mxfp8_pipeline(
         expert_weights_t,
         offs=mx_group_offsets,
         block_size=block_size,
-        use_cuda_kernel_for_blocked_layout=False,
         wgrad_with_hp=True,
     )
 

--- a/test/prototype/moe_training/ep/test_integration.py
+++ b/test/prototype/moe_training/ep/test_integration.py
@@ -231,8 +231,6 @@ class TestIntegration(MultiProcessTestCase):
                 expert_weights.transpose(-2, -1),
                 offs=mx_group_offsets,
                 block_size=block_size,
-                # TODO: why does CUDA blocked layout throw an error in this test, but works in e2e torchtitan runs?
-                use_cuda_kernel_for_blocked_layout=False,
                 # wgrad_with_hp must be true if inputs are pre-quantized (MXTensor)
                 wgrad_with_hp=True,
             )

--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -326,7 +326,6 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 @pytest.mark.parametrize(
     "kernel_preference", (KernelPreference.AUTO, KernelPreference.EMULATED)
 )
-@pytest.mark.parametrize("use_cuda_kernel_for_blocked_layout", (True, False))
 @pytest.mark.parametrize(
     "scale_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
@@ -338,21 +337,12 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     wgrad_with_hp,
     use_compile,
     kernel_preference,
-    use_cuda_kernel_for_blocked_layout,
     scale_mode,
 ):
     # Emulated mode with compile is not supported
     if kernel_preference == KernelPreference.EMULATED and use_compile:
         pytest.skip(
             "Skipping use_compile=True with kernel_preference=EMULATED, not currently supported"
-        )
-
-    if (
-        kernel_preference == KernelPreference.EMULATED
-        and use_cuda_kernel_for_blocked_layout
-    ):
-        pytest.skip(
-            "CUDA blocked layout per group along M kernel not supported in emulated mode."
         )
 
     # MXFP8 hardware path requires SM100
@@ -392,7 +382,6 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
         kernel_preference=kernel_preference,
         wgrad_with_hp=wgrad_with_hp,
         scale_calculation_mode=scale_mode,
-        use_cuda_kernel_for_blocked_layout=use_cuda_kernel_for_blocked_layout,
     )
     ref_out = torch._grouped_mm(x_ref, w_t_ref, offs=offs_ref, out_dtype=torch.bfloat16)
     sqnr = compute_error(ref_out, out)

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -98,11 +98,11 @@ def test_moe_training(
                 "Skipping FP8 rowwise tests with kernel_preference=EMULATED, emulated mode only applies to MXFP8"
             )
 
-    # Emulated mode with compile is not supported
-    if compile and kernel_preference == KernelPreference.EMULATED:
-        pytest.skip(
-            "Skipping compile=True with kernel_preference=EMULATED, not currently supported"
-        )
+        # Emulated mode with compile is not supported
+        if compile:
+            pytest.skip(
+                "Skipping compile=True with kernel_preference=EMULATED, not currently supported"
+            )
 
     # FP8_ROWWISE hardware path requires SM90
     if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (


### PR DESCRIPTION
Stacked PRs:
 * __->__#3735
 * #3734
 * #3724


--- --- ---

[mxfp8 moe training] remove use_cuda_kernel_for_blocked_layout param

Param is now redundant.

- `kernel_preference` is AUTO, we use the CUDA kernel (after checking sm100 kernels exist)
- `kernel_preference` is EMULATED, we don't need to do per group blocked layout at all, since we are just dequantizing and doing bf16 grouped mm

## Tests
- `pytest test/prototype/moe_training/test_training.py -v -s `
- `pytest test/prototype/moe_training/test_scaled_grouped_mm.py -v -s`