### PR TITLE
[reland][xpu] INT8 quantization on Intel XPU

### DIFF
--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -301,14 +301,15 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
             weight_cpu.dequantize(), weight_pinned.dequantize(), atol=0, rtol=0
         )
 
-    def test_int8_weight_only_v1_v2_per_group_equivalence(self):
+    @common_utils.parametrize("device", get_available_devices())
+    def test_int8_weight_only_v1_v2_per_group_equivalence(self, device):
         """Test that v1 per-group and v2 PerGroup produce equivalent outputs."""
         torch.manual_seed(42)
         group_size = 64
         K, N = 256, 128
 
         model_v1 = ToyTwoLinearModel(
-            K, N, K, dtype=torch.bfloat16, device="cuda"
+            K, N, K, dtype=torch.bfloat16, device=device
         ).eval()
         model_v2 = copy.deepcopy(model_v1)
 
@@ -318,7 +319,7 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
         quantize_(model_v1, config_v1)
         quantize_(model_v2, config_v2)
 
-        input_tensor = torch.randn(32, K, dtype=torch.bfloat16, device="cuda")
+        input_tensor = torch.randn(32, K, dtype=torch.bfloat16, device=device)
 
         with torch.no_grad():
             output_v1 = model_v1(input_tensor)


### PR DESCRIPTION
# Motivation
This feature is one of features listed in the #3576. There is the XMX intrinsic on the Intel GPUs, e.g., Intel Arc B580, to speedup the int8 computation. This PR is target to ensure the int8 quantization works on the XPU and user can use same quantization config with CUDA. 
# Implementation

Since the int8 quantization design of torchAO design is device agnostic,  the only need to do on XPU is to enable the [int_mm on XPU](https://github.com/pytorch/pytorch/pull/157769) and This PR has landed into the PyTorch core since torch-2.9. In this PR, we add the UT test to ensure the entire int quantization workflow on XPU works. 

# Usage
Users can use same quantization config, such as Int8StaticActivationInt8WeightConfig or Int8DynamicActivationInt8WeightConfig, as CUDA to run the fp8 models on XPU. This device dispatched by the PyTorch op.
```
#For dynamic int8 quantization
dynamic_config = Int8DynamicActivationInt8WeightConfig(version=2)
quantize_(model, dynamic_config)

#For static int8 quantization
static_config = Int8StaticActivationInt8WeightConfig(
            scale=int8_input.scale.detach().clone(),
            granularity=granularity,
        )
quantize_(model, static_config)
```