### PR TITLE
Fix float8 + FSDP2 crash with uneven parameter sharding

### DIFF
--- a/test/float8/test_float8_utils.py
+++ b/test/float8/test_float8_utils.py
@@ -8,7 +8,7 @@ import unittest
 import pytest
 import torch
 
-from torchao.float8.float8_utils import _round_scale_down_to_power_of_2
+from torchao.float8.float8_utils import _round_scale_down_to_power_of_2, tensor_to_amax
 from torchao.testing.utils import skip_if_rocm
 
 
@@ -67,3 +67,12 @@ def test_non_float32_input(invalid_dtype: torch.dtype):
     non_float32_tensor = torch.tensor([3.0], dtype=invalid_dtype)
     with pytest.raises(AssertionError, match="scale must be float32 tensor"):
         _round_scale_down_to_power_of_2(non_float32_tensor)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+def test_tensor_to_amax_empty():
+    """tensor_to_amax should return 0 for empty tensors (FSDP2 uneven sharding)."""
+    empty = torch.empty(0, device="cuda", dtype=torch.bfloat16)
+    amax = tensor_to_amax(empty)
+    assert amax.item() == 0.0
+    assert amax.dtype == torch.float32

--- a/test/float8/test_fsdp2/test_fsdp2.py
+++ b/test/float8/test_fsdp2/test_fsdp2.py
@@ -596,5 +596,31 @@ class TestFloat8MultiThread(FSDPTestMultiThread, TestFloat8Common):
         )
 
 
+class TestFloat8UnevenShardMultiThread(FSDPTestMultiThread, TestFloat8Common):
+    """Tests float8 + FSDP2 with uneven parameter sharding (numel % world_size != 0)."""
+
+    @property
+    def world_size(self) -> int:
+        return 3
+
+    @unittest.skipIf(not TEST_CUDA, "no cuda")
+    @skip_if_lt_x_gpu(3)
+    def test_uneven_shard_fwd_bwd(self):
+        """Forward+backward with uneven sharding should not crash."""
+        torch.manual_seed(42)
+        # 17 * 16 = 272, 272 % 3 = 2 → uneven sharding
+        module = nn.Linear(16, 17, bias=False, device="cuda")
+        self.broadcast_module(module)
+        float8_config = Float8LinearConfig(
+            enable_fsdp_float8_all_gather=True,
+            emulate=True,
+        )
+        module = convert_to_float8_training(module, config=float8_config)
+        fully_shard(module)
+        inp = torch.randn(4, 16, device="cuda")
+        out = module(inp)
+        out.sum().backward()
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -62,7 +62,10 @@ def tensor_to_amax(
     axiswise_dim: Optional[int] = None,
 ) -> torch.Tensor:
     if scaling_granularity is ScalingGranularity.TENSORWISE:
-        amax = torch.max(torch.abs(x))
+        if x.numel() == 0:
+            amax = torch.tensor(0.0, dtype=torch.float32, device=x.device)
+        else:
+            amax = torch.max(torch.abs(x))
     else:
         assert scaling_granularity is ScalingGranularity.AXISWISE, "unsupported"
         assert axiswise_dim is not None, "unsupported"

--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -225,7 +225,9 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
     def __repr__(self):
         return f"WeightWithDynamicFloat8CastTensor(tensor={self._tensor}, linear_mm_config={self._linear_mm_config}, dtype={self._dtype})"
 
-    def fsdp_pre_all_gather(self, mesh):
+    def fsdp_pre_all_gather(
+        self, mesh, outer_size=None, outer_stride=None, module=None, mp_policy=None
+    ):
         if self._precomputed_scale is not None:
             float8_training_tensor = hp_tensor_and_scale_to_float8(
                 self._tensor,
@@ -243,7 +245,21 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
                 gemm_input_role=GemmInputRole.WEIGHT,
                 device_mesh=mesh,
             )
-        return (float8_training_tensor._data,), (float8_training_tensor._scale,)
+        data = float8_training_tensor._data
+        # Pad the fp8 data to match FSDP2's padded shard size for uneven sharding.
+        # When the parameter's shard dim doesn't divide evenly by world_size,
+        # FSDP2 expects all-gather inputs at the padded (ceil) size.
+        if outer_size is not None:
+            import math
+            shard_dim = 0
+            padded_dim0 = math.ceil(outer_size[shard_dim] / mesh.size())
+            if data.shape[shard_dim] < padded_dim0:
+                padded_shape = list(data.shape)
+                padded_shape[shard_dim] = padded_dim0
+                padded = data.new_zeros(padded_shape)
+                padded[: data.shape[shard_dim]] = data
+                data = padded
+        return (data,), (float8_training_tensor._scale,)
 
     def fsdp_post_all_gather(
         self,


### PR DESCRIPTION
Fix for #3982 and #1938.

## Problem

Float8 training with `enable_fsdp_float8_all_gather=True` crashes when `param.numel() % world_size != 0`. FSDP2 shards along dim 0 and the last rank gets fewer rows. Two crashes result:

1. **`tensor_to_amax` on empty shards**: `torch.max(torch.abs(x))` crashes when `x.numel() == 0` (small layers where some ranks get zero elements)
2. **Storage mismatch after all-gather**: `fsdp_pre_all_gather` uses the old 1-param signature, so FSDP2 cannot enforce padding. The last rank returns unpadded fp8 data, causing the all-gather buffer to be too small to reconstruct the original weight shape.

Example: `nn.Linear(1024, 4096)` with 3 GPUs → dim 0 splits as (1366, 1366, 1364). Rank 2 returns `(1364, 1024)` fp8 data. All-gather buffer = `1364*1024*3 = 4,190,208` but original needs `4096*1024 = 4,194,304`.

## Fix

1. **`float8_utils.py`**: Return `torch.tensor(0.0)` for empty tensors in `tensor_to_amax`
2. **`fsdp_utils.py`**: Upgrade `fsdp_pre_all_gather` to the 5-param signature (receives `outer_size`). Compute `padded_dim0 = ceil(outer_size[0] / mesh.size())` and zero-pad the fp8 data when the shard is smaller. This lets FSDP2 handle padding/unpadding correctly during all-gather.

## Tests

- `test_float8_utils.py`: Verify `tensor_to_amax` returns 0.0 for empty tensors
- `test_fsdp2.py`: 3-GPU forward+backward with `nn.Linear(16, 17)` where `17*16 % 3 != 0`

## Repro

```python
import torch, torch.nn as nn, torch.distributed as dist
from torch.distributed._composable.fsdp import fully_shard
from torchao.float8 import convert_to_float8_training
from torchao.float8.config import Float8LinearConfig

dist.init_process_group("nccl")
torch.cuda.set_device(dist.get_rank())

model = nn.Linear(1024, 4096, bias=False).cuda().bfloat16()
convert_to_float8_training(model, config=Float8LinearConfig(enable_fsdp_float8_all_gather=True))
fully_shard(model)

x = torch.randn(2, 128, 1024, device="cuda", dtype=torch.bfloat16)
model(x).sum().backward()  # crashes with world_size=3, works with world_size=4
```

Tested on H100 with torch 2.12.0.dev nightly.

Made with [Cursor](https://cursor.com)