### PR TITLE
add deprecation warning to `torchao.autoquant`

### DIFF
--- a/torchao/quantization/autoquant.py
+++ b/torchao/quantization/autoquant.py
@@ -3,6 +3,8 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
+
 import torch
 import torch.nn.functional as F
 from torch.utils._python_dispatch import return_and_correct_aliasing
@@ -1241,6 +1243,12 @@ def autoquant(
         model(*example_input2)
         model.finalize_autoquant()
     """
+    warnings.warn(
+        "torchao.autoquant is deprecated and will be removed in a future release. "
+        "For more information, see: https://github.com/pytorch/ao/issues/3739",
+        FutureWarning,
+        stacklevel=2,
+    )
     torch._C._log_api_usage_once("torchao.quantization.autoquant")
 
     if set_inductor_config:


### PR DESCRIPTION
Summary:

Context: https://github.com/pytorch/ao/issues/3739

Test Plan:

CI

Also,

```python
>>> torchao.autoquant(m)
/home/dev/.conda/envs/pt_nightly/lib/python3.12/site-packages/torch/utils/_contextlib.py:124: FutureWarning: torchao.autoquant is deprecated and will be removed in a future release. For more information, see: https://github.c
om/pytorch/ao/issues/3739
  return func(*args, **kwargs)
Linear(in_features=4, out_features=4, bias=True)
```