### PR TITLE
Add MXFP8 support for GPTQ quantization

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -15,8 +15,19 @@ from torchao.prototype.gptq import (
     gptq_quantize,
 )
 from torchao.prototype.gptq.observer import GPTQObserverTensor
-from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
+from torchao.prototype.mx_formats.inference_workflow import (
+    MXDynamicActivationMXWeightConfig,
+)
+
+# MXFP8 imports
+from torchao.quantization import (
+    Float8DynamicActivationFloat8WeightConfig,
+    Int4WeightOnlyConfig,
+    Int8WeightOnlyConfig,
+    quantize_,
+)
 from torchao.quantization.granularity import PerRow
+from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import _is_mslk_available
 
 
@@ -565,6 +576,90 @@ class TestGPTQFlow:
             assert sqnr_gptq > 25, f"GPTQ SQNR: {sqnr_gptq} is too low"
         elif isinstance(base_config, Int8WeightOnlyConfig):
             assert sqnr_gptq > 30, f"GPTQ SQNR: {sqnr_gptq} is too low"
+        assert sqnr_gptq > sqnr_rtn, (
+            f"GPTQ SQNR: {sqnr_gptq} is not better than RTN SQNR: {sqnr_rtn}"
+        )
+
+
+class TestGPTQMXFP8:
+    """Test suite for MXFP8 GPTQ support."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
+    def test_mxfp8_gptq_sqnr(self):
+        """End-to-end SQNR test: GPTQ should produce better quality than RTN.
+
+        Compares the output SQNR (Signal-to-Quantization-Noise Ratio) of:
+        - GPTQ: Hessian-aware quantization with error propagation
+        - RTN: Naive round-to-nearest quantization (using MXTensor.to_mx directly)
+
+        Since MXTensor weight-only dispatch is not yet available, we dequantize
+        the quantized weights back to bfloat16 before running the forward pass.
+        This isolates the weight quantization quality comparison.
+        """
+        torch.manual_seed(43)
+
+        # Use dimensions divisible by block_size=32
+        model = ToyLinearModel(m=512, n=2048, k=1024).cuda().to(torch.bfloat16)
+
+        # Create calibration and test inputs
+        calibration_inputs = [
+            torch.randn(4, 512, dtype=torch.bfloat16, device="cuda") for _ in range(10)
+        ]
+        test_input = calibration_inputs[0]
+
+        # Get baseline output (full precision)
+        out = model(test_input)
+
+        # Make copies for comparison
+        model_rtn = copy.deepcopy(model)
+        model_gptq = copy.deepcopy(model)
+        model_float8 = copy.deepcopy(model)
+
+        # --- Float8 weight-only RTN baseline ---
+        quantize_(
+            model_float8,
+            Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
+        )
+        out_float8 = model_float8(test_input)
+
+        # --- MXFP8 RTN baseline ---
+        base_config = MXDynamicActivationMXWeightConfig(
+            activation_dtype=torch.float8_e4m3fn,
+            weight_dtype=torch.float8_e4m3fn,
+            kernel_preference=KernelPreference.EMULATED,
+        )
+        quantize_(model_rtn, base_config)
+        out_rtn = model_rtn(test_input)
+
+        # --- MXFP8 GPTQ ---
+        # Phase 1: Observe
+        observe_config = GPTQConfig(step="observe", base_config=base_config)
+        quantize_(model_gptq, observe_config)
+
+        # Run calibration
+        for inp in calibration_inputs:
+            model_gptq(inp)
+
+        # Phase 2: Convert
+        convert_config = GPTQConfig(step="convert", base_config=base_config)
+        quantize_(model_gptq, convert_config)
+        out_gptq = model_gptq(test_input)
+
+        # Compare using SQNR
+        from torchao.quantization.utils import compute_error
+
+        sqnr_float8 = compute_error(out_float8, out)
+        sqnr_rtn = compute_error(out_rtn, out)
+        sqnr_gptq = compute_error(out_gptq, out)
+
+        print(
+            f"Float8 RTN SQNR: {sqnr_float8}, "
+            f"MXFP8 RTN SQNR: {sqnr_rtn}, "
+            f"MXFP8 GPTQ SQNR: {sqnr_gptq}"
+        )
+
+        # MXFP8 has good precision (8-bit float), so SQNR should be high
+        assert sqnr_gptq > 25, f"MXFP8 GPTQ SQNR: {sqnr_gptq} is too low"
         assert sqnr_gptq > sqnr_rtn, (
             f"GPTQ SQNR: {sqnr_gptq} is not better than RTN SQNR: {sqnr_rtn}"
         )

--- a/torchao/prototype/gptq/observer.py
+++ b/torchao/prototype/gptq/observer.py
@@ -29,9 +29,8 @@ class GPTQObserverTensor(TorchAOBaseTensor):
         self.hessian = hessian
         self.total_batches = total_batches
 
-    def update(self, input: torch.Tensor):
+    def update(self, input: torch.Tensor, quantize_activation=False):
         """Incrementally update Hessian matrix from input activations."""
-        # Move input to same device as hp_data and convert to float
         x = input.float().to(self.hp_data.device)
         shape = x.shape
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3896
* #3895

Extend GPTQ to support MX format (float8_e4m3fn/e5m2) as a base config
alongside the existing int4 and int8 paths. The GPTQ algorithm uses
block-wise MX scaling (block_size=32) with per-column error propagation.

- Add MXDynamicActivationMXWeightConfig branching in gptq_quantize()
- Add mxfp8-rtn, mxfp8-gptq-sequential, mxfp8-gptq-nonsequential modes
  to gptq_example.py
- Add end-to-end SQNR test verifying GPTQ > RTN for MXFP8

Co-authored-by: Cursor <cursoragent@cursor.com>