### PR TITLE
[moe training] rename MoETrainingConfig -> GroupedMMConfig

### DIFF
--- a/benchmarks/prototype/moe_training/bench_moe_layer.py
+++ b/benchmarks/prototype/moe_training/bench_moe_layer.py
@@ -17,7 +17,7 @@ from torch.nn import functional as F
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
 from torchao.prototype.moe_training.conversion_utils import (
     FP8GroupedMMRecipe,
-    MoETrainingConfig,
+    GroupedMMConfig,
     MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
@@ -120,7 +120,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         return False
 
     # quantize test model
-    config = MoETrainingConfig(recipe=recipe)
+    config = GroupedMMConfig(recipe=recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # inputs

--- a/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
+++ b/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
@@ -26,7 +26,7 @@ from torch.nn import functional as F
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
 from torchao.prototype.moe_training.conversion_utils import (
     FP8GroupedMMRecipe,
-    MoETrainingConfig,
+    GroupedMMConfig,
     MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
@@ -115,7 +115,7 @@ def bench_moe_training_fsdp(recipe_name: str, enable_profile: bool, use_compile:
         return False
 
     # quantize test model
-    config = MoETrainingConfig(recipe=recipe)
+    config = GroupedMMConfig(recipe=recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # FSDP2

--- a/test/prototype/moe_training/test_distributed.py
+++ b/test/prototype/moe_training/test_distributed.py
@@ -55,7 +55,7 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.conversion_utils import (
     FP8GroupedMMRecipe,
-    MoETrainingConfig,
+    GroupedMMConfig,
     MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
@@ -243,7 +243,7 @@ def test_moe_training_parallel(
         return False
 
     # quantize test model
-    config = MoETrainingConfig(recipe, kernel_preference=kernel_preference)
+    config = GroupedMMConfig(recipe, kernel_preference=kernel_preference)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -14,7 +14,7 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.conversion_utils import (
     FP8GroupedMMRecipe,
-    MoETrainingConfig,
+    GroupedMMConfig,
     MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
@@ -155,7 +155,7 @@ def test_moe_training(
         return False
 
     # quantize test model
-    config = MoETrainingConfig(recipe=recipe, kernel_preference=kernel_preference)
+    config = GroupedMMConfig(recipe=recipe, kernel_preference=kernel_preference)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted

--- a/torchao/prototype/moe_training/README.md
+++ b/torchao/prototype/moe_training/README.md
@@ -277,7 +277,7 @@ This prototype is specifically designed to be used on MoE models using
 where expert weights are implemented as 3D nn.Parameters with `num_experts` as
 the leading dim.
 
-The `MoETrainingConfig` has a module handler registered to it which will
+The `GroupedMMConfig` has a module handler registered to it which will
 find all nn.Parameters whose parent module matches the module filter function,
 and swap their data tensor with a ScaledGroupedMMTensor.
 

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -36,14 +36,14 @@ class MXFP8GroupedMMRecipe(Enum):
 GroupedMMRecipe = Union[FP8GroupedMMRecipe, MXFP8GroupedMMRecipe]
 
 
-class MoETrainingConfig(AOBaseConfig):
+class GroupedMMConfig(AOBaseConfig):
     """
-    The MoETrainingConfig is specifically designed to be used on MoE models using
+    The GroupedMMConfig is specifically designed to be used on MoE models using
     `torch._grouped_mm` to implement expert computation in token-choice routing,
     where expert weights are implemented as 3D nn.Parameters wit `num_experts` as
     the leading dim.
 
-    MoETrainingConfig has a module handler registered to it which will
+    GroupedMMConfig has a module handler registered to it which will
     find all nn.Parameters whose parent module matches the module filter function,
     and swap their data tensor with a ScaledGroupedMMTensor.
 
@@ -67,17 +67,17 @@ class MoETrainingConfig(AOBaseConfig):
         self.kernel_preference = kernel_preference
 
 
-@register_quantize_module_handler(MoETrainingConfig)
+@register_quantize_module_handler(GroupedMMConfig)
 def _moe_training_transform(
     module: nn.Module,
-    config: MoETrainingConfig,
+    config: GroupedMMConfig,
 ) -> nn.Module:
     """
     Swaps `torch.nn.Parameter` data tensor with a ScaledGroupedMMTensor.
 
     Args:
         module: Module to modify.
-        config: MoETrainingConfig which defines how to perform the MoE training transform.
+        config: GroupedMMConfig which defines how to perform the MoE training transform.
 
     Returns:
      nn.Module: The modified module with swapped parameters.
@@ -90,7 +90,7 @@ def _swap_params(
     module: nn.Module,
     *,
     module_filter_fn: Optional[Callable[[nn.Module, str], bool]] = None,
-    config: Optional[MoETrainingConfig] = None,
+    config: Optional[GroupedMMConfig] = None,
 ) -> nn.Module:
     """
     Recurses through the nn.Module, recursively swapping the data tensor of


### PR DESCRIPTION
Stacked PRs:
 * #3858
 * #3855
 * __->__#3854
 * #3853
 * #3852


--- --- ---

### [moe training] rename MoETrainingConfig -> GroupedMMConfig

## Summary
- Refactoring to be organized by "Linear vs Grouped MM" instead of "Linear vs MoETraining." This is more consistent/clear.

## Tests
- `pytest test/prototype/moe_training/test_training.py -rvs`