### PR TITLE
Update quant_api.py

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1809,7 +1809,7 @@ def _intx_weight_only_transform(
 
 @dataclass
 class FqnToConfig(AOBaseConfig):
-    """Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
+    r"""Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
 
     Args:
         `fqn_to_config`: typing.OrderedDict[str, Optional[AOBaseConfig]]: an


### PR DESCRIPTION
Summary:
Trying to resolve

```
/data/users/jerryzh/ao/torchao/quantization/quant_api.py:1826: SyntaxWarning: invalid escape sequence '\.'
  * regex for parameter names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj.weight`.
```

Test Plan:

install pytorch: `pip install torch`
install torchao: https://github.com/pytorch/ao#-installation
install vllm: `pip install vllm`

use vllm `vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-8B --batch-size 32`

