### PR TITLE
Add flashinfer-python to CI

### DIFF
--- a/.github/scripts/torchao_model_releases/quantize_and_upload.py
+++ b/.github/scripts/torchao_model_releases/quantize_and_upload.py
@@ -7,6 +7,7 @@
 import argparse
 from typing import List
 
+import huggingface_hub
 import torch
 import transformers
 from huggingface_hub import ModelCard, get_token, whoami
@@ -16,7 +17,8 @@ _transformers_version = str(transformers.__version__)
 if _transformers_version >= "5":
     from transformers.quantizers.auto import get_hf_quantizer
 
-from torchao._models._eval import TransformerEvalWrapper
+_huggingface_hub_version = str(huggingface_hub.__version__)
+
 from torchao.prototype.awq import (
     AWQConfig,
 )
@@ -27,6 +29,7 @@ from torchao.prototype.mx_formats.inference_workflow import (
 from torchao.prototype.smoothquant import SmoothQuantConfig
 from torchao.quantization import (
     Float8DynamicActivationFloat8WeightConfig,
+    Float8DynamicActivationInt4WeightConfig,
     Int4WeightOnlyConfig,
     Int8DynamicActivationInt8WeightConfig,
     Int8DynamicActivationIntxWeightConfig,
@@ -233,6 +236,14 @@ tokenizer = AutoTokenizer.from_pretrained(model_id)
 _fp8_quant_code = """
 from torchao.quantization import Float8DynamicActivationFloat8WeightConfig, PerRow
 quant_config = Float8DynamicActivationFloat8WeightConfig(granularity=PerRow())
+quantization_config = TorchAoConfig(quant_type=quant_config)
+quantized_model = AutoModelForCausalLM.from_pretrained(model_to_quantize, device_map="{device}", torch_dtype=torch.bfloat16, quantization_config=quantization_config)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+"""
+
+_fp8_int4_quant_code = """
+from torchao.quantization import Float8DynamicActivationInt4WeightConfig
+quant_config = Float8DynamicActivationInt4WeightConfig(int4_packing_format="plain")
 quantization_config = TorchAoConfig(quant_type=quant_config)
 quantized_model = AutoModelForCausalLM.from_pretrained(model_to_quantize, device_map="{device}", torch_dtype=torch.bfloat16, quantization_config=quantization_config)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -687,6 +698,9 @@ def quantize_and_upload(
 
     quant_to_config = {
         "FP8": Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
+        "FP8-INT4": Float8DynamicActivationInt4WeightConfig(
+            int4_packing_format="plain"
+        ),
         "INT4": Int4WeightOnlyConfig(
             group_size=128,
             int4_packing_format="tile_packed_to_4d",
@@ -725,6 +739,7 @@ def quantize_and_upload(
 
     quant_to_quant_code = {
         "FP8": _fp8_quant_code,
+        "FP8-INT4": _fp8_int4_quant_code,
         "INT4": _int4_quant_code,
         "INT8-INT4": _int8_int4_quant_code,
         "INT8-INT4-HQQ": _int8_int4_hqq_quant_code,
@@ -766,6 +781,8 @@ def quantize_and_upload(
             quantize_(model, awq_config, filter_fn=filter_fn_skip_lmhead)
         else:
             quantize_(model, awq_config)
+
+        from torchao._models._eval import TransformerEvalWrapper
 
         TransformerEvalWrapper(
             model=model,
@@ -908,16 +925,24 @@ def quantize_and_upload(
 
     # Push to hub
     if push_to_hub:
-        quantized_model.push_to_hub(
-            quantized_model_id, safe_serialization=safe_serialization
-        )
+        if _huggingface_hub_version < "1.4.1":
+            quantized_model.push_to_hub(
+                quantized_model_id, safe_serialization=safe_serialization
+            )
+        else:
+            quantized_model.push_to_hub(quantized_model_id)
+
         tokenizer.push_to_hub(quantized_model_id)
         if populate_model_card_template:
             card.push_to_hub(quantized_model_id)
     else:
-        quantized_model.save_pretrained(
-            quantized_model_id, safe_serialization=safe_serialization
-        )
+        if _huggingface_hub_version < "1.4.1":
+            quantized_model.save_pretrained(
+                quantized_model_id, safe_serialization=safe_serialization
+            )
+        else:
+            quantized_model.save_pretrained(quantized_model_id)
+
         tokenizer.save_pretrained(quantized_model_id)
 
     # Manual Testing
@@ -960,7 +985,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--quant",
         type=str,
-        help="Quantization method. Options are FP8, INT4, INT8-INT4, INT8-INT4-HQQ, AWQ-INT4, SmoothQuant-INT8-INT8, MXFP8, NVFP4",
+        help="Quantization method. Options are FP8, FP8-INT4, INT4, INT8-INT4, INT8-INT4-HQQ, AWQ-INT4, SmoothQuant-INT8-INT8, MXFP8, NVFP4",
     )
     parser.add_argument(
         "--tasks",

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -877,7 +877,7 @@ def _float8_dynamic_activation_int4_weight_transform(
     )
     weight = module.weight
     group_size = 128
-    block_size = tuple([1 for _ in range(weight.ndim - 1)] + [group_size])
+    block_size = list([1 for _ in range(weight.ndim - 1)] + [group_size])
 
     if int4_packing_format == "preshuffled":
         new_weight = Int4PreshuffledTensor.from_hp(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #3912
* #3911
* __->__ #3910

Summary:
Adding flashinfer as an optional depenency so we can use their nvfp4_quantize op
(it's faster for some workloads that we are interested in)

Test Plan:
tested `_is_flashinfer_available` locally

Reviewers:

Subscribers:

Tasks:

Tags: