### PR TITLE
Fix float8 test_kernel_preference_numerical_equivalence

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -802,8 +802,9 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
         kp_and_res = list(quantized_outputs.items())
         for i in range(len(kp_and_res)):
             kp, res = kp_and_res[i]
-            self.assertTrue(
-                compute_error(res, res_ref) > 28,
+            self.assertGreater(
+                compute_error(res, res_ref),
+                28,
                 f"mismatch between {kp=} and {kp_ref}, {sizes=}, {granularity=}",
             )
 


### PR DESCRIPTION
**Summary:** TBD

**Test Plan:**
python test/quantization/quantize_/workflows/float8/test_float8_tensor.py -k test_kernel_preference_numerical_equivalence