### PR TITLE
Add versions.json with documentation URLs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "main (unstable)",
+    "version": "main",
+    "url": "https://docs.pytorch.org/ao/main/"
+  },
+  {
+    "name": "v0.16.0 (stable)",
+    "version": "0.16",
+    "url": "https://docs.pytorch.org/ao/0.16/",
+    "preferred": true
+  },
+  {
+    "name": "v0.15.0",
+    "version": "0.15",
+    "url": "https://docs.pytorch.org/ao/0.15/"
+  },
+  {
+    "name": "v0.14.0",
+    "version": "0.14",
+    "url": "https://docs.pytorch.org/ao/0.14/"
+  }
+]


### PR DESCRIPTION
This pull request adds a new `versions.json` file that defines available documentation versions for the project, including URLs for each version and marking the preferred (stable) version. It needs to be used in docs/source/conf.py:
```
switcher_version = "main" if not RELEASE else version
html_theme_options = {
    "switcher": {
        "json_url": "https://github.com/pytorch/ao/blob/gh-pages/versions.json",
		"version_match": switcher_version,
     },
```