### PR TITLE
Add MXFP4/MXFP8 support for GPTQ quantization and separate eval script

### DIFF
--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -19,6 +19,13 @@ except:
     pack_int4 = None
 
 from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats.inference_workflow import (
+    MXDynamicActivationMXWeightConfig,
+)
+from torchao.prototype.mx_formats.mx_tensor import (
+    MXTensor,
+    to_mx,
+)
 from torchao.quantization import Int4Tensor, Int8Tensor
 from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_api import (
@@ -26,6 +33,7 @@ from torchao.quantization.quant_api import (
     Int8WeightOnlyConfig,
     _module_extra_repr,
 )
+from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
 from torchao.quantization.transform_module import register_quantize_module_handler
 from torchao.quantization.utils import get_block_size
 
@@ -34,6 +42,7 @@ from .observer import GPTQObserverTensor
 CONFIG_TO_TORCHAO_BASE_TENSOR = {
     Int4WeightOnlyConfig: Int4Tensor,
     Int8WeightOnlyConfig: Int8Tensor,
+    MXDynamicActivationMXWeightConfig: MXTensor,
 }
 
 
@@ -42,7 +51,7 @@ class GPTQConfig(AOBaseConfig):
     """Config for GPTQ quantization
 
     GPTQ uses a two-step process:
-    - step="observe": Wraps weights as GPTQObserverTensor to collect Hessian information
+    - step="observe": Wraps weights as ObserverTensor to collect input activations
     - step="convert": Applies GPTQ quantization using the collected observations
 
     Note: By default, the "observe" step uses unquantized weights during forward passes.
@@ -56,13 +65,16 @@ class GPTQConfig(AOBaseConfig):
     Args:
         step: Either "observe" or "convert"
         base_config: Base quantization configuration that determines the target dtype.
-            Use Int4WeightOnlyConfig() for int4 or Int8WeightOnlyConfig() for int8.
+            Use Int4WeightOnlyConfig() for int4, Int8WeightOnlyConfig() for int8,
+            or MXDynamicActivationMXWeightConfig() for MX formats (mxfp8/mxfp4).
         percdamp: Damping factor for Hessian diagonal (default: 0.01)
         gptq_quantize_block_size: Block size for GPTQ algorithm (default: 256)
     """
 
     step: str = "observe"  # "observe" or "convert"
-    base_config: Union[Int4WeightOnlyConfig, Int8WeightOnlyConfig] = None
+    base_config: Union[
+        Int4WeightOnlyConfig, Int8WeightOnlyConfig, MXDynamicActivationMXWeightConfig
+    ] = None
     percdamp: float = 0.01
     gptq_quantize_block_size: int = 256
 
@@ -84,8 +96,24 @@ def _gptq_config_transform(
     tensor = getattr(module, parameter_name)
 
     if config.step == "observe":
-        # Observation phase: wrap as GPTQObserverTensor
-        new_tensor = GPTQObserverTensor.from_hp(tensor)
+        # Observation phase: wrap as GPTQObserverTensor which incrementally
+        # computes the Hessian during forward passes.
+        # For MX dynamic activation configs, pass a quantize_fn so that
+        # activation quantization noise is captured during observation.
+        quantize_fn = None
+        if isinstance(config.base_config, MXDynamicActivationMXWeightConfig):
+            base = config.base_config
+
+            def quantize_fn(x):
+                mx = MXTensor.to_mx(
+                    x.to(torch.bfloat16),
+                    base.activation_dtype,
+                    block_size=base.block_size,
+                    kernel_preference=KernelPreference.EMULATED,
+                )
+                return mx.dequantize(torch.float)
+
+        new_tensor = GPTQObserverTensor.from_hp(tensor, quantize_fn=quantize_fn)
         setattr(module, parameter_name, nn.Parameter(new_tensor, requires_grad=False))
         module.extra_repr = types.MethodType(
             partial(
@@ -97,7 +125,7 @@ def _gptq_config_transform(
         )
         return module
     elif config.step == "convert":
-        # Quantization phase: tensor should be an GPTQObserverTensor
+        # Quantization phase: tensor should be a GPTQObserverTensor
         if not isinstance(tensor, GPTQObserverTensor):
             raise ValueError(
                 f"Expected {parameter_name} to be GPTQObserverTensor in 'convert' step, "
@@ -105,13 +133,12 @@ def _gptq_config_transform(
             )
 
         # Validate that observations were recorded
-        if tensor.hessian is None:
+        if tensor.hessian is None or tensor.total_batches == 0:
             raise ValueError(
                 f"No observations recorded for {parameter_name}. "
-                f"Hessian is None. Did you run forward passes during the observe step?"
+                f"Hessian is empty. Did you run forward passes during the observe step?"
             )
 
-        # Use pre-computed Hessian directly
         hessian = tensor.hessian
         new_tensor = gptq_quantize(hessian, tensor.hp_data, config)
         new_quantized_tensor = nn.Parameter(new_tensor, requires_grad=False)
@@ -225,7 +252,7 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
         config: GPTQ configuration
 
     Returns:
-        Int4Tensor or Int8Tensor: Quantized weight matrix
+        Quantized weight matrix (Int4Tensor, Int8Tensor, or dequantized MXTensor)
     """
     assert W.dim() == 2
     gptq_quantize_block_size = config.gptq_quantize_block_size
@@ -242,6 +269,10 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
         block_size = get_block_size(W.shape, base_config.granularity)
         block_size = list(block_size)
         group_size = block_size[-1]
+    elif isinstance(base_config, MXDynamicActivationMXWeightConfig):
+        group_size = base_config.block_size
+        block_size = [1, group_size]
+        mx_elem_dtype = base_config.weight_dtype
 
     assert group_size > 0
 
@@ -295,6 +326,17 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
                         ],
                         base_config.granularity,
                     )
+                elif isinstance(base_config, MXDynamicActivationMXWeightConfig):
+                    # Compute MX scale for this group of columns
+                    group_data = W_quantize_block[
+                        :, group_start - block_start : group_end - block_start
+                    ]
+                    mx_scale_e8m0, _ = to_mx(
+                        group_data.contiguous(),
+                        mx_elem_dtype,
+                        group_size,
+                    )
+                    group_qparams.append(mx_scale_e8m0)
 
             # Quantize each column and propagate errors to subsequent columns
             for i in range(group_start - block_start, group_end - block_start):
@@ -311,6 +353,26 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
                         scale=quantized_tensor.scale,
                     )
                     dq = q.dequantize(output_dtype=torch.float)
+                elif isinstance(base_config, MXDynamicActivationMXWeightConfig):
+                    # Quantize and dequantize the single column directly
+                    # using the precomputed per-row MX scale.
+                    # Pad w from [N, 1] to [N, group_size] so that
+                    # _mx_quantize_precomputed_scale and to_dtype can
+                    # reshape along the block dimension correctly.
+                    # has shape constraints on
+                    w_padded = torch.zeros(
+                        w.shape[0], group_size, dtype=w.dtype, device=w.device
+                    )
+                    w_padded[:, 0:1] = w
+                    test = MXTensor.to_mx(
+                        w_padded,
+                        mx_elem_dtype,
+                        group_size,
+                        kernel_preference=KernelPreference.EMULATED,
+                        is_swizzled_scales=False,
+                        scale=mx_scale_e8m0,
+                    )
+                    dq = test.dequantize(torch.float)[:, 0:1]
 
                 err1 = (w - dq) / Hinv_quantize_block[i, i]
                 W_quantize_block[:, i:] -= err1.matmul(
@@ -340,7 +402,17 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
         result = Int8Tensor.from_hp(
             W, granularity=base_config.granularity, scale=quantized_tensor.scale
         )
-
+    elif isinstance(base_config, MXDynamicActivationMXWeightConfig):
+        scale = torch.cat(group_qparams, dim=1)
+        result = MXTensor.to_mx(
+            W,
+            base_config.weight_dtype,
+            block_size=base_config.block_size,
+            kernel_preference=KernelPreference.EMULATED,
+            act_quant_kwargs=None,
+            is_swizzled_scales=False,
+            scale=scale,
+        ).dequantize(torch.bfloat16)
     return result
 
 

--- a/torchao/prototype/gptq/gptq_eval.py
+++ b/torchao/prototype/gptq/gptq_eval.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Standalone evaluation script for quantized model checkpoints.
+
+Usage:
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir <path_to_checkpoint>
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir dir1 dir2 dir3
+    python -m torchao.prototype.gptq.gptq_eval --checkpoint-dir Llama-3.1-8B-Instruct_mxfp8-*
+"""
+
+import argparse
+import subprocess
+import sys
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run lm_eval on quantized model checkpoints"
+    )
+    parser.add_argument(
+        "checkpoint_dirs",
+        nargs="+",
+        help="One or more checkpoint directories to evaluate",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="arc_challenge,arc_easy,hellaswag,piqa,winogrande",
+        help="Comma-separated list of lm_eval tasks",
+    )
+    parser.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=0,
+        help="Number of few-shot examples",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=str,
+        default="auto",
+        help="Batch size for evaluation",
+    )
+    return parser.parse_args()
+
+
+def run_lm_eval(checkpoint_dir: str, tasks: str, num_fewshot: int, batch_size: str):
+    print(f"\n{'=' * 60}")
+    print(f"Evaluating: {checkpoint_dir}")
+    print(f"{'=' * 60}\n")
+
+    lm_eval_cmd = [
+        "lm_eval",
+        "--model",
+        "hf",
+        "--model_args",
+        f"pretrained={checkpoint_dir}",
+        "--tasks",
+        tasks,
+        "--num_fewshot",
+        str(num_fewshot),
+        "--batch_size",
+        batch_size,
+    ]
+
+    print(f"Running: {' '.join(lm_eval_cmd)}")
+    try:
+        subprocess.run(lm_eval_cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"lm_eval failed for {checkpoint_dir}: {e}")
+        return False
+    except FileNotFoundError:
+        print("lm_eval not found. Install with: pip install lm-eval")
+        sys.exit(1)
+    return True
+
+
+def main():
+    args = parse_args()
+
+    results = {}
+    for checkpoint_dir in args.checkpoint_dirs:
+        success = run_lm_eval(
+            checkpoint_dir, args.tasks, args.num_fewshot, args.batch_size
+        )
+        results[checkpoint_dir] = "OK" if success else "FAILED"
+
+    if len(args.checkpoint_dirs) > 1:
+        print(f"\n{'=' * 60}")
+        print("Summary:")
+        print(f"{'=' * 60}")
+        for checkpoint_dir, status in results.items():
+            print(f"  {status}: {checkpoint_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Llama-3.1-8B-Instruct | 0-shot accuracy | group_size=128

| Method                         | arc_challenge | arc_easy | hellaswag | piqa   | winogrande | avg    | vs baseline |
|--------------------------------|---------------|----------|-----------|--------|------------|--------|-------------|
| baseline (bf16)                | 0.5529        | 0.7980   | 0.7959    | 0.8145 | 0.7372     | 0.7397 | —           |
| mxfp8 rtn                      | 0.5486        | 0.7904   | 0.7955    | 0.8139 | 0.7435     | 0.7384 | -0.18%      |
| mxfp8 gptq (nonsequential)     | 0.5512        | 0.7959   | 0.7944    | 0.8128 | 0.7490     | 0.7407 | +0.14%      |
| mxfp8 gptq (sequential)        | 0.5529        | 0.7971   | 0.7935    | 0.8134 | 0.7316     | 0.7377 | -0.27%      |
| mxfp4 rtn                      | 0.5179        | 0.7820   | 0.7803    | 0.7987 | 0.7238     | 0.7205 | -2.60%      |
| mxfp4 gptq (sequential)        | 0.5290        | 0.7988   | 0.7817    | 0.8052 | 0.7348     | 0.7299 | -1.32%      |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>