### PR TITLE
[CPU][QSDPA] Fix issue with strided input

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -247,6 +247,132 @@ class TestOps(TestCase):
             )
         self.assertEqual(actual.float(), math_ref.float(), atol=atol, rtol=rtol)
 
+    @pytest.mark.skipif(
+        not torch_version_at_least("2.7.0"),
+        reason="quantized sdpa requires torch 2.7 or later",
+    )
+    @pytest.mark.skipif(not IS_LINUX, reason="only support on linux")
+    @pytest.mark.skipif(
+        "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
+        reason="cpp kernels not built",
+    )
+    @parametrize("input_dtype", [torch.uint8, torch.float8_e4m3fn])
+    def test_quantized_scaled_dot_product_op_with_strided(
+        self,
+        input_dtype,
+    ):
+        torch.manual_seed(1234)
+        device = "cpu"
+        if input_dtype == torch.uint8:
+            q_scale = float(1.7907238006591797)
+            k_scale = float(1.8039721250534058)
+            v_scale = float(1.839004635810852)
+            a_scale = float(0.003919653594493866)
+            o_scale = float(1.8191684484481812)
+            q_zp = int(127)
+            k_zp = int(125)
+            v_zp = int(127)
+            a_zp = int(120)
+            o_zp = int(128)
+            atol, rtol = 1.0, 5e-6
+        else:
+            q_scale = float(5.96875)
+            k_scale = float(5.78125)
+            v_scale = float(0.98046875)
+            a_scale = float(4.84375)
+            o_scale = float(3.171875)
+            atol, rtol = 0.125, 5e-6
+        batch_size, seq_len, num_head, head_dim = 56, 100, 16, 32
+        hidden_size = num_head * head_dim
+        proj = torch.nn.Linear(hidden_size, 3 * hidden_size, bias=False)
+        input_shape = (batch_size, seq_len, num_head * head_dim)
+        qkv_shape = (batch_size, seq_len, num_head, head_dim)
+        input_tensor = torch.randn(input_shape, dtype=torch.float, device=device)
+        hidden_state = proj(input_tensor)
+        q, k, v = torch.split(hidden_state, hidden_size, dim=-1)
+        q = q.view(*qkv_shape).transpose(1, 2)
+        k = k.view(*qkv_shape).transpose(1, 2)
+        v = v.view(*qkv_shape).transpose(1, 2)
+        if input_dtype == torch.uint8:
+            q = q * 100
+            k = k * 100
+            v = v * 100
+        q = q.to(input_dtype)
+        k = k.to(input_dtype)
+        v = v.to(input_dtype)
+        q2, k2, v2 = (
+            q.clone(),
+            k.clone(),
+            v.clone(),
+        )
+
+        if input_dtype == torch.uint8:
+            math_ref = self._scaled_dot_product_int8_op_ref(
+                q2,
+                k2,
+                v2,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=False,
+                q_scale=q_scale,
+                q_zp=q_zp,
+                k_scale=k_scale,
+                k_zp=k_zp,
+                v_scale=v_scale,
+                v_zp=v_zp,
+                a_scale=a_scale,
+                a_zp=a_zp,
+                o_scale=o_scale,
+                o_zp=o_zp,
+            )
+            actual = torch.ops.torchao.qscaled_dot_product(
+                q,
+                k,
+                v,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=False,
+                q_scale=q_scale,
+                q_zp=q_zp,
+                k_scale=k_scale,
+                k_zp=k_zp,
+                v_scale=v_scale,
+                v_zp=v_zp,
+                a_scale=a_scale,
+                a_zp=a_zp,
+                o_scale=o_scale,
+                o_zp=o_zp,
+            )
+        else:
+            math_ref = self._scaled_dot_product_fp8_op_ref(
+                q2,
+                k2,
+                v2,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=False,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                a_scale=a_scale,
+                o_scale=o_scale,
+            )
+            actual = torch.ops.torchao.qscaled_dot_product(
+                q,
+                k,
+                v,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=False,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                a_scale=a_scale,
+                o_scale=o_scale,
+            )
+        assert actual.transpose(1, 2).is_contiguous(), "Output is not contiguous!"
+        self.assertEqual(actual.float(), math_ref.float(), atol=atol, rtol=rtol)
+
 
 instantiate_parametrized_tests(TestOps)
 

--- a/torchao/csrc/cpu/aten_kernels/quantized_sdpa.cpp
+++ b/torchao/csrc/cpu/aten_kernels/quantized_sdpa.cpp
@@ -2525,11 +2525,15 @@ at::Tensor _qscaled_dot_product_cpu(
     TORCH_CHECK(q_zp == 0 && k_zp == 0 && v_zp == 0 && a_zp == 0 && o_zp == 0,
       "_qscaled_dot_product_cpu: Don't accept zero point for Float8_e4m3");
   }
+  int64_t batch_size = query.size(0);
+  int64_t num_head = query.size(1);
+  int64_t q_seq_len = query.size(2);
+  int64_t head_size = query.size(3);
 
   if (dtype == at::ScalarType::Byte) {
 #ifdef CPU_CAPABILITY_AVX512
       if (at::native::cpublas::could_pack(dtype)) {
-          at::Tensor output = at::empty_like(query, query.options()).transpose(1, 2);
+          at::Tensor output = at::empty({batch_size, q_seq_len, num_head, head_size}, query.options());
           int8_sdpa_fused_kernel(output, query, key, value,
               dropout_p, is_causal, attn_mask, scale,
               q_scale, q_zp,
@@ -2554,7 +2558,7 @@ at::Tensor _qscaled_dot_product_cpu(
 #if defined(CPUBLAS_BRGEMM_F8F8F32) && defined(CPU_CAPABILITY_AVX512)
 // CPUBLAS_BRGEMM_F8F8F32 is defined if FP8 BRGEMM is supported in PyTorch CPUBlas.
       if (at::native::cpublas::could_pack(dtype)) {
-          at::Tensor output = at::empty_like(query, query.options()).transpose(1, 2);
+          at::Tensor output = at::empty({batch_size, q_seq_len, num_head, head_size}, query.options());
           fp8_sdpa_fused_kernel(output, query, key, value,
               dropout_p, is_causal, attn_mask, scale,
               q_scale, k_scale,

--- a/torchao/ops.py
+++ b/torchao/ops.py
@@ -152,7 +152,7 @@ def _(
     o_scale: float = 1.0,
     o_zp: int = 0,
 ) -> Tensor:
-    return query
+    return query.transpose(1, 2).contiguous().transpose(1, 2)
 
 
 def rowwise_scaled_linear_sparse_cutlass_f8f8(


### PR DESCRIPTION
When applying the concat QKV optimization before quantized SDPA, we do not wish the output has the same stride as the input for quantized SDPA, which requires more memory and can also cause potential issues.
For example, an input with shape `(56, 16, 100, 32)`, the stride w/o concat QKV is `(51200, 32, 512, 1)`, and the one with concat QKV is `(153600, 32, 1536, 1)`. We always expect the output with stride `(51200, 32, 512, 1)`, whether concat QKV applies.

This PR tends to fix the issue.