### PR TITLE
Add inference_mode support for PrototypeFloat8Tensor

### DIFF
--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -432,6 +432,38 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
             f"SQNR of compiled quantized vs original should be > 15 dB, got {error_compiled}",
         )
 
+    def test_create_tensor_out_of_inference_mode(self):
+        # Test https://github.com/pytorch/pytorch/issues/170419
+        dtype = self.dtype
+        linear = torch.nn.Linear(32, 48, bias=True, device="cuda", dtype=dtype)
+        linear.eval()
+        linear.requires_grad_(False)
+
+        # Get activation scale from dynamic quantization
+        input_tensor = torch.randn(16, 32, dtype=dtype, device="cuda")
+        dynamic_config = Float8DynamicActivationFloat8WeightConfig(
+            granularity=PerTensor()
+        )
+        linear_dynamic = copy.deepcopy(linear)
+        quantize_(linear_dynamic, dynamic_config)
+        quantized_input = _choose_quant_func_and_quantize_tensor(
+            input_tensor, linear_dynamic.weight.act_quant_kwargs
+        )
+
+        quantize_(
+            linear,
+            Float8StaticActivationFloat8WeightConfig(
+                act_quant_scale=quantized_input.scale.detach().clone(),
+                granularity=PerTensor(),
+            ),
+        )
+
+        # Forward pass inside inference_mode should work
+        with torch.inference_mode():
+            output = linear(input_tensor)
+            self.assertEqual(output.shape, (16, 48))
+            self.assertEqual(output.dtype, dtype)
+
     def test_static_quant_softmax(self):
         """
         Test static quantization of Softmax output.

--- a/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
+++ b/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
@@ -1041,6 +1041,26 @@ def _(func, types, args, kwargs):
     return return_and_correct_aliasing(func, args, kwargs, new_tensor)
 
 
+@implements_torch_function(torch.Tensor.t)
+def _(func, types, args, kwargs):
+    assert len(args) == 1
+    self = args[0]
+    assert len(self.block_size) == 2
+    new_tensor = self.__class__(
+        self.qdata.t(),
+        self.scale.t(),
+        act_quant_scale=self.act_quant_scale,
+        output_act_quant_scale=self.output_act_quant_scale,
+        block_size=(self.block_size[1], self.block_size[0]),
+        mm_config=self.mm_config,
+        act_quant_kwargs=self.act_quant_kwargs,
+        kernel_preference=self.kernel_preference,
+        dtype=self.dtype,
+        output_act_quant_kwargs=self.output_act_quant_kwargs,
+    )
+    return new_tensor
+
+
 @implements(aten.split.Tensor)
 def _(func, types, args, kwargs):
     tensor, split_size_or_sections, dim = args


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3840

Summary

- Add torch.Tensor.t torch function override to PrototypeFloat8Tensor, mirroring the existing implementation in Float8Tensor. Without this, torch.inference_mode() fails because aten.t.default uses
return_and_correct_aliasing which is incompatible with inference mode tensors.
- Add test_create_tensor_out_of_inference_mode test for PrototypeFloat8Tensor.

Test Plan

- Run the new test:
python -m pytest test/prototype/test_prototype_float8_tensor.py -xvs -k test_create_tensor_out_of_inference_mode
- Run all existing PrototypeFloat8Tensor tests to verify no regressions:
python -m pytest test/prototype/test_prototype_float8_tensor.py -xvs

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: