### PR TITLE
[metal] Fix meta registration of lowbit ops

### DIFF
--- a/torchao/experimental/ops/mps/__init__.py
+++ b/torchao/experimental/ops/mps/__init__.py
@@ -1,3 +1,6 @@
 from torchao.experimental.ops.mps.utils import _load_torchao_mps_lib
 
 _load_torchao_mps_lib()
+
+# Import to register Meta implementations
+from torchao.experimental.ops.mps import mps_op_lib  # noqa: F401

--- a/torchao/experimental/ops/mps/mps_op_lib.py
+++ b/torchao/experimental/ops/mps/mps_op_lib.py
@@ -16,8 +16,8 @@ for nbit in range(1, 8):
         activations: Tensor,
         packed_weights: Tensor,
         group_size: int,
-        scales: int,
-        zeros: int,
+        scales: Tensor,
+        zeros: Tensor,
     ):
         assert activations.dtype in [torch.float32, torch.float16, torch.bfloat16]
         assert activations.is_contiguous()


### PR DESCRIPTION
**Problem**: AOTI was generating code with hardcoded shape constants (e.g., `625`) instead of dynamic shapes for the `torchao._linear_fp_act_4bit_weight` custom op.

**Root Cause**: The Meta implementation for the custom op was defined in `mps_op_lib.py` but never imported, so it was never registered with PyTorch.

**Fix**: Imported `mps_op_lib` in `torchao/experimental/ops/mps/__init__.py` to ensure the Meta implementation is registered when importing `torchao.experimental.ops.mps`. Also fixed the type annotations (in the Meta implementation) for `scales` and `zeros` (were incorrectly declared as `int` instead of `Tensor`).

**Result**: AOTI can now symbolically compute the output shape of the custom op during export (e.g., `[s18//8, 1024]` instead of `[625, 1024]`), allowing it to generate code with dynamic shapes that work correctly for variable sequence lengths.