### PR TITLE
[mxpf8 moe training] add unit tests to CI

### DIFF
--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -54,3 +54,4 @@ jobs:
         python test/quantization/quantize_/workflows/int4/test_int4_preshuffled_tensor.py
         ./test/float8/test_everything_single_gpu.sh
         pytest test/prototype/mx_formats/ -s
+        pytest test/prototype/moe_training/test_scaled_grouped_mm.py -v -s -k mx


### PR DESCRIPTION
After landing emulated mode in #3724, these unit tests can run on non-sm100 devices. Verified locally on H100 devgpu.