### PR TITLE
Remove Float8DynamicActivationFloat8SemiSparseWeightConfig

### DIFF
--- a/benchmarks/microbenchmarks/test/test_utils.py
+++ b/benchmarks/microbenchmarks/test/test_utils.py
@@ -13,7 +13,6 @@ from benchmarks.microbenchmarks.utils import (
     BenchmarkConfig,
     BenchmarkResult,
     BlockSparseWeightConfig,
-    Float8DynamicActivationFloat8SemiSparseWeightConfig,
     Int4WeightOnlyConfig,
     SemiSparseWeightConfig,
     clean_caches,
@@ -111,12 +110,6 @@ class TestUtils(unittest.TestCase):
         # Test combined sparsity and quantization
         config = string_to_config("marlin", "semi-sparse")
         self.assertIsInstance(config, Int4WeightOnlyConfig)
-
-        # Test float8 with semi-sparse
-        config = string_to_config("float8dq", "semi-sparse")
-        self.assertIsInstance(
-            config, Float8DynamicActivationFloat8SemiSparseWeightConfig
-        )
 
     def test_block_sparsity_with_baseline_quantization(self):
         """Test that block sparsity with baseline quantization returns BlockSparseWeightConfig"""

--- a/benchmarks/microbenchmarks/utils.py
+++ b/benchmarks/microbenchmarks/utils.py
@@ -14,7 +14,6 @@ from torch.utils.benchmark import Timer
 
 from torchao.core.config import AOBaseConfig
 from torchao.quantization import (
-    Float8DynamicActivationFloat8SemiSparseWeightConfig,
     Float8DynamicActivationFloat8WeightConfig,
     Float8WeightOnlyConfig,
     GemliteUIntXWeightOnlyConfig,
@@ -242,8 +241,6 @@ def string_to_config(
     elif "float8wo" in quantization:
         return Float8WeightOnlyConfig()
     elif "float8dq" in quantization:
-        if sparsity and "semi" in sparsity:
-            return Float8DynamicActivationFloat8SemiSparseWeightConfig()
         granularity = str(quantization.split("-")[-1])
         if granularity == "tensor":
             granularity = PerTensor()

--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -12,10 +12,6 @@ from torch import nn
 from torch.testing._internal import common_utils
 
 from torchao.dtypes import SemiSparseLayout
-from torchao.quantization import (
-    Float8DynamicActivationFloat8SemiSparseWeightConfig,
-    Float8DynamicActivationFloat8WeightConfig,
-)
 from torchao.quantization.quant_api import (
     Int8DynamicActivationInt8WeightConfig,
     quantize_,
@@ -92,69 +88,6 @@ class TestQuantSemiSparse(common_utils.TestCase):
         sparse_result = model(input)
 
         torch.testing.assert_close(dense_result, sparse_result, rtol=1e-2, atol=1e-2)
-
-    @unittest.skipIf(not is_sm_at_least_90(), "Need H100 to run")
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    @common_utils.parametrize("compile", [True, False])
-    def test_fp8_cutlass_sparse(self, compile):
-        input = torch.rand((256, 256)).half().cuda()
-        model = (
-            nn.Sequential(
-                nn.Linear(256, 1024),
-                nn.Linear(1024, 256),
-            )
-            .half()
-            .cuda()
-            .eval()
-        )
-
-        apply_fake_sparsity(model)
-        model_copy = copy.deepcopy(model)
-
-        # Quantized
-        quantize_(model_copy.bfloat16(), Float8DynamicActivationFloat8WeightConfig())
-        dense_result = model_copy(input.bfloat16()).half()
-
-        # Sparse + quantized
-        quantize_(model, Float8DynamicActivationFloat8SemiSparseWeightConfig())
-        if compile:
-            model = torch.compile(model)
-        sparse_result = model(input)
-
-        torch.testing.assert_close(dense_result, sparse_result, atol=3e-1, rtol=3e-1)
-
-    @unittest.skipIf(not is_sm_at_least_90(), "Need H100 to run")
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_fp8_cutlass_sparse_lowering_op_clone(self):
-        with torch.inference_mode():
-            model = nn.Linear(256, 1024).half().cuda().eval()
-            apply_fake_sparsity(model)
-            quantize_(model, Float8DynamicActivationFloat8SemiSparseWeightConfig())
-
-            original = model.weight.original_weight_tensor.tensor_impl.get_plain()
-            cloned = model.weight.original_weight_tensor.tensor_impl.clone().get_plain()
-
-            for o, c in zip(original, cloned):
-                torch.testing.assert_close(o, c, atol=0.0, rtol=0.0)
-
-    @unittest.skipIf(not is_sm_at_least_90(), "Need H100 to run")
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_fp8_cutlass_sparse_lowering_op_to(self):
-        # Need to run with inference mode to avoid dispatching to `aten.to_copy`
-        with torch.inference_mode():
-            model = nn.Linear(256, 1024).half().cuda().eval()
-            apply_fake_sparsity(model)
-            model_copy = copy.deepcopy(model)
-            expected = model_copy.weight.to(dtype=torch.float)
-
-            quantize_(model, Float8DynamicActivationFloat8SemiSparseWeightConfig())
-
-            original = torch.ops.aten.to.dtype_layout(
-                model.weight.original_weight_tensor.tensor_impl,
-                dtype=torch.float,
-                layout=torch.strided,
-            )
-            torch.testing.assert_close(expected, original, atol=1e-1, rtol=1e-1)
 
 
 class TestBlockSparseWeight(common_utils.TestCase):

--- a/torchao/quantization/__init__.py
+++ b/torchao/quantization/__init__.py
@@ -52,7 +52,6 @@ from .observer import (
     AffineQuantizedObserverBase,
 )
 from .quant_api import (
-    Float8DynamicActivationFloat8SemiSparseWeightConfig,
     Float8DynamicActivationFloat8WeightConfig,
     Float8DynamicActivationInt4WeightConfig,
     Float8MMConfig,
@@ -129,7 +128,6 @@ __all__ = [
     "Float8WeightOnlyConfig",
     "Float8DynamicActivationFloat8WeightConfig",
     "Float8StaticActivationFloat8WeightConfig",
-    "Float8DynamicActivationFloat8SemiSparseWeightConfig",
     "UIntXWeightOnlyConfig",
     "IntxWeightOnlyConfig",
     "GemliteUIntXWeightOnlyConfig",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3887
* #3886
* #3885
* #3884
* __->__ #3883

This config was deprecated in favor of Float8DynamicActivationFloat8WeightConfig
with packing_format=Float8PackingFormat.SPARSE_CUTLASS and granularity=PerRow().
Remove the class definition, handler, and all references from imports, tests, and
benchmarks.

Co-authored-by: Cursor <cursoragent@cursor.com>

Differential Revision: [D93251982](https://our.internmc.facebook.com/intern/diff/D93251982)