### PR TITLE
[mxfp8 training] unified MXFP8TrainingConfig and MXFP8TrainingTensor

### DIFF
--- a/benchmarks/prototype/moe_training/bench_moe_layer.py
+++ b/benchmarks/prototype/moe_training/bench_moe_layer.py
@@ -17,8 +17,8 @@ from torch.nn import functional as F
 from benchmarks.utils import bench_fwd_bwd_microseconds, profile_fwd_bwd
 from torchao.prototype.moe_training.config import (
     FP8GroupedMMRecipe,
-    MXFP8GroupedMMConfig,
-    MXFP8GroupedMMRecipe,
+    MXFP8TrainingConfig,
+    MXFP8TrainingRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -60,11 +60,13 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     if recipe_name == "fp8_rowwise":
         recipe = FP8GroupedMMRecipe.FP8_ROWWISE
     elif recipe_name == "mxfp8_rceil":
-        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL
+        recipe = MXFP8TrainingRecipe.MXFP8_RCEIL
     elif recipe_name == "mxfp8_rceil_wgrad_with_hp":
-        recipe = MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+        recipe = MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
     else:
         raise ValueError(f"Unknown recipe: {recipe_name}")
+
+    # Check hardware requirements
     if (
         recipe == FP8GroupedMMRecipe.FP8_ROWWISE
         and torch.cuda.get_device_capability()
@@ -78,8 +80,8 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         )
         return
 
-    elif (
-        recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    if (
+        recipe == MXFP8TrainingRecipe.MXFP8_RCEIL
         and torch.cuda.get_device_capability()
         != (
             10,
@@ -110,7 +112,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
     model = copy.deepcopy(ref_model)
 
     # Token group alignment size must be 16 for fp8 rowwise training
-    alignment_size = 32 if recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL else 16
+    alignment_size = 32 if recipe == MXFP8TrainingRecipe.MXFP8_RCEIL else 16
     set_token_group_alignment_size_m(alignment_size)
 
     # assert starting params are identical for both models
@@ -125,7 +127,7 @@ def bench_moe_training_fsdp(args: argparse.Namespace):
         return False
 
     # quantize test model
-    config = MXFP8GroupedMMConfig.from_recipe(recipe)
+    config = MXFP8TrainingConfig.from_recipe(recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # inputs

--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -23,8 +23,8 @@ from torchao.prototype.moe_training import _quantize_then_scaled_grouped_mm
 from torchao.prototype.moe_training.config import (
     FP8GroupedMMConfig,
     FP8GroupedMMRecipe,
-    MXFP8GroupedMMConfig,
-    MXFP8GroupedMMRecipe,
+    MXFP8TrainingConfig,
+    MXFP8TrainingRecipe,
 )
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 
@@ -41,7 +41,7 @@ torch._dynamo.config.automatic_dynamic_shapes = False
 class ExperimentConfig:
     high_precision_dtype: torch.dtype
     MNKG: tuple[int]
-    recipe: Union[FP8GroupedMMRecipe, MXFP8GroupedMMRecipe]
+    recipe: Union[FP8GroupedMMRecipe, MXFP8TrainingRecipe]
 
 
 @dataclass(frozen=True)
@@ -91,9 +91,8 @@ def get_configs() -> List[ExperimentConfig]:
         (128000, 2048, 7168, 8),
     ]
     recipes = [
-        FP8GroupedMMRecipe.FP8_ROWWISE,
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL,
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
+        MXFP8TrainingRecipe.MXFP8_RCEIL,
+        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
     ]
     high_precision_dtypes = [torch.bfloat16]
     configs = []
@@ -172,7 +171,7 @@ def run_experiment(
     if isinstance(config.recipe, FP8GroupedMMRecipe):
         quant_config = FP8GroupedMMConfig.from_recipe(config.recipe)
     else:
-        quant_config = MXFP8GroupedMMConfig.from_recipe(config.recipe)
+        quant_config = MXFP8TrainingConfig.from_recipe(config.recipe)
 
     # fwd_bwd scaled benchmark + profiling
     scaled_fwd_bwd_us = bench_fwd_bwd_microseconds(
@@ -270,8 +269,8 @@ def main(args: argparse.Namespace):
             continue
 
         elif config.recipe in (
-            MXFP8GroupedMMRecipe.MXFP8_RCEIL,
-            MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
+            MXFP8TrainingRecipe.MXFP8_RCEIL,
+            MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
         ) and torch.cuda.get_device_capability() != (10, 0):
             logging.warning(
                 f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"

--- a/test/prototype/moe_training/test_distributed.py
+++ b/test/prototype/moe_training/test_distributed.py
@@ -52,9 +52,8 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
 
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.config import (
-    FP8GroupedMMRecipe,
-    MXFP8GroupedMMConfig,
-    MXFP8GroupedMMRecipe,
+    MXFP8TrainingConfig,
+    MXFP8TrainingRecipe,
 )
 from torchao.quantization.quant_api import quantize_
 
@@ -133,28 +132,21 @@ def distributed_env():
     "recipe_config",
     [
         {
-            "recipe": FP8GroupedMMRecipe.FP8_ROWWISE,
-            "group_alignment_size": 16,
-            "min_out_sqnr": 29.0,
-            "min_input_grad_sqnr": 29.0,
-            "min_param_grad_sqnr": 23.0,
-        },
-        {
-            "recipe": MXFP8GroupedMMRecipe.MXFP8_RCEIL,
+            "recipe": MXFP8TrainingRecipe.MXFP8_RCEIL,
             "group_alignment_size": 32,
             "min_out_sqnr": 27.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 21.0,
         },
         {
-            "recipe": MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
+            "recipe": MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
             "group_alignment_size": 32,
             "min_out_sqnr": 27.0,
             "min_input_grad_sqnr": 29.0,
             "min_param_grad_sqnr": 25.0,
         },
         {
-            "recipe": MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL,
+            "recipe": MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL,
             "group_alignment_size": 32,
             "min_out_sqnr": 27.0,
             "min_input_grad_sqnr": 29.0,
@@ -183,19 +175,15 @@ def test_moe_training_parallel(
     )
     assert torch.cuda.is_available()
 
-    # Skip FP8 tests - FP8GroupedMMConfig not yet implemented
-    if isinstance(recipe, FP8GroupedMMRecipe):
-        pytest.skip("FP8GroupedMMConfig not yet implemented, will be added separately")
-
     if recipe in (
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL,
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
+        MXFP8TrainingRecipe.MXFP8_RCEIL,
+        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
     ):
         if torch.cuda.get_device_capability() != (10, 0):
             pytest.skip(
                 f"Non-emulated mode only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
             )
-    elif recipe == MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL:
+    elif recipe == MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
         if compile:
             pytest.skip("MXFP8 emulated mode does not support torch.compile")
 
@@ -238,7 +226,7 @@ def test_moe_training_parallel(
         return False
 
     # quantize test model using MXFP8 config
-    config = MXFP8GroupedMMConfig.from_recipe(recipe)
+    config = MXFP8TrainingConfig.from_recipe(recipe)
     quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 
     # validate that only the experts were converted

--- a/test/prototype/moe_training/test_fqn_to_config.py
+++ b/test/prototype/moe_training/test_fqn_to_config.py
@@ -14,10 +14,10 @@ import torch
 from torch import nn
 
 from torchao.prototype.moe_training.config import (
-    MXFP8GroupedMMConfig,
-    MXFP8GroupedMMRecipe,
+    MXFP8TrainingConfig,
+    MXFP8TrainingRecipe,
 )
-from torchao.prototype.moe_training.tensor import ScaledGroupedMMTensor
+from torchao.prototype.moe_training.tensor import MXFP8TrainingTensor
 from torchao.prototype.mx_formats.config import MXLinearConfig, MXLinearRecipeName
 from torchao.prototype.mx_formats.mx_linear import MXLinear
 from torchao.quantization import FqnToConfig
@@ -61,10 +61,10 @@ def test_fqn_to_config_simple():
     config = FqnToConfig(
         fqn_to_config=OrderedDict(
             [
-                # Apply MXFP8GroupedMMConfig to expert parameters
+                # Apply MXFP8TrainingConfig to expert parameters
                 (
                     "experts",
-                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                    MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL),
                 ),
                 # Apply MXLinearConfig to dense layers
                 (
@@ -87,14 +87,14 @@ def test_fqn_to_config_simple():
     quantize_(model, config, filter_fn=None)
 
     # Verify transformations
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
-    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    assert model.experts.w1.data.config == MXFP8TrainingConfig.from_recipe(
+        MXFP8TrainingRecipe.MXFP8_RCEIL
     )
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
     assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
@@ -110,7 +110,7 @@ def test_fqn_to_config_with_regex():
             [
                 (
                     "re:.*experts.*",
-                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                    MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL),
                 ),
                 (
                     "re:^(pre_moe|post_moe)$",
@@ -125,14 +125,14 @@ def test_fqn_to_config_with_regex():
     quantize_(model, config, filter_fn=None)
 
     # Verify transformations
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    assert model.experts.w1.data.config == MXFP8TrainingConfig.from_recipe(
+        MXFP8TrainingRecipe.MXFP8_RCEIL
     )
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
     assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
@@ -148,7 +148,7 @@ def test_fqn_to_config_experts_only():
             [
                 (
                     "re:.*experts.*",
-                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                    MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL),
                 ),
             ]
         )
@@ -157,11 +157,11 @@ def test_fqn_to_config_experts_only():
     quantize_(model, config, filter_fn=None)
 
     # Verify transformations
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
     # Dense layers should remain unchanged
     assert isinstance(model.pre_moe, nn.Linear) and not isinstance(
@@ -182,7 +182,7 @@ def test_fqn_to_config_selective_layers():
             [
                 (
                     "re:.*experts.*",
-                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                    MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL),
                 ),
                 (
                     "pre_moe",
@@ -197,11 +197,11 @@ def test_fqn_to_config_selective_layers():
     quantize_(model, config, filter_fn=None)
 
     # Verify transformations
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
     # post_moe should remain unchanged
@@ -219,8 +219,8 @@ def test_fqn_to_config_mxfp8_wgrad_with_hp():
             [
                 (
                     "re:.*experts.*",
-                    MXFP8GroupedMMConfig.from_recipe(
-                        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+                    MXFP8TrainingConfig.from_recipe(
+                        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
                     ),
                 ),
                 (
@@ -236,14 +236,14 @@ def test_fqn_to_config_mxfp8_wgrad_with_hp():
     quantize_(model, config, filter_fn=None)
 
     # Verify transformations
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    assert model.experts.w1.data.config == MXFP8TrainingConfig.from_recipe(
+        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
     ), "w1 should use RCEIL_WGRAD_WITH_HP recipe"
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
     assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"
@@ -270,10 +270,10 @@ def test_fqn_to_config_dense_only():
     quantize_(model, config, filter_fn=None)
 
     # Verify only Linear layers were transformed
-    assert not isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
+    assert not isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
         "w1 should remain regular tensor"
     )
-    assert not isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
+    assert not isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
         "w2 should remain regular tensor"
     )
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
@@ -291,12 +291,12 @@ def test_fqn_to_config_specific_expert_params():
                 # Apply different MXFP8 recipes to test granular fqn selection
                 (
                     "experts.w1",
-                    MXFP8GroupedMMConfig.from_recipe(MXFP8GroupedMMRecipe.MXFP8_RCEIL),
+                    MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_RCEIL),
                 ),
                 (
                     "experts.w2",
-                    MXFP8GroupedMMConfig.from_recipe(
-                        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+                    MXFP8TrainingConfig.from_recipe(
+                        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
                     ),
                 ),
                 (
@@ -311,17 +311,17 @@ def test_fqn_to_config_specific_expert_params():
     quantize_(model, config, filter_fn=None)
 
     # Verify different recipes were applied
-    assert isinstance(model.experts.w1.data, ScaledGroupedMMTensor), (
-        "w1 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w1.data, MXFP8TrainingTensor), (
+        "w1 should be MXFP8TrainingTensor"
     )
-    assert model.experts.w1.data.config == MXFP8GroupedMMConfig.from_recipe(
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL
+    assert model.experts.w1.data.config == MXFP8TrainingConfig.from_recipe(
+        MXFP8TrainingRecipe.MXFP8_RCEIL
     ), "w1 should use MXFP8 RCEIL"
-    assert isinstance(model.experts.w2.data, ScaledGroupedMMTensor), (
-        "w2 should be ScaledGroupedMMTensor"
+    assert isinstance(model.experts.w2.data, MXFP8TrainingTensor), (
+        "w2 should be MXFP8TrainingTensor"
     )
-    assert model.experts.w2.data.config == MXFP8GroupedMMConfig.from_recipe(
-        MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
+    assert model.experts.w2.data.config == MXFP8TrainingConfig.from_recipe(
+        MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP
     ), "w2 should use MXFP8 RCEIL_WGRAD_WITH_HP"
     assert isinstance(model.pre_moe, MXLinear), "pre_moe should be MXLinear"
     assert isinstance(model.post_moe, MXLinear), "post_moe should be MXLinear"

--- a/test/prototype/moe_training/test_mxfp8_training_tensor.py
+++ b/test/prototype/moe_training/test_mxfp8_training_tensor.py
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from torchao.utils import torch_version_at_least
+
+# Skip module if basic requirements aren't met
+if not (torch_version_at_least("2.7.0") and torch.cuda.is_available()):
+    pytest.skip("CUDA and PyTorch 2.7.0+ required", allow_module_level=True)
+
+from torchao.prototype.moe_training.config import (
+    MXFP8TrainingConfig,
+    MXFP8TrainingRecipe,
+)
+from torchao.prototype.moe_training.tensor import MXFP8TrainingTensor
+from torchao.quantization.utils import compute_error
+
+
+@pytest.mark.parametrize("op_name", ["mm", "matmul", "linear"])
+@pytest.mark.parametrize("batch_size", [None, 2, 4])
+def test_mxfp8_training_tensor_ops_fwd_bwd(op_name, batch_size):
+    # mm doesn't support batching
+    if op_name == "mm" and batch_size is not None:
+        pytest.skip("mm doesn't support batching")
+
+    config = MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL)
+
+    # Create input tensors - dimensions must be divisible by 32
+    # Use larger sizes for better SQNR, especially with bias in linear ops
+    M, K, N = 1024, 1024, 2048
+    if batch_size is None:
+        A_shape = (M, K)
+    else:
+        A_shape = (batch_size, M, K)
+
+    A = torch.randn(*A_shape, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    bias = (
+        torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        if op_name == "linear"
+        else None
+    )
+
+    # Reference computation with bf16
+    A_ref = A.clone().detach().requires_grad_(True)
+    B_ref = B.clone().detach().requires_grad_(True)
+
+    if op_name == "mm":
+        result_ref = torch.mm(A_ref, B_ref.t())
+    elif op_name == "matmul":
+        result_ref = torch.matmul(A_ref, B_ref.t())
+    elif op_name == "linear":
+        result_ref = F.linear(A_ref, B_ref, bias)
+
+    # MXFP8 computation
+    B_mxfp8 = MXFP8TrainingTensor(B, config)
+
+    if op_name == "mm":
+        result_mxfp8 = torch.mm(A, B_mxfp8)
+    elif op_name == "matmul":
+        result_mxfp8 = torch.matmul(A, B_mxfp8)
+    elif op_name == "linear":
+        result_mxfp8 = F.linear(A, B_mxfp8, bias)
+
+    # Validate forward pass
+    assert result_mxfp8.shape == result_ref.shape, "Shape mismatch"
+    assert result_mxfp8.dtype == torch.bfloat16, "Dtype should be bfloat16"
+    assert not isinstance(result_mxfp8, MXFP8TrainingTensor), (
+        "Result should be unwrapped"
+    )
+
+    # Check forward SQNR
+    # Linear with bias has slightly lower SQNR due to bias addition
+    sqnr_fwd = compute_error(result_ref, result_mxfp8)
+    min_sqnr_fwd = 26.0 if op_name == "linear" else 27.0
+    assert sqnr_fwd >= min_sqnr_fwd, (
+        f"Forward SQNR {sqnr_fwd} is too low, must be >= {min_sqnr_fwd}"
+    )
+
+    # Backward pass with MSE loss to avoid contiguity issues
+    labels_ref = torch.ones_like(result_ref)
+    labels_mxfp8 = torch.ones_like(result_mxfp8)
+    loss_ref = F.mse_loss(result_ref, labels_ref)
+    loss_mxfp8 = F.mse_loss(result_mxfp8, labels_mxfp8)
+    loss_ref.backward()
+    loss_mxfp8.backward()
+
+    # Verify gradients exist
+    assert A.grad is not None, "A.grad should be computed"
+    assert A_ref.grad is not None, "A_ref.grad should be computed"
+    assert B_mxfp8.grad is not None, "B_mxfp8.grad should be computed"
+    assert B_ref.grad is not None, "B_ref.grad should be computed"
+
+    # Check input gradient SQNR
+    sqnr_input_grad = compute_error(A_ref.grad, A.grad)
+    min_sqnr_input_grad = 25.0
+    assert sqnr_input_grad >= min_sqnr_input_grad, (
+        f"Input grad SQNR {sqnr_input_grad} is too low, must be >= {min_sqnr_input_grad}"
+    )
+
+    # Check weight gradient SQNR
+    sqnr_weight_grad = compute_error(B_ref.grad, B_mxfp8.grad)
+    min_sqnr_weight_grad = 24.0
+    assert sqnr_weight_grad >= min_sqnr_weight_grad, (
+        f"Weight grad SQNR {sqnr_weight_grad} is too low, must be >= {min_sqnr_weight_grad}"
+    )
+
+
+def test_mxfp8_training_tensor_ops_preserve_subclass():
+    config = MXFP8TrainingConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL)
+
+    B = torch.randn(64, 32, dtype=torch.bfloat16, device="cuda")
+    B_mxfp8 = MXFP8TrainingTensor(B, config)
+
+    # view
+    result = B_mxfp8.view(32, 64)
+    assert isinstance(result, MXFP8TrainingTensor), "view should preserve subclass"
+
+    # transpose.int
+    result = B_mxfp8.transpose(0, 1)
+    assert isinstance(result, MXFP8TrainingTensor), (
+        "transpose.int should preserve subclass"
+    )
+
+    # transpose.default
+    result = B_mxfp8.t()
+    assert isinstance(result, MXFP8TrainingTensor), (
+        "transpose.default should preserve subclass"
+    )
+
+    # clone
+    result = B_mxfp8.clone()
+    assert isinstance(result, MXFP8TrainingTensor), "clone should preserve subclass"
+
+    # slice
+    result = B_mxfp8[:32, :]
+    assert isinstance(result, MXFP8TrainingTensor), "slice should preserve subclass"

--- a/test/prototype/moe_training/testing_utils.py
+++ b/test/prototype/moe_training/testing_utils.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from torchao.prototype.moe_training.tensor import ScaledGroupedMMTensor
+from torchao.prototype.moe_training.tensor import MXFP8TrainingTensor
 
 
 def _validate_model_conversion(
@@ -16,7 +16,7 @@ def _validate_model_conversion(
 
         # check current module params
         for param_name, param in module.named_parameters(recurse=False):
-            is_converted_type = isinstance(param, ScaledGroupedMMTensor)
+            is_converted_type = isinstance(param, MXFP8TrainingTensor)
             if is_converted_type:
                 assert is_allowed_module, (
                     f"Module {cur_fqn} is not in target_fqns, but has converted param {param_name}."

--- a/torchao/prototype/moe_training/README.md
+++ b/torchao/prototype/moe_training/README.md
@@ -273,16 +273,16 @@ This prototype is specifically designed to be used on MoE models using
 where expert weights are implemented as 3D nn.Parameters with `num_experts` as
 the leading dim.
 
-The `MXFP8GroupedMMConfig` has a module handler registered to it which will
+The `MXFP8TrainingConfig` has a module handler registered to it which will
 find all nn.Parameters whose parent module matches the module filter function,
-and swap their data tensor with a ScaledGroupedMMTensor.
+and swap their data tensor with a MXFP8TrainingTensor.
 
-The ScaledGroupedMMTensor is a tensor subclass which overrides the
+The MXFP8TrainingTensor is a tensor subclass which overrides the
 `torch._grouped_mm` op by dispatching to a differentiable scaled grouped mm,
 which performs dynamic quantization on scaled grouped GEMM operands in both 
 the forward and backward pass, based on the quantization config (FP8/MXFP8/etc).
 
-For all other ops, ScaledGroupedMMTensor behaves like a regular torch.Tensor.
+For all other ops, MXFP8TrainingTensor behaves like a regular torch.Tensor.
 
 ## Limitations
 - The new CUDA kernel for MXFP8 quantization of the non-transposed expert weights in the backwards pass does not support TP yet.

--- a/torchao/prototype/moe_training/config.py
+++ b/torchao/prototype/moe_training/config.py
@@ -24,7 +24,7 @@ class FP8GroupedMMRecipe(Enum):
     FP8_ROWWISE = "fp8_rowwise"
 
 
-class MXFP8GroupedMMRecipe(Enum):
+class MXFP8TrainingRecipe(Enum):
     """MXFP8 recipes for grouped matrix multiplication."""
 
     # TODO: add floor variants
@@ -33,14 +33,19 @@ class MXFP8GroupedMMRecipe(Enum):
     MXFP8_EMULATED_RCEIL = "mxfp8_emulated_rceil"
 
 
-class GroupedMMConfig(AOBaseConfig):
-    """Base configuration for grouped matrix multiplication. Not intended to be used directly."""
+class TrainingBaseConfig(AOBaseConfig):
+    """
+    Base configuration for low precision training. Not intended to be used directly.
+
+    Purpose is to support generic model conversion function for linear and grouped gemm
+    low precision training.
+    """
 
     pass
 
 
 @dataclass
-class FP8GroupedMMConfig(GroupedMMConfig):
+class FP8GroupedMMConfig(TrainingBaseConfig):
     """
     Configuration for FP8 grouped matrix multiplication.
     """
@@ -63,23 +68,19 @@ class FP8GroupedMMConfig(GroupedMMConfig):
 # register as pytree constant so we can use dynamo nonstrict trace in torchao.prototype.moe_training.ep
 @register_as_pytree_constant
 @dataclass
-class MXFP8GroupedMMConfig(GroupedMMConfig):
+class MXFP8TrainingConfig(TrainingBaseConfig):
     """
-    The MXFP8GroupedMMConfig is specifically designed to be used on MoE models using
-    `torch._grouped_mm` to implement expert computation in token-choice routing,
-    where expert weights are implemented as 3D nn.Parameters wit `num_experts` as
-    the leading dim.
+    The MXFP8TrainingConfig defines the MXFP8 training config for nn.Linear layers
+    and grouped GEMM ops.
 
-    MXFP8GroupedMMConfig has a module handler registered to it which will
+    MXFP8TrainingConfig has a module handler registered to it which will
     find all nn.Parameters whose parent module matches the module filter function,
-    and swap their data tensor with a ScaledGroupedMMTensor.
+    and swap their data tensor with a MXFP8TrainingTensor.
 
-    The ScaledGroupedMMTensor is a tensor subclass which overrides the
-    `torch._grouped_mm` op by dispatching to a differentiable scaled grouped mm,
-    which performs dynamic quantization on scaled grouped GEMM operands in both
-    the forward and backward pass, based on the quantization config (FP8/MXFP8/etc).
+    The MXFP8TrainingTensor dispatches matmul and grouped gemm ops to custom
+    autograd functions which dynamically quantize inputs to MXFP8.
 
-    For all other ops, ScaledGroupedMMTensor behaves like a regular torch.Tensor.
+    For all other ops, MXFP8TrainingTensor behaves like a regular torch.Tensor.
     """
 
     # AUTO = Use best supported kernel for quantization ops and GEMMs (CUDA and Triton for quantizatoin, CUTLASS for MXFP8 grouped GEM
@@ -100,24 +101,24 @@ class MXFP8GroupedMMConfig(GroupedMMConfig):
     @classmethod
     def from_recipe(
         cls,
-        recipe: MXFP8GroupedMMRecipe,
-    ) -> "MXFP8GroupedMMConfig":
-        """Factory method to create a MXFP8GroupedMMConfig from a MXFP8GroupedMMRecipe."""
-        if recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL:
+        recipe: MXFP8TrainingRecipe,
+    ) -> "MXFP8TrainingConfig":
+        """Factory method to create a MXFP8TrainingConfig from a MXFP8TrainingRecipe."""
+        if recipe == MXFP8TrainingRecipe.MXFP8_RCEIL:
             return cls(
                 kernel_preference=KernelPreference.AUTO,
                 out_dtype=torch.bfloat16,
                 wgrad_with_hp=False,
                 scale_calculation_mode=ScaleCalculationMode.RCEIL,
             )
-        elif recipe == MXFP8GroupedMMRecipe.MXFP8_RCEIL_WGRAD_WITH_HP:
+        elif recipe == MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP:
             return cls(
                 kernel_preference=KernelPreference.AUTO,
                 out_dtype=torch.bfloat16,
                 wgrad_with_hp=True,
                 scale_calculation_mode=ScaleCalculationMode.RCEIL,
             )
-        elif recipe == MXFP8GroupedMMRecipe.MXFP8_EMULATED_RCEIL:
+        elif recipe == MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
             return cls(
                 kernel_preference=KernelPreference.EMULATED,
                 out_dtype=torch.bfloat16,
@@ -128,7 +129,7 @@ class MXFP8GroupedMMConfig(GroupedMMConfig):
             raise ValueError(f"Unsupported MXFP8 recipe: {recipe}")
 
     def __eq__(self, other):
-        if isinstance(other, MXFP8GroupedMMConfig):
+        if isinstance(other, MXFP8TrainingConfig):
             return (
                 self.kernel_preference == other.kernel_preference
                 and self.out_dtype == other.out_dtype
@@ -148,19 +149,18 @@ class MXFP8GroupedMMConfig(GroupedMMConfig):
         )
 
 
-@register_quantize_module_handler(FP8GroupedMMConfig)
-@register_quantize_module_handler(MXFP8GroupedMMConfig)
+@register_quantize_module_handler(MXFP8TrainingConfig)
 def _moe_training_transform(
     module: nn.Module,
-    config: GroupedMMConfig,
+    config: TrainingBaseConfig,
     parameter_name: Optional[str] = None,
 ) -> nn.Module:
     """
-    Swaps `torch.nn.Parameter` data tensor with a ScaledGroupedMMTensor.
+    Swaps `torch.nn.Parameter` data tensor with a MXFP8TrainingTensor.
 
     Args:
         module: Module to modify.
-        config: GroupedMMConfig which defines how to perform the MoE training transform.
+        config: TrainingBaseConfig which defines how to perform the training transform (i.e., convert linears and grouped GEMMs)
         parameter_name: If specified, only transform this specific parameter. Otherwise transform all parameters.
 
     Returns:

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 from torch import nn
 
 from torchao.prototype.moe_training.config import (
-    GroupedMMConfig,
+    TrainingBaseConfig,
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -19,12 +19,12 @@ def _swap_params(
     module: nn.Module,
     *,
     module_filter_fn: Optional[Callable[[nn.Module, str], bool]] = None,
-    config: Optional[GroupedMMConfig] = None,
+    config: Optional[TrainingBaseConfig] = None,
     target_parameter_name: Optional[str] = None,
 ) -> nn.Module:
     """
     Recurses through the nn.Module, recursively swapping the data tensor of
-    each nn.Parameter with a ScaledGroupedMMTensor. Only applies if the module
+    each nn.Parameter with a MXFP8TrainingTensor. Only applies if the module
     passed the module_filter_fn, if specified.
 
     Args:
@@ -36,7 +36,7 @@ def _swap_params(
     Returns:
      nn.Module: The modified module with swapped linear layers.
     """
-    from torchao.prototype.moe_training.tensor import ScaledGroupedMMTensor
+    from torchao.prototype.moe_training.tensor import MXFP8TrainingTensor
 
     if isinstance(module, nn.Parameter) and (
         module_filter_fn is None or module_filter_fn(module, "")
@@ -45,8 +45,8 @@ def _swap_params(
             raise AssertionError(
                 f"Does not support a root nn.Parameter with children: {module}"
             )
-        if not isinstance(module.data, ScaledGroupedMMTensor):
-            new_data = ScaledGroupedMMTensor(module.data, config)
+        if not isinstance(module.data, MXFP8TrainingTensor):
+            new_data = MXFP8TrainingTensor(module.data, config)
             return nn.Parameter(new_data, requires_grad=module.requires_grad)
         return module
 
@@ -67,7 +67,6 @@ def _swap_params(
                 new_fqn = f"{cur_fqn}.{child_module_name}"
 
             post_order_traversal(child_module, new_fqn, module)
-
         if module_filter_fn is None or module_filter_fn(module, cur_fqn):
             for param_name, param in module.named_parameters(recurse=False):
                 if (
@@ -75,14 +74,14 @@ def _swap_params(
                     and param_name != target_parameter_name
                 ):
                     continue
-                if not isinstance(param.data, ScaledGroupedMMTensor):
+                if not isinstance(param.data, MXFP8TrainingTensor):
                     new_param = nn.Parameter(
-                        ScaledGroupedMMTensor(param.data, config),
+                        MXFP8TrainingTensor(param.data, config),
                         requires_grad=param.requires_grad,
                     )
                     setattr(module, param_name, new_param)
                     logger.info(
-                        f"Swapped {cur_fqn}.{param_name} to ScaledGroupedMMTensor"
+                        f"Swapped {cur_fqn}.{param_name} to MXFP8TrainingTensor"
                     )
 
     post_order_traversal(root_module)


### PR DESCRIPTION
## Config changes

- Add unified `MXFP8TrainingConfig` for linear and grouped_mm. This replaces `MXFP8GroupedMMConfig`. 
    - It can eventually replace `MXLinearConfig` as well (not done in this PR).
    - Simplified set of options shared between both ops. AUTO kernel preference handles all the different kernel dispatch options distinct to each op in an opinionated way, using the best kernel we have for that operation based on our benchmarks.
- Rename `MXFP8GroupedMMRecipe` -> `MXFP8TrainingRecipe`. 

## Tensor subclass changes
- Rename `ScaledGroupedMMTensor` to `MXFP8TrainingTensor`

## Autograd func changes
- Add convenience wrapper `_to_mxfp8_then_scaled_mm`
- Update `mx_mm` autograd func to support `wgrad_with_hp` recipe


## Limitations
- `torch.compile` is not working yet. Dynamo nonstrict trace mode error needs either compile team support or migration of MXFP8 expert parallel training from MXTensor -> separate qdata/scale tensors.
 
## Temporarily removed FP8GroupedMM quantize_ workflow support
- In the future, we can refactor float8 training to follow a similar pattern if we wish. For now, given that FP8 MOE training is in a less mature state (~10% TPS increase for Llama4 Scout, less interest in github issues/PRs/etc), I am simplifying this MXFP8 refactor effort by disabling FP8 GroupedMM tests and workflow support (`quantize_()`). 
- If/when we get to FP8 blockwise training, this can be added back without much effort.

## Tests
- Added linear test cases in `test/prototype/moe_training/test_training.py`
- `./test/prototype/moe_training/test_everything.sh `