### PR TITLE
Fix FqnToConfig module skipping for _default and regex modules

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1980,6 +1980,8 @@ def _fqn_to_config_handler(
                 if c is not None:
                     handler = _QUANTIZE_CONFIG_HANDLER[type(c)]
                     return handler(module, c)
+                else:
+                    return module
 
     # If no module_fqn or parameter_fqn matches, then we apply _default
     if not parameter_config_found:


### PR DESCRIPTION
Summary:

Fixes #3867. We were missing handling None appropriately like we do for exact fqn match earlier in the function.

Test Plan:

```
pytest test/quantization/test_quant_api.py -k
test_fqn_to_config_regex_skip
```

Reviewers:

Subscribers:

Tasks:

Tags: