### PR TITLE
Add extra_repr for PrototypeFloat8Tensor

### DIFF
--- a/torchao/prototype/quantization/quant_api.py
+++ b/torchao/prototype/quantization/quant_api.py
@@ -674,6 +674,7 @@ def _float8_static_activation_float8_weight_transform(
         )
 
         module.weight = torch.nn.Parameter(quantized_tensor, requires_grad=False)
+        module.extra_repr = types.MethodType(_linear_extra_repr, module)
         return module
 
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3772

Summary:
make sure quantized tensor information is displayed when we
print linear with quantized weights in float8 static quantization flow

Test Plan:
tested locally:

```

import torch
from torchao.prototype.quantization.quant_api import (
    Float8StaticActivationFloat8WeightConfig,
)
from torchao.quantization import PerTensor
from torchao import quantize_

x = torch.randn(2, 16, device='cuda').to(torch.bfloat16)
linear = torch.nn.Sequential(torch.nn.Linear(16, 32).cuda().to(torch.bfloat16))

config = Float8StaticActivationFloat8WeightConfig(
   step="prepare",
   granularity=PerTensor(),
   quantize_and_dequantize_output=True,
)
quantize_(linear, config)
print("after prepare:", linear)
linear(x)
config = Float8StaticActivationFloat8WeightConfig(step="convert", kernel_preference="torch")
quantize_(linear, config)
print("after convert:", linear)
out = linear(x)

before:

after prepare: Sequential(
  (0): Float8ObservedLinear(
    in_features=16, out_features=32, bias=True
    (input_act_obs): AffineQuantizedMinMaxObserver()
    (output_act_obs): AffineQuantizedMinMaxObserver()
  )
)
after convert: Sequential(
  (0): Linear(in_features=16, out_features=32, bias=True)
)

after:

after prepare: Sequential(
  (0): Float8ObservedLinear(
    in_features=16, out_features=32, bias=True
    (input_act_obs): AffineQuantizedMinMaxObserver()
    (output_act_obs): AffineQuantizedMinMaxObserver()
  )
)
after convert: Sequential(
  (0): Linear(in_features=16, out_features=32, weight=PrototypeFloat8Tensor(self.act_quant_kwargs=QuantizeTensorToFloat8Kwargs(float8_dtype=torch.float8_e4m3fn, granularity=PerTensor(), mm_config=Float8MMConfig(emulate=False, use_fast_accum=True, pad_inner_dim=False), hp_value_lb=None, hp_value_ub=None, kernel_preference='torch'), self.block_size=[32, 16], self.mm_config=Float8MMConfig(emulate=False, use_fast_accum=True, pad_inner_dim=False), self.scale.shape=torch.Size([1, 1]), self.kernel_preference='torch'))
)
```

step=None

```
import torch
from torchao.prototype.quantization.quant_api import (
    Float8StaticActivationFloat8WeightConfig,
)
from torchao.quantization import PerTensor
from torchao import quantize_

x = torch.randn(2, 16, device='cuda').to(torch.bfloat16)
linear = torch.nn.Sequential(torch.nn.Linear(16, 32).cuda().to(torch.bfloat16))

config = Float8StaticActivationFloat8WeightConfig(
   act_quant_scale=torch.ones((1, 1), device="cuda", dtype=torch.float32),
   granularity=PerTensor(),
   quantize_and_dequantize_output=True,
   kernel_preference="torch",
)
quantize_(linear, config)
print("after convert:", linear)
out = linear(x)

after convert: Sequential(
  (0): Linear(in_features=16, out_features=32, weight=PrototypeFloat8Tensor(self.act_quant_kwargs=QuantizeTensorToFloat8Kwargs(float8_dtype=torch.float8_e4m3fn, granularity=PerTensor(), mm_config=Float8MMConfig(emulate=False, use_fast_accum=True, pad_inner_dim=False), hp_value_lb=None, hp_value_ub=None, kernel_preference='torch'), self.block_size=[32, 16], self.mm_config=Float8MMConfig(emulate=False, use_fast_accum=True, pad_inner_dim=False), self.scale.shape=torch.Size([1, 1]), self.kernel_preference='torch'))
)
```

Reviewers:

Subscribers:

Tasks:

Tags: