### PR TITLE
Fix a few API reference Sphinx warnings

### DIFF
--- a/docs/source/api_reference/api_ref_float8.rst
+++ b/docs/source/api_reference/api_ref_float8.rst
@@ -7,7 +7,7 @@ torchao.float8
 .. currentmodule:: torchao.float8
 
 Main float8 training APIs
-----------------------
+-------------------------
 
 .. autosummary::
     :toctree: generated/

--- a/docs/source/api_reference/api_ref_qat.rst
+++ b/docs/source/api_reference/api_ref_qat.rst
@@ -6,9 +6,9 @@ torchao.quantization.qat
 
 .. currentmodule:: torchao.quantization.qat
 
-Main Config for quantize_
----------------------------------------
-For a full example of how to use QAT with our main `quantize_` API,
+Main config for ``quantize_``
+-----------------------------
+For a full example of how to use QAT with our main ``quantize_`` API,
 please refer to the `QAT README <https://github.com/pytorch/ao/blob/main/torchao/quantization/qat/README.md#quantize_-api-recommended>`__.
 
 .. autosummary::


### PR DESCRIPTION
## Summary
- fix an underline length warning in `api_ref_float8.rst`
- update wording and formatting in `api_ref_qat.rst` to avoid unresolved inline reference for `quantize_`
- normalize heading capitalization in the touched section

These changes target warning cleanup from the docs build output in #3863.

Fixing part of #3863