### PR TITLE
Fix operator precedence bug in is_Navi4() GPU detection

### DIFF
--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1193,7 +1193,7 @@ def is_MI350():
 def is_Navi4():
     if is_ROCM():
         archName = torch.cuda.get_device_properties(0).gcnArchName
-        if "gfx1200" or "gfx1201" in archName:
+        if "gfx1200" in archName or "gfx1201" in archName:
             return True
     return False
 


### PR DESCRIPTION
## Summary
- Fix Python operator precedence bug in `is_Navi4()` in `torchao/utils.py`
- The condition `if "gfx1200" or "gfx1201" in archName` is parsed as `if ("gfx1200") or ("gfx1201" in archName)` due to Python operator precedence. Since `"gfx1200"` is a non-empty string (always truthy), every ROCm GPU is incorrectly identified as Navi4.
- Fixed to `if "gfx1200" in archName or "gfx1201" in archName`

## Test plan
- [x] Verified with `ruff check` and `ruff format` (all passing)
- [x] One-line fix, no behavioral change on NVIDIA (function returns `False` early via `is_ROCM()` check)
- [x] Verified on AMD ROCm GPU that non-Navi4 GPUs (e.g., MI300X) are no longer misidentified