### PR TITLE
Disable NCCL NVLS in 4xH100 CI to fix multicast memory binding error

### DIFF
--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -40,6 +40,7 @@ jobs:
         conda create -n venv python=3.10 -y
         conda activate venv
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
+        export NCCL_NVLS_ENABLE=0
         python -m pip install --upgrade pip
         pip install uv
         pip install ${{ matrix.torch-spec }}


### PR DESCRIPTION
The H100 CI runners have Fabric Manager/NVSwitch configuration that doesn't properly support NVLS (NVLink SHARP) multicast operations. This causes NCCL errors during FSDP all-gather operations:

https://github.com/pytorch/ao/actions/runs/21758397652/job/62780747223

  Failed to bind NVLink SHARP (NVLS) Multicast memory: CUDA error 401

Setting NCCL_NVLS_ENABLE=0 disables NVLS and falls back to standard NVLink communication which works correctly.