### PR TITLE
Static quantization tutorial: Reshape weight for FP8 quant

### DIFF
--- a/tutorials/calibration_flow/static_quant.py
+++ b/tutorials/calibration_flow/static_quant.py
@@ -112,10 +112,13 @@ def _apply_static_quant_transform(
                 weight, weight_scale, weight_zero_point, block_size, target_dtype
             )
         elif target_dtype == torch.float8_e4m3fn:
+            weight_scale_2d = (
+                weight_scale.view(-1, 1) if weight_scale.dim() == 1 else weight_scale
+            )
             mm_config = Float8MMConfig(use_fast_accum=True)
             return to_affine_quantized_floatx_static(
                 weight,
-                weight_scale,
+                weight_scale_2d,
                 block_size,
                 target_dtype,
                 Float8Layout(mm_config=mm_config),
@@ -181,10 +184,13 @@ class QuantizedLinear(torch.nn.Module):
                 weight, weight_scale, weight_zero_point, block_size, self.target_dtype
             )
         elif self.target_dtype == torch.float8_e4m3fn:
+            weight_scale_2d = (
+                weight_scale.view(-1, 1) if weight_scale.dim() == 1 else weight_scale
+            )
             mm_config = Float8MMConfig(use_fast_accum=True)
             self.qweight = to_affine_quantized_floatx_static(
                 weight,
-                weight_scale,
+                weight_scale_2d,
                 block_size,
                 target_dtype,
                 Float8Layout(mm_config=mm_config),


### PR DESCRIPTION
Running the tutorial script results in the error below. The reshape fix in this PR resolves the error

```
Traceback (most recent call last):
  File "/home/scratch.asfiyab_sw/ao/tutorials/calibration_flow/static_quant.py", line 332, in <module>
    test_static_quant(torch.float8_e4m3fn, MappingType.SYMMETRIC)
  File "/home/scratch.asfiyab_sw/ao/tutorials/calibration_flow/static_quant.py", line 321, in test_static_quant
    quantize_(m2, StaticQuantConfig2(target_dtype), is_observed_linear)
  File "/usr/local/lib/python3.12/dist-packages/torchao/quantization/quant_api.py", line 497, in quantize_
    _replace_with_custom_fn_if_matches_filter(
  File "/usr/local/lib/python3.12/dist-packages/torchao/quantization/quant_api.py", line 212, in _replace_with_custom_fn_if_matches_filter
    new_child = _replace_with_custom_fn_if_matches_filter(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torchao/quantization/quant_api.py", line 207, in _replace_with_custom_fn_if_matches_filter
    model = replacement_fn(model, *extra_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.asfiyab_sw/ao/tutorials/calibration_flow/static_quant.py", line 247, in apply_static_quant
    return QuantizedLinear.from_observed(module, config.target_dtype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.asfiyab_sw/ao/tutorials/calibration_flow/static_quant.py", line 225, in from_observed
    quantized_linear = cls(
                       ^^^^
  File "/home/scratch.asfiyab_sw/ao/tutorials/calibration_flow/static_quant.py", line 191, in __init__
    self.qweight = to_affine_quantized_floatx_static(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torchao/dtypes/affine_quantized_tensor.py", line 509, in from_hp_to_floatx_static
    data = _quantize_affine_float8(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torchao/quantization/quant_primitives.py", line 2401, in _quantize_affine_float8
    tensor_scaled = tensor_fp32 / scale_expanded
                    ~~~~~~~~~~~~^~~~~~~~~~~~~~~~
RuntimeError: The size of tensor a (64) must match the size of tensor b (32) at non-singleton dimension 1
```