### PR TITLE
rename params for MXTensor

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -494,14 +494,14 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     x_mx_dq = to_dtype(
         x_mx.qdata,
         x_mx.scale,
-        x_mx._elem_dtype,
+        x_mx.elem_dtype,
         x_mx.block_size,
         hp_dtype,  # noqa: E501
     )
     x_mx_c_dq = to_dtype_c(
         x_mx_c.qdata,
         x_mx_c.scale,
-        x_mx_c._elem_dtype,
+        x_mx_c.elem_dtype,
         x_mx_c.block_size,
         hp_dtype,
     )

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -100,9 +100,9 @@ class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
         mx_output = MXTensor(
             qdata_permuted,
             scales_permuted,
-            elem_dtype=mx_tensor._elem_dtype,
+            elem_dtype=mx_tensor.elem_dtype,
             block_size=mx_tensor.block_size,
-            orig_dtype=mx_tensor._orig_dtype,
+            orig_dtype=mx_tensor.orig_dtype,
             kernel_preference=mx_tensor.kernel_preference,
             act_quant_kwargs=mx_tensor.act_quant_kwargs,
             is_swizzled_scales=mx_tensor.is_swizzled_scales,

--- a/torchao/prototype/moe_training/ep/unpermute.py
+++ b/torchao/prototype/moe_training/ep/unpermute.py
@@ -91,9 +91,9 @@ class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
             grad_input = MXTensor(
                 qdata_permuted,
                 scales_permuted,
-                elem_dtype=grad_output._elem_dtype,
+                elem_dtype=grad_output.elem_dtype,
                 block_size=grad_output.block_size,
-                orig_dtype=grad_output._orig_dtype,
+                orig_dtype=grad_output.orig_dtype,
                 kernel_preference=grad_output.kernel_preference,
                 act_quant_kwargs=grad_output.act_quant_kwargs,
                 is_swizzled_scales=grad_output.is_swizzled_scales,

--- a/torchao/prototype/moe_training/scaled_grouped_mm.py
+++ b/torchao/prototype/moe_training/scaled_grouped_mm.py
@@ -785,7 +785,7 @@ def _dequantize_if_mxtensor(
         return triton_mxfp8_dequant_dim0(
             tensor.qdata,
             tensor.scale.view(torch.uint8),  # Triton can't handle e8m0 directly yet
-            out_dtype=tensor._orig_dtype,
+            out_dtype=tensor.orig_dtype,
             scale_block_size=block_size,
         )
     return tensor

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -447,9 +447,9 @@ def tensor_size_fp4x2_to_hp(orig_size, is_contiguous):
 class MXTensor(TorchAOBaseTensor):
     tensor_data_names = ["qdata", "scale"]
     tensor_attribute_names = [
-        "_elem_dtype",
+        "elem_dtype",
         "block_size",
-        "_orig_dtype",
+        "orig_dtype",
         "kernel_preference",
         "act_quant_kwargs",
         "is_swizzled_scales",
@@ -458,7 +458,7 @@ class MXTensor(TorchAOBaseTensor):
     def __new__(
         cls,
         qdata,
-        scale_e8m0_bits,
+        scale,
         elem_dtype,
         block_size,
         orig_dtype,
@@ -486,8 +486,8 @@ class MXTensor(TorchAOBaseTensor):
             dtype=orig_dtype,
             device=qdata.device,
         )
-        assert scale_e8m0_bits.dtype == torch.float8_e8m0fnu, (
-            f"scale_e8m0_bits.dtype must be `torch.float8_e8m0fnu`, got {scale_e8m0_bits.dtype}"
+        assert scale.dtype == torch.float8_e8m0fnu, (
+            f"scale.dtype must be `torch.float8_e8m0fnu`, got {scale.dtype}"
         )
         assert qdata.dtype in (
             torch.float8_e4m3fn,
@@ -495,10 +495,10 @@ class MXTensor(TorchAOBaseTensor):
             torch.uint8,
         ), "unsupported"
         self.qdata = qdata
-        self.scale = scale_e8m0_bits
-        self._elem_dtype = elem_dtype
+        self.scale = scale
+        self.elem_dtype = elem_dtype
         self.block_size = block_size
-        self._orig_dtype = orig_dtype
+        self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
         self.is_swizzled_scales = is_swizzled_scales
@@ -506,10 +506,10 @@ class MXTensor(TorchAOBaseTensor):
 
     def __repr__(self):
         # TODO better elem dtype print for fp4
-        return f"MXTensor: elem_dtype: {self._elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, is_swizzled_scales={self.is_swizzled_scales}"  # noqa: E501
+        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, is_swizzled_scales={self.is_swizzled_scales}"  # noqa: E501
 
     def _quantization_type(self):
-        return f"{self._elem_dtype=}, {self.block_size=}, {self._orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
+        return f"{self.elem_dtype=}, {self.block_size=}, {self.orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:
@@ -533,7 +533,7 @@ class MXTensor(TorchAOBaseTensor):
         return to_dtype(
             self.qdata,
             scale,
-            self._elem_dtype,
+            self.elem_dtype,
             self.block_size,
             output_dtype,
         )
@@ -680,8 +680,8 @@ def _addmm_mx_dispatch(
             b_scale = b.scale.t().view(N, K // b.block_size)
             b_scale_block = to_blocked(b_scale)
 
-        if a._elem_dtype == torch.float8_e4m3fn:
-            assert b._elem_dtype == torch.float8_e4m3fn
+        if a.elem_dtype == torch.float8_e4m3fn:
+            assert b.elem_dtype == torch.float8_e4m3fn
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
@@ -691,8 +691,8 @@ def _addmm_mx_dispatch(
                 out_dtype=torch.bfloat16,
             )
         else:
-            assert a._elem_dtype == torch.float4_e2m1fn_x2
-            assert b._elem_dtype == torch.float4_e2m1fn_x2
+            assert a.elem_dtype == torch.float4_e2m1fn_x2
+            assert b.elem_dtype == torch.float4_e2m1fn_x2
             if not torch_version_at_least("2.10.0"):
                 raise RuntimeError(
                     "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
@@ -714,8 +714,8 @@ def _addmm_mx_dispatch(
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"
         # emulated MX gemm
-        a_hp = a.dequantize(a._orig_dtype)
-        b_hp = b.dequantize(b._orig_dtype)
+        a_hp = a.dequantize(a.orig_dtype)
+        b_hp = b.dequantize(b.orig_dtype)
         # assert memory layout we expect to be required in hardware
         assert a_hp.is_contiguous()
         assert b_hp.t().is_contiguous()
@@ -775,9 +775,9 @@ def mx_t(func, types, args, kwargs):
     new = MXTensor(
         old.qdata.t(),
         old.scale.t(),
-        old._elem_dtype,
+        old.elem_dtype,
         old.block_size,
-        old._orig_dtype,
+        old.orig_dtype,
         old.kernel_preference,
         old.act_quant_kwargs,
         old.is_swizzled_scales,
@@ -797,7 +797,7 @@ def mx_cast_up_op(func, types, args, kwargs):
 
     def unwrap(x):
         if isinstance(x, MXTensor):
-            return x.dequantize(x._orig_dtype)
+            return x.dequantize(x.orig_dtype)
         return x
 
     new_args = tree_map(unwrap, args)
@@ -809,16 +809,16 @@ def mx_cast_up_op(func, types, args, kwargs):
 def mx_view_op(func, types, args, kwargs):
     data = args[0].qdata
     new_size = args[1]
-    if args[0]._elem_dtype == torch.float4_e2m1fn_x2:
+    if args[0].elem_dtype == torch.float4_e2m1fn_x2:
         # special case fp4 as we pack two elements per byte
         new_size = tensor_size_hp_to_fp4x2(new_size, data.is_contiguous())
     new_data = func(data, new_size, *args[2:], **kwargs)
     return MXTensor(
         new_data,
         args[0].scale,
-        args[0]._elem_dtype,
+        args[0].elem_dtype,
         args[0].block_size,
-        args[0]._orig_dtype,
+        args[0].orig_dtype,
         args[0].kernel_preference,
         args[0].act_quant_kwargs,
         args[0].is_swizzled_scales,
@@ -841,9 +841,9 @@ def mx_slice(func, types, args, kwargs):
         MXTensor(
             sliced_data,
             sliced_scale,
-            x._elem_dtype,
+            x.elem_dtype,
             x.block_size,
-            x._orig_dtype,
+            x.orig_dtype,
             x.kernel_preference,
             x.act_quant_kwargs,
             x.is_swizzled_scales,
@@ -875,9 +875,9 @@ def mx_select(func, types, args, kwargs):
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],
-        old_mx_tensor._elem_dtype,
+        old_mx_tensor.elem_dtype,
         old_mx_tensor.block_size,
-        old_mx_tensor._orig_dtype,
+        old_mx_tensor.orig_dtype,
         old_mx_tensor.kernel_preference,
         old_mx_tensor.act_quant_kwargs,
         old_mx_tensor.is_swizzled_scales,
@@ -924,9 +924,9 @@ def mx_all_gather(func, types, args, kwargs):
     return MXTensor(
         gathered_qdata,
         gathered_scale,
-        mx_tensor._elem_dtype,
+        mx_tensor.elem_dtype,
         mx_tensor.block_size,
-        mx_tensor._orig_dtype,
+        mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
         mx_tensor.is_swizzled_scales,
@@ -955,9 +955,9 @@ def mx_wait_tensor(func, types, args, kwargs):
     return MXTensor(
         waited_qdata,
         waited_scale,
-        mx_tensor._elem_dtype,
+        mx_tensor.elem_dtype,
         mx_tensor.block_size,
-        mx_tensor._orig_dtype,
+        mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
         mx_tensor.is_swizzled_scales,

--- a/torchao/prototype/qat/mx.py
+++ b/torchao/prototype/qat/mx.py
@@ -145,8 +145,8 @@ class _MXQuantizedForwardFakeQuantizedBackward(torch.autograd.Function):
         orig_shape = ctx.orig_shape
         assert isinstance(_input_2d, MXTensor)
         assert isinstance(weight, MXTensor)
-        _input_2d = _input_2d.dequantize(_input_2d._orig_dtype)
-        weight = weight.dequantize(weight._orig_dtype)
+        _input_2d = _input_2d.dequantize(_input_2d.orig_dtype)
+        weight = weight.dequantize(weight.orig_dtype)
 
         grad_output_2d = grad_output.view(-1, grad_output.shape[-1])
 


### PR DESCRIPTION
renaming `_orig_dtype` to `orig_dtype`, `_elem_dtype` to `elem_dtype`, and `scale_e8m0_bits` to `scale` so that it is easier to unflatten data after saving w/ safetensors