### PR TITLE
Add precomputed scale support to MXTensor and fix swizzled scales

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -785,7 +785,7 @@ def test_to_mx_precomputed_scale(elem_dtype, shape, block_size):
     # The scale stored in the result must match the one we passed in
     torch.testing.assert_close(result.scale, ref.scale, atol=0, rtol=0)
 
-    # # Round-trip dequantization must also match exactly
-    # ref_dq = ref.dequantize(data.dtype)
-    # result_dq = result.dequantize(data.dtype)
-    # torch.testing.assert_close(result_dq, ref_dq, atol=0, rtol=0)
+    # Round-trip dequantization must also match exactly
+    ref_dq = ref.dequantize(data.dtype)
+    result_dq = result.dequantize(data.dtype)
+    torch.testing.assert_close(result_dq, ref_dq, atol=0, rtol=0)

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -751,3 +751,41 @@ def test_swizzle(elem_dtype, transpose, shape):
     x_dq = x.dequantize(x.dtype)
     xs_dq = xs.dequantize(xs.dtype)
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize(
+    "shape,block_size",
+    [
+        ((128, 128), 32),
+        ((64, 256), 32),
+        ((32, 64), 4),
+    ],
+)
+def test_to_mx_precomputed_scale(elem_dtype, shape, block_size):
+    """Passing a precomputed scale to MXTensor.to_mx should produce the same
+    qdata and scale as letting to_mx compute the scale itself."""
+    data = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+
+    # Reference: let to_mx compute the scale from data
+    ref = MXTensor.to_mx(
+        data, elem_dtype, block_size, kernel_preference=KernelPreference.EMULATED
+    )
+
+    # Test: pass the reference scale back in as a precomputed scale with the same data
+    result = MXTensor.to_mx(
+        data,
+        elem_dtype,
+        block_size,
+        scale=ref.scale,
+        kernel_preference=KernelPreference.EMULATED,
+    )
+
+    # The scale stored in the result must match the one we passed in
+    torch.testing.assert_close(result.scale, ref.scale, atol=0, rtol=0)
+
+    # # Round-trip dequantization must also match exactly
+    # ref_dq = ref.dequantize(data.dtype)
+    # result_dq = result.dequantize(data.dtype)
+    # torch.testing.assert_close(result_dq, ref_dq, atol=0, rtol=0)

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -367,14 +367,17 @@ def _mx_quantize_precomputed_scale(
         torch.bfloat16,
         torch.float,
     ), f"{data_hp.dtype} is not supported yet"
+    assert data_hp.shape[-1] % block_size == 0, (
+        f"the last dimension of shape {data_hp.shape} must be divisible by block_size {block_size}"
+    )
     assert data_hp.is_contiguous(), "unsupported"
     assert elem_dtype in SUPPORTED_ELEM_DTYPES, "unsupported"
+
     assert scale_e8m0_biased.dtype == torch.float8_e8m0fnu, (
         f"scale_e8m0_biased.dtype must be float8_e8m0fnu, got {scale_e8m0_biased.dtype}"
     )
 
     orig_shape = data_hp.shape
-    data_hp = data_hp.to(torch.float32)
     data_hp = data_hp.reshape(
         *orig_shape[:-1], orig_shape[-1] // block_size, block_size
     )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -348,6 +348,98 @@ def to_mx(
     return scale_e8m0_biased, data_lp
 
 
+def _mx_quantize_precomputed_scale(
+    data_hp: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int,
+    scale_e8m0_biased: torch.Tensor,
+    is_swizzled_scales: bool = False,
+):
+    """
+    Like to_mx, but uses a precomputed e8m0 scale instead of computing one
+    from the data.  This is useful for GPTQ which computes the scale once
+    per group and then quantizes each column individually with that same
+    scale.
+
+    Returns (scale_e8m0_biased, data_lp) -- the same signature as to_mx.
+    """
+    assert data_hp.dtype in (
+        torch.bfloat16,
+        torch.float,
+    ), f"{data_hp.dtype} is not supported yet"
+    assert data_hp.is_contiguous(), "unsupported"
+    assert elem_dtype in SUPPORTED_ELEM_DTYPES, "unsupported"
+    assert scale_e8m0_biased.dtype == torch.float8_e8m0fnu, (
+        f"scale_e8m0_biased.dtype must be float8_e8m0fnu, got {scale_e8m0_biased.dtype}"
+    )
+
+    orig_shape = data_hp.shape
+    data_hp = data_hp.to(torch.float32)
+    data_hp = data_hp.reshape(
+        *orig_shape[:-1], orig_shape[-1] // block_size, block_size
+    )
+
+    # Determine max_pos for saturated clamp
+    if elem_dtype == torch.float8_e4m3fn:
+        max_pos = F8E4M3_MAX
+    elif elem_dtype == torch.float8_e5m2:
+        max_pos = F8E5M2_MAX
+    elif elem_dtype == DTYPE_FP6_E2M3:
+        max_pos = F6_E2M3_MAX
+    elif elem_dtype == DTYPE_FP6_E3M2:
+        max_pos = F6_E3M2_MAX
+    elif elem_dtype == torch.float4_e2m1fn_x2:
+        max_pos = F4_E2M1_MAX
+    else:
+        raise AssertionError("unsupported element dtype")
+
+    # Convert e8m0 scale to fp32 using the same bit-shift pattern as to_mx.
+    # The scale needs an extra trailing dim for broadcasting against blocks.
+    scale_fp32 = (
+        torch.bitwise_left_shift(
+            scale_e8m0_biased.view(torch.uint8).to(torch.int32), MBITS_F32
+        )
+    ).view(torch.float32)
+    scale_fp32 = torch.clamp(scale_fp32, min=F32_MIN_NORMAL)
+    scale_fp32 = scale_fp32.unsqueeze(-1)
+
+    # Scale and saturated cast
+    data_lp = data_hp / scale_fp32
+
+    if (
+        elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+        and not torch._dynamo.is_compiling()
+    ):
+        data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
+
+    # Cast to target dtype
+    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        data_lp = data_lp.to(elem_dtype)
+        data_lp = data_lp.reshape(orig_shape)
+    elif elem_dtype == DTYPE_FP6_E2M3:
+        data_lp = f32_to_f6_e2m3_unpacked(data_lp)
+        data_lp = data_lp.reshape(orig_shape)
+    elif elem_dtype == DTYPE_FP6_E3M2:
+        data_lp = f32_to_f6_e3m2_unpacked(data_lp)
+        data_lp = data_lp.reshape(orig_shape)
+    elif elem_dtype == torch.float4_e2m1fn_x2:
+        data_lp = data_lp.reshape(orig_shape)
+        data_lp = f32_to_f4_unpacked(data_lp)
+        data_lp = pack_uint4(data_lp)
+    else:
+        raise AssertionError("unsupported")
+
+    # If user requested scale swizzling, do it here
+    if is_swizzled_scales:
+        leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
+        scale_shape = (math.prod(leading_dims) * M, K // block_size)
+        s = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
+        scale_e8m0_biased = s.view(*leading_dims, scale_M, scale_K)
+
+    return scale_e8m0_biased, data_lp
+
+
 def get_fp_scale(scale_e8m0):
     scale_e8m0 = scale_e8m0.view(torch.uint8)
     s_offset = scale_e8m0.to(torch.int16) - E8M0_EXPONENT_BIAS
@@ -551,6 +643,8 @@ class MXTensor(TorchAOBaseTensor):
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
         is_swizzled_scales: bool = False,
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
+        *,
+        scale: Optional[torch.Tensor] = None,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
             MXFP8Dim0CastKernelChoice.TRITON,
@@ -559,22 +653,31 @@ class MXTensor(TorchAOBaseTensor):
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
 
-        triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
-        )
-        if mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TRITON:
-            assert triton_kernel_supported, (
-                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
-            )
-            data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
-                data_hp,
-                inner_block_size=block_size,
-                scaling_mode=scaling_mode.value,
+        orig_dtype = data_hp.dtype
+
+        if scale is not None:
+            # breakpoint()
+            scale_e8m0_biased, data_lp = _mx_quantize_precomputed_scale(
+                data_hp, elem_dtype, block_size, scale, is_swizzled_scales
             )
         else:
-            scale_e8m0_biased, data_lp = to_mx(
-                data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+            triton_kernel_supported = (
+                elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
             )
+            if mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TRITON:
+                assert triton_kernel_supported, (
+                    f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
+                )
+                data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
+                    data_hp,
+                    inner_block_size=block_size,
+                    scaling_mode=scaling_mode.value,
+                )
+            else:
+                scale_e8m0_biased, data_lp = to_mx(
+                    data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+                )
+
         if isinstance(scale_e8m0_biased, DTensor):
             assert isinstance(data_lp, DTensor), "unsupported"
             local_scale_e8m0_biased = scale_e8m0_biased.to_local()
@@ -584,7 +687,7 @@ class MXTensor(TorchAOBaseTensor):
                 local_scale_e8m0_biased,
                 elem_dtype,
                 block_size,
-                data_hp.dtype,
+                orig_dtype,
                 kernel_preference,
                 act_quant_kwargs,
                 is_swizzled_scales,
@@ -602,7 +705,7 @@ class MXTensor(TorchAOBaseTensor):
             scale_e8m0_biased,
             elem_dtype,
             block_size,
-            data_hp.dtype,
+            orig_dtype,
             kernel_preference,
             act_quant_kwargs,
             is_swizzled_scales,

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -535,7 +535,7 @@ class MXTensor(TorchAOBaseTensor):
     def __new__(
         cls,
         qdata,
-        scale,
+        scale_e8m0_bits,
         elem_dtype,
         block_size,
         orig_dtype,
@@ -563,8 +563,8 @@ class MXTensor(TorchAOBaseTensor):
             dtype=orig_dtype,
             device=qdata.device,
         )
-        assert scale.dtype == torch.float8_e8m0fnu, (
-            f"scale.dtype must be `torch.float8_e8m0fnu`, got {scale.dtype}"
+        assert scale_e8m0_bits.dtype == torch.float8_e8m0fnu, (
+            f"scale_e8m0_bits.dtype must be `torch.float8_e8m0fnu`, got {scale_e8m0_bits.dtype}"
         )
         assert qdata.dtype in (
             torch.float8_e4m3fn,
@@ -572,7 +572,7 @@ class MXTensor(TorchAOBaseTensor):
             torch.uint8,
         ), "unsupported"
         self.qdata = qdata
-        self.scale = scale
+        self.scale = scale_e8m0_bits
         self._elem_dtype = elem_dtype
         self.block_size = block_size
         self._orig_dtype = orig_dtype

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -103,54 +103,6 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     is_swizzled_scales: bool = False
 
 
-def _to_mx_rceil(
-    data_hp: torch.Tensor,
-    max_abs: torch.Tensor,
-    max_pos: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    A prototype implementation of MXFP scale factor derivation method described in
-    https://docs.nvidia.com/cuda/cublas/#d-block-quantization
-
-    For Nvidia GPU with Blackwell+ architecture, the scale factor derivation method
-    could be accelerated by the `cvt.rp.satfinite.ue8m0x2.f32` instruction.
-
-    Args:
-        data_hp: High precision data.
-        max_abs: Maximum absolute value for data_hp along specified dimension/block_size.
-        max_pos: The maximum value of the low precision data type.
-
-    Returns:
-        exponent: The biased exponent with dtype E8M0 in uint8 container.
-        data_lp: The targeted low precision data, in high precision container
-            (requires cast to low precision data type).
-    """
-    descale = max_abs / max_pos
-    # TODO: nan/inf needs to be set for any value
-    # of nan/inf in input not just amax.
-    exponent = torch.where(
-        torch.isnan(descale),
-        0xFF,  # Handle biased exponent for nan
-        # NOTE: descale < (torch.finfo(torch.float32).smallest_normal / 2) is handled through clamping
-        (
-            torch.clamp(
-                torch.ceil(torch.log2(descale)),
-                min=-E8M0_EXPONENT_BIAS,
-                max=E8M0_EXPONENT_BIAS,
-            )
-            + E8M0_EXPONENT_BIAS
-        ).to(torch.uint8),
-    )
-
-    descale_fp = torch.where(
-        exponent == 0, 1.0, torch.exp2(E8M0_EXPONENT_BIAS - exponent.to(torch.float32))
-    )
-
-    # scale and saturated cast the data elements to max of target dtype
-    data_lp = torch.clamp(data_hp * descale_fp, min=-1 * max_pos, max=max_pos)
-    return exponent, data_lp
-
-
 def to_mx(
     data_hp: torch.Tensor,
     elem_dtype: Union[torch.dtype, str],
@@ -159,9 +111,10 @@ def to_mx(
     is_swizzled_scales: bool = False,
     scale: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Takes a high precision tensor and converts to MX scale and raw data, in
-    naive layout (scale and raw data are separate tensors).
+    """Quantizes a high-precision tensor to MX format, returning (scale, data).
+
+    If ``scale`` is None, then it is computed from the data. (dynamic quant)
+    Otherwise the caller-provided scale is used directly. (static quant)
     """
     assert data_hp.dtype in (
         torch.bfloat16,
@@ -206,29 +159,40 @@ def to_mx(
             data_hp, target_max_pow2, mbits, max_pos, block_size, scaling_mode
         )
         data_lp = scale_and_cast_hp_data(
-            data_hp, scale_e8m0_uint8, elem_dtype, max_pos, block_size
+            data_hp,
+            scale_e8m0_uint8,
+            elem_dtype,
+            max_pos,
+            block_size,
+            scaling_mode,
         )
         scale_out = scale_e8m0_uint8.view(torch.float8_e8m0fnu).squeeze(-1)
         if is_swizzled_scales:
-            orig_shape = data_hp.shape
-            leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
+            leading_dims, M, K = (
+                data_hp.shape[:-2],
+                data_hp.shape[-2],
+                data_hp.shape[-1],
+            )
             scale_shape = (math.prod(leading_dims) * M, K // block_size)
-            scale = to_blocked(scale_out.view(scale_shape)).flatten()
+            scale_out = to_blocked(scale_out.view(scale_shape)).flatten()
             scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
-            scale_out = scale.view(*leading_dims, scale_M, scale_K)
+            scale_out = scale_out.view(*leading_dims, scale_M, scale_K)
 
     else:
-        # static quant case, use the given scale
+        # static quant case, use the provided scale
+        scale_e8m0_uint8 = scale.view(torch.uint8)
         if is_swizzled_scales:
             M, K = data_hp.shape[-2], data_hp.shape[-1]
-            unswizzled = from_blocked(
-                scale.view(torch.uint8).flatten(), M, K // block_size
+            scale_e8m0_uint8 = from_blocked(
+                scale_e8m0_uint8.flatten(), M, K // block_size
             )
-            scale_e8m0_uint8 = unswizzled.unsqueeze(-1)
-        else:
-            scale_e8m0_uint8 = scale.view(torch.uint8).unsqueeze(-1)
         data_lp = scale_and_cast_hp_data(
-            data_hp, scale_e8m0_uint8, elem_dtype, max_pos, block_size
+            data_hp,
+            scale_e8m0_uint8.unsqueeze(-1),
+            elem_dtype,
+            max_pos,
+            block_size,
+            scaling_mode,
         )
         scale_out = scale
 
@@ -273,7 +237,25 @@ def compute_mx_scale(
     max_abs = max_abs.to(torch.float32)
 
     if scaling_mode == ScaleCalculationMode.RCEIL:
-        scale_e8m0_biased, _ = _to_mx_rceil(data_hp, max_abs, max_pos)
+        # RCEIL scale derivation as described in
+        # https://docs.nvidia.com/cuda/cublas/#d-block-quantization
+        # For Blackwell+ GPUs this can be accelerated by the
+        # cvt.rp.satfinite.ue8m0x2.f32 instruction.
+        descale = max_abs / max_pos
+        scale_e8m0_biased = torch.where(
+            torch.isnan(descale),
+            0xFF,  # Handle biased exponent for nan
+            # NOTE: descale < (torch.finfo(torch.float32).smallest_normal / 2)
+            # is handled through clamping
+            (
+                torch.clamp(
+                    torch.ceil(torch.log2(descale)),
+                    min=-E8M0_EXPONENT_BIAS,
+                    max=E8M0_EXPONENT_BIAS,
+                )
+                + E8M0_EXPONENT_BIAS
+            ).to(torch.uint8),
+        )
     else:
         assert data_hp.dtype is torch.float32
         hp_int_dtype = torch.int32
@@ -340,6 +322,7 @@ def scale_and_cast_hp_data(
     elem_dtype: Union[torch.dtype, str],
     max_pos: float,
     block_size: int,
+    scaling_mode: ScaleCalculationMode,
 ) -> torch.Tensor:
     """
     Takes high-precision data and a precomputed E8M0 scale, and quantizes
@@ -352,6 +335,8 @@ def scale_and_cast_hp_data(
         elem_dtype: Target element dtype.
         max_pos: Maximum representable positive value of elem_dtype.
         block_size: MX block size.
+        scaling_mode: Scale calculation mode, affects how the scale is
+            reconstructed for data scaling.
 
     Returns:
         Quantized data tensor.
@@ -366,24 +351,36 @@ def scale_and_cast_hp_data(
     )
     data_hp = data_hp.to(torch.float32)
 
-    # For now, calculate the scale in floating point.
-    # For now, use `torch.bitwise_left_shift` instead of `<<` to support DTensor
-    # See https://github.com/pytorch/pytorch/issues/156533.
-    scale_fp32 = (
-        torch.bitwise_left_shift(scale_e8m0_biased.to(torch.int32), MBITS_F32)
-    ).view(torch.float32)
+    if scaling_mode == ScaleCalculationMode.RCEIL:
+        descale_fp = torch.where(
+            scale_e8m0_biased == 0xFF,
+            0.0,
+            torch.where(
+                scale_e8m0_biased == 0,
+                1.0,
+                torch.exp2(E8M0_EXPONENT_BIAS - scale_e8m0_biased.to(torch.float32)),
+            ),
+        )
+        data_lp = torch.clamp(data_hp * descale_fp, min=-1 * max_pos, max=max_pos)
+    else:
+        # For now, calculate the scale in floating point.
+        # For now, use `torch.bitwise_left_shift` instead of `<<` to support DTensor
+        # See https://github.com/pytorch/pytorch/issues/156533.
+        scale_fp32 = (
+            torch.bitwise_left_shift(scale_e8m0_biased.to(torch.int32), MBITS_F32)
+        ).view(torch.float32)
 
-    # Today, 2**-127 returns 0 in compile+inductor+triton because it is in the
-    # float32 denormal range. For now, manually adjust the fp scale. This is
-    # relevant if all of the incoming block values are zeroes.
-    # See https://github.com/pytorch/pytorch/issues/125557 for details.
-    # Note: it would be more correct to set the minimum to 2**-127, but this
-    # does not work in triton either as it looks like subnormal value handling
-    # has some gaps.  So, for now just set to the minimum normal value.
-    scale_fp32 = torch.clamp(scale_fp32, min=F32_MIN_NORMAL)
+        # Today, 2**-127 returns 0 in compile+inductor+triton because it is in the
+        # float32 denormal range. For now, manually adjust the fp scale. This is
+        # relevant if all of the incoming block values are zeroes.
+        # See https://github.com/pytorch/pytorch/issues/125557 for details.
+        # Note: it would be more correct to set the minimum to 2**-127, but this
+        # does not work in triton either as it looks like subnormal value handling
+        # has some gaps.  So, for now just set to the minimum normal value.
+        scale_fp32 = torch.clamp(scale_fp32, min=F32_MIN_NORMAL)
 
-    # scale and saturated cast the data elements to max of target dtype
-    data_lp = data_hp / scale_fp32
+        # scale and saturated cast the data elements to max of target dtype
+        data_lp = data_hp / scale_fp32
 
     if (
         elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -103,6 +103,69 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     is_swizzled_scales: bool = False
 
 
+def to_mx_with_precomputed_scale(
+    data_hp: torch.Tensor,
+    scale: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
+    is_swizzled_scales: bool = False,
+) -> torch.Tensor:
+    """Quantizes data using precomputed scale, returning only quantized data.
+
+    Args:
+        data_hp: High-precision input tensor to quantize.
+        scale: Precomputed scale tensor.
+        elem_dtype: Target MX element dtype.
+        block_size: MX block size.
+        scaling_mode: Scale calculation mode for data scaling.
+        is_swizzled_scales: Whether the scale tensor uses swizzled layout.
+
+    Returns:
+        Quantized data tensor only.
+    """
+    assert data_hp.dtype in (
+        torch.bfloat16,
+        torch.float,
+    ), f"{data_hp.dtype} is not supported yet"
+    assert data_hp.shape[-1] % block_size == 0, (
+        f"the last dimension of shape {data_hp.shape} must be divisible by block_size {block_size}"
+    )
+    assert data_hp.is_contiguous(), "unsupported"
+    assert elem_dtype in SUPPORTED_ELEM_DTYPES, "unsupported"
+
+    # Get the max_pos value for the element dtype
+    if elem_dtype == torch.float8_e4m3fn:
+        max_pos = F8E4M3_MAX
+    elif elem_dtype == torch.float8_e5m2:
+        max_pos = F8E5M2_MAX
+    elif elem_dtype == DTYPE_FP6_E2M3:
+        max_pos = F6_E2M3_MAX
+    elif elem_dtype == DTYPE_FP6_E3M2:
+        max_pos = F6_E3M2_MAX
+    elif elem_dtype == torch.float4_e2m1fn_x2:
+        max_pos = F4_E2M1_MAX
+    else:
+        raise AssertionError("unsupported element dtype")
+
+    # Convert scale to uint8 format expected by scale_and_cast_hp_data
+    scale_e8m0_uint8 = scale.view(torch.uint8)
+    if is_swizzled_scales:
+        M, K = data_hp.shape[-2], data_hp.shape[-1]
+        scale_e8m0_uint8 = from_blocked(scale_e8m0_uint8.flatten(), M, K // block_size)
+
+    data_lp = scale_and_cast_hp_data(
+        data_hp,
+        scale_e8m0_uint8.unsqueeze(-1),
+        elem_dtype,
+        max_pos,
+        block_size,
+        scaling_mode,
+    )
+
+    return data_lp
+
+
 def to_mx(
     data_hp: torch.Tensor,
     elem_dtype: Union[torch.dtype, str],
@@ -184,71 +247,6 @@ def to_mx(
         scale_e8m0_biased = scale_e8m0_biased.view(*leading_dims, scale_M, scale_K)
 
     return scale_e8m0_biased, data_lp
-
-
-def to_mx_with_precomputed_scale(
-    data_hp: torch.Tensor,
-    scale: torch.Tensor,
-    elem_dtype: Union[torch.dtype, str],
-    block_size: int,
-    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    is_swizzled_scales: bool = False,
-) -> torch.Tensor:
-    """Quantizes data using precomputed scale, returning only quantized data.
-
-    Args:
-        data_hp: High-precision input tensor to quantize.
-        scale: Precomputed scale tensor.
-        elem_dtype: Target MX element dtype.
-        block_size: MX block size.
-        scaling_mode: Scale calculation mode for data scaling.
-        is_swizzled_scales: Whether the scale tensor uses swizzled layout.
-
-    Returns:
-        Quantized data tensor only.
-    """
-    assert data_hp.dtype in (
-        torch.bfloat16,
-        torch.float,
-    ), f"{data_hp.dtype} is not supported yet"
-    assert data_hp.shape[-1] % block_size == 0, (
-        f"the last dimension of shape {data_hp.shape} must be divisible by block_size {block_size}"
-    )
-    assert data_hp.is_contiguous(), "unsupported"
-    assert elem_dtype in SUPPORTED_ELEM_DTYPES, "unsupported"
-
-    # Get the max_pos value for the element dtype
-    if elem_dtype == torch.float8_e4m3fn:
-        max_pos = F8E4M3_MAX
-    elif elem_dtype == torch.float8_e5m2:
-        max_pos = F8E5M2_MAX
-    elif elem_dtype == DTYPE_FP6_E2M3:
-        max_pos = F6_E2M3_MAX
-    elif elem_dtype == DTYPE_FP6_E3M2:
-        max_pos = F6_E3M2_MAX
-    elif elem_dtype == torch.float4_e2m1fn_x2:
-        max_pos = F4_E2M1_MAX
-    else:
-        raise AssertionError("unsupported element dtype")
-
-    # Convert scale to uint8 format expected by scale_and_cast_hp_data
-    scale_e8m0_uint8 = scale.view(torch.uint8)
-    if is_swizzled_scales:
-        M, K = data_hp.shape[-2], data_hp.shape[-1]
-        scale_e8m0_uint8 = from_blocked(
-            scale_e8m0_uint8.flatten(), M, K // block_size
-        )
-
-    data_lp = scale_and_cast_hp_data(
-        data_hp,
-        scale_e8m0_uint8.unsqueeze(-1),
-        elem_dtype,
-        max_pos,
-        block_size,
-        scaling_mode,
-    )
-
-    return data_lp
 
 
 def compute_mx_scale(

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -109,12 +109,18 @@ def to_mx(
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
     is_swizzled_scales: bool = False,
-    scale: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Quantizes a high-precision tensor to MX format, returning (scale, data).
+    """Quantizes a high-precision tensor to MX format, returning (scale, data)
 
-    If ``scale`` is None, then it is computed from the data. (dynamic quant)
-    Otherwise the caller-provided scale is used directly. (static quant)
+    Args:
+        data_hp: High-precision input tensor to quantize.
+        elem_dtype: Target MX element dtype.
+        block_size: MX block size.
+        scaling_mode: Scale calculation mode.
+        is_swizzled_scales: Whether to return scales in swizzled layout.
+
+    Returns:
+        Tuple of (scale, quantized_data).
     """
     assert data_hp.dtype in (
         torch.bfloat16,
@@ -153,50 +159,96 @@ def to_mx(
     else:
         raise AssertionError("unsupported element dtype")
 
-    if scale is None:
-        # dynamic quant case, compute the scale
-        scale_e8m0_uint8 = compute_mx_scale(
-            data_hp, target_max_pow2, mbits, max_pos, block_size, scaling_mode
+    # Dynamic quantization: compute the scale from data
+    scale_e8m0_uint8 = compute_mx_scale(
+        data_hp, target_max_pow2, mbits, max_pos, block_size, scaling_mode
+    )
+    data_lp = scale_and_cast_hp_data(
+        data_hp,
+        scale_e8m0_uint8,
+        elem_dtype,
+        max_pos,
+        block_size,
+        scaling_mode,
+    )
+    scale_e8m0_biased = scale_e8m0_uint8.view(torch.float8_e8m0fnu).squeeze(-1)
+    if is_swizzled_scales:
+        leading_dims, M, K = (
+            data_hp.shape[:-2],
+            data_hp.shape[-2],
+            data_hp.shape[-1],
         )
-        data_lp = scale_and_cast_hp_data(
-            data_hp,
-            scale_e8m0_uint8,
-            elem_dtype,
-            max_pos,
-            block_size,
-            scaling_mode,
-        )
-        scale_out = scale_e8m0_uint8.view(torch.float8_e8m0fnu).squeeze(-1)
-        if is_swizzled_scales:
-            leading_dims, M, K = (
-                data_hp.shape[:-2],
-                data_hp.shape[-2],
-                data_hp.shape[-1],
-            )
-            scale_shape = (math.prod(leading_dims) * M, K // block_size)
-            scale_out = to_blocked(scale_out.view(scale_shape)).flatten()
-            scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
-            scale_out = scale_out.view(*leading_dims, scale_M, scale_K)
+        scale_shape = (math.prod(leading_dims) * M, K // block_size)
+        scale_e8m0_biased = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
+        scale_e8m0_biased = scale_e8m0_biased.view(*leading_dims, scale_M, scale_K)
 
+    return scale_e8m0_biased, data_lp
+
+
+def to_mx_with_precomputed_scale(
+    data_hp: torch.Tensor,
+    scale: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
+    is_swizzled_scales: bool = False,
+) -> torch.Tensor:
+    """Quantizes data using precomputed scale, returning only quantized data.
+
+    Args:
+        data_hp: High-precision input tensor to quantize.
+        scale: Precomputed scale tensor.
+        elem_dtype: Target MX element dtype.
+        block_size: MX block size.
+        scaling_mode: Scale calculation mode for data scaling.
+        is_swizzled_scales: Whether the scale tensor uses swizzled layout.
+
+    Returns:
+        Quantized data tensor only.
+    """
+    assert data_hp.dtype in (
+        torch.bfloat16,
+        torch.float,
+    ), f"{data_hp.dtype} is not supported yet"
+    assert data_hp.shape[-1] % block_size == 0, (
+        f"the last dimension of shape {data_hp.shape} must be divisible by block_size {block_size}"
+    )
+    assert data_hp.is_contiguous(), "unsupported"
+    assert elem_dtype in SUPPORTED_ELEM_DTYPES, "unsupported"
+
+    # Get the max_pos value for the element dtype
+    if elem_dtype == torch.float8_e4m3fn:
+        max_pos = F8E4M3_MAX
+    elif elem_dtype == torch.float8_e5m2:
+        max_pos = F8E5M2_MAX
+    elif elem_dtype == DTYPE_FP6_E2M3:
+        max_pos = F6_E2M3_MAX
+    elif elem_dtype == DTYPE_FP6_E3M2:
+        max_pos = F6_E3M2_MAX
+    elif elem_dtype == torch.float4_e2m1fn_x2:
+        max_pos = F4_E2M1_MAX
     else:
-        # static quant case, use the provided scale
-        scale_e8m0_uint8 = scale.view(torch.uint8)
-        if is_swizzled_scales:
-            M, K = data_hp.shape[-2], data_hp.shape[-1]
-            scale_e8m0_uint8 = from_blocked(
-                scale_e8m0_uint8.flatten(), M, K // block_size
-            )
-        data_lp = scale_and_cast_hp_data(
-            data_hp,
-            scale_e8m0_uint8.unsqueeze(-1),
-            elem_dtype,
-            max_pos,
-            block_size,
-            scaling_mode,
-        )
-        scale_out = scale
+        raise AssertionError("unsupported element dtype")
 
-    return scale_out, data_lp
+    # Convert scale to uint8 format expected by scale_and_cast_hp_data
+    scale_e8m0_uint8 = scale.view(torch.uint8)
+    if is_swizzled_scales:
+        M, K = data_hp.shape[-2], data_hp.shape[-1]
+        scale_e8m0_uint8 = from_blocked(
+            scale_e8m0_uint8.flatten(), M, K // block_size
+        )
+
+    data_lp = scale_and_cast_hp_data(
+        data_hp,
+        scale_e8m0_uint8.unsqueeze(-1),
+        elem_dtype,
+        max_pos,
+        block_size,
+        scaling_mode,
+    )
+
+    return data_lp
 
 
 def compute_mx_scale(
@@ -645,14 +697,24 @@ class MXTensor(TorchAOBaseTensor):
                 scaling_mode=scaling_mode.value,
             )
         else:
-            scale_e8m0_biased, data_lp = to_mx(
-                data_hp,
-                elem_dtype,
-                block_size,
-                scaling_mode,
-                is_swizzled_scales,
-                scale=scale,
-            )
+            if scale is None:
+                scale_e8m0_biased, data_lp = to_mx(
+                    data_hp,
+                    elem_dtype,
+                    block_size,
+                    scaling_mode,
+                    is_swizzled_scales,
+                )
+            else:
+                data_lp = to_mx_with_precomputed_scale(
+                    data_hp,
+                    scale,
+                    elem_dtype,
+                    block_size,
+                    scaling_mode,
+                    is_swizzled_scales,
+                )
+                scale_e8m0_biased = scale
         if isinstance(scale_e8m0_biased, DTensor):
             assert isinstance(data_lp, DTensor), "unsupported"
             local_scale_e8m0_biased = scale_e8m0_biased.to_local()

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -151,10 +151,32 @@ def to_mx_with_precomputed_scale(
         raise AssertionError("unsupported element dtype")
 
     # Convert scale to uint8 format expected by scale_and_cast_hp_data
+    # Validate input scale format
+    if scale.dtype != torch.float8_e8m0fnu:
+        raise ValueError(f"scale must be torch.float8_e8m0fnu, got {scale.dtype}")
+
     scale_e8m0_uint8 = scale.view(torch.uint8)
+
     if is_swizzled_scales:
         M, K = data_hp.shape[-2], data_hp.shape[-1]
+        # Validate swizzled scale dimensions match expected blocked format
+        expected_scale_M, expected_scale_K = hp_data_dims_to_swizzled_scale_dims_mx(
+            M, K
+        )
+        if scale.shape[-2:] != (expected_scale_M, expected_scale_K):
+            raise ValueError(
+                f"For swizzled scales with data shape {data_hp.shape}, expected scale shape "
+                f"ending with {(expected_scale_M, expected_scale_K)}, got {scale.shape}"
+            )
         scale_e8m0_uint8 = from_blocked(scale_e8m0_uint8.flatten(), M, K // block_size)
+    else:
+        # Validate non-swizzled scale shape (before unsqueeze(-1))
+        expected_scale_shape = (*data_hp.shape[:-1], data_hp.shape[-1] // block_size)
+        if scale_e8m0_uint8.shape != expected_scale_shape:
+            raise ValueError(
+                f"scale shape {scale_e8m0_uint8.shape} does not match expected "
+                f"shape {expected_scale_shape} for data shape {data_hp.shape} and block_size {block_size}"
+            )
 
     data_lp = scale_and_cast_hp_data(
         data_hp,
@@ -396,6 +418,14 @@ def scale_and_cast_hp_data(
     assert scale_e8m0_biased.dtype == torch.uint8, (
         f"scale_e8m0_biased.dtype must be uint8, got {scale_e8m0_biased.dtype}"
     )
+
+    # Validate scale shape matches expected format
+    expected_scale_shape = (*data_hp.shape[:-1], data_hp.shape[-1] // block_size, 1)
+    if scale_e8m0_biased.shape != expected_scale_shape:
+        raise ValueError(
+            f"scale_e8m0_biased shape {scale_e8m0_biased.shape} does not match expected "
+            f"shape {expected_scale_shape} for data shape {data_hp.shape} and block_size {block_size}"
+        )
 
     orig_shape = data_hp.shape
     data_hp = data_hp.reshape(

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -112,8 +112,7 @@ def to_mx_with_precomputed_scale(
     is_swizzled_scales: bool = False,
 ) -> torch.Tensor:
     """
-    Takes a high precision tensor and converts to MX scale and raw data, in
-    naive layout (scale and raw data are separate tensors).
+    Takes a high precision tensor and mx scale and quantizes the high precesion tensor to MX format with the given scale.
 
     Args:
         data_hp: High-precision input tensor to quantize.
@@ -197,7 +196,9 @@ def to_mx(
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
     is_swizzled_scales: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Quantizes a high-precision tensor to MX format, returning (scale, data)
+    """
+    Takes a high precision tensor and converts to MX scale and raw data, in
+    naive layout (scale and raw data are separate tensors).
 
     Args:
         data_hp: High-precision input tensor to quantize.

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -432,17 +432,17 @@ def scale_and_cast_hp_data(
         # scale and saturated cast the data elements to max of target dtype
         data_lp = data_hp / scale_fp32
 
-    if (
-        elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-        and not torch._dynamo.is_compiling()
-    ):
-        # As of 20250317, the Pytorch eager mode cast to `torch.float8_e4m3fn`
-        # is unsaturated. This cast is saturated in triton. If we are compute bound,
-        # we see a speedup if we remove this redundant clamp if we are compiling
-        # to triton.
-        # TODO(#1912): make the saturated cast work in eager mode and remove this
-        # workaround.
-        data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
+        if (
+            elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+            and not torch._dynamo.is_compiling()
+        ):
+            # As of 20250317, the Pytorch eager mode cast to `torch.float8_e4m3fn`
+            # is unsaturated. This cast is saturated in triton. If we are compute bound,
+            # we see a speedup if we remove this redundant clamp if we are compiling
+            # to triton.
+            # TODO(#1912): make the saturated cast work in eager mode and remove this
+            # workaround.
+            data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
 
     # cast to target dtype
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -111,7 +111,9 @@ def to_mx_with_precomputed_scale(
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
     is_swizzled_scales: bool = False,
 ) -> torch.Tensor:
-    """Quantizes data using precomputed scale, returning only quantized data.
+    """
+    Takes a high precision tensor and converts to MX scale and raw data, in
+    naive layout (scale and raw data are separate tensors).
 
     Args:
         data_hp: High-precision input tensor to quantize.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3935
* #3897
* #3899
* __->__ #3895

This PR adds in support for passing a precomputed scale to MXTensor, via a `scale` kwarg in `to_mx`. 
When specified, we will use the precomputed scale to do MX quantization instead of calculating a scale dynamically.

This is needed for GPTQ. 


Test:
```python
pytest test/prototype/mx_formats_test_mx_tensor.py -k test_to_mx_precomputed_scale
```

Co-authored-by: Cursor <cursoragent@cursor.com>
