### PR TITLE
Add better debug print for failed prepare

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -584,7 +584,13 @@ def _is_connected(source: torch.fx.Node, dest: torch.fx.Node) -> bool:
 def _get_tensor_constant_from_node(node, m):
     if node is None:
         return None
-    assert node.op == "get_attr"
+    if node.op == "placeholder":
+        raise ValueError(
+            "Expected get_attr node, got placeholder. "
+            "If working with an ExportedProgram, make sure you are using .module()"
+        )
+    if node.op != "get_attr":
+        raise ValueError(f"Expected get_attr node, got {node.op}")
     target_atoms = node.target.split(".")
     attr_itr = m
     for i, atom in enumerate(target_atoms):


### PR DESCRIPTION
Summary:
If you pass a "raw" graph_module from an exported module, prepare will fail.  It is not immediately clear why.

This PR makes it more clear.

Differential Revision: D94379595


