### PR TITLE
[xpu][float8] device agnostic test base,compile, numerics_integration

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -50,14 +50,12 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_gpu_devices,
+    get_available_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
-
-_GPU_DEVICES = get_gpu_devices()
 
 random.seed(0)
 torch.manual_seed(0)
@@ -245,7 +243,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -341,7 +339,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -390,7 +388,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -419,7 +417,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -470,7 +468,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -483,7 +481,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -507,7 +505,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -551,7 +549,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -593,7 +591,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -679,7 +677,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -50,14 +50,14 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_current_accelerator_device,
+    get_gpu_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_GPU_DEVICE = [str(get_current_accelerator_device())]
+_GPU_DEVICES = get_gpu_devices()
 
 random.seed(0)
 torch.manual_seed(0)
@@ -245,7 +245,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -341,7 +341,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -390,7 +390,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -419,7 +419,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -470,7 +470,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -483,7 +483,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -507,7 +507,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -551,7 +551,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -593,7 +593,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -679,7 +679,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -55,6 +55,10 @@ random.seed(0)
 torch.manual_seed(0)
 
 _DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+if not _DEVICES:
+    _DEVICES = [
+        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
+    ]
 
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -12,11 +12,6 @@ import unittest
 import pytest
 import torch
 import torch.nn as nn
-from torch.testing._internal.common_utils import (
-    TestCase,
-    instantiate_parametrized_tests,
-    parametrize,
-)
 
 from torchao.float8.config import (
     Float8LinearConfig,
@@ -68,8 +63,7 @@ def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     return True
 
 
-@instantiate_parametrized_tests
-class TestFloat8TrainingTensor(TestCase):
+class TestFloat8TrainingTensor:
     def test_preserves_dtype(self) -> None:
         # hp means high precision, lp means low precision
         hp_dtypes = (torch.float32, torch.float16, torch.bfloat16)
@@ -159,9 +153,9 @@ class TestFloat8TrainingTensor(TestCase):
                 (fp8_b_t._data, fp8_b_t._scale),
             )
 
-    @parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
-    @parametrize("axiswise_dim", [0, -1])
-    @parametrize("round_scales_to_power_of_2", [True, False])
+    @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
+    @pytest.mark.parametrize("axiswise_dim", [0, -1])
+    @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
     def test_axiswise_dynamic_cast(
         self, shape, axiswise_dim, round_scales_to_power_of_2
     ):
@@ -231,8 +225,8 @@ class TestFloat8TrainingTensor(TestCase):
         with pytest.raises(RuntimeError):
             a_fp8_d2.reshape(3, -1)
 
-    @parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
-    @parametrize(
+    @pytest.mark.parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
+    @pytest.mark.parametrize(
         "a_granularity,b_granularity",
         [
             (ScalingGranularity.AXISWISE, ScalingGranularity.AXISWISE),
@@ -245,7 +239,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -287,8 +281,7 @@ class TestFloat8TrainingTensor(TestCase):
             assert e4m3_dtype == torch.float8_e4m3fn
 
 
-@instantiate_parametrized_tests
-class TestFloat8Linear(TestCase):
+class TestFloat8Linear:
     def _test_linear_impl(
         self,
         x,
@@ -324,25 +317,27 @@ class TestFloat8Linear(TestCase):
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
-    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @parametrize(
+    @pytest.mark.parametrize(
+        "emulate", [True, False] if is_sm_at_least_89() else [True]
+    )
+    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @pytest.mark.parametrize(
         "scaling_type_input",
         [ScalingType.DYNAMIC],
     )
-    @parametrize(
+    @pytest.mark.parametrize(
         "scaling_type_weight",
         [ScalingType.DYNAMIC],
     )
-    @parametrize(
+    @pytest.mark.parametrize(
         "scaling_type_grad_output",
         [ScalingType.DYNAMIC],
     )
-    @parametrize("linear_dtype", [torch.bfloat16, torch.float32])
-    @parametrize("linear_bias", [False, True])
-    @parametrize("use_ac", [False, True])
+    @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
+    @pytest.mark.parametrize("linear_bias", [False, True])
+    @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -375,23 +370,25 @@ class TestFloat8Linear(TestCase):
     # them, so this function factors out some of the recipes which are annoying
     # to combine with the main testing function.
     # TODO(future PR): make this cleaner.
-    @parametrize(
+    @pytest.mark.parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.ROWWISE,
             Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
         ],
     )
-    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @parametrize("linear_bias", [True, False])
-    @parametrize("linear_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @pytest.mark.parametrize("linear_bias", [True, False])
+    @pytest.mark.parametrize(
+        "linear_dtype", [torch.bfloat16, torch.float16, torch.float32]
+    )
     @skip_if_rocm("ROCm enablement in progress")
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -409,9 +406,13 @@ class TestFloat8Linear(TestCase):
             config,
         )
 
-    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
-    @parametrize("linear_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize(
+    @pytest.mark.parametrize(
+        "emulate", [True, False] if is_sm_at_least_89() else [True]
+    )
+    @pytest.mark.parametrize(
+        "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.TENSORWISE,
@@ -420,7 +421,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -471,7 +472,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -484,7 +485,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -500,16 +501,17 @@ class TestFloat8Linear(TestCase):
             m(x)
 
 
-@instantiate_parametrized_tests
-class TestScaledMM(TestCase):
-    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize("use_fast_accum", [True, False])
+class TestScaledMM:
+    @pytest.mark.parametrize(
+        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize("use_fast_accum", [True, False])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -553,7 +555,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -588,14 +590,16 @@ class TestScaledMM(TestCase):
         ):
             a @ b
 
-    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize("use_fast_accum", [True, False])
+    @pytest.mark.parametrize(
+        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize("use_fast_accum", [True, False])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -670,9 +674,8 @@ class TestScaledMM(TestCase):
         assert sqnr > 50.0
 
 
-@instantiate_parametrized_tests
-class TestNumerics(TestCase):
-    @parametrize(
+class TestNumerics:
+    @pytest.mark.parametrize(
         "float8_dtype",
         [
             torch.float8_e4m3fn,
@@ -682,7 +685,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
@@ -706,8 +709,7 @@ class TestNumerics(TestCase):
         assert not torch.any(torch.isinf(scale))
 
 
-@instantiate_parametrized_tests
-class TestFloat8LinearUtils(TestCase):
+class TestFloat8LinearUtils(unittest.TestCase):
     def test_swap_root_linear(self):
         for emulate in [True, False]:
             module = nn.Linear(3, 3)

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -16,7 +16,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     instantiate_parametrized_tests,
     parametrize,
-    run_tests,
 )
 
 from torchao.float8.config import (
@@ -60,6 +59,8 @@ from torchao.utils import (
 random.seed(0)
 torch.manual_seed(0)
 
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     assert torch.all(a._scale == b._scale).item(), "scales are not identical"
@@ -67,6 +68,7 @@ def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     return True
 
 
+@instantiate_parametrized_tests
 class TestFloat8TrainingTensor(TestCase):
     def test_preserves_dtype(self) -> None:
         # hp means high precision, lp means low precision
@@ -243,7 +245,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -285,6 +287,7 @@ class TestFloat8TrainingTensor(TestCase):
             assert e4m3_dtype == torch.float8_e4m3fn
 
 
+@instantiate_parametrized_tests
 class TestFloat8Linear(TestCase):
     def _test_linear_impl(
         self,
@@ -339,7 +342,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -388,7 +391,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -417,7 +420,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -468,7 +471,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -481,7 +484,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -497,6 +500,7 @@ class TestFloat8Linear(TestCase):
             m(x)
 
 
+@instantiate_parametrized_tests
 class TestScaledMM(TestCase):
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
     @parametrize("use_fast_accum", [True, False])
@@ -505,7 +509,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -549,7 +553,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -591,7 +595,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -666,6 +670,7 @@ class TestScaledMM(TestCase):
         assert sqnr > 50.0
 
 
+@instantiate_parametrized_tests
 class TestNumerics(TestCase):
     @parametrize(
         "float8_dtype",
@@ -677,7 +682,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
@@ -701,7 +706,8 @@ class TestNumerics(TestCase):
         assert not torch.any(torch.isinf(scale))
 
 
-class TestFloat8LinearUtils(unittest.TestCase):
+@instantiate_parametrized_tests
+class TestFloat8LinearUtils(TestCase):
     def test_swap_root_linear(self):
         for emulate in [True, False]:
             module = nn.Linear(3, 3)
@@ -828,11 +834,5 @@ class TestFloat8LinearUtils(unittest.TestCase):
             self.assertEqual((zero_cnt, max_cnt), (tensor_len, tensor_len))
 
 
-instantiate_parametrized_tests(TestFloat8TrainingTensor)
-instantiate_parametrized_tests(TestFloat8Linear)
-instantiate_parametrized_tests(TestScaledMM)
-instantiate_parametrized_tests(TestNumerics)
-instantiate_parametrized_tests(TestFloat8LinearUtils)
-
 if __name__ == "__main__":
-    run_tests()
+    pytest.main([__file__])

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -275,7 +275,7 @@ class TestFloat8TrainingTensor:
         sqnr = compute_error(c_ref, c_fp8_compute)
         assert sqnr >= 25.0
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     def test_fp8_dtype(
         self,
     ):
@@ -321,9 +321,7 @@ class TestFloat8Linear:
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
+    @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
     @pytest.mark.parametrize(
         "scaling_type_input",
@@ -354,6 +352,8 @@ class TestFloat8Linear:
         use_ac: bool,
         device: torch.device,
     ):
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
+            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
         x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = get_test_float8_linear_config(
@@ -410,9 +410,7 @@ class TestFloat8Linear:
             config,
         )
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
+    @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
@@ -433,6 +431,8 @@ class TestFloat8Linear:
         recipe_name: Float8LinearRecipeName,
         device,
     ):
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
+            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
             nn.Linear(32, 32, device=device, dtype=linear_dtype),
             nn.Linear(32, 32, device=device, dtype=linear_dtype),

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -51,14 +51,12 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_gpu_devices,
+    get_available_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
-
-_GPU_DEVICES = get_gpu_devices()
 
 random.seed(0)
 torch.manual_seed(0)
@@ -251,7 +249,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -347,7 +345,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -396,7 +394,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -425,7 +423,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -486,7 +484,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -499,7 +497,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -523,7 +521,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -567,7 +565,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -609,7 +607,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -695,7 +693,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -12,6 +12,12 @@ import unittest
 import pytest
 import torch
 import torch.nn as nn
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 
 from torchao.float8.config import (
     CastConfig,
@@ -45,11 +51,14 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
+    get_current_accelerator_device,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
+
+_GPU_DEVICE = [str(get_current_accelerator_device())]
 
 random.seed(0)
 torch.manual_seed(0)
@@ -61,7 +70,7 @@ def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     return True
 
 
-class TestFloat8TrainingTensor:
+class TestFloat8TrainingTensor(TestCase):
     def test_preserves_dtype(self) -> None:
         # hp means high precision, lp means low precision
         hp_dtypes = (torch.float32, torch.float16, torch.bfloat16)
@@ -156,9 +165,9 @@ class TestFloat8TrainingTensor:
             assert fp8_a_transposed._axiswise_dim == expected_axiswise_dim
             assert fp8_b_t._axiswise_dim == expected_axiswise_dim
 
-    @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
-    @pytest.mark.parametrize("axiswise_dim", [0, -1])
-    @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
+    @parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
+    @parametrize("axiswise_dim", [0, -1])
+    @parametrize("round_scales_to_power_of_2", [True, False])
     def test_axiswise_dynamic_cast(
         self, shape, axiswise_dim, round_scales_to_power_of_2
     ):
@@ -228,8 +237,8 @@ class TestFloat8TrainingTensor:
         with pytest.raises(RuntimeError):
             a_fp8_d2.reshape(3, -1)
 
-    @pytest.mark.parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
-    @pytest.mark.parametrize(
+    @parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
+    @parametrize(
         "a_granularity,b_granularity",
         [
             (ScalingGranularity.AXISWISE, ScalingGranularity.AXISWISE),
@@ -237,11 +246,15 @@ class TestFloat8TrainingTensor:
             (ScalingGranularity.TENSORWISE, ScalingGranularity.AXISWISE),
         ],
     )
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    @unittest.skipIf(not is_sm_at_least_90(), "Requires CUDA capability >= 9.0")
-    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity):
-        a = torch.randn(*a_shape, dtype=torch.bfloat16, device="cuda")
-        b = torch.randn(64, 32, dtype=torch.bfloat16, device="cuda")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_90(),
+        "Requires CUDA capability >= 9.0",
+    )
+    @parametrize("device", _GPU_DEVICE)
+    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
+        a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
+        b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
 
         linear_mm_config = LinearMMConfig()
 
@@ -280,7 +293,7 @@ class TestFloat8TrainingTensor:
             assert e4m3_dtype == torch.float8_e4m3fn
 
 
-class TestFloat8Linear:
+class TestFloat8Linear(TestCase):
     def _test_linear_impl(
         self,
         x,
@@ -316,26 +329,25 @@ class TestFloat8Linear:
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
-    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @pytest.mark.parametrize(
+    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
+    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @parametrize(
         "scaling_type_input",
         [ScalingType.DYNAMIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_weight",
         [ScalingType.DYNAMIC],
     )
-    @pytest.mark.parametrize(
+    @parametrize(
         "scaling_type_grad_output",
         [ScalingType.DYNAMIC],
     )
-    @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
-    @pytest.mark.parametrize("linear_bias", [False, True])
-    @pytest.mark.parametrize("use_ac", [False, True])
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @parametrize("linear_dtype", [torch.bfloat16, torch.float32])
+    @parametrize("linear_bias", [False, True])
+    @parametrize("use_ac", [False, True])
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @parametrize("device", _GPU_DEVICE)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -346,10 +358,10 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
         use_ac: bool,
+        device: torch.device,
     ):
-        x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
-        m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)
-
+        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
+        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
@@ -368,32 +380,33 @@ class TestFloat8Linear:
     # them, so this function factors out some of the recipes which are annoying
     # to combine with the main testing function.
     # TODO(future PR): make this cleaner.
-    @pytest.mark.parametrize(
+    @parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.ROWWISE,
             Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
         ],
     )
-    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @pytest.mark.parametrize("linear_bias", [True, False])
-    @pytest.mark.parametrize(
-        "linear_dtype", [torch.bfloat16, torch.float16, torch.float32]
-    )
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_90(), "CUDA capability < 9.0"
-    )
+    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @parametrize("linear_bias", [True, False])
+    @parametrize("linear_dtype", [torch.bfloat16, torch.float16, torch.float32])
     @skip_if_rocm("ROCm enablement in progress")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_90(),
+        "Requires CUDA capability >= 9.0",
+    )
+    @parametrize("device", _GPU_DEVICE)
     def test_linear_from_recipe(
         self,
         recipe_name,
         x_shape,
         linear_dtype: torch.dtype,
         linear_bias: bool,
+        device,
     ):
-        x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype)
-        m_ref = nn.Linear(16, 32, bias=linear_bias, device="cuda", dtype=linear_dtype)
+        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
+        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_linear_impl(
             x,
@@ -401,13 +414,9 @@ class TestFloat8Linear:
             config,
         )
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
-    @pytest.mark.parametrize(
-        "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
-    )
-    @pytest.mark.parametrize(
+    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
+    @parametrize("linear_dtype", [torch.float16, torch.bfloat16, torch.float32])
+    @parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.TENSORWISE,
@@ -415,16 +424,18 @@ class TestFloat8Linear:
             Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
         ],
     )
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @parametrize("device", _GPU_DEVICE)
     def test_autocast_outputs(
         self,
         emulate: bool,
         linear_dtype: torch.dtype,
         recipe_name: Float8LinearRecipeName,
+        device,
     ):
         m_ref = nn.Sequential(
-            nn.Linear(32, 32, device="cuda", dtype=linear_dtype),
-            nn.Linear(32, 32, device="cuda", dtype=linear_dtype),
+            nn.Linear(32, 32, device=device, dtype=linear_dtype),
+            nn.Linear(32, 32, device=device, dtype=linear_dtype),
         )
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         # work around config being frozen
@@ -433,16 +444,16 @@ class TestFloat8Linear:
         m = convert_to_float8_training(copy.deepcopy(m_ref), config=config)
 
         # autocast off
-        x = torch.randn(16, 32, device="cuda", dtype=linear_dtype)
+        x = torch.randn(16, 32, device=device, dtype=linear_dtype)
         y = m(x)
         assert y.dtype == linear_dtype, f"y.dtype is {y.dtype}, expected {linear_dtype}"
 
         # autocast on
-        with torch.autocast("cuda"):
+        with torch.autocast(device):
             y = m(x)
         assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
 
-        with torch.autocast("cuda", dtype=torch.bfloat16):
+        with torch.autocast(device, dtype=torch.bfloat16):
             y = m(x)
         assert y.dtype == torch.bfloat16, (
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
@@ -470,18 +481,28 @@ class TestFloat8Linear:
                 cast_config_weight=CastConfig(scaling_type=ScalingType.DYNAMIC),
             )
 
-    @unittest.skipIf(not is_sm_at_least_89(), "CUDA 8.9 not available")
-    def test_inference_mode(self):
-        x = torch.randn(32, 32, device="cuda")
-        m = nn.Sequential(nn.Linear(32, 32)).cuda()
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA with float8 support not available",
+    )
+    @parametrize("device", _GPU_DEVICE)
+    def test_inference_mode(self, device):
+        x = torch.randn(32, 32, device=device)
+        m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
         with torch.inference_mode(mode=True):
             m(x)
 
-    @unittest.skipIf(not is_sm_at_least_89(), "CUDA arch 8.9 not available")
-    def test_quantize(self):
-        x = torch.randn(32, 32, device="cuda")
-        m = nn.Sequential(nn.Linear(32, 32)).cuda()
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA with float8 support not available",
+    )
+    @parametrize("device", _GPU_DEVICE)
+    def test_quantize(self, device):
+        x = torch.randn(32, 32, device=device)
+        m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
         assert isinstance(m[0], Float8Linear), "Module is not a Float8Linear"
         from torchao.quantization import Float8WeightOnlyConfig, quantize_
@@ -494,23 +515,23 @@ class TestFloat8Linear:
             m(x)
 
 
-class TestScaledMM:
+class TestScaledMM(TestCase):
+    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
+    @parametrize("use_fast_accum", [True, False])
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        not is_sm_at_least_89(),
-        "CUDA not available",
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize(
-        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
-    )
-    @pytest.mark.parametrize("use_fast_accum", [True, False])
-    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
+    @parametrize("device", _GPU_DEVICE)
+    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         output_dtype = base_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 16, device="cuda", dtype=base_dtype)
-        b = torch.randn(32, 16, device="cuda", dtype=base_dtype).t()
+        a = torch.randn(16, 16, device=device, dtype=base_dtype)
+        b = torch.randn(32, 16, device=device, dtype=base_dtype).t()
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -541,10 +562,15 @@ class TestScaledMM:
             atol, rtol = 3e-3, 3e-3
         torch.testing.assert_close(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 
-    @unittest.skipIf(not is_sm_at_least_89(), "CUDA not available")
-    def test_different_configs_error(self):
-        x_fp32 = torch.randn(16, 16, device="cuda")
-        x_scale = torch.tensor(1.0, device="cuda")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA with float8 support not available",
+    )
+    @parametrize("device", _GPU_DEVICE)
+    def test_different_configs_error(self, device):
+        x_fp32 = torch.randn(16, 16, device=device)
+        x_scale = torch.tensor(1.0, device=device)
         fp8_dtype = e4m3_dtype
         linear_config_a = LinearMMConfig(
             ScaledMMConfig(False, True, False, False),
@@ -576,21 +602,21 @@ class TestScaledMM:
         ):
             a @ b
 
+    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
+    @parametrize("use_fast_accum", [True, False])
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        not is_sm_at_least_89(),
-        "CUDA not available",
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize(
-        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
-    )
-    @pytest.mark.parametrize("use_fast_accum", [True, False])
-    def test_pad_inner_dim(self, base_dtype, use_fast_accum):
+    @parametrize("device", _GPU_DEVICE)
+    def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 41, device="cuda", dtype=base_dtype)
-        b = torch.randn(41, 128, device="cuda", dtype=base_dtype)
+        a = torch.randn(16, 41, device=device, dtype=base_dtype)
+        b = torch.randn(41, 128, device=device, dtype=base_dtype)
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -658,8 +684,8 @@ class TestScaledMM:
         assert sqnr > 50.0
 
 
-class TestNumerics:
-    @pytest.mark.parametrize(
+class TestNumerics(TestCase):
+    @parametrize(
         "float8_dtype",
         [
             torch.float8_e4m3fn,
@@ -668,8 +694,9 @@ class TestNumerics:
             torch.float8_e5m2fnuz,
         ],
     )
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    def test_small_amax_float16(self, float8_dtype):
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @parametrize("device", _GPU_DEVICE)
+    def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
         # the way we calculate scales actually works for tensors with
@@ -687,7 +714,7 @@ class TestNumerics:
         FP16_MAX_POS = torch.finfo(torch.float16).max
 
         target_amax = float8_max_pos / (FP16_MAX_POS + 1e-12)
-        x = torch.tensor([target_amax], dtype=torch.float16, device="cuda")
+        x = torch.tensor([target_amax], dtype=torch.float16, device=device)
         scale = tensor_to_scale(x, float8_dtype)
         assert not torch.any(torch.isinf(scale))
 
@@ -819,5 +846,11 @@ class TestFloat8LinearUtils(unittest.TestCase):
             self.assertEqual((zero_cnt, max_cnt), (tensor_len, tensor_len))
 
 
+instantiate_parametrized_tests(TestFloat8TrainingTensor)
+instantiate_parametrized_tests(TestFloat8Linear)
+instantiate_parametrized_tests(TestScaledMM)
+instantiate_parametrized_tests(TestNumerics)
+instantiate_parametrized_tests(TestFloat8LinearUtils)
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    run_tests()

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -45,7 +45,6 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_available_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
@@ -54,13 +53,6 @@ from torchao.utils import (
 
 random.seed(0)
 torch.manual_seed(0)
-
-
-# Skip the first device (CPU) since we only want accelerator devices for these tests
-_DEVICES = get_available_devices()[1:]
-
-if not _DEVICES:
-    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
@@ -250,8 +242,8 @@ class TestFloat8TrainingTensor:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
+    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity):
+        device = torch.accelerator.current_accelerator()
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
 
@@ -346,7 +338,6 @@ class TestFloat8Linear:
     @pytest.mark.parametrize("linear_bias", [False, True])
     @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -357,8 +348,8 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
         use_ac: bool,
-        device: str,
     ):
+        device = torch.accelerator.current_accelerator()
         if not emulate and device == "cuda" and not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
@@ -399,15 +390,14 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
         x_shape,
         linear_dtype: torch.dtype,
         linear_bias: bool,
-        device: str,
     ):
+        device = torch.accelerator.current_accelerator()
         x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = Float8LinearConfig.from_recipe_name(recipe_name)
@@ -430,14 +420,13 @@ class TestFloat8Linear:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
         linear_dtype: torch.dtype,
         recipe_name: Float8LinearRecipeName,
-        device: str,
     ):
+        device = torch.accelerator.current_accelerator()
         if not emulate and device == "cuda" and not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
@@ -456,11 +445,11 @@ class TestFloat8Linear:
         assert y.dtype == linear_dtype, f"y.dtype is {y.dtype}, expected {linear_dtype}"
 
         # autocast on
-        with torch.autocast(device):
+        with torch.autocast(str(device)):
             y = m(x)
         assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
 
-        with torch.autocast(device, dtype=torch.bfloat16):
+        with torch.autocast(str(device), dtype=torch.bfloat16):
             y = m(x)
         assert y.dtype == torch.bfloat16, (
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
@@ -493,8 +482,8 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA capability >= 8.9 required for native float8 support",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_inference_mode(self, device: str):
+    def test_inference_mode(self):
+        device = torch.accelerator.current_accelerator()
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
@@ -506,8 +495,8 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA capability >= 8.9 required for native float8 support",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_quantize(self, device: str):
+    def test_quantize(self):
+        device = torch.accelerator.current_accelerator()
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
@@ -527,13 +516,13 @@ class TestFloat8Linear:
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA capability >= 8.9 required for native float8 support",
 )
-@pytest.mark.parametrize("device", _DEVICES)
 class TestScaledMM:
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_fast_accum", [True, False])
-    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
+    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
+        device = torch.accelerator.current_accelerator()
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         output_dtype = base_dtype
@@ -571,7 +560,8 @@ class TestScaledMM:
             atol, rtol = 3e-3, 3e-3
         torch.testing.assert_close(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 
-    def test_different_configs_error(self, device: str):
+    def test_different_configs_error(self):
+        device = torch.accelerator.current_accelerator()
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
         fp8_dtype = e4m3_dtype
@@ -609,7 +599,8 @@ class TestScaledMM:
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_fast_accum", [True, False])
-    def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
+    def test_pad_inner_dim(self, base_dtype, use_fast_accum):
+        device = torch.accelerator.current_accelerator()
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         compare_type = torch.float32
@@ -694,8 +685,7 @@ class TestNumerics:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_small_amax_float16(self, float8_dtype, device):
+    def test_small_amax_float16(self, float8_dtype):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
         # the way we calculate scales actually works for tensors with
@@ -709,6 +699,7 @@ class TestNumerics:
         #
         #   amax + eps >= fp8_max_pos / fp16_max_pos
 
+        device = torch.accelerator.current_accelerator()
         float8_max_pos = torch.finfo(float8_dtype).max
         FP16_MAX_POS = torch.finfo(torch.float16).max
 

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -355,7 +355,7 @@ class TestFloat8Linear:
         use_ac: bool,
     ):
         if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
-            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
+            pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         x = torch.randn(*x_shape, device=_GPU_DEVICE, dtype=linear_dtype)
         m_ref = nn.Linear(
             16, 32, bias=linear_bias, device=_GPU_DEVICE, dtype=linear_dtype
@@ -434,7 +434,7 @@ class TestFloat8Linear:
         recipe_name: Float8LinearRecipeName,
     ):
         if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
-            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
+            pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
             nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),
             nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -51,14 +51,14 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_current_accelerator_device,
+    get_gpu_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_GPU_DEVICE = [str(get_current_accelerator_device())]
+_GPU_DEVICES = get_gpu_devices()
 
 random.seed(0)
 torch.manual_seed(0)
@@ -251,7 +251,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -347,7 +347,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -396,7 +396,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -425,7 +425,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -486,7 +486,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -499,7 +499,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -523,7 +523,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -567,7 +567,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -609,7 +609,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -695,7 +695,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -45,6 +45,7 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
+    get_available_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
@@ -54,11 +55,12 @@ from torchao.utils import (
 random.seed(0)
 torch.manual_seed(0)
 
-_GPU_DEVICE = (
-    str(torch.accelerator.current_accelerator())
-    if torch.accelerator.is_available()
-    else "no_gpu"
-)
+
+# Skip the first device (CPU) since we only want accelerator devices for these tests
+_DEVICES = get_available_devices()[1:]
+
+if not _DEVICES:
+    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
@@ -248,9 +250,10 @@ class TestFloat8TrainingTensor:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity):
-        a = torch.randn(*a_shape, dtype=torch.bfloat16, device=_GPU_DEVICE)
-        b = torch.randn(64, 32, dtype=torch.bfloat16, device=_GPU_DEVICE)
+    @pytest.mark.parametrize("device", _DEVICES)
+    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
+        a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
+        b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
 
         linear_mm_config = LinearMMConfig()
 
@@ -343,6 +346,7 @@ class TestFloat8Linear:
     @pytest.mark.parametrize("linear_bias", [False, True])
     @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -353,13 +357,12 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
         use_ac: bool,
+        device: str,
     ):
-        if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for native float8 support")
-        x = torch.randn(*x_shape, device=_GPU_DEVICE, dtype=linear_dtype)
-        m_ref = nn.Linear(
-            16, 32, bias=linear_bias, device=_GPU_DEVICE, dtype=linear_dtype
-        )
+        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
+        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
@@ -396,17 +399,17 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
         x_shape,
         linear_dtype: torch.dtype,
         linear_bias: bool,
+        device: str,
     ):
-        x = torch.randn(*x_shape, device=_GPU_DEVICE, dtype=linear_dtype)
-        m_ref = nn.Linear(
-            16, 32, bias=linear_bias, device=_GPU_DEVICE, dtype=linear_dtype
-        )
+        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
+        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_linear_impl(
             x,
@@ -427,17 +430,19 @@ class TestFloat8Linear:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
         linear_dtype: torch.dtype,
         recipe_name: Float8LinearRecipeName,
+        device: str,
     ):
-        if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
-            nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),
-            nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),
+            nn.Linear(32, 32, device=device, dtype=linear_dtype),
+            nn.Linear(32, 32, device=device, dtype=linear_dtype),
         )
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         # work around config being frozen
@@ -446,16 +451,16 @@ class TestFloat8Linear:
         m = convert_to_float8_training(copy.deepcopy(m_ref), config=config)
 
         # autocast off
-        x = torch.randn(16, 32, device=_GPU_DEVICE, dtype=linear_dtype)
+        x = torch.randn(16, 32, device=device, dtype=linear_dtype)
         y = m(x)
         assert y.dtype == linear_dtype, f"y.dtype is {y.dtype}, expected {linear_dtype}"
 
         # autocast on
-        with torch.autocast(_GPU_DEVICE):
+        with torch.autocast(device):
             y = m(x)
         assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
 
-        with torch.autocast(_GPU_DEVICE, dtype=torch.bfloat16):
+        with torch.autocast(device, dtype=torch.bfloat16):
             y = m(x)
         assert y.dtype == torch.bfloat16, (
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
@@ -488,9 +493,10 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA capability >= 8.9 required for native float8 support",
     )
-    def test_inference_mode(self):
-        x = torch.randn(32, 32, device=_GPU_DEVICE)
-        m = nn.Sequential(nn.Linear(32, 32)).to(_GPU_DEVICE)
+    @pytest.mark.parametrize("device", _DEVICES)
+    def test_inference_mode(self, device: str):
+        x = torch.randn(32, 32, device=device)
+        m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
         with torch.inference_mode(mode=True):
             m(x)
@@ -500,9 +506,10 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA capability >= 8.9 required for native float8 support",
     )
-    def test_quantize(self):
-        x = torch.randn(32, 32, device=_GPU_DEVICE)
-        m = nn.Sequential(nn.Linear(32, 32)).to(_GPU_DEVICE)
+    @pytest.mark.parametrize("device", _DEVICES)
+    def test_quantize(self, device: str):
+        x = torch.randn(32, 32, device=device)
+        m = nn.Sequential(nn.Linear(32, 32)).to(device)
         m = convert_to_float8_training(m)
         assert isinstance(m[0], Float8Linear), "Module is not a Float8Linear"
         from torchao.quantization import Float8WeightOnlyConfig, quantize_
@@ -515,24 +522,25 @@ class TestFloat8Linear:
             m(x)
 
 
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@unittest.skipIf(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
+    "CUDA capability >= 8.9 required for native float8 support",
+)
+@pytest.mark.parametrize("device", _DEVICES)
 class TestScaledMM:
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_fast_accum", [True, False])
-    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA capability >= 8.9 required for native float8 support",
-    )
-    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
+    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         output_dtype = base_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 16, device=_GPU_DEVICE, dtype=base_dtype)
-        b = torch.randn(32, 16, device=_GPU_DEVICE, dtype=base_dtype).t()
+        a = torch.randn(16, 16, device=device, dtype=base_dtype)
+        b = torch.randn(32, 16, device=device, dtype=base_dtype).t()
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -563,14 +571,9 @@ class TestScaledMM:
             atol, rtol = 3e-3, 3e-3
         torch.testing.assert_close(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA capability >= 8.9 required for native float8 support",
-    )
-    def test_different_configs_error(self):
-        x_fp32 = torch.randn(16, 16, device=_GPU_DEVICE)
-        x_scale = torch.tensor(1.0, device=_GPU_DEVICE)
+    def test_different_configs_error(self, device: str):
+        x_fp32 = torch.randn(16, 16, device=device)
+        x_scale = torch.tensor(1.0, device=device)
         fp8_dtype = e4m3_dtype
         linear_config_a = LinearMMConfig(
             ScaledMMConfig(False, True, False, False),
@@ -606,18 +609,13 @@ class TestScaledMM:
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
     @pytest.mark.parametrize("use_fast_accum", [True, False])
-    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA capability >= 8.9 required for native float8 support",
-    )
-    def test_pad_inner_dim(self, base_dtype, use_fast_accum):
+    def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 41, device=_GPU_DEVICE, dtype=base_dtype)
-        b = torch.randn(41, 128, device=_GPU_DEVICE, dtype=base_dtype)
+        a = torch.randn(16, 41, device=device, dtype=base_dtype)
+        b = torch.randn(41, 128, device=device, dtype=base_dtype)
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -696,7 +694,8 @@ class TestNumerics:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    def test_small_amax_float16(self, float8_dtype):
+    @pytest.mark.parametrize("device", _DEVICES)
+    def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
         # the way we calculate scales actually works for tensors with
@@ -714,7 +713,7 @@ class TestNumerics:
         FP16_MAX_POS = torch.finfo(torch.float16).max
 
         target_amax = float8_max_pos / (FP16_MAX_POS + 1e-12)
-        x = torch.tensor([target_amax], dtype=torch.float16, device=_GPU_DEVICE)
+        x = torch.tensor([target_amax], dtype=torch.float16, device=device)
         scale = tensor_to_scale(x, float8_dtype)
         assert not torch.any(torch.isinf(scale))
 

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -16,7 +16,6 @@ from torch.testing._internal.common_utils import (
     TestCase,
     instantiate_parametrized_tests,
     parametrize,
-    run_tests,
 )
 
 from torchao.float8.config import (
@@ -61,6 +60,8 @@ from torchao.utils import (
 random.seed(0)
 torch.manual_seed(0)
 
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     assert torch.all(a._scale == b._scale).item(), "scales are not identical"
@@ -68,6 +69,7 @@ def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     return True
 
 
+@instantiate_parametrized_tests
 class TestFloat8TrainingTensor(TestCase):
     def test_preserves_dtype(self) -> None:
         # hp means high precision, lp means low precision
@@ -249,7 +251,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -291,6 +293,7 @@ class TestFloat8TrainingTensor(TestCase):
             assert e4m3_dtype == torch.float8_e4m3fn
 
 
+@instantiate_parametrized_tests
 class TestFloat8Linear(TestCase):
     def _test_linear_impl(
         self,
@@ -345,7 +348,7 @@ class TestFloat8Linear(TestCase):
     @parametrize("linear_bias", [False, True])
     @parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -394,7 +397,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -423,7 +426,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -484,7 +487,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -497,7 +500,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -513,6 +516,7 @@ class TestFloat8Linear(TestCase):
             m(x)
 
 
+@instantiate_parametrized_tests
 class TestScaledMM(TestCase):
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
     @parametrize("use_fast_accum", [True, False])
@@ -521,7 +525,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -565,7 +569,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -607,7 +611,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -682,6 +686,7 @@ class TestScaledMM(TestCase):
         assert sqnr > 50.0
 
 
+@instantiate_parametrized_tests
 class TestNumerics(TestCase):
     @parametrize(
         "float8_dtype",
@@ -693,7 +698,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", get_available_devices(False))
+    @parametrize("device", _DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
@@ -717,7 +722,8 @@ class TestNumerics(TestCase):
         assert not torch.any(torch.isinf(scale))
 
 
-class TestFloat8LinearUtils(unittest.TestCase):
+@instantiate_parametrized_tests
+class TestFloat8LinearUtils(TestCase):
     def test_swap_root_linear(self):
         for emulate in [True, False]:
             module = nn.Linear(3, 3)
@@ -844,11 +850,5 @@ class TestFloat8LinearUtils(unittest.TestCase):
             self.assertEqual((zero_cnt, max_cnt), (tensor_len, tensor_len))
 
 
-instantiate_parametrized_tests(TestFloat8TrainingTensor)
-instantiate_parametrized_tests(TestFloat8Linear)
-instantiate_parametrized_tests(TestScaledMM)
-instantiate_parametrized_tests(TestNumerics)
-instantiate_parametrized_tests(TestFloat8LinearUtils)
-
 if __name__ == "__main__":
-    run_tests()
+    pytest.main([__file__])

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -45,7 +45,6 @@ from torchao.float8.float8_utils import (
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
-    get_available_devices,
     is_MI300,
     is_ROCM,
     is_sm_at_least_89,
@@ -55,11 +54,11 @@ from torchao.utils import (
 random.seed(0)
 torch.manual_seed(0)
 
-_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
-if not _DEVICES:
-    _DEVICES = [
-        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
-    ]
+_GPU_DEVICE = (
+    str(torch.accelerator.current_accelerator())
+    if torch.accelerator.is_available()
+    else "no_gpu"
+)
 
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
@@ -249,10 +248,9 @@ class TestFloat8TrainingTensor:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
-        a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
-        b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
+    def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity):
+        a = torch.randn(*a_shape, dtype=torch.bfloat16, device=_GPU_DEVICE)
+        b = torch.randn(64, 32, dtype=torch.bfloat16, device=_GPU_DEVICE)
 
         linear_mm_config = LinearMMConfig()
 
@@ -345,7 +343,6 @@ class TestFloat8Linear:
     @pytest.mark.parametrize("linear_bias", [False, True])
     @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -356,12 +353,13 @@ class TestFloat8Linear:
         linear_dtype: torch.dtype,
         linear_bias: bool,
         use_ac: bool,
-        device: torch.device,
     ):
-        if not emulate and device == "cuda" and not is_sm_at_least_89():
+        if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
             self.skipTest("CUDA capability >= 8.9 required for native float8 support")
-        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
-        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
+        x = torch.randn(*x_shape, device=_GPU_DEVICE, dtype=linear_dtype)
+        m_ref = nn.Linear(
+            16, 32, bias=linear_bias, device=_GPU_DEVICE, dtype=linear_dtype
+        )
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
@@ -398,17 +396,17 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
         x_shape,
         linear_dtype: torch.dtype,
         linear_bias: bool,
-        device,
     ):
-        x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
-        m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
+        x = torch.randn(*x_shape, device=_GPU_DEVICE, dtype=linear_dtype)
+        m_ref = nn.Linear(
+            16, 32, bias=linear_bias, device=_GPU_DEVICE, dtype=linear_dtype
+        )
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_linear_impl(
             x,
@@ -429,19 +427,17 @@ class TestFloat8Linear:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
         linear_dtype: torch.dtype,
         recipe_name: Float8LinearRecipeName,
-        device,
     ):
-        if not emulate and device == "cuda" and not is_sm_at_least_89():
+        if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
             self.skipTest("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
-            nn.Linear(32, 32, device=device, dtype=linear_dtype),
-            nn.Linear(32, 32, device=device, dtype=linear_dtype),
+            nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),
+            nn.Linear(32, 32, device=_GPU_DEVICE, dtype=linear_dtype),
         )
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         # work around config being frozen
@@ -450,16 +446,16 @@ class TestFloat8Linear:
         m = convert_to_float8_training(copy.deepcopy(m_ref), config=config)
 
         # autocast off
-        x = torch.randn(16, 32, device=device, dtype=linear_dtype)
+        x = torch.randn(16, 32, device=_GPU_DEVICE, dtype=linear_dtype)
         y = m(x)
         assert y.dtype == linear_dtype, f"y.dtype is {y.dtype}, expected {linear_dtype}"
 
         # autocast on
-        with torch.autocast(device):
+        with torch.autocast(_GPU_DEVICE):
             y = m(x)
         assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
 
-        with torch.autocast(device, dtype=torch.bfloat16):
+        with torch.autocast(_GPU_DEVICE, dtype=torch.bfloat16):
             y = m(x)
         assert y.dtype == torch.bfloat16, (
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
@@ -492,10 +488,9 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_inference_mode(self, device):
-        x = torch.randn(32, 32, device=device)
-        m = nn.Sequential(nn.Linear(32, 32)).to(device)
+    def test_inference_mode(self):
+        x = torch.randn(32, 32, device=_GPU_DEVICE)
+        m = nn.Sequential(nn.Linear(32, 32)).to(_GPU_DEVICE)
         m = convert_to_float8_training(m)
         with torch.inference_mode(mode=True):
             m(x)
@@ -505,10 +500,9 @@ class TestFloat8Linear:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_quantize(self, device):
-        x = torch.randn(32, 32, device=device)
-        m = nn.Sequential(nn.Linear(32, 32)).to(device)
+    def test_quantize(self):
+        x = torch.randn(32, 32, device=_GPU_DEVICE)
+        m = nn.Sequential(nn.Linear(32, 32)).to(_GPU_DEVICE)
         m = convert_to_float8_training(m)
         assert isinstance(m[0], Float8Linear), "Module is not a Float8Linear"
         from torchao.quantization import Float8WeightOnlyConfig, quantize_
@@ -531,15 +525,14 @@ class TestScaledMM:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
+    def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         output_dtype = base_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 16, device=device, dtype=base_dtype)
-        b = torch.randn(32, 16, device=device, dtype=base_dtype).t()
+        a = torch.randn(16, 16, device=_GPU_DEVICE, dtype=base_dtype)
+        b = torch.randn(32, 16, device=_GPU_DEVICE, dtype=base_dtype).t()
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -575,10 +568,9 @@ class TestScaledMM:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_different_configs_error(self, device):
-        x_fp32 = torch.randn(16, 16, device=device)
-        x_scale = torch.tensor(1.0, device=device)
+    def test_different_configs_error(self):
+        x_fp32 = torch.randn(16, 16, device=_GPU_DEVICE)
+        x_scale = torch.tensor(1.0, device=_GPU_DEVICE)
         fp8_dtype = e4m3_dtype
         linear_config_a = LinearMMConfig(
             ScaledMMConfig(False, True, False, False),
@@ -619,14 +611,13 @@ class TestScaledMM:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
+    def test_pad_inner_dim(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
         compare_type = torch.float32
 
-        a = torch.randn(16, 41, device=device, dtype=base_dtype)
-        b = torch.randn(41, 128, device=device, dtype=base_dtype)
+        a = torch.randn(16, 41, device=_GPU_DEVICE, dtype=base_dtype)
+        b = torch.randn(41, 128, device=_GPU_DEVICE, dtype=base_dtype)
 
         a_scale = tensor_to_scale(a, input_dtype).float()
         b_scale = tensor_to_scale(b, input_dtype).float()
@@ -705,8 +696,7 @@ class TestNumerics:
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @pytest.mark.parametrize("device", _DEVICES)
-    def test_small_amax_float16(self, float8_dtype, device):
+    def test_small_amax_float16(self, float8_dtype):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
         # the way we calculate scales actually works for tensors with
@@ -724,7 +714,7 @@ class TestNumerics:
         FP16_MAX_POS = torch.finfo(torch.float16).max
 
         target_amax = float8_max_pos / (FP16_MAX_POS + 1e-12)
-        x = torch.tensor([target_amax], dtype=torch.float16, device=device)
+        x = torch.tensor([target_amax], dtype=torch.float16, device=_GPU_DEVICE)
         scale = tensor_to_scale(x, float8_dtype)
         assert not torch.any(torch.isinf(scale))
 

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -481,7 +481,8 @@ class TestFloat8Linear:
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_89(),
+        torch.cuda.is_available()
+        and not is_sm_at_least_89(),  # torch.cuda.is_available() condition is needed for non-CUDA devices
         "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_inference_mode(self):

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -281,7 +281,7 @@ class TestFloat8TrainingTensor:
         sqnr = compute_error(c_ref, c_fp8_compute)
         assert sqnr >= 25.0
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     def test_fp8_dtype(
         self,
     ):
@@ -327,9 +327,7 @@ class TestFloat8Linear:
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
+    @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
     @pytest.mark.parametrize(
         "scaling_type_input",
@@ -360,6 +358,8 @@ class TestFloat8Linear:
         use_ac: bool,
         device: torch.device,
     ):
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
+            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
         x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = get_test_float8_linear_config(
@@ -416,9 +416,7 @@ class TestFloat8Linear:
             config,
         )
 
-    @pytest.mark.parametrize(
-        "emulate", [True, False] if is_sm_at_least_89() else [True]
-    )
+    @pytest.mark.parametrize("emulate", [True, False])
     @pytest.mark.parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
@@ -439,6 +437,8 @@ class TestFloat8Linear:
         recipe_name: Float8LinearRecipeName,
         device,
     ):
+        if not emulate and device == "cuda" and not is_sm_at_least_89():
+            self.skipTest("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
             nn.Linear(32, 32, device=device, dtype=linear_dtype),
             nn.Linear(32, 32, device=device, dtype=linear_dtype),

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -56,6 +56,10 @@ random.seed(0)
 torch.manual_seed(0)
 
 _DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+if not _DEVICES:
+    _DEVICES = [
+        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
+    ]
 
 
 def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -486,7 +486,7 @@ class TestFloat8Linear:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_inference_mode(self):
         x = torch.randn(32, 32, device=_GPU_DEVICE)
@@ -498,7 +498,7 @@ class TestFloat8Linear:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_quantize(self):
         x = torch.randn(32, 32, device=_GPU_DEVICE)
@@ -523,7 +523,7 @@ class TestScaledMM:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
@@ -566,7 +566,7 @@ class TestScaledMM:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_different_configs_error(self):
         x_fp32 = torch.randn(16, 16, device=_GPU_DEVICE)
@@ -609,7 +609,7 @@ class TestScaledMM:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_pad_inner_dim(self, base_dtype, use_fast_accum):
         torch.manual_seed(42)
@@ -802,10 +802,13 @@ class TestFloat8LinearUtils(unittest.TestCase):
                 self.lin2 = nn.Linear(4 * dim, dim)
 
         model = nn.Sequential(MLP(3), nn.Linear(3, 3), MLP(3))
-        module_filter_fn = lambda mod, fqn: fqn not in [
-            "0.lin2",
-            "2.lin1",
-        ]
+        module_filter_fn = lambda mod, fqn: (
+            fqn
+            not in [
+                "0.lin2",
+                "2.lin1",
+            ]
+        )
         config = Float8LinearConfig(emulate=True)
         model = convert_to_float8_training(
             model,

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -511,12 +511,12 @@ class TestFloat8Linear:
             m(x)
 
 
-@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@unittest.skipIf(
-    torch.cuda.is_available() and not is_sm_at_least_89(),
-    "CUDA capability >= 8.9 required for native float8 support",
-)
 class TestScaledMM:
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA not available",
+    )
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
@@ -560,6 +560,10 @@ class TestScaledMM:
             atol, rtol = 3e-3, 3e-3
         torch.testing.assert_close(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(), "CUDA not available"
+    )
     def test_different_configs_error(self):
         device = torch.accelerator.current_accelerator()
         x_fp32 = torch.randn(16, 16, device=device)
@@ -595,6 +599,11 @@ class TestScaledMM:
         ):
             a @ b
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA not available",
+    )
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -518,7 +518,7 @@ class TestScaledMM:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
@@ -565,7 +565,8 @@ class TestScaledMM:
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        torch.cuda.is_available() and not is_sm_at_least_89(), "CUDA not available"
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_different_configs_error(self):
         device = torch.accelerator.current_accelerator()
@@ -605,7 +606,7 @@ class TestScaledMM:
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     @pytest.mark.parametrize(
         "base_dtype", [torch.float16, torch.bfloat16, torch.float32]

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -12,11 +12,6 @@ import unittest
 import pytest
 import torch
 import torch.nn as nn
-from torch.testing._internal.common_utils import (
-    TestCase,
-    instantiate_parametrized_tests,
-    parametrize,
-)
 
 from torchao.float8.config import (
     CastConfig,
@@ -69,8 +64,7 @@ def bitwise_identical(a: Float8TrainingTensor, b: Float8TrainingTensor) -> bool:
     return True
 
 
-@instantiate_parametrized_tests
-class TestFloat8TrainingTensor(TestCase):
+class TestFloat8TrainingTensor:
     def test_preserves_dtype(self) -> None:
         # hp means high precision, lp means low precision
         hp_dtypes = (torch.float32, torch.float16, torch.bfloat16)
@@ -165,9 +159,9 @@ class TestFloat8TrainingTensor(TestCase):
             assert fp8_a_transposed._axiswise_dim == expected_axiswise_dim
             assert fp8_b_t._axiswise_dim == expected_axiswise_dim
 
-    @parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
-    @parametrize("axiswise_dim", [0, -1])
-    @parametrize("round_scales_to_power_of_2", [True, False])
+    @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
+    @pytest.mark.parametrize("axiswise_dim", [0, -1])
+    @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
     def test_axiswise_dynamic_cast(
         self, shape, axiswise_dim, round_scales_to_power_of_2
     ):
@@ -237,8 +231,8 @@ class TestFloat8TrainingTensor(TestCase):
         with pytest.raises(RuntimeError):
             a_fp8_d2.reshape(3, -1)
 
-    @parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
-    @parametrize(
+    @pytest.mark.parametrize("a_shape", [(16, 32), (2, 16, 32), (1, 2, 16, 32)])
+    @pytest.mark.parametrize(
         "a_granularity,b_granularity",
         [
             (ScalingGranularity.AXISWISE, ScalingGranularity.AXISWISE),
@@ -251,7 +245,7 @@ class TestFloat8TrainingTensor(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_axiswise_gemm(self, a_shape, a_granularity, b_granularity, device):
         a = torch.randn(*a_shape, dtype=torch.bfloat16, device=device)
         b = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
@@ -293,8 +287,7 @@ class TestFloat8TrainingTensor(TestCase):
             assert e4m3_dtype == torch.float8_e4m3fn
 
 
-@instantiate_parametrized_tests
-class TestFloat8Linear(TestCase):
+class TestFloat8Linear:
     def _test_linear_impl(
         self,
         x,
@@ -330,25 +323,27 @@ class TestFloat8Linear(TestCase):
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
-    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @parametrize(
+    @pytest.mark.parametrize(
+        "emulate", [True, False] if is_sm_at_least_89() else [True]
+    )
+    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @pytest.mark.parametrize(
         "scaling_type_input",
         [ScalingType.DYNAMIC],
     )
-    @parametrize(
+    @pytest.mark.parametrize(
         "scaling_type_weight",
         [ScalingType.DYNAMIC],
     )
-    @parametrize(
+    @pytest.mark.parametrize(
         "scaling_type_grad_output",
         [ScalingType.DYNAMIC],
     )
-    @parametrize("linear_dtype", [torch.bfloat16, torch.float32])
-    @parametrize("linear_bias", [False, True])
-    @parametrize("use_ac", [False, True])
+    @pytest.mark.parametrize("linear_dtype", [torch.bfloat16, torch.float32])
+    @pytest.mark.parametrize("linear_bias", [False, True])
+    @pytest.mark.parametrize("use_ac", [False, True])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_config_params(
         self,
         x_shape,
@@ -381,23 +376,25 @@ class TestFloat8Linear(TestCase):
     # them, so this function factors out some of the recipes which are annoying
     # to combine with the main testing function.
     # TODO(future PR): make this cleaner.
-    @parametrize(
+    @pytest.mark.parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.ROWWISE,
             Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
         ],
     )
-    @parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
-    @parametrize("linear_bias", [True, False])
-    @parametrize("linear_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
+    @pytest.mark.parametrize("linear_bias", [True, False])
+    @pytest.mark.parametrize(
+        "linear_dtype", [torch.bfloat16, torch.float16, torch.float32]
+    )
     @skip_if_rocm("ROCm enablement in progress")
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "Requires CUDA capability >= 9.0",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_linear_from_recipe(
         self,
         recipe_name,
@@ -415,9 +412,13 @@ class TestFloat8Linear(TestCase):
             config,
         )
 
-    @parametrize("emulate", [True, False] if is_sm_at_least_89() else [True])
-    @parametrize("linear_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize(
+    @pytest.mark.parametrize(
+        "emulate", [True, False] if is_sm_at_least_89() else [True]
+    )
+    @pytest.mark.parametrize(
+        "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize(
         "recipe_name",
         [
             Float8LinearRecipeName.TENSORWISE,
@@ -426,7 +427,7 @@ class TestFloat8Linear(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_autocast_outputs(
         self,
         emulate: bool,
@@ -487,7 +488,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_inference_mode(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -500,7 +501,7 @@ class TestFloat8Linear(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_quantize(self, device):
         x = torch.randn(32, 32, device=device)
         m = nn.Sequential(nn.Linear(32, 32)).to(device)
@@ -516,16 +517,17 @@ class TestFloat8Linear(TestCase):
             m(x)
 
 
-@instantiate_parametrized_tests
-class TestScaledMM(TestCase):
-    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize("use_fast_accum", [True, False])
+class TestScaledMM:
+    @pytest.mark.parametrize(
+        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize("use_fast_accum", [True, False])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_scaled_mm_vs_emulated(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -569,7 +571,7 @@ class TestScaledMM(TestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_different_configs_error(self, device):
         x_fp32 = torch.randn(16, 16, device=device)
         x_scale = torch.tensor(1.0, device=device)
@@ -604,14 +606,16 @@ class TestScaledMM(TestCase):
         ):
             a @ b
 
-    @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])
-    @parametrize("use_fast_accum", [True, False])
+    @pytest.mark.parametrize(
+        "base_dtype", [torch.float16, torch.bfloat16, torch.float32]
+    )
+    @pytest.mark.parametrize("use_fast_accum", [True, False])
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_pad_inner_dim(self, base_dtype, use_fast_accum, device):
         torch.manual_seed(42)
         input_dtype = e4m3_dtype
@@ -686,9 +690,8 @@ class TestScaledMM(TestCase):
         assert sqnr > 50.0
 
 
-@instantiate_parametrized_tests
-class TestNumerics(TestCase):
-    @parametrize(
+class TestNumerics:
+    @pytest.mark.parametrize(
         "float8_dtype",
         [
             torch.float8_e4m3fn,
@@ -698,7 +701,7 @@ class TestNumerics(TestCase):
         ],
     )
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-    @parametrize("device", _DEVICES)
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_small_amax_float16(self, float8_dtype, device):
         # If we calculate scale naively with FP8_MAX_POS / amax,
         # the result may not be representable in fp16. Verify that
@@ -722,8 +725,7 @@ class TestNumerics(TestCase):
         assert not torch.any(torch.isinf(scale))
 
 
-@instantiate_parametrized_tests
-class TestFloat8LinearUtils(TestCase):
+class TestFloat8LinearUtils(unittest.TestCase):
     def test_swap_root_linear(self):
         for emulate in [True, False]:
             module = nn.Linear(3, 3)

--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -320,7 +320,10 @@ class TestFloat8Linear:
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
-    @pytest.mark.parametrize("emulate", [True, False])
+    @pytest.mark.parametrize(
+        "emulate",
+        [True, False] if is_sm_at_least_89() or torch.xpu.is_available() else [True],
+    )
     @pytest.mark.parametrize("x_shape", [(16, 16), (2, 16, 16), (3, 2, 16, 16)])
     @pytest.mark.parametrize(
         "scaling_type_input",
@@ -350,8 +353,6 @@ class TestFloat8Linear:
         use_ac: bool,
     ):
         device = torch.accelerator.current_accelerator()
-        if not emulate and device == "cuda" and not is_sm_at_least_89():
-            pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         x = torch.randn(*x_shape, device=device, dtype=linear_dtype)
         m_ref = nn.Linear(16, 32, bias=linear_bias, device=device, dtype=linear_dtype)
         config = get_test_float8_linear_config(
@@ -407,7 +408,10 @@ class TestFloat8Linear:
             config,
         )
 
-    @pytest.mark.parametrize("emulate", [True, False])
+    @pytest.mark.parametrize(
+        "emulate",
+        [True, False] if is_sm_at_least_89() or torch.xpu.is_available() else [True],
+    )
     @pytest.mark.parametrize(
         "linear_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
@@ -427,8 +431,6 @@ class TestFloat8Linear:
         recipe_name: Float8LinearRecipeName,
     ):
         device = torch.accelerator.current_accelerator()
-        if not emulate and device == "cuda" and not is_sm_at_least_89():
-            pytest.skip("CUDA capability >= 8.9 required for native float8 support")
         m_ref = nn.Sequential(
             nn.Linear(32, 32, device=device, dtype=linear_dtype),
             nn.Linear(32, 32, device=device, dtype=linear_dtype),

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -37,12 +37,10 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_gpu_devices,
+    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
-
-_GPU_DEVICES = get_gpu_devices()
 
 
 def _test_compile_base(
@@ -95,7 +93,7 @@ def _test_compile_base(
 @pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _GPU_DEVICES)
+@pytest.mark.parametrize("device", get_available_devices(False))
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -134,7 +132,7 @@ def test_eager_only(
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _GPU_DEVICES)
+@pytest.mark.parametrize("device", get_available_devices(False))
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -182,7 +180,7 @@ def test_aot_eager(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA with float8 support not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICES)
+@pytest.mark.parametrize("device", get_available_devices(False))
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -224,7 +222,7 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICES)
+@pytest.mark.parametrize("device", get_available_devices(False))
 def test_inductor_from_recipe(recipe_name, device: torch.device):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
@@ -263,7 +261,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "CUDA with capability 9.0 or greater not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_float8_with_graph_break_in_the_middle(self, device: torch.device):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
@@ -281,7 +279,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_float8_graph_input(self, device: torch.device):
         # """Test that having Float8TrainingTensor object as a graph input"""
 
@@ -307,7 +305,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICES)
+    @parametrize("device", get_available_devices(False))
     def test_float8_graph_output(self, device: torch.device):
         """Test that having Float8TrainingTensor object as a graph output works"""
         cnts = CompileCounterWithBackend("inductor")
@@ -371,7 +369,7 @@ class capture_stderr(list):
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICES)
+@pytest.mark.parametrize("device", get_available_devices(False))
 def test_dynamic_scale_numeric_parity(
     dtype: torch.dtype, round_scales_to_power_of_2: bool, device: torch.device
 ):

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -37,12 +37,12 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_current_accelerator_device,
+    get_gpu_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_GPU_DEVICE = [str(get_current_accelerator_device())]
+_GPU_DEVICES = get_gpu_devices()
 
 
 def _test_compile_base(
@@ -95,7 +95,7 @@ def _test_compile_base(
 @pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _GPU_DEVICE)
+@pytest.mark.parametrize("device", _GPU_DEVICES)
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -134,7 +134,7 @@ def test_eager_only(
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _GPU_DEVICE)
+@pytest.mark.parametrize("device", _GPU_DEVICES)
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -182,7 +182,7 @@ def test_aot_eager(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA with float8 support not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICE)
+@pytest.mark.parametrize("device", _GPU_DEVICES)
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -224,7 +224,7 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICE)
+@pytest.mark.parametrize("device", _GPU_DEVICES)
 def test_inductor_from_recipe(recipe_name, device: torch.device):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
@@ -263,7 +263,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "CUDA with capability 9.0 or greater not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_float8_with_graph_break_in_the_middle(self, device: torch.device):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
@@ -281,7 +281,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_float8_graph_input(self, device: torch.device):
         # """Test that having Float8TrainingTensor object as a graph input"""
 
@@ -307,7 +307,7 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _GPU_DEVICE)
+    @parametrize("device", _GPU_DEVICES)
     def test_float8_graph_output(self, device: torch.device):
         """Test that having Float8TrainingTensor object as a graph output works"""
         cnts = CompileCounterWithBackend("inductor")
@@ -371,7 +371,7 @@ class capture_stderr(list):
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA not available",
 )
-@pytest.mark.parametrize("device", _GPU_DEVICE)
+@pytest.mark.parametrize("device", _GPU_DEVICES)
 def test_dynamic_scale_numeric_parity(
     dtype: torch.dtype, round_scales_to_power_of_2: bool, device: torch.device
 ):

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -14,6 +14,10 @@ import torch
 import torch.nn as nn
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 from torchao.float8.config import (
     CastConfig,
@@ -33,9 +37,12 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
+    get_current_accelerator_device,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
+
+_GPU_DEVICE = [str(get_current_accelerator_device())]
 
 
 def _test_compile_base(
@@ -43,15 +50,16 @@ def _test_compile_base(
     fullgraph: bool,
     config: Float8LinearConfig,
     dtype: torch.dtype,
+    device: torch.device,
 ):
     random.seed(0)
     torch.manual_seed(0)
     x_shape = (16, 16)
     linear_dtype = torch.bfloat16
 
-    x = torch.randn(*x_shape, device="cuda", dtype=linear_dtype).requires_grad_()
+    x = torch.randn(*x_shape, device=device, dtype=linear_dtype).requires_grad_()
     x_ref = copy.deepcopy(x)
-    m_ref = nn.Linear(16, 32, bias=True, device="cuda", dtype=linear_dtype)
+    m_ref = nn.Linear(16, 32, bias=True, device=device, dtype=linear_dtype)
 
     m_fp8 = Float8Linear.from_float(
         copy.deepcopy(m_ref),
@@ -86,7 +94,8 @@ def _test_compile_base(
 )
 @pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@pytest.mark.parametrize("device", _GPU_DEVICE)
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -94,6 +103,7 @@ def test_eager_only(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: torch.device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -107,6 +117,7 @@ def test_eager_only(
         fullgraph,
         config,
         dtype,
+        device,
     )
 
 
@@ -122,7 +133,8 @@ def test_eager_only(
     [ScalingType.DYNAMIC],
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@pytest.mark.parametrize("device", _GPU_DEVICE)
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -130,6 +142,7 @@ def test_aot_eager(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: torch.device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -143,9 +156,15 @@ def test_aot_eager(
         fullgraph,
         config,
         dtype,
+        device,
     )
 
 
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@unittest.skipIf(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
+    "CUDA with float8 support not available",
+)
 @pytest.mark.parametrize("fullgraph", [True])
 @pytest.mark.parametrize("emulate", [False])
 @pytest.mark.parametrize("scaling_type_input", [ScalingType.DYNAMIC])
@@ -157,11 +176,13 @@ def test_aot_eager(
     "scaling_type_grad_output",
     [ScalingType.DYNAMIC],
 )
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 @unittest.skipIf(
-    not torch.cuda.is_available() or not is_sm_at_least_89(),
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA with float8 support not available",
 )
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("device", _GPU_DEVICE)
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -169,6 +190,7 @@ def test_inductor_from_config_params(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: torch.device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -182,6 +204,7 @@ def test_inductor_from_config_params(
         fullgraph,
         config,
         dtype,
+        device,
     )
 
 
@@ -196,10 +219,13 @@ def test_inductor_from_config_params(
         Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
     ],
 )
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 @unittest.skipIf(
-    not is_sm_at_least_90(), "CUDA with capability 9.0 or greater not available"
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    "CUDA with capability 9.0 or greater not available",
 )
-def test_inductor_from_recipe(recipe_name):
+@pytest.mark.parametrize("device", _GPU_DEVICE)
+def test_inductor_from_recipe(recipe_name, device: torch.device):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -209,9 +235,11 @@ def test_inductor_from_recipe(recipe_name):
         fullgraph,
         config,
         dtype,
+        device,
     )
 
 
+@instantiate_parametrized_tests
 class TestGraphBreaks(DynamoTestCase):
     class MockLinear(torch.nn.Module):
         def __init__(self, graph_break: bool):
@@ -230,36 +258,39 @@ class TestGraphBreaks(DynamoTestCase):
                 return x_hp
             return x_fp8
 
-    # TODO(future): figure out why the test below fails on CUDA capability 8.9
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        not torch.cuda.is_available() or not is_sm_at_least_90(),
+        torch.cuda.is_available() and not is_sm_at_least_90(),
         "CUDA with capability 9.0 or greater not available",
     )
-    def test_float8_with_graph_break_in_the_middle(self):
+    @parametrize("device", _GPU_DEVICE)
+    def test_float8_with_graph_break_in_the_middle(self, device: torch.device):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=True).cuda()
+        mod = self.MockLinear(graph_break=True).to(device)
         compiled_mod = copy.deepcopy(mod)
         compiled_mod = torch.compile(compiled_mod, backend=cnts)
-        x = torch.randn(16, 16, device="cuda")
+        x = torch.randn(16, 16, device=device)
         y_eager = mod(x)
         y_compiled = compiled_mod(x)
         self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
         torch.testing.assert_close(y_eager, y_compiled)
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        not torch.cuda.is_available() or not is_sm_at_least_89(),
+        torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    def test_float8_graph_input(self):
-        """Test that having Float8TrainingTensor object as a graph input"""
+    @parametrize("device", _GPU_DEVICE)
+    def test_float8_graph_input(self, device: torch.device):
+        # """Test that having Float8TrainingTensor object as a graph input"""
 
         def to_float(x):
             return x.to_original_precision()
 
         cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).cuda()
-        x = torch.randn(2, 2, device="cuda")
+        mod = self.MockLinear(graph_break=False).to(device)
+        x = torch.randn(2, 2, device=device)
         compiled_to_float = torch.compile(to_float, backend=cnts)
         y = mod(x)
         y2_eager = to_float(y)
@@ -271,16 +302,18 @@ class TestGraphBreaks(DynamoTestCase):
         )
         torch.testing.assert_close(y2_eager, y2_compiled)
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
-        not torch.cuda.is_available() or not is_sm_at_least_89(),
+        torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    def test_float8_graph_output(self):
+    @parametrize("device", _GPU_DEVICE)
+    def test_float8_graph_output(self, device: torch.device):
         """Test that having Float8TrainingTensor object as a graph output works"""
         cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).cuda()
+        mod = self.MockLinear(graph_break=False).to(device)
         compiled_mod = torch.compile(mod, backend=cnts)
-        x = torch.randn(16, 16, device="cuda")
+        x = torch.randn(16, 16, device=device)
         y_compiled = compiled_mod(x)
 
         self.assertEqual(cnts.frame_count, 1, "Compiled graph should have 1 frame!")
@@ -318,10 +351,6 @@ class capture_stderr(list):
         sys.stderr = self.sys_stderr
 
 
-@unittest.skipIf(
-    not is_sm_at_least_89(),
-    "CUDA not available",
-)
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -337,12 +366,18 @@ class capture_stderr(list):
         False,
     ],
 )
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@unittest.skipIf(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
+    "CUDA not available",
+)
+@pytest.mark.parametrize("device", _GPU_DEVICE)
 def test_dynamic_scale_numeric_parity(
-    dtype: torch.dtype, round_scales_to_power_of_2: bool
+    dtype: torch.dtype, round_scales_to_power_of_2: bool, device: torch.device
 ):
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)
-    hp_tensor1 = torch.randn(16, 16, device="cuda", dtype=dtype)
+    hp_tensor1 = torch.randn(16, 16, device=device, dtype=dtype)
     hp_tensor2 = hp_tensor1.detach().clone()
     float8_config = Float8LinearConfig(
         cast_config_weight=CastConfig(scaling_type=scaling_type_weight),

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -14,10 +14,6 @@ import torch
 import torch.nn as nn
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
-)
 
 from torchao.float8.config import (
     CastConfig,
@@ -43,6 +39,10 @@ from torchao.utils import (
 )
 
 _DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+if not _DEVICES:
+    _DEVICES = [
+        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
+    ]
 
 
 @pytest.fixture(scope="module", params=_DEVICES)
@@ -163,11 +163,6 @@ def test_aot_eager(
     )
 
 
-@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@unittest.skipIf(
-    torch.cuda.is_available() and not is_sm_at_least_89(),
-    "CUDA with float8 support not available",
-)
 @pytest.mark.parametrize("fullgraph", [True])
 @pytest.mark.parametrize("emulate", [False])
 @pytest.mark.parametrize("scaling_type_input", [ScalingType.DYNAMIC])
@@ -240,7 +235,6 @@ def test_inductor_from_recipe(recipe_name, device):
     )
 
 
-@instantiate_parametrized_tests
 class TestGraphBreaks(DynamoTestCase):
     class MockLinear(torch.nn.Module):
         def __init__(self, graph_break: bool):
@@ -264,75 +258,83 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "CUDA with capability 9.0 or greater not available",
     )
-    @parametrize("device", _DEVICES)
-    def test_float8_with_graph_break_in_the_middle(self, device):
+    def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=True).to(device)
-        compiled_mod = copy.deepcopy(mod)
-        compiled_mod = torch.compile(compiled_mod, backend=cnts)
-        x = torch.randn(16, 16, device=device)
-        y_eager = mod(x)
-        y_compiled = compiled_mod(x)
-        self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
-        torch.testing.assert_close(y_eager, y_compiled)
+        for device in _DEVICES:
+            with self.subTest(device=device):
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=True).to(device)
+                compiled_mod = copy.deepcopy(mod)
+                compiled_mod = torch.compile(compiled_mod, backend=cnts)
+                x = torch.randn(16, 16, device=device)
+                y_eager = mod(x)
+                y_compiled = compiled_mod(x)
+                self.assertEqual(
+                    cnts.frame_count, 2, "Compiled graph should have 2 frames!"
+                )
+                torch.testing.assert_close(y_eager, y_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
-    def test_float8_graph_input(self, device):
+    def test_float8_graph_input(self):
         # """Test that having Float8TrainingTensor object as a graph input"""
+        for device in _DEVICES:
+            with self.subTest(device=device):
 
-        def to_float(x):
-            return x.to_original_precision()
+                def to_float(x):
+                    return x.to_original_precision()
 
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).to(device)
-        x = torch.randn(2, 2, device=device)
-        compiled_to_float = torch.compile(to_float, backend=cnts)
-        y = mod(x)
-        y2_eager = to_float(y)
-        y2_compiled = compiled_to_float(y)
-        self.assertEqual(
-            cnts.frame_count,
-            1,
-            "to_float was not compiled into 1 frame and likely encountered a skip!",
-        )
-        torch.testing.assert_close(y2_eager, y2_compiled)
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=False).to(device)
+                x = torch.randn(2, 2, device=device)
+                compiled_to_float = torch.compile(to_float, backend=cnts)
+                y = mod(x)
+                y2_eager = to_float(y)
+                y2_compiled = compiled_to_float(y)
+                self.assertEqual(
+                    cnts.frame_count,
+                    1,
+                    "to_float was not compiled into 1 frame and likely encountered a skip!",
+                )
+                torch.testing.assert_close(y2_eager, y2_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", _DEVICES)
-    def test_float8_graph_output(self, device):
+    def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).to(device)
-        compiled_mod = torch.compile(mod, backend=cnts)
-        x = torch.randn(16, 16, device=device)
-        y_compiled = compiled_mod(x)
+        for device in _DEVICES:
+            with self.subTest(device=device):
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=False).to(device)
+                compiled_mod = torch.compile(mod, backend=cnts)
+                x = torch.randn(16, 16, device=device)
+                y_compiled = compiled_mod(x)
 
-        self.assertEqual(cnts.frame_count, 1, "Compiled graph should have 1 frame!")
-        tensors, ctx = y_compiled.__tensor_flatten__()
-        for tensor in tensors:
-            assert not isinstance(
-                getattr(y_compiled, tensor), torch._subclasses.fake_tensor.FakeTensor
-            ), "Float8TrainingTensor should not contain any FakeTensors!"
-        assert isinstance(y_compiled._orig_dtype, torch.dtype), (
-            "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
-                type(y_compiled._orig_dtype)
-            )
-        )
-        assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
-            "Float8TrainingTensor._emulate should be a bool but got {}".format(
-                type(y_compiled._linear_mm_config.output.emulate)
-            )
-        )
+                self.assertEqual(
+                    cnts.frame_count, 1, "Compiled graph should have 1 frame!"
+                )
+                tensors, ctx = y_compiled.__tensor_flatten__()
+                for tensor in tensors:
+                    assert not isinstance(
+                        getattr(y_compiled, tensor),
+                        torch._subclasses.fake_tensor.FakeTensor,
+                    ), "Float8TrainingTensor should not contain any FakeTensors!"
+                assert isinstance(y_compiled._orig_dtype, torch.dtype), (
+                    "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
+                        type(y_compiled._orig_dtype)
+                    )
+                )
+                assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
+                    "Float8TrainingTensor._emulate should be a bool but got {}".format(
+                        type(y_compiled._linear_mm_config.output.emulate)
+                    )
+                )
 
 
 class capture_stderr(list):

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -42,13 +42,20 @@ from torchao.utils import (
     is_sm_at_least_90,
 )
 
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
 
 def _test_compile_base(
     backend: str,
     fullgraph: bool,
     config: Float8LinearConfig,
     dtype: torch.dtype,
-    device: torch.device,
+    device,
 ):
     random.seed(0)
     torch.manual_seed(0)
@@ -93,7 +100,6 @@ def _test_compile_base(
 @pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", get_available_devices(False))
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -101,7 +107,7 @@ def test_eager_only(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: torch.device,
+    device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -132,7 +138,6 @@ def test_eager_only(
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", get_available_devices(False))
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -140,7 +145,7 @@ def test_aot_eager(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: torch.device,
+    device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -180,7 +185,6 @@ def test_aot_eager(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA with float8 support not available",
 )
-@pytest.mark.parametrize("device", get_available_devices(False))
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -188,7 +192,7 @@ def test_inductor_from_config_params(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: torch.device,
+    device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -222,8 +226,7 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-@pytest.mark.parametrize("device", get_available_devices(False))
-def test_inductor_from_recipe(recipe_name, device: torch.device):
+def test_inductor_from_recipe(recipe_name, device):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -261,8 +264,8 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "CUDA with capability 9.0 or greater not available",
     )
-    @parametrize("device", get_available_devices(False))
-    def test_float8_with_graph_break_in_the_middle(self, device: torch.device):
+    @parametrize("device", _DEVICES)
+    def test_float8_with_graph_break_in_the_middle(self, device):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
         cnts = CompileCounterWithBackend("inductor")
         mod = self.MockLinear(graph_break=True).to(device)
@@ -279,8 +282,8 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
-    def test_float8_graph_input(self, device: torch.device):
+    @parametrize("device", _DEVICES)
+    def test_float8_graph_input(self, device):
         # """Test that having Float8TrainingTensor object as a graph input"""
 
         def to_float(x):
@@ -305,8 +308,8 @@ class TestGraphBreaks(DynamoTestCase):
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "CUDA with float8 support not available",
     )
-    @parametrize("device", get_available_devices(False))
-    def test_float8_graph_output(self, device: torch.device):
+    @parametrize("device", _DEVICES)
+    def test_float8_graph_output(self, device):
         """Test that having Float8TrainingTensor object as a graph output works"""
         cnts = CompileCounterWithBackend("inductor")
         mod = self.MockLinear(graph_break=False).to(device)
@@ -369,9 +372,8 @@ class capture_stderr(list):
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA not available",
 )
-@pytest.mark.parametrize("device", get_available_devices(False))
 def test_dynamic_scale_numeric_parity(
-    dtype: torch.dtype, round_scales_to_power_of_2: bool, device: torch.device
+    dtype: torch.dtype, round_scales_to_power_of_2: bool, device
 ):
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -33,21 +33,15 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
-if not _DEVICES:
-    _DEVICES = [
-        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
-    ]
-
-
-@pytest.fixture(scope="module", params=_DEVICES)
-def device(request):
-    return request.param
+_GPU_DEVICE = (
+    str(torch.accelerator.current_accelerator())
+    if torch.accelerator.is_available()
+    else "no_gpu"
+)
 
 
 def _test_compile_base(
@@ -55,7 +49,7 @@ def _test_compile_base(
     fullgraph: bool,
     config: Float8LinearConfig,
     dtype: torch.dtype,
-    device,
+    device: str,
 ):
     random.seed(0)
     torch.manual_seed(0)
@@ -107,9 +101,8 @@ def test_eager_only(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device,
 ):
-    if not emulate and device == "cuda" and not is_sm_at_least_89():
+    if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
     torch._dynamo.reset()
@@ -124,7 +117,7 @@ def test_eager_only(
         fullgraph,
         config,
         dtype,
-        device,
+        _GPU_DEVICE,
     )
 
 
@@ -148,9 +141,8 @@ def test_aot_eager(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device,
 ):
-    if not emulate and device == "cuda" and not is_sm_at_least_89():
+    if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
     torch._dynamo.reset()
@@ -165,7 +157,7 @@ def test_aot_eager(
         fullgraph,
         config,
         dtype,
-        device,
+        _GPU_DEVICE,
     )
 
 
@@ -193,7 +185,6 @@ def test_inductor_from_config_params(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -207,7 +198,7 @@ def test_inductor_from_config_params(
         fullgraph,
         config,
         dtype,
-        device,
+        _GPU_DEVICE,
     )
 
 
@@ -227,7 +218,7 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-def test_inductor_from_recipe(recipe_name, device):
+def test_inductor_from_recipe(recipe_name):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -237,7 +228,7 @@ def test_inductor_from_recipe(recipe_name, device):
         fullgraph,
         config,
         dtype,
-        device,
+        _GPU_DEVICE,
     )
 
 
@@ -266,19 +257,15 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=True).to(device)
-                compiled_mod = copy.deepcopy(mod)
-                compiled_mod = torch.compile(compiled_mod, backend=cnts)
-                x = torch.randn(16, 16, device=device)
-                y_eager = mod(x)
-                y_compiled = compiled_mod(x)
-                self.assertEqual(
-                    cnts.frame_count, 2, "Compiled graph should have 2 frames!"
-                )
-                torch.testing.assert_close(y_eager, y_compiled)
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=True).to(_GPU_DEVICE)
+        compiled_mod = copy.deepcopy(mod)
+        compiled_mod = torch.compile(compiled_mod, backend=cnts)
+        x = torch.randn(16, 16, device=_GPU_DEVICE)
+        y_eager = mod(x)
+        y_compiled = compiled_mod(x)
+        self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
+        torch.testing.assert_close(y_eager, y_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -287,25 +274,23 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_input(self):
         """Test that having Float8TrainingTensor object as a graph input"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
 
-                def to_float(x):
-                    return x.to_original_precision()
+        def to_float(x):
+            return x.to_original_precision()
 
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=False).to(device)
-                x = torch.randn(2, 2, device=device)
-                compiled_to_float = torch.compile(to_float, backend=cnts)
-                y = mod(x)
-                y2_eager = to_float(y)
-                y2_compiled = compiled_to_float(y)
-                self.assertEqual(
-                    cnts.frame_count,
-                    1,
-                    "to_float was not compiled into 1 frame and likely encountered a skip!",
-                )
-                torch.testing.assert_close(y2_eager, y2_compiled)
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=False).to(_GPU_DEVICE)
+        x = torch.randn(2, 2, device=_GPU_DEVICE)
+        compiled_to_float = torch.compile(to_float, backend=cnts)
+        y = mod(x)
+        y2_eager = to_float(y)
+        y2_compiled = compiled_to_float(y)
+        self.assertEqual(
+            cnts.frame_count,
+            1,
+            "to_float was not compiled into 1 frame and likely encountered a skip!",
+        )
+        torch.testing.assert_close(y2_eager, y2_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -314,33 +299,29 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=False).to(device)
-                compiled_mod = torch.compile(mod, backend=cnts)
-                x = torch.randn(16, 16, device=device)
-                y_compiled = compiled_mod(x)
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=False).to(_GPU_DEVICE)
+        compiled_mod = torch.compile(mod, backend=cnts)
+        x = torch.randn(16, 16, device=_GPU_DEVICE)
+        y_compiled = compiled_mod(x)
 
-                self.assertEqual(
-                    cnts.frame_count, 1, "Compiled graph should have 1 frame!"
-                )
-                tensors, ctx = y_compiled.__tensor_flatten__()
-                for tensor in tensors:
-                    assert not isinstance(
-                        getattr(y_compiled, tensor),
-                        torch._subclasses.fake_tensor.FakeTensor,
-                    ), "Float8TrainingTensor should not contain any FakeTensors!"
-                assert isinstance(y_compiled._orig_dtype, torch.dtype), (
-                    "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
-                        type(y_compiled._orig_dtype)
-                    )
-                )
-                assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
-                    "Float8TrainingTensor._emulate should be a bool but got {}".format(
-                        type(y_compiled._linear_mm_config.output.emulate)
-                    )
-                )
+        self.assertEqual(cnts.frame_count, 1, "Compiled graph should have 1 frame!")
+        tensors, ctx = y_compiled.__tensor_flatten__()
+        for tensor in tensors:
+            assert not isinstance(
+                getattr(y_compiled, tensor),
+                torch._subclasses.fake_tensor.FakeTensor,
+            ), "Float8TrainingTensor should not contain any FakeTensors!"
+        assert isinstance(y_compiled._orig_dtype, torch.dtype), (
+            "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
+                type(y_compiled._orig_dtype)
+            )
+        )
+        assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
+            "Float8TrainingTensor._emulate should be a bool but got {}".format(
+                type(y_compiled._linear_mm_config.output.emulate)
+            )
+        )
 
 
 class capture_stderr(list):
@@ -381,11 +362,11 @@ class capture_stderr(list):
     "CUDA not available",
 )
 def test_dynamic_scale_numeric_parity(
-    dtype: torch.dtype, round_scales_to_power_of_2: bool, device
+    dtype: torch.dtype, round_scales_to_power_of_2: bool
 ):
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)
-    hp_tensor1 = torch.randn(16, 16, device=device, dtype=dtype)
+    hp_tensor1 = torch.randn(16, 16, device=_GPU_DEVICE, dtype=dtype)
     hp_tensor2 = hp_tensor1.detach().clone()
     float8_config = Float8LinearConfig(
         cast_config_weight=CastConfig(scaling_type=scaling_type_weight),

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -97,7 +97,7 @@ def _test_compile_base(
     "scaling_type_grad_output",
     [ScalingType.DYNAMIC],
 )
-@pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
+@pytest.mark.parametrize("emulate", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 def test_eager_only(
@@ -109,6 +109,9 @@ def test_eager_only(
     dtype: torch.dtype,
     device,
 ):
+    if not emulate and device == "cuda" and not is_sm_at_least_89():
+        pytest.skip("CUDA capability >= 8.9 required for native float8 support")
+
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -126,7 +129,7 @@ def test_eager_only(
 
 
 @pytest.mark.parametrize("fullgraph", [True])
-@pytest.mark.parametrize("emulate", [False, True] if is_sm_at_least_89() else [True])
+@pytest.mark.parametrize("emulate", [False, True])
 @pytest.mark.parametrize("scaling_type_input", [ScalingType.DYNAMIC])
 @pytest.mark.parametrize(
     "scaling_type_weight",
@@ -147,6 +150,9 @@ def test_aot_eager(
     dtype: torch.dtype,
     device,
 ):
+    if not emulate and device == "cuda" and not is_sm_at_least_89():
+        pytest.skip("CUDA capability >= 8.9 required for native float8 support")
+
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -280,7 +280,7 @@ class TestGraphBreaks(DynamoTestCase):
         "CUDA with float8 support not available",
     )
     def test_float8_graph_input(self):
-        # """Test that having Float8TrainingTensor object as a graph input"""
+        """Test that having Float8TrainingTensor object as a graph input"""
         for device in _DEVICES:
             with self.subTest(device=device):
 

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -33,16 +33,9 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
-
-# Skip the first device (CPU) since we only want accelerator devices for these tests
-_DEVICES = get_available_devices()[1:]
-
-if not _DEVICES:
-    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 def _test_compile_base(
@@ -95,7 +88,6 @@ def _test_compile_base(
 @pytest.mark.parametrize("emulate", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _DEVICES)
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -103,8 +95,8 @@ def test_eager_only(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: str,
 ):
+    device = str(torch.accelerator.current_accelerator())
     if not emulate and device == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
@@ -137,7 +129,6 @@ def test_eager_only(
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
-@pytest.mark.parametrize("device", _DEVICES)
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -145,8 +136,8 @@ def test_aot_eager(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: str,
 ):
+    device = str(torch.accelerator.current_accelerator())
     if not emulate and device == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
@@ -183,7 +174,6 @@ def test_aot_eager(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA capability >= 8.9 required for native float8 support",
 )
-@pytest.mark.parametrize("device", _DEVICES)
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -191,8 +181,8 @@ def test_inductor_from_config_params(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
-    device: str,
 ):
+    device = str(torch.accelerator.current_accelerator())
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -225,8 +215,8 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-@pytest.mark.parametrize("device", _DEVICES)
-def test_inductor_from_recipe(recipe_name, device: str):
+def test_inductor_from_recipe(recipe_name):
+    device = str(torch.accelerator.current_accelerator())
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -265,19 +255,16 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=True).to(device)
-                compiled_mod = copy.deepcopy(mod)
-                compiled_mod = torch.compile(compiled_mod, backend=cnts)
-                x = torch.randn(16, 16, device=device)
-                y_eager = mod(x)
-                y_compiled = compiled_mod(x)
-                self.assertEqual(
-                    cnts.frame_count, 2, "Compiled graph should have 2 frames!"
-                )
-                torch.testing.assert_close(y_eager, y_compiled)
+        device = str(torch.accelerator.current_accelerator())
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=True).to(device)
+        compiled_mod = copy.deepcopy(mod)
+        compiled_mod = torch.compile(compiled_mod, backend=cnts)
+        x = torch.randn(16, 16, device=device)
+        y_eager = mod(x)
+        y_compiled = compiled_mod(x)
+        self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
+        torch.testing.assert_close(y_eager, y_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -286,25 +273,24 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_input(self):
         """Test that having Float8TrainingTensor object as a graph input"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
+        device = str(torch.accelerator.current_accelerator())
 
-                def to_float(x):
-                    return x.to_original_precision()
+        def to_float(x):
+            return x.to_original_precision()
 
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=False).to(device)
-                x = torch.randn(2, 2, device=device)
-                compiled_to_float = torch.compile(to_float, backend=cnts)
-                y = mod(x)
-                y2_eager = to_float(y)
-                y2_compiled = compiled_to_float(y)
-                self.assertEqual(
-                    cnts.frame_count,
-                    1,
-                    "to_float was not compiled into 1 frame and likely encountered a skip!",
-                )
-                torch.testing.assert_close(y2_eager, y2_compiled)
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=False).to(device)
+        x = torch.randn(2, 2, device=device)
+        compiled_to_float = torch.compile(to_float, backend=cnts)
+        y = mod(x)
+        y2_eager = to_float(y)
+        y2_compiled = compiled_to_float(y)
+        self.assertEqual(
+            cnts.frame_count,
+            1,
+            "to_float was not compiled into 1 frame and likely encountered a skip!",
+        )
+        torch.testing.assert_close(y2_eager, y2_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -313,33 +299,30 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""
-        for device in _DEVICES:
-            with self.subTest(device=device):
-                cnts = CompileCounterWithBackend("inductor")
-                mod = self.MockLinear(graph_break=False).to(device)
-                compiled_mod = torch.compile(mod, backend=cnts)
-                x = torch.randn(16, 16, device=device)
-                y_compiled = compiled_mod(x)
+        device = str(torch.accelerator.current_accelerator())
+        cnts = CompileCounterWithBackend("inductor")
+        mod = self.MockLinear(graph_break=False).to(device)
+        compiled_mod = torch.compile(mod, backend=cnts)
+        x = torch.randn(16, 16, device=device)
+        y_compiled = compiled_mod(x)
 
-                self.assertEqual(
-                    cnts.frame_count, 1, "Compiled graph should have 1 frame!"
-                )
-                tensors, ctx = y_compiled.__tensor_flatten__()
-                for tensor in tensors:
-                    assert not isinstance(
-                        getattr(y_compiled, tensor),
-                        torch._subclasses.fake_tensor.FakeTensor,
-                    ), "Float8TrainingTensor should not contain any FakeTensors!"
-                assert isinstance(y_compiled._orig_dtype, torch.dtype), (
-                    "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
-                        type(y_compiled._orig_dtype)
-                    )
-                )
-                assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
-                    "Float8TrainingTensor._emulate should be a bool but got {}".format(
-                        type(y_compiled._linear_mm_config.output.emulate)
-                    )
-                )
+        self.assertEqual(cnts.frame_count, 1, "Compiled graph should have 1 frame!")
+        tensors, ctx = y_compiled.__tensor_flatten__()
+        for tensor in tensors:
+            assert not isinstance(
+                getattr(y_compiled, tensor),
+                torch._subclasses.fake_tensor.FakeTensor,
+            ), "Float8TrainingTensor should not contain any FakeTensors!"
+        assert isinstance(y_compiled._orig_dtype, torch.dtype), (
+            "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
+                type(y_compiled._orig_dtype)
+            )
+        )
+        assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
+            "Float8TrainingTensor._emulate should be a bool but got {}".format(
+                type(y_compiled._linear_mm_config.output.emulate)
+            )
+        )
 
 
 class capture_stderr(list):
@@ -379,10 +362,10 @@ class capture_stderr(list):
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA capability >= 8.9 required for native float8 support",
 )
-@pytest.mark.parametrize("device", _DEVICES)
 def test_dynamic_scale_numeric_parity(
-    dtype: torch.dtype, round_scales_to_power_of_2: bool, device: str
+    dtype: torch.dtype, round_scales_to_power_of_2: bool
 ):
+    device = str(torch.accelerator.current_accelerator())
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)
     hp_tensor1 = torch.randn(16, 16, device=device, dtype=dtype)

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -176,7 +176,7 @@ def test_aot_eager(
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 @unittest.skipIf(
     torch.cuda.is_available() and not is_sm_at_least_89(),
-    "CUDA with float8 support not available",
+    "CUDA capability >= 8.9 required for native float8 support",
 )
 def test_inductor_from_config_params(
     fullgraph,
@@ -270,7 +270,7 @@ class TestGraphBreaks(DynamoTestCase):
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_float8_graph_input(self):
         """Test that having Float8TrainingTensor object as a graph input"""
@@ -295,7 +295,7 @@ class TestGraphBreaks(DynamoTestCase):
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
-        "CUDA with float8 support not available",
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -33,15 +33,16 @@ from torchao.float8.float8_training_tensor import (
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
+    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_GPU_DEVICE = (
-    str(torch.accelerator.current_accelerator())
-    if torch.accelerator.is_available()
-    else "no_gpu"
-)
+# Skip the first device (CPU) since we only want accelerator devices for these tests
+_DEVICES = get_available_devices()[1:]
+
+if not _DEVICES:
+    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 def _test_compile_base(
@@ -94,6 +95,7 @@ def _test_compile_base(
 @pytest.mark.parametrize("emulate", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@pytest.mark.parametrize("device", _DEVICES)
 def test_eager_only(
     fullgraph,
     emulate: bool,
@@ -101,8 +103,9 @@ def test_eager_only(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: str,
 ):
-    if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
+    if not emulate and device == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
     torch._dynamo.reset()
@@ -117,7 +120,7 @@ def test_eager_only(
         fullgraph,
         config,
         dtype,
-        _GPU_DEVICE,
+        device,
     )
 
 
@@ -134,6 +137,7 @@ def test_eager_only(
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@pytest.mark.parametrize("device", _DEVICES)
 def test_aot_eager(
     fullgraph,
     emulate: bool,
@@ -141,8 +145,9 @@ def test_aot_eager(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: str,
 ):
-    if not emulate and _GPU_DEVICE == "cuda" and not is_sm_at_least_89():
+    if not emulate and device == "cuda" and not is_sm_at_least_89():
         pytest.skip("CUDA capability >= 8.9 required for native float8 support")
 
     torch._dynamo.reset()
@@ -157,7 +162,7 @@ def test_aot_eager(
         fullgraph,
         config,
         dtype,
-        _GPU_DEVICE,
+        device,
     )
 
 
@@ -178,6 +183,7 @@ def test_aot_eager(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     "CUDA capability >= 8.9 required for native float8 support",
 )
+@pytest.mark.parametrize("device", _DEVICES)
 def test_inductor_from_config_params(
     fullgraph,
     emulate: bool,
@@ -185,6 +191,7 @@ def test_inductor_from_config_params(
     scaling_type_weight: ScalingType,
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
+    device: str,
 ):
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
@@ -198,7 +205,7 @@ def test_inductor_from_config_params(
         fullgraph,
         config,
         dtype,
-        _GPU_DEVICE,
+        device,
     )
 
 
@@ -218,7 +225,8 @@ def test_inductor_from_config_params(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     "CUDA with capability 9.0 or greater not available",
 )
-def test_inductor_from_recipe(recipe_name):
+@pytest.mark.parametrize("device", _DEVICES)
+def test_inductor_from_recipe(recipe_name, device: str):
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -228,7 +236,7 @@ def test_inductor_from_recipe(recipe_name):
         fullgraph,
         config,
         dtype,
-        _GPU_DEVICE,
+        device,
     )
 
 
@@ -257,15 +265,19 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=True).to(_GPU_DEVICE)
-        compiled_mod = copy.deepcopy(mod)
-        compiled_mod = torch.compile(compiled_mod, backend=cnts)
-        x = torch.randn(16, 16, device=_GPU_DEVICE)
-        y_eager = mod(x)
-        y_compiled = compiled_mod(x)
-        self.assertEqual(cnts.frame_count, 2, "Compiled graph should have 2 frames!")
-        torch.testing.assert_close(y_eager, y_compiled)
+        for device in _DEVICES:
+            with self.subTest(device=device):
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=True).to(device)
+                compiled_mod = copy.deepcopy(mod)
+                compiled_mod = torch.compile(compiled_mod, backend=cnts)
+                x = torch.randn(16, 16, device=device)
+                y_eager = mod(x)
+                y_compiled = compiled_mod(x)
+                self.assertEqual(
+                    cnts.frame_count, 2, "Compiled graph should have 2 frames!"
+                )
+                torch.testing.assert_close(y_eager, y_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -274,23 +286,25 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_input(self):
         """Test that having Float8TrainingTensor object as a graph input"""
+        for device in _DEVICES:
+            with self.subTest(device=device):
 
-        def to_float(x):
-            return x.to_original_precision()
+                def to_float(x):
+                    return x.to_original_precision()
 
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).to(_GPU_DEVICE)
-        x = torch.randn(2, 2, device=_GPU_DEVICE)
-        compiled_to_float = torch.compile(to_float, backend=cnts)
-        y = mod(x)
-        y2_eager = to_float(y)
-        y2_compiled = compiled_to_float(y)
-        self.assertEqual(
-            cnts.frame_count,
-            1,
-            "to_float was not compiled into 1 frame and likely encountered a skip!",
-        )
-        torch.testing.assert_close(y2_eager, y2_compiled)
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=False).to(device)
+                x = torch.randn(2, 2, device=device)
+                compiled_to_float = torch.compile(to_float, backend=cnts)
+                y = mod(x)
+                y2_eager = to_float(y)
+                y2_compiled = compiled_to_float(y)
+                self.assertEqual(
+                    cnts.frame_count,
+                    1,
+                    "to_float was not compiled into 1 frame and likely encountered a skip!",
+                )
+                torch.testing.assert_close(y2_eager, y2_compiled)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
@@ -299,29 +313,33 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""
-        cnts = CompileCounterWithBackend("inductor")
-        mod = self.MockLinear(graph_break=False).to(_GPU_DEVICE)
-        compiled_mod = torch.compile(mod, backend=cnts)
-        x = torch.randn(16, 16, device=_GPU_DEVICE)
-        y_compiled = compiled_mod(x)
+        for device in _DEVICES:
+            with self.subTest(device=device):
+                cnts = CompileCounterWithBackend("inductor")
+                mod = self.MockLinear(graph_break=False).to(device)
+                compiled_mod = torch.compile(mod, backend=cnts)
+                x = torch.randn(16, 16, device=device)
+                y_compiled = compiled_mod(x)
 
-        self.assertEqual(cnts.frame_count, 1, "Compiled graph should have 1 frame!")
-        tensors, ctx = y_compiled.__tensor_flatten__()
-        for tensor in tensors:
-            assert not isinstance(
-                getattr(y_compiled, tensor),
-                torch._subclasses.fake_tensor.FakeTensor,
-            ), "Float8TrainingTensor should not contain any FakeTensors!"
-        assert isinstance(y_compiled._orig_dtype, torch.dtype), (
-            "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
-                type(y_compiled._orig_dtype)
-            )
-        )
-        assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
-            "Float8TrainingTensor._emulate should be a bool but got {}".format(
-                type(y_compiled._linear_mm_config.output.emulate)
-            )
-        )
+                self.assertEqual(
+                    cnts.frame_count, 1, "Compiled graph should have 1 frame!"
+                )
+                tensors, ctx = y_compiled.__tensor_flatten__()
+                for tensor in tensors:
+                    assert not isinstance(
+                        getattr(y_compiled, tensor),
+                        torch._subclasses.fake_tensor.FakeTensor,
+                    ), "Float8TrainingTensor should not contain any FakeTensors!"
+                assert isinstance(y_compiled._orig_dtype, torch.dtype), (
+                    "Float8TrainingTensor._orig_dtype should be a dtype but got {}".format(
+                        type(y_compiled._orig_dtype)
+                    )
+                )
+                assert isinstance(y_compiled._linear_mm_config.output.emulate, bool), (
+                    "Float8TrainingTensor._emulate should be a bool but got {}".format(
+                        type(y_compiled._linear_mm_config.output.emulate)
+                    )
+                )
 
 
 class capture_stderr(list):
@@ -359,14 +377,15 @@ class capture_stderr(list):
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 @unittest.skipIf(
     torch.cuda.is_available() and not is_sm_at_least_89(),
-    "CUDA not available",
+    "CUDA capability >= 8.9 required for native float8 support",
 )
+@pytest.mark.parametrize("device", _DEVICES)
 def test_dynamic_scale_numeric_parity(
-    dtype: torch.dtype, round_scales_to_power_of_2: bool
+    dtype: torch.dtype, round_scales_to_power_of_2: bool, device: str
 ):
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)
-    hp_tensor1 = torch.randn(16, 16, device=_GPU_DEVICE, dtype=dtype)
+    hp_tensor1 = torch.randn(16, 16, device=device, dtype=dtype)
     hp_tensor2 = hp_tensor1.detach().clone()
     float8_config = Float8LinearConfig(
         cast_config_weight=CastConfig(scaling_type=scaling_type_weight),

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -85,7 +85,10 @@ def _test_compile_base(
     "scaling_type_grad_output",
     [ScalingType.DYNAMIC],
 )
-@pytest.mark.parametrize("emulate", [True, False])
+@pytest.mark.parametrize(
+    "emulate",
+    [False, True] if is_sm_at_least_89() or torch.xpu.is_available() else [True],
+)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 def test_eager_only(
@@ -96,10 +99,7 @@ def test_eager_only(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = str(torch.accelerator.current_accelerator())
-    if not emulate and device == "cuda" and not is_sm_at_least_89():
-        pytest.skip("CUDA capability >= 8.9 required for native float8 support")
-
+    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -117,7 +117,10 @@ def test_eager_only(
 
 
 @pytest.mark.parametrize("fullgraph", [True])
-@pytest.mark.parametrize("emulate", [False, True])
+@pytest.mark.parametrize(
+    "emulate",
+    [False, True] if is_sm_at_least_89() or torch.xpu.is_available() else [True],
+)
 @pytest.mark.parametrize("scaling_type_input", [ScalingType.DYNAMIC])
 @pytest.mark.parametrize(
     "scaling_type_weight",
@@ -137,10 +140,7 @@ def test_aot_eager(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = str(torch.accelerator.current_accelerator())
-    if not emulate and device == "cuda" and not is_sm_at_least_89():
-        pytest.skip("CUDA capability >= 8.9 required for native float8 support")
-
+    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -182,7 +182,7 @@ def test_inductor_from_config_params(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = str(torch.accelerator.current_accelerator())
+    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -216,7 +216,7 @@ def test_inductor_from_config_params(
     "CUDA with capability 9.0 or greater not available",
 )
 def test_inductor_from_recipe(recipe_name):
-    device = str(torch.accelerator.current_accelerator())
+    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -248,6 +248,7 @@ class TestGraphBreaks(DynamoTestCase):
                 return x_hp
             return x_fp8
 
+    # TODO(future): figure out why the test below fails on CUDA capability 8.9
     @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_90(),
@@ -255,7 +256,7 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_with_graph_break_in_the_middle(self):
         """Test that having Float8TrainingTensor object at the boundary of a subgraph"""
-        device = str(torch.accelerator.current_accelerator())
+        device = torch.accelerator.current_accelerator()
         cnts = CompileCounterWithBackend("inductor")
         mod = self.MockLinear(graph_break=True).to(device)
         compiled_mod = copy.deepcopy(mod)
@@ -273,7 +274,7 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_input(self):
         """Test that having Float8TrainingTensor object as a graph input"""
-        device = str(torch.accelerator.current_accelerator())
+        device = torch.accelerator.current_accelerator()
 
         def to_float(x):
             return x.to_original_precision()
@@ -299,7 +300,7 @@ class TestGraphBreaks(DynamoTestCase):
     )
     def test_float8_graph_output(self):
         """Test that having Float8TrainingTensor object as a graph output works"""
-        device = str(torch.accelerator.current_accelerator())
+        device = torch.accelerator.current_accelerator()
         cnts = CompileCounterWithBackend("inductor")
         mod = self.MockLinear(graph_break=False).to(device)
         compiled_mod = torch.compile(mod, backend=cnts)
@@ -365,7 +366,7 @@ class capture_stderr(list):
 def test_dynamic_scale_numeric_parity(
     dtype: torch.dtype, round_scales_to_power_of_2: bool
 ):
-    device = str(torch.accelerator.current_accelerator())
+    device = torch.accelerator.current_accelerator()
     scaling_type_weight = ScalingType.DYNAMIC
     torch.manual_seed(42)
     hp_tensor1 = torch.randn(16, 16, device=device, dtype=dtype)

--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -43,12 +43,12 @@ def _test_compile_base(
     fullgraph: bool,
     config: Float8LinearConfig,
     dtype: torch.dtype,
-    device: str,
 ):
     random.seed(0)
     torch.manual_seed(0)
     x_shape = (16, 16)
     linear_dtype = torch.bfloat16
+    device = torch.accelerator.current_accelerator()
 
     x = torch.randn(*x_shape, device=device, dtype=linear_dtype).requires_grad_()
     x_ref = copy.deepcopy(x)
@@ -99,7 +99,6 @@ def test_eager_only(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -112,7 +111,6 @@ def test_eager_only(
         fullgraph,
         config,
         dtype,
-        device,
     )
 
 
@@ -140,7 +138,6 @@ def test_aot_eager(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -153,7 +150,6 @@ def test_aot_eager(
         fullgraph,
         config,
         dtype,
-        device,
     )
 
 
@@ -182,7 +178,6 @@ def test_inductor_from_config_params(
     scaling_type_grad_output: ScalingType,
     dtype: torch.dtype,
 ):
-    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = get_test_float8_linear_config(
         scaling_type_input,
@@ -195,7 +190,6 @@ def test_inductor_from_config_params(
         fullgraph,
         config,
         dtype,
-        device,
     )
 
 
@@ -216,7 +210,6 @@ def test_inductor_from_config_params(
     "CUDA with capability 9.0 or greater not available",
 )
 def test_inductor_from_recipe(recipe_name):
-    device = torch.accelerator.current_accelerator()
     torch._dynamo.reset()
     config = Float8LinearConfig.from_recipe_name(recipe_name)
     fullgraph = True
@@ -226,7 +219,6 @@ def test_inductor_from_recipe(recipe_name):
         fullgraph,
         config,
         dtype,
-        device,
     )
 
 

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -26,12 +26,10 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_gpu_devices,
+    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
-
-_GPU_DEVICES = get_gpu_devices()
 
 torch.manual_seed(0)
 
@@ -162,7 +160,7 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "requires SM89 compatible machine",
     )
-    @pytest.mark.parametrize("device", _GPU_DEVICES)
+    @pytest.mark.parametrize("device", get_available_devices(False))
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
@@ -191,7 +189,7 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "requires SM90 compatible machine",
     )
-    @pytest.mark.parametrize("device", _GPU_DEVICES)
+    @pytest.mark.parametrize("device", get_available_devices(False))
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -7,6 +7,7 @@
 # Tests LLaMa FeedForward numerics with float8
 
 import copy
+import unittest
 from typing import Optional
 
 import pytest
@@ -25,9 +26,12 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
+    get_current_accelerator_device,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
+
+_GPU_DEVICE = [str(get_current_accelerator_device())]
 
 torch.manual_seed(0)
 
@@ -78,7 +82,7 @@ class FeedForward(nn.Module):
 
 
 class TestFloat8NumericsIntegrationTest:
-    def _test_impl(self, config: Float8LinearConfig) -> None:
+    def _test_impl(self, config: Float8LinearConfig, device: str) -> None:
         data_dtype = torch.bfloat16
         # LLaMa 3 70B shapes
         model_ref = (
@@ -88,7 +92,7 @@ class TestFloat8NumericsIntegrationTest:
                 multiple_of=1024,
                 ffn_dim_multiplier=1.3,
             )
-            .cuda()
+            .to(device)
             .to(data_dtype)
         )
 
@@ -109,8 +113,8 @@ class TestFloat8NumericsIntegrationTest:
         # logic of delayed scaling behaves as dynamic scaling
         # TODO(future PR): delete ^, since we deleted delayed scaling
         shape = (1, 8192, 4096)
-        data1 = torch.randn(*shape, device="cuda", dtype=data_dtype)
-        data2 = torch.randn(*shape, device="cuda", dtype=data_dtype)
+        data1 = torch.randn(*shape, device=device, dtype=data_dtype)
+        data2 = torch.randn(*shape, device=device, dtype=data_dtype)
 
         model_ref(data1).sum().backward()
         # zero out grads without stepping, since we just want to compare grads
@@ -153,15 +157,19 @@ class TestFloat8NumericsIntegrationTest:
         "scaling_type_grad_output",
         [ScalingType.DYNAMIC],
     )
-    @pytest.mark.skipif(
-        not is_sm_at_least_89(), reason="requires SM89 compatible machine"
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "requires SM89 compatible machine",
     )
+    @pytest.mark.parametrize("device", _GPU_DEVICE)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
+        device: str,
     ):
         config = get_test_float8_linear_config(
             scaling_type_input,
@@ -169,7 +177,7 @@ class TestFloat8NumericsIntegrationTest:
             scaling_type_grad_output,
             emulate=False,
         )
-        self._test_impl(config)
+        self._test_impl(config, device)
 
     @pytest.mark.parametrize(
         "recipe_name",
@@ -178,16 +186,20 @@ class TestFloat8NumericsIntegrationTest:
             Float8LinearRecipeName.ROWWISE_WITH_GW_HP,
         ],
     )
-    @pytest.mark.skipif(
-        not is_sm_at_least_90(), reason="requires SM90 compatible machine"
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not is_sm_at_least_90(),
+        "requires SM90 compatible machine",
     )
+    @pytest.mark.parametrize("device", _GPU_DEVICE)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,
+        device: str,
     ):
         config = Float8LinearConfig.from_recipe_name(recipe_name)
-        self._test_impl(config)
+        self._test_impl(config, device)
 
 
 if __name__ == "__main__":

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -26,12 +26,12 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_current_accelerator_device,
+    get_gpu_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
-_GPU_DEVICE = [str(get_current_accelerator_device())]
+_GPU_DEVICES = get_gpu_devices()
 
 torch.manual_seed(0)
 
@@ -162,7 +162,7 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "requires SM89 compatible machine",
     )
-    @pytest.mark.parametrize("device", _GPU_DEVICE)
+    @pytest.mark.parametrize("device", _GPU_DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
@@ -191,7 +191,7 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "requires SM90 compatible machine",
     )
-    @pytest.mark.parametrize("device", _GPU_DEVICE)
+    @pytest.mark.parametrize("device", _GPU_DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -33,6 +33,8 @@ from torchao.utils import (
 
 torch.manual_seed(0)
 
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
 
 # copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py
 class FeedForward(nn.Module):
@@ -160,14 +162,14 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "requires SM89 compatible machine",
     )
-    @pytest.mark.parametrize("device", get_available_devices(False))
+    @pytest.mark.parametrize("device", _DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
-        device: str,
+        device,
     ):
         config = get_test_float8_linear_config(
             scaling_type_input,
@@ -189,12 +191,12 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "requires SM90 compatible machine",
     )
-    @pytest.mark.parametrize("device", get_available_devices(False))
+    @pytest.mark.parametrize("device", _DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,
-        device: str,
+        device,
     ):
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_impl(config, device)

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -34,6 +34,10 @@ from torchao.utils import (
 torch.manual_seed(0)
 
 _DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+if not _DEVICES:
+    _DEVICES = [
+        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
+    ]
 
 
 # copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -26,18 +26,17 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
 torch.manual_seed(0)
 
-_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
-if not _DEVICES:
-    _DEVICES = [
-        pytest.param("no_gpu", marks=pytest.mark.skip(reason="GPU not available"))
-    ]
+_GPU_DEVICE = (
+    str(torch.accelerator.current_accelerator())
+    if torch.accelerator.is_available()
+    else "no_gpu"
+)
 
 
 # copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py
@@ -166,14 +165,12 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "requires SM89 compatible machine",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
-        device,
     ):
         config = get_test_float8_linear_config(
             scaling_type_input,
@@ -181,7 +178,7 @@ class TestFloat8NumericsIntegrationTest:
             scaling_type_grad_output,
             emulate=False,
         )
-        self._test_impl(config, device)
+        self._test_impl(config, _GPU_DEVICE)
 
     @pytest.mark.parametrize(
         "recipe_name",
@@ -195,15 +192,13 @@ class TestFloat8NumericsIntegrationTest:
         torch.cuda.is_available() and not is_sm_at_least_90(),
         "requires SM90 compatible machine",
     )
-    @pytest.mark.parametrize("device", _DEVICES)
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,
-        device,
     ):
         config = Float8LinearConfig.from_recipe_name(recipe_name)
-        self._test_impl(config, device)
+        self._test_impl(config, _GPU_DEVICE)
 
 
 if __name__ == "__main__":

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -26,18 +26,11 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
-    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
 torch.manual_seed(0)
-
-# Skip the first device (CPU) since we only want accelerator devices for these tests
-_DEVICES = get_available_devices()[1:]
-
-if not _DEVICES:
-    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 # copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py
@@ -167,14 +160,13 @@ class TestFloat8NumericsIntegrationTest:
         "requires SM89 compatible machine",
     )
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
-        device: str,
     ):
+        device = str(torch.accelerator.current_accelerator())
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
@@ -196,12 +188,11 @@ class TestFloat8NumericsIntegrationTest:
         "requires SM90 compatible machine",
     )
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
-    @pytest.mark.parametrize("device", _DEVICES)
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,
-        device: str,
     ):
+        device = str(torch.accelerator.current_accelerator())
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_impl(config, device)
 

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -166,7 +166,7 @@ class TestFloat8NumericsIntegrationTest:
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
     ):
-        device = str(torch.accelerator.current_accelerator())
+        device = torch.accelerator.current_accelerator()
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
@@ -192,7 +192,7 @@ class TestFloat8NumericsIntegrationTest:
         self,
         recipe_name: str,
     ):
-        device = str(torch.accelerator.current_accelerator())
+        device = torch.accelerator.current_accelerator()
         config = Float8LinearConfig.from_recipe_name(recipe_name)
         self._test_impl(config, device)
 

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -26,17 +26,18 @@ from torchao.float8.float8_linear_utils import (
 from torchao.float8.float8_utils import IS_ROCM, compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
+    get_available_devices,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
 
 torch.manual_seed(0)
 
-_GPU_DEVICE = (
-    str(torch.accelerator.current_accelerator())
-    if torch.accelerator.is_available()
-    else "no_gpu"
-)
+# Skip the first device (CPU) since we only want accelerator devices for these tests
+_DEVICES = get_available_devices()[1:]
+
+if not _DEVICES:
+    _DEVICES = [pytest.param("cpu", marks=pytest.mark.skip(reason="GPU not available"))]
 
 
 # copied from https://github.com/pytorch/torchtitan/blob/main/torchtitan/models/llama/model.py
@@ -166,11 +167,13 @@ class TestFloat8NumericsIntegrationTest:
         "requires SM89 compatible machine",
     )
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
+        device: str,
     ):
         config = get_test_float8_linear_config(
             scaling_type_input,
@@ -178,7 +181,7 @@ class TestFloat8NumericsIntegrationTest:
             scaling_type_grad_output,
             emulate=False,
         )
-        self._test_impl(config, _GPU_DEVICE)
+        self._test_impl(config, device)
 
     @pytest.mark.parametrize(
         "recipe_name",
@@ -193,12 +196,14 @@ class TestFloat8NumericsIntegrationTest:
         "requires SM90 compatible machine",
     )
     @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
+    @pytest.mark.parametrize("device", _DEVICES)
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,
+        device: str,
     ):
         config = Float8LinearConfig.from_recipe_name(recipe_name)
-        self._test_impl(config, _GPU_DEVICE)
+        self._test_impl(config, device)
 
 
 if __name__ == "__main__":

--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -79,7 +79,8 @@ class FeedForward(nn.Module):
 
 
 class TestFloat8NumericsIntegrationTest:
-    def _test_impl(self, config: Float8LinearConfig, device: str) -> None:
+    def _test_impl(self, config: Float8LinearConfig) -> None:
+        device = torch.accelerator.current_accelerator()
         data_dtype = torch.bfloat16
         # LLaMa 3 70B shapes
         model_ref = (
@@ -166,14 +167,13 @@ class TestFloat8NumericsIntegrationTest:
         scaling_type_weight: ScalingType,
         scaling_type_grad_output: ScalingType,
     ):
-        device = torch.accelerator.current_accelerator()
         config = get_test_float8_linear_config(
             scaling_type_input,
             scaling_type_weight,
             scaling_type_grad_output,
             emulate=False,
         )
-        self._test_impl(config, device)
+        self._test_impl(config)
 
     @pytest.mark.parametrize(
         "recipe_name",
@@ -192,9 +192,8 @@ class TestFloat8NumericsIntegrationTest:
         self,
         recipe_name: str,
     ):
-        device = torch.accelerator.current_accelerator()
         config = Float8LinearConfig.from_recipe_name(recipe_name)
-        self._test_impl(config, device)
+        self._test_impl(config)
 
 
 if __name__ == "__main__":

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -152,8 +152,10 @@ def profiler_runner(path, fn, *args, **kwargs):
     return result
 
 
-def get_available_devices():
-    devices = ["cpu"]
+def get_available_devices(include_cpu=True):
+    devices = []
+    if include_cpu:
+        devices.append("cpu")
     if torch.cuda.is_available():
         devices.append("cuda")
     elif torch.xpu.is_available():
@@ -162,6 +164,8 @@ def get_available_devices():
         devices.append("mps")
     return devices
 
+def get_gpu_devices():
+    return get_available_devices(include_cpu=False)
 
 def get_current_accelerator_device():
     assert torch.accelerator.is_available()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -152,10 +152,8 @@ def profiler_runner(path, fn, *args, **kwargs):
     return result
 
 
-def get_available_devices(include_cpu=True):
-    devices = []
-    if include_cpu:
-        devices.append("cpu")
+def get_available_devices():
+    devices = ["cpu"]
     if torch.cuda.is_available():
         devices.append("cuda")
     elif torch.xpu.is_available():

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -164,8 +164,6 @@ def get_available_devices(include_cpu=True):
         devices.append("mps")
     return devices
 
-def get_gpu_devices():
-    return get_available_devices(include_cpu=False)
 
 def get_current_accelerator_device():
     assert torch.accelerator.is_available()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -155,10 +155,8 @@ def profiler_runner(path, fn, *args, **kwargs):
     return result
 
 
-def get_available_devices(include_cpu=True):
-    devices = []
-    if include_cpu:
-        devices.append("cpu")
+def get_available_devices():
+    devices = ["cpu"]
     if torch.cuda.is_available():
         devices.append("cuda")
     elif torch.xpu.is_available():

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -155,8 +155,10 @@ def profiler_runner(path, fn, *args, **kwargs):
     return result
 
 
-def get_available_devices():
-    devices = ["cpu"]
+def get_available_devices(include_cpu=True):
+    devices = []
+    if include_cpu:
+        devices.append("cpu")
     if torch.cuda.is_available():
         devices.append("cuda")
     elif torch.xpu.is_available():
@@ -165,6 +167,8 @@ def get_available_devices():
         devices.append("mps")
     return devices
 
+def get_gpu_devices():
+    return get_available_devices(include_cpu=False)
 
 def get_current_accelerator_device():
     assert torch.accelerator.is_available()

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -167,8 +167,6 @@ def get_available_devices(include_cpu=True):
         devices.append("mps")
     return devices
 
-def get_gpu_devices():
-    return get_available_devices(include_cpu=False)
 
 def get_current_accelerator_device():
     assert torch.accelerator.is_available()


### PR DESCRIPTION
This PR activates a subset of float8 tests for Intel XPU as part of the [XPU Enabling Plan for TorchAO](https://github.com/pytorch/ao/issues/3576).

Details:
- The PR does not add any new test logic.
- It introduces a device parameter to allow running the tests on XPU.
- Unsupported scenarios are skipped.