### PR TITLE
Add support for `torch._higher_order_ops.while_loop` in pt2e quantization

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -3349,6 +3349,123 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         sqnr = compute_error(output_ref, output)
         self.assertGreater(sqnr, 35, f"SQNR too low: {sqnr} dB")
 
+    def test_while_loop_op_quantization(self):
+        """Test that prepare_pt2e and convert_pt2e correctly quantize ops
+        inside the body_fn subgraph of torch._higher_order_ops.while_loop.
+        """
+        from torch._higher_order_ops.while_loop import while_loop
+
+        class WhileLoopModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(5, 5)
+
+            def forward(self, x):
+                # x: (features,)
+                def cond_fn(iter, x):
+                    return iter < 3
+
+                def body_fn(iter, x):
+                    return iter + 1, self.linear(x)
+
+                _, result = while_loop(cond_fn, body_fn, (torch.tensor(0), x))
+                return result
+
+        quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
+
+        m = WhileLoopModel().eval()
+        example_inputs = (torch.randn(5),)
+
+        m_export = torch.export.export(m, example_inputs).module()
+        # Compute reference output before quantization modifies the model
+        with torch.no_grad():
+            output_ref = m_export(*example_inputs)
+        m_prepared = prepare_pt2e(m_export, quantizer)
+
+        # Verify that while_loop body_fn subgraph has observers inserted
+        while_loop_body_fn = None
+        for node in m_prepared.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is torch.ops.higher_order.while_loop
+            ):
+                submod_node = node.args[1]
+                while_loop_body_fn = m_prepared.get_submodule(submod_node.target)
+                break
+        self.assertIsNotNone(while_loop_body_fn, "while_loop op not found in graph")
+
+        # Check that observers are present in the body_fn subgraph
+        observer_count = 0
+        for node in while_loop_body_fn.graph.nodes:
+            if node.op == "call_module":
+                self.assertTrue(
+                    node.target.startswith("activation_post_process_"),
+                    f"Unexpected call_module target: {node.target}",
+                )
+                obs_mod = getattr(while_loop_body_fn, node.target)
+                self.assertIsInstance(obs_mod, ObserverBase)
+                observer_count += 1
+        self.assertGreater(
+            observer_count,
+            0,
+            "No observers found in while_loop body_fn subgraph after prepare",
+        )
+
+        # Calibrate - use no_grad because while_loop's runtime re-traces the
+        # body_fn and observers contain data-dependent branching
+        with torch.no_grad():
+            m_prepared(*example_inputs)
+
+        # Convert
+        m_converted = convert_pt2e(m_prepared)
+
+        # Verify that while_loop body_fn subgraph has q/dq ops after conversion
+        while_loop_body_fn_converted = None
+        for node in m_converted.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is torch.ops.higher_order.while_loop
+            ):
+                submod_node = node.args[1]
+                while_loop_body_fn_converted = m_converted.get_submodule(
+                    submod_node.target
+                )
+                break
+        self.assertIsNotNone(
+            while_loop_body_fn_converted,
+            "while_loop op not found in converted graph",
+        )
+
+        # Check that q/dq ops are present in the converted body_fn subgraph
+        body_fn_targets = {
+            node.target
+            for node in while_loop_body_fn_converted.graph.nodes
+            if node.op == "call_function"
+        }
+        self.assertTrue(
+            torch.ops.quantized_decomposed.quantize_per_tensor.default
+            in body_fn_targets
+            or torch.ops.quantized_decomposed.quantize_per_channel.default
+            in body_fn_targets,
+            f"No quantize ops found in converted while_loop body_fn subgraph. "
+            f"Found targets: {body_fn_targets}",
+        )
+        self.assertTrue(
+            torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            in body_fn_targets
+            or torch.ops.quantized_decomposed.dequantize_per_channel.default
+            in body_fn_targets,
+            f"No dequantize ops found in converted while_loop body_fn subgraph. "
+            f"Found targets: {body_fn_targets}",
+        )
+
+        # Verify the model runs successfully and produces accurate results
+        with torch.no_grad():
+            output = m_converted(*example_inputs)
+        self.assertEqual(output.shape, (5,))
+        sqnr = compute_error(output_ref, output)
+        self.assertGreater(sqnr, 35, f"SQNR too low: {sqnr} dB")
+
 
 @skipIfNoQNNPACK
 @unittest.skipIf(not torch_version_at_least("2.7.0"), "Requires torch 2.7+")

--- a/torchao/quantization/pt2e/graph_utils.py
+++ b/torchao/quantization/pt2e/graph_utils.py
@@ -159,6 +159,8 @@ def _get_control_flow_submodules(
             control_flow_submodules.append(_get_submodule(graph_module, node, 0))
         if node.target is torch.ops.higher_order.scan:
             control_flow_submodules.append(_get_submodule(graph_module, node, 0))
+        if node.target is torch.ops.higher_order.while_loop:
+            control_flow_submodules.append(_get_submodule(graph_module, node, 1))
 
     return control_flow_submodules
 

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -126,6 +126,19 @@ def prepare_pt2e(
             scan_combine_fn = model.get_submodule(scan_combine_fn_node.target)
             prepared_scan_combine_fn = prepare_pt2e(scan_combine_fn, quantizer)
             setattr(model, scan_combine_fn_node.target, prepared_scan_combine_fn)
+    # Recursively prepare body_fn subgraphs of while_loop ops.
+    for node in model.graph.nodes:
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.higher_order.while_loop
+        ):
+            while_loop_body_fn_node = node.args[1]
+            assert isinstance(while_loop_body_fn_node, Node)
+            assert while_loop_body_fn_node.op == "get_attr"
+            assert isinstance(while_loop_body_fn_node.target, str)
+            while_loop_body_fn = model.get_submodule(while_loop_body_fn_node.target)
+            prepared_while_loop_body_fn = prepare_pt2e(while_loop_body_fn, quantizer)
+            setattr(model, while_loop_body_fn_node.target, prepared_while_loop_body_fn)
     return model
 
 
@@ -311,6 +324,23 @@ def convert_pt2e(
                 fold_quantize=fold_quantize,
             )
             setattr(model, scan_combine_fn_node.target, converted_scan_combine_fn)
+    # Recursively convert body_fn subgraphs of while_loop ops.
+    for node in model.graph.nodes:
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.higher_order.while_loop
+        ):
+            while_loop_body_fn_node = node.args[1]
+            assert isinstance(while_loop_body_fn_node, Node)
+            assert while_loop_body_fn_node.op == "get_attr"
+            assert isinstance(while_loop_body_fn_node.target, str)
+            while_loop_body_fn = model.get_submodule(while_loop_body_fn_node.target)
+            converted_while_loop_body_fn = convert_pt2e(
+                while_loop_body_fn,
+                use_reference_representation=use_reference_representation,
+                fold_quantize=fold_quantize,
+            )
+            setattr(model, while_loop_body_fn_node.target, converted_while_loop_body_fn)
     model = _convert_to_reference_decomposed_fx(model)
     model = _fold_conv_bn_qat(model)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3916

Summary:

- Add support for torch._higher_order_ops.while_loop in pt2e quantization by recursively applying prepare_pt2e and convert_pt2e to the while_loop op's body_fn subgraph (arg index 1) using the same quantizer from
  the top-level module
- Register while_loop's body_fn subgraph in _get_control_flow_submodules alongside existing cond, map_impl, and scan handlers
- In convert_pt2e, process while_loop subgraphs before the main conversion passes to prevent DuplicateDQPass from encountering stale observer references during recursive graph linting
- Only the body_fn subgraph is quantized; the cond_fn subgraph (arg index 0) is not quantized

Test Plan:

- Added test_while_loop_op_quantization which exports a model using while_loop with a linear layer in the body_fn, runs prepare_pt2e + calibration + convert_pt2e, and verifies observers are inserted after
prepare, q/dq ops are present after convert, and the quantized model produces correct output (SQNR 42.8 dB > 35 dB threshold)
- Verified existing test_scan_op_quantization still passes

Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: