### PR TITLE
Fix wrong type annotations

### DIFF
--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -1208,7 +1208,7 @@ def _do_fake_quantize_affine(
 def choose_qparams_affine(
     input: torch.Tensor,
     mapping_type: MappingType,
-    block_size: Tuple[int],
+    block_size: List[int],
     target_dtype: torch.dtype,
     quant_min: Optional[Union[int, float]] = None,
     quant_max: Optional[Union[int, float]] = None,
@@ -1221,7 +1221,7 @@ def choose_qparams_affine(
     Args:
         input (torch.Tensor): fp32, bf16, fp16 input Tensor
         mapping_type (MappingType): determines how the qparams are calculated, symmetric or asymmetric
-        block_size: (Tuple[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
+        block_size: (List[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
           e.g. when size is the same as the input tensor dimension, we are using per tensor quantization
         target_dtype (torch.dtype): dtype for target quantized Tensor
         quant_min (Optional[int]): minimum quantized value for target quantized Tensor
@@ -1256,7 +1256,7 @@ def choose_qparams_affine(
 def _choose_qparams_affine_tinygemm(
     input: torch.Tensor,
     mapping_type: MappingType,
-    block_size: Tuple[int],
+    block_size: List[int],
     target_dtype: torch.dtype,
     quant_min: Optional[Union[int, float]] = None,
     quant_max: Optional[Union[int, float]] = None,
@@ -1273,7 +1273,7 @@ def _choose_qparams_affine_tinygemm(
     Args:
         input (torch.Tensor): fp32, bf16, fp16 input Tensor
         mapping_type (MappingType): determines how the qparams are calculated, symmetric or asymmetric
-        block_size: (Tuple[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
+        block_size: (List[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
         target_dtype (torch.dtype): dtype for target quantized Tensor
         quant_min (Optional[int]): minimum quantized value for target quantized Tensor
         quant_max (Optioanl[int]): maximum quantized value for target quantized Tensor
@@ -1327,7 +1327,7 @@ def _choose_qparams_affine_tinygemm(
 def _choose_qparams_affine_dont_preserve_zero(
     input: torch.Tensor,
     mapping_type: MappingType,
-    block_size: Tuple[int],
+    block_size: List[int],
     target_dtype: torch.dtype,
     quant_min: Optional[Union[int, float, bool]] = None,
     quant_max: Optional[Union[int, float, bool]] = None,
@@ -1340,7 +1340,7 @@ def _choose_qparams_affine_dont_preserve_zero(
     Args:
         input (torch.Tensor): fp32, bf16, fp16 input Tensor
         mapping_type (MappingType): determines how the qparams are calculated, asymmetric only
-        block_size: (Tuple[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
+        block_size: (List[int]): granularity of quantization, this means the size of the tensor elements that's sharing the same qparam
         target_dtype (torch.dtype): dtype for target quantized Tensor
         quant_min (Optional[int]): minimum quantized value for target quantized Tensor
         quant_max (Optioanl[int]): maximum quantized value for target quantized Tensor


### PR DESCRIPTION
Tuple[int] should be Tuple[int, ...]
However,
block_size = _get_per_token_block_size(hp_tensor)
will return List[int]

So they are changed to List[int]

PS: another type annotation bug #3461
