### PR TITLE
[DRAFT] Move all torch._scaled_mm calls to F.scaled_mm

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -341,7 +341,7 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
             # one scaled_mm call
             FileCheck().check("def call(").check_count(
-                "._scaled_mm(", 1, exactly=True
+                "._scaled_mm_v2.default(", 1, exactly=True
             ).run(code[0])
         else:
             assert granularity == PerTensor(), "unsupported"
@@ -354,7 +354,7 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             )
             # one scaled_mm call
             FileCheck().check("def call(").check_count(
-                "._scaled_mm(", 1, exactly=True
+                "._scaled_mm_v2.default(", 1, exactly=True
             ).run(code[0])
 
 

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -587,7 +587,7 @@ class TestScaledMM:
         )
 
         with pytest.raises(
-            RuntimeError,
+            ValueError,
             match=re.escape(
                 "Expected trailing dimension of mat1 to be divisible by 16 but got mat1 shape: (16x41"
             ),

--- a/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
+++ b/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
@@ -24,7 +24,7 @@ from torchao.prototype.blockwise_fp8_training.kernels import (
     triton_fp8_gemm_1x128_128x128,
 )
 from torchao.testing.utils import skip_if_rocm
-from torchao.utils import is_sm_at_least_90
+from torchao.utils import is_sm_exactly_90
 
 BLOCKWISE_SIZE_MNK = [
     # (128, 128, 128),
@@ -39,7 +39,7 @@ BLOCKWISE_SIZE_MNK = [
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.skipif(
     version.parse(triton.__version__) < version.parse("3.3.0"),
     reason="Triton version < 3.3.0, test skipped",
@@ -64,7 +64,7 @@ def test_triton_fp8_gemm_1x128_128x128(M, N, K, dtype):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.skipif(
     version.parse(triton.__version__) < version.parse("3.3.0"),
     reason="Triton version < 3.3.0, test skipped",
@@ -90,7 +90,7 @@ def test_triton_fp8_gemm_1x128_128x1(M, N, K, dtype):
 
 
 @skip_if_rocm("ROCm not supported")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.parametrize("block_size", [128, 256])
 def test_triton_quantize_fp8_act_quant_lhs(block_size):
     device = "cuda"
@@ -137,7 +137,7 @@ def test_triton_quantize_fp8_act_quant_lhs(block_size):
 
 
 @skip_if_rocm("ROCm not supported")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.parametrize("block_size", [128, 256])
 def test_triton_quantize_fp8_act_quant_rhs(block_size: int):
     device = "cuda"
@@ -184,7 +184,7 @@ def test_triton_quantize_fp8_act_quant_rhs(block_size: int):
 
 
 @skip_if_rocm("ROCm not supported")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.parametrize("block_size", [128, 256])
 @pytest.mark.parametrize("M,K", [(4096, 1024), (4096, 4 * 4096)])
 def test_triton_quantize_fp8_act_quant_transposed_lhs(M, K, block_size: int):
@@ -233,7 +233,7 @@ def test_triton_quantize_fp8_act_quant_transposed_lhs(M, K, block_size: int):
 
 
 @skip_if_rocm("ROCm not supported")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.parametrize("block_size", [128, 256])
 @pytest.mark.parametrize("M,K", [(4096, 1024), (4096, 4 * 4096)])
 def test_triton_quantize_fp8_weight_quant_rhs(M, K, block_size: int):
@@ -279,7 +279,7 @@ def test_triton_quantize_fp8_weight_quant_rhs(M, K, block_size: int):
 
 
 @skip_if_rocm("ROCm not supported")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Requires CUDA capability >= 9.0")
+@pytest.mark.skipif(not is_sm_exactly_90(), reason="Requires CUDA capability == 9.0")
 @pytest.mark.parametrize("block_size", [128, 256])
 def test_triton_quantize_fp8_weight_quant_transposed_rhs(block_size: int):
     device = "cuda"

--- a/test/prototype/blockwise_fp8_training/test_blockwise_linear.py
+++ b/test/prototype/blockwise_fp8_training/test_blockwise_linear.py
@@ -9,11 +9,11 @@ import copy
 import pytest
 import torch
 
-from torchao.utils import is_sm_at_least_90
+from torchao.utils import is_sm_exactly_90
 
 triton = pytest.importorskip("triton", reason="Triton required to run this test")
-if not is_sm_at_least_90():
-    pytest.skip("This test requires SM90 or higher", allow_module_level=True)
+if not is_sm_exactly_90():
+    pytest.skip("This test requires SM90 exactly", allow_module_level=True)
 
 
 from torchao.float8.float8_utils import compute_error

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -32,6 +32,9 @@ torch.manual_seed(2)
 if not torch_version_at_least("2.8.0"):
     pytest.skip("Unsupported PyTorch version", allow_module_level=True)
 
+# Check if MSLK is available for MXFP4
+mslk_available = "USE_MSLK" in torch.__config__.show()
+
 
 # source: https://stackoverflow.com/a/22638709
 @pytest.fixture(autouse=True)
@@ -95,6 +98,8 @@ def test_inference_workflow_mx(
     elif elem_dtype == torch.float4_e2m1fn_x2:
         if not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
+        elif not mslk_available:
+            pytest.skip("mxfp4 requires torch + MSLK support, not found")
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -457,9 +457,6 @@ def test_nvfp4_matmul_with_amax(
     if quant_type == "dynamic" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
 
-    if bias and inpt_dtype == torch.float32:
-        pytest.xfail("Bias is not supported when module weight is in fp32")
-
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only currently errors w/ compile")
 

--- a/torchao/dtypes/floatx/float8_layout.py
+++ b/torchao/dtypes/floatx/float8_layout.py
@@ -331,7 +331,7 @@ def _linear_fp8_act_fp8_weight_impl(
     weight_tensor: "AffineQuantizedTensor",
     bias: Optional[torch.Tensor],
 ):
-    """Implements matmul between FP8 input and FP8 weight with compute using _scaled_mm"""
+    """Implements matmul between FP8 input and FP8 weight with compute using scaled_mm"""
     scaled_mm_config = weight_tensor._layout.mm_config
     assert scaled_mm_config is not None
     assert not weight_tensor.tensor_impl.transposed, "Weight tensor must be contiguous"

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -185,7 +185,7 @@ class Float8LinearConfig:
 
     # If True, then prior to performing the fp8 scaled mamtmul we will pad the
     # inner dimension of a (dim 1) and b (dim 2) with 0s. This is needed for matmuls
-    # _scaled_mm since it has the strong constraint that for M,N,K  N, K must be a multiple of 16.
+    # scaled_mm since it has the strong constraint that for M,N,K  N, K must be a multiple of 16.
     # This can cause a memory spike however so we keep this off by default.
     pad_inner_dim: bool = False
 

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -7,12 +7,13 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 from torch.utils._pytree import tree_map
+import torch.nn.functional as F
 
 from torchao.float8.float8_training_tensor import (
     Float8TrainingTensor,
     choose_scaled_mm_config,
 )
-from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul
+from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul, infer_scale_swizzle
 from torchao.utils import torch_version_at_least
 
 aten = torch.ops.aten
@@ -58,26 +59,32 @@ def addmm_float8_unwrapped(
         a_inverse_scale = a_inverse_scale.new_ones(())
         b_inverse_scale = a_inverse_scale.new_ones(())
 
-    # work around torch._scaled_mm not having float32 output type
-    # TODO(pytorch/pytorch#156771): remove this once torch._scaled_mm supports float32 output
+    scale_recipe_a, swizzle_a = infer_scale_swizzle(a_data, a_inverse_scale)
+    scale_recipe_b, swizzle_b = infer_scale_swizzle(b_data, b_inverse_scale)
+
+    # work around F.scaled_mm not having float32 output type
+    # TODO(pytorch/pytorch#156771): remove this once F.scaled_mm supports float32 output
     orig_dtype = output_dtype
     if orig_dtype in (torch.float16, torch.float32) and is_rowwise_scaling:
         output_dtype = torch.bfloat16
 
     post_bias = None
     if output_dtype == torch.float32:
-        # Bias is not supported by _scaled_mm when output is fp32
+        # Bias is not supported by scaled_mm when output is fp32
         post_bias = bias
         bias = None
 
-    output = torch._scaled_mm(
+    output = F.scaled_mm(
         a_data,
         b_data,
         scale_a=a_inverse_scale,
+        scale_recipe_a=scale_recipe_a,
         scale_b=b_inverse_scale,
+        scale_recipe_b=scale_recipe_b,
+        swizzle_a=swizzle_a,
+        swizzle_b=swizzle_b,
         bias=bias,
-        scale_result=output_scale,
-        out_dtype=output_dtype,
+        output_dtype=output_dtype,
         use_fast_accum=use_fast_accum,
     )
 
@@ -345,11 +352,11 @@ def preprocess_addmm(a: Float8TrainingTensor, b: Float8TrainingTensor):
         b_data = b_data.t().contiguous().t()
     b_scale = b._scale
 
-    # Today, torch._scaled_mm only supports both operands using the
+    # Today, F.scaled_mm only supports both operands using the
     # same granularity. The code below checks for cases where one
     # operand is scaled axiswise and one tensorwise. If this case is found,
     # we reshape the tensorwise scale to be repeat along the needed axis,
-    # so that torch._scaled_mm can call the axiswise-axiswise kernel.
+    # so that F.scaled_mm can call the axiswise-axiswise kernel.
     # Note: using shape/size info does not work with compile here, which is
     # why we are using inferring scaling type from the presence of
     # axiswise_dim.

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -6,14 +6,18 @@
 from typing import Any, Dict, Optional, Tuple
 
 import torch
-from torch.utils._pytree import tree_map
 import torch.nn.functional as F
+from torch.utils._pytree import tree_map
 
 from torchao.float8.float8_training_tensor import (
     Float8TrainingTensor,
     choose_scaled_mm_config,
 )
-from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul, infer_scale_swizzle
+from torchao.float8.float8_utils import (
+    infer_scale_swizzle,
+    is_row_major,
+    pad_tensor_for_matmul,
+)
 from torchao.utils import torch_version_at_least
 
 aten = torch.ops.aten

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -14,7 +14,7 @@ from torchao.float8.float8_training_tensor import (
     choose_scaled_mm_config,
 )
 from torchao.float8.float8_utils import (
-    infer_scale_swizzle,
+    infer_float8_scaling,
     is_row_major,
     pad_tensor_for_matmul,
 )
@@ -63,8 +63,8 @@ def addmm_float8_unwrapped(
         a_inverse_scale = a_inverse_scale.new_ones(())
         b_inverse_scale = a_inverse_scale.new_ones(())
 
-    scale_recipe_a, swizzle_a = infer_scale_swizzle(a_data, a_inverse_scale)
-    scale_recipe_b, swizzle_b = infer_scale_swizzle(b_data, b_inverse_scale)
+    scale_recipe_a = infer_float8_scaling(a_data, a_inverse_scale)
+    scale_recipe_b = infer_float8_scaling(b_data, b_inverse_scale)
 
     # work around F.scaled_mm not having float32 output type
     # TODO(pytorch/pytorch#156771): remove this once F.scaled_mm supports float32 output
@@ -85,8 +85,6 @@ def addmm_float8_unwrapped(
         scale_recipe_a=scale_recipe_a,
         scale_b=b_inverse_scale,
         scale_recipe_b=scale_recipe_b,
-        swizzle_a=swizzle_a,
-        swizzle_b=swizzle_b,
         bias=bias,
         output_dtype=output_dtype,
         use_fast_accum=use_fast_accum,

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -4,17 +4,14 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
 from torch.distributed._functional_collectives import AsyncCollectiveTensor, all_reduce
+from torch.nn.functional import ScalingType
 
 from torchao.float8.config import ScalingGranularity
-from torchao.utils import (
-    ceil_div,
-    round_up,
-)
 
 # Helpful visualizer for debugging (only supports fp32):
 # https://www.h-schmidt.net/FloatConverter/IEEE754.html
@@ -31,131 +28,31 @@ FP8_TYPES = {
     torch.float8_e5m2fnuz,
 }
 
-infer_scale_swizzle = None
-try:
-    from torch._inductor.utils import infer_scale_swizzle as _infer_scale_swizzle
 
-    infer_scale_swizzle = _infer_scale_swizzle
-except ImportError:
-    from collections.abc import (
-        Callable,
-    )
+def infer_float8_scaling(
+    a: torch.Tensor,
+    scale: torch.Tensor,
+) -> ScalingType:
+    """
+    Infer based on the shapes of the tensor & its scale
+    what form of scaling we're doing.
+    Note: This only handles tensor/row-wise scaling.
+    """
+    # Tensor-wise: single scale for entire tensor
+    if scale.numel() == 1:
+        return ScalingType.TensorWise
 
-    def _infer_scale_swizzle_impl(
-        mat_size: tuple[Any, Any],
-        scale_size: tuple[Any, ...],
-        scale_numel: Any,
-        mat_dtype: torch.dtype,
-        scale_dtype: torch.dtype,
-        eq_fn: Callable[[Any, Any], bool],
-    ) -> tuple[Optional[Any], Optional[Any]]:
-        """
-        Core implementation for scale/swizzle inference.
-        """
-        from torch.nn.functional import ScalingType, SwizzleType
+    # Row-wise: one scale per row or column
+    if scale.ndim >= 2:
+        if (
+            (scale.shape[0] == a.shape[0])
+            and (scale.shape[1] == 1)
+            or (scale.shape[0] == 1)
+            and (scale.shape[1] == a.shape[1])
+        ):
+            return ScalingType.RowWise
 
-        # Tensor-wise: single scale for entire tensor
-        if eq_fn(scale_numel, 1):
-            return ScalingType.TensorWise, SwizzleType.NO_SWIZZLE
-
-        # Row-wise: one scale per row or column
-        if len(scale_size) >= 2:
-            if (eq_fn(scale_size[0], mat_size[0]) and eq_fn(scale_size[1], 1)) or (
-                eq_fn(scale_size[0], 1) and eq_fn(scale_size[1], mat_size[1])
-            ):
-                return ScalingType.RowWise, SwizzleType.NO_SWIZZLE
-
-            # Block-wise 1x128 / 128x1 (DeepGemm style)
-            if (
-                eq_fn(scale_size[0], mat_size[0])
-                and eq_fn(scale_size[1], ceil_div(mat_size[1], 128))
-            ) or (
-                eq_fn(scale_size[1], mat_size[1])
-                and eq_fn(scale_size[0], ceil_div(mat_size[0], 128))
-            ):
-                return ScalingType.BlockWise1x128, SwizzleType.NO_SWIZZLE
-
-            # Block-wise 128x128
-            if eq_fn(scale_size[0], ceil_div(mat_size[0], 128)) and eq_fn(
-                scale_size[1], ceil_div(mat_size[1], 128)
-            ):
-                return ScalingType.BlockWise128x128, SwizzleType.NO_SWIZZLE
-
-        # Adjust for packed FP4 data (2 values per element)
-        K_multiplier = 2 if mat_dtype == torch.float4_e2m1fn_x2 else 1
-
-        # NVFP4: BlockWise1x16 with float8_e4m3fn scales
-        if mat_dtype == torch.float4_e2m1fn_x2 and scale_dtype == torch.float8_e4m3fn:
-            expected_numel_a = round_up(mat_size[0], 128) * round_up(
-                ceil_div(K_multiplier * mat_size[1], 16), 4
-            )
-            expected_numel_b = round_up(mat_size[1], 128) * round_up(
-                ceil_div(K_multiplier * mat_size[0], 16), 4
-            )
-            if eq_fn(scale_numel, expected_numel_a) or eq_fn(
-                scale_numel, expected_numel_b
-            ):
-                return ScalingType.BlockWise1x16, SwizzleType.SWIZZLE_32_4_4
-
-        # MXFP8: BlockWise1x32 with float8_e8m0fnu scales
-        if scale_dtype == torch.float8_e8m0fnu:
-            if not torch.version.hip:
-                # NVIDIA: uses swizzled 32x4x4 layout
-                expected_numel_a = round_up(mat_size[0], 128) * round_up(
-                    ceil_div(K_multiplier * mat_size[1], 32), 4
-                )
-                expected_numel_b = round_up(mat_size[1], 128) * round_up(
-                    ceil_div(K_multiplier * mat_size[0], 32), 4
-                )
-                if eq_fn(scale_numel, expected_numel_a) or eq_fn(
-                    scale_numel, expected_numel_b
-                ):
-                    return ScalingType.BlockWise1x32, SwizzleType.SWIZZLE_32_4_4
-            else:
-                # AMD: no swizzle
-                expected_numel_a = (
-                    ceil_div(mat_size[0], 32) * K_multiplier * mat_size[1]
-                )
-                expected_numel_b = (
-                    ceil_div(K_multiplier * mat_size[1], 32) * mat_size[0]
-                )
-                if eq_fn(scale_numel, expected_numel_a) or eq_fn(
-                    scale_numel, expected_numel_b
-                ):
-                    return ScalingType.BlockWise1x32, SwizzleType.NO_SWIZZLE
-
-        return None, None
-
-    def _infer_scale_swizzle(
-        mat: torch.Tensor, scale: torch.Tensor
-    ) -> tuple[Optional[Any], Optional[Any]]:
-        """
-        Infer the scaling type and swizzle mode from matrix and scale tensor shapes/dtypes.
-
-        This function determines how scale factors are laid out relative to the matrix:
-        - TensorWise: Single scale for entire tensor
-        - RowWise: One scale per row
-        - BlockWise1x128/128x128: Block-scaled with float32 scales
-        - BlockWise1x32: MXFP8 with float8_e8m0fnu scales (swizzled on NVIDIA)
-        - BlockWise1x16: NVFP4 with float8_e4m3fn scales (swizzled)
-
-        Args:
-            mat: The matrix tensor (FP8 or FP4)
-            scale: The scale factor tensor
-
-        Returns:
-            Tuple of (ScalingType, SwizzleType) or (None, None) if unrecognized
-        """
-        return _infer_scale_swizzle_impl(
-            mat_size=(mat.shape[0], mat.shape[1]),
-            scale_size=tuple(scale.shape),
-            scale_numel=scale.numel(),
-            mat_dtype=mat.dtype,
-            scale_dtype=scale.dtype,
-            eq_fn=lambda a, b: a == b,
-        )
-
-    infer_scale_swizzle = _infer_scale_swizzle
+    raise ValueError(f"Could not infer scaling from a: {a.shape}, scale: {scale.shape}")
 
 
 @torch.no_grad()

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -12,8 +12,8 @@ from torch.distributed._functional_collectives import AsyncCollectiveTensor, all
 
 from torchao.float8.config import ScalingGranularity
 from torchao.utils import (
-    round_up,
     ceil_div,
+    round_up,
 )
 
 # Helpful visualizer for debugging (only supports fp32):
@@ -34,11 +34,13 @@ FP8_TYPES = {
 infer_scale_swizzle = None
 try:
     from torch._inductor.utils import infer_scale_swizzle as _infer_scale_swizzle
+
     infer_scale_swizzle = _infer_scale_swizzle
 except ImportError:
     from collections.abc import (
         Callable,
     )
+
     def _infer_scale_swizzle_impl(
         mat_size: tuple[Any, Any],
         scale_size: tuple[Any, ...],
@@ -90,7 +92,9 @@ except ImportError:
             expected_numel_b = round_up(mat_size[1], 128) * round_up(
                 ceil_div(K_multiplier * mat_size[0], 16), 4
             )
-            if eq_fn(scale_numel, expected_numel_a) or eq_fn(scale_numel, expected_numel_b):
+            if eq_fn(scale_numel, expected_numel_a) or eq_fn(
+                scale_numel, expected_numel_b
+            ):
                 return ScalingType.BlockWise1x16, SwizzleType.SWIZZLE_32_4_4
 
         # MXFP8: BlockWise1x32 with float8_e8m0fnu scales
@@ -109,8 +113,12 @@ except ImportError:
                     return ScalingType.BlockWise1x32, SwizzleType.SWIZZLE_32_4_4
             else:
                 # AMD: no swizzle
-                expected_numel_a = ceil_div(mat_size[0], 32) * K_multiplier * mat_size[1]
-                expected_numel_b = ceil_div(K_multiplier * mat_size[1], 32) * mat_size[0]
+                expected_numel_a = (
+                    ceil_div(mat_size[0], 32) * K_multiplier * mat_size[1]
+                )
+                expected_numel_b = (
+                    ceil_div(K_multiplier * mat_size[1], 32) * mat_size[0]
+                )
                 if eq_fn(scale_numel, expected_numel_a) or eq_fn(
                     scale_numel, expected_numel_b
                 ):
@@ -146,8 +154,8 @@ except ImportError:
             scale_dtype=scale.dtype,
             eq_fn=lambda a, b: a == b,
         )
-    infer_scale_swizzle = _infer_scale_swizzle
 
+    infer_scale_swizzle = _infer_scale_swizzle
 
 
 @torch.no_grad()

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -11,8 +11,9 @@ import math
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 import torch
+import torch.nn.functional as F
 
-from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul
+from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul, infer_scale_swizzle
 from torchao.float8.types import FP8Granularity
 from torchao.quantization.granularity import (
     PerBlock,
@@ -52,9 +53,9 @@ def preprocess_data(
     Args:
         a_data: Input tensor A.
         b_data: Input tensor B.
-        scaled_mm_config: Configuration for _scaled_mm.
+        scaled_mm_config: Configuration for scaled_mm.
     Returns:
-        Preprocessed tensors A and B in the format for _scaled_mm.
+        Preprocessed tensors A and B in the format for scaled_mm.
     """
     if scaled_mm_config.pad_inner_dim:
         assert a_data.size(1) == b_data.size(0), (
@@ -70,11 +71,11 @@ def preprocess_data(
 
 
 def preprocess_scale(input_scale: torch.Tensor, input_shape: Tuple[int, ...]):
-    """Ensures input tensor is correctly formatted for _scaled_mm"""
+    """Ensures input tensor is correctly formatted for scaled_mm"""
 
     # For PerTensor quantization, scale should be a scalar or have shape [1]
     if input_scale.numel() == 1:
-        # Already a scalar, ensure it has the right shape for _scaled_mm
+        # Already a scalar, ensure it has the right shape for scaled_mm
         return input_scale.reshape(1, 1)
 
     # For per-row/block quantization, we need to handle the reshaping
@@ -103,26 +104,35 @@ def addmm_float8_unwrapped_inference(
     versions of the linear module.
     """
 
+    scale_recipe_a, swizzle_a = infer_scale_swizzle(a_data, a_scale)
+    scale_recipe_b, swizzle_b = infer_scale_swizzle(b_data, b_scale)
+
     if output_dtype == torch.float32 and bias is not None:
-        # Bias is not supported by _scaled_mm when output is fp32
-        output = torch._scaled_mm(
+        # Bias is not supported by scaled_mm when output is fp32
+        output = F.scaled_mm(
             a_data,
             b_data,
             scale_a=a_scale,
+            scale_recipe_a=scale_recipe_a,
             scale_b=b_scale,
-            scale_result=output_scale,
-            out_dtype=output_dtype,
+            scale_recipe_b=scale_recipe_b,
+            swizzle_a=swizzle_a,
+            swizzle_b=swizzle_b,
+            output_dtype=output_dtype,
             use_fast_accum=use_fast_accum,
         )
         return output + bias
-    return torch._scaled_mm(
+    return F.scaled_mm(
         a_data,
         b_data,
         scale_a=a_scale,
+        scale_recipe_a=scale_recipe_a,
         scale_b=b_scale,
+        scale_recipe_b=scale_recipe_b,
+        swizzle_a=swizzle_a,
+        swizzle_b=swizzle_b,
         bias=bias,
-        scale_result=output_scale,
-        out_dtype=output_dtype,
+        output_dtype=output_dtype,
         use_fast_accum=use_fast_accum,
     )
 

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -13,7 +13,11 @@ from typing import List, NamedTuple, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 
-from torchao.float8.float8_utils import is_row_major, pad_tensor_for_matmul, infer_scale_swizzle
+from torchao.float8.float8_utils import (
+    infer_scale_swizzle,
+    is_row_major,
+    pad_tensor_for_matmul,
+)
 from torchao.float8.types import FP8Granularity
 from torchao.quantization.granularity import (
     PerBlock,

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn.functional as F
 
 from torchao.float8.float8_utils import (
-    infer_scale_swizzle,
+    infer_float8_scaling,
     is_row_major,
     pad_tensor_for_matmul,
 )
@@ -108,8 +108,8 @@ def addmm_float8_unwrapped_inference(
     versions of the linear module.
     """
 
-    scale_recipe_a, swizzle_a = infer_scale_swizzle(a_data, a_scale)
-    scale_recipe_b, swizzle_b = infer_scale_swizzle(b_data, b_scale)
+    scale_recipe_a = infer_float8_scaling(a_data, a_scale)
+    scale_recipe_b = infer_float8_scaling(b_data, b_scale)
 
     if output_dtype == torch.float32 and bias is not None:
         # Bias is not supported by scaled_mm when output is fp32
@@ -120,8 +120,6 @@ def addmm_float8_unwrapped_inference(
             scale_recipe_a=scale_recipe_a,
             scale_b=b_scale,
             scale_recipe_b=scale_recipe_b,
-            swizzle_a=swizzle_a,
-            swizzle_b=swizzle_b,
             output_dtype=output_dtype,
             use_fast_accum=use_fast_accum,
         )
@@ -133,8 +131,6 @@ def addmm_float8_unwrapped_inference(
         scale_recipe_a=scale_recipe_a,
         scale_b=b_scale,
         scale_recipe_b=scale_recipe_b,
-        swizzle_a=swizzle_a,
-        swizzle_b=swizzle_b,
         bias=bias,
         output_dtype=output_dtype,
         use_fast_accum=use_fast_accum,

--- a/torchao/prototype/blockwise_fp8_training/linear.py
+++ b/torchao/prototype/blockwise_fp8_training/linear.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from torch import nn
 
 from torchao.core.config import AOBaseConfig
-from torchao.float8.float8_utils import infer_scale_swizzle
 from torchao.prototype.blockwise_fp8_training.kernels import (
     triton_fp8_blockwise_act_quant_lhs,
     triton_fp8_blockwise_act_quant_rhs,
@@ -22,29 +21,33 @@ from torchao.prototype.blockwise_fp8_training.kernels import (
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
-from torchao.utils import is_sm_at_least_90
+
+# Note: cublasLt only supports DeepSeek-style scaling on Hopper (sm90),
+#       _NOT_ 90+
+from torchao.utils import is_sm_exactly_90
 
 
-def torch_scaled_mm_wrap(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    scale_a: torch.Tensor,
-    scale_b: torch.Tensor,
-    out_dtype: torch.dtype,
+def triton_mm_1x128_128x128_wrap(
+    a, b, scale_a, scale_recipe_a, scale_b, scale_recipe_b, output_dtype
 ) -> torch.Tensor:
-    scale_recipe_a, swizzle_a = infer_scale_swizzle(a, scale_a)
-    scale_recipe_b, swizzle_b = infer_scale_swizzle(a, scale_a)
-
-    return F.scaled_mm(
+    return triton_fp8_gemm_1x128_128x128(
         a,
         b,
-        scale_a=scale_a,
-        scale_recipe_a=scale_recipe_a,
-        scale_b=scale_b,
-        scale_recipe_b=scale_recipe_b,
-        swizzle_a=swizzle_a,
-        swizzle_b=swizzle_b,
-        output_dtype=out_dtype,
+        scale_a,
+        scale_b,
+        out_dtype=output_dtype,
+    )
+
+
+def triton_mm_1x128_128x1_wrap(
+    a, b, scale_a, scale_recipe_a, scale_b, scale_recipe_b, output_dtype
+) -> torch.Tensor:
+    return triton_fp8_gemm_1x128_128x1(
+        a,
+        b,
+        scale_a,
+        scale_b,
+        out_dtype=output_dtype,
     )
 
 
@@ -67,13 +70,15 @@ class fp8_blockwise_mm(torch.autograd.Function):
         )
 
         # out = input @ weight.T
-        fp8_gemm = triton_fp8_gemm_1x128_128x128 if use_triton else torch_scaled_mm_wrap
+        fp8_gemm = triton_mm_1x128_128x128_wrap if use_triton else F.scaled_mm
         out = fp8_gemm(
             x_fp8,
             weight_t_fp8,
             x_scale,
+            F.ScalingType.BlockWise1x128,
             weight_t_scale,
-            out_dtype=out_dtype,
+            F.ScalingType.BlockWise128x128,
+            output_dtype=out_dtype,
         )
         out = out.reshape(*x_orig_shape[:-1], out.shape[-1])
         ctx.save_for_backward(x, weight)
@@ -112,14 +117,16 @@ class fp8_blockwise_mm(torch.autograd.Function):
 
         # grad_x = grad_output @ weight
         fp8_gemm_1x128_128x128 = (
-            triton_fp8_gemm_1x128_128x128 if use_triton else torch_scaled_mm_wrap
+            triton_mm_1x128_128x128_wrap if use_triton else F.scaled_mm
         )
         grad_x = fp8_gemm_1x128_128x128(
             grad_output_fp8,
             weight_fp8,
             grad_output_scale,
+            F.ScalingType.BlockWise1x128,
             weight_scale,
-            out_dtype=out_dtype,
+            F.ScalingType.BlockWise1x128,
+            output_dtype=out_dtype,
         )
 
         # Cast grad_output_t to fp8 blockwise with (1 x block_size) scaling groups, since it is
@@ -138,15 +145,15 @@ class fp8_blockwise_mm(torch.autograd.Function):
         x_fp8, x_scale = triton_fp8_blockwise_act_quant_rhs(x, block_size)
 
         # grad_weight = grad_output.T @ x
-        fp8_gemm_1x128_128x1 = (
-            triton_fp8_gemm_1x128_128x1 if use_triton else torch_scaled_mm_wrap
-        )
+        fp8_gemm_1x128_128x1 = triton_mm_1x128_128x1_wrap if use_triton else F.scaled_mm
         grad_weight = fp8_gemm_1x128_128x1(
             grad_output_t_fp8,
             x_fp8,
             grad_output_t_scale,
+            F.ScalingType.BlockWise1x128,
             x_scale,
-            out_dtype=out_dtype,
+            F.ScalingType.BlockWise1x128,
+            output_dtype=out_dtype,
         )
 
         # Reshape grad_x to expected potentially 3D+ shape
@@ -183,10 +190,13 @@ class Float8BlockwiseLinear(nn.Linear):
         assert dtype in self.supported_dtypes, (
             f"Unsupported dtype: {dtype}. Supported dtypes: {self.supported_dtypes}"
         )
-        assert is_sm_at_least_90(), "Only support SM90"
+        # Note: Triton kernels are broken (as-of 01/29/26), so must only run on
+        #       H100 w/cublasLt
+        assert is_sm_exactly_90(), "Only supported on SM90 + cublasLt"
         self.block_size = block_size
         self.dtype = dtype
-        self.use_triton = use_triton
+        # Must use triton on non-Hopper.
+        self.use_triton = use_triton or not is_sm_exactly_90()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """

--- a/torchao/prototype/blockwise_fp8_training/linear.py
+++ b/torchao/prototype/blockwise_fp8_training/linear.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 
 from torchao.core.config import AOBaseConfig
+from torchao.float8.float8_utils import infer_scale_swizzle
 from torchao.prototype.blockwise_fp8_training.kernels import (
     triton_fp8_blockwise_act_quant_lhs,
     triton_fp8_blockwise_act_quant_rhs,
@@ -22,7 +23,7 @@ from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
 from torchao.utils import is_sm_at_least_90
-from torchao.float8.float8_utils import infer_scale_swizzle
+
 
 def torch_scaled_mm_wrap(
     a: torch.Tensor,

--- a/torchao/prototype/mx_formats/README.md
+++ b/torchao/prototype/mx_formats/README.md
@@ -188,7 +188,7 @@ x_hp = x_mx.to_dtype(torch.float)
 
 ## mxfp8 gemm
 
-On NVIDIA B200 machines, we use the cuBLAS mxfp8 gemm exposed via the `torch._scaled_mm` op.
+On NVIDIA B200 machines, we use the cuBLAS mxfp8 gemm exposed via the `F.scaled_mm` op.
 We observe a speedup of **up to ~2x** vs the bf16 baseline on common shapes.  To reproduce this
 on supported hardware, you can run the following command:
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -682,13 +682,17 @@ def _addmm_mx_dispatch(
 
         if a._elem_dtype == torch.float8_e4m3fn:
             assert b._elem_dtype == torch.float8_e4m3fn
-            res = torch._scaled_mm(
+            res = F.scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
+                scale_a=a_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_b=ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
                 bias=bias,
-                out_dtype=torch.bfloat16,
+                output_dtype=torch.bfloat16,
             )
         else:
             assert a._elem_dtype == torch.float4_e2m1fn_x2

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -10,9 +10,9 @@ from typing import Optional
 
 import torch
 from torch.nn.functional import (
-    scaled_mm,
     ScalingType,
     SwizzleType,
+    scaled_mm,
 )
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
@@ -467,11 +467,19 @@ def _addmm_nvfp4_dispatch(
         b_scale = b.scale.t().view(N, K // b.block_size)
         b_scale_blocked = to_blocked(b_scale)
 
-    scale_recipes = [ScalingType.BlockWise1x16, ]
-    swizzles = [SwizzleType.SWIZZLE_32_4_4, ]
+    scale_recipes = [
+        ScalingType.BlockWise1x16,
+    ]
+    swizzles = [
+        SwizzleType.SWIZZLE_32_4_4,
+    ]
 
-    scale_a = [a_scale_blocked.view(torch.float8_e4m3fn), ]
-    scale_b = [b_scale_blocked.view(torch.float8_e4m3fn), ]
+    scale_a = [
+        a_scale_blocked.view(torch.float8_e4m3fn),
+    ]
+    scale_b = [
+        b_scale_blocked.view(torch.float8_e4m3fn),
+    ]
     # Merge double quant scales into 1 scale for Scale_In^D
     if a.per_tensor_scale is not None:
         assert b.per_tensor_scale is not None
@@ -482,7 +490,6 @@ def _addmm_nvfp4_dispatch(
         scale_b.append(b.per_tensor_scale)
     else:
         assert b.per_tensor_scale is None and a.per_tensor_scale is None
-        scale_result = None
 
     # Bias is not supported when output dtype == Float32, so note that, and add separately,
     # post-scaled_mm call.

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -9,6 +9,11 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from torch.nn.functional import (
+    scaled_mm,
+    ScalingType,
+    SwizzleType,
+)
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 from torchao.prototype.mx_formats.constants import F4_E2M1_MAX, F8E4M3_MAX
@@ -462,56 +467,42 @@ def _addmm_nvfp4_dispatch(
         b_scale = b.scale.t().view(N, K // b.block_size)
         b_scale_blocked = to_blocked(b_scale)
 
+    scale_recipes = [ScalingType.BlockWise1x16, ]
+    swizzles = [SwizzleType.SWIZZLE_32_4_4, ]
+
+    scale_a = [a_scale_blocked.view(torch.float8_e4m3fn), ]
+    scale_b = [b_scale_blocked.view(torch.float8_e4m3fn), ]
     # Merge double quant scales into 1 scale for Scale_In^D
     if a.per_tensor_scale is not None:
         assert b.per_tensor_scale is not None
-        scale_result = a.per_tensor_scale * b.per_tensor_scale
+        scale_recipes.append(ScalingType.TensorWise)
+        swizzles.append(SwizzleType.NO_SWIZZLE)
+
+        scale_a.append(a.per_tensor_scale)
+        scale_b.append(b.per_tensor_scale)
     else:
         assert b.per_tensor_scale is None and a.per_tensor_scale is None
         scale_result = None
 
-    # THIS IS A WORKAROUND FOR TWO ERRORS:
-    #
-    # (1) RuntimeError: CUDA error: CUBLAS_STATUS_INVALID_VALUE when calling
-    # When we have per-tensor scaling, we need to apply it before bias
-    # since bias is not quantized
-    #
-    # (2) RuntimeError: Bias is not supported when out_dtype is set to Float32
-    # This is not supported by _scaled_mm
-    should_add_bias_separately = (
-        scale_result is not None or a._orig_dtype == torch.float32
-    ) and (bias is not None)
-    # should_add_bias_separately = bias is not None
+    # Bias is not supported when output dtype == Float32, so note that, and add separately,
+    # post-scaled_mm call.
+    # Note: scaled_mm _does_ support bias w/per-tensor scales, which was previously
+    #       not supported.
+    should_add_bias_separately = (a._orig_dtype == torch.float32) and (bias is not None)
 
-    # For gemm(A, B) with original high precision inputs A and B:
-    #
-    # 1. A and B are always cast to fp32 before being quantized and packed
-    #    into uint8 (2 fp4 values per byte)
-    # 2. _scaled_mm (cublas) always accumulates in fp32 since use_fast_accum=False
-    # 3. Outputs are cast to A.dtype before returning
-    # 4. Bias is added outside _scaled_mm if per_tensor_scale exists
-    #    or output dtype is fp32
-    #
-    # -----------------------------------------------------------------------------
-    # | A.dtype | B.dtype | Accum dtype | Out dtype | Bias added in _scaled_mm?   |
-    # -----------------------------------------------------------------------------
-    # | fp32    | fp32    | fp32        | fp32      | No                          |
-    # | fp32    | bf16    | fp32        | fp32      | No                          |
-    # | bf16    | fp32    | fp32        | bf16      | Only if no per_tensor_scale |
-    # | bf16    | bf16    | fp32        | bf16      | Only if no per_tensor_scale |
-    # -----------------------------------------------------------------------------
-    result = torch._scaled_mm(
+    result = scaled_mm(
         a.qdata.view(torch.float4_e2m1fn_x2),
         b.qdata.view(torch.float4_e2m1fn_x2),
-        a_scale_blocked.view(torch.float8_e4m3fn),
-        b_scale_blocked.view(torch.float8_e4m3fn),
+        scale_a=scale_a,
+        scale_recipe_a=scale_recipes,
+        scale_b=scale_b,
+        scale_recipe_b=scale_recipes,
+        swizzle_a=swizzles,
+        swizzle_b=swizzles,
         bias=None if should_add_bias_separately else bias,
-        out_dtype=a._orig_dtype,
-        # scale_result=scale_result,  # Not supported yet
+        # bias=bias,
+        output_dtype=a._orig_dtype,
     )
-
-    if scale_result is not None:
-        result = result * scale_result.to(a._orig_dtype)
 
     # Add bias after scaling if needed
     if should_add_bias_separately:

--- a/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
+++ b/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
@@ -427,7 +427,7 @@ def _float8_addmm_impl(
             inpt_data, w_data = preprocess_data(inpt_data, w_data, scaled_mm_config)
 
             if _is_128_128_scaled(weight_tensor):
-                # TODO(future PR): add testing for torch._scaled_mm with
+                # TODO(future PR): add testing for F.scaled_mm with
                 # blockwise scaling on CUDA 12.9
                 # TODO(future PR): add mslk path if available
                 # TODO(future PR): proper out_dtype handling

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -786,7 +786,7 @@ def _fp8_mm_compat(weight: torch.Tensor) -> bool:
 
     if not is_compatible:
         logger.info(
-            f"Skipping float8 quantization: weight shape {weight.shape} is not compatible with _scaled_mm. "
+            f"Skipping float8 quantization: weight shape {weight.shape} is not compatible with scaled_mm. "
             f"Both input dimension ({in_dim}) and output dimension ({out_dim}) must be multiples of 16. "
         )
 

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1132,6 +1132,14 @@ def is_sm_at_least_90():
     )
 
 
+def is_sm_exactly_90():
+    return (
+        torch.cuda.is_available()
+        and torch.version.cuda
+        and torch.cuda.get_device_capability() == (9, 0)
+    )
+
+
 # TODO(future PR): rename to 8_9, 9_0, 10_0 instead of 89, 10, 100
 def is_sm_at_least_100():
     return (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #3742

All `torch._scaled_mm` calls & references should now be replaced with
`F.scaled_mm`.

Changed some logic w.r.t. nvfp4 gemm + per-tensor-scales and bias to
reflect improved functionality.

Test Plan:

Relevant tests I've found pass:
```
pytest test/float8
pytest test/prototype/mx_formats
pytest test/prototype/blockwise_fp8_training
```
Note that there are plenty of failing tests, but some, like fp8 FSDP fail on my test machine without this patch, others, like DeepSeek-style gemms have to be running through triton on this (B200) node, as functionality through `F.scaled_mm` only exists for sm90 (Hopper). 

NOTE: This requires https://github.com/pytorch/pytorch/pull/173646 to be merged, otherwise compiled tests will fail.

Signed-off-by: Simon Layton <simonlayton@meta.com>