### PR TITLE
Add NVFP4 support for GPTQ

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -21,6 +21,17 @@ from torchao.prototype.gptq.observer import (
 )
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
+    NVFP4DynamicActivationNVFP4WeightConfig,
+    NVFP4WeightOnlyConfig,
+)
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    nvfp4_quantize,
+    per_tensor_amax_to_scale,
+)
+from torchao.prototype.mx_formats.utils import (
+    hp_data_dims_to_swizzled_scale_dims_nvfp4,
+    to_blocked,
 )
 from torchao.quantization import (
     Float8DynamicActivationFloat8WeightConfig,
@@ -30,7 +41,7 @@ from torchao.quantization import (
 )
 from torchao.quantization.granularity import PerRow
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.utils import _is_mslk_available
+from torchao.utils import _is_mslk_available, is_sm_at_least_100
 
 
 class ToyLinearModel(torch.nn.Module):
@@ -763,6 +774,147 @@ class TestGPTQMXFP8:
             is_swizzled_scales=True,
             scale=scale_swizzled,
             kernel_preference=KernelPreference.AUTO,
+        )
+
+        # The dequantized results should match
+        ref_dq = ref.dequantize(data.dtype)
+        result_dq = result.dequantize(data.dtype)
+        torch.testing.assert_close(result_dq, ref_dq, atol=0, rtol=0)
+
+
+class TestGPTQNVFP4:
+    """Test suite for NVFP4 GPTQ support."""
+
+    @pytest.mark.skipif(not is_sm_at_least_100(), reason="Requires SM100+ (Blackwell)")
+    @pytest.mark.parametrize(
+        "base_config",
+        [
+            pytest.param(
+                NVFP4WeightOnlyConfig(use_dynamic_per_tensor_scale=True),
+                id="nvfp4-weight-only-pts",
+            ),
+            pytest.param(
+                NVFP4WeightOnlyConfig(use_dynamic_per_tensor_scale=False),
+                id="nvfp4-weight-only-no-pts",
+            ),
+            pytest.param(
+                NVFP4DynamicActivationNVFP4WeightConfig(
+                    use_triton_kernel=False,
+                    use_dynamic_per_tensor_scale=True,
+                ),
+                id="nvfp4-dynamic",
+            ),
+        ],
+    )
+    def test_nvfp4_gptq_sqnr(self, base_config):
+        """End-to-end SQNR test: GPTQ should produce better quality than RTN for NVFP4."""
+        torch.manual_seed(43)
+
+        # Use dimensions divisible by 16 and 128
+        model = ToyLinearModel(m=512, n=2048, k=1024).cuda().to(torch.bfloat16)
+
+        calibration_inputs = [
+            torch.randn(4, 512, dtype=torch.bfloat16, device="cuda") for _ in range(10)
+        ]
+        test_input = calibration_inputs[0]
+
+        # Get baseline output (full precision)
+        out = model(test_input)
+
+        model_rtn = copy.deepcopy(model)
+        model_gptq = copy.deepcopy(model)
+
+        # --- NVFP4 RTN baseline ---
+        quantize_(model_rtn, base_config)
+        out_rtn = model_rtn(test_input)
+
+        # --- NVFP4 GPTQ ---
+        observe_config = GPTQConfig(step="observe", base_config=base_config)
+        quantize_(model_gptq, observe_config)
+
+        for inp in calibration_inputs:
+            model_gptq(inp)
+
+        convert_config = GPTQConfig(step="convert", base_config=base_config)
+        quantize_(model_gptq, convert_config)
+        out_gptq = model_gptq(test_input)
+
+        from torchao.quantization.utils import compute_error
+
+        sqnr_rtn = compute_error(out_rtn, out)
+        sqnr_gptq = compute_error(out_gptq, out)
+
+        print(f"NVFP4 RTN SQNR: {sqnr_rtn}, NVFP4 GPTQ SQNR: {sqnr_gptq}")
+
+        assert sqnr_gptq > sqnr_rtn, (
+            f"GPTQ SQNR: {sqnr_gptq} is not better than RTN SQNR: {sqnr_rtn}"
+        )
+
+    @pytest.mark.skipif(not is_sm_at_least_100(), reason="Requires SM100+ (Blackwell)")
+    def test_nvfp4_precomputed_scale(self):
+        """Unit test verifying nvfp4_quantize with precomputed scale produces
+        identical results to computing scale from data."""
+        torch.manual_seed(42)
+        data = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda")
+
+        # Compute without precomputed scale
+        scale_ref, data_lp_ref = nvfp4_quantize(data, block_size=16)
+
+        # Now pass the computed scale back as precomputed
+        scale_pre, data_lp_pre = nvfp4_quantize(data, block_size=16, scale=scale_ref)
+
+        torch.testing.assert_close(scale_pre, scale_ref, atol=0, rtol=0)
+        torch.testing.assert_close(data_lp_pre, data_lp_ref, atol=0, rtol=0)
+
+        # Also test with per_tensor_scale
+        pts = per_tensor_amax_to_scale(torch.max(torch.abs(data)))
+        scale_ref2, data_lp_ref2 = nvfp4_quantize(data, block_size=16, per_tensor_scale=pts)
+        scale_pre2, data_lp_pre2 = nvfp4_quantize(
+            data, block_size=16, per_tensor_scale=pts, scale=scale_ref2
+        )
+
+        torch.testing.assert_close(scale_pre2, scale_ref2, atol=0, rtol=0)
+        torch.testing.assert_close(data_lp_pre2, data_lp_ref2, atol=0, rtol=0)
+
+    @pytest.mark.skipif(not is_sm_at_least_100(), reason="Requires SM100+ (Blackwell)")
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (128, 128),
+            (64, 256),
+            (256, 512),
+        ],
+    )
+    def test_manual_scale_swizzling_for_nvfp4_gptq(self, shape):
+        """Verify that scale swizzling round-trip produces correct dequantized results for NVFP4.
+
+        GPTQ computes scales column-by-column in unswizzled format. For CUBLAS mode,
+        these scales must be manually swizzled before passing to NVFP4Tensor.to_nvfp4
+        with is_swizzled_scales=True.
+        """
+        data = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+
+        # Reference: compute with is_swizzled_scales=True directly
+        ref = NVFP4Tensor.to_nvfp4(
+            data_hp=data,
+            block_size=16,
+            is_swizzled_scales=True,
+        )
+
+        # Simulate GPTQ: compute scale in unswizzled format
+        unswizzled = NVFP4Tensor.to_nvfp4(
+            data_hp=data,
+            block_size=16,
+            is_swizzled_scales=False,
+        )
+
+        # Pass unswizzled scale with is_swizzled_scales=True and scale param
+        # to_nvfp4 handles swizzling when is_swizzled_scales=True
+        result = NVFP4Tensor.to_nvfp4(
+            data_hp=data,
+            block_size=16,
+            is_swizzled_scales=True,
+            scale=unswizzled.scale,
         )
 
         # The dequantized results should match

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -21,14 +21,23 @@ except:
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
+    NVFP4DynamicActivationNVFP4WeightConfig,
+    NVFP4WeightOnlyConfig,
 )
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     QuantizeTensorToMXKwargs,
     to_mx,
 )
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    QuantizeTensorToNVFP4Kwargs,
+    nvfp4_quantize,
+    per_tensor_amax_to_scale,
+)
 from torchao.prototype.mx_formats.utils import (
     hp_data_dims_to_swizzled_scale_dims_mx,
+    hp_data_dims_to_swizzled_scale_dims_nvfp4,
     to_blocked,
 )
 from torchao.quantization import Int4Tensor, Int8Tensor
@@ -49,6 +58,8 @@ CONFIG_TO_TORCHAO_BASE_TENSOR = {
     Int4WeightOnlyConfig: Int4Tensor,
     Int8WeightOnlyConfig: Int8Tensor,
     MXDynamicActivationMXWeightConfig: MXTensor,
+    NVFP4WeightOnlyConfig: NVFP4Tensor,
+    NVFP4DynamicActivationNVFP4WeightConfig: NVFP4Tensor,
 }
 
 
@@ -82,6 +93,8 @@ class GPTQConfig(AOBaseConfig):
         Int4WeightOnlyConfig,
         Int8WeightOnlyConfig,
         MXDynamicActivationMXWeightConfig,
+        NVFP4WeightOnlyConfig,
+        NVFP4DynamicActivationNVFP4WeightConfig,
     ] = None
     percdamp: float = 0.01
     gptq_quantize_block_size: int = 256
@@ -120,6 +133,14 @@ def _gptq_config_transform(
                     kernel_preference=base.kernel_preference,  # Use the actual kernel preference
                 )
                 return mx.dequantize(torch.float)
+
+        elif isinstance(config.base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+            base = config.base_config
+
+            def quantize_fn(x):
+                pts = per_tensor_amax_to_scale(torch.max(torch.abs(x))) if base.use_dynamic_per_tensor_scale else None
+                nvfp4 = NVFP4Tensor.to_nvfp4(x.to(torch.bfloat16), block_size=16, per_tensor_scale=pts)
+                return nvfp4.dequantize(torch.float)
 
         new_tensor = GPTQObserverTensor.from_hp(tensor, quantize_fn=quantize_fn)
         setattr(module, parameter_name, nn.Parameter(new_tensor, requires_grad=False))
@@ -281,12 +302,21 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
         group_size = base_config.block_size
         block_size = [1, group_size]
         mx_elem_dtype = base_config.weight_dtype
+    elif isinstance(base_config, (NVFP4WeightOnlyConfig, NVFP4DynamicActivationNVFP4WeightConfig)):
+        group_size = 16
+        block_size = [1, group_size]
 
     assert group_size > 0
 
     W = W.view(-1, W.shape[-1]).detach()
     columns = W.shape[1]
     device = W.device
+
+    # Compute optional NVFP4 per-tensor scale from the original weights
+    nvfp4_per_tensor_scale = None
+    if isinstance(base_config, (NVFP4WeightOnlyConfig, NVFP4DynamicActivationNVFP4WeightConfig)):
+        if base_config.use_dynamic_per_tensor_scale:
+            nvfp4_per_tensor_scale = per_tensor_amax_to_scale(torch.max(torch.abs(W)))
 
     assert device.type == "cuda", "GPTQ only supports CUDA currently"
 
@@ -345,6 +375,16 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
                         group_size,
                     )
                     group_qparams.append(mx_scale_e8m0)
+                elif isinstance(base_config, (NVFP4WeightOnlyConfig, NVFP4DynamicActivationNVFP4WeightConfig)):
+                    group_data = W_quantize_block[
+                        :, group_start - block_start : group_end - block_start
+                    ]
+                    nvfp4_scale, _ = nvfp4_quantize(
+                        group_data.contiguous(),
+                        block_size=16,
+                        per_tensor_scale=nvfp4_per_tensor_scale,
+                    )
+                    group_qparams.append(nvfp4_scale)
 
             # Quantize each column and propagate errors to subsequent columns
             for i in range(group_start - block_start, group_end - block_start):
@@ -381,6 +421,18 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
                         scale=mx_scale_e8m0,
                     )
                     dq = test.dequantize(torch.float)[:, 0:1]
+                elif isinstance(base_config, (NVFP4WeightOnlyConfig, NVFP4DynamicActivationNVFP4WeightConfig)):
+                    w_padded = torch.zeros(
+                        w.shape[0], 16, dtype=w.dtype, device=w.device
+                    )
+                    w_padded[:, 0:1] = w
+                    nvfp4 = NVFP4Tensor.to_nvfp4(
+                        w_padded,
+                        block_size=16,
+                        per_tensor_scale=nvfp4_per_tensor_scale,
+                        scale=nvfp4_scale,
+                    )
+                    dq = nvfp4.dequantize(torch.float)[:, 0:1]
 
                 err1 = (w - dq) / Hinv_quantize_block[i, i]
                 W_quantize_block[:, i:] -= err1.matmul(
@@ -437,6 +489,25 @@ def gptq_quantize(H: torch.Tensor, W: torch.Tensor, config: GPTQConfig):
             is_swizzled_scales=True,
             scaling_mode=base_config.scaling_mode,
             scale=scale_swizzled,
+        )
+    elif isinstance(base_config, (NVFP4WeightOnlyConfig, NVFP4DynamicActivationNVFP4WeightConfig)):
+        scale = torch.cat(group_qparams, dim=1)  # [M, K//16] unswizzled
+
+        act_quant_kwargs = None
+        if isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+            act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
+                use_dynamic_per_tensor_scale=base_config.use_dynamic_per_tensor_scale,
+                use_triton_kernel=base_config.use_triton_kernel,
+                is_swizzled_scales=True,
+            )
+
+        result = NVFP4Tensor.to_nvfp4(
+            W,
+            block_size=16,
+            per_tensor_scale=nvfp4_per_tensor_scale,
+            is_swizzled_scales=True,
+            scale=scale,  # Unswizzled; to_nvfp4 handles swizzling
+            act_quant_kwargs=act_quant_kwargs,
         )
     return result
 

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -17,8 +17,11 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from torchao.prototype.gptq import GPTQConfig
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
+    NVFP4DynamicActivationNVFP4WeightConfig,
+    NVFP4WeightOnlyConfig,
 )
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
@@ -168,6 +171,32 @@ def dequantize_mx_tensors(model):
             setattr(module, keys[-1], torch.nn.Parameter(dequantized, requires_grad=False))
 
 
+def dequantize_nvfp4_tensors(model):
+    """Dequantize any NVFP4Tensor parameters before saving."""
+    # First pass: dequantize all module parameters (weight, bias, etc.)
+    for name, module in model.named_modules():
+        for param_name, param in list(module.named_parameters(recurse=False)):
+            if isinstance(param, NVFP4Tensor):
+                print(f"Dequantizing NVFP4Tensor in {name}.{param_name}")
+                dequantized = param.dequantize(output_dtype=param.orig_dtype)
+                setattr(module, param_name, torch.nn.Parameter(dequantized, requires_grad=False))
+
+    # Second pass: check all parameters in state_dict to catch any remaining NVFP4Tensors
+    state_dict = model.state_dict()
+    for param_name, param in list(state_dict.items()):
+        if isinstance(param, NVFP4Tensor):
+            print(f"Dequantizing remaining NVFP4Tensor: {param_name}")
+            dequantized = param.dequantize(output_dtype=param.orig_dtype)
+            keys = param_name.split('.')
+            module = model
+            for key in keys[:-1]:
+                if key.isdigit():
+                    module = module[int(key)]
+                else:
+                    module = getattr(module, key)
+            setattr(module, keys[-1], torch.nn.Parameter(dequantized, requires_grad=False))
+
+
 def run_lm_eval(model, tokenizer, tasks: str, num_fewshot: int, batch_size: str):
     """Run lm_eval on an in-memory model."""
     import lm_eval
@@ -242,6 +271,12 @@ def parse_args():
             "mxfp4-rtn",
             "mxfp4-gptq-sequential",
             "mxfp4-gptq-nonsequential",
+            "nvfp4-rtn",
+            "nvfp4-gptq-sequential",
+            "nvfp4-gptq-nonsequential",
+            "nvfp4-dynamic-rtn",
+            "nvfp4-dynamic-gptq-sequential",
+            "nvfp4-dynamic-gptq-nonsequential",
         ],
         help="Quantization method to use",
     )
@@ -332,6 +367,10 @@ def main():
         "mxfp8-gptq-nonsequential",
         "mxfp4-gptq-sequential",
         "mxfp4-gptq-nonsequential",
+        "nvfp4-gptq-sequential",
+        "nvfp4-gptq-nonsequential",
+        "nvfp4-dynamic-gptq-sequential",
+        "nvfp4-dynamic-gptq-nonsequential",
     ]:
         output_dir += f"_{args.dataset_id}_n{args.num_calibration_samples}"
         output_dir += f"_damp{args.percdamp}_bs{args.gptq_block_size}"
@@ -369,6 +408,16 @@ def main():
         )
         quantize_(model, config, filter_fn=None)
 
+    elif args.quantization == "nvfp4-rtn":
+        print("Applying NVFP4 weight-only RTN quantization...")
+        config = NVFP4WeightOnlyConfig()
+        quantize_(model, config, filter_fn=None)
+
+    elif args.quantization == "nvfp4-dynamic-rtn":
+        print("Applying NVFP4 dynamic activation RTN quantization...")
+        config = NVFP4DynamicActivationNVFP4WeightConfig()
+        quantize_(model, config, filter_fn=None)
+
     elif args.quantization in [
         "int4-gptq-sequential",
         "int4-gptq-nonsequential",
@@ -378,6 +427,10 @@ def main():
         "mxfp8-gptq-nonsequential",
         "mxfp4-gptq-sequential",
         "mxfp4-gptq-nonsequential",
+        "nvfp4-dynamic-gptq-sequential",
+        "nvfp4-dynamic-gptq-nonsequential",
+        "nvfp4-gptq-sequential",
+        "nvfp4-gptq-nonsequential",
     ]:
         # Determine base config based on quantization type
         if "int4" in args.quantization:
@@ -386,6 +439,12 @@ def main():
         elif "int8" in args.quantization:
             base_config = Int8WeightOnlyConfig(granularity=PerRow(), version=2)
             quant_type = "Int8"
+        elif "nvfp4-dynamic" in args.quantization:
+            base_config = NVFP4DynamicActivationNVFP4WeightConfig()
+            quant_type = "NVFP4-Dynamic"
+        elif "nvfp4" in args.quantization:
+            base_config = NVFP4WeightOnlyConfig()
+            quant_type = "NVFP4"
         elif "mxfp4" in args.quantization:
             base_config = MXDynamicActivationMXWeightConfig(
                 activation_dtype=torch.float4_e2m1fn_x2,
@@ -463,10 +522,13 @@ def main():
         print("Running evaluation...")
         run_lm_eval(model, tokenizer, args.eval_tasks, args.eval_num_fewshot, args.eval_batch_size)
 
-    # Before saving, dequantize any MX tensors
+    # Before saving, dequantize any MX/NVFP4 tensors
     if args.quantization in ["mxfp8-rtn", "mxfp4-rtn", "mxfp8-gptq-sequential", "mxfp8-gptq-nonsequential", "mxfp4-gptq-sequential", "mxfp4-gptq-nonsequential"]:
         print("Dequantizing MX tensors before saving...")
         dequantize_mx_tensors(model)
+    if args.quantization in ["nvfp4-rtn", "nvfp4-dynamic-rtn", "nvfp4-gptq-sequential", "nvfp4-gptq-nonsequential", "nvfp4-dynamic-gptq-sequential", "nvfp4-dynamic-gptq-nonsequential"]:
+        print("Dequantizing NVFP4 tensors before saving...")
+        dequantize_nvfp4_tensors(model)
 
     # Save model to generated output directory
     print(f"Saving model to {output_dir}...")

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -130,6 +130,7 @@ class NVFP4Tensor(TorchAOBaseTensor):
         is_swizzled_scales: bool = False,
         use_triton_kernel: bool = False,
         act_quant_kwargs: Optional[QuantizeTensorToNVFP4Kwargs] = None,
+        scale: Optional[torch.Tensor] = None,
     ):
         """Convert high precision tensor to NVFP4 format.
 
@@ -158,7 +159,7 @@ class NVFP4Tensor(TorchAOBaseTensor):
             blockwise_scales, data_lp = triton_quantize_nvfp4(data_hp, per_tensor_scale)
         else:
             blockwise_scales, data_lp = nvfp4_quantize(
-                data_hp, block_size, per_tensor_scale
+                data_hp, block_size, per_tensor_scale, scale=scale
             )
             if is_swizzled_scales:
                 scale_shape = (math.prod(leading_dims) * M, K // block_size)
@@ -642,6 +643,7 @@ def nvfp4_quantize(
     data_hp: torch.Tensor,
     block_size: int = 16,
     per_tensor_scale: Optional[torch.Tensor] = None,
+    scale: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """NVIDIA FP4 quantization with UE4M3 scales.
 
@@ -674,6 +676,21 @@ def nvfp4_quantize(
     orig_shape = data_hp.shape
     # Convert to float32 early for consistent precision with Triton implementation
     data_hp = data_hp.float().reshape(orig_shape[0], -1, block_size)
+
+    # If precomputed scale is provided, skip scale computation
+    if scale is not None:
+        if per_tensor_scale is None:
+            block_scale_fp32 = scale.to(torch.float32).unsqueeze(-1)
+            data_scaled = data_hp / block_scale_fp32
+        else:
+            total_scale = per_tensor_scale * scale.to(torch.float32)
+            data_scaled = data_hp / total_scale.unsqueeze(-1)
+        out_scales = scale
+        data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+        data_scaled = data_scaled.view(orig_shape)
+        data_lp = f32_to_f4_unpacked(data_scaled)
+        data_lp = pack_uint4(data_lp)
+        return out_scales, data_lp
 
     max_abs = torch.amax(torch.abs(data_hp), dim=-1)
     # These scales are currently in fp32, we are going to `quantize` them to e4m3


### PR DESCRIPTION


Method | arc_challenge | arc_easy | hellaswag | piqa | winogrande | avg | % recovery
-- | -- | -- | -- | -- | -- | -- | --
baseline (bf16) | 0.5529 | 0.7980 | 0.7959 | 0.8145 | 0.7372 | 0.7397 | 100.00%
mxfp8 rtn | 0.5486 | 0.7904 | 0.7955 | 0.8139 | 0.7435 | 0.7384 | 99.82%
mxfp8 gptq (nonsequential) | 0.5512 | 0.7959 | 0.7944 | 0.8128 | 0.7490 | 0.7407 | 100.14%
mxfp8 gptq (sequential) | 0.5529 | 0.7971 | 0.7935 | 0.8134 | 0.7316 | 0.7377 | 99.73%
mxfp4 rtn | 0.5179 | 0.7820 | 0.7803 | 0.7987 | 0.7238 | 0.7205 | 97.40%
mxfp4 gptq (sequential) | 0.5290 | 0.7988 | 0.7817 | 0.8052 | 0.7348 | 0.7299 | 98.68%
nvfp4 weight-only rtn | 0.5392 | 0.7774 | 0.7852 | 0.7900 | 0.7372 | 0.7258 | 98.12%
nvfp4 weight-only gptq (sequential) | 0.5461 | 0.7837 | 0.7868 | 0.7927 | 0.7285 | 0.7276 | 98.36%
nvfp4 dynamic rtn | 0.5367 | 0.7635 | 0.7783 | 0.7764 | 0.7198 | 0.7149 | 96.65%
nvfp4 dynamic gptq (sequential) | 0.5162 | 0.7639 | 0.7794 | 0.7911 | 0.7159 | 0.7133 | 96.43%
