### PR TITLE
[mxfp8 moe training] update tensor subclass emulated param name

### DIFF
--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -210,13 +210,13 @@ class ScaledGroupedMMTensor(torch.Tensor):
             if isinstance(out, ScaledGroupedMMTensor):
                 out_data = out._data
                 out.scaling_type = self.scaling_type
-                out.emulated = self.emulated
+                out.kernel_preference = self.kernel_preference
             elif isinstance(out, DTensor) and isinstance(
                 out._local_tensor, ScaledGroupedMMTensor
             ):
                 out_data = out._local_tensor._data
                 out._local_tensor.scaling_type = self.scaling_type
-                out._local_tensor.emulated = self.emulated
+                out._local_tensor.kernel_preference = self.kernel_preference
             else:
                 raise RuntimeError(
                     f"expect out to be ScaledGroupedMMTensor or DTensor with local_tensor=ScaledGroupedMM, but got {type(out)}"
@@ -239,6 +239,6 @@ class ScaledGroupedMMTensor(torch.Tensor):
             return
 
         # For training step 0, out=None, so we need to return a new ScaledGroupedMMTensor.
-        output = ScaledGroupedMMTensor(data, self.scaling_type, self.emulated)
+        output = ScaledGroupedMMTensor(data, self.scaling_type, self.kernel_preference)
         inner_tensors = (data,)
         return output, inner_tensors


### PR DESCRIPTION
Stacked PRs:
 * #3815
 * #3814
 * #3813
 * #3812
 * __->__#3811


--- --- ---

Fixes tensor subclass attribute name for emulated mode (bool -> enum).

Missed because it only affects FSDP, and did not run the FDSP tests. 

This PR fixes the issue, then the rest of the stack updates our distributed tests so that they are suitable to add to 4xH100 CI and avoid this in the future.

## Tests
- `./test/prototype/moe_training/test_fsdp.sh`