### PR TITLE
Change PR check to check for `module:` labels instead

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -2,7 +2,6 @@ name: PR Label Check
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-  workflow_dispatch:
 
 jobs:
   check-labels:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3888

Summary:
- Changed from checking for topic: to module:, since we are planning to do per module highlight commits in release notes going forward, all module labels: https://github.com/pytorch/ao/labels?q=module
- Also remove redundant empty-labels check in PR label CI workflow — the existing module: prefix check already covers the case where no labels are present.

Test Plan:
test with the current PR

Reviewers:

Subscribers:

Tasks:

Tags: