### PR TITLE
Reduce memory consumption during sparse_2x4_cutlass_float8_tensor::dequantize

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py
@@ -115,10 +115,10 @@ class Sparse2x4CUTLASSFloat8Tensor(TorchAOBaseTensor):
         # semi-structured format, so multiplying with identity matrix,
         # and using identity scale factors, for the conversion.
         cols = self.shape[1]
-        plain_input = torch.eye(cols, device=self.qdata.device)
-        input = plain_input.to(dtype=self.qdata.dtype)
-        plain_input_scale = torch.ones((cols,), device=self.qdata.device)
-        input_scale = plain_input_scale.to(dtype=self.scale.dtype)
+        input = torch.eye(cols, dtype=self.qdata.dtype, device=self.qdata.device)
+        input_scale = torch.ones(
+            (cols,), dtype=self.scale.dtype, device=self.qdata.device
+        )
 
         out_dtype = torch.bfloat16
         dense = (


### PR DESCRIPTION
Summary:
As title ~ this is to silence OOM issue surfaced from the lowering [pipeline](https://www.internalfb.com/mlhub/flow/1027398639/overview):
 {F1985001852}

Test Plan

CI, where dequantize() accuracy is covered by the test [case](https://github.com/pytorch/ao/blob/a003c324d7859a9928ebde98a075c6b5e94afb7a/test/quantization/quantize_/workflows/float8/test_sparse_2x4_cutlass_float8_tensor.py#L98).

Differential Revision: D91647984


