### PR TITLE
docs: fix duplicate reference labels

### DIFF
--- a/docs/source/api_reference/api_ref_float8.rst
+++ b/docs/source/api_reference/api_ref_float8.rst
@@ -1,4 +1,4 @@
-.. _api_quantization:
+.. _api_float8:
 
 ====================
 torchao.float8

--- a/docs/source/eager_tutorials/mxfp8_expert_parallel_training.rst
+++ b/docs/source/eager_tutorials/mxfp8_expert_parallel_training.rst
@@ -44,6 +44,8 @@ In this tutorial we'll train a DeepSeek-V3-16B model using torchtitan with torch
 
 `Torchtitan <https://github.com/pytorch/torchtitan/>`__ is PyTorch's official pre-training framework that is natively integrated with torchao. For MoE models, torchtitan supports expert parallelism combined with other forms of parallelism like FSDP and tensor parallelism.
 
+.. _mxfp8-torchtitan-prerequisites:
+
 Prerequisites
 ^^^^^^^^^^^^^
 
@@ -175,6 +177,8 @@ Training with torchao directly
 In this tutorial we'll apply MXFP8 expert parallelism to a custom MoE layer using torchao APIs directly.
 
 You can use this workflow to integrate MXFP8 expert parallelism into your own custom training code.
+
+.. _mxfp8-torchao-prerequisites:
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/docs/source/eager_tutorials/pretraining.rst
+++ b/docs/source/eager_tutorials/pretraining.rst
@@ -30,6 +30,8 @@ See the torchtitan `docs <https://github.com/pytorch/torchtitan>`__ for addition
 You can use this workflow to get started quickly with a "batteries included" experience. Users commonly
 fork torchtitan and build on top of it when they're ready.
 
+.. _pretraining-torchtitan-prerequisites:
+
 Prerequisites
 ================
 
@@ -131,6 +133,8 @@ Pre-training with torchao directly
 In this tutorial we'll pre-train a toy model using torchao APIs directly.
 
 You can use this workflow to integrate torchao into your own custom pre-training code directly.
+
+.. _pretraining-torchao-prerequisites:
 
 Prerequisites
 ================

--- a/docs/source/pt2e_quantization/index.rst
+++ b/docs/source/pt2e_quantization/index.rst
@@ -1,6 +1,8 @@
 PT2E Quantization
 =================
 
+.. _pt2e-quick-start:
+
 Quick Start
 -----------
 PyTorch 2 Export Quantization is a full graph quantization workflow mostly for static quantization. It targets hardwares that requires both input and output activation and weight to be quantized and relies of recognizing an operator pattern to make quantization decisions (such as linear - relu). PT2E quantization produces a pattern with quantize and dequantize ops inserted around the operators and during lowering quantized operator patterns will be fused into real quantized ops. Currently there are two typical lowering paths, 1. torch.compile through inductor lowering 2. ExecuTorch through delegation

--- a/docs/source/pt2e_quantization/pt2e_quant_openvino_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_openvino_inductor.rst
@@ -3,6 +3,8 @@ PyTorch 2 Export Quantization for OpenVINO torch.compile Backend
 
 **Authors**: `Daniil Lyakhov <https://github.com/daniil-lyakhov>`_,  `Aamir Nazir <https://github.com/anzr299>`_,  `Alexander Suslov <https://github.com/alexsu52>`_, `Yamini Nimmagadda <https://github.com/ynimmaga>`_, `Alexander Kozlov <https://github.com/AlexKoff88>`_
 
+.. _pt2e-openvino-prerequisites:
+
 Prerequisites
 --------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_x86_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_x86_inductor.rst
@@ -3,6 +3,8 @@ PyTorch 2 Export Quantization with X86 Backend through Inductor
 
 **Author**: `Leslie Fang <https://github.com/leslie-fang-intel>`_, `Weiwen Xia <https://github.com/Xia-Weiwen>`_, `Jiong Gong <https://github.com/jgong5>`_, `Jerry Zhang <https://github.com/jerryzh168>`_
 
+.. _pt2e-x86-prerequisites:
+
 Prerequisites
 ---------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
@@ -3,6 +3,8 @@ PyTorch 2 Export Quantization with Intel GPU Backend through Inductor
 
 **Author**: `Yan Zhiwei <https://github.com/ZhiweiYan-96>`_, `Wang Eikan <https://github.com/EikanWang>`_, `Zhang Liangang <https://github.com/liangan1>`_, `Liu River <https://github.com/riverliuintel>`_, `Cui Yifeng <https://github.com/CuiYifeng>`_
 
+.. _pt2e-xpu-prerequisites:
+
 Prerequisites
 ---------------
 


### PR DESCRIPTION
Add unique reference labels to resolve autosectionlabel conflicts:

- api_quantization -> api_float8 (api_ref_float8.rst)
- Add pretraining-torchtitan-prerequisites label
- Add pretraining-torchao-prerequisites label
- Add mxfp8-torchtitan-prerequisites label
- Add mxfp8-torchao-prerequisites label
- Add pt2e-openvino-prerequisites label
- Add pt2e-x86-prerequisites label
- Add pt2e-xpu-prerequisites label
- Add pt2e-quick-start label

Resolves 9 duplicate label warnings from issue #3863