### PR TITLE
[QAT] Add low-bit FSDP all-gather path for affine fake quant tensor

### DIFF
--- a/torchao/quantization/qat/affine_fake_quantized_tensor.py
+++ b/torchao/quantization/qat/affine_fake_quantized_tensor.py
@@ -3,7 +3,8 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 import torch.utils._pytree as pytree
@@ -14,13 +15,173 @@ from torchao.quantization.quant_primitives import (
     ZeroPointDomain,
     _choose_qparams_affine_dont_preserve_zero,
     _choose_qparams_affine_tinygemm,
+    _dequantize_affine_no_dtype_check,
+    _dequantize_affine_no_zero_point_no_dtype_check,
+    _dequantize_affine_tinygemm_no_dtype_check,
     _fake_quantize_affine,
     _get_and_check_qmin_qmax,
+    _quantize_affine_no_dtype_cast,
+    _quantize_affine_no_zero_point_no_dtype_cast,
+    _quantize_affine_tinygemm_no_dtype_cast,
     choose_qparams_affine,
 )
 from torchao.utils import TorchAOBaseTensor
 
 aten = torch.ops.aten
+
+
+@dataclass(frozen=True)
+class _AffineFakeQuantizedConfig:
+    mapping_type: MappingType
+    block_size: Tuple[int, ...]
+    target_dtype: torch.dtype
+    quant_min: Optional[int]
+    quant_max: Optional[int]
+    eps: Optional[float]
+    scale_dtype: Optional[torch.dtype]
+    zero_point_dtype: Optional[torch.dtype]
+    preserve_zero: bool
+    zero_point_domain: ZeroPointDomain
+    is_per_tensor: bool
+
+
+def _get_effective_block_size(
+    config: _AffineFakeQuantizedConfig, input_tensor: torch.Tensor
+) -> Tuple[int, ...]:
+    return tuple(input_tensor.shape) if config.is_per_tensor else config.block_size
+
+
+def _choose_qparams_for_config(
+    input_tensor: torch.Tensor, config: _AffineFakeQuantizedConfig
+) -> Tuple[Tuple[int, ...], torch.Tensor, Optional[torch.Tensor], int, int]:
+    block_size = _get_effective_block_size(config, input_tensor)
+    quant_min, quant_max = _get_and_check_qmin_qmax(
+        config.target_dtype, config.quant_min, config.quant_max
+    )
+
+    if config.zero_point_domain == ZeroPointDomain.FLOAT and not config.preserve_zero:
+        scale, zero_point = _choose_qparams_affine_tinygemm(
+            input_tensor,
+            config.mapping_type,
+            block_size,
+            config.target_dtype,
+            quant_min,
+            quant_max,
+            config.eps,
+            config.scale_dtype,
+            config.zero_point_dtype,
+        )
+    elif config.zero_point_domain == ZeroPointDomain.INT and not config.preserve_zero:
+        scale, zero_point = _choose_qparams_affine_dont_preserve_zero(
+            input_tensor,
+            config.mapping_type,
+            block_size,
+            config.target_dtype,
+            quant_min,
+            quant_max,
+            config.eps,
+            config.scale_dtype,
+            config.zero_point_dtype,
+        )
+    else:
+        scale, zero_point = choose_qparams_affine(
+            input_tensor,
+            config.mapping_type,
+            block_size,
+            config.target_dtype,
+            quant_min,
+            quant_max,
+            config.eps,
+            config.scale_dtype,
+            config.zero_point_dtype,
+        )
+        if config.zero_point_domain == ZeroPointDomain.NONE:
+            zero_point = None
+
+    return block_size, scale, zero_point, quant_min, quant_max
+
+
+def _get_quantized_comm_dtype(quant_min: int, quant_max: int) -> torch.dtype:
+    if quant_min >= 0 and quant_max <= torch.iinfo(torch.uint8).max:
+        return torch.uint8
+    if (
+        quant_min >= torch.iinfo(torch.int8).min
+        and quant_max <= torch.iinfo(torch.int8).max
+    ):
+        return torch.int8
+    raise RuntimeError(
+        f"Expected 8-bit quantization range, but got quant_min={quant_min}, quant_max={quant_max}"
+    )
+
+
+def _quantize_for_fsdp_all_gather(
+    input_tensor: torch.Tensor,
+    block_size: Tuple[int, ...],
+    scale: torch.Tensor,
+    zero_point: Optional[torch.Tensor],
+    quant_min: int,
+    quant_max: int,
+    zero_point_domain: ZeroPointDomain,
+) -> torch.Tensor:
+    comm_dtype = _get_quantized_comm_dtype(quant_min, quant_max)
+    if zero_point_domain == ZeroPointDomain.INT:
+        quantized = _quantize_affine_no_dtype_cast(
+            input_tensor, block_size, scale, zero_point, quant_min, quant_max
+        )
+    elif zero_point_domain == ZeroPointDomain.FLOAT:
+        quantized = _quantize_affine_tinygemm_no_dtype_cast(
+            input_tensor, block_size, scale, zero_point, quant_min, quant_max
+        )
+    elif zero_point_domain == ZeroPointDomain.NONE:
+        quantized = _quantize_affine_no_zero_point_no_dtype_cast(
+            input_tensor, block_size, scale, None, quant_min, quant_max
+        )
+    else:
+        raise ValueError(f"Unrecognized zero_point_domain: {zero_point_domain}")
+    return quantized.to(comm_dtype)
+
+
+def _dequantize_from_fsdp_all_gather(
+    quantized_tensor: torch.Tensor,
+    block_size: Tuple[int, ...],
+    scale: torch.Tensor,
+    zero_point: Optional[torch.Tensor],
+    quant_min: int,
+    quant_max: int,
+    zero_point_domain: ZeroPointDomain,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    if zero_point_domain == ZeroPointDomain.INT:
+        return _dequantize_affine_no_dtype_check(
+            quantized_tensor,
+            block_size,
+            scale,
+            zero_point,
+            quant_min,
+            quant_max,
+            output_dtype,
+        )
+    if zero_point_domain == ZeroPointDomain.FLOAT:
+        return _dequantize_affine_tinygemm_no_dtype_check(
+            quantized_tensor,
+            block_size,
+            scale,
+            zero_point,
+            quant_min,
+            quant_max,
+            output_dtype,
+        )
+    if zero_point_domain == ZeroPointDomain.NONE:
+        return _dequantize_affine_no_zero_point_no_dtype_check(
+            quantized_tensor,
+            block_size,
+            scale,
+            None,
+            quant_min,
+            quant_max,
+            output_dtype,
+        )
+    raise ValueError(f"Unrecognized zero_point_domain: {zero_point_domain}")
 
 
 class _ToAffineFakeQuantized(torch.autograd.Function):
@@ -47,54 +208,43 @@ class _ToAffineFakeQuantized(torch.autograd.Function):
         if zero_point_domain is None:
             raise ValueError("Please use ZeroPointDomain.NONE instead of None")
 
+        quantization_config = _AffineFakeQuantizedConfig(
+            mapping_type=mapping_type,
+            block_size=block_size,
+            target_dtype=target_dtype,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            eps=eps,
+            scale_dtype=scale_dtype,
+            zero_point_dtype=zero_point_dtype,
+            preserve_zero=preserve_zero,
+            zero_point_domain=zero_point_domain,
+            is_per_tensor=tuple(block_size) == tuple(original_tensor.shape),
+        )
+
         def apply_fake_quant_fn(t: torch.Tensor):
             assert isinstance(t, _AffineFakeQuantizedTensor)
-            qmin, qmax = _get_and_check_qmin_qmax(target_dtype, quant_min, quant_max)
-            if zero_point_domain == ZeroPointDomain.FLOAT and not preserve_zero:
-                scale, zero_point = _choose_qparams_affine_tinygemm(
-                    t.original_tensor,
-                    mapping_type,
-                    block_size,
-                    target_dtype,
-                    qmin,
-                    qmax,
-                    eps,
-                    scale_dtype,
-                    zero_point_dtype,
-                )
-            elif zero_point_domain == ZeroPointDomain.INT and not preserve_zero:
-                scale, zero_point = _choose_qparams_affine_dont_preserve_zero(
-                    t.original_tensor,
-                    mapping_type,
-                    block_size,
-                    target_dtype,
-                    qmin,
-                    qmax,
-                    eps,
-                    scale_dtype,
-                    zero_point_dtype,
-                )
-            else:  # Default case: zero_point_domain == ZeroPointDomain.INT and preserve_zero
-                scale, zero_point = choose_qparams_affine(
-                    t.original_tensor,
-                    mapping_type,
-                    block_size,
-                    target_dtype,
-                    qmin,
-                    qmax,
-                    eps,
-                    scale_dtype,
-                    zero_point_dtype,
-                )
+            config = (
+                t.quantization_config
+                if t.quantization_config is not None
+                else quantization_config
+            )
+            (
+                effective_block_size,
+                scale,
+                zero_point,
+                qmin,
+                qmax,
+            ) = _choose_qparams_for_config(t.original_tensor, config)
             fq = _fake_quantize_affine(
-                t,
-                block_size,
+                t.original_tensor,
+                effective_block_size,
                 scale,
                 zero_point,
                 quant_dtype=torch.int32,
                 quant_min=qmin,
                 quant_max=qmax,
-                zero_point_domain=zero_point_domain,
+                zero_point_domain=config.zero_point_domain,
             )
             return fq
 
@@ -102,6 +252,7 @@ class _ToAffineFakeQuantized(torch.autograd.Function):
             original_tensor,
             apply_fake_quant_fn,
             fake_quant_enabled=True,
+            quantization_config=quantization_config,
         )
 
     @staticmethod
@@ -124,6 +275,8 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
     fields:
       original_tensor (torch.Tensor): tensor holding the original float values, needed for actual quantization later
       apply_fake_quant_fn (Callable): function that transforms `original_tensor` to fake quantized values
+      quantization_config (Optional[_AffineFakeQuantizedConfig]): quantization metadata used for
+          reproducing fake quant numerics and for FSDP low-bit all-gather hooks
     """
 
     @staticmethod
@@ -132,6 +285,7 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
         original_tensor: torch.Tensor,
         apply_fake_quant_fn: Callable,
         fake_quant_enabled: bool = True,
+        quantization_config: Optional[_AffineFakeQuantizedConfig] = None,
         **kwargs,
     ):
         kwargs.setdefault("dtype", original_tensor.dtype)
@@ -148,14 +302,20 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
         original_tensor: torch.Tensor,
         apply_fake_quant_fn: Callable,
         fake_quant_enabled: bool = True,
+        quantization_config: Optional[_AffineFakeQuantizedConfig] = None,
         **kwargs,
     ):
         self.original_tensor = original_tensor
         self.apply_fake_quant_fn = apply_fake_quant_fn
         self.fake_quant_enabled = fake_quant_enabled
+        self.quantization_config = quantization_config
 
     def __tensor_flatten__(self):
-        return ["original_tensor"], [self.apply_fake_quant_fn, self.fake_quant_enabled]
+        return ["original_tensor"], [
+            self.apply_fake_quant_fn,
+            self.fake_quant_enabled,
+            self.quantization_config,
+        ]
 
     @classmethod
     def __tensor_unflatten__(
@@ -166,11 +326,18 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
         outer_stride,
     ):
         original_tensor = tensor_data_dict["original_tensor"]
-        (apply_fake_quant_fn, fake_quant_enabled) = tensor_attributes
+        if len(tensor_attributes) == 2:
+            (apply_fake_quant_fn, fake_quant_enabled) = tensor_attributes
+            quantization_config = None
+        else:
+            (apply_fake_quant_fn, fake_quant_enabled, quantization_config) = (
+                tensor_attributes
+            )
         return cls(
             original_tensor,
             apply_fake_quant_fn,
             fake_quant_enabled,
+            quantization_config,
         )
 
     @classmethod
@@ -210,6 +377,92 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
         else:
             return self.original_tensor
 
+    def _require_quantization_config(self) -> _AffineFakeQuantizedConfig:
+        if self.quantization_config is None:
+            raise RuntimeError(
+                "Missing quantization metadata on _AffineFakeQuantizedTensor. "
+                "Please construct this tensor via `_to_affine_fake_quantized`."
+            )
+        return self.quantization_config
+
+    # FSDP all-gather extension v2
+    # https://github.com/pytorch/pytorch/pull/137005
+    # default values keep compatibility with older torch versions
+    def fsdp_pre_all_gather(
+        self,
+        mesh,
+        outer_size=None,
+        outer_stride=None,
+        module=None,
+        mp_policy=None,
+    ):
+        input_tensor = self.original_tensor
+        if mp_policy is not None and mp_policy.param_dtype is not None:
+            input_tensor = input_tensor.to(mp_policy.param_dtype)
+        config = self._require_quantization_config()
+        block_size, scale, zero_point, quant_min, quant_max = _choose_qparams_for_config(
+            input_tensor, config
+        )
+        quantized_tensor = _quantize_for_fsdp_all_gather(
+            input_tensor,
+            block_size,
+            scale,
+            zero_point,
+            quant_min,
+            quant_max,
+            config.zero_point_domain,
+        )
+        metadata = (
+            scale,
+            zero_point,
+            block_size,
+            quant_min,
+            quant_max,
+            config.zero_point_domain,
+        )
+        return (quantized_tensor,), metadata
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs: Tuple[torch.Tensor, ...],
+        metadata: Any,
+        param_dtype: torch.dtype,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ):
+        (quantized_tensor,) = all_gather_outputs
+        (
+            scale,
+            zero_point,
+            block_size,
+            quant_min,
+            quant_max,
+            zero_point_domain,
+        ) = metadata
+
+        dequantized = _dequantize_from_fsdp_all_gather(
+            quantized_tensor,
+            block_size,
+            scale,
+            zero_point,
+            quant_min,
+            quant_max,
+            zero_point_domain,
+            param_dtype,
+        )
+
+        if out is not None:
+            from torch.distributed._tensor import DTensor
+
+            if isinstance(out, DTensor):
+                out._local_tensor.copy_(dequantized)
+            elif isinstance(out, _AffineFakeQuantizedTensor):
+                out.original_tensor.copy_(dequantized)
+            else:
+                out.copy_(dequantized)
+            return
+        return dequantized, (dequantized,)
+
     def _get_to_kwargs(self, *args, **kwargs):
         device, dtype, _, memory_format = torch._C._nn._parse_to(*args, **kwargs)
         device = self.device if device is None else device
@@ -234,6 +487,7 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
             self.original_tensor.to(device),
             self.apply_fake_quant_fn,
             self.fake_quant_enabled,
+            self.quantization_config,
             **kwargs,
         )
 
@@ -259,6 +513,7 @@ class _AffineFakeQuantizedTensor(TorchAOBaseTensor):
             new_value,
             self.apply_fake_quant_fn,
             self.fake_quant_enabled,
+            self.quantization_config,
             requires_grad=False,
         )
 


### PR DESCRIPTION
## What
- add FSDP pre/post all-gather hooks to `_AffineFakeQuantizedTensor`
- quantize local shards before all-gather and dequantize gathered weights after all-gather
- preserve quantization metadata on the tensor subclass for deterministic behavior

## Tests
- add two QAT tests covering low-bit all-gather roundtrip and per-tensor block size behavior
- `python -m pytest test/quantization/test_qat.py -k "affine_fake_quantized_tensor_fsdp_all_gather" -q`

closes #1224