### PR TITLE
[ROCm] Remove redundant ROCm test skips in NF4 and use accelerator-ag…

### DIFF
--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -44,7 +44,6 @@ from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import (
     _INNER_TENSOR_NAMES_FOR_SHARDING,
     linear_nf4,
 )
-from torchao.testing.utils import skip_if_rocm
 from torchao.utils import get_current_accelerator_device, torch_version_at_least
 
 bnb_available = False
@@ -127,7 +126,6 @@ class TestNF4Linear(TestCase):
     @unittest.skipIf(
         torch_version_at_least("2.7.0"), reason="Failing in CI"
     )  # TODO: fix this
-    @skip_if_rocm("ROCm enablement in progress")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_reconstruction_qlora_vs_bnb(self, dtype: torch.dtype):
         # From https://github.com/drisspg/transformer_nuggets/blob/f05afad68ad9086d342268f46a7f344617a02314/test/test_qlora.py#L65C1-L81C47
@@ -150,7 +148,6 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not bnb_available, "Need bnb availble")
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @skip_if_rocm("ROCm enablement in progress")
     @unittest.skipIf(
         torch_version_at_least("2.7.0"), reason="Failing in CI"
     )  # TODO: fix this
@@ -267,11 +264,12 @@ class TestNF4Linear(TestCase):
         _ = torch.nn.functional.linear(inp, a)
         _ = torch.nn.functional.linear(inp, a_nf4)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_smoketest_linear_compile(self, dtype: torch.dtype):
         if (
-            torch.cuda.is_available()
+            not torch.version.hip
+            and torch.cuda.is_available()
             and torch.cuda.get_device_capability() < (8, 0)
             and dtype == torch.bfloat16
         ):


### PR DESCRIPTION
NF4 is pure PyTorch with no CUDA kernel dependencies, so it runs correctly on ROCm without any library changes.

- Remove @skip_if_rocm from test_reconstruction_qlora_vs_bnb and test_nf4_bnb_linear (both already gated by bnb availability and torch_version_at_least("2.7.0"))
- Use torch.accelerator.is_available() instead of torch.cuda.is_available() in test_smoketest_linear_compile
- Guard get_device_capability() < (8, 0) check with not torch.version.hip since MI300X supports bf16 natively

Validated: 87 passed, 6 skipped, 0 failed on MI300X. The 6 skips are pre-existing upstream issues (bnb + torch version gate), not ROCm-related.

cc: @bowenbao