### PR TITLE
Add MXFP4 support for GPTQ quantization and separate eval script

### DIFF
--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -65,13 +65,16 @@ class GPTQConfig(AOBaseConfig):
     Args:
         step: Either "observe" or "convert"
         base_config: Base quantization configuration that determines the target dtype.
-            Use Int4WeightOnlyConfig() for int4 or Int8WeightOnlyConfig() for int8.
+            Use Int4WeightOnlyConfig() for int4, Int8WeightOnlyConfig() for int8,
+            or MXDynamicActivationMXWeightConfig() for MX formats (mxfp8/mxfp4).
         percdamp: Damping factor for Hessian diagonal (default: 0.01)
         gptq_quantize_block_size: Block size for GPTQ algorithm (default: 256)
     """
 
     step: str = "observe"  # "observe" or "convert"
-    base_config: Union[Int4WeightOnlyConfig, Int8WeightOnlyConfig] = None
+    base_config: Union[
+        Int4WeightOnlyConfig, Int8WeightOnlyConfig, MXDynamicActivationMXWeightConfig
+    ] = None
     percdamp: float = 0.01
     gptq_quantize_block_size: int = 256
 
@@ -252,7 +255,7 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
         config: GPTQ configuration
 
     Returns:
-        Int4Tensor or Int8Tensor: Quantized weight matrix
+        Quantized weight matrix (Int4Tensor, Int8Tensor, or dequantized MXTensor)
     """
     assert W.dim() == 2
     gptq_quantize_block_size = config.gptq_quantize_block_size

--- a/torchao/prototype/gptq/gptq_eval.py
+++ b/torchao/prototype/gptq/gptq_eval.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Standalone evaluation script for quantized model checkpoints.
+
+Usage:
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir <path_to_checkpoint>
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir dir1 dir2 dir3
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir Llama-3.1-8B-Instruct_mxfp8-*
+"""
+
+import argparse
+import subprocess
+import sys
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run lm_eval on quantized model checkpoints"
+    )
+    parser.add_argument(
+        "checkpoint_dirs",
+        nargs="+",
+        help="One or more checkpoint directories to evaluate",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="arc_challenge,arc_easy,hellaswag,piqa,winogrande",
+        help="Comma-separated list of lm_eval tasks",
+    )
+    parser.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=0,
+        help="Number of few-shot examples",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=str,
+        default="auto",
+        help="Batch size for evaluation",
+    )
+    return parser.parse_args()
+
+
+def run_lm_eval(checkpoint_dir: str, tasks: str, num_fewshot: int, batch_size: str):
+    print(f"\n{'=' * 60}")
+    print(f"Evaluating: {checkpoint_dir}")
+    print(f"{'=' * 60}\n")
+
+    lm_eval_cmd = [
+        "lm_eval",
+        "--model",
+        "hf",
+        "--model_args",
+        f"pretrained={checkpoint_dir}",
+        "--tasks",
+        tasks,
+        "--num_fewshot",
+        str(num_fewshot),
+        "--batch_size",
+        batch_size,
+    ]
+
+    print(f"Running: {' '.join(lm_eval_cmd)}")
+    try:
+        subprocess.run(lm_eval_cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"lm_eval failed for {checkpoint_dir}: {e}")
+        return False
+    except FileNotFoundError:
+        print("lm_eval not found. Install with: pip install lm-eval")
+        sys.exit(1)
+    return True
+
+
+def main():
+    args = parse_args()
+
+    results = {}
+    for checkpoint_dir in args.checkpoint_dirs:
+        success = run_lm_eval(
+            checkpoint_dir, args.tasks, args.num_fewshot, args.batch_size
+        )
+        results[checkpoint_dir] = "OK" if success else "FAILED"
+
+    if len(args.checkpoint_dirs) > 1:
+        print(f"\n{'=' * 60}")
+        print("Summary:")
+        print(f"{'=' * 60}")
+        for checkpoint_dir, status in results.items():
+            print(f"  {status}: {checkpoint_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3921
* #3897
* #3899
* #3895

Add mxfp4-rtn, mxfp4-gptq-sequential, and mxfp4-gptq-nonsequential
quantization options. Extract lm_eval evaluation into a standalone
gptq_eval.py script.

Llama-3.1-8B-Instruct | 0-shot accuracy | group_size=128

| Method                         | arc_challenge | arc_easy | hellaswag | piqa   | winogrande | avg    | vs baseline |
|--------------------------------|---------------|----------|-----------|--------|------------|--------|-------------|
| baseline (bf16)                | 0.5529        | 0.7980   | 0.7959    | 0.8145 | 0.7372     | 0.7397 | —           |
| mxfp8 rtn                      | 0.5486        | 0.7904   | 0.7955    | 0.8139 | 0.7435     | 0.7384 | -0.18%      |
| mxfp8 gptq (nonsequential)     | 0.5512        | 0.7959   | 0.7944    | 0.8128 | 0.7490     | 0.7407 | +0.14%      |
| mxfp8 gptq (sequential)        | 0.5529        | 0.7971   | 0.7935    | 0.8134 | 0.7316     | 0.7377 | -0.27%      |
| mxfp4 rtn                      | 0.5179        | 0.7820   | 0.7803    | 0.7987 | 0.7238     | 0.7205 | -2.60%      |
| mxfp4 gptq (sequential)        | 0.5290        | 0.7988   | 0.7817    | 0.8052 | 0.7348     | 0.7299 | -1.32%      |

Co-authored-by: Cursor <cursoragent@cursor.com>