### PR TITLE
[bug][pt2e] Fix Python 3.14 compatibility for EdgeOrNode type alias

### DIFF
--- a/torchao/quantization/pt2e/quantizer/quantizer.py
+++ b/torchao/quantization/pt2e/quantizer/quantizer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # mypy: allow-untyped-defs
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Union
@@ -93,7 +94,8 @@ input edge is the connection between input node and the node consuming the input
 output value is an fx Node
 """
 EdgeOrNode = Union[tuple[Node, Node], Node]
-EdgeOrNode.__module__ = "torchao.quantization.pt2e.quantizer.quantizer"
+if sys.version_info < (3, 14):
+    EdgeOrNode.__module__ = "torchao.quantization.pt2e.quantizer.quantizer"
 
 
 @dataclass(eq=True, frozen=True)


### PR DESCRIPTION
## Summary

Python 3.14 made `typing.Union` attributes read-only . This causes an `AttributeError` when importing the quantizer module:

```
AttributeError: 'typing.Union' object has no attribute '__module__'
```

This PR guards the `EdgeOrNode.__module__` assignment with a version check to maintain compatibility across Python versions.

## Reproduction

```bash
# Create a fresh Python 3.14 environment
uv venv --python 3.14 /tmp/test-py314
source /tmp/test-py314/bin/activate

# Install torchao (or PyTorch with torch.ao)
uv pip install torch torchao

# This will fail on Python 3.14 without the fix:
python -c "from torchao.quantization.pt2e.quantizer.quantizer import EdgeOrNode"
```

**Expected error (before fix):**
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../torchao/quantization/pt2e/quantizer/quantizer.py", line 96, in <module>
    EdgeOrNode.__module__ = "torchao.quantization.pt2e.quantizer.quantizer"
AttributeError: 'typing.Union' object has no attribute '__module__'
```

## Details

The `__module__` assignment is cosmetic - it improves how the type alias appears in error messages and documentation. It is not required for functionality, so skipping it on Python 3.14+ seems safe.

## Test Plan

- Verified import works on Python 3.14
