### PR TITLE
[ROCm] Enable affine quantized, quant API, and integration tests on ROCm

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -29,7 +29,7 @@ from torchao.quantization import (
     quantize_,
 )
 from torchao.quantization.quant_primitives import MappingType
-from torchao.testing.utils import skip_if_no_gemlite, skip_if_rocm
+from torchao.testing.utils import skip_if_no_gemlite
 from torchao.utils import (
     check_cpu_version,
     check_xpu_version,
@@ -169,11 +169,12 @@ class TestAffineQuantized(TestCase):
 
         deregister_aqt_quantized_linear_dispatch(dispatch_condition)
 
-    @skip_if_rocm("ROCm enablement in progress")
     @unittest.skipIf(len(GPU_DEVICES) == 0, "Need GPU available")
     def test_print_quantized_module(self):
         for device in self.GPU_DEVICES:
-            apply_quant_list = get_quantization_functions(True, True, device, True)
+            apply_quant_list = get_quantization_functions(
+                is_cusparselt_available, True, device, True
+            )
             for apply_quant in apply_quant_list:
                 linear = torch.nn.Linear(128, 256, dtype=torch.bfloat16, device=device)
                 if isinstance(apply_quant, AOBaseConfig):
@@ -254,7 +255,6 @@ class TestAffineQuantizedBasic(TestCase):
 
     @common_utils.parametrize("device", COMMON_DEVICES)
     @common_utils.parametrize("dtype", COMMON_DTYPES)
-    @skip_if_rocm("ROCm enablement in progress")
     def test_flatten_unflatten(self, device, dtype):
         if device == "cuda" and dtype == torch.bfloat16 and is_fbcode():
             raise unittest.SkipTest("TODO: Failing for cuda + bfloat16 in fbcode")

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -281,7 +281,6 @@ class PythonQuantUtilOpUnitTest(unittest.TestCase):
             self._test_per_token_linear_impl("cpu", dtype)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @skip_if_rocm("ROCm enablement in progress")
     def test_per_token_linear_cuda(self):
         device = get_current_accelerator_device()
         for dtype in (torch.float32, torch.float16, torch.bfloat16):
@@ -591,7 +590,6 @@ class TestSubclass(unittest.TestCase):
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
     @torch._inductor.config.patch({"freezing": True})
-    @skip_if_rocm("Test flaky on ROCm, under investigation")
     def test_int8_weight_only_quant_with_freeze(self, device, dtype):
         torch._dynamo.reset()
         self._test_lin_weight_subclass_api_impl(
@@ -643,7 +641,7 @@ class TestSubclass(unittest.TestCase):
         )
 
     @parameterized.expand(COMMON_DEVICE_DTYPE)
-    @skip_if_rocm("ROCm enablement in progress")
+    @skip_if_rocm("_weight_int4pack_mm scale layout incompatible with ROCm")
     @skip_if_xpu("XPU enablement in progress")
     def test_int4_weight_only_quant_subclass_api_grouped(self, device, dtype):
         if dtype != torch.bfloat16:

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -55,7 +55,7 @@ from torchao.testing.pt2e._xnnpack_quantizer import (
     XNNPACKQuantizer,
     get_symmetric_quantization_config,
 )
-from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.testing.utils import skip_if_xpu
 from torchao.utils import (
     get_current_accelerator_device,
     is_sm_at_least_89,
@@ -349,7 +349,6 @@ class TestQuantFlow(TestCase):
         ],
     )
     @skip_if_xpu("XPU enablement in progress")
-    @skip_if_rocm("ROCm enablement in progress")
     def test_workflow_e2e_numerics(self, config):
         """
         Simple test of e2e Int4WeightOnlyConfig workflow, comparing numerics


### PR DESCRIPTION
Remove stale @skip_if_rocm decorators from tests that work on ROCm. These tests use Triton-based or pure PyTorch codepaths with no CUDA-specific kernel dependencies.

- test_affine_quantized.py: Remove @skip_if_rocm from test_print_quantized_module and test_flatten_unflatten. Fix test_print_quantized_module to gate sparse configs on actual cusparselt availability instead of hardcoded True.
- test_integration.py: Remove @skip_if_rocm from test_per_token_linear_cuda and test_int8_weight_only_quant_with_freeze. Keep int4 grouped test skip with specific reason (scale layout incompatible with ROCm).
- test_quant_api.py: Remove @skip_if_rocm from test_workflow_e2e_numerics.

Validated 17 newly-enabled tests on MI300X (gfx942), 0 failures.

cc: @bowenbao