### PR TITLE
[moe training] refactor configs, recipes; support converting linears + grouped gemms in a single quantize_() call

### DIFF
--- a/benchmarks/prototype/moe_training/bench_moe_layer.py
+++ b/benchmarks/prototype/moe_training/bench_moe_layer.py
@@ -15,9 +15,10 @@ from torch import nn
 from torch.nn import functional as F
 
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
-from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
-    MoETrainingConfig,
+from torchao.prototype.moe_training.config import (
+    FP8GroupedMMRecipe,
+    MXFP8GroupedMMConfig,
+    MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -53,20 +54,37 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         args.hidden_dim,
     )
     assert torch.cuda.is_available()
-    assert recipe_name in ["fp8_rowwise", "mxfp8"]
-    recipe = MoEScalingType[recipe_name.upper()]
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    assert recipe_name in ["fp8_rowwise", "mxfp8_rceil", "mxfp8_rceil_wgrad_with_hp"]
+
+    # Map recipe name to enum
+    if recipe_name == "fp8_rowwise":
+        recipe = FP8GroupedMMRecipe.FP8_ROWWISE
+    elif recipe_name == "mxfp8_rceil":
+        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    elif recipe_name == "mxfp8_rceil_wgrad_with_hp":
+        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    else:
+        raise ValueError(f"Unknown recipe: {recipe_name}")
+    if (
+        recipe == FP8GroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping FP8 rowwise benchmarks, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
         return
 
-    elif recipe == MoEScalingType.MXFP8 and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    elif (
+        recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
@@ -92,7 +110,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     model = copy.deepcopy(ref_model)
 
     # Token group alignment size must be 16 for fp8 rowwise training
-    alignment_size = 32 if recipe == MoEScalingType.MXFP8 else 16
+    alignment_size = 32 if recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL else 16
     set_token_group_alignment_size_m(alignment_size)
 
     # assert starting params are identical for both models
@@ -107,7 +125,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         return False
 
     # quantize test model
-    config = MoETrainingConfig(scaling_type=recipe)
+    config = MXFP8GroupedMMConfig.from_recipe(recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # inputs
@@ -190,7 +208,10 @@ if __name__ == "__main__":
         help="Enable PyTorch profiling and save results to file",
     )
     parser.add_argument(
-        "--recipe", type=str, help="[fp8_rowwise, mxfp8]", required=True
+        "--recipe",
+        type=str,
+        help="[fp8_rowwise, rceil, rceil_wgrad_with_hp]",
+        required=True,
     )
     parser.add_argument(
         "--local_num_experts",

--- a/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
+++ b/benchmarks/prototype/moe_training/benchmark_moe_layer_fsdp.py
@@ -24,9 +24,10 @@ from torch.distributed._composable.fsdp import fully_shard
 from torch.nn import functional as F
 
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
-from torchao.prototype.moe_training.conversion_utils import (
-    MoEScalingType,
-    MoETrainingConfig,
+from torchao.prototype.moe_training.config import (
+    FP8GroupedMMRecipe,
+    MXFP8GroupedMMConfig,
+    MXFP8GroupedMMRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -44,20 +45,36 @@ except ImportError:
 
 def bench_moe_training_fsdp(recipe_name: str, enable_profile: bool, use_compile: bool):
     assert torch.cuda.is_available()
-    assert recipe_name in ["fp8_rowwise", "mxfp8"]
-    recipe = MoEScalingType[recipe_name.upper()]
-    if recipe == MoEScalingType.FP8_ROWWISE and torch.cuda.get_device_capability() != (
-        9,
-        0,
+    assert recipe_name in ["fp8_rowwise", "mxfp8_rceil", "mxfp8_rceil_wgrad_with_hp"]
+    # Map recipe names to enums
+    if recipe_name.upper() == "fp8_rowwise":
+        recipe = FP8GroupedMMRecipe.FP8_ROWWISE
+    elif recipe_name.upper() == "mxfp8_rceil":
+        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    elif recipe_name.upper() == "mxfp8_rceil_wgrad_with_hp":
+        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    else:
+        raise ValueError(f"Unknown recipe: {recipe_name}")
+    if (
+        recipe == FP8GroupedMMRecipe.FP8_ROWWISE
+        and torch.cuda.get_device_capability()
+        != (
+            9,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping FP8 rowwise benchmarks, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
         )
         return
 
-    elif recipe == MoEScalingType.MXFP8 and torch.cuda.get_device_capability() != (
-        10,
-        0,
+    elif (
+        recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL
+        and torch.cuda.get_device_capability()
+        != (
+            10,
+            0,
+        )
     ):
         logging.warning(
             f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
@@ -87,7 +104,7 @@ def bench_moe_training_fsdp(recipe_name: str, enable_profile: bool, use_compile:
     model = copy.deepcopy(ref_model)
 
     # Token group alignment size must be 16 for fp8 rowwise training
-    alignment_size = 32 if recipe == MoEScalingType.MXFP8 else 16
+    alignment_size = 32 if recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL else 16
     set_token_group_alignment_size_m(alignment_size)
 
     # assert starting params are identical for both models
@@ -102,7 +119,7 @@ def bench_moe_training_fsdp(recipe_name: str, enable_profile: bool, use_compile:
         return False
 
     # quantize test model
-    config = MoETrainingConfig(scaling_type=recipe)
+    config = MXFP8GroupedMMConfig.from_recipe(recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # FSDP2
@@ -169,7 +186,10 @@ if __name__ == "__main__":
         help="Enable PyTorch profiling and save results to file",
     )
     parser.add_argument(
-        "--recipe", type=str, help="[fp8_rowwise, mxfp8]", required=True
+        "--recipe",
+        type=str,
+        help="[fp8_rowwise, rceil, rceil_wgrad_with_hp]",
+        required=True,
     )
     parser.add_argument(
         "--compile",

--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -8,7 +8,7 @@ import argparse
 import itertools
 import logging
 from dataclasses import dataclass
-from typing import List
+from typing import List, Union
 
 import torch
 from tabulate import tabulate
@@ -20,7 +20,12 @@ from benchmarks.utils import (
     profile_fwd_bwd,
 )
 from torchao.prototype.moe_training import _quantize_then_scaled_grouped_mm
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
+from torchao.prototype.moe_training.config import (
+    FP8GroupedMMConfig,
+    FP8GroupedMMRecipe,
+    MXFP8GroupedMMConfig,
+    MXFP8GroupedMMRecipe,
+)
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 
 device = torch.device("cuda")
@@ -36,7 +41,7 @@ torch._dynamo.config.automatic_dynamic_shapes = False
 class ExperimentConfig:
     high_precision_dtype: torch.dtype
     MNKG: tuple[int]
-    recipe: MoEScalingType
+    recipe: Union[FP8GroupedMMRecipe, MXFP8GroupedMMRecipe]
 
 
 @dataclass(frozen=True)
@@ -86,9 +91,9 @@ def get_configs() -> List[ExperimentConfig]:
         (128000, 2048, 7168, 8),
     ]
     recipes = [
-        MoEScalingType.FP8_ROWWISE,
-        MoEScalingType.MXFP8,
-        MoEScalingType.MXFP8_WGRAD_WITH_HP,
+        FP8GroupedMMRecipe.FP8_ROWWISE,
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL,
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
     ]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
@@ -131,7 +136,10 @@ def run_experiment(
     #   that occurs in the backward pass of the differentiable scaled grouped mm.
     # - the transposed tensor in col-major format with groups along the row dimension,
     #    which represents the right operand.
-    token_group_alignment_size = 32 if config.recipe == MoEScalingType.MXFP8 else 16
+    token_group_alignment_size = (
+        16 if config.recipe == FP8GroupedMMRecipe.FP8_ROWWISE else 32
+    )
+
     offs = generate_jagged_offs(G, total_M, multiple_of=token_group_alignment_size)
 
     labels = torch.ones(
@@ -160,13 +168,19 @@ def run_experiment(
             profile_name="bf16_profile",
         )
 
+    # Create config object from recipe
+    if isinstance(config.recipe, FP8GroupedMMRecipe):
+        quant_config = FP8GroupedMMConfig.from_recipe(config.recipe)
+    else:
+        quant_config = MXFP8GroupedMMConfig.from_recipe(config.recipe)
+
     # fwd_bwd scaled benchmark + profiling
     scaled_fwd_bwd_us = bench_fwd_bwd_microseconds(
         _quantize_then_scaled_grouped_mm,
         A,
         B_t,
+        quant_config,
         offs,
-        scaling_type=config.recipe,
         labels=labels,
         use_compile=args.compile,
         fullgraph=False,
@@ -176,8 +190,8 @@ def run_experiment(
             _quantize_then_scaled_grouped_mm,
             A,
             B_t,
+            quant_config,
             offs,
-            scaling_type=config.recipe,
             labels=labels,
             use_compile=args.compile,
             profile_name="scaled_profile",
@@ -197,8 +211,8 @@ def run_experiment(
         _quantize_then_scaled_grouped_mm,
         A,
         B_t,
+        quant_config,
         offs,
-        scaling_type=config.recipe,
         use_compile=args.compile,
         fullgraph=True,
     )
@@ -247,7 +261,7 @@ def main(args: argparse.Namespace):
     results = []
     for config in tqdm(configs):
         if (
-            config.recipe == MoEScalingType.FP8_ROWWISE
+            config.recipe == FP8GroupedMMRecipe.FP8_ROWWISE
             and torch.cuda.get_device_capability() != (9, 0)
         ):
             logging.warning(
@@ -255,10 +269,10 @@ def main(args: argparse.Namespace):
             )
             continue
 
-        elif (
-            config.recipe == MoEScalingType.MXFP8
-            and torch.cuda.get_device_capability() != (10, 0)
-        ):
+        elif config.recipe in (
+            MXFP8GroupedMMRecipe.MXFP8_RCEIL,
+            MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
+        ) and torch.cuda.get_device_capability() != (10, 0):
             logging.warning(
                 f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
             )

--- a/benchmarks/prototype/moe_training/mxfp8/bench_ep_pipeline.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_ep_pipeline.py
@@ -38,7 +38,7 @@ from torchao.prototype.moe_training.ep import (
 )
 from torchao.prototype.moe_training.ep.permute import _permute_bf16
 from torchao.prototype.moe_training.ep.unpermute import _unpermute_bf16
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_then_scaled_grouped_mm,
 )
 

--- a/benchmarks/prototype/moe_training/mxfp8/bench_quantize_3d.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_quantize_3d.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from benchmarks.utils import benchmark_cuda_function_in_microseconds
 from torchao.prototype.moe_training.kernels.mxfp8 import mxfp8_quantize_cuda_3d
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_dim1_3d,
 )
 from torchao.prototype.mx_formats.config import ScaleCalculationMode

--- a/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
+++ b/benchmarks/prototype/moe_training/mxfp8/roofline_unified.py
@@ -28,10 +28,10 @@ from torchao.prototype.moe_training.kernels.mxfp8 import (
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
     mxfp8_quantize_cuda_3d,
 )
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     ScaleCalculationMode as MoEScaleCalculationMode,
 )
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_then_scaled_grouped_mm,
 )
 from torchao.prototype.moe_training.utils import generate_jagged_offs

--- a/docs/source/eager_tutorials/mxfp8_expert_parallel_training.rst
+++ b/docs/source/eager_tutorials/mxfp8_expert_parallel_training.rst
@@ -476,7 +476,7 @@ Below is a complete example showing how to apply MXFP8 expert parallelism to a s
             x: torch.Tensor,
             num_tokens_per_expert: torch.Tensor,
         ) -> torch.Tensor:
-            from torchao.prototype.moe_training.scaled_grouped_mm import (
+            from torchao.prototype.moe_training.mxfp8_grouped_mm import (
                 _to_mxfp8_then_scaled_grouped_mm as mxfp8_gmm,
             )
 

--- a/test/prototype/moe_training/ep/test_compile.py
+++ b/test/prototype/moe_training/ep/test_compile.py
@@ -39,7 +39,7 @@ from torchao.prototype.moe_training.ep import (
 )
 from torchao.prototype.moe_training.ep.permute import _permute_bf16
 from torchao.prototype.moe_training.ep.unpermute import _unpermute_bf16
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_then_scaled_grouped_mm,
 )
 

--- a/test/prototype/moe_training/ep/test_integration.py
+++ b/test/prototype/moe_training/ep/test_integration.py
@@ -38,7 +38,7 @@ from torchao.prototype.moe_training.ep import (
 )
 from torchao.prototype.moe_training.ep.permute import _permute_bf16
 from torchao.prototype.moe_training.ep.unpermute import _unpermute_bf16
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_then_scaled_grouped_mm,
 )
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
@@ -157,7 +157,7 @@ class TestIntegration(MultiProcessTestCase):
                 input_tensor,
                 output_splits.tolist(),
                 input_splits.tolist(),
-                group=group,
+                group_name=group.group_name,
             )
             assert isinstance(mx_dispatched, MXTensor)
 
@@ -292,7 +292,7 @@ class TestIntegration(MultiProcessTestCase):
                 mx_unpermuted,
                 output_splits=input_splits.tolist(),
                 input_splits=output_splits.tolist(),
-                group=group,
+                group_name=group.group_name,
             )
             assert mxfp8_output.dtype == torch.bfloat16
 

--- a/test/prototype/moe_training/test_fqn_to_config.py
+++ b/test/prototype/moe_training/test_fqn_to_config.py
@@ -1,0 +1,327 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for unified MoE and dense layer training using FqnToConfig.
+"""
+
+from collections import OrderedDict
+
+import torch
+from torch import nn
+
+from torchao.prototype.moe_training.config import (
+    MXFP8GroupedMMConfig,
+    MXFP8GroupedMMRecipe,
+)
+from torchao.prototype.moe_training.tensor import ScaledGroupedMMTensor
+from torchao.prototype.mx_formats.config import MXLinearConfig, MXLinearRecipeName
+from torchao.prototype.mx_formats.mx_linear import MXLinear
+from torchao.quantization import FqnToConfig
+from torchao.quantization.quant_api import quantize_
+
+
+class ExpertWeights(nn.Module):
+    """Container for expert parameters."""
+
+    def __init__(self, num_experts, hidden_dim, dim):
+        super().__init__()
+        self.w1 = nn.Parameter(
+            torch.randn(num_experts, hidden_dim, dim, dtype=torch.bfloat16)
+        )
+        self.w2 = nn.Parameter(
+            torch.randn(num_experts, dim, hidden_dim, dtype=torch.bfloat16)
+        )
+
+
+class MoEModel(nn.Module):
+    """Model with both MoE-style expert layers and regular dense layers."""
+
+    def __init__(self, num_experts=8, dim=128, hidden_dim=256):
+        super().__init__()
+        self.experts = ExpertWeights(num_experts, hidden_dim, dim)
+
+        # Dense layers
+        self.pre_moe = nn.Linear(dim, dim, bias=False, dtype=torch.bfloat16)
+        self.post_moe = nn.Linear(dim, dim, bias=False, dtype=torch.bfloat16)
+
+    def forward(self, x):
+        # just testing conversion here, no need to implement real forward pass
+        return x
+
+
+def test_fqn_to_config_simple():
+    """Test simple FQN-based configuration with single quantize_() call."""
+    model = MoEModel()
+
+    # Configure different quantization for experts vs dense layers using FqnToConfig
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                # Apply MXFP8GroupedMMConfig to expert parameters
+                (
+                    "experts",
+                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                ),
+                # Apply MXLinearConfig to dense layers
+                (
+                    "pre_moe",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+                (
+                    "post_moe",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+
+    # Single quantize_() call transforms both layer types!
+    quantize_(model, config, filter_fn=None)
+
+    # Verify transformations
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    )
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
+
+
+def test_fqn_to_config_with_regex():
+    """Test FQN-based configuration using regex patterns."""
+    model = MoEModel()
+
+    # Use regex patterns to match multiple modules
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                (
+                    "re:.*experts.*",
+                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                ),
+                (
+                    "re:^(pre_moe|post_moe)$",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+
+    quantize_(model, config, filter_fn=None)
+
+    # Verify transformations
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    )
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
+
+
+def test_fqn_to_config_experts_only():
+    """Test FQN-based configuration for experts only."""
+    model = MoEModel()
+
+    # Only quantize expert parameters using FqnToConfig
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                (
+                    "re:.*experts.*",
+                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                ),
+            ]
+        )
+    )
+
+    quantize_(model, config, filter_fn=None)
+
+    # Verify transformations
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    # Dense layers should remain unchanged
+    assert isinstance(model.pre_moe, nn.Linear) and not isinstance(
+        model.pre_moe, MXLinear
+    ), "pre_moe should remain nn.Linear"
+    assert isinstance(model.post_moe, nn.Linear) and not isinstance(
+        model.post_moe, MXLinear
+    ), "post_moe should remain nn.Linear"
+
+
+def test_fqn_to_config_selective_layers():
+    """Test selective layer quantization using FqnToConfig."""
+    model = MoEModel()
+
+    # Quantize experts and only pre_moe
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                (
+                    "re:.*experts.*",
+                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                ),
+                (
+                    "pre_moe",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+
+    quantize_(model, config, filter_fn=None)
+
+    # Verify transformations
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    # post_moe should remain unchanged
+    assert isinstance(model.post_moe, nn.Linear) and not isinstance(
+        model.post_moe, MXLinear
+    ), "post_moe should remain nn.Linear"
+
+
+def test_fqn_to_config_mxfp8_wgrad_with_hp():
+    """Test FqnToConfig with MXFP8 high-precision weight gradients recipe."""
+    model = MoEModel()
+
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                (
+                    "re:.*experts.*",
+                    MXFP8GroupedMMConfig.from_recipe(
+                        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+                    ),
+                ),
+                (
+                    "re:^(pre_moe|post_moe)$",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+
+    quantize_(model, config, filter_fn=None)
+
+    # Verify transformations
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    ), "w1 should use RCEIL_WGRAD_WITH_HP recipe"
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
+
+
+def test_fqn_to_config_dense_only():
+    """Test FqnToConfig for dense layers only, leaving experts unchanged."""
+    model = MoEModel()
+
+    # Only quantize dense layers
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                (
+                    "re:^(pre_moe|post_moe)$",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+
+    quantize_(model, config, filter_fn=None)
+
+    # Verify only Linear layers were transformed
+    assert not isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should remain regular tensor"
+    )
+    assert not isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should remain regular tensor"
+    )
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
+
+
+def test_fqn_to_config_specific_expert_params():
+    """Test FqnToConfig with different configs for different expert parameters."""
+    model = MoEModel()
+
+    # Apply different configs to w1 vs w2
+    config = FqnToConfig(
+        fqn_to_config=OrderedDict(
+            [
+                # Apply different MXFP8 recipes to test granular fqn selection
+                (
+                    "experts.w1",
+                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                ),
+                (
+                    "experts.w2",
+                    MXFP8GroupedMMConfig.from_recipe(
+                        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+                    ),
+                ),
+                (
+                    "re:^(pre_moe|post_moe)$",
+                    MXLinearConfig.from_recipe_name(
+                        MXLinearRecipeName.MXFP8_CUBLAS_RCEIL
+                    ),
+                ),
+            ]
+        )
+    )
+    quantize_(model, config, filter_fn=None)
+
+    # Verify different recipes were applied
+    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+        "w1 should be ScaledGroupedMMTensor"
+    )
+    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    ), "w1 should use MXFP8 RCEIL"
+    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+        "w2 should be ScaledGroupedMMTensor"
+    )
+    assert model.experts.w2.data.config == MXFP8GroupedMMConfig.from_recipe(
+        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    ), "w2 should use MXFP8 RCEIL_WGRAD_WITH_HP"
+    assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
+    assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"

--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -29,13 +29,16 @@ from torchao.float8.config import (
 from torchao.float8.float8_linear import matmul_with_hp_or_float8_args
 from torchao.float8.float8_training_tensor import LinearMMConfig
 from torchao.float8.float8_utils import compute_error, tensor_to_scale, to_fp8_saturated
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
-from torchao.prototype.moe_training.scaled_grouped_mm import (
+from torchao.prototype.moe_training.config import (
+    MXFP8GroupedMMConfig,
+    MXFP8GroupedMMRecipe,
+)
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _emulated_mxfp8_scaled_grouped_mm_2d_2d,
     _emulated_mxfp8_scaled_grouped_mm_2d_3d,
-    _quantize_then_scaled_grouped_mm,
     _to_mxfp8_then_scaled_grouped_mm,
 )
+from torchao.prototype.moe_training.tensor import _quantize_then_scaled_grouped_mm
 from torchao.prototype.moe_training.utils import (
     _to_mxfp8_per_group_colwise,
     _to_mxfp8_per_group_rowwise,
@@ -83,12 +86,12 @@ def test_valid_scaled_grouped_mm_2d_3d(m, n, k, n_groups):
     b_t = b.contiguous().transpose(-2, -1).requires_grad_(True)
 
     # Compute output.
+    config = MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL)
     out = _quantize_then_scaled_grouped_mm(
         a,
         b_t,
         offs=offs,
-        out_dtype=out_dtype,
-        scaling_type=MoEScalingType.FP8_ROWWISE,
+        config=config,
     )
 
     # Validate result.
@@ -125,7 +128,6 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     # - Last 2 dims of B must be divisible by 16.
     if n % 16 == 0 and k % 16 == 0:
         return
-    out_dtype = torch.bfloat16
     device = "cuda"
     n_groups = 4
     a = torch.randn(
@@ -148,16 +150,12 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     b_t = b.transpose(-2, -1)
     b_t = b_t.transpose(-2, -1).contiguous().transpose(-2, -1)
 
+    config = MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL)
     offs = torch.arange(m, n_groups * m + 1, m, device="cuda", dtype=torch.int32)
 
     # Compute output.
     with pytest.raises(AssertionError):
-        _quantize_then_scaled_grouped_mm(
-            a,
-            b_t,
-            offs=offs,
-            out_dtype=out_dtype,
-        )
+        _quantize_then_scaled_grouped_mm(a, b_t, offs=offs, config=config)
 
 
 def compute_reference_forward(

--- a/torchao/prototype/moe_training/__init__.py
+++ b/torchao/prototype/moe_training/__init__.py
@@ -1,9 +1,15 @@
-from torchao.prototype.moe_training.scaled_grouped_mm import (
-    _quantize_then_scaled_grouped_mm,
+from torchao.prototype.moe_training.fp8_grouped_mm import (
+    _to_fp8_rowwise_then_scaled_grouped_mm,
+)
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
     _to_mxfp8_then_scaled_grouped_mm,
+)
+from torchao.prototype.moe_training.tensor import (
+    _quantize_then_scaled_grouped_mm,
 )
 
 __all__ = [
     "_quantize_then_scaled_grouped_mm",
     "_to_mxfp8_then_scaled_grouped_mm",
+    "_to_fp8_rowwise_then_scaled_grouped_mm",
 ]

--- a/torchao/prototype/moe_training/config.py
+++ b/torchao/prototype/moe_training/config.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import torch
+from torch import nn
+
+from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.quantization.quantize_.common import KernelPreference
+from torchao.quantization.transform_module import register_quantize_module_handler
+from torchao.utils import register_as_pytree_constant
+
+
+class FP8GroupedMMRecipe(Enum):
+    """FP8 recipes for grouped matrix multiplication."""
+
+    FP8_ROWWISE = "fp8_rowwise"
+
+
+class MXFP8GroupedMMRecipe(Enum):
+    """MXFP8 recipes for grouped matrix multiplication."""
+
+    # TODO: add floor variants
+    MXFP8_RCEIL = "mxfp8_rceil"
+    MXFP8_RCEIL_WGRAD_WITH_HP = "mxfp8_rceil_wgrad_with_hp"
+    MXFP8_EMULATED_RCEIL = "mxfp8_emulated_rceil"
+
+
+class GroupedMMConfig(AOBaseConfig):
+    """Base configuration for grouped matrix multiplication. Not intended to be used directly."""
+
+    pass
+
+
+@dataclass
+class FP8GroupedMMConfig(GroupedMMConfig):
+    """
+    Configuration for FP8 grouped matrix multiplication.
+    """
+
+    # Output dtype for the FP8 grouped GEMMs.
+    out_dtype: Optional[torch.dtype] = torch.bfloat16
+
+    @classmethod
+    def from_recipe(
+        cls,
+        recipe: FP8GroupedMMRecipe,
+    ) -> "FP8GroupedMMConfig":
+        """Factory method to create a FP8GroupedMMConfig from a FP8GroupedMMRecipe."""
+        if recipe == FP8GroupedMMRecipe.FP8_ROWWISE:
+            return cls()
+        else:
+            raise ValueError(f"Unsupported FP8 recipe: {recipe}")
+
+
+# register as pytree constant so we can use dynamo nonstrict trace in torchao.prototype.moe_training.ep
+@register_as_pytree_constant
+@dataclass
+class MXFP8GroupedMMConfig(GroupedMMConfig):
+    """
+    The MXFP8GroupedMMConfig is specifically designed to be used on MoE models using
+    `torch._grouped_mm` to implement expert computation in token-choice routing,
+    where expert weights are implemented as 3D nn.Parameters wit `num_experts` as
+    the leading dim.
+
+    MXFP8GroupedMMConfig has a module handler registered to it which will
+    find all nn.Parameters whose parent module matches the module filter function,
+    and swap their data tensor with a ScaledGroupedMMTensor.
+
+    The ScaledGroupedMMTensor is a tensor subclass which overrides the
+    `torch._grouped_mm` op by dispatching to a differentiable scaled grouped mm,
+    which performs dynamic quantization on scaled grouped GEMM operands in both
+    the forward and backward pass, based on the quantization config (FP8/MXFP8/etc).
+
+    For all other ops, ScaledGroupedMMTensor behaves like a regular torch.Tensor.
+    """
+
+    # AUTO = Use best supported kernel for quantization ops and GEMMs (CUDA and Triton for quantizatoin, CUTLASS for MXFP8 grouped GEM
+    # EMULATED = Hardware agnostic mode that can be used for debugging or development on non-SM100 machines.
+    #            Uses PyTorch native quantization ops, then dequantizes and uses emulated MXFP8 grouped GEMMs implemented in PyTorch.
+    #            Not recommended for performance.
+    kernel_preference: KernelPreference = KernelPreference.AUTO
+
+    # Output dtype for the MXFP8 grouped GEMMs.
+    out_dtype: Optional[torch.dtype] = torch.bfloat16
+
+    # Whether to compute the gradient of the weights in high precision (True) or use MXFP8 (False).
+    wgrad_with_hp: bool = False
+
+    # Rounding mode to use when calculating the e8m0 scale factors.
+    scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
+
+    @classmethod
+    def from_recipe(
+        cls,
+        recipe: MXFP8GroupedMMRecipe,
+    ) -> "MXFP8GroupedMMConfig":
+        """Factory method to create a MXFP8GroupedMMConfig from a MXFP8GroupedMMRecipe."""
+        if recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL:
+            return cls(
+                kernel_preference=KernelPreference.AUTO,
+                out_dtype=torch.bfloat16,
+                wgrad_with_hp=False,
+                scale_calculation_mode=ScaleCalculationMode.RCEIL,
+            )
+        elif recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP:
+            return cls(
+                kernel_preference=KernelPreference.AUTO,
+                out_dtype=torch.bfloat16,
+                wgrad_with_hp=True,
+                scale_calculation_mode=ScaleCalculationMode.RCEIL,
+            )
+        elif recipe == MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL:
+            return cls(
+                kernel_preference=KernelPreference.EMULATED,
+                out_dtype=torch.bfloat16,
+                wgrad_with_hp=False,
+                scale_calculation_mode=ScaleCalculationMode.RCEIL,
+            )
+        else:
+            raise ValueError(f"Unsupported MXFP8 recipe: {recipe}")
+
+    def __eq__(self, other):
+        if isinstance(other, MXFP8GroupedMMConfig):
+            return (
+                self.kernel_preference == other.kernel_preference
+                and self.out_dtype == other.out_dtype
+                and self.wgrad_with_hp == other.wgrad_with_hp
+                and self.scale_calculation_mode == other.scale_calculation_mode
+            )
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(
+            (
+                self.kernel_preference,
+                self.out_dtype,
+                self.wgrad_with_hp,
+                self.scale_calculation_mode,
+            )
+        )
+
+
+@register_quantize_module_handler(FP8GroupedMMConfig)
+@register_quantize_module_handler(MXFP8GroupedMMConfig)
+def _moe_training_transform(
+    module: nn.Module,
+    config: GroupedMMConfig,
+    parameter_name: Optional[str] = None,
+) -> nn.Module:
+    """
+    Swaps `torch.nn.Parameter` data tensor with a ScaledGroupedMMTensor.
+
+    Args:
+        module: Module to modify.
+        config: GroupedMMConfig which defines how to perform the MoE training transform.
+        parameter_name: If specified, only transform this specific parameter. Otherwise transform all parameters.
+
+    Returns:
+     nn.Module: The modified module with swapped parameters.
+    """
+    from torchao.prototype.moe_training.conversion_utils import _swap_params
+
+    out = _swap_params(module, config=config, target_parameter_name=parameter_name)
+    return out

--- a/torchao/prototype/moe_training/examples/mxfp8_expert_parallel_example.py
+++ b/torchao/prototype/moe_training/examples/mxfp8_expert_parallel_example.py
@@ -95,7 +95,7 @@ class GroupedExperts(nn.Module):
             Output tensor of shape (num_tokens, dim)
         """
 
-        from torchao.prototype.moe_training.scaled_grouped_mm import (
+        from torchao.prototype.moe_training.mxfp8_grouped_mm import (
             _to_mxfp8_then_scaled_grouped_mm as mxfp8_gmm,
         )
 

--- a/torchao/prototype/moe_training/fp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/fp8_grouped_mm.py
@@ -1,0 +1,255 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+
+from torchao.float8.config import ScalingGranularity
+from torchao.float8.float8_utils import tensor_to_scale, to_fp8_saturated
+from torchao.prototype.moe_training.kernels import (
+    triton_fp8_per_group_colwise_scales,
+    triton_fp8_rowwise_3d_transpose_rhs,
+)
+from torchao.prototype.moe_training.utils import _is_column_major
+
+
+def _to_fp8_rowwise_then_scaled_grouped_mm(
+    A: torch.Tensor,
+    B_t: torch.Tensor,
+    offs: torch.Tensor,
+    out_dtype: Optional[torch.dtype] = torch.bfloat16,
+) -> torch.Tensor:
+    """
+    Differentiable FP8 grouped matrix multiplication with dynamic FP8 rowwise quantization.
+
+    This function quantizes inputs A and B_t to FP8 format using rowwise scaling,
+    then performs a scaled grouped matrix multiplication. It's differentiable and
+    supports backpropagation through the quantization and GEMM operations.
+
+    Args:
+        A: Left operand tensor of shape (M, K). Must be row-major,
+            with dtype float32 or bfloat16, and K divisible by 16.
+        B_t: Right operand tensor of shape (E, K, N), transposed and in per-group column-major
+            format, meaning strides of (K*N, 1, K). Must have dtype float32 or bfloat16, with K and N divisible by 16.
+        offs: Offset tensor of shape (num_groups + 1,) with dtype int32, defining
+            group boundaries for the grouped GEMM operation. Group sizes must be divisible by 16.
+        out_dtype: Output dtype for the result. Defaults to torch.bfloat16.
+
+    Returns:
+        torch.Tensor: Result of grouped matrix multiplication with shape (M, N).
+
+    Note:
+        - A must be row-major and B_t must be column-major due to hardware requirements
+        - Both A and B_t are quantized to float8_e4m3fn with rowwise scaling
+        - Scales are computed per-row and rounded to powers of 2 for efficiency
+        - This function is fully differentiable via custom autograd implementation
+    """
+    return _Float8GroupedMM.apply(A, B_t, offs, out_dtype)
+
+
+class _Float8GroupedMM(torch.autograd.Function):
+    """Differentiable implementation of grouped GEMM with dynamic float8 quantization."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        A: torch.Tensor,
+        B_t: torch.Tensor,
+        offs: Optional[torch.Tensor] = None,
+        out_dtype: Optional[torch.dtype] = torch.bfloat16,
+    ) -> torch.Tensor:
+        # torchao _quantize_then_scaled_grouped_mm only supports A=2D|3D and B=3D.
+        assert A.ndim == 2 or A.ndim == 3, "A must be 2D or 3D"
+        assert B_t.ndim == 3, "B must be 3D"
+
+        assert A.size(-1) % 16 == 0, (
+            f"A must have a last dim divisible by 16, but got shape: {A.shape}"
+        )
+        assert B_t.size(-2) % 16 == 0 and B_t.size(-1) % 16 == 0, (
+            f"B must have last 2 dims divisible by 16, but got shape: {B_t.shape}"
+        )
+
+        # Assert input tensors are in high-precision dtypes.
+        assert A.dtype == torch.float32 or A.dtype == torch.bfloat16, (
+            "A must be float32 or bfloat16"
+        )
+        assert B_t.dtype == torch.float32 or B_t.dtype == torch.bfloat16, (
+            "B must be float32 or bfloat16"
+        )
+        assert offs is None or offs.dtype == torch.int32, (
+            "offs must be int32 tensor or None"
+        )
+
+        # Assert A and B dims are compatible for a scaled grouped GEMM.
+        assert A.size(-1) == B_t.size(-2), (
+            f"shape {A.shape} and {B_t.shape} are not compatible for _quantize_then_scaled_grouped_mm"
+        )
+
+        # The left operand in the scaled grouped GEMM must be row-major due to hardware requirements.
+        assert not _is_column_major(A), "A must be row-major"
+
+        # Due to hardware requirements, the right operand in a scaled grouped GEMM must be column-major.
+        assert _is_column_major(B_t), "B must be column-major"
+
+        # Convert high precision input tensor to float8, row-major for left operand of grouped GEMM.
+        # A shape: (M, K) or (B, M, K)
+        # A_scales shape: (M,1) or (B, M, 1)
+        A_scales = tensor_to_scale(
+            A,
+            torch.float8_e4m3fn,
+            scaling_granularity=ScalingGranularity.AXISWISE,
+            axiswise_dim=-1,
+            round_scales_to_power_of_2=True,
+        )
+        A_scaled = A.to(torch.float32) * A_scales
+        A_data_row_major = to_fp8_saturated(A_scaled, torch.float8_e4m3fn)
+
+        # Convert B to float8, column-major for right operand of grouped GEMM.
+        # B_t shape: (E, K, N)
+        # B_t scales must be computed rowwise keeping the outer/final dim, so:
+        # B_t_scales shape: (E, 1, N)
+        B_t_scales = tensor_to_scale(
+            B_t,
+            torch.float8_e4m3fn,
+            scaling_granularity=ScalingGranularity.AXISWISE,
+            axiswise_dim=-2,
+            round_scales_to_power_of_2=True,
+        )
+        B_t_scaled = B_t.to(torch.float32) * B_t_scales
+        B_t_data_col_major = to_fp8_saturated(B_t_scaled, torch.float8_e4m3fn)
+
+        # Store what we need for backward.
+        ctx.save_for_backward(A, B_t, offs)
+        ctx.out_dtype = out_dtype
+
+        # Perform scaled grouped GEMM and return result.
+        # output shape: scaled grouped mm of (M,K) @ (B,K,N) = (M,N)
+        assert not _is_column_major(A_data_row_major), (
+            "A must be row-major for output = A @ B"
+        )
+        assert _is_column_major(B_t_data_col_major), (
+            "B must be column-major for output = A @ B"
+        )
+
+        # Squeeze empty dims out of scales, to comply with grouped mm API.
+        # A_scales shape: (M,1) or (B, M, 1)
+        # B_t_scales shape: (E, 1, N)
+        A_scales = A_scales.squeeze(-1)
+        B_t_scales = B_t_scales.squeeze(1)
+        return torch._scaled_grouped_mm(
+            A_data_row_major,
+            B_t_data_col_major,
+            A_scales.reciprocal(),  # Reciprocals are needed for rescaling the output.
+            B_t_scales.reciprocal(),
+            offs,
+            out_dtype=out_dtype,
+            use_fast_accum=True,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        A, B_t, offs = ctx.saved_tensors
+        out_dtype = ctx.out_dtype
+
+        # Convert grad_output to float8, row-major for left operand of grouped GEMM
+        # needed for grad_A: grad_output @ B
+        #
+        # grad_output shape: (Mg, N)
+        # grad_output_scale shape: (Mg, 1)
+        grad_output_scales = tensor_to_scale(
+            grad_output,
+            torch.float8_e4m3fn,
+            scaling_granularity=ScalingGranularity.AXISWISE,
+            axiswise_dim=-1,
+            round_scales_to_power_of_2=True,
+        )
+        grad_output_scaled = grad_output.to(torch.float32) * grad_output_scales
+        grad_output_data_row_major = to_fp8_saturated(
+            grad_output_scaled, torch.float8_e4m3fn
+        )
+
+        # Compute B fp8 column-major for right operand of grouped GEMM:
+        # grad_A = grad_output @ B.
+        B_data_col_major, B_scales = triton_fp8_rowwise_3d_transpose_rhs(
+            B_t._data if hasattr(B_t, "_data") else B_t,
+            output_dtype=torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+
+        # Compute grad_A.
+        # grad_A = grad_output @ B
+        # grad_A = scaled grouped mm of (M,N) @ (B,N,K) = (M,K)
+        assert not _is_column_major(grad_output_data_row_major), (
+            "grad_output must be row-major for grad_A = grad_output @ B"
+        )
+        assert _is_column_major(B_data_col_major), (
+            "B must be column-major for grad_A = grad_output @ B"
+        )
+
+        # Squeeze empty dims out of scales, to comply with grouped mm API.
+        # grad_output_scales shape: (M,1) or (B, M, 1)
+        # B_scales shape: (E, 1, N)
+        grad_output_scales = grad_output_scales.squeeze(-1)
+        B_scales = B_scales.squeeze(1)
+        grad_A = torch._scaled_grouped_mm(
+            grad_output_data_row_major,
+            B_data_col_major,
+            grad_output_scales.reciprocal(),
+            B_scales.reciprocal(),
+            offs,
+            out_dtype=out_dtype,
+            use_fast_accum=True,
+        )
+
+        # grad_B is a special case. both operands of the grouped gemm will be 2D with offsets determing the "groups."
+        # Compute scales for grad_output_t and A, which are both 2D tensors with offsets which define the "jagged" groups.
+
+        # Convert transpose of grad_output to float8, row-major for left operand of grouped GEMM
+        # needed for grad_B: grad_output_t @ A
+        # Use transpose method to avoid uncoalesced memory accesses.
+        grad_out_data_colwise, grad_out_scales = triton_fp8_per_group_colwise_scales(
+            grad_output.t()
+            .contiguous()
+            .t(),  # Quantization is over 2x faster when input is col major, even with this transformation
+            offs,
+            torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+        grad_output_t_data_row_major = grad_out_data_colwise.t()
+        grad_output_t_scales = grad_out_scales.t()
+
+        A_data_col_major, A_scales = triton_fp8_per_group_colwise_scales(
+            A.t()
+            .contiguous()
+            .t(),  # Quantization is over 2x faster when input is col major, even with this transformation
+            offs,
+            torch.float8_e4m3fn,
+            round_scales_to_power_of_2=True,
+        )
+
+        # Compute grad_B = grad_output_t @ A.
+        # grad_B = grad_output_t @ A
+        assert not _is_column_major(grad_output_t_data_row_major), (
+            "grad_output_t must be row-major for grad_B = grad_output_t @ A"
+        )
+        assert _is_column_major(A_data_col_major), (
+            "A must be column-major for grad_B = grad_output_t @ A"
+        )
+
+        # Per-token group scales computed via triton kernels above do not have
+        # the empty dim like the scales computed via tensor_to_scale, so we need
+        # don't need to squeeze here.
+        grad_B = torch._scaled_grouped_mm(
+            grad_output_t_data_row_major,
+            A_data_col_major,
+            grad_output_t_scales.reciprocal(),
+            A_scales.reciprocal(),
+            offs,
+            out_dtype=out_dtype,
+            use_fast_accum=True,
+        )
+        return grad_A, grad_B.transpose(-2, -1), None, None, None, None

--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -8,462 +8,489 @@
 from typing import Tuple
 
 import torch
-import triton
-import triton.language as tl
+from torch.utils._triton import has_triton
 
-EPS = 1e-12
+from torchao.utils import torch_version_at_least
 
-FP8_DTYPE_MAP = {
-    torch.int8: tl.int8,
-    torch.int16: tl.int16,
-    torch.int32: tl.int32,
-    torch.int64: tl.int64,
-    torch.float8_e4m3fn: tl.float8e4nv,
-    torch.float8_e5m2: tl.float8e5,
-    torch.float16: tl.float16,
-    torch.bfloat16: tl.bfloat16,
-    torch.float32: tl.float32,
-    torch.float64: tl.float64,
-}
+if torch_version_at_least("2.7.0") and has_triton():
+    import triton
+    import triton.language as tl
 
-block_sizes_n = [128]  # large dim (output_features)
-block_sizes_k = [128]  # small dim (input_features)
-num_warps = [4]
-num_stages = [4]
-atomic_kernel_configs_2D = [
-    triton.Config(
-        {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
-        num_warps=warps,
-        num_stages=stages,
+    EPS = 1e-12
+
+    FP8_DTYPE_MAP = {
+        torch.int8: tl.int8,
+        torch.int16: tl.int16,
+        torch.int32: tl.int32,
+        torch.int64: tl.int64,
+        torch.float8_e4m3fn: tl.float8e4nv,
+        torch.float8_e5m2: tl.float8e5,
+        torch.float16: tl.float16,
+        torch.bfloat16: tl.bfloat16,
+        torch.float32: tl.float32,
+        torch.float64: tl.float64,
+    }
+
+    block_sizes_n = [128]  # large dim (output_features)
+    block_sizes_k = [128]  # small dim (input_features)
+    num_warps = [4]
+    num_stages = [4]
+    atomic_kernel_configs_2D = [
+        triton.Config(
+            {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
+            num_warps=warps,
+            num_stages=stages,
+        )
+        for block_size_n in block_sizes_n
+        for block_size_k in block_sizes_k
+        for warps in num_warps
+        for stages in num_stages
+    ]
+
+    @torch.library.custom_op(
+        "torchao::triton_fp8_rowwise_transpose_rhs", mutates_args={}
     )
-    for block_size_n in block_sizes_n
-    for block_size_k in block_sizes_k
-    for warps in num_warps
-    for stages in num_stages
-]
+    def triton_fp8_rowwise_3d_transpose_rhs(
+        hp_tensor: torch.Tensor,  # (E, K, N)
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert hp_tensor.ndim == 3, "input tensor must be 3D"
 
+        tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+        tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
 
-@torch.library.custom_op("torchao::triton_fp8_rowwise_transpose_rhs", mutates_args={})
-def triton_fp8_rowwise_3d_transpose_rhs(
-    hp_tensor: torch.Tensor,  # (E, K, N)
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert hp_tensor.ndim == 3, "input tensor must be 3D"
+        fp8_dtype_min = torch.finfo(output_dtype).min
+        fp8_dtype_max = torch.finfo(output_dtype).max
 
-    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
-    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+        e, k, n = hp_tensor.shape
 
-    fp8_dtype_min = torch.finfo(output_dtype).min
-    fp8_dtype_max = torch.finfo(output_dtype).max
+        # allocate on-device buffers for output and scales
+        # output shape = input.transpose(-2, -1).shape = (E, N, K) in column major layout
+        output_buffer = torch.empty(
+            (e, n, k), dtype=output_dtype, device=hp_tensor.device
+        ).as_strided((e, n, k), (n * k, 1, n))
 
-    e, k, n = hp_tensor.shape
+        scales_buffer = torch.full(
+            (e, k), float("inf"), dtype=torch.float32, device=hp_tensor.device
+        )
 
-    # allocate on-device buffers for output and scales
-    # output shape = input.transpose(-2, -1).shape = (E, N, K) in column major layout
-    output_buffer = torch.empty(
-        (e, n, k), dtype=output_dtype, device=hp_tensor.device
-    ).as_strided((e, n, k), (n * k, 1, n))
+        # parallelize across experts, and for each expert, parallelize across rows and cols
+        grid = lambda meta: (
+            e,
+            triton.cdiv(k, meta["BLOCK_SIZE_K"]),
+            triton.cdiv(n, meta["BLOCK_SIZE_N"]),
+        )
 
-    scales_buffer = torch.full(
-        (e, k), float("inf"), dtype=torch.float32, device=hp_tensor.device
-    )
+        # compute scales
+        _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel[grid](
+            hp_tensor,
+            hp_tensor.stride(0),
+            hp_tensor.stride(1),
+            hp_tensor.stride(2),
+            scales_buffer,
+            scales_buffer.stride(0),
+            scales_buffer.stride(1),
+            e,
+            n,
+            k,
+            fp8_dtype_min,
+            fp8_dtype_max,
+            tl_input_dtype,
+            round_scales_to_power_of_2=round_scales_to_power_of_2,
+            EPS=EPS,
+        )
 
-    # parallelize across experts, and for each expert, parallelize across rows and cols
-    grid = lambda meta: (
-        e,
-        triton.cdiv(k, meta["BLOCK_SIZE_K"]),
-        triton.cdiv(n, meta["BLOCK_SIZE_N"]),
-    )
+        # perform casting
+        _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel[grid](
+            hp_tensor,
+            hp_tensor.stride(0),
+            hp_tensor.stride(1),
+            hp_tensor.stride(2),
+            output_buffer,
+            output_buffer.stride(0),
+            output_buffer.stride(1),
+            output_buffer.stride(2),
+            scales_buffer,
+            scales_buffer.stride(0),
+            scales_buffer.stride(1),
+            e,
+            n,
+            k,
+            fp8_dtype_min,
+            fp8_dtype_max,
+            tl_input_dtype,
+            tl_output_dtype,
+        )
+        return output_buffer, scales_buffer
 
-    # compute scales
-    _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel[grid](
-        hp_tensor,
-        hp_tensor.stride(0),
-        hp_tensor.stride(1),
-        hp_tensor.stride(2),
-        scales_buffer,
-        scales_buffer.stride(0),
-        scales_buffer.stride(1),
-        e,
-        n,
-        k,
-        fp8_dtype_min,
-        fp8_dtype_max,
-        tl_input_dtype,
-        round_scales_to_power_of_2=round_scales_to_power_of_2,
-        EPS=EPS,
-    )
+    @triton_fp8_rowwise_3d_transpose_rhs.register_fake
+    def _fake_triton_fp8_rowwise_3d_transpose_rhs(
+        hp_tensor: torch.Tensor,  # (E, K, N)
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert hp_tensor.ndim == 3, "input tensor must be 3D"
+        e, k, n = hp_tensor.shape
+        output_buffer = torch.empty(
+            (e, n, k), dtype=output_dtype, device=hp_tensor.device
+        ).as_strided((e, n, k), (n * k, 1, n))
 
-    # perform casting
-    _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel[grid](
-        hp_tensor,
-        hp_tensor.stride(0),
-        hp_tensor.stride(1),
-        hp_tensor.stride(2),
-        output_buffer,
-        output_buffer.stride(0),
-        output_buffer.stride(1),
-        output_buffer.stride(2),
-        scales_buffer,
-        scales_buffer.stride(0),
-        scales_buffer.stride(1),
-        e,
-        n,
-        k,
-        fp8_dtype_min,
-        fp8_dtype_max,
-        tl_input_dtype,
-        tl_output_dtype,
-    )
-    return output_buffer, scales_buffer
+        scales_buffer = torch.empty(
+            (e, k), dtype=torch.float32, device=hp_tensor.device
+        )
+        return output_buffer, scales_buffer
 
+    @triton.autotune(configs=atomic_kernel_configs_2D, key=["K", "N"])
+    @triton.jit
+    def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
+        input_ptr,
+        stride_input_dim0: tl.int64,
+        stride_input_dim1,
+        stride_input_dim2,
+        scales_ptr,
+        stride_scales_dim0: int,
+        stride_scales_dim1,
+        E: int,
+        N: int,
+        K: int,
+        fp8_dtype_min: tl.constexpr,
+        fp8_dtype_max: tl.constexpr,
+        input_dtype: tl.constexpr,
+        round_scales_to_power_of_2: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        EPS: tl.constexpr,
+    ):
+        # parallelize across experts, rows, and cols
+        expert_idx = tl.program_id(0)
+        k_block_idx = tl.program_id(1)
+        n_block_idx = tl.program_id(2)
 
-@triton_fp8_rowwise_3d_transpose_rhs.register_fake
-def _fake_triton_fp8_rowwise_3d_transpose_rhs(
-    hp_tensor: torch.Tensor,  # (E, K, N)
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert hp_tensor.ndim == 3, "input tensor must be 3D"
-    e, k, n = hp_tensor.shape
-    output_buffer = torch.empty(
-        (e, n, k), dtype=output_dtype, device=hp_tensor.device
-    ).as_strided((e, n, k), (n * k, 1, n))
+        # compute offsets for each dimension
+        k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        n_offs = n_block_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
 
-    scales_buffer = torch.empty((e, k), dtype=torch.float32, device=hp_tensor.device)
-    return output_buffer, scales_buffer
-
-
-@triton.autotune(configs=atomic_kernel_configs_2D, key=["K", "N"])
-@triton.jit
-def _triton_fp8_rowwise_3d_transpose_scales_rhs_kernel(
-    input_ptr,
-    stride_input_dim0: tl.int64,
-    stride_input_dim1,
-    stride_input_dim2,
-    scales_ptr,
-    stride_scales_dim0: int,
-    stride_scales_dim1,
-    E: int,
-    N: int,
-    K: int,
-    fp8_dtype_min: tl.constexpr,
-    fp8_dtype_max: tl.constexpr,
-    input_dtype: tl.constexpr,
-    round_scales_to_power_of_2: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    EPS: tl.constexpr,
-):
-    # parallelize across experts, rows, and cols
-    expert_idx = tl.program_id(0)
-    k_block_idx = tl.program_id(1)
-    n_block_idx = tl.program_id(2)
-
-    # compute offsets for each dimension
-    k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
-    n_offs = n_block_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-
-    # load block of input data, shape (K, N)
-    input_offs = (
-        expert_idx * stride_input_dim0
-        + k_offs[:, None] * stride_input_dim1
-        + (n_offs[None, :] * stride_input_dim2)
-    )
-    input_mask = (k_offs[:, None] < K) & (n_offs[None, :] < N)
-    input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
-
-    # In a normal torch implementation, we should transpose the tensor then compute the amax
-    # along the dim1 (N), to compute colwise scales for a RHS operand of a scaled grouped gemm:
-    #    input_data = input_data.transpose(-2,-1) # (E, K, N) -> (E, N, K)
-    #    amaxes = input_data.abs().max(dim=1) # (E, N, K) -> (E, 1, K)
-    #
-    # Here, we are reading a (K, N) chunk for a given E, and computing the amax along the dim=1 (N)
-    # to compute an equivalent scale of shape (K,) for this chunk of the expert.
-    # We then use atomic min to compute the final scale for these logical columns of the transposed tensor.
-    #
-    # Later, we will use this scale to cast the same (K,N) input chunk to fp8 and transpose it to (N, K) before
-    # writing it to the output tensor.
-    #    ((K, N) * (K, 1))^T = (N, K)
-    amaxes = tl.max(tl.abs(input_data), axis=1).to(tl.float64)  # (K,)
-    scales = (fp8_dtype_max / tl.clamp(amaxes, min=EPS, max=float("inf"))).to(
-        tl.float32
-    )
-    if round_scales_to_power_of_2:
-        scales = tl.exp2(tl.floor(tl.log2(scales)))
-
-    # compute global scales using atomics with local scales - shape (1, K)
-    scales_offs = (
-        expert_idx[:, None] * stride_scales_dim0 + k_offs[None, :] * stride_scales_dim1
-    )
-    scales_mask = k_offs[None, :] < K
-    tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
-
-
-@triton.autotune(configs=atomic_kernel_configs_2D, key=["num_elements"])
-@triton.jit
-def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
-    input_ptr,
-    stride_input_dim0: tl.int64,
-    stride_input_dim1,
-    stride_input_dim2,
-    output_ptr,
-    stride_output_dim0: tl.int64,
-    stride_output_dim1,
-    stride_output_dim2,
-    scales_ptr,
-    stride_scales_dim0: int,
-    stride_scales_dim1,
-    E: int,
-    N: int,
-    K: int,
-    fp8_dtype_min: tl.constexpr,
-    fp8_dtype_max: tl.constexpr,
-    input_dtype: tl.constexpr,
-    output_dtype: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-):
-    # parallelize across experts, rows, and cols
-    expert_idx = tl.program_id(0)
-    k_block_idx = tl.program_id(1)
-    n_block_idx = tl.program_id(2)
-
-    # compute offsets for each dimension
-    k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
-    n_offs = n_block_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-
-    # load block of input data for this expert - shape (K, N)
-    input_offs = (
-        expert_idx * stride_input_dim0
-        + k_offs[:, None] * stride_input_dim1
-        + (n_offs[None, :] * stride_input_dim2)
-    )
-    input_mask = (k_offs[:, None] < K) & (n_offs[None, :] < N)
-    input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
-    input_data = input_data.trans(1, 0)  # (K, N) -> (N, K)
-
-    # load global scales for this block of the given expert - shape (1, K)
-    scales_offs = (
-        expert_idx[:, None] * stride_scales_dim0 + k_offs[None, :] * stride_scales_dim1
-    )
-    scales_mask = k_offs[None, :] < K
-    scales = tl.load(scales_ptr + scales_offs, mask=scales_mask, other=0.0)
-
-    # transpose data and apply scales - shape (N,K) * (1,K) = (N,K)
-    output_data = tl.clamp(
-        input_data * scales, min=fp8_dtype_min, max=fp8_dtype_max
-    ).to(output_dtype)
-
-    # store transpose and store output data - shape (N, K)
-    output_offs = (
-        expert_idx * stride_output_dim0
-        + n_offs[:, None] * stride_output_dim1
-        + (k_offs[None, :] * stride_output_dim2)
-    )
-    output_mask = (n_offs[:, None] < N) & (k_offs[None, :] < K)
-    tl.store(output_ptr + output_offs, output_data, mask=output_mask)
-
-
-block_sizes_n = [
-    64,
-]  # large dim (output_features)
-block_sizes_k = [128]  # small dim (input_features)
-num_warps = [8]
-num_stages = [6]
-reduction_kernel_configs_2D = [
-    triton.Config(
-        {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
-        num_warps=warps,
-        num_stages=stages,
-    )
-    for block_size_n in block_sizes_n
-    for block_size_k in block_sizes_k
-    for warps in num_warps
-    for stages in num_stages
-]
-
-
-@triton.autotune(configs=reduction_kernel_configs_2D, key=["K", "N"])
-@triton.jit
-def _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel(
-    input_ptr,
-    stride_input_dim0: tl.int64,
-    stride_input_dim1,
-    stride_input_dim2,
-    output_ptr,
-    stride_output_dim0: tl.int64,
-    stride_output_dim1,
-    stride_output_dim2,
-    scales_ptr,
-    stride_scales_dim0: int,
-    stride_scales_dim1,
-    E: int,
-    N: int,
-    K: int,
-    fp8_dtype_min: tl.constexpr,
-    fp8_dtype_max: tl.constexpr,
-    input_dtype: tl.constexpr,
-    output_dtype: tl.constexpr,
-    round_scales_to_power_of_2: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    EPS: tl.constexpr,
-):
-    # This kernel parallelizes across experts and K blocks
-    # Each program computes scales for one K block of one expert
-    expert_idx = tl.program_id(0)
-    k_block_idx = tl.program_id(1)
-
-    # Compute K offsets for this block
-    k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
-    k_mask = k_offs < K
-
-    # Initialize row maxes for this K block
-    row_maxes = tl.zeros((BLOCK_SIZE_K,), dtype=tl.float64) - float("inf")
-
-    # First pass: compute row-wise maximum absolute values across all N
-    for n_block_start in range(0, N, BLOCK_SIZE_N):
-        n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
-        n_mask = n_offs < N
-
-        # Load block of input data - shape (K, N)
+        # load block of input data, shape (K, N)
         input_offs = (
             expert_idx * stride_input_dim0
             + k_offs[:, None] * stride_input_dim1
-            + n_offs[None, :] * stride_input_dim2
+            + (n_offs[None, :] * stride_input_dim2)
         )
-        input_mask = k_mask[:, None] & n_mask[None, :]
+        input_mask = (k_offs[:, None] < K) & (n_offs[None, :] < N)
         input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
 
-        # Compute row-wise max for this N block
-        block_row_maxes = tl.max(tl.abs(input_data), axis=1)
+        # In a normal torch implementation, we should transpose the tensor then compute the amax
+        # along the dim1 (N), to compute colwise scales for a RHS operand of a scaled grouped gemm:
+        #    input_data = input_data.transpose(-2,-1) # (E, K, N) -> (E, N, K)
+        #    amaxes = input_data.abs().max(dim=1) # (E, N, K) -> (E, 1, K)
+        #
+        # Here, we are reading a (K, N) chunk for a given E, and computing the amax along the dim=1 (N)
+        # to compute an equivalent scale of shape (K,) for this chunk of the expert.
+        # We then use atomic min to compute the final scale for these logical columns of the transposed tensor.
+        #
+        # Later, we will use this scale to cast the same (K,N) input chunk to fp8 and transpose it to (N, K) before
+        # writing it to the output tensor.
+        #    ((K, N) * (K, 1))^T = (N, K)
+        amaxes = tl.max(tl.abs(input_data), axis=1).to(tl.float64)  # (K,)
+        scales = (fp8_dtype_max / tl.clamp(amaxes, min=EPS, max=float("inf"))).to(
+            tl.float32
+        )
+        if round_scales_to_power_of_2:
+            scales = tl.exp2(tl.floor(tl.log2(scales)))
 
-        # Update running maxes
-        row_maxes = tl.maximum(row_maxes, block_row_maxes)
+        # compute global scales using atomics with local scales - shape (1, K)
+        scales_offs = (
+            expert_idx[:, None] * stride_scales_dim0
+            + k_offs[None, :] * stride_scales_dim1
+        )
+        scales_mask = k_offs[None, :] < K
+        tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
 
-    # Convert row maxes to scales
-    clamped_maxes = tl.clamp(row_maxes, min=EPS, max=float("inf"))
-    scales = (fp8_dtype_max / clamped_maxes.to(tl.float64)).to(tl.float32)
+    @triton.autotune(configs=atomic_kernel_configs_2D, key=["num_elements"])
+    @triton.jit
+    def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
+        input_ptr,
+        stride_input_dim0: tl.int64,
+        stride_input_dim1,
+        stride_input_dim2,
+        output_ptr,
+        stride_output_dim0: tl.int64,
+        stride_output_dim1,
+        stride_output_dim2,
+        scales_ptr,
+        stride_scales_dim0: int,
+        stride_scales_dim1,
+        E: int,
+        N: int,
+        K: int,
+        fp8_dtype_min: tl.constexpr,
+        fp8_dtype_max: tl.constexpr,
+        input_dtype: tl.constexpr,
+        output_dtype: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+    ):
+        # parallelize across experts, rows, and cols
+        expert_idx = tl.program_id(0)
+        k_block_idx = tl.program_id(1)
+        n_block_idx = tl.program_id(2)
 
-    if round_scales_to_power_of_2:
-        scales = tl.exp2(tl.floor(tl.log2(scales)))
+        # compute offsets for each dimension
+        k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        n_offs = n_block_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
 
-    # Store computed scales for this K block
-    scales_offs = expert_idx * stride_scales_dim0 + k_offs * stride_scales_dim1
-    tl.store(scales_ptr + scales_offs, scales, mask=k_mask)
-
-    # Second pass: apply scales and transpose data for output
-    for n_block_start in range(0, N, BLOCK_SIZE_N):
-        n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
-        n_mask = n_offs < N
-
-        # Load block of input data - shape (K, N)
+        # load block of input data for this expert - shape (K, N)
         input_offs = (
             expert_idx * stride_input_dim0
             + k_offs[:, None] * stride_input_dim1
-            + n_offs[None, :] * stride_input_dim2
+            + (n_offs[None, :] * stride_input_dim2)
         )
-        input_mask = k_mask[:, None] & n_mask[None, :]
+        input_mask = (k_offs[:, None] < K) & (n_offs[None, :] < N)
         input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
+        input_data = input_data.trans(1, 0)  # (K, N) -> (N, K)
 
-        # Transpose data: (K, N) -> (N, K)
-        input_data_transposed = input_data.trans(1, 0)
-
-        # Apply scales: (N, K) * (1, K) = (N, K)
-        scaled_data = input_data_transposed * scales[None, :]
-
-        # Clamp and cast to output dtype
-        output_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
-            output_dtype
+        # load global scales for this block of the given expert - shape (1, K)
+        scales_offs = (
+            expert_idx[:, None] * stride_scales_dim0
+            + k_offs[None, :] * stride_scales_dim1
         )
+        scales_mask = k_offs[None, :] < K
+        scales = tl.load(scales_ptr + scales_offs, mask=scales_mask, other=0.0)
 
-        # Store transposed output - shape (N, K)
+        # transpose data and apply scales - shape (N,K) * (1,K) = (N,K)
+        output_data = tl.clamp(
+            input_data * scales, min=fp8_dtype_min, max=fp8_dtype_max
+        ).to(output_dtype)
+
+        # store transpose and store output data - shape (N, K)
         output_offs = (
             expert_idx * stride_output_dim0
             + n_offs[:, None] * stride_output_dim1
-            + k_offs[None, :] * stride_output_dim2
+            + (k_offs[None, :] * stride_output_dim2)
         )
-        output_mask = n_mask[:, None] & k_mask[None, :]
+        output_mask = (n_offs[:, None] < N) & (k_offs[None, :] < K)
         tl.store(output_ptr + output_offs, output_data, mask=output_mask)
 
+    block_sizes_n = [
+        64,
+    ]  # large dim (output_features)
+    block_sizes_k = [128]  # small dim (input_features)
+    num_warps = [8]
+    num_stages = [6]
+    reduction_kernel_configs_2D = [
+        triton.Config(
+            {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k},
+            num_warps=warps,
+            num_stages=stages,
+        )
+        for block_size_n in block_sizes_n
+        for block_size_k in block_sizes_k
+        for warps in num_warps
+        for stages in num_stages
+    ]
 
-@torch.library.custom_op(
-    "torchao::triton_fp8_rowwise_transpose_rhs_fused", mutates_args={}
-)
-def triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
-    hp_tensor: torch.Tensor,  # (E, K, N)
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Equivalent fused Triton kernel to triton_fp8_rowwise_3d_transpose_rhs that uses
-    reduction to calculate rowwise scales instead of atomic operations.
+    @triton.autotune(configs=reduction_kernel_configs_2D, key=["K", "N"])
+    @triton.jit
+    def _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel(
+        input_ptr,
+        stride_input_dim0: tl.int64,
+        stride_input_dim1,
+        stride_input_dim2,
+        output_ptr,
+        stride_output_dim0: tl.int64,
+        stride_output_dim1,
+        stride_output_dim2,
+        scales_ptr,
+        stride_scales_dim0: int,
+        stride_scales_dim1,
+        E: int,
+        N: int,
+        K: int,
+        fp8_dtype_min: tl.constexpr,
+        fp8_dtype_max: tl.constexpr,
+        input_dtype: tl.constexpr,
+        output_dtype: tl.constexpr,
+        round_scales_to_power_of_2: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        EPS: tl.constexpr,
+    ):
+        # This kernel parallelizes across experts and K blocks
+        # Each program computes scales for one K block of one expert
+        expert_idx = tl.program_id(0)
+        k_block_idx = tl.program_id(1)
 
-    This kernel fuses the scale computation and casting into a single kernel,
-    avoiding the need for atomic operations by using reduction operations.
-    """
-    assert hp_tensor.ndim == 3, "input tensor must be 3D"
+        # Compute K offsets for this block
+        k_offs = k_block_idx * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        k_mask = k_offs < K
 
-    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
-    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+        # Initialize row maxes for this K block
+        row_maxes = tl.zeros((BLOCK_SIZE_K,), dtype=tl.float64) - float("inf")
 
-    fp8_dtype_min = torch.finfo(output_dtype).min
-    fp8_dtype_max = torch.finfo(output_dtype).max
+        # First pass: compute row-wise maximum absolute values across all N
+        for n_block_start in range(0, N, BLOCK_SIZE_N):
+            n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
+            n_mask = n_offs < N
 
-    e, k, n = hp_tensor.shape
+            # Load block of input data - shape (K, N)
+            input_offs = (
+                expert_idx * stride_input_dim0
+                + k_offs[:, None] * stride_input_dim1
+                + n_offs[None, :] * stride_input_dim2
+            )
+            input_mask = k_mask[:, None] & n_mask[None, :]
+            input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
 
-    # allocate on-device buffers for output and scales
-    # output shape = input.transpose(-2, -1).shape = (E, N, K) in column major layout
-    output_buffer = torch.empty(
-        (e, n, k), dtype=output_dtype, device=hp_tensor.device
-    ).as_strided((e, n, k), (n * k, 1, n))
+            # Compute row-wise max for this N block
+            block_row_maxes = tl.max(tl.abs(input_data), axis=1)
 
-    scales_buffer = torch.empty((e, k), dtype=torch.float32, device=hp_tensor.device)
+            # Update running maxes
+            row_maxes = tl.maximum(row_maxes, block_row_maxes)
 
-    # Use a grid that parallelizes across experts and K blocks
-    # Each program handles one K block of one expert
-    grid = lambda meta: (e, triton.cdiv(k, meta["BLOCK_SIZE_K"]), 1)
+        # Convert row maxes to scales
+        clamped_maxes = tl.clamp(row_maxes, min=EPS, max=float("inf"))
+        scales = (fp8_dtype_max / clamped_maxes.to(tl.float64)).to(tl.float32)
 
-    # Single fused kernel that computes scales using reduction and performs casting
-    _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel[grid](
-        hp_tensor,
-        hp_tensor.stride(0),
-        hp_tensor.stride(1),
-        hp_tensor.stride(2),
-        output_buffer,
-        output_buffer.stride(0),
-        output_buffer.stride(1),
-        output_buffer.stride(2),
-        scales_buffer,
-        scales_buffer.stride(0),
-        scales_buffer.stride(1),
-        e,
-        n,
-        k,
-        fp8_dtype_min,
-        fp8_dtype_max,
-        tl_input_dtype,
-        tl_output_dtype,
-        round_scales_to_power_of_2=round_scales_to_power_of_2,
-        EPS=EPS,
+        if round_scales_to_power_of_2:
+            scales = tl.exp2(tl.floor(tl.log2(scales)))
+
+        # Store computed scales for this K block
+        scales_offs = expert_idx * stride_scales_dim0 + k_offs * stride_scales_dim1
+        tl.store(scales_ptr + scales_offs, scales, mask=k_mask)
+
+        # Second pass: apply scales and transpose data for output
+        for n_block_start in range(0, N, BLOCK_SIZE_N):
+            n_offs = n_block_start + tl.arange(0, BLOCK_SIZE_N)
+            n_mask = n_offs < N
+
+            # Load block of input data - shape (K, N)
+            input_offs = (
+                expert_idx * stride_input_dim0
+                + k_offs[:, None] * stride_input_dim1
+                + n_offs[None, :] * stride_input_dim2
+            )
+            input_mask = k_mask[:, None] & n_mask[None, :]
+            input_data = tl.load(input_ptr + input_offs, mask=input_mask, other=0.0)
+
+            # Transpose data: (K, N) -> (N, K)
+            input_data_transposed = input_data.trans(1, 0)
+
+            # Apply scales: (N, K) * (1, K) = (N, K)
+            scaled_data = input_data_transposed * scales[None, :]
+
+            # Clamp and cast to output dtype
+            output_data = tl.clamp(
+                scaled_data, min=fp8_dtype_min, max=fp8_dtype_max
+            ).to(output_dtype)
+
+            # Store transposed output - shape (N, K)
+            output_offs = (
+                expert_idx * stride_output_dim0
+                + n_offs[:, None] * stride_output_dim1
+                + k_offs[None, :] * stride_output_dim2
+            )
+            output_mask = n_mask[:, None] & k_mask[None, :]
+            tl.store(output_ptr + output_offs, output_data, mask=output_mask)
+
+    @torch.library.custom_op(
+        "torchao::triton_fp8_rowwise_transpose_rhs_fused", mutates_args={}
     )
+    def triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
+        hp_tensor: torch.Tensor,  # (E, K, N)
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Equivalent fused Triton kernel to triton_fp8_rowwise_3d_transpose_rhs that uses
+        reduction to calculate rowwise scales instead of atomic operations.
 
-    return output_buffer, scales_buffer
+        This kernel fuses the scale computation and casting into a single kernel,
+        avoiding the need for atomic operations by using reduction operations.
+        """
+        assert hp_tensor.ndim == 3, "input tensor must be 3D"
 
+        tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+        tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
 
-@triton_fp8_rowwise_3d_transpose_rhs_fused_reduction.register_fake
-def _fake_triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
-    hp_tensor: torch.Tensor,  # (E, K, N)
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert hp_tensor.ndim == 3, "input tensor must be 3D"
-    e, k, n = hp_tensor.shape
-    output_buffer = torch.empty(
-        (e, n, k), dtype=output_dtype, device=hp_tensor.device
-    ).as_strided((e, n, k), (n * k, 1, n))
+        fp8_dtype_min = torch.finfo(output_dtype).min
+        fp8_dtype_max = torch.finfo(output_dtype).max
 
-    scales_buffer = torch.empty((e, k), dtype=torch.float32, device=hp_tensor.device)
-    return output_buffer, scales_buffer
+        e, k, n = hp_tensor.shape
+
+        # allocate on-device buffers for output and scales
+        # output shape = input.transpose(-2, -1).shape = (E, N, K) in column major layout
+        output_buffer = torch.empty(
+            (e, n, k), dtype=output_dtype, device=hp_tensor.device
+        ).as_strided((e, n, k), (n * k, 1, n))
+
+        scales_buffer = torch.empty(
+            (e, k), dtype=torch.float32, device=hp_tensor.device
+        )
+
+        # Use a grid that parallelizes across experts and K blocks
+        # Each program handles one K block of one expert
+        grid = lambda meta: (e, triton.cdiv(k, meta["BLOCK_SIZE_K"]), 1)
+
+        # Single fused kernel that computes scales using reduction and performs casting
+        _triton_fp8_rowwise_3d_transpose_rhs_fused_reduction_kernel[grid](
+            hp_tensor,
+            hp_tensor.stride(0),
+            hp_tensor.stride(1),
+            hp_tensor.stride(2),
+            output_buffer,
+            output_buffer.stride(0),
+            output_buffer.stride(1),
+            output_buffer.stride(2),
+            scales_buffer,
+            scales_buffer.stride(0),
+            scales_buffer.stride(1),
+            e,
+            n,
+            k,
+            fp8_dtype_min,
+            fp8_dtype_max,
+            tl_input_dtype,
+            tl_output_dtype,
+            round_scales_to_power_of_2=round_scales_to_power_of_2,
+            EPS=EPS,
+        )
+
+        return output_buffer, scales_buffer
+
+    @triton_fp8_rowwise_3d_transpose_rhs_fused_reduction.register_fake
+    def _fake_triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
+        hp_tensor: torch.Tensor,  # (E, K, N)
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert hp_tensor.ndim == 3, "input tensor must be 3D"
+        e, k, n = hp_tensor.shape
+        output_buffer = torch.empty(
+            (e, n, k), dtype=output_dtype, device=hp_tensor.device
+        ).as_strided((e, n, k), (n * k, 1, n))
+
+        scales_buffer = torch.empty(
+            (e, k), dtype=torch.float32, device=hp_tensor.device
+        )
+        return output_buffer, scales_buffer
+
+else:
+
+    def triton_fp8_rowwise_3d_transpose_rhs(
+        hp_tensor: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "triton_fp8_rowwise_3d_transpose_rhs requires torch 2.7.0+ and triton installed"
+        )
+
+    def triton_fp8_rowwise_3d_transpose_rhs_fused_reduction(
+        hp_tensor: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "triton_fp8_rowwise_3d_transpose_rhs_fused_reduction requires torch 2.7.0+ and triton installed"
+        )

--- a/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
@@ -13,410 +13,441 @@ the offsets).
 from typing import Tuple
 
 import torch
-import triton
-import triton.language as tl
+from torch.utils._triton import has_triton
 
-EPS = 1e-12
+from torchao.utils import torch_version_at_least
 
-FP8_DTYPE_MAP = {
-    torch.int8: tl.int8,
-    torch.int16: tl.int16,
-    torch.int32: tl.int32,
-    torch.int64: tl.int64,
-    torch.float8_e4m3fn: tl.float8e4nv,
-    torch.float8_e5m2: tl.float8e5,
-    torch.float16: tl.float16,
-    torch.bfloat16: tl.bfloat16,
-    torch.float32: tl.float32,
-    torch.float64: tl.float64,
-}
+if torch_version_at_least("2.7.0") and has_triton():
+    import triton
+    import triton.language as tl
 
-block_sizes = [32]  # [16, 32, 64]
-block_sizes_iter = [128]  # [64, 128, 256]
-num_warps = [4]
-num_stages = [3]
-kernel_configs_2D = [
-    triton.Config(
-        {"BLOCK_SIZE": block_size, "BLOCK_SIZE_ITER": block_size_iter},
-        num_warps=warps,
-        num_stages=stages,
+    EPS = 1e-12
+
+    FP8_DTYPE_MAP = {
+        torch.int8: tl.int8,
+        torch.int16: tl.int16,
+        torch.int32: tl.int32,
+        torch.int64: tl.int64,
+        torch.float8_e4m3fn: tl.float8e4nv,
+        torch.float8_e5m2: tl.float8e5,
+        torch.float16: tl.float16,
+        torch.bfloat16: tl.bfloat16,
+        torch.float32: tl.float32,
+        torch.float64: tl.float64,
+    }
+
+    block_sizes = [32]  # [16, 32, 64]
+    block_sizes_iter = [128]  # [64, 128, 256]
+    num_warps = [4]
+    num_stages = [3]
+    kernel_configs_2D = [
+        triton.Config(
+            {"BLOCK_SIZE": block_size, "BLOCK_SIZE_ITER": block_size_iter},
+            num_warps=warps,
+            num_stages=stages,
+        )
+        for block_size in block_sizes
+        for block_size_iter in block_sizes_iter
+        for warps in num_warps
+        for stages in num_stages
+    ]
+
+    @torch.library.custom_op(
+        "torchao::triton_fp8_per_group_rowwise_scales", mutates_args={}
     )
-    for block_size in block_sizes
-    for block_size_iter in block_sizes_iter
-    for warps in num_warps
-    for stages in num_stages
-]
+    def triton_fp8_per_group_rowwise_scales(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Converts a high precision tensor to a float8 tensor in row-major memory layout,
+        using 'jagged' rowwise scales (i.e., separate scales for each group/subtensor as
+        determined by the offsets).
 
+        Args:
+            - hp_tensor: 2D high precision tensor to be converted
+            - offsets: end index for each group/subtensor along dim 0
+            - output_dtype: desired float8 dtype for the output tensor
+            - round_scales_to_power_of_2: boolean indicating if scales should be rounded
+                down to the nearest power of 2.
+        Returns:
+            - float8 tensor
+            - jagged rowwise scales (i.e., rowwise scales for each group)
+        """
+        assert hp_tensor.ndim == 2, "input tensor must be 2D"
 
-@torch.library.custom_op(
-    "torchao::triton_fp8_per_group_rowwise_scales", mutates_args={}
-)
-def triton_fp8_per_group_rowwise_scales(
-    hp_tensor: torch.Tensor,
-    offsets: torch.Tensor,
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Converts a high precision tensor to a float8 tensor in row-major memory layout,
-    using 'jagged' rowwise scales (i.e., separate scales for each group/subtensor as
-    determined by the offsets).
+        num_elements = hp_tensor.numel()
+        tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+        tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
 
-    Args:
-        - hp_tensor: 2D high precision tensor to be converted
-        - offsets: end index for each group/subtensor along dim 0
-        - output_dtype: desired float8 dtype for the output tensor
-        - round_scales_to_power_of_2: boolean indicating if scales should be rounded
-            down to the nearest power of 2.
-    Returns:
-        - float8 tensor
-        - jagged rowwise scales (i.e., rowwise scales for each group)
-    """
-    assert hp_tensor.ndim == 2, "input tensor must be 2D"
+        fp8_dtype_min = torch.finfo(output_dtype).min
+        fp8_dtype_max = torch.finfo(output_dtype).max
 
-    num_elements = hp_tensor.numel()
-    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
-    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
+        m, k = hp_tensor.shape
+        n_groups = offsets.numel()
 
-    fp8_dtype_min = torch.finfo(output_dtype).min
-    fp8_dtype_max = torch.finfo(output_dtype).max
+        # allocate on-device buffers for output and scales
+        output_buffer = torch.empty((m, k), dtype=output_dtype, device=hp_tensor.device)
+        scales_buffer = torch.empty(
+            (m * n_groups), dtype=torch.float32, device=hp_tensor.device
+        )
 
-    m, k = hp_tensor.shape
-    n_groups = offsets.numel()
+        # parallelize across rows and groups (offsets)
+        grid = lambda meta: (
+            triton.cdiv(m, meta["BLOCK_SIZE"]),
+            offsets.numel(),
+        )
+        _triton_fp8_per_group_rowwise_scales_kernel[grid](
+            hp_tensor,
+            offsets,
+            output_buffer,
+            scales_buffer,
+            m,
+            k,
+            hp_tensor.stride(0),
+            hp_tensor.stride(1),
+            output_buffer.stride(0),
+            output_buffer.stride(1),
+            num_elements,
+            fp8_dtype_min,
+            fp8_dtype_max,
+            tl_input_dtype,
+            tl_output_dtype,
+            round_scales_to_power_of_2,
+            EPS=EPS,
+        )
+        return output_buffer, scales_buffer
 
-    # allocate on-device buffers for output and scales
-    output_buffer = torch.empty((m, k), dtype=output_dtype, device=hp_tensor.device)
-    scales_buffer = torch.empty(
-        (m * n_groups), dtype=torch.float32, device=hp_tensor.device
+    @triton_fp8_per_group_rowwise_scales.register_fake
+    def _fake_triton_fp8_per_group_rowwise_scales_kernel(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert hp_tensor.ndim == 2, "input tensor must be 2D"
+        m, k = hp_tensor.shape
+        n_groups = offsets.numel()
+        output = torch.empty_like(hp_tensor, dtype=output_dtype).as_strided(
+            (m, k),  # shape
+            (k, 1),  # stride
+        )
+        scales = torch.empty(
+            (m * n_groups), dtype=torch.float32, device=hp_tensor.device
+        )
+        return output, scales
+
+    # This kernel is used on grad_output.t() which has shape (K, M),
+    # before the calculation `grad_B = grad_output_t @ input`.
+    # However, in this code, we use the conventional dim names (M, K)
+    # so the kernel is easily interpretable in a standalone fasion.
+    # The tokens per expert will vary per iteration, so don't want
+    # to recompile on `token` dim (K, in this case) changes.
+    @triton.autotune(configs=kernel_configs_2D, key=["M"])
+    @triton.jit
+    def _triton_fp8_per_group_rowwise_scales_kernel(
+        input_ptr,
+        offsets_ptr,
+        out_ptr,
+        scales_ptr,
+        M: int,
+        K: int,
+        stride_input_row: int,
+        stride_input_col: int,
+        stride_output_row: int,
+        stride_output_col: int,
+        num_elements: int,
+        fp8_dtype_min: tl.constexpr,
+        fp8_dtype_max: tl.constexpr,
+        input_dtype: tl.constexpr,
+        output_dtype: tl.constexpr,
+        round_scales_to_power_of_2: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_SIZE_ITER: tl.constexpr,
+        EPS: tl.constexpr,
+    ):
+        # parallel across rows and groups (offsets)
+        block_row_id = tl.program_id(axis=0)
+        offset_idx = tl.program_id(axis=1)
+
+        # determine start and end column idx for this group
+        group_col_start_idx = tl.load(
+            offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
+        )
+        group_col_end_idx = tl.load(offsets_ptr + offset_idx)
+        block_row_offs = block_row_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+        # compute rowwise amaxes for this group
+        amax_buffer = tl.zeros((BLOCK_SIZE,), dtype=input_dtype)
+        for col_start_idx in range(
+            group_col_start_idx, group_col_end_idx, BLOCK_SIZE_ITER
+        ):
+            block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
+            block_offs = (
+                block_row_offs[:, None] * stride_input_row
+                + block_col_offs[None, :] * stride_input_col
+            )
+            block_mask = (block_row_offs[:, None] < M) & (
+                block_col_offs[None, :] < group_col_end_idx
+            )
+            data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+                input_dtype
+            )
+            # we need to cast back to input dtype since triton promotes bf16 to fp32:
+            # https://github.com/triton-lang/triton/blob/981e987eed9053b952f81153bc0779c99d8c642e/python/triton/language/standard.py#L173
+            amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=1)).to(
+                input_dtype
+            )
+
+        # compute rowwise scales for this group. round scales to nearest power of 2.
+        amax_buffer = amax_buffer.to(tl.float64)
+        scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
+            tl.float32
+        )
+        if round_scales_to_power_of_2:
+            scales = tl.exp2(tl.floor(tl.log2(scales)))
+
+        # store rowwise scales for each group in contiguous memory:
+        # [group0_row0, group_0_row1, ..., group2_row0, group2_row1]
+        scales_offs = block_row_offs + (M * offset_idx)
+        scales_mask = tl.arange(0, BLOCK_SIZE) < M
+        tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
+
+        # perform float8 conversion for this group
+        for col_start_idx in range(
+            group_col_start_idx, group_col_end_idx, BLOCK_SIZE_ITER
+        ):
+            block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
+            block_offs = (
+                block_row_offs[:, None] * stride_input_row
+                + block_col_offs[None, :] * stride_input_col
+            )
+            block_mask = (block_row_offs[:, None] < M) & (
+                block_col_offs[None, :] < group_col_end_idx
+            )
+            data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+                input_dtype
+            )
+            scaled_data = data * scales[:, None]
+            fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
+                output_dtype
+            )
+            out_offs = (
+                block_row_offs[:, None] * stride_output_row
+                + block_col_offs[None, :] * stride_output_col
+            )
+            tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)
+
+    @torch.library.custom_op(
+        "torchao::triton_fp8_per_group_colwise_scales", mutates_args={}
     )
+    def triton_fp8_per_group_colwise_scales(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Converts a high precision tensor to a float8 tensor in row-major memory layout,
+        using 'jagged' column-wise scales (i.e., separate scales for each group/subtensor as
+        determined by the offsets).
 
-    # parallelize across rows and groups (offsets)
-    grid = lambda meta: (
-        triton.cdiv(m, meta["BLOCK_SIZE"]),
-        offsets.numel(),
-    )
-    _triton_fp8_per_group_rowwise_scales_kernel[grid](
-        hp_tensor,
-        offsets,
-        output_buffer,
-        scales_buffer,
-        m,
-        k,
-        hp_tensor.stride(0),
-        hp_tensor.stride(1),
-        output_buffer.stride(0),
-        output_buffer.stride(1),
-        num_elements,
-        fp8_dtype_min,
-        fp8_dtype_max,
-        tl_input_dtype,
-        tl_output_dtype,
-        round_scales_to_power_of_2,
-        EPS=EPS,
-    )
-    return output_buffer, scales_buffer
+        Args:
+            - hp_tensor: 2D high precision tensor to be converted
+            - offsets: end index for each group/subtensor along dim 0
+            - output_dtype: desired float8 dtype for the output tensor
+            - round_scales_to_power_of_2: boolean indicating if scales should be rounded
+                down to the nearest power of 2.
+        Returns:
+            - float8 tensor
+            - jagged column-wise scales (i.e., column-wise scales for each group)
+        """
+        assert hp_tensor.ndim == 2, "input tensor must be 2D"
 
+        num_elements = hp_tensor.numel()
+        tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
+        tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
 
-@triton_fp8_per_group_rowwise_scales.register_fake
-def _fake_triton_fp8_per_group_rowwise_scales_kernel(
-    hp_tensor: torch.Tensor,
-    offsets: torch.Tensor,
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert hp_tensor.ndim == 2, "input tensor must be 2D"
-    m, k = hp_tensor.shape
-    n_groups = offsets.numel()
-    output = torch.empty_like(hp_tensor, dtype=output_dtype).as_strided(
-        (m, k),  # shape
-        (k, 1),  # stride
-    )
-    scales = torch.empty((m * n_groups), dtype=torch.float32, device=hp_tensor.device)
-    return output, scales
+        fp8_dtype_min = torch.finfo(output_dtype).min
+        fp8_dtype_max = torch.finfo(output_dtype).max
 
+        k, n = hp_tensor.shape
+        n_groups = offsets.numel()
 
-# This kernel is used on grad_output.t() which has shape (K, M),
-# before the calculation `grad_B = grad_output_t @ input`.
-# However, in this code, we use the conventional dim names (M, K)
-# so the kernel is easily interpretable in a standalone fasion.
-# The tokens per expert will vary per iteration, so don't want
-# to recompile on `token` dim (K, in this case) changes.
-@triton.autotune(configs=kernel_configs_2D, key=["M"])
-@triton.jit
-def _triton_fp8_per_group_rowwise_scales_kernel(
-    input_ptr,
-    offsets_ptr,
-    out_ptr,
-    scales_ptr,
-    M: int,
-    K: int,
-    stride_input_row: int,
-    stride_input_col: int,
-    stride_output_row: int,
-    stride_output_col: int,
-    num_elements: int,
-    fp8_dtype_min: tl.constexpr,
-    fp8_dtype_max: tl.constexpr,
-    input_dtype: tl.constexpr,
-    output_dtype: tl.constexpr,
-    round_scales_to_power_of_2: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    BLOCK_SIZE_ITER: tl.constexpr,
-    EPS: tl.constexpr,
-):
-    # parallel across rows and groups (offsets)
-    block_row_id = tl.program_id(axis=0)
-    offset_idx = tl.program_id(axis=1)
+        # Output buffer in column major
+        output_buffer = torch.empty_like(
+            hp_tensor, dtype=output_dtype, device=hp_tensor.device
+        ).as_strided(hp_tensor.size(), (1, k))
 
-    # determine start and end column idx for this group
-    group_col_start_idx = tl.load(
-        offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
-    )
-    group_col_end_idx = tl.load(offsets_ptr + offset_idx)
-    block_row_offs = block_row_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-
-    # compute rowwise amaxes for this group
-    amax_buffer = tl.zeros((BLOCK_SIZE,), dtype=input_dtype)
-    for col_start_idx in range(group_col_start_idx, group_col_end_idx, BLOCK_SIZE_ITER):
-        block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
-        block_offs = (
-            block_row_offs[:, None] * stride_input_row
-            + block_col_offs[None, :] * stride_input_col
-        )
-        block_mask = (block_row_offs[:, None] < M) & (
-            block_col_offs[None, :] < group_col_end_idx
-        )
-        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
-            input_dtype
-        )
-        # we need to cast back to input dtype since triton promotes bf16 to fp32:
-        # https://github.com/triton-lang/triton/blob/981e987eed9053b952f81153bc0779c99d8c642e/python/triton/language/standard.py#L173
-        amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=1)).to(
-            input_dtype
+        scales_buffer = torch.empty(
+            (n * n_groups), dtype=torch.float32, device=hp_tensor.device
         )
 
-    # compute rowwise scales for this group. round scales to nearest power of 2.
-    amax_buffer = amax_buffer.to(tl.float64)
-    scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
-        tl.float32
-    )
-    if round_scales_to_power_of_2:
-        scales = tl.exp2(tl.floor(tl.log2(scales)))
-
-    # store rowwise scales for each group in contiguous memory:
-    # [group0_row0, group_0_row1, ..., group2_row0, group2_row1]
-    scales_offs = block_row_offs + (M * offset_idx)
-    scales_mask = tl.arange(0, BLOCK_SIZE) < M
-    tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
-
-    # perform float8 conversion for this group
-    for col_start_idx in range(group_col_start_idx, group_col_end_idx, BLOCK_SIZE_ITER):
-        block_col_offs = col_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
-        block_offs = (
-            block_row_offs[:, None] * stride_input_row
-            + block_col_offs[None, :] * stride_input_col
+        # parallelize across columns and groups (offsets)
+        grid = lambda meta: (
+            triton.cdiv(n, meta["BLOCK_SIZE"]),
+            offsets.numel(),
         )
-        block_mask = (block_row_offs[:, None] < M) & (
-            block_col_offs[None, :] < group_col_end_idx
+        _triton_fp8_per_group_colwise_scales_kernel[grid](
+            hp_tensor,
+            offsets,
+            output_buffer,
+            scales_buffer,
+            k,
+            n,
+            hp_tensor.stride(0),
+            hp_tensor.stride(1),
+            output_buffer.stride(0),
+            output_buffer.stride(1),
+            num_elements,
+            fp8_dtype_min,
+            fp8_dtype_max,
+            tl_input_dtype,
+            tl_output_dtype,
+            round_scales_to_power_of_2,
+            EPS=EPS,
         )
-        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
-            input_dtype
+        return output_buffer, scales_buffer
+
+    @triton_fp8_per_group_colwise_scales.register_fake
+    def _fake_triton_fp8_per_group_colwise_scales(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert hp_tensor.ndim == 2, "input tensor must be 2D"
+        k, n = hp_tensor.shape
+        n_groups = offsets.numel()
+        output_buffer = torch.empty_like(
+            hp_tensor, dtype=output_dtype, device=hp_tensor.device
+        ).as_strided(hp_tensor.size(), (1, k))
+
+        scales_buffer = torch.empty(
+            (n * n_groups), dtype=torch.float32, device=hp_tensor.device
         )
-        scaled_data = data * scales[:, None]
-        fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
-            output_dtype
+        return output_buffer, scales_buffer
+
+    # This kernel is used on `input` which has shape (M, K),
+    # before the calculation `grad_B = grad_output_t @ input`.
+    # The tokens per expert will vary per iteration, so don't want
+    # to recompile on `token` dim (M) changes.
+    @triton.autotune(configs=kernel_configs_2D, key=["K"])
+    @triton.jit
+    def _triton_fp8_per_group_colwise_scales_kernel(
+        input_ptr,
+        offsets_ptr,
+        out_ptr,
+        scales_ptr,
+        K: int,
+        N: int,
+        stride_input_row: int,
+        stride_input_col: int,
+        stride_output_row: int,
+        stride_output_col: int,
+        num_elements: int,
+        fp8_dtype_min: tl.constexpr,
+        fp8_dtype_max: tl.constexpr,
+        input_dtype: tl.constexpr,
+        output_dtype: tl.constexpr,
+        round_scales_to_power_of_2: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_SIZE_ITER: tl.constexpr,
+        EPS: tl.constexpr,
+    ):
+        # parallel across columns and groups (offsets)
+        block_col_id = tl.program_id(axis=0)
+        offset_idx = tl.program_id(axis=1)
+
+        # determine start and end row idx for this group
+        group_row_start_idx = tl.load(
+            offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
         )
-        out_offs = (
-            block_row_offs[:, None] * stride_output_row
-            + block_col_offs[None, :] * stride_output_col
+        group_row_end_idx = tl.load(offsets_ptr + offset_idx)
+        block_col_offs = block_col_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+        # compute colwise amaxes for this group
+        amax_buffer = tl.zeros((BLOCK_SIZE,), dtype=input_dtype)
+        for row_start_idx in range(
+            group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ITER
+        ):
+            block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
+            block_offs = (
+                block_row_offs[:, None] * stride_input_row
+                + block_col_offs[None, :] * stride_input_col
+            )
+            block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
+                block_col_offs[None, :] < N
+            )
+            data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+                input_dtype
+            )
+            # we need to cast back to input dtype since triton promotes bf16 to fp32:
+            # https://github.com/triton-lang/triton/blob/981e987eed9053b952f81153bc0779c99d8c642e/python/triton/language/standard.py#L173
+            amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=0)).to(
+                input_dtype
+            )
+
+        # compute rowwise scales for this group.
+        amax_buffer = amax_buffer.to(tl.float64)
+        scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
+            tl.float32
         )
-        tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)
+        if round_scales_to_power_of_2:
+            scales = tl.exp2(tl.floor(tl.log2(scales)))
 
+        # store colwise scales for each group in contiguous memory:
+        # [group0_col0, group_0_col1, ..., group2_col0, group2_col1]
+        # note: input tensor is in col-major memory layout.
+        scales_offs = block_col_offs + (N * offset_idx)
+        scales_mask = tl.arange(0, BLOCK_SIZE) < N
+        tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
 
-@torch.library.custom_op(
-    "torchao::triton_fp8_per_group_colwise_scales", mutates_args={}
-)
-def triton_fp8_per_group_colwise_scales(
-    hp_tensor: torch.Tensor,
-    offsets: torch.Tensor,
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Converts a high precision tensor to a float8 tensor in row-major memory layout,
-    using 'jagged' column-wise scales (i.e., separate scales for each group/subtensor as
-    determined by the offsets).
+        # perform float8 conversion for this group
+        for row_start_idx in range(
+            group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ITER
+        ):
+            block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
+            block_offs = (
+                block_row_offs[:, None] * stride_input_row
+                + block_col_offs[None, :] * stride_input_col
+            )
+            block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
+                block_col_offs[None, :] < N
+            )
+            data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
+                input_dtype
+            )
+            scaled_data = data * scales[None, :]
+            fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
+                output_dtype
+            )
+            out_offs = (
+                block_row_offs[:, None] * stride_output_row
+                + block_col_offs[None, :] * stride_output_col
+            )
+            tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)
 
-    Args:
-        - hp_tensor: 2D high precision tensor to be converted
-        - offsets: end index for each group/subtensor along dim 0
-        - output_dtype: desired float8 dtype for the output tensor
-        - round_scales_to_power_of_2: boolean indicating if scales should be rounded
-            down to the nearest power of 2.
-    Returns:
-        - float8 tensor
-        - jagged column-wise scales (i.e., column-wise scales for each group)
-    """
-    assert hp_tensor.ndim == 2, "input tensor must be 2D"
+else:
 
-    num_elements = hp_tensor.numel()
-    tl_input_dtype = FP8_DTYPE_MAP[hp_tensor.dtype]
-    tl_output_dtype = FP8_DTYPE_MAP[output_dtype]
-
-    fp8_dtype_min = torch.finfo(output_dtype).min
-    fp8_dtype_max = torch.finfo(output_dtype).max
-
-    k, n = hp_tensor.shape
-    n_groups = offsets.numel()
-
-    # Output buffer in column major
-    output_buffer = torch.empty_like(
-        hp_tensor, dtype=output_dtype, device=hp_tensor.device
-    ).as_strided(hp_tensor.size(), (1, k))
-
-    scales_buffer = torch.empty(
-        (n * n_groups), dtype=torch.float32, device=hp_tensor.device
-    )
-
-    # parallelize across columns and groups (offsets)
-    grid = lambda meta: (
-        triton.cdiv(n, meta["BLOCK_SIZE"]),
-        offsets.numel(),
-    )
-    _triton_fp8_per_group_colwise_scales_kernel[grid](
-        hp_tensor,
-        offsets,
-        output_buffer,
-        scales_buffer,
-        k,
-        n,
-        hp_tensor.stride(0),
-        hp_tensor.stride(1),
-        output_buffer.stride(0),
-        output_buffer.stride(1),
-        num_elements,
-        fp8_dtype_min,
-        fp8_dtype_max,
-        tl_input_dtype,
-        tl_output_dtype,
-        round_scales_to_power_of_2,
-        EPS=EPS,
-    )
-    return output_buffer, scales_buffer
-
-
-@triton_fp8_per_group_colwise_scales.register_fake
-def _fake_triton_fp8_per_group_colwise_scales(
-    hp_tensor: torch.Tensor,
-    offsets: torch.Tensor,
-    output_dtype: torch.dtype = torch.float8_e4m3fn,
-    round_scales_to_power_of_2: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert hp_tensor.ndim == 2, "input tensor must be 2D"
-    k, n = hp_tensor.shape
-    n_groups = offsets.numel()
-    output_buffer = torch.empty_like(
-        hp_tensor, dtype=output_dtype, device=hp_tensor.device
-    ).as_strided(hp_tensor.size(), (1, k))
-
-    scales_buffer = torch.empty(
-        (n * n_groups), dtype=torch.float32, device=hp_tensor.device
-    )
-    return output_buffer, scales_buffer
-
-
-# This kernel is used on `input` which has shape (M, K),
-# before the calculation `grad_B = grad_output_t @ input`.
-# The tokens per expert will vary per iteration, so don't want
-# to recompile on `token` dim (M) changes.
-@triton.autotune(configs=kernel_configs_2D, key=["K"])
-@triton.jit
-def _triton_fp8_per_group_colwise_scales_kernel(
-    input_ptr,
-    offsets_ptr,
-    out_ptr,
-    scales_ptr,
-    K: int,
-    N: int,
-    stride_input_row: int,
-    stride_input_col: int,
-    stride_output_row: int,
-    stride_output_col: int,
-    num_elements: int,
-    fp8_dtype_min: tl.constexpr,
-    fp8_dtype_max: tl.constexpr,
-    input_dtype: tl.constexpr,
-    output_dtype: tl.constexpr,
-    round_scales_to_power_of_2: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    BLOCK_SIZE_ITER: tl.constexpr,
-    EPS: tl.constexpr,
-):
-    # parallel across columns and groups (offsets)
-    block_col_id = tl.program_id(axis=0)
-    offset_idx = tl.program_id(axis=1)
-
-    # determine start and end row idx for this group
-    group_row_start_idx = tl.load(
-        offsets_ptr + offset_idx - 1, mask=offset_idx > 0, other=0
-    )
-    group_row_end_idx = tl.load(offsets_ptr + offset_idx)
-    block_col_offs = block_col_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-
-    # compute colwise amaxes for this group
-    amax_buffer = tl.zeros((BLOCK_SIZE,), dtype=input_dtype)
-    for row_start_idx in range(group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ITER):
-        block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
-        block_offs = (
-            block_row_offs[:, None] * stride_input_row
-            + block_col_offs[None, :] * stride_input_col
-        )
-        block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
-            block_col_offs[None, :] < N
-        )
-        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
-            input_dtype
-        )
-        # we need to cast back to input dtype since triton promotes bf16 to fp32:
-        # https://github.com/triton-lang/triton/blob/981e987eed9053b952f81153bc0779c99d8c642e/python/triton/language/standard.py#L173
-        amax_buffer = tl.maximum(amax_buffer, tl.max(tl.abs(data), axis=0)).to(
-            input_dtype
+    def triton_fp8_per_group_rowwise_scales(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "triton_fp8_per_group_rowwise_scales requires torch 2.7.0+ and triton installed"
         )
 
-    # compute rowwise scales for this group.
-    amax_buffer = amax_buffer.to(tl.float64)
-    scales = (fp8_dtype_max / tl.clamp(amax_buffer, min=EPS, max=float("inf"))).to(
-        tl.float32
-    )
-    if round_scales_to_power_of_2:
-        scales = tl.exp2(tl.floor(tl.log2(scales)))
-
-    # store colwise scales for each group in contiguous memory:
-    # [group0_col0, group_0_col1, ..., group2_col0, group2_col1]
-    # note: input tensor is in col-major memory layout.
-    scales_offs = block_col_offs + (N * offset_idx)
-    scales_mask = tl.arange(0, BLOCK_SIZE) < N
-    tl.store(scales_ptr + scales_offs, scales, mask=scales_mask)
-
-    # perform float8 conversion for this group
-    for row_start_idx in range(group_row_start_idx, group_row_end_idx, BLOCK_SIZE_ITER):
-        block_row_offs = row_start_idx + tl.arange(0, BLOCK_SIZE_ITER)
-        block_offs = (
-            block_row_offs[:, None] * stride_input_row
-            + block_col_offs[None, :] * stride_input_col
+    def triton_fp8_per_group_colwise_scales(
+        hp_tensor: torch.Tensor,
+        offsets: torch.Tensor,
+        output_dtype: torch.dtype = torch.float8_e4m3fn,
+        round_scales_to_power_of_2: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "triton_fp8_per_group_colwise_scales requires torch 2.7.0+ and triton installed"
         )
-        block_mask = (block_row_offs[:, None] < group_row_end_idx) & (
-            block_col_offs[None, :] < N
-        )
-        data = tl.load(input_ptr + block_offs, mask=block_mask, other=0.0).to(
-            input_dtype
-        )
-        scaled_data = data * scales[None, :]
-        fp8_data = tl.clamp(scaled_data, min=fp8_dtype_min, max=fp8_dtype_max).to(
-            output_dtype
-        )
-        out_offs = (
-            block_row_offs[:, None] * stride_output_row
-            + block_col_offs[None, :] * stride_output_col
-        )
-        tl.store(out_ptr + out_offs, fp8_data, mask=block_mask)

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -9,13 +9,6 @@ from typing import Optional
 
 import torch
 
-from torchao.float8.config import ScalingGranularity
-from torchao.float8.float8_utils import tensor_to_scale, to_fp8_saturated
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
-from torchao.prototype.moe_training.kernels import (
-    triton_fp8_per_group_colwise_scales,
-    triton_fp8_rowwise_3d_transpose_rhs,
-)
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
 )
@@ -26,7 +19,6 @@ from torchao.prototype.moe_training.kernels.mxfp8 import (
     triton_mx_block_rearrange_per_group_3d,
 )
 from torchao.prototype.moe_training.utils import (
-    _is_column_major,
     conditional_nostrict_trace,
 )
 from torchao.prototype.mx_formats.config import (
@@ -56,258 +48,50 @@ _SM100_KERNELS_AVAILABLE = (
 )
 
 
-def _quantize_then_scaled_grouped_mm(
+# Aliases for convenience/clarity
+@conditional_nostrict_trace
+def _to_mxfp8_then_scaled_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,
     offs: Optional[torch.Tensor] = None,
+    block_size: Optional[int] = None,
     out_dtype: Optional[torch.dtype] = torch.bfloat16,
-    scaling_type: MoEScalingType = MoEScalingType.FP8_ROWWISE,
     kernel_preference: KernelPreference = KernelPreference.AUTO,
+    wgrad_with_hp: bool = False,
+    scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
 ) -> torch.Tensor:
     """
-    This function performs dynamic quantization with the given recipe
-    on the input tensors A and B, then performs a scaled grouped GEMM and returns the results.
+    Differentiable mxfp8 grouped gemm with dynamic mxfp8 quantization.
 
     Args:
-        A (bf16/float32 torch.Tensor): The first high-precision input tensor, which must be a 2D tensor of shape (M * num_groups, K)
+        A (bf16/float32 torch.Tensor): The first high-precision input tensor,
+            which must be a 2D tensor of shape (M * num_groups, K)
             and in row-major memory layout.
-        B_t (bf16/float32 torch.Tensor): The second high-precision input tensor which must be 3D, which must be shape (E, K, N)
-            and in column-major memory layout.
-        offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
-        out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Currently only torch.bfloat16 is supported.
-        scaling_type (MoEScalingType): The scaling type to use for quantization.
-        kernel_preference (KernelPreference): Kernel preference for quantization and compute. Only applies to MXFP8 scaling types.
+        B_t (bf16/float32 torch.Tensor): The second high-precision input tensor
+            which must be 3D, which must be shape (G, K, N)
+            and in "per group column-major memory" layout (i.e., strides of (N*K, 1, N)).
+        offs (int32 torch.Tensor): The offsets to use to mark the end index of each group along the dim0 of the A tensor.
+        block_size (int): Block size for MXFP8 quantization. Must be 32 (the only supported value). This parameter exists for backward compatibility but is ignored.
+        out_dtype (torch.dtype): Output dtype for the result. Defaults to torch.bfloat16.
+        kernel_preference (KernelPreference): Kernel preference (AUTO uses CUDA/Triton, EMULATED uses to_mx). Defaults to KernelPreference.AUTO.
+        wgrad_with_hp (bool): Whether to compute weight gradient in high precision. Defaults to False.
+        scale_calculation_mode (ScaleCalculationMode): Mode for scale calculation (RCEIL, FLOOR, etc.). Defaults to ScaleCalculationMode.RCEIL.
+
+    Returns:
+        out (torch.Tensor): The result of the mxfp8 scaled grouped gemm.
     """
-    # TODO: Remove logging once prototype is more mature. This is currently very useful for development and debugging.
-    if scaling_type == MoEScalingType.FP8_ROWWISE:
-        return _to_fp8_rowwise_then_scaled_grouped_mm(
-            A,
-            B_t,
-            offs,
-            out_dtype,
-        )
-    elif (
-        scaling_type == MoEScalingType.MXFP8
-        or scaling_type == MoEScalingType.MXFP8_WGRAD_WITH_HP
-    ):
-        block_size = 32
-        wgrad_with_hp = scaling_type == MoEScalingType.MXFP8_WGRAD_WITH_HP
-        return _to_mxfp8_then_scaled_grouped_mm(
-            A,
-            B_t,
-            offs,
-            block_size,
-            out_dtype,
-            kernel_preference=kernel_preference,
-            wgrad_with_hp=wgrad_with_hp,
-            scale_calculation_mode=ScaleCalculationMode.RCEIL,
-        )
-    else:
-        raise ValueError(f"Unsupported scaling type {scaling_type}")
-
-
-class _Float8GroupedMM(torch.autograd.Function):
-    """Differentiable implementation of grouped GEMM with dynamic float8 quantization."""
-
-    @staticmethod
-    def forward(
-        ctx,
-        A: torch.Tensor,
-        B_t: torch.Tensor,
-        offs: Optional[torch.Tensor] = None,
-        out_dtype: Optional[torch.dtype] = torch.bfloat16,
-    ) -> torch.Tensor:
-        # torchao _quantize_then_scaled_grouped_mm only supports A=2D|3D and B=3D.
-        assert A.ndim == 2 or A.ndim == 3, "A must be 2D or 3D"
-        assert B_t.ndim == 3, "B must be 3D"
-
-        assert A.size(-1) % 16 == 0, (
-            f"A must have a last dim divisible by 16, but got shape: {A.shape}"
-        )
-        assert B_t.size(-2) % 16 == 0 and B_t.size(-1) % 16 == 0, (
-            f"B must have last 2 dims divisible by 16, but got shape: {B_t.shape}"
-        )
-
-        # Assert input tensors are in high-precision dtypes.
-        assert A.dtype == torch.float32 or A.dtype == torch.bfloat16, (
-            "A must be float32 or bfloat16"
-        )
-        assert B_t.dtype == torch.float32 or B_t.dtype == torch.bfloat16, (
-            "B must be float32 or bfloat16"
-        )
-        assert offs is None or offs.dtype == torch.int32, (
-            "offs must be int32 tensor or None"
-        )
-
-        # Assert A and B dims are compatible for a scaled grouped GEMM.
-        assert A.size(-1) == B_t.size(-2), (
-            f"shape {A.shape} and {B_t.shape} are not compatible for _quantize_then_scaled_grouped_mm"
-        )
-
-        # The left operand in the scaled grouped GEMM must be row-major due to hardware requirements.
-        assert not _is_column_major(A), "A must be row-major"
-
-        # Due to hardware requirements, the right operand in a scaled grouped GEMM must be column-major.
-        assert _is_column_major(B_t), "B must be column-major"
-
-        # Convert high precision input tensor to float8, row-major for left operand of grouped GEMM.
-        # A shape: (M, K) or (B, M, K)
-        # A_scales shape: (M,1) or (B, M, 1)
-        A_scales = tensor_to_scale(
-            A,
-            torch.float8_e4m3fn,
-            scaling_granularity=ScalingGranularity.AXISWISE,
-            axiswise_dim=-1,
-            round_scales_to_power_of_2=True,
-        )
-        A_scaled = A.to(torch.float32) * A_scales
-        A_data_row_major = to_fp8_saturated(A_scaled, torch.float8_e4m3fn)
-
-        # Convert B to float8, column-major for right operand of grouped GEMM.
-        # B_t shape: (E, K, N)
-        # B_t scales must be computed rowwise keeping the outer/final dim, so:
-        # B_t_scales shape: (E, 1, N)
-        B_t_scales = tensor_to_scale(
-            B_t,
-            torch.float8_e4m3fn,
-            scaling_granularity=ScalingGranularity.AXISWISE,
-            axiswise_dim=-2,
-            round_scales_to_power_of_2=True,
-        )
-        B_t_scaled = B_t.to(torch.float32) * B_t_scales
-        B_t_data_col_major = to_fp8_saturated(B_t_scaled, torch.float8_e4m3fn)
-
-        # Store what we need for backward.
-        ctx.save_for_backward(A, B_t, offs)
-        ctx.out_dtype = out_dtype
-
-        # Perform scaled grouped GEMM and return result.
-        # output shape: scaled grouped mm of (M,K) @ (B,K,N) = (M,N)
-        assert not _is_column_major(A_data_row_major), (
-            "A must be row-major for output = A @ B"
-        )
-        assert _is_column_major(B_t_data_col_major), (
-            "B must be column-major for output = A @ B"
-        )
-
-        # Squeeze empty dims out of scales, to comply with grouped mm API.
-        # A_scales shape: (M,1) or (B, M, 1)
-        # B_t_scales shape: (E, 1, N)
-        A_scales = A_scales.squeeze(-1)
-        B_t_scales = B_t_scales.squeeze(1)
-        return torch._scaled_grouped_mm(
-            A_data_row_major,
-            B_t_data_col_major,
-            A_scales.reciprocal(),  # Reciprocals are needed for rescaling the output.
-            B_t_scales.reciprocal(),
-            offs,
-            out_dtype=out_dtype,
-            use_fast_accum=True,
-        )
-
-    @staticmethod
-    def backward(ctx, grad_output: torch.Tensor):
-        A, B_t, offs = ctx.saved_tensors
-        out_dtype = ctx.out_dtype
-
-        # Convert grad_output to float8, row-major for left operand of grouped GEMM
-        # needed for grad_A: grad_output @ B
-        #
-        # grad_output shape: (Mg, N)
-        # grad_output_scale shape: (Mg, 1)
-        grad_output_scales = tensor_to_scale(
-            grad_output,
-            torch.float8_e4m3fn,
-            scaling_granularity=ScalingGranularity.AXISWISE,
-            axiswise_dim=-1,
-            round_scales_to_power_of_2=True,
-        )
-        grad_output_scaled = grad_output.to(torch.float32) * grad_output_scales
-        grad_output_data_row_major = to_fp8_saturated(
-            grad_output_scaled, torch.float8_e4m3fn
-        )
-
-        # Compute B fp8 column-major for right operand of grouped GEMM:
-        # grad_A = grad_output @ B.
-        B_data_col_major, B_scales = triton_fp8_rowwise_3d_transpose_rhs(
-            B_t._data if hasattr(B_t, "_data") else B_t,
-            output_dtype=torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-
-        # Compute grad_A.
-        # grad_A = grad_output @ B
-        # grad_A = scaled grouped mm of (M,N) @ (B,N,K) = (M,K)
-        assert not _is_column_major(grad_output_data_row_major), (
-            "grad_output must be row-major for grad_A = grad_output @ B"
-        )
-        assert _is_column_major(B_data_col_major), (
-            "B must be column-major for grad_A = grad_output @ B"
-        )
-
-        # Squeeze empty dims out of scales, to comply with grouped mm API.
-        # grad_output_scales shape: (M,1) or (B, M, 1)
-        # B_scales shape: (E, 1, N)
-        grad_output_scales = grad_output_scales.squeeze(-1)
-        B_scales = B_scales.squeeze(1)
-        grad_A = torch._scaled_grouped_mm(
-            grad_output_data_row_major,
-            B_data_col_major,
-            grad_output_scales.reciprocal(),
-            B_scales.reciprocal(),
-            offs,
-            out_dtype=out_dtype,
-            use_fast_accum=True,
-        )
-
-        # grad_B is a special case. both operands of the grouped gemm will be 2D with offsets determing the "groups."
-        # Compute scales for grad_output_t and A, which are both 2D tensors with offsets which define the "jagged" groups.
-
-        # Convert transpose of grad_output to float8, row-major for left operand of grouped GEMM
-        # needed for grad_B: grad_output_t @ A
-        # Use transpose method to avoid uncoalesced memory accesses.
-        grad_out_data_colwise, grad_out_scales = triton_fp8_per_group_colwise_scales(
-            grad_output.t()
-            .contiguous()
-            .t(),  # Quantization is over 2x faster when input is col major, even with this transformation
-            offs,
-            torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-        grad_output_t_data_row_major = grad_out_data_colwise.t()
-        grad_output_t_scales = grad_out_scales.t()
-
-        A_data_col_major, A_scales = triton_fp8_per_group_colwise_scales(
-            A.t()
-            .contiguous()
-            .t(),  # Quantization is over 2x faster when input is col major, even with this transformation
-            offs,
-            torch.float8_e4m3fn,
-            round_scales_to_power_of_2=True,
-        )
-
-        # Compute grad_B = grad_output_t @ A.
-        # grad_B = grad_output_t @ A
-        assert not _is_column_major(grad_output_t_data_row_major), (
-            "grad_output_t must be row-major for grad_B = grad_output_t @ A"
-        )
-        assert _is_column_major(A_data_col_major), (
-            "A must be column-major for grad_B = grad_output_t @ A"
-        )
-
-        # Per-token group scales computed via triton kernels above do not have
-        # the empty dim like the scales computed via tensor_to_scale, so we need
-        # don't need to squeeze here.
-        grad_B = torch._scaled_grouped_mm(
-            grad_output_t_data_row_major,
-            A_data_col_major,
-            grad_output_t_scales.reciprocal(),
-            A_scales.reciprocal(),
-            offs,
-            out_dtype=out_dtype,
-            use_fast_accum=True,
-        )
-        return grad_A, grad_B.transpose(-2, -1), None, None, None, None
+    # block_size is always 32 for MXFP8
+    block_size = 32
+    return _MXFP8GroupedMM.apply(
+        A,
+        B_t,
+        offs,
+        block_size,
+        out_dtype,
+        kernel_preference,
+        wgrad_with_hp,
+        scale_calculation_mode,
+    )
 
 
 class _MXFP8GroupedMM(torch.autograd.Function):
@@ -933,50 +717,3 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
 
 def round_up(x, y):
     return ((x + y - 1) // y) * y
-
-
-# Aliases for convenience/clarity
-@conditional_nostrict_trace
-def _to_mxfp8_then_scaled_grouped_mm(
-    A: torch.Tensor,
-    B_t: torch.Tensor,
-    offs: Optional[torch.Tensor] = None,
-    block_size: int = 32,
-    out_dtype: Optional[torch.dtype] = torch.bfloat16,
-    kernel_preference: KernelPreference = KernelPreference.AUTO,
-    wgrad_with_hp: bool = False,
-    scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
-) -> torch.Tensor:
-    """
-    Differentiable mxfp8 grouped gemm with dynamic mxfp8 quantization.
-
-    Args:
-        - A (bf16/float32 torch.Tensor): The first high-precision input tensor,
-            which must be a 2D tensor of shape (M * num_groups, K)
-            and in row-major memory layout.
-        - B_t (bf16/float32 torch.Tensor): The second high-precision input tensor
-            which must be 3D, which must be shape (G, K, N)
-            and in "per group column-major memory" layout (i.e., strides of (N*K, 1, N)).
-        - offs (int32 torch.Tensor): The offsets to use to mark the end index of each group along the dim0 of the A tensor.
-        - block_size (int): The block size to use for mxpf8 quantization. Currently only 32 is supported.
-        - out_dtype (Optional[torch.dtype]): The dtype of the output tensor. Default is torch.bfloat16.
-        - kernel_preference (KernelPreference): Kernel preference (AUTO uses CUDA/Triton, EMULATED uses to_mx).
-        - wgrad_with_hp (bool): Whether to compute weight gradients in high precision.
-        - scale_calculation_mode (ScaleCalculationMode): The mode to use for scale calculation.
-
-    Returns:
-        - out (torch.Tensor): The result of the mxpf8 scaled grouped gemm.
-    """
-    return _MXFP8GroupedMM.apply(
-        A,
-        B_t,
-        offs,
-        block_size,
-        out_dtype,
-        kernel_preference,
-        wgrad_with_hp,
-        scale_calculation_mode,
-    )
-
-
-_to_fp8_rowwise_then_scaled_grouped_mm = _Float8GroupedMM.apply

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -15,9 +15,17 @@ from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import MixedPrecisionPolicy
 
-from torchao.prototype.moe_training import _quantize_then_scaled_grouped_mm
-from torchao.prototype.moe_training.conversion_utils import MoEScalingType
-from torchao.quantization.quantize_.common import KernelPreference
+from torchao.prototype.moe_training.config import (
+    FP8GroupedMMConfig,
+    GroupedMMConfig,
+    MXFP8GroupedMMConfig,
+)
+from torchao.prototype.moe_training.fp8_grouped_mm import (
+    _to_fp8_rowwise_then_scaled_grouped_mm,
+)
+from torchao.prototype.moe_training.mxfp8_grouped_mm import (
+    _to_mxfp8_then_scaled_grouped_mm,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -43,8 +51,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     differentiable _quantize_then_scaled_grouped_mm autograd function.
     """
 
-    scaling_type: MoEScalingType = MoEScalingType.FP8_ROWWISE
-    kernel_preference: KernelPreference = KernelPreference.AUTO
+    config: GroupedMMConfig = None
     grouped_mm_func_name = "_grouped_mm"
     offs_arg_name = "offs"
 
@@ -52,8 +59,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     def __new__(
         cls,
         tensor: torch.Tensor,
-        scaling_type: MoEScalingType,
-        kernel_preference: KernelPreference = KernelPreference.AUTO,
+        config: GroupedMMConfig,
     ):
         self = torch.Tensor._make_wrapper_subclass(
             cls,
@@ -67,19 +73,16 @@ class ScaledGroupedMMTensor(torch.Tensor):
             pin_memory=tensor.is_pinned(),
             requires_grad=tensor.requires_grad,
         )
-        self.scaling_type = scaling_type
-        self.kernel_preference = kernel_preference
+        self.config = config
         return self
 
     def __init__(
         self,
         tensor: torch.Tensor,
-        scaling_type: MoEScalingType,
-        kernel_preference: KernelPreference = KernelPreference.AUTO,
+        config: GroupedMMConfig,
     ):
         self._data = tensor
-        self.scaling_type = scaling_type
-        self.kernel_preference = kernel_preference
+        self.config = config
 
     @classmethod
     def __torch_function__(cls, func, types, args, kwargs={}):
@@ -99,8 +102,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
             assert isinstance(B, ScaledGroupedMMTensor), (
                 "B should be a ScaledGroupedMMTensor"
             )
-            scaling_type = B.scaling_type
-            kernel_preference = B.kernel_preference
+            config = B.config
             A_is_2d = A.ndim == 2
             B_is_2d_or_3d = B.ndim == 2 or B.ndim == 3
             has_offs = kwargs.get(cls.offs_arg_name) is not None
@@ -109,9 +111,8 @@ class ScaledGroupedMMTensor(torch.Tensor):
                 return _quantize_then_scaled_grouped_mm(
                     A,
                     B,
+                    config,
                     *other_args,
-                    scaling_type=scaling_type,
-                    kernel_preference=kernel_preference,
                     **kwargs,
                 )
 
@@ -122,32 +123,29 @@ class ScaledGroupedMMTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs={}):
-        # unwrap args/kwargs and extract scaling_type and kernel_preference
-        scaling_type = None
-        kernel_preference = None
+        # unwrap args/kwargs and extract config
+        config = None
 
         def unwrap(t):
-            nonlocal scaling_type, kernel_preference
-            if scaling_type is None:
-                scaling_type = t.scaling_type
-                kernel_preference = t.kernel_preference
+            nonlocal config
+            if config is None:
+                config = t.config
             else:
-                assert t.scaling_type == scaling_type
-                assert t.kernel_preference == kernel_preference
+                assert t.config == config, (
+                    "All ScaledGroupedMMTensor instances must have the same config"
+                )
             return t._data
 
         args_unwrapped, kwargs_unwrapped = pytree.tree_map_only(
             ScaledGroupedMMTensor, unwrap, (args, kwargs or {})
         )
-        assert scaling_type is not None, (
+        assert config is not None, (
             f"__torch_dispatch__ called on {func.__name__} without any ScaledGroupedMMTensor arguments"
         )
 
         # detach is special case
         if func == torch.ops.aten.detach.default:
-            return ScaledGroupedMMTensor(
-                args_unwrapped[0], scaling_type, kernel_preference
-            )
+            return ScaledGroupedMMTensor(args_unwrapped[0], config)
 
         # perform op
         out = func(*args_unwrapped, **kwargs_unwrapped)
@@ -159,17 +157,16 @@ class ScaledGroupedMMTensor(torch.Tensor):
         # wrap outputs back into ScaledGroupedMMTensor for ops that do preserve subclass
         return pytree.tree_map_only(
             torch.Tensor,
-            lambda x: ScaledGroupedMMTensor(x, scaling_type, kernel_preference),
+            lambda x: ScaledGroupedMMTensor(x, config),
             out,
         )
 
     def __repr__(self):
-        return f"ScaledGroupedMMTensor(data={self._data}, scaling_type={self.scaling_type}, kernel_preference={self.kernel_preference})"
+        return f"ScaledGroupedMMTensor(data={self._data}, config={self.config})"
 
     def __tensor_flatten__(self):
         metadata = {
-            "scaling_type": self.scaling_type,
-            "kernel_preference": self.kernel_preference,
+            "config": self.config,
         }
         return ["_data"], metadata
 
@@ -177,8 +174,7 @@ class ScaledGroupedMMTensor(torch.Tensor):
     def __tensor_unflatten__(inner_tensors, flatten_spec, outer_size, outer_stride):
         return ScaledGroupedMMTensor(
             inner_tensors["_data"],
-            flatten_spec["scaling_type"],
-            flatten_spec["kernel_preference"],
+            flatten_spec["config"],
         )
 
     # fsdp hooks based on https://github.com/pytorch/pytorch/blob/20e40492b046b9287726d3ec656117e4dc38f0e2/test/distributed/_composable/fsdp/test_fully_shard_extensions.py#L81
@@ -209,14 +205,12 @@ class ScaledGroupedMMTensor(torch.Tensor):
         if out is not None:
             if isinstance(out, ScaledGroupedMMTensor):
                 out_data = out._data
-                out.scaling_type = self.scaling_type
-                out.kernel_preference = self.kernel_preference
+                out.config = self.config
             elif isinstance(out, DTensor) and isinstance(
                 out._local_tensor, ScaledGroupedMMTensor
             ):
                 out_data = out._local_tensor._data
-                out._local_tensor.scaling_type = self.scaling_type
-                out._local_tensor.kernel_preference = self.kernel_preference
+                out._local_tensor.config = self.config
             else:
                 raise RuntimeError(
                     f"expect out to be ScaledGroupedMMTensor or DTensor with local_tensor=ScaledGroupedMM, but got {type(out)}"
@@ -239,6 +233,47 @@ class ScaledGroupedMMTensor(torch.Tensor):
             return
 
         # For training step 0, out=None, so we need to return a new ScaledGroupedMMTensor.
-        output = ScaledGroupedMMTensor(data, self.scaling_type, self.kernel_preference)
+        output = ScaledGroupedMMTensor(data, self.config)
         inner_tensors = (data,)
         return output, inner_tensors
+
+
+# dispatching helper for ScaledGroupedMMTensor
+def _quantize_then_scaled_grouped_mm(
+    A: torch.Tensor,
+    B_t: torch.Tensor,
+    config: GroupedMMConfig,
+    offs: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    This function performs dynamic quantization with the given config
+    on the input tensors A and B, then performs a scaled grouped GEMM and returns the results.
+
+    Args:
+        A (bf16/float32 torch.Tensor): The first high-precision input tensor, which must be a 2D tensor of shape (M * num_groups, K)
+            and in row-major memory layout.
+        B_t (bf16/float32 torch.Tensor): The second high-precision input tensor which must be 3D, which must be shape (E, K, N)
+            and in column-major memory layout.
+        offs (int32 torch.Tensor): The offsets to use to mark the starting index of each group along dim0 of the A tensor.
+        config (MXFP8GroupedMMConfig): Configuration for grouped matmul quantization.
+    """
+    # Dispatch based on derived dtype
+    if isinstance(config, FP8GroupedMMConfig):
+        return _to_fp8_rowwise_then_scaled_grouped_mm(
+            A,
+            B_t,
+            offs,
+            config.out_dtype,
+        )
+    elif isinstance(config, MXFP8GroupedMMConfig):
+        return _to_mxfp8_then_scaled_grouped_mm(
+            A,
+            B_t,
+            offs,
+            out_dtype=config.out_dtype,
+            kernel_preference=config.kernel_preference,
+            wgrad_with_hp=config.wgrad_with_hp,
+            scale_calculation_mode=config.scale_calculation_mode,
+        )
+    else:
+        raise ValueError(f"Unsupported config type: {type(config)}")

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -16,7 +16,7 @@ from torchao.prototype.mx_formats.constants import (
     SUPPORTED_ELEM_DTYPES,
 )
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
-from torchao.utils import is_ROCM
+from torchao.utils import is_ROCM, register_as_pytree_constant
 
 
 class MXFP8Dim0CastKernelChoice(Enum):
@@ -47,6 +47,8 @@ class MXLinearRecipeName(Enum):
     MXFP4_CUTLASS = "mxfp4_cutlass"
 
 
+# register as pytree constant so we can use dynamo nonstrict trace in torchao.prototype.moe_training.ep
+@register_as_pytree_constant
 class ScaleCalculationMode(Enum):
     """
     Enum representing the different methods for calculating MX block scaling.
@@ -81,11 +83,6 @@ class ScaleCalculationMode(Enum):
 
     def __hash__(self):
         return hash(self.value)
-
-
-# Register ScaleCalculationMode with pytree so torch.compile can handle it
-# as a function argument in @torch._dynamo.nonstrict_trace functions.
-torch.utils._pytree.register_constant(ScaleCalculationMode)
 
 
 def _validate_elem_dtype(elem_dtype):

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -865,7 +865,10 @@ def _float8_dynamic_activation_int4_weight_transform(
     )
     int4_packing_format = config.int4_packing_format
 
-    assert int4_packing_format in ("preshuffled", "plain"), (
+    assert int4_packing_format in (
+        "preshuffled",
+        "plain",
+    ), (
         f"only preshuffled and plain int4_packing_format supported right now, got: {int4_packing_format}"
     )
     weight = module.weight

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -35,7 +35,14 @@ __all__ = [
     "is_sm_at_least_100",
     "is_package_at_least",
     "DummyModule",
+    "register_as_pytree_constant",
 ]
+
+
+def register_as_pytree_constant(cls):
+    """Decorator to register a class as a pytree constant for dynamo non-strict trace mode."""
+    torch.utils._pytree.register_constant(cls)
+    return cls
 
 
 # Referenced from: https://github.com/pytorch/pytorch/blob/9105d54c6b37099575c0059ef274c86c4dc80c57/torch/ao/quantization/utils.py#L711


### PR DESCRIPTION
# Summary
To prepare the MoE training prototype to stable we need the dev experience to be consistent with the rest of torchao, namely the fp8/mxfp8 linear training.

This PR:
- Splits FP8 grouped mm and MXFP8 grouped mm related code into separate files to organize by derived dtype
- Update APIs and configs to align with the patterns of MXLinearConfig, MXLinear.
- Add support for converting both linears and grouped gemms in a single `quantize_()` call

These files contain the important changes, everything else is peripheral:
- `torchao/prototype/moe_training/config.py`
- `torchao/prototype/moe_training/conversion_utils.py`
- `torchao/prototype/moe_training/mxfp8_grouped_mm.py`
- `torchao/prototype/moe_training/fp8_grouped_mm.py`
-  `torchao/prototype/moe_training/tensor.py`
- `torchao/quantization/quant_api.py`

#### New model conversion API

```python
    model = MoEModel()

    config = FqnToConfig(
        fqn_to_config=OrderedDict(
            [
                (
                    "re:.*experts.*",
                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
                ),
                (
                    "re:^(pre_moe|post_moe)$",
                    MXLinearConfig.from_recipe_name(MXLinearRecipeName.MXFP8_CUBLAS_RCEIL),
                ),
            ]
        )
    )

    quantize_(model, config, filter_fn=None)
```

#### New recipes

```python

class FP8GroupedMMRecipe(Enum):
    """FP8 recipes for grouped matrix multiplication."""
    FP8_ROWWISE = "fp8_rowwise"


class MXFP8GroupedMMRecipe(Enum):
    """MXFP8 recipes for grouped matrix multiplication."""
    # TODO: add floor variants
    MXFP8_RCEIL = "mxfp8_rceil"
    MXFP8_RCEIL_WGRAD_WITH_HP = "mxfp8_rceil_wgrad_with_hp"
    MXFP8_EMULATED_RCEIL = "mxfp8_emulated_rceil"
```

#### New configs

```python
class GroupedMMConfig(AOBaseConfig):
    """Base configuration for grouped matrix multiplication. Not intended to be used directly."""
    pass


@dataclass
class FP8GroupedMMConfig(GroupedMMConfig):
    # Output dtype for the FP8 grouped GEMMs.
    out_dtype: Optional[torch.dtype] = torch.bfloat16

    @classmethod
    def from_recipe(
        cls,
        recipe: FP8GroupedMMRecipe,
    ) -> "FP8GroupedMMConfig":
        ...

@dataclass
class MXFP8GroupedMMConfig(GroupedMMConfig):
    # AUTO = Use best supported kernel for quantization ops and GEMMs (CUDA and Triton for quantizatoin, CUTLASS for MXFP8 grouped GEM
    # EMULATED = Hardware agnostic mode that can be used for debugging or development on non-SM100 machines.
    #            Uses PyTorch native quantization ops, then dequantizes and uses emulated MXFP8 grouped GEMMs implemented in PyTorch.
    #            Not recommended for performance.
    kernel_preference: KernelPreference = KernelPreference.AUTO

    # Output dtype for the MXFP8 grouped GEMMs.
    out_dtype: Optional[torch.dtype] = torch.bfloat16

    # Whether to compute the gradient of the weights in high precision (True) or use MXFP8 (False).
    wgrad_with_hp: bool = False

    # Rounding mode to use when calculating the e8m0 scale factors.
    scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL

    @classmethod
    def from_recipe(
        cls,
        recipe: MXFP8GroupedMMRecipe,
    ) -> "MXFP8GroupedMMConfig":
         ...
```

## Testing
Added new test:
- `pytest test/prototype/moe_training/test_fqn_to_config.py`

Existing tests passing:
- `./test/prototype/moe_training/test_everything.sh`

# Detailed change list (optional read)

### Configuration Refactoring

**Created new config.py file containing all MoE training configurations:**
- Added FP8GroupedMMRecipe enum with FP8_ROWWISE recipe
- Added MXFP8GroupedMMRecipe enum with recipes: MXFP8_RCEIL, MXFP8_RCEIL_WGRAD_WITH_HP, MXFP8_EMULATED_RCEIL
- Added GroupedMMConfig base class for type abstraction
- Added FP8GroupedMMConfig dataclass with out_dtype field (defaults to bf16)
- Added MXFP8GroupedMMConfig dataclass with fields: kernel_preference, out_dtype, wgrad_with_hp, scale_calculation_mode
- Implemented .from_recipe() factory methods for both config classes
- Added __eq__ and __hash__ methods to MXFP8GroupedMMConfig (context: is needed for `torch._dynamo.nonstrict_trace` mode, which is in turn needed to support accept pre-quantized MXTensor inputs and regular torch.Tensor outputs and backward input gradients)

### Code Organization

**Split grouped GEMM autograd func implementations:**
- Renamed scaled_grouped_mm.py → mxfp8_grouped_mm.py (contains MXFP8-specific implementation)
- Created new fp8_grouped_mm.py (contains FP8 rowwise implementation extracted from previous file)

**Refactored conversion_utils.py:**
- Removed MoEScalingType enum (replaced by recipe enums in config.py)
- Removed MoETrainingConfig class (replaced by config classes in config.py)
- Added target_parameter_name parameter for compatibility with FqnToConfig per-parameter quantization

**Updates to tensor.py:**
- Added _quantize_then_scaled_grouped_mm dispatcher function that routes to appropriate implementation based on config type
- Dispatcher checks if config is FP8GroupedMMConfig or MXFP8GroupedMMConfig and calls corresponding function


**Support linear and grouped mm conversion in single quantize_() call:**
- Registered FP8GroupedMMConfig and MXFP8GroupedMMConfig in CUSTOM_PARAM_QUANTIZATION_SUPPORTED_CONFIGS in quant_api.py
- Enables using FqnToConfig to apply different quantization configs to different modules/parameters in a single quantize_() call
- Created comprehensive test suite (test_fqn_to_config.py):
- Tests regex pattern matching for FQN-based configuration
- Tests selective quantization (experts only, dense only, specific parameters)
- Tests different recipe configurations on different parameters

**API Changes:** 
- Deprecated API: MoETrainingConfig and MoEScalingType
- New API: Use FP8GroupedMMConfig.from_recipe(FP8GroupedMMRecipe.FP8_ROWWISE) or MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL)
- New exports in __init__.py: Added _to_fp8_rowwise_then_scaled_grouped_mm to public API