### PR TITLE
[mxfp8 moe training] single distributed test for fdsp/tp/ep/etp

### DIFF
--- a/test/prototype/moe_training/reference_parallel_styles.py
+++ b/test/prototype/moe_training/reference_parallel_styles.py
@@ -1,0 +1,203 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Reference implementations of expert parallelism copied from torchtitan
+# to allow running tests without requiring torchtitan to be installed.
+# See: https://github.com/pytorch/torchtitan/blob/main/torchtitan/distributed/expert_parallel.py
+
+import torch
+import torch.nn as nn
+from torch.distributed._tensor import DTensor
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Partial, Replicate, Shard
+from torch.distributed.tensor.parallel import ParallelStyle
+
+from .reference_moe import _permute, _unpermute
+
+
+class NoParallel(ParallelStyle):
+    """Placeholder for no parallelization."""
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        return module
+
+
+class TensorParallel(ParallelStyle):
+    """Tensor parallelism for MoE layers (matches torchtitan implementation)."""
+
+    def _prepare_input_fn(self, mod, inputs, device_mesh):
+        routed_input, num_tokens_per_expert = inputs
+        routed_input = DTensor.from_local(
+            routed_input, device_mesh, (Replicate(),)
+        ).to_local(grad_placements=(Partial(),))
+        return routed_input, num_tokens_per_expert
+
+    def _partition_fn(self, name, module, device_mesh):
+        from torch.distributed.tensor import distribute_tensor
+
+        module.register_parameter(
+            "w1", nn.Parameter(distribute_tensor(module.w1, device_mesh, [Shard(1)]))
+        )
+        module.register_parameter(
+            "w2", nn.Parameter(distribute_tensor(module.w2, device_mesh, [Shard(2)]))
+        )
+        module.register_parameter(
+            "w3", nn.Parameter(distribute_tensor(module.w3, device_mesh, [Shard(1)]))
+        )
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        from torch.distributed.tensor import distribute_module
+
+        return distribute_module(
+            module,
+            device_mesh,
+            self._partition_fn,
+            self._prepare_input_fn,
+        )
+
+
+class ExpertParallel(ParallelStyle):
+    """Expert parallelism for MoE layers (matches torchtitan implementation)."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_splits = None
+        self.output_splits = None
+        self.input_shape = None
+        self.permuted_indices = None
+
+    def _partition_fn(self, name: str, mod: nn.Module, device_mesh: DeviceMesh) -> None:
+        from torch.distributed.tensor import distribute_tensor
+
+        for param_name, param in mod.named_parameters(recurse=False):
+            dist_param = nn.Parameter(distribute_tensor(param, device_mesh, [Shard(0)]))
+            mod.register_parameter(param_name, dist_param)
+
+    def _token_dispatch(
+        self, mod: nn.Module, inputs: tuple, device_mesh: DeviceMesh
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from torch.distributed._functional_collectives import (
+            all_to_all_single,
+            all_to_all_single_autograd,
+        )
+
+        routed_input, num_tokens_per_expert = inputs
+        ep_degree = device_mesh.shape[0]
+        num_local_experts = num_tokens_per_expert.shape[0] // ep_degree
+
+        with torch.no_grad():
+            num_tokens_per_expert_group = all_to_all_single(
+                num_tokens_per_expert,
+                None,
+                None,
+                group=device_mesh.get_group(),
+            )
+            num_tokens_per_expert_group = torch.ops._c10d_functional.wait_tensor(
+                num_tokens_per_expert_group
+            )
+            input_splits = (
+                num_tokens_per_expert.view(ep_degree, -1)
+                .sum(dim=1)
+                .to(torch.device("cpu"), non_blocking=True)
+            )
+            output_splits = (
+                num_tokens_per_expert_group.view(ep_degree, -1)
+                .sum(dim=1)
+                .to(torch.device("cpu"), non_blocking=False)
+            )
+            self.input_splits = input_splits.tolist()
+            self.output_splits = output_splits.tolist()
+
+        routed_input = all_to_all_single_autograd(
+            routed_input,
+            self.output_splits,
+            self.input_splits,
+            device_mesh.get_group(),
+        )
+
+        (
+            self.input_shape,
+            routed_input,
+            self.permuted_indices,
+            num_tokens_per_expert_group,
+        ) = _permute(
+            routed_input, num_tokens_per_expert_group, ep_degree, num_local_experts
+        )
+
+        return routed_input, num_tokens_per_expert_group
+
+    def _token_combine(
+        self, mod: nn.Module, routed_output: torch.Tensor, device_mesh: DeviceMesh
+    ) -> torch.Tensor:
+        from torch.distributed._functional_collectives import all_to_all_single_autograd
+
+        routed_output = _unpermute(
+            routed_output, self.input_shape, self.permuted_indices
+        )
+
+        routed_output = all_to_all_single_autograd(
+            routed_output,
+            self.input_splits,
+            self.output_splits,
+            device_mesh.get_group(),
+        )
+        return routed_output
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        from torch.distributed.tensor import distribute_module
+
+        return distribute_module(
+            module,
+            device_mesh,
+            partition_fn=self._partition_fn,
+            input_fn=self._token_dispatch,
+            output_fn=self._token_combine,
+        )
+
+
+class ExpertTensorParallel(ExpertParallel):
+    """Combined expert and tensor parallelism for MoE layers (matches torchtitan implementation)."""
+
+    def _token_dispatch(self, mod, inputs, device_mesh):
+        routed_input, num_tokens_per_expert = inputs
+
+        routed_input = DTensor.from_local(
+            routed_input, device_mesh["tp"], (Replicate(),)
+        ).to_local(grad_placements=(Partial(),))
+
+        inputs = (routed_input, num_tokens_per_expert)
+
+        return super()._token_dispatch(mod, inputs, device_mesh["ep"])
+
+    def _partition_fn(self, name: str, mod: nn.Module, device_mesh: DeviceMesh) -> None:
+        from torch.distributed.tensor import distribute_tensor
+
+        mod.register_parameter(
+            "w1",
+            nn.Parameter(distribute_tensor(mod.w1, device_mesh, [Shard(0), Shard(1)])),
+        )
+        mod.register_parameter(
+            "w2",
+            nn.Parameter(distribute_tensor(mod.w2, device_mesh, [Shard(0), Shard(2)])),
+        )
+        mod.register_parameter(
+            "w3",
+            nn.Parameter(distribute_tensor(mod.w3, device_mesh, [Shard(0), Shard(1)])),
+        )
+
+    def _token_combine(self, mod, routed_output, device_mesh):
+        return super()._token_combine(mod, routed_output, device_mesh["ep"])
+
+    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
+        from torch.distributed.tensor import distribute_module
+
+        return distribute_module(
+            module,
+            device_mesh,
+            partition_fn=self._partition_fn,
+            input_fn=self._token_dispatch,
+            output_fn=self._token_combine,
+        )

--- a/test/prototype/moe_training/test_distributed.py
+++ b/test/prototype/moe_training/test_distributed.py
@@ -27,6 +27,7 @@ if torch.version.hip is not None:
 
 from torch import distributed as dist
 from torch import nn
+from torch.distributed._composable.fsdp import fully_shard
 from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import Partial, Replicate, Shard
@@ -34,8 +35,9 @@ from torch.nn import functional as F
 
 try:
     from torch.distributed.tensor.parallel import (
-        ParallelStyle,
+        ColwiseParallel,
         PrepareModuleInputOutput,
+        RowwiseParallel,
         parallelize_module,
     )
 except ImportError:
@@ -58,118 +60,73 @@ from torchao.prototype.moe_training.conversion_utils import (
 from torchao.quantization.quant_api import quantize_
 
 from .reference_moe import MoE, MoEArgs, set_token_group_alignment_size_m
+from .reference_parallel_styles import (
+    ExpertParallel,
+    ExpertTensorParallel,
+    NoParallel,
+    TensorParallel,
+)
 from .testing_utils import _validate_model_conversion
 
 
-class NoParallel(ParallelStyle):
-    """Placeholder for no parallelization."""
+class ParallelStrategy:
+    """Enum-like class for parallelization strategies."""
 
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        return module
-
-
-class TensorParallel(ParallelStyle):
-    """Tensor parallelism for MoE layers."""
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from torch.distributed.tensor import distribute_module, distribute_tensor
-
-        def _partition_fn(name: str, mod: nn.Module, device_mesh: DeviceMesh) -> None:
-            # Shard w1 and w3 on dim 1 (hidden_dim), w2 on dim 2 (hidden_dim)
-            for param_name, param in mod.named_parameters(recurse=False):
-                if param_name in ("w1", "w3"):
-                    dist_param = nn.Parameter(
-                        distribute_tensor(param, device_mesh, [Shard(1)])
-                    )
-                elif param_name == "w2":
-                    dist_param = nn.Parameter(
-                        distribute_tensor(param, device_mesh, [Shard(2)])
-                    )
-                else:
-                    dist_param = nn.Parameter(
-                        distribute_tensor(param, device_mesh, [Replicate()])
-                    )
-                mod.register_parameter(param_name, dist_param)
-
-        return distribute_module(module, device_mesh, partition_fn=_partition_fn)
-
-
-class ExpertParallel(ParallelStyle):
-    """Expert parallelism for MoE layers."""
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from torch.distributed.tensor import distribute_tensor
-        from torch.distributed.tensor.parallel import distribute_module
-
-        def _partition_fn(name: str, mod: nn.Module, device_mesh: DeviceMesh) -> None:
-            # Shard experts along the expert dimension (dim 0)
-            for param_name, param in mod.named_parameters(recurse=False):
-                dist_param = nn.Parameter(
-                    distribute_tensor(param, device_mesh, [Shard(0)])
-                )
-                mod.register_parameter(param_name, dist_param)
-
-        return distribute_module(module, device_mesh, partition_fn=_partition_fn)
-
-
-class ExpertTensorParallel(ParallelStyle):
-    """Combined expert and tensor parallelism for MoE layers."""
-
-    def __init__(self, tp_mesh: DeviceMesh, ep_mesh: DeviceMesh):
-        super().__init__()
-        self.tp_mesh = tp_mesh
-        self.ep_mesh = ep_mesh
-
-    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
-        from torch.distributed.tensor import distribute_tensor
-        from torch.distributed.tensor.parallel import distribute_module
-
-        def _partition_fn(name: str, mod: nn.Module, device_mesh: DeviceMesh) -> None:
-            # Shard along expert dim (EP) and hidden dim (TP)
-            for param_name, param in mod.named_parameters(recurse=False):
-                if param_name in ("w1", "w3"):
-                    # Shard on expert dim and hidden_dim
-                    dist_param = nn.Parameter(
-                        distribute_tensor(param, device_mesh, [Shard(0), Shard(1)])
-                    )
-                elif param_name == "w2":
-                    # Shard on expert dim and hidden_dim (dim 2 for w2)
-                    dist_param = nn.Parameter(
-                        distribute_tensor(param, device_mesh, [Shard(0), Shard(2)])
-                    )
-                else:
-                    dist_param = nn.Parameter(
-                        distribute_tensor(
-                            param, device_mesh, [Replicate(), Replicate()]
-                        )
-                    )
-                mod.register_parameter(param_name, dist_param)
-
-        return distribute_module(module, device_mesh, partition_fn=_partition_fn)
+    TENSOR_PARALLEL = "tensor_parallel"
+    EXPERT_PARALLEL = "expert_parallel"
+    EXPERT_TENSOR_PARALLEL = "expert_tensor_parallel"
+    FSDP = "fsdp"
+    FSDP_TP = "fsdp_tp"
 
 
 @pytest.fixture(scope="module")
-def device_mesh_1d() -> DeviceMesh:
+def distributed_env():
     """
     Fixture for setting up and tearing down the distributed environment
-    for the entire test module.
+    for the entire test module. Requires world_size of 4.
     """
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
-    device_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("tp",))
+
+    assert world_size == 4, (
+        f"This test requires world_size=4, but got world_size={world_size}. "
+        "Run with: torchrun --nproc_per_node=4 -m pytest test_distributed.py"
+    )
+
     torch.manual_seed(1)
     torch.cuda.set_device(rank)
 
-    yield device_mesh
+    # Create meshes for different parallelization strategies:
+    # - tp_mesh: 1D mesh for tensor parallel only
+    # - ep_mesh: 1D mesh for expert parallel only
+    # - dp_mesh: 1D mesh for FSDP only
+    # - ep_tp_mesh: 2D mesh for combined EP and TP
+    # - dp_tp_mesh: 2D mesh for combined FSDP and TP
+    tp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("tp",))
+    ep_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("ep",))
+    dp_mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp",))
+    ep_tp_mesh = init_device_mesh("cuda", (2, 2), mesh_dim_names=("ep", "tp"))
+    dp_tp_mesh = init_device_mesh("cuda", (2, 2), mesh_dim_names=("dp", "tp"))
+
+    yield {
+        "tp_mesh": tp_mesh,
+        "ep_mesh": ep_mesh,
+        "dp_mesh": dp_mesh,
+        "ep_tp_mesh": ep_tp_mesh,
+        "dp_tp_mesh": dp_tp_mesh,
+    }
 
     dist.destroy_process_group()
 
 
 @pytest.mark.parametrize(
-    "target_fqns",
+    "parallel_strategy",
     [
-        ["experts"],
-        ["experts,shared_experts"],
+        ParallelStrategy.TENSOR_PARALLEL,
+        ParallelStrategy.EXPERT_PARALLEL,
+        ParallelStrategy.EXPERT_TENSOR_PARALLEL,
+        ParallelStrategy.FSDP,
+        ParallelStrategy.FSDP_TP,
     ],
 )
 @pytest.mark.parametrize(
@@ -189,25 +146,25 @@ def device_mesh_1d() -> DeviceMesh:
         {
             "recipe": MoEScalingType.MXFP8,
             "group_alignment_size": 32,
-            "min_out_sqnr": 28.0,
+            "min_out_sqnr": 27.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 21.0,
         },
         {
             "recipe": MoEScalingType.MXFP8_WGRAD_WITH_HP,
             "group_alignment_size": 32,
-            "min_out_sqnr": 28.0,
+            "min_out_sqnr": 27.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 25.0,
         },
     ],
 )
-def test_moe_training_tp(
-    target_fqns: list[str],
+def test_moe_training_parallel(
+    parallel_strategy: str,
     kernel_preference: KernelPreference,
     compile: bool,
     recipe_config: dict,
-    device_mesh_1d: DeviceMesh,
+    distributed_env: dict,
 ):
     (
         recipe,
@@ -223,13 +180,13 @@ def test_moe_training_tp(
         recipe_config["min_param_grad_sqnr"],
     )
     assert torch.cuda.is_available()
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
-    ):
-        pytest.skip(
-            f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
-        )
+    if recipe == MoEScalingType.FP8_ROWWISE:
+        if torch.cuda.get_device_capability() != (9, 0):
+            pytest.skip(
+                f"FP8 rowwise only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
+            )
+        if parallel_strategy == ParallelStrategy.EXPERT_TENSOR_PARALLEL:
+            pytest.skip("FP8 rowwise with EP+TP currently not supported")
 
     elif recipe in (MoEScalingType.MXFP8, MoEScalingType.MXFP8_WGRAD_WITH_HP):
         emulated = kernel_preference == KernelPreference.EMULATED
@@ -246,6 +203,11 @@ def test_moe_training_tp(
     # set token group alignment size needed for GEMM (contraction dim stride must be 16 byte aligned)
     # or quantization ops (mxfp8 scaling groups are size 1x32)
     set_token_group_alignment_size_m(group_alignment_size)
+
+    # Get the appropriate meshes based on parallelization strategy
+    tp_mesh = distributed_env["tp_mesh"]
+    ep_mesh = distributed_env["ep_mesh"]
+    ep_tp_mesh = distributed_env["ep_tp_mesh"]
 
     # define model args
     model_args = MoEArgs(
@@ -268,6 +230,8 @@ def test_moe_training_tp(
         assert torch.equal(param1, param2)
 
     # convert MoE to float8 training
+    target_fqns = "experts"
+
     def moe_module_filter_fn(mod: nn.Module, cur_fqn: str) -> bool:
         for target_fqn in target_fqns:
             if target_fqn in cur_fqn:
@@ -288,29 +252,61 @@ def test_moe_training_tp(
         model = torch.compile(model, fullgraph=False)
         ref_model = torch.compile(ref_model, fullgraph=False)
 
-    # apply TP
-    apply_moe_ep_tp(model, tp_mesh=device_mesh_1d, ep_mesh=None, ep_tp_mesh=None)
-    apply_moe_ep_tp(ref_model, tp_mesh=device_mesh_1d, ep_mesh=None, ep_tp_mesh=None)
+    # Apply parallelization based on strategy
+    if parallel_strategy == ParallelStrategy.TENSOR_PARALLEL:
+        apply_moe_ep_tp(model, tp_mesh=tp_mesh, ep_mesh=None, ep_tp_mesh=None)
+        apply_moe_ep_tp(ref_model, tp_mesh=tp_mesh, ep_mesh=None, ep_tp_mesh=None)
+    elif parallel_strategy == ParallelStrategy.EXPERT_PARALLEL:
+        apply_moe_ep_tp(model, tp_mesh=None, ep_mesh=ep_mesh, ep_tp_mesh=None)
+        apply_moe_ep_tp(ref_model, tp_mesh=None, ep_mesh=ep_mesh, ep_tp_mesh=None)
+    elif parallel_strategy == ParallelStrategy.EXPERT_TENSOR_PARALLEL:
+        apply_moe_ep_tp(model, tp_mesh=tp_mesh, ep_mesh=ep_mesh, ep_tp_mesh=ep_tp_mesh)
+        apply_moe_ep_tp(
+            ref_model, tp_mesh=tp_mesh, ep_mesh=ep_mesh, ep_tp_mesh=ep_tp_mesh
+        )
+    elif parallel_strategy == ParallelStrategy.FSDP:
+        # FSDP only - use 1D dp mesh
+        dp_mesh = distributed_env["dp_mesh"]
+        fsdp_config = {"mesh": dp_mesh}
+        fully_shard(model, **fsdp_config)
+        fully_shard(ref_model, **fsdp_config)
+    elif parallel_strategy == ParallelStrategy.FSDP_TP:
+        # FSDP + TP - use 2D mesh with (dp, tp) dimensions
+        dp_tp_mesh = distributed_env["dp_tp_mesh"]
+        tp_submesh = dp_tp_mesh["tp"]
+        dp_submesh = dp_tp_mesh["dp"]
+
+        # First apply TP
+        apply_moe_ep_tp(model, tp_mesh=tp_submesh, ep_mesh=None, ep_tp_mesh=None)
+        apply_moe_ep_tp(ref_model, tp_mesh=tp_submesh, ep_mesh=None, ep_tp_mesh=None)
+
+        # Then apply FSDP
+        fsdp_config = {"mesh": dp_submesh}
+        fully_shard(model, **fsdp_config)
+        fully_shard(ref_model, **fsdp_config)
 
     # Rough validation that parallelization was applied properly.
-    assert isinstance(model.experts.w1.data, DTensor), (
-        "test model experts.w1 is not a DTensor"
-    )
-    assert isinstance(model.experts.w2.data, DTensor), (
-        "test model experts.w2 is not a DTensor"
-    )
-    assert isinstance(model.experts.w3.data, DTensor), (
-        "test model experts.w3 is not a DTensor"
-    )
-    assert isinstance(ref_model.experts.w1.data, DTensor), (
-        "ref model experts.w1 is not a DTensor"
-    )
-    assert isinstance(ref_model.experts.w2.data, DTensor), (
-        "ref model experts.w2 is not a DTensor"
-    )
-    assert isinstance(ref_model.experts.w3.data, DTensor), (
-        "ref model experts.w3 is not a DTensor"
-    )
+    # For pure FSDP, the weights are managed by FSDP and are not DTensors
+    # in the same way as when using parallelize_module.
+    if parallel_strategy != ParallelStrategy.FSDP:
+        assert isinstance(model.experts.w1.data, DTensor), (
+            "test model experts.w1 is not a DTensor"
+        )
+        assert isinstance(model.experts.w2.data, DTensor), (
+            "test model experts.w2 is not a DTensor"
+        )
+        assert isinstance(model.experts.w3.data, DTensor), (
+            "test model experts.w3 is not a DTensor"
+        )
+        assert isinstance(ref_model.experts.w1.data, DTensor), (
+            "ref model experts.w1 is not a DTensor"
+        )
+        assert isinstance(ref_model.experts.w2.data, DTensor), (
+            "ref model experts.w2 is not a DTensor"
+        )
+        assert isinstance(ref_model.experts.w3.data, DTensor), (
+            "ref model experts.w3 is not a DTensor"
+        )
 
     # inputs
     batch, seq = 8, 2048
@@ -373,8 +369,11 @@ def apply_moe_ep_tp(
             ),
             # replicate computation for the router
             "router.gate": NoParallel(),
-            # input Replicate, output Partial
-            "shared_expert": TensorParallel(),
+            # shared_experts uses ColwiseParallel/RowwiseParallel for individual weights
+            # (unlike GroupedExperts which uses TensorParallel for the whole module)
+            "shared_experts.w1": ColwiseParallel(),
+            "shared_experts.w2": RowwiseParallel(output_layouts=Partial()),
+            "shared_experts.w3": ColwiseParallel(),
         }
         parallelize_module(
             module=model,
@@ -394,7 +393,7 @@ def apply_moe_ep_tp(
         experts_plan = ExpertParallel()
     else:
         experts_mesh = ep_tp_mesh
-        experts_plan = ExpertTensorParallel(tp_mesh=tp_mesh, ep_mesh=ep_mesh)
+        experts_plan = ExpertTensorParallel()
 
     parallelize_module(
         module=model.experts,

--- a/test/prototype/moe_training/test_distributed.sh
+++ b/test/prototype/moe_training/test_distributed.sh
@@ -1,0 +1,2 @@
+NGPU=${NGPU:-4}
+torchrun --nproc_per_node=$NGPU --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_distributed.py -s -v

--- a/test/prototype/moe_training/test_tp.sh
+++ b/test/prototype/moe_training/test_tp.sh
@@ -1,1 +1,0 @@
-torchrun --nproc_per_node=2 --local-ranks-filter=0 -m pytest test/prototype/moe_training/test_tp.py -s -v


### PR DESCRIPTION
Stacked PRs:
 * #3815
 * #3814
 * __->__#3813
 * #3812


--- --- ---

### [mxfp8 moe training] single distributed test for fdsp/tp/ep/etp

Used claude to consolidate our distributed tests into one parameterized `test_distributed.py` file that tests different combinations of parallelisms, compile, etc.


## Tests
- `./test/prototype/moe_training/test_distributed.sh`