### PR TITLE
Add HQQ option in UIntxWeightOnlyConfig

### DIFF
--- a/torchao/experimental/ops/mps/test/test_quantizer.py
+++ b/torchao/experimental/ops/mps/test/test_quantizer.py
@@ -13,7 +13,12 @@ from parameterized import parameterized
 
 # Need to import to load the ops
 import torchao.experimental.ops.mps  # noqa: F401
-from torchao.experimental.quant_api import UIntxWeightOnlyConfig, _quantize
+from torchao.experimental.quant_api import (
+    UIntxChooseQParamsAlgorithm,
+    UIntxWeightOnlyConfig,
+    UIntxWeightOnlyQuantizedLinear,
+    _quantize,
+)
 from torchao.quantization.quant_api import quantize_
 
 
@@ -197,6 +202,219 @@ class TestUIntxWeightOnlyLinearQuantizer(unittest.TestCase):
 
             # Compare results
             torch.testing.assert_close(result.cpu(), expected, rtol=0.01, atol=0.01)
+
+    @parameterized.expand([4])  # HQQ is optimized for 4-bit
+    def test_hqq_accuracy(self, nbit):
+        """Test that HQQ quantization produces results consistent with the kernel contract.
+
+        The kernel expects: W_dequant = W_q * scale + zeros
+        HQQ with raw_output=True gives: W_dequant = (W_q - zero) * scale
+        We convert: zeros = -zero * scale to match the kernel format.
+
+        This test verifies that:
+        1. HQQ quantization runs without error
+        2. The quantized model produces output reasonably close to the original
+        3. The output is not corrupted (which would indicate format mismatch)
+        """
+        group_size = 32
+        m = 3
+        n = 12
+        k = 64
+        with torch.no_grad():
+            torch.manual_seed(42)
+            activations = torch.rand(m, k, dtype=torch.float32)
+            model = torch.nn.Sequential(*[torch.nn.Linear(k, n, bias=False)])
+
+            # Get original unquantized output for reference
+            original_output = model(activations)
+
+            # Quantize with HQQ
+            config = UIntxWeightOnlyConfig(
+                bitwidth=nbit,
+                group_size=group_size,
+                uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.HQQ,
+            )
+            quantized_model = copy.deepcopy(model)
+            quantized_model = quantized_model.to(device="mps", dtype=torch.float32)
+            quantize_(quantized_model, config)
+
+            result = quantized_model(activations.to("mps"))
+
+            # Verify the quantized layer has the expected attributes
+            qlinear = quantized_model[0]
+            self.assertIsInstance(qlinear, UIntxWeightOnlyQuantizedLinear)
+            self.assertEqual(qlinear.nbit, nbit)
+            self.assertEqual(qlinear.group_size, group_size)
+
+            # Verify output is valid (not NaN or Inf)
+            self.assertFalse(torch.isnan(result).any(), "HQQ output contains NaN")
+            self.assertFalse(torch.isinf(result).any(), "HQQ output contains Inf")
+
+            # Verify output is reasonably close to original
+            # 4-bit quantization typically has ~1-5% relative error
+            torch.testing.assert_close(
+                result.cpu(), original_output, rtol=0.1, atol=0.1
+            )
+
+    def test_hqq_vs_default_quantization(self):
+        """Test that HQQ produces different (typically better) quantization than default."""
+        nbit = 4
+        group_size = 32
+        m = 3
+        n = 12
+        k = 64
+
+        with torch.no_grad():
+            # Use a fixed seed for reproducibility
+            torch.manual_seed(42)
+            activations = torch.rand(m, k, dtype=torch.float32)
+            model = torch.nn.Sequential(*[torch.nn.Linear(k, n, bias=False)])
+
+            # Quantize with default (no HQQ)
+            config_default = UIntxWeightOnlyConfig(
+                bitwidth=nbit,
+                group_size=group_size,
+                uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.MIN_MAX,
+            )
+            model_default = copy.deepcopy(model).to(device="mps", dtype=torch.float32)
+            quantize_(model_default, config_default)
+            result_default = model_default(activations.to("mps"))
+
+            # Quantize with HQQ
+            config_hqq = UIntxWeightOnlyConfig(
+                bitwidth=nbit,
+                group_size=group_size,
+                uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.HQQ,
+            )
+            model_hqq = copy.deepcopy(model).to(device="mps", dtype=torch.float32)
+            quantize_(model_hqq, config_hqq)
+            result_hqq = model_hqq(activations.to("mps"))
+
+            # Both should produce valid results (not NaN or Inf)
+            self.assertFalse(torch.isnan(result_default).any())
+            self.assertFalse(torch.isnan(result_hqq).any())
+            self.assertFalse(torch.isinf(result_default).any())
+            self.assertFalse(torch.isinf(result_hqq).any())
+
+            # HQQ and default should produce different results
+            # (unless the weights happen to be perfectly distributed)
+            # We don't assert which is better, just that they're different
+            self.assertFalse(
+                torch.allclose(
+                    result_default.cpu(), result_hqq.cpu(), rtol=1e-5, atol=1e-5
+                ),
+                "HQQ and default quantization should produce different results",
+            )
+
+    def test_hqq_better_accuracy_than_default(self):
+        """Test that HQQ produces better quantization accuracy than default min-max.
+
+        HQQ uses an iterative optimization to find better scale/zero parameters,
+        which should result in lower quantization error compared to simple min-max.
+        """
+        nbit = 4
+        group_size = 32
+        m = 10
+        n = 64
+        k = 128
+
+        # Run multiple trials to ensure HQQ is consistently better
+        hqq_wins = 0
+        num_trials = 5
+
+        for trial in range(num_trials):
+            with torch.no_grad():
+                torch.manual_seed(trial * 100)
+                activations = torch.randn(m, k, dtype=torch.float32)
+                model = torch.nn.Sequential(*[torch.nn.Linear(k, n, bias=False)])
+
+                # Get original unquantized output
+                original_output = model(activations)
+
+                # Quantize with default (no HQQ)
+                config_default = UIntxWeightOnlyConfig(
+                    bitwidth=nbit,
+                    group_size=group_size,
+                    uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.MIN_MAX,
+                )
+                model_default = copy.deepcopy(model).to(
+                    device="mps", dtype=torch.float32
+                )
+                quantize_(model_default, config_default)
+                result_default = model_default(activations.to("mps"))
+
+                # Quantize with HQQ
+                config_hqq = UIntxWeightOnlyConfig(
+                    bitwidth=nbit,
+                    group_size=group_size,
+                    uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.HQQ,
+                )
+                model_hqq = copy.deepcopy(model).to(device="mps", dtype=torch.float32)
+                quantize_(model_hqq, config_hqq)
+                result_hqq = model_hqq(activations.to("mps"))
+
+                # Compute mean squared error for each method
+                mse_default = torch.mean(
+                    (result_default.cpu() - original_output) ** 2
+                ).item()
+                mse_hqq = torch.mean((result_hqq.cpu() - original_output) ** 2).item()
+
+                if mse_hqq < mse_default:
+                    hqq_wins += 1
+
+        # HQQ should win in majority of trials (at least 3 out of 5)
+        self.assertGreaterEqual(
+            hqq_wins,
+            3,
+            f"HQQ should have lower error than default in most trials, "
+            f"but only won {hqq_wins}/{num_trials} times",
+        )
+
+    def test_config_accepts_string_algorithm(self):
+        """Test that UIntxWeightOnlyConfig accepts string values for algorithm."""
+        # Test "hqq" string
+        config_hqq = UIntxWeightOnlyConfig(uintx_choose_qparams_algorithm="hqq")
+        self.assertEqual(
+            config_hqq.uintx_choose_qparams_algorithm,
+            UIntxChooseQParamsAlgorithm.HQQ,
+        )
+
+        # Test "min_max" string
+        config_min_max = UIntxWeightOnlyConfig(uintx_choose_qparams_algorithm="min_max")
+        self.assertEqual(
+            config_min_max.uintx_choose_qparams_algorithm,
+            UIntxChooseQParamsAlgorithm.MIN_MAX,
+        )
+
+        # Test enum values directly (should also work)
+        config_enum = UIntxWeightOnlyConfig(
+            uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.HQQ
+        )
+        self.assertEqual(
+            config_enum.uintx_choose_qparams_algorithm,
+            UIntxChooseQParamsAlgorithm.HQQ,
+        )
+
+    def test_config_rejects_invalid_algorithm(self):
+        """Test that UIntxWeightOnlyConfig raises ValueError for invalid algorithm."""
+        with self.assertRaises(ValueError):
+            UIntxWeightOnlyConfig(uintx_choose_qparams_algorithm="invalid_algorithm")
+
+    def test_config_default_algorithm_is_min_max(self):
+        """Test backward compatibility: default algorithm is MIN_MAX when not specified."""
+        # Default config without specifying algorithm
+        config = UIntxWeightOnlyConfig()
+        self.assertEqual(
+            config.uintx_choose_qparams_algorithm,
+            UIntxChooseQParamsAlgorithm.MIN_MAX,
+        )
+
+        # Config with only other params specified
+        config_with_bitwidth = UIntxWeightOnlyConfig(bitwidth=3, group_size=64)
+        self.assertEqual(
+            config_with_bitwidth.uintx_choose_qparams_algorithm,
+            UIntxChooseQParamsAlgorithm.MIN_MAX,
+        )
 
 
 if __name__ == "__main__":

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -7,7 +7,8 @@
 import logging
 import sys
 from dataclasses import dataclass
-from typing import Optional
+from enum import Enum
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -16,6 +17,9 @@ from torch.ao.quantization.fx._decomposed import (
 )
 
 from torchao.core.config import AOBaseConfig
+from torchao.quantization.quant_primitives import (
+    _choose_qparams_and_quantize_affine_hqq,
+)
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
@@ -28,6 +32,26 @@ handler = logging.StreamHandler(sys.stdout)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
+
+
+# can switch to StrEnum (https://docs.python.org/3/library/enum.html#enum.StrEnum)
+# after python 3.10 is end of life (https://devguide.python.org/versions/)
+class UIntxChooseQParamsAlgorithm(str, Enum):
+    """Variant of quantization algorithm to calculate scale and zero_point for UIntx quantization."""
+
+    """
+    Default min-max quantization algorithm.
+    Uses simple (max - min) / (qmax - qmin) scaling.
+    """
+    MIN_MAX = "min_max"
+
+    """
+    Half-Quadratic Quantization (HQQ) algorithm.
+    Uses iterative optimization to find better scale/zero parameters.
+    Typically produces better accuracy than min-max at the cost of slower quantization.
+    See: https://mobiusml.github.io/hqq_blog/
+    """
+    HQQ = "hqq"
 
 
 def _quantize(
@@ -87,14 +111,43 @@ class UIntxWeightOnlyQuantizedLinear(nn.Module):
         else:
             self.register_parameter("bias", None)
 
-    def quantize_and_pack_weights(self, weights, nbit, group_size):
+    def quantize_and_pack_weights(
+        self,
+        weights,
+        nbit,
+        group_size,
+        uintx_choose_qparams_algorithm: UIntxChooseQParamsAlgorithm = UIntxChooseQParamsAlgorithm.MIN_MAX,
+    ):
         self.nbit = nbit
         self.group_size = group_size
 
-        weight_qvals, weight_scales, weight_zeros = _quantize(
-            weights, self.group_size, self.nbit, has_weight_zeros=True, signed=False
-        )
-        weight_zeros = -weight_zeros * weight_scales
+        if uintx_choose_qparams_algorithm == UIntxChooseQParamsAlgorithm.HQQ:
+            weight_qvals, weight_scales, weight_zeros, _ = (
+                _choose_qparams_and_quantize_affine_hqq(
+                    weights,
+                    nbits=nbit,
+                    group_size=group_size,
+                    axis=1,
+                    compute_dtype=weights.dtype,
+                    device=weights.device,
+                    verbose=False,
+                    raw_output=True,  # Get raw HQQ format, not tinygemm format
+                )
+            )
+            weight_qvals = weight_qvals.to(torch.uint8)
+            # HQQ raw format: W_dequant = (W_q - zero) * scale
+            # Kernel expects: W_dequant = W_q * scale + zeros
+            # So: zeros = -zero * scale
+            weight_zeros = -weight_zeros * weight_scales
+        elif uintx_choose_qparams_algorithm == UIntxChooseQParamsAlgorithm.MIN_MAX:
+            weight_qvals, weight_scales, weight_zeros = _quantize(
+                weights, self.group_size, self.nbit, has_weight_zeros=True, signed=False
+            )
+            weight_zeros = -weight_zeros * weight_scales
+        else:
+            raise ValueError(
+                f"Unsupported uintx_choose_qparams_algorithm: {uintx_choose_qparams_algorithm}"
+            )
         self.weight_scales = nn.Parameter(weight_scales, requires_grad=False)
         self.weight_zeros = nn.Parameter(weight_zeros, requires_grad=False)
         packed_weights = self._pack_weights_op(weight_qvals.cpu()).to(
@@ -232,10 +285,17 @@ class UIntxWeightOnlyConfig(AOBaseConfig):
             Default is 4.
         group_size (int): Group size for quantization. Must be one of [32, 64, 128, 256].
             Default is 128.
+        uintx_choose_qparams_algorithm (Union[UIntxChooseQParamsAlgorithm, str]): Algorithm for
+            choosing quantization parameters. Options:
+            - "min_max" (default): Simple min-max scaling
+            - "hqq": Half-Quadratic Quantization for better accuracy
     """
 
     bitwidth: int = 4
     group_size: int = 128
+    uintx_choose_qparams_algorithm: Union[UIntxChooseQParamsAlgorithm, str] = (
+        UIntxChooseQParamsAlgorithm.MIN_MAX
+    )
 
     def __post_init__(self):
         if self.bitwidth not in range(1, 8):
@@ -246,6 +306,11 @@ class UIntxWeightOnlyConfig(AOBaseConfig):
             raise ValueError(
                 f"group_size must be one of [32, 64, 128, 256], got {self.group_size}"
             )
+        # Convert string to enum if necessary
+        if isinstance(self.uintx_choose_qparams_algorithm, str):
+            self.uintx_choose_qparams_algorithm = UIntxChooseQParamsAlgorithm(
+                self.uintx_choose_qparams_algorithm
+            )
 
 
 @register_quantize_module_handler(UIntxWeightOnlyConfig)
@@ -254,6 +319,7 @@ def _uintx_weight_only_mps_transform(
 ) -> torch.nn.Module:
     nbit = config.bitwidth
     group_size = config.group_size
+    uintx_choose_qparams_algorithm = config.uintx_choose_qparams_algorithm
 
     if not module.weight.is_contiguous():
         raise ValueError(
@@ -266,5 +332,7 @@ def _uintx_weight_only_mps_transform(
         linear_op=getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight"),
         bias=module.bias,
     )
-    qlinear.quantize_and_pack_weights(module.weight, nbit, group_size)
+    qlinear.quantize_and_pack_weights(
+        module.weight, nbit, group_size, uintx_choose_qparams_algorithm
+    )
     return qlinear


### PR DESCRIPTION
We'll be leaving accuracy on the top. Seems like it's an easy thing to do in general to run HQQ.

```
USE_CPP=1 TORCHAO_BUILD_EXPERIMENTAL_MPS=1 pip install . --no-build-isolation
python -m pytest torchao/experimental/ops/mps/test/test_quantizer.py
```
