### PR TITLE
Make `_emulated_mxfp8_scaled_grouped_mm_2d_2d` torch.compile compatible

### DIFF
--- a/test/prototype/moe_training/test_scaled_grouped_mm.py
+++ b/test/prototype/moe_training/test_scaled_grouped_mm.py
@@ -310,8 +310,8 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
     out = _emulated_mxfp8_scaled_grouped_mm_2d_2d(
         grad_out_t_mx,
         grad_out_t_scale,
-        x_mx,
-        x_scale.transpose(-2, -1),  # (M//block_size, N) -> (N, M//block_size)
+        x_mx.transpose(-2, -1),  # (K, N) -> (N, K)
+        x_scale.transpose(-2, -1),  # (K//block_size, N) -> (N, K//block_size)
         offs=offs,
         out_dtype=torch.bfloat16,
         block_size=block_size,


### PR DESCRIPTION
* Replace loop-based dequantization in `_emulated_mxfp8_scaled_grouped_mm_2d_2d` with vectorized ops, removing the `@torch.compiler.disable` decorator
* The previous implementation used `offs.tolist()` and a Python loop with data-dependent control flow, which prevented `torch.compile` from tracing through the emulated MXFP8 wgrad path
* Remove the `pytest.skip` for `EMULATED` + `use_compile=True` in `test_mxfp8_grouped_gemm_with_dq_fwd_bwd`