### PR TITLE
fix test_bf16_stochastic_round_dtensor

### DIFF
--- a/test/test_low_bit_optim.py
+++ b/test/test_low_bit_optim.py
@@ -129,7 +129,7 @@ class TestQuantize(TestCase):
 
         created_pg = False
         if dist.is_available() and not dist.is_initialized():
-            store = dist.TCPStore("127.0.0.1", 29500, 1, True)
+            store = dist.FileStore(tempfile.mktemp(), 1)
             dist.init_process_group(
                 backend="gloo",
                 store=store,


### PR DESCRIPTION
Summary:

This test started failing on recent versions of PyTorch nightly, the
test cases passed individually but failed when run in sequence.
What I think was broken is that the ports were not released by the OS
fast enough between the tests. I did not debug what specifically
changed in PyTorch, fixing defensively by using a FileStore instead of
kTCPStore, which does not use any ports.

Test Plan:

```
pytest test/test_low_bit_optim.py -k test_bf16_stochastic_round_dtensor
```