### PR TITLE
[mxfp8 training] 128b alignment for CUTensormap to support CUDA 13.0+

### DIFF
--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -480,7 +480,7 @@ void launch_mx_block_rearrange_2d_M_groups_cuda(
     // Create TMA tensor map for input (chunk size = SF_ROWS × effective_chunk_width)
     // When scale_cols < chunk_width, use scale_cols as box width to avoid OOB issues
     const int effective_chunk_width = min(chunk_width, scale_cols);
-    alignas(64) CUtensorMap input_tensor_map = {};
+    alignas(128) CUtensorMap input_tensor_map = {};
     create_tensor_map(
         (void*)scales_ptr,
         input_tensor_map,

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -1231,9 +1231,9 @@ public:
     const dim3 grid(blocks_X, blocks_Y);
 
     // Create TMA descriptors
-    alignas(64) CUtensorMap tensor_map_input{};
-    alignas(64) CUtensorMap tensor_map_output_rowwise{};
-    alignas(64) CUtensorMap tensor_map_output_colwise{};
+    alignas(128) CUtensorMap tensor_map_input{};
+    alignas(128) CUtensorMap tensor_map_output_rowwise{};
+    alignas(128) CUtensorMap tensor_map_output_colwise{};
     int32_t input_bits_per_elem = get_dtype_bits(input_dtype);
     int32_t output_bits_per_elem = get_dtype_bits(output_dtype);
 
@@ -1371,8 +1371,8 @@ public:
 
     // Create TMA descriptors for each expert
     // Allocate GPU-accessible memory for TMA descriptors
-    alignas(64) CUtensorMap tensor_map_input{};
-    alignas(64) CUtensorMap tensor_map_output{};
+    alignas(128) CUtensorMap tensor_map_input{};
+    alignas(128) CUtensorMap tensor_map_output{};
     int32_t input_bits_per_elem = get_dtype_bits(input_dtype);
     int32_t output_bits_per_elem = get_dtype_bits(output_dtype);
 


### PR DESCRIPTION
This was developed with CUDA 12.8, but the alignment requirement changed in 13.0.

- 12.8: https://docs.nvidia.com/cuda/archive/12.8.0/cuda-driver-api/structCUtensorMap.html#structCUtensorMap
- 13.1: https://docs.nvidia.com/cuda/archive/13.1.0/cuda-driver-api/structCUtensorMap.html
### Test

```bash
(torch) dev@gpu-dev-b0912ea8:/tmp/ao$ export CUDA_VERSION=13.0
(torch) dev@gpu-dev-b0912ea8:/tmp/ao$ export CUDA_HOME=/usr/local/cuda-13.0     
(torch) dev@gpu-dev-b0912ea8:/tmp/ao$ USE_CPP=1 pip install --no-build-isolation -e ./ -v
```

- `CUDA_VISIBLE_DEVICES=1 pytest test/prototype/moe_training/test_training.py -v -s`