### PR TITLE
[ROCm] Enable float8 utils and base tests on ROCm

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -42,7 +42,6 @@ from torchao.float8.float8_utils import (
     tensor_to_scale,
 )
 from torchao.testing.training.test_utils import get_test_float8_linear_config
-from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
     is_MI300,
     is_ROCM,
@@ -378,7 +377,6 @@ class TestFloat8Linear:
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_90(), "CUDA capability < 9.0"
     )
-    @skip_if_rocm("ROCm enablement in progress")
     def test_linear_from_recipe(
         self,
         recipe_name,

--- a/test/float8/test_float8_utils.py
+++ b/test/float8/test_float8_utils.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 
 from torchao.float8.float8_utils import _round_scale_down_to_power_of_2
-from torchao.testing.utils import skip_if_rocm
 
 
 # source for notable single-precision cases:
@@ -23,7 +22,11 @@ from torchao.testing.utils import skip_if_rocm
         ("inf", float("inf"), float("inf")),
         ("nan", float("nan"), float("nan")),
         ("smallest positive subnormal number", 2**-126 * 2**-23, 2**-126 * 2**-23),
-        ("largest normal number", 2**127 * (2 - 2**-23), float("inf")),
+        (
+            "largest normal number",
+            2**127 * (2 - 2**-23),
+            2**127 if torch.version.hip else float("inf"),
+        ),
         ("smallest positive normal number", 2**-126, 2**-126),
         ("largest number less than one", 1.0 - 2**-24, 0.5),
         ("smallest number larger than one", 1.0 + 2**-23, 1.0),
@@ -32,7 +35,6 @@ from torchao.testing.utils import skip_if_rocm
         # ("largest subnormal number", [2**-126 * (1 - 2**-23), 1.1754943508222875e-38]),
     ],
 )
-@skip_if_rocm("ROCm enablement in progress")
 def test_round_scale_down_to_power_of_2_valid_inputs(
     test_case: dict,
 ):


### PR DESCRIPTION
- Remove @skip_if_rocm from test_round_scale_down_to_power_of_2 in test_float8_utils.py and test_linear_from_recipe in test_base.py
- Fix expected value for "largest normal number" test case: _round_scale_down_to_power_of_2(2^127 * (2 - 2^-23)) returns 2^127 on ROCm vs inf on CUDA. This is because log2(FLT_MAX) rounds to exactly 127.0 on ROCm (giving 2^127) while CUDA rounds up slightly (giving 2^128 = inf). Both are valid behaviors for this edge case value (3.4028235e+38).

Validated on MI300X (gfx942), PyTorch 2.9.0a0, ROCm 7.1.

cc: @bowenbao