### PR TITLE
Allow prototype float8 tensor to be saved

### DIFF
--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -432,6 +432,35 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
             f"SQNR of compiled quantized vs original should be > 15 dB, got {error_compiled}",
         )
 
+    @common_utils.parametrize("granularity", [PerRow(), PerTensor()])
+    def test_module_path(self, granularity):
+        dtype = self.dtype
+        K, N = 32, 32
+        input_tensor = torch.randn(1, K, dtype=dtype, device="cuda")
+        linear = torch.nn.Linear(K, N, bias=False, dtype=dtype, device="cuda")
+
+        # Get activation scale from dynamic quantization
+        dynamic_config = Float8DynamicActivationFloat8WeightConfig(
+            granularity=granularity,
+        )
+        model_dynamic = copy.deepcopy(linear)
+        quantize_(model_dynamic, dynamic_config)
+
+        quantized_input = _choose_quant_func_and_quantize_tensor(
+            input_tensor, model_dynamic.weight.act_quant_kwargs
+        )
+
+        static_config = Float8StaticActivationFloat8WeightConfig(
+            act_quant_scale=quantized_input.scale.detach().clone(),
+            granularity=granularity,
+        )
+        quantize_(linear, static_config)
+
+        self.assertEqual(
+            str(type(linear.weight)),
+            "<class 'torchao.prototype.quantization.float8_static_quant.prototype_float8_tensor.PrototypeFloat8Tensor'>",
+        )
+
     def test_create_tensor_out_of_inference_mode(self):
         # Test https://github.com/pytorch/pytorch/issues/170419
         dtype = self.dtype

--- a/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
+++ b/torchao/prototype/quantization/float8_static_quant/prototype_float8_tensor.py
@@ -1149,7 +1149,5 @@ def _choose_quant_func_and_quantize_tensor(
     raise NotImplementedError(f"Quant kwargs not supported: {quant_kwargs}")
 
 
-PrototypeFloat8Tensor.__module__ = "torchao.quantization"
-
 # Allow a model with PrototypeFloat8Tensor weights to be loaded with `weights_only=True`
 torch.serialization.add_safe_globals([PrototypeFloat8Tensor])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3909

Summary:
Fixes: https://github.com/pytorch/ao/issues/3860

Test Plan:
python test/prototype/test_prototype_float8_tensor.py -k test_module_path

Reviewers:

Subscribers:

Tasks:

Tags: