### PR TITLE
Use relaxed memory ordering for Triton atomics on AMDGPU.

### DIFF
--- a/torchao/prototype/common/triton/matmul.py
+++ b/torchao/prototype/common/triton/matmul.py
@@ -259,7 +259,11 @@ def _kernel(
     if SPLIT_K == 1:
         tl.store(C, acc, mask=mask)
     else:
-        tl.atomic_add(C, acc, mask=mask)
+        # AMD GPUs need relaxed semantics for better performance
+        if tl.constexpr(torch.version.hip is not None):
+            tl.atomic_add(C, acc, mask=mask, sem="relaxed")
+        else:
+            tl.atomic_add(C, acc, mask=mask)
 
 
 class _matmul(torch.autograd.Function):

--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -205,7 +205,16 @@ if torch_version_at_least("2.7.0") and has_triton():
             + k_offs[None, :] * stride_scales_dim1
         )
         scales_mask = k_offs[None, :] < K
-        tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
+        # AMD GPUs need relaxed semantics for better performance
+        if tl.constexpr(torch.version.hip is not None):
+            tl.atomic_min(
+                scales_ptr + scales_offs,
+                scales[None, :],
+                mask=scales_mask,
+                sem="relaxed",
+            )
+        else:
+            tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
 
     @triton.autotune(configs=atomic_kernel_configs_2D, key=["num_elements"])
     @triton.jit


### PR DESCRIPTION
`tl.atomic_add` and the like needs to use relaxed memory ordering on AMDGPU for performance. When the default acquire-release semantic is used, memory fence will be inserted before and after the atomics op and thus hurts performance. Such memory fences are not necessary for the functionality of `atomic_add` and the like (they usually required for `tl.atomic_xchg`).

Here is an example result when running the benchmarking for 
`python benchmarks/prototype/moe_training/fp8_rowwise/bench_triton_fp8_rowwise_3d_transpose_rhs.py`

Before the changes:
<img width="1736" height="134" alt="image" src="https://github.com/user-attachments/assets/6d38bc5e-c844-4c25-aa85-648ef5eebb74" />
After the change:
<img width="1765" height="139" alt="image" src="https://github.com/user-attachments/assets/7867994e-a773-4d3a-9258-f0978e60dac0" />
