### PR TITLE
Revert "[X86] add inductor lowering path for dequantize_float8 (#3818)"

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -291,9 +291,9 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
                 expected_scale,
                 hp_dtype,
             )
-            # After lowering the op is not in the output code but the base name is
-            dequant_op_base_name = f"{dequantize_affine_float8}".split(".")[-1]
-            torch.testing.FileCheck().check(dequant_op_base_name).run(code_dq)
+            torch.testing.FileCheck().check(f"{dequantize_affine_float8}.default").run(
+                code_dq
+            )
             torch.testing.assert_close(expected_quantized, test_q)
             torch.testing.assert_close(expected_dequantized, test_dq)
 

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3471,37 +3471,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             )
 
 
-@unittest.skipIf(not torch_version_at_least("2.8.0"), "Requires torch 2.8+")
-@unittest.skipIf(torch.version.hip is not None, "Not applicable to ROCm")
-class TestLowering(TestPatternMatcherBase):
-    def test_lowering_quant_dequant_fp8(self):
-        r"""
-        This testcase will test lowering of quant-dequant pattern.
-        """
-
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, x):
-                return qdq_fp8(x, scale=0.2)
-
-        mod = M().eval()
-        x = torch.randn((4, 4))
-
-        self._test_code_common(
-            mod,
-            (x,),
-            include_ops=[],
-            # these ops should be lowered away
-            exclude_ops=[
-                "torch.ops.torchao.quantize_affine_float8_non_decomposed.default",
-                "torch.ops.torchao.dequantize_affine_float8_non_decomposed.default",
-            ],
-            is_fp8=True,
-        )
-
-
 instantiate_parametrized_tests(TestPatternMatcher)
 if __name__ == "__main__":
     if IS_LINUX and HAS_CPU and torch.backends.mkldnn.is_available():

--- a/torchao/quantization/pt2e/inductor_passes/lowering.py
+++ b/torchao/quantization/pt2e/inductor_passes/lowering.py
@@ -11,12 +11,12 @@ from torch._inductor.lowering import register_lowering, to_dtype
 from torch._inductor.virtualized import ops
 
 
-def _register_quantize_dequantize_fp8_lowering():
+def _register_dequantize_fp8_lowering():
     @register_lowering(
         torch.ops.torchao.quantize_affine_float8_non_decomposed.default,
         type_promotion_kind=None,
     )
-    def quantize_fp8(
+    def dequantize_fp8(
         input: TensorBox,
         scale: TensorBox,
         float8_dtype: torch.dtype = torch.float8_e4m3fn,
@@ -46,38 +46,6 @@ def _register_quantize_dequantize_fp8_lowering():
         return Pointwise.create(
             device=input.get_device(),
             dtype=float8_dtype,
-            inner_fn=inner_fn,
-            ranges=input.get_size(),
-        )
-
-    @register_lowering(
-        torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
-        type_promotion_kind=None,
-    )
-    def dequantize_fp8(
-        input: TensorBox,
-        scale: TensorBox,
-        output_dtype: torch.dtype = torch.float32,
-    ) -> TensorBox:
-        # Expect scale to be a scalar tensor or a 1D tensor with size 1
-        assert len(scale.get_size()) <= 1 and scale.get_numel() == 1, (
-            "Only support per-tensor dequantization for float8 now."
-        )
-        if input.get_dtype() != torch.float32:
-            input = to_dtype(input, torch.float32)
-        input_loader = input.make_loader()
-        scale_loader = scale.make_loader()
-        scale_idx = 0 if len(scale.get_size()) == 1 else []
-
-        def inner_fn(idx):
-            input = input_loader(idx)
-            scale = scale_loader(scale_idx)
-            val = input * scale
-            return ops.to_dtype(val, output_dtype)
-
-        return Pointwise.create(
-            device=input.get_device(),
-            dtype=output_dtype,
             inner_fn=inner_fn,
             ranges=input.get_size(),
         )

--- a/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
+++ b/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
@@ -1631,7 +1631,7 @@ class X86InductorQuantizer(Quantizer):
 import torch._inductor.config
 
 from torchao.quantization.pt2e.inductor_passes.lowering import (
-    _register_quantize_dequantize_fp8_lowering,
+    _register_dequantize_fp8_lowering,
 )
 from torchao.quantization.pt2e.inductor_passes.x86 import (
     _register_quantization_weight_pack_pass,
@@ -1642,4 +1642,4 @@ from torchao.utils import torch_version_at_least
 if torch_version_at_least("2.8.0"):
     torch._inductor.config.pre_grad_custom_pass = quant_lift_up
     _register_quantization_weight_pack_pass()
-    _register_quantize_dequantize_fp8_lowering()
+    _register_dequantize_fp8_lowering()


### PR DESCRIPTION
This reverts commit ff8ef3752b9a0e7087dd5234ede915acedc996e1.
Revert this because it uses a utility that brought by a reverted PR. Need to wait for that PR to reland first