### PR TITLE
docs: fix duplicate conclusion labels

### DIFF
--- a/docs/source/eager_tutorials/serving.rst
+++ b/docs/source/eager_tutorials/serving.rst
@@ -395,6 +395,8 @@ Results (H100 machine)
 | serving (num_prompts=1000) | 66.68 req/s         | 80.53 req/s (1.21x speedup)  |
 +----------------------------+---------------------+------------------------------+
 
+.. _serving-conclusion:
+
 Conclusion
 ---------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_openvino_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_openvino_inductor.rst
@@ -246,6 +246,8 @@ These advanced NNCF algorithms can be accessed via the NNCF `quantize_pt2e` API:
 For further details, please see the `documentation <https://openvinotoolkit.github.io/nncf/autoapi/nncf/experimental/torch/fx/index.html#nncf.experimental.torch.fx.quantize_pt2e>`_
 and a complete `example on Resnet18 quantization <https://github.com/openvinotoolkit/nncf/blob/develop/examples/post_training_quantization/torch_fx/resnet18/README.md>`_.
 
+.. _pt2e_quant_openvino_inductor-conclusion:
+
 Conclusion
 ------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_ptq.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_ptq.rst
@@ -591,6 +591,8 @@ to get a model that runs on real devices, we'll need to lower the model.
 For example, for the models that run on edge devices, we can lower with delegation and ExecuTorch runtime
 operators.
 
+.. _pt2e_quant_ptq-conclusion:
+
 Conclusion
 --------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_qat.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_qat.rst
@@ -474,6 +474,8 @@ to incorrectly apply dropout in the forward pass during inference, for example.
 .. TODO: add results here
 
 
+.. _pt2e_quant_qat-conclusion:
+
 Conclusion
 --------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_x86_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_x86_inductor.rst
@@ -294,6 +294,8 @@ For example:
 
     TORCHINDUCTOR_FREEZING=1 python example_x86inductorquantizer_qat.py
 
+.. _pt2e_quant_x86_inductor-conclusion:
+
 Conclusion
 ------------
 

--- a/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
@@ -254,6 +254,8 @@ script within the BFloat16 Autocast context.
             optimized_model(*example_inputs)
 
 
+.. _pt2e_quant_xpu_inductor-conclusion:
+
 Conclusion
 ------------
 

--- a/docs/source/pt2e_quantization/pt2e_quantizer.rst
+++ b/docs/source/pt2e_quantization/pt2e_quantizer.rst
@@ -372,6 +372,8 @@ Another caveat is that we need to make sure we have an exhaustive list of exampl
 
 Note: We may provide some (pattern, list of example_inputs) or some pre-generated matcher object so people can just use them directly in the future.
 
+.. _pt2e_quantizer-conclusion:
+
 Conclusion
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Add unique reference labels for conclusion sections to resolve autosectionlabel conflicts:

- Add serving-conclusion label (eager_tutorials/serving.rst)
- Add pt2e_quant_xpu_inductor-conclusion label
- Add pt2e_quantizer-conclusion label
- Add pt2e_quant_ptq-conclusion label
- Add pt2e_quant_openvino_inductor-conclusion label
- Add pt2e_quant_qat-conclusion label
- Add pt2e_quant_x86_inductor-conclusion label

Resolves 7 duplicate conclusion label warnings from issue #3863