### PR TITLE
Add back the missing bias term in SmoothQuantObservedLinear.forward

### DIFF
--- a/torchao/prototype/smoothquant/core.py
+++ b/torchao/prototype/smoothquant/core.py
@@ -88,7 +88,7 @@ class SmoothQuantObservedLinear(torch.nn.Linear):
 
     def forward(self, input: torch.Tensor):
         input = self.obs(input)
-        return F.linear(input, self.weight)
+        return F.linear(input, self.weight, self.bias)
 
     @classmethod
     def from_float(cls, float_linear: torch.nn.Linear, obs: SmoothQuantObserver):


### PR DESCRIPTION
Summary: I discovered this when I was check output accuracy of a smooth quantized model against the original. The bias term was left out in https://github.com/pytorch/ao/pull/2728 but I assume that was not intended?

Differential Revision: D92538732


