### PR TITLE
[13/x] docs update: make QAT readme point to docs

### DIFF
--- a/torchao/quantization/qat/README.md
+++ b/torchao/quantization/qat/README.md
@@ -2,4 +2,4 @@
 
 The QAT documentation has moved to the torchao docs:
 
-https://pytorch.org/ao/stable/workflows/qat.html
+https://pytorch.org/ao/main/workflows/qat.html


### PR DESCRIPTION
Summary:

Addressing comments from https://github.com/pytorch/ao/pull/3764

Fixes https://github.com/pytorch/ao/issues/3778

Test Plan: look at CI readme