### PR TITLE
Assign meta["val"] to new bias nodes in fold_bn_weights_into_conv_node.

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -177,6 +177,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             traced_outputs = traced_model(*example_inputs)
             prepared_model = prepare_pt2e(traced_model, XNNPACKQuantizer())
             prepared_outputs = prepared_model(*example_inputs)
+            # Expect all nodes to have their meta populated.
+            self.assertTrue(all(n.meta for n in prepared_model.graph.nodes))
             torch.testing.assert_close(ref_outputs, traced_outputs)
             torch.testing.assert_close(traced_outputs, prepared_outputs)
 

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -734,6 +734,11 @@ def fold_bn_weights_into_conv_node(
         _assign_attr(fused_bias, m, bias_attr_name, _AttrKind.PARAMETER)
         with m.graph.inserting_before(conv_node):
             get_bias_node = m.graph.get_attr(bias_attr_name)
+        if "val" in conv_node.meta:
+            get_bias_node.meta["val"] = conv_node.meta["val"].fake_mode.from_tensor(
+                fused_bias,
+                static_shapes=True,
+            )
         # NOTE: here we assume the bias of conv is not quantized!
         conv_args[2] = get_bias_node
     conv_node.args = tuple(conv_args)


### PR DESCRIPTION
Summary: fold_bn_weights_into_conv_node doesn't properly assign a meta["val"] to the bias node if the node is created from scratch.

Reviewed By: mcremon-meta

Differential Revision: D93496648


