### PR TITLE
Float8StaticActivationFloat8WeightConfig support 3D input

### DIFF
--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -353,7 +353,8 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
         act_quant_kwargs = config.get_act_quant_kwargs()
         self.assertIsNotNone(act_quant_kwargs)
 
-    def test_static_quant_with_output_quantization(self):
+    @common_utils.parametrize("input_shape", [(4, 64), (2, 4, 64)])
+    def test_static_quant_with_output_quantization(self, input_shape):
         """
         Test static quantization with output quantization enabled.
 
@@ -361,6 +362,8 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
         1. An output observer is created during prepare step
         2. The output of the linear layer is quantized to float8 after scaled_mm
         3. The output is then dequantized back to original dtype
+
+        Tests both 2D (batch_size, input_dim) and 3D (batch_size, seq_len, input_dim) inputs.
         """
         torch.compiler.reset()
         torch.manual_seed(42)
@@ -371,7 +374,7 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
         model = ToySingleLinearModel(
             input_dim=64, output_dim=32, dtype=dtype, device="cuda"
         ).eval()
-        example_inputs = model.example_inputs(batch_size=4)
+        example_inputs = (torch.randn(*input_shape, dtype=dtype, device="cuda"),)
 
         # Get reference output before quantization
         before_quant = model(*example_inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3754

Summary:
- Pass keepdim=True to all AffineQuantizedMinMaxObserver instances in Float8StaticActivationFloat8WeightConfig transform to preserve scale tensor dimensions
- Remove manual scale reshaping workarounds after calculate_qparams() calls since keepdim=True now handles this
- Extend test_static_quant_with_output_quantization with parametrize to test both 2D and 3D inputs

Test Plan:
- Run test_static_quant_with_output_quantization with both input shapes:
  - 2D: (4, 64)
  - 3D: (2, 4, 64)
- Verify existing float8 static quantization tests still pass

```
pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128
pip install --pre mslk --index-url https://download.pytorch.org/whl/nightly/cu128
pytest test/prototype/test_prototype_float8_tensor.py
```

some tests only passing after changing kernel_preference to "torch" in B200 machine

Reviewers:

Subscribers:

Tasks:

Tags: