### PR TITLE
[mxfp8 moe training] add custom sharding for triton dim0 quant kernel

### DIFF
--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -1134,6 +1134,14 @@ if _triton_kernels_available:
             col_scale.view(torch.float8_e8m0fnu).squeeze(-1),
         )
 
+    @register_sharding(torch.ops.torchao.triton_to_mxfp8_dim0.default)
+    def custom_triton_to_mxfp8_dim0_sharding(x, inner_block_size=32):
+        replicate = ([Replicate(), Replicate()], [Replicate(), None])
+        shard_dim0 = ([Shard(0), Shard(0)], [Shard(0), None])
+        shard_dim1 = ([Shard(1), Shard(1)], [Shard(1), None])
+        acceptable_shardings = [replicate, shard_dim0, shard_dim1]
+        return acceptable_shardings
+
     @register_sharding(torch.ops.torchao.triton_to_mxfp8_dim1.default)
     def custom_triton_to_mxfp8_dim1_sharding(x, inner_block_size=32):
         replicate = ([Replicate(), Replicate()], [Replicate(), None])


### PR DESCRIPTION
Stacked PRs:
 * #3815
 * #3814
 * #3813
 * __->__#3812


--- --- ---

### [mxfp8 moe training] add custom sharding for triton dim0 quant kernel

## Sumary

We have custom sharding for triton dim1 mxfp8 quant kernel but not dim0 kernel. This PR adds one, and updates the TP tests to ensure they pass.

## Tests
- `./test/prototype/moe_training/test_tp.sh`