### PR TITLE
add int8 qkv-fusion pass for x86

### DIFF
--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,6 +245,33 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
+class fuse_MHAModule(torch.nn.Module):
+    def __init__(
+        self,
+        input_dim,
+        has_mask,
+        num_attention_heads,
+        attention_head_size,
+    ) -> None:
+        super().__init__()
+        self.qkv_proj = torch.nn.Linear(input_dim * 3, input_dim * 3, bias=False)
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_size = attention_head_size
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+        self.dense = torch.nn.Linear(self.all_head_size, self.all_head_size)
+        self.attn_mod = SDPA(
+            input_dim,
+            has_mask,
+            num_attention_heads,
+            attention_head_size,
+        )
+
+    def forward(self, x, mask):
+        q, k, v = self.qkv_proj(x).chunk(3, dim=-1)
+        context_layer = self.attn_mod(q, k, v, mask)
+        return self.dense(context_layer)
+
+
 class TestSDPAPatternRewriterTemplate(TestCase):
     def _clone_inputs(self, inputs):
         def clone(x):
@@ -343,19 +370,22 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, has_mask, bs in itertools.product(
-            [torch.float32, torch.bfloat16], [True, False], [56, 1]
-        ):
+        for dtype, has_mask, bs, fused in itertools.product(
+            [torch.float32], [True], [56], [True]
+        ):#, torch.bfloat16, False, 1, False
             seqlen, numhead, headsize = 197, 16, 64
-            mod = MHAModule(
-                input_dim=headsize * numhead,
+            input_dim = headsize * numhead
+            mod = (fuse_MHAModule if fused else MHAModule)(
+                input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
+                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 torch.randn((bs, 1, 1, seqlen), device=self.device)
                 if has_mask
@@ -400,17 +430,22 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, bs in itertools.product([torch.float32, torch.bfloat16], [56, 1]):
+        for dtype, bs, fused in itertools.product(
+            [torch.float32, torch.bfloat16], [56, 1], [True, False]
+        ):
             seqlen, numhead, headsize = 197, 16, 64
-            mod = MHAModule(
-                input_dim=headsize * numhead,
+            input_dim = headsize * numhead
+            mod = (fuse_MHAModule if fused else MHAModule)(
+                input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
+                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 None,
             )

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -371,8 +371,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         # pattern is different for bs=1
         torch.manual_seed(1234)
         for dtype, has_mask, bs, fused in itertools.product(
-            [torch.float32], [True], [56], [True]
-        ):#, torch.bfloat16, False, 1, False
+             [torch.float32, torch.bfloat16], [True, False], [56, 1], [True, False]
+        ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
             mod = (fuse_MHAModule if fused else MHAModule)(

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,7 +245,7 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
-class fuse_MHAModule(torch.nn.Module):
+class fusedMHAModule(torch.nn.Module):
     def __init__(
         self,
         input_dim,
@@ -254,7 +254,7 @@ class fuse_MHAModule(torch.nn.Module):
         attention_head_size,
     ) -> None:
         super().__init__()
-        self.qkv_proj = torch.nn.Linear(input_dim * 3, input_dim * 3, bias=False)
+        self.qkv_proj = torch.nn.Linear(input_dim, input_dim * 3, bias=False)
         self.num_attention_heads = num_attention_heads
         self.attention_head_size = attention_head_size
         self.all_head_size = self.num_attention_heads * self.attention_head_size
@@ -375,7 +375,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fuse_MHAModule if fused else MHAModule)(
+            mod = (fusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
@@ -383,7 +383,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    (bs, seqlen, input_dim),
                     device=self.device,
                     dtype=dtype,
                 ),
@@ -435,7 +435,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fuse_MHAModule if fused else MHAModule)(
+            mod = (fusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,
@@ -443,7 +443,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    (bs, seqlen, input_dim),
                     device=self.device,
                     dtype=dtype,
                 ),

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,7 +245,7 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
-class fusedMHAModule(torch.nn.Module):
+class FusedMHAModule(torch.nn.Module):
     def __init__(
         self,
         input_dim,
@@ -375,7 +375,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fusedMHAModule if fused else MHAModule)(
+            mod = (FusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
@@ -435,7 +435,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fusedMHAModule if fused else MHAModule)(
+            mod = (FusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,33 +245,6 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
-class FusedMHAModule(torch.nn.Module):
-    def __init__(
-        self,
-        input_dim,
-        has_mask,
-        num_attention_heads,
-        attention_head_size,
-    ) -> None:
-        super().__init__()
-        self.qkv_proj = torch.nn.Linear(input_dim, input_dim * 3, bias=False)
-        self.num_attention_heads = num_attention_heads
-        self.attention_head_size = attention_head_size
-        self.all_head_size = self.num_attention_heads * self.attention_head_size
-        self.dense = torch.nn.Linear(self.all_head_size, self.all_head_size)
-        self.attn_mod = SDPA(
-            input_dim,
-            has_mask,
-            num_attention_heads,
-            attention_head_size,
-        )
-
-    def forward(self, x, mask):
-        q, k, v = self.qkv_proj(x).chunk(3, dim=-1)
-        context_layer = self.attn_mod(q, k, v, mask)
-        return self.dense(context_layer)
-
-
 class TestSDPAPatternRewriterTemplate(TestCase):
     def _clone_inputs(self, inputs):
         def clone(x):
@@ -369,22 +342,19 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, has_mask, bs, fused in itertools.product(
-             [torch.float32, torch.bfloat16], [True, False], [56, 1], [True, False]
+        for dtype, has_mask, bs in itertools.product(
+            [torch.float32, torch.bfloat16], [True, False], [56, 1]
         ):
             seqlen, numhead, headsize = 197, 16, 64
-            input_dim = headsize * numhead
-            mod = (FusedMHAModule if fused else MHAModule)(
-                input_dim=input_dim,
+            mod = MHAModule(
+                input_dim=headsize * numhead,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim),
-                    device=self.device,
-                    dtype=dtype,
+                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
                 ),
                 torch.randn((bs, 1, 1, seqlen), device=self.device)
                 if has_mask
@@ -423,28 +393,91 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
         reason="cpp kernels not built",
     )
+    @config.patch({"freezing": True, "cpp.enable_concat_linear": True})
+    def _test_int8_fusedmha_rewriter(self):
+        import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
+        from torchao.prototype.inductor.fx_passes.int8_concat_linear_fusion_cpu import (
+            register_int8_concat_linear_cpu_pass,
+        )
+        from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+        from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import (
+            X86InductorQuantizer,
+        )
+
+        # pattern is different for bs=1
+        torch.manual_seed(1234)
+        for dtype, has_mask, bs in itertools.product(
+            [torch.float32, torch.bfloat16], [True, False], [56, 1]
+        ):
+            seqlen, numhead, headsize = 197, 16, 64
+            mod = MHAModule(
+                input_dim=headsize * numhead,
+                has_mask=has_mask,
+                num_attention_heads=numhead,
+                attention_head_size=headsize,
+            ).eval()
+            inputs = (
+                torch.randn(
+                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
+                ),
+                torch.randn((bs, 1, 1, seqlen), device=self.device)
+                if has_mask
+                else None,
+            )
+            enable_autocast = dtype == torch.bfloat16
+            with (
+                torch.no_grad(),
+                torch.amp.autocast(
+                    self.device, enabled=enable_autocast, dtype=torch.bfloat16
+                ),
+                config.patch(
+                    post_grad_custom_pre_pass=custom_pass,
+                    post_grad_custom_post_pass=None,
+                ),
+            ):
+                _qsdpa_init()
+                register_int8_concat_linear_cpu_pass()
+                quantizer = X86InductorQuantizer()
+                quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())
+                quantizer.set_function_type_qconfig(
+                    torch.matmul, quantizer.get_global_quantization_config()
+                )
+                export_model = torch.export.export(mod, inputs, strict=True).module()
+                prepare_model = prepare_pt2e(export_model, quantizer)
+                prepare_model(*inputs)
+                convert_model = convert_pt2e(prepare_model)
+                torchao.quantization.pt2e.move_exported_model_to_eval(convert_model)
+
+                self._check_common(
+                    convert_model, args1=inputs, check_train=False, atol=1.0
+                )
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not torch_version_at_least("2.7.0"),
+        reason="qsdpa requires torch 2.7 or later",
+    )
+    @unittest.skipIf(
+        "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
+        reason="cpp kernels not built",
+    )
     @config.patch({"freezing": True})
     def _test_fp8_sdpa_rewriter(self):
         import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq  # noqa: F401
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, bs, fused in itertools.product(
-            [torch.float32, torch.bfloat16], [56, 1], [True, False]
-        ):
+        for dtype, bs in itertools.product([torch.float32, torch.bfloat16], [56, 1]):
             seqlen, numhead, headsize = 197, 16, 64
-            input_dim = headsize * numhead
-            mod = (FusedMHAModule if fused else MHAModule)(
-                input_dim=input_dim,
+            mod = MHAModule(
+                input_dim=headsize * numhead,
                 has_mask=False,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim),
-                    device=self.device,
-                    dtype=dtype,
+                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
                 ),
                 None,
             )
@@ -470,6 +503,9 @@ if HAS_CPU:
         device = "cpu"
         test_int8_sdpa_rewriter_cpu = (
             TestSDPAPatternRewriterTemplate._test_int8_sdpa_rewriter
+        )
+        test_int8_fusedmha_rewriter_cpu = (
+            TestSDPAPatternRewriterTemplate._test_int8_fusedmha_rewriter
         )
         test_fp8_sdpa_rewriter_cpu = (
             TestSDPAPatternRewriterTemplate._test_fp8_sdpa_rewriter

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -332,7 +332,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
         reason="cpp kernels not built",
     )
-    @config.patch({"freezing": True, "cpp.enable_concat_linear": True})
+    @config.patch({"freezing": True})
     def _test_int8_sdpa_rewriter(self):
         import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
         from torchao.prototype.inductor.fx_passes.int8_concat_linear_fusion_cpu import (

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,7 +245,7 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
-class fusedMHAModule(torch.nn.Module):
+class FusedMHAModule(torch.nn.Module):
     def __init__(
         self,
         input_dim,
@@ -374,7 +374,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fusedMHAModule if fused else MHAModule)(
+            mod = (FusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
@@ -434,7 +434,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fusedMHAModule if fused else MHAModule)(
+            mod = (FusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,7 +245,7 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
-class fuse_MHAModule(torch.nn.Module):
+class fusedMHAModule(torch.nn.Module):
     def __init__(
         self,
         input_dim,
@@ -254,7 +254,7 @@ class fuse_MHAModule(torch.nn.Module):
         attention_head_size,
     ) -> None:
         super().__init__()
-        self.qkv_proj = torch.nn.Linear(input_dim * 3, input_dim * 3, bias=False)
+        self.qkv_proj = torch.nn.Linear(input_dim, input_dim * 3, bias=False)
         self.num_attention_heads = num_attention_heads
         self.attention_head_size = attention_head_size
         self.all_head_size = self.num_attention_heads * self.attention_head_size
@@ -374,7 +374,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fuse_MHAModule if fused else MHAModule)(
+            mod = (fusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
@@ -382,7 +382,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    (bs, seqlen, input_dim),
                     device=self.device,
                     dtype=dtype,
                 ),
@@ -434,7 +434,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
-            mod = (fuse_MHAModule if fused else MHAModule)(
+            mod = (fusedMHAModule if fused else MHAModule)(
                 input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,
@@ -442,7 +442,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    (bs, seqlen, input_dim),
                     device=self.device,
                     dtype=dtype,
                 ),

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -398,6 +398,7 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                     self.assertGreaterEqual(
                         counters["inductor"]["int8_concat_linear_fusion"], 1
                     )
+
     @skipIfRocm
     @unittest.skipIf(
         not torch_version_at_least("2.7.0"),

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -394,7 +394,10 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 self._check_common(
                     convert_model, args1=inputs, check_train=False, atol=1.0
                 )
-
+                if enable_concat_linear_fusion:
+                    self.assertGreaterEqual(
+                        counters["inductor"]["int8_concat_linear_fusion"], 1
+                    )
     @skipIfRocm
     @unittest.skipIf(
         not torch_version_at_least("2.7.0"),

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -245,6 +245,33 @@ class MHAModule(torch.nn.Module):
         return self.dense(context_layer)
 
 
+class fuse_MHAModule(torch.nn.Module):
+    def __init__(
+        self,
+        input_dim,
+        has_mask,
+        num_attention_heads,
+        attention_head_size,
+    ) -> None:
+        super().__init__()
+        self.qkv_proj = torch.nn.Linear(input_dim * 3, input_dim * 3, bias=False)
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_size = attention_head_size
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+        self.dense = torch.nn.Linear(self.all_head_size, self.all_head_size)
+        self.attn_mod = SDPA(
+            input_dim,
+            has_mask,
+            num_attention_heads,
+            attention_head_size,
+        )
+
+    def forward(self, x, mask):
+        q, k, v = self.qkv_proj(x).chunk(3, dim=-1)
+        context_layer = self.attn_mod(q, k, v, mask)
+        return self.dense(context_layer)
+
+
 class TestSDPAPatternRewriterTemplate(TestCase):
     def _clone_inputs(self, inputs):
         def clone(x):
@@ -342,19 +369,22 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, has_mask, bs in itertools.product(
-            [torch.float32, torch.bfloat16], [True, False], [56, 1]
-        ):
+        for dtype, has_mask, bs, fused in itertools.product(
+            [torch.float32], [True], [56], [True]
+        ):#, torch.bfloat16, False, 1, False
             seqlen, numhead, headsize = 197, 16, 64
-            mod = MHAModule(
-                input_dim=headsize * numhead,
+            input_dim = headsize * numhead
+            mod = (fuse_MHAModule if fused else MHAModule)(
+                input_dim=input_dim,
                 has_mask=has_mask,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
+                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 torch.randn((bs, 1, 1, seqlen), device=self.device)
                 if has_mask
@@ -399,17 +429,22 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, bs in itertools.product([torch.float32, torch.bfloat16], [56, 1]):
+        for dtype, bs, fused in itertools.product(
+            [torch.float32, torch.bfloat16], [56, 1], [True, False]
+        ):
             seqlen, numhead, headsize = 197, 16, 64
-            mod = MHAModule(
-                input_dim=headsize * numhead,
+            input_dim = headsize * numhead
+            mod = (fuse_MHAModule if fused else MHAModule)(
+                input_dim=input_dim,
                 has_mask=False,
                 num_attention_heads=numhead,
                 attention_head_size=headsize,
             ).eval()
             inputs = (
                 torch.randn(
-                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
+                    (bs, seqlen, input_dim * 3 if fused else input_dim),
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 None,
             )

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -370,8 +370,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         # pattern is different for bs=1
         torch.manual_seed(1234)
         for dtype, has_mask, bs, fused in itertools.product(
-            [torch.float32], [True], [56], [True]
-        ):#, torch.bfloat16, False, 1, False
+             [torch.float32, torch.bfloat16], [True, False], [56, 1], [True, False]
+        ):
             seqlen, numhead, headsize = 197, 16, 64
             input_dim = headsize * numhead
             mod = (fuse_MHAModule if fused else MHAModule)(

--- a/test/prototype/inductor/test_qsdpa_fusion.py
+++ b/test/prototype/inductor/test_qsdpa_fusion.py
@@ -332,69 +332,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
         "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
         reason="cpp kernels not built",
     )
-    @config.patch({"freezing": True})
-    def _test_int8_sdpa_rewriter(self):
-        import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
-        from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
-        from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import (
-            X86InductorQuantizer,
-        )
-
-        # pattern is different for bs=1
-        torch.manual_seed(1234)
-        for dtype, has_mask, bs in itertools.product(
-            [torch.float32, torch.bfloat16], [True, False], [56, 1]
-        ):
-            seqlen, numhead, headsize = 197, 16, 64
-            mod = MHAModule(
-                input_dim=headsize * numhead,
-                has_mask=has_mask,
-                num_attention_heads=numhead,
-                attention_head_size=headsize,
-            ).eval()
-            inputs = (
-                torch.randn(
-                    (bs, seqlen, headsize * numhead), device=self.device, dtype=dtype
-                ),
-                torch.randn((bs, 1, 1, seqlen), device=self.device)
-                if has_mask
-                else None,
-            )
-            enable_autocast = dtype == torch.bfloat16
-            with (
-                torch.no_grad(),
-                torch.amp.autocast(
-                    self.device, enabled=enable_autocast, dtype=torch.bfloat16
-                ),
-                config.patch(post_grad_custom_pre_pass=custom_pass),
-            ):
-                _qsdpa_init()
-                quantizer = X86InductorQuantizer()
-                quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())
-                quantizer.set_function_type_qconfig(
-                    torch.matmul, quantizer.get_global_quantization_config()
-                )
-                export_model = torch.export.export(mod, inputs, strict=True).module()
-                prepare_model = prepare_pt2e(export_model, quantizer)
-                prepare_model(*inputs)
-                convert_model = convert_pt2e(prepare_model)
-                torchao.quantization.pt2e.move_exported_model_to_eval(convert_model)
-
-                self._check_common(
-                    convert_model, args1=inputs, check_train=False, atol=1.0
-                )
-
-    @skipIfRocm
-    @unittest.skipIf(
-        not torch_version_at_least("2.7.0"),
-        reason="qsdpa requires torch 2.7 or later",
-    )
-    @unittest.skipIf(
-        "CPU" not in torch._C._dispatch_dump("torchao::qscaled_dot_product"),
-        reason="cpp kernels not built",
-    )
     @config.patch({"freezing": True, "cpp.enable_concat_linear": True})
-    def _test_int8_fusedmha_rewriter(self):
+    def _test_int8_sdpa_rewriter(self):
         import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
         from torchao.prototype.inductor.fx_passes.int8_concat_linear_fusion_cpu import (
             register_int8_concat_linear_cpu_pass,
@@ -406,10 +345,13 @@ class TestSDPAPatternRewriterTemplate(TestCase):
 
         # pattern is different for bs=1
         torch.manual_seed(1234)
-        for dtype, has_mask, bs in itertools.product(
-            [torch.float32, torch.bfloat16], [True, False], [56, 1]
+        for enable_concat_linear_fusion, dtype, has_mask, bs in itertools.product(
+            [False, True],
+            [torch.float32, torch.bfloat16],
+            [True, False],
+            [56, 1],
         ):
-            seqlen, numhead, headsize = 197, 16, 64
+            seqlen, numhead, headsize = 100, 12, 64
             mod = MHAModule(
                 input_dim=headsize * numhead,
                 has_mask=has_mask,
@@ -436,7 +378,8 @@ class TestSDPAPatternRewriterTemplate(TestCase):
                 ),
             ):
                 _qsdpa_init()
-                register_int8_concat_linear_cpu_pass()
+                if enable_concat_linear_fusion:
+                    register_int8_concat_linear_cpu_pass()
                 quantizer = X86InductorQuantizer()
                 quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())
                 quantizer.set_function_type_qconfig(
@@ -503,9 +446,6 @@ if HAS_CPU:
         device = "cpu"
         test_int8_sdpa_rewriter_cpu = (
             TestSDPAPatternRewriterTemplate._test_int8_sdpa_rewriter
-        )
-        test_int8_fusedmha_rewriter_cpu = (
-            TestSDPAPatternRewriterTemplate._test_int8_fusedmha_rewriter
         )
         test_fp8_sdpa_rewriter_cpu = (
             TestSDPAPatternRewriterTemplate._test_fp8_sdpa_rewriter

--- a/torchao/prototype/inductor/codegen/cpp_int8_sdpa_template.py
+++ b/torchao/prototype/inductor/codegen/cpp_int8_sdpa_template.py
@@ -799,9 +799,7 @@ extern "C"
 {%- endif %}
 
   // Data ptrs
-  const scalar_t* q_data = query;
-  const scalar_t* k_data = key;
-  const scalar_t* v_data = value;
+  {{template.codegen_qkv_ptr(kernel)}}
   scalar_t* out_data = output;
 
   bool headSize_mul64 = headSize % 64 == 0;
@@ -1223,9 +1221,7 @@ extern "C"
 {%- endif %}
 
   // Data ptrs
-  const scalar_t* q_data = query;
-  const scalar_t* k_data = key;
-  const scalar_t* v_data = value;
+  {{template.codegen_qkv_ptr(kernel)}}
   scalar_t* out_data = output;
 
   int64_t qk_reduce_strideL = qSplitSize * rndkvSplitSize;
@@ -1776,3 +1772,18 @@ class CppInt8SdpaTemplate(CppFlexAttentionTemplate):
                 buffer_size=buffer_size,
             )
         )
+
+    def codegen_qkv_ptr(self, kernel):
+        if len(kernel.args.input_buffers)==1:
+            buf_name = next(iter(kernel.args.input_buffers.values()))
+            return f"""
+  const scalar_t* q_data = {buf_name} + {self.input_nodes[0].layout.offset};
+  const scalar_t* k_data = {buf_name} + {self.input_nodes[1].layout.offset};
+  const scalar_t* v_data = {buf_name} + {self.input_nodes[2].layout.offset};
+"""
+        else:
+            return f"""
+  const scalar_t* q_data = query;
+  const scalar_t* k_data = key;
+  const scalar_t* v_data = value;
+"""

--- a/torchao/prototype/inductor/codegen/cpp_qsdpa_template.py
+++ b/torchao/prototype/inductor/codegen/cpp_qsdpa_template.py
@@ -2294,16 +2294,11 @@ class CppQsdpaTemplate(CppFlexAttentionTemplate):
         )
 
     def codegen_qkv_ptr(self, kernel):
-        if len(kernel.args.input_buffers)==1:
-            buf_name = next(iter(kernel.args.input_buffers.values()))
-            return f"""
-  const scalar_t* q_data = {buf_name} + {self.input_nodes[0].layout.offset};
-  const scalar_t* k_data = {buf_name} + {self.input_nodes[1].layout.offset};
-  const scalar_t* v_data = {buf_name} + {self.input_nodes[2].layout.offset};
-"""
-        else:
-            return f"""
-  const scalar_t* q_data = query;
-  const scalar_t* k_data = key;
-  const scalar_t* v_data = value;
+        q_name = kernel.args.input(self.input_nodes[0].get_name())
+        k_name = kernel.args.input(self.input_nodes[1].get_name())
+        v_name = kernel.args.input(self.input_nodes[2].get_name())
+        return f"""
+  const scalar_t* q_data = {q_name} + {self.input_nodes[0].layout.offset};
+  const scalar_t* k_data = {k_name} + {self.input_nodes[1].layout.offset};
+  const scalar_t* v_data = {v_name} + {self.input_nodes[2].layout.offset};
 """

--- a/torchao/prototype/inductor/codegen/cpp_qsdpa_template.py
+++ b/torchao/prototype/inductor/codegen/cpp_qsdpa_template.py
@@ -1012,9 +1012,7 @@ extern "C"
 {%- endif %}
 
   // Data ptrs
-  const scalar_t* q_data = query;
-  const scalar_t* k_data = key;
-  const scalar_t* v_data = value;
+  {{template.codegen_qkv_ptr(kernel)}}
   scalar_t* out_data = output;
 
   bool headSize_mul64 = headSize % 64 == 0;
@@ -1437,9 +1435,7 @@ extern "C"
 {%- endif %}
 
   // Data ptrs
-  const scalar_t* q_data = query;
-  const scalar_t* k_data = key;
-  const scalar_t* v_data = value;
+  {{template.codegen_qkv_ptr(kernel)}}
   scalar_t* out_data = output;
 
   int64_t qk_reduce_strideL = qSplitSize * rndkvSplitSize;
@@ -2296,3 +2292,18 @@ class CppQsdpaTemplate(CppFlexAttentionTemplate):
                 buffer_size=buffer_size,
             )
         )
+
+    def codegen_qkv_ptr(self, kernel):
+        if len(kernel.args.input_buffers)==1:
+            buf_name = next(iter(kernel.args.input_buffers.values()))
+            return f"""
+  const scalar_t* q_data = {buf_name} + {self.input_nodes[0].layout.offset};
+  const scalar_t* k_data = {buf_name} + {self.input_nodes[1].layout.offset};
+  const scalar_t* v_data = {buf_name} + {self.input_nodes[2].layout.offset};
+"""
+        else:
+            return f"""
+  const scalar_t* q_data = query;
+  const scalar_t* k_data = key;
+  const scalar_t* v_data = value;
+"""

--- a/torchao/prototype/inductor/fx_passes/__init__.py
+++ b/torchao/prototype/inductor/fx_passes/__init__.py
@@ -1,7 +1,9 @@
 from .da8w4_concat_linear_fusion_cpu import register_da8w4_concat_linear_cpu_pass
+from .int8_concat_linear_fusion_cpu import  register_int8_concat_linear_cpu_pass
 from .qsdpa_fusion import _qsdpa_init
 
 __all__ = [
     "_qsdpa_init",
     "register_da8w4_concat_linear_cpu_pass",
+    "register_int8_concat_linear_cpu_pass",
 ]

--- a/torchao/prototype/inductor/fx_passes/__init__.py
+++ b/torchao/prototype/inductor/fx_passes/__init__.py
@@ -1,5 +1,5 @@
 from .da8w4_concat_linear_fusion_cpu import register_da8w4_concat_linear_cpu_pass
-from .int8_concat_linear_fusion_cpu import  register_int8_concat_linear_cpu_pass
+from .int8_concat_linear_fusion_cpu import register_int8_concat_linear_cpu_pass
 from .qsdpa_fusion import _qsdpa_init
 
 __all__ = [

--- a/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
+++ b/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
@@ -1,0 +1,444 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+
+import torch
+
+
+QLINEAR_TARGETS = {
+    torch.ops.onednn.qlinear_pointwise.default,
+    torch.ops.onednn.qlinear_pointwise.tensor,
+}
+
+
+def _is_qlinear_target(target):
+    if target in QLINEAR_TARGETS:
+        return True
+    return (
+        callable(target)
+        and getattr(target, "__module__", "") == "torch._inductor.fx_passes.quantization"
+        and getattr(target, "__name__", "") == "qlinear"
+    )
+
+
+def _get_node_arg(node, kwarg_name, arg_index):
+    if kwarg_name in node.kwargs:
+        return node.kwargs[kwarg_name]
+    return node.args[arg_index]
+
+
+def _build_qlinear_node(graph, target, **kwargs):
+    if target in QLINEAR_TARGETS:
+        ordered_args = (
+            kwargs["x"],
+            kwargs["x_scale"],
+            kwargs["x_zp"],
+            kwargs["packed_weight"],
+            kwargs["w_scale"],
+            kwargs["w_zp"],
+            kwargs["b"],
+            kwargs["output_scale"],
+            kwargs["output_zero_point"],
+            kwargs["output_dtype"],
+            kwargs["postop_name"],
+            kwargs["postop_args"],
+            kwargs["postop_algorithm"],
+        )
+        return graph.create_node("call_function", target, ordered_args)
+    return graph.create_node("call_function", target, (), kwargs)
+
+
+def _create_constant_tensor_node(graph, gm, base_name, value):
+    if not isinstance(value, torch.Tensor):
+        return None
+    node_name = _make_unique_buffer_name(gm, base_name)
+    gm.register_buffer(node_name, value)
+    return graph.create_node("get_attr", node_name, (), {})
+
+
+def _build_concat_arg(graph, gm, args, dim, base_name):
+    resolved_values = [_resolve_arg_value(arg, gm) for arg in args]
+    if all(isinstance(value, torch.Tensor) for value in resolved_values):
+        concat_value = _concat_tensors(resolved_values)
+        if concat_value is None:
+            return None
+        return _create_constant_tensor_node(graph, gm, base_name, concat_value)
+
+    input_nodes = []
+    for idx, arg in enumerate(args):
+        if isinstance(arg, torch.fx.Node):
+            input_nodes.append(arg)
+            continue
+        resolved_value = _resolve_arg_value(arg, gm)
+        if not isinstance(resolved_value, torch.Tensor):
+            return None
+        constant_node = _create_constant_tensor_node(
+            graph,
+            gm,
+            f"{base_name}_{idx}",
+            resolved_value,
+        )
+        if constant_node is None:
+            return None
+        input_nodes.append(constant_node)
+
+    return graph.create_node(
+        "call_function",
+        torch.ops.aten.cat.default,
+        (input_nodes, dim),
+    )
+
+
+def _is_get_attr_node(node):
+    return isinstance(node, torch.fx.Node) and node.op == "get_attr"
+
+
+def _resolve_arg_value(arg, gm):
+    if _is_get_attr_node(arg):
+        return getattr(gm, arg.target)
+    if isinstance(arg, torch.Tensor):
+        return arg
+    if isinstance(arg, (int, float)):
+        return arg
+    return None
+
+
+def _as_dense_tensor(value):
+    if not isinstance(value, torch.Tensor):
+        return None
+    if getattr(value, "is_mkldnn", False):
+        return value.to_dense()
+    return value
+
+
+def _to_scalar(arg, gm, cast=float):
+    value = _resolve_arg_value(arg, gm)
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return None
+        return cast(value.item())
+    if isinstance(value, (int, float)):
+        return cast(value)
+    return None
+
+
+def _concat_tensors(values):
+    if len(values) == 0:
+        return None
+    dense_values = [_as_dense_tensor(value) for value in values]
+    if not isinstance(dense_values[0], torch.Tensor):
+        return None
+    if dense_values[0].dim() == 0:
+        return torch.stack(dense_values)
+    return torch.cat(dense_values, dim=0)
+
+
+def _concat_packed_weights(packed_weights):
+    concat_dense_weight = _concat_tensors(packed_weights)
+    if concat_dense_weight is None:
+        return (None, None)
+    concat_packed_weight = torch.ops.onednn.qlinear_prepack(concat_dense_weight, None)
+    return (concat_packed_weight, concat_dense_weight)
+
+
+def _make_unique_buffer_name(gm, base_name):
+    name = base_name
+    idx = 1
+    while hasattr(gm, name):
+        name = f"{base_name}_{idx}"
+        idx += 1
+    return name
+
+
+def _compute_merged_qparams(qlinear_nodes, gm):
+    qmin = 0
+    qmax = 255
+    global_min = None
+    global_max = None
+
+    for node in qlinear_nodes:
+        scale = _to_scalar(_get_node_arg(node, "output_scale", 7), gm, float)
+        zp = _to_scalar(_get_node_arg(node, "output_zero_point", 8), gm, int)
+        if scale is None or zp is None:
+            return None
+        cur_min = (qmin - zp) * scale
+        cur_max = (qmax - zp) * scale
+        global_min = cur_min if global_min is None else min(global_min, cur_min)
+        global_max = cur_max if global_max is None else max(global_max, cur_max)
+
+    if global_min is None or global_max is None:
+        return None
+
+    eps = 1e-12
+    scale = max((global_max - global_min) / float(qmax - qmin), eps)
+    zp = int(round(qmin - global_min / scale))
+    zp = max(qmin, min(qmax, zp))
+    return (float(scale), int(zp))
+
+
+def _get_fused_output_qparams(qlinear_nodes, gm):
+    merged_qparams = _compute_merged_qparams(qlinear_nodes, gm)
+    if merged_qparams is not None:
+        return merged_qparams
+    return (
+        _get_node_arg(qlinear_nodes[0], "output_scale", 7),
+        _get_node_arg(qlinear_nodes[0], "output_zero_point", 8),
+    )
+
+
+def _is_valid_concat_linear_int8_fusion(qlinear_nodes):
+    if len(qlinear_nodes) != 3:
+        return False
+
+    computation_op = qlinear_nodes[0].target
+    if not _is_qlinear_target(computation_op):
+        return False
+    act = _get_node_arg(qlinear_nodes[0], "x", 0)
+    act_scale = _get_node_arg(qlinear_nodes[0], "x_scale", 1)
+    act_zp = _get_node_arg(qlinear_nodes[0], "x_zp", 2)
+    output_dtype = _get_node_arg(qlinear_nodes[0], "output_dtype", 9)
+    postop_name = _get_node_arg(qlinear_nodes[0], "postop_name", 10)
+    postop_args = _get_node_arg(qlinear_nodes[0], "postop_args", 11)
+    postop_algorithm = _get_node_arg(qlinear_nodes[0], "postop_algorithm", 12)
+    with_bias = _get_node_arg(qlinear_nodes[0], "b", 6) is not None
+    first_weight = _get_node_arg(qlinear_nodes[0], "packed_weight", 3)
+
+    return all(
+        (
+            _is_qlinear_target(node.target)
+            and _get_node_arg(node, "x", 0) == act
+            and _get_node_arg(node, "x_scale", 1) == act_scale
+            and _get_node_arg(node, "x_zp", 2) == act_zp
+            and _is_get_attr_node(_get_node_arg(node, "packed_weight", 3))
+            and (
+                gemm_idx == 0
+                or _get_node_arg(node, "packed_weight", 3) != first_weight
+            )
+            and (((_get_node_arg(node, "b", 6) is not None)) if with_bias else ((_get_node_arg(node, "b", 6) is None)))
+            and _get_node_arg(node, "output_dtype", 9) == output_dtype
+            and _get_node_arg(node, "postop_name", 10) == postop_name
+            and _get_node_arg(node, "postop_args", 11) == postop_args
+            and _get_node_arg(node, "postop_algorithm", 12) == postop_algorithm
+        )
+        for gemm_idx, node in enumerate(qlinear_nodes)
+    )
+
+
+def _collect_first_dequant_on_single_user_chain(start_node):
+    cur = start_node
+    while True:
+        users = list(cur.users)
+        if len(users) != 1:
+            return None
+        nxt = users[0]
+        if (
+            nxt.op == "call_function"
+            and nxt.target
+            == torch.ops.quantized_decomposed.dequantize_per_tensor.default
+        ):
+            return nxt
+        cur = nxt
+
+
+def _collect_quant_dequant_pair_on_single_user_chain(start_node):
+    cur = start_node
+    while True:
+        users = list(cur.users)
+        if len(users) != 1:
+            return None
+        nxt = users[0]
+        if (
+            nxt.op == "call_function"
+            and nxt.target
+            == torch.ops.quantized_decomposed.quantize_per_tensor.default
+        ):
+            q_users = list(nxt.users)
+            if len(q_users) != 1:
+                return None
+            dq = q_users[0]
+            if (
+                dq.op == "call_function"
+                and dq.target
+                == torch.ops.quantized_decomposed.dequantize_per_tensor.default
+            ):
+                return (nxt, dq)
+            return None
+        cur = nxt
+
+
+def _concat_linear_int8_cpu(graph: torch.fx.Graph):
+    """
+    Concat Linear optimization pass for int8 on CPU
+    This pass fuses the original pattern:
+    def ...
+        return (qlinear_cpu(x, ..., w1, ...), qlinear_cpu(x, ..., w2, ...), ...)
+    into a single operation:
+    def ...
+        concat_res = qlinear_cpu(x, ..., concat_w, ...)
+        return split(concat_res, split_size_list)
+    """
+    gm = graph.owning_module
+    processed = set()
+
+    for node in list(graph.nodes):
+        if (
+            node.op == "call_function"
+            and _is_qlinear_target(node.target)
+            and node not in processed
+            and not node._erased
+            and isinstance(node.meta.get("val"), torch.Tensor)
+            and node.meta["val"].device.type == "cpu"
+        ):
+            act = _get_node_arg(node, "x", 0)
+            qlinear_users = [
+                u
+                for u in act.users
+                if u.op == "call_function" and _is_qlinear_target(u.target)
+            ]
+            if _is_valid_concat_linear_int8_fusion(qlinear_users):
+                fused_output_scale, fused_output_zero_point = _get_fused_output_qparams(
+                    qlinear_users, gm
+                )
+
+                with graph.inserting_before(node):
+                    computation_node_0 = qlinear_users[0]
+                    packed_wgts = [
+                        getattr(gm, _get_node_arg(user, "packed_weight", 3).target)
+                        for user in qlinear_users
+                    ]
+                    with_bias = _get_node_arg(qlinear_users[0], "b", 6) is not None
+
+                    concat_wgt, concat_dense_wgt = _concat_packed_weights(packed_wgts)
+                    if concat_wgt is None or concat_dense_wgt is None:
+                        continue
+
+                    out_feature_size_list = [
+                        _as_dense_tensor(w).size(0) for w in packed_wgts
+                    ]
+
+                    concat_w_node = _create_constant_tensor_node(
+                        graph,
+                        gm,
+                        f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_concat",
+                        concat_wgt,
+                    )
+                    if concat_w_node is None:
+                        continue
+
+                    with graph.inserting_after(concat_w_node):
+                        concat_wgt_scales_node = _build_concat_arg(
+                            graph,
+                            gm,
+                            [_get_node_arg(user, "w_scale", 4) for user in qlinear_users],
+                            0,
+                            f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_scales_concat",
+                        )
+                    if concat_wgt_scales_node is None:
+                        continue
+
+                    with graph.inserting_after(concat_wgt_scales_node):
+                        concat_wgt_qzeros_node = _build_concat_arg(
+                            graph,
+                            gm,
+                            [_get_node_arg(user, "w_zp", 5) for user in qlinear_users],
+                            0,
+                            f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_qzeros_concat",
+                        )
+                    if concat_wgt_qzeros_node is None:
+                        continue
+
+                    node_before_linear = concat_wgt_qzeros_node
+                    if with_bias:
+                        with graph.inserting_after(concat_wgt_qzeros_node):
+                            concat_bias_node = _build_concat_arg(
+                                graph,
+                                gm,
+                                [_get_node_arg(user, "b", 6) for user in qlinear_users],
+                                0,
+                                "concat_bias",
+                            )
+                        if concat_bias_node is None:
+                            continue
+                        node_before_linear = concat_bias_node
+                    else:
+                        concat_bias_node = None
+
+                    with graph.inserting_after(node_before_linear):
+                        new_qlinear_node = _build_qlinear_node(
+                            graph,
+                            node.target,
+                            x=act,
+                            x_scale=_get_node_arg(qlinear_users[0], "x_scale", 1),
+                            x_zp=_get_node_arg(qlinear_users[0], "x_zp", 2),
+                            packed_weight=concat_w_node,
+                            w_scale=concat_wgt_scales_node,
+                            w_zp=concat_wgt_qzeros_node,
+                            b=concat_bias_node,
+                            output_scale=fused_output_scale,
+                            output_zero_point=fused_output_zero_point,
+                            output_dtype=_get_node_arg(qlinear_users[0], "output_dtype", 9),
+                            postop_name=_get_node_arg(qlinear_users[0], "postop_name", 10),
+                            postop_args=_get_node_arg(qlinear_users[0], "postop_args", 11),
+                            postop_algorithm=_get_node_arg(qlinear_users[0], "postop_algorithm", 12),
+                        )
+
+                    with graph.inserting_after(new_qlinear_node):
+                        split_node = graph.create_node(
+                            "call_function",
+                            torch.ops.aten.split_with_sizes.default,
+                            (
+                                new_qlinear_node,
+                                out_feature_size_list,
+                                -1,  # split along the out feature dimension
+                            ),
+                        )
+
+                    delayed_erase_nodes = []
+                    split_outputs = []
+                    with graph.inserting_after(split_node):
+                        for gemm_idx, user in enumerate(qlinear_users):
+                            get_item = graph.create_node(
+                                "call_function",
+                                operator.getitem,
+                                (
+                                    split_node,
+                                    gemm_idx,
+                                ),
+                            )
+                            split_outputs.append(get_item)
+                            user.replace_all_uses_with(get_item)
+
+                            delayed_erase_nodes.append(user)
+
+                    for split_out in split_outputs:
+                        dequant_node = _collect_first_dequant_on_single_user_chain(split_out)
+                        if dequant_node is not None:
+                            dequant_node.args = (
+                                dequant_node.args[0],
+                                fused_output_scale,
+                                fused_output_zero_point,
+                                dequant_node.args[3],
+                                dequant_node.args[4],
+                                dequant_node.args[5],
+                            )
+
+                        qdq_pair = _collect_quant_dequant_pair_on_single_user_chain(split_out)
+                        if qdq_pair is not None:
+                            quant_node, dequant_node = qdq_pair
+                            dequant_node.replace_input_with(quant_node, quant_node.args[0])
+                            delayed_erase_nodes.append(quant_node)
+
+                    for old_node in delayed_erase_nodes:
+                        if not old_node._erased:
+                            graph.erase_node(old_node)
+
+                processed.update(qlinear_users)
+
+
+def register_int8_concat_linear_cpu_pass():
+    from torch._inductor import config as inductor_config
+    inductor_config.post_grad_custom_post_pass = _concat_linear_int8_cpu

--- a/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
+++ b/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
@@ -242,6 +242,32 @@ def _collect_quant_dequant_pair_on_single_user_chain(start_node):
         cur = nxt
 
 
+_QPARAM_KWARG_KEYS = ("q_scale", "q_zp", "k_scale", "k_zp", "v_scale", "v_zp")
+
+
+def _find_node_with_qparam_kwargs_on_single_user_chain(start_node):
+    cur = start_node
+    while True:
+        users = list(cur.users)
+        if len(users) != 1:
+            return None
+        cur = users[0]
+        if all(key in cur.kwargs for key in _QPARAM_KWARG_KEYS):
+            return cur
+
+
+def _replace_node_qparam_kwargs(node, fused_output_scale, fused_output_zero_point):
+    new_kwargs = dict(node.kwargs)
+    for key in _QPARAM_KWARG_KEYS:
+        new_kwargs[key] = (
+            fused_output_scale
+            if key.endswith("scale")
+            else fused_output_zero_point
+        )
+    node.kwargs = new_kwargs
+
+
+
 def _concat_linear_int8_cpu(graph: torch.fx.Graph):
     """
     Concat Linear optimization pass for int8 on CPU
@@ -402,6 +428,21 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             quant_node, dequant_node = qdq_pair
                             dequant_node.replace_input_with(quant_node, quant_node.args[0])
                             delayed_erase_nodes.append(quant_node)
+
+                    if len(split_outputs) == 3:
+                        qparam_nodes = [
+                            _find_node_with_qparam_kwargs_on_single_user_chain(split_out)
+                            for split_out in split_outputs
+                        ]
+                        if (
+                            qparam_nodes[0] is not None
+                            and qparam_nodes[0] == qparam_nodes[1] == qparam_nodes[2]
+                        ):
+                            _replace_node_qparam_kwargs(
+                                qparam_nodes[0],
+                                fused_output_scale,
+                                fused_output_zero_point,
+                            )
 
                     for old_node in delayed_erase_nodes:
                         graph.erase_node(old_node)

--- a/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
+++ b/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
@@ -7,6 +7,7 @@
 import operator
 
 import torch
+from torch._dynamo.utils import counters
 
 
 QLINEAR_TARGETS = {
@@ -53,10 +54,13 @@ def _build_qlinear_node(graph, target, **kwargs):
 
 
 def _create_constant_tensor_node(graph, gm, base_name, value):
-    if not isinstance(value, torch.Tensor):
-        return None
-    node_name = _make_unique_buffer_name(gm, base_name)
+    node_name = base_name
+    idx = 1
+    while hasattr(gm, node_name):
+        node_name = f"{base_name}_{idx}"
+        idx += 1
     gm.register_buffer(node_name, value)
+    setattr(gm, node_name, value)
     return graph.create_node("get_attr", node_name, (), {})
 
 
@@ -64,8 +68,6 @@ def _build_concat_arg(graph, gm, args, dim, base_name):
     resolved_values = [_resolve_arg_value(arg, gm) for arg in args]
     if all(isinstance(value, torch.Tensor) for value in resolved_values):
         concat_value = _concat_tensors(resolved_values)
-        if concat_value is None:
-            return None
         return _create_constant_tensor_node(graph, gm, base_name, concat_value)
 
     input_nodes = []
@@ -82,8 +84,6 @@ def _build_concat_arg(graph, gm, args, dim, base_name):
             f"{base_name}_{idx}",
             resolved_value,
         )
-        if constant_node is None:
-            return None
         input_nodes.append(constant_node)
 
     return graph.create_node(
@@ -108,50 +108,27 @@ def _resolve_arg_value(arg, gm):
 
 
 def _as_dense_tensor(value):
-    if not isinstance(value, torch.Tensor):
-        return None
     if getattr(value, "is_mkldnn", False):
-        return value.to_dense()
+        return value.to_dense().t().contiguous()
     return value
 
 
 def _to_scalar(arg, gm, cast=float):
     value = _resolve_arg_value(arg, gm)
+    if isinstance(value, (int, float)):
+        return cast(value)
     if isinstance(value, torch.Tensor):
         if value.numel() != 1:
             return None
         return cast(value.item())
-    if isinstance(value, (int, float)):
-        return cast(value)
     return None
 
 
 def _concat_tensors(values):
-    if len(values) == 0:
-        return None
     dense_values = [_as_dense_tensor(value) for value in values]
-    if not isinstance(dense_values[0], torch.Tensor):
-        return None
     if dense_values[0].dim() == 0:
         return torch.stack(dense_values)
     return torch.cat(dense_values, dim=0)
-
-
-def _concat_packed_weights(packed_weights):
-    concat_dense_weight = _concat_tensors(packed_weights)
-    if concat_dense_weight is None:
-        return (None, None)
-    concat_packed_weight = torch.ops.onednn.qlinear_prepack(concat_dense_weight, None)
-    return (concat_packed_weight, concat_dense_weight)
-
-
-def _make_unique_buffer_name(gm, base_name):
-    name = base_name
-    idx = 1
-    while hasattr(gm, name):
-        name = f"{base_name}_{idx}"
-        idx += 1
-    return name
 
 
 def _compute_merged_qparams(qlinear_nodes, gm):
@@ -170,9 +147,7 @@ def _compute_merged_qparams(qlinear_nodes, gm):
         global_min = cur_min if global_min is None else min(global_min, cur_min)
         global_max = cur_max if global_max is None else max(global_max, cur_max)
 
-    if global_min is None or global_max is None:
-        return None
-
+    assert global_min is not None and global_max is not None
     eps = 1e-12
     scale = max((global_max - global_min) / float(qmax - qmin), eps)
     zp = int(round(qmin - global_min / scale))
@@ -194,9 +169,6 @@ def _is_valid_concat_linear_int8_fusion(qlinear_nodes):
     if len(qlinear_nodes) != 3:
         return False
 
-    computation_op = qlinear_nodes[0].target
-    if not _is_qlinear_target(computation_op):
-        return False
     act = _get_node_arg(qlinear_nodes[0], "x", 0)
     act_scale = _get_node_arg(qlinear_nodes[0], "x_scale", 1)
     act_zp = _get_node_arg(qlinear_nodes[0], "x_zp", 2)
@@ -298,8 +270,11 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                 u
                 for u in act.users
                 if u.op == "call_function" and _is_qlinear_target(u.target)
-            ]
+            ][::-1]
+            
             if _is_valid_concat_linear_int8_fusion(qlinear_users):
+                counters["inductor"]["int8_concat_linear_fusion"] += 1
+                counters["inductor"]["int8_concat_linear_nodes"] += len(qlinear_users)
                 fused_output_scale, fused_output_zero_point = _get_fused_output_qparams(
                     qlinear_users, gm
                 )
@@ -310,11 +285,16 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                         getattr(gm, _get_node_arg(user, "packed_weight", 3).target)
                         for user in qlinear_users
                     ]
+                    act_shape = None
+                    if isinstance(act, torch.fx.Node):
+                        act_val = act.meta.get("val")
+                        if isinstance(act_val, torch.Tensor):
+                            act_shape = list(act_val.shape)
                     with_bias = _get_node_arg(qlinear_users[0], "b", 6) is not None
 
-                    concat_wgt, concat_dense_wgt = _concat_packed_weights(packed_wgts)
-                    if concat_wgt is None or concat_dense_wgt is None:
-                        continue
+                    concat_wgt = torch.ops.onednn.qlinear_prepack(
+                        _concat_tensors(packed_wgts), act_shape
+                    )
 
                     out_feature_size_list = [
                         _as_dense_tensor(w).size(0) for w in packed_wgts
@@ -326,8 +306,6 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                         f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_concat",
                         concat_wgt,
                     )
-                    if concat_w_node is None:
-                        continue
 
                     with graph.inserting_after(concat_w_node):
                         concat_wgt_scales_node = _build_concat_arg(
@@ -337,8 +315,6 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             0,
                             f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_scales_concat",
                         )
-                    if concat_wgt_scales_node is None:
-                        continue
 
                     with graph.inserting_after(concat_wgt_scales_node):
                         concat_wgt_qzeros_node = _build_concat_arg(
@@ -348,9 +324,6 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             0,
                             f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_qzeros_concat",
                         )
-                    if concat_wgt_qzeros_node is None:
-                        continue
-
                     node_before_linear = concat_wgt_qzeros_node
                     if with_bias:
                         with graph.inserting_after(concat_wgt_qzeros_node):
@@ -361,8 +334,6 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                                 0,
                                 "concat_bias",
                             )
-                        if concat_bias_node is None:
-                            continue
                         node_before_linear = concat_bias_node
                     else:
                         concat_bias_node = None
@@ -433,8 +404,7 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             delayed_erase_nodes.append(quant_node)
 
                     for old_node in delayed_erase_nodes:
-                        if not old_node._erased:
-                            graph.erase_node(old_node)
+                        graph.erase_node(old_node)
 
                 processed.update(qlinear_users)
 

--- a/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
+++ b/torchao/prototype/inductor/fx_passes/int8_concat_linear_fusion_cpu.py
@@ -9,7 +9,6 @@ import operator
 import torch
 from torch._dynamo.utils import counters
 
-
 QLINEAR_TARGETS = {
     torch.ops.onednn.qlinear_pointwise.default,
     torch.ops.onednn.qlinear_pointwise.tensor,
@@ -21,7 +20,8 @@ def _is_qlinear_target(target):
         return True
     return (
         callable(target)
-        and getattr(target, "__module__", "") == "torch._inductor.fx_passes.quantization"
+        and getattr(target, "__module__", "")
+        == "torch._inductor.fx_passes.quantization"
         and getattr(target, "__name__", "") == "qlinear"
     )
 
@@ -187,10 +187,13 @@ def _is_valid_concat_linear_int8_fusion(qlinear_nodes):
             and _get_node_arg(node, "x_zp", 2) == act_zp
             and _is_get_attr_node(_get_node_arg(node, "packed_weight", 3))
             and (
-                gemm_idx == 0
-                or _get_node_arg(node, "packed_weight", 3) != first_weight
+                gemm_idx == 0 or _get_node_arg(node, "packed_weight", 3) != first_weight
             )
-            and (((_get_node_arg(node, "b", 6) is not None)) if with_bias else ((_get_node_arg(node, "b", 6) is None)))
+            and (
+                (_get_node_arg(node, "b", 6) is not None)
+                if with_bias
+                else (_get_node_arg(node, "b", 6) is None)
+            )
             and _get_node_arg(node, "output_dtype", 9) == output_dtype
             and _get_node_arg(node, "postop_name", 10) == postop_name
             and _get_node_arg(node, "postop_args", 11) == postop_args
@@ -225,8 +228,7 @@ def _collect_quant_dequant_pair_on_single_user_chain(start_node):
         nxt = users[0]
         if (
             nxt.op == "call_function"
-            and nxt.target
-            == torch.ops.quantized_decomposed.quantize_per_tensor.default
+            and nxt.target == torch.ops.quantized_decomposed.quantize_per_tensor.default
         ):
             q_users = list(nxt.users)
             if len(q_users) != 1:
@@ -260,12 +262,9 @@ def _replace_node_qparam_kwargs(node, fused_output_scale, fused_output_zero_poin
     new_kwargs = dict(node.kwargs)
     for key in _QPARAM_KWARG_KEYS:
         new_kwargs[key] = (
-            fused_output_scale
-            if key.endswith("scale")
-            else fused_output_zero_point
+            fused_output_scale if key.endswith("scale") else fused_output_zero_point
         )
     node.kwargs = new_kwargs
-
 
 
 def _concat_linear_int8_cpu(graph: torch.fx.Graph):
@@ -297,7 +296,7 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                 for u in act.users
                 if u.op == "call_function" and _is_qlinear_target(u.target)
             ][::-1]
-            
+
             if _is_valid_concat_linear_int8_fusion(qlinear_users):
                 counters["inductor"]["int8_concat_linear_fusion"] += 1
                 counters["inductor"]["int8_concat_linear_nodes"] += len(qlinear_users)
@@ -337,7 +336,10 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                         concat_wgt_scales_node = _build_concat_arg(
                             graph,
                             gm,
-                            [_get_node_arg(user, "w_scale", 4) for user in qlinear_users],
+                            [
+                                _get_node_arg(user, "w_scale", 4)
+                                for user in qlinear_users
+                            ],
                             0,
                             f"{_get_node_arg(computation_node_0, 'packed_weight', 3).target}_scales_concat",
                         )
@@ -377,10 +379,18 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             b=concat_bias_node,
                             output_scale=fused_output_scale,
                             output_zero_point=fused_output_zero_point,
-                            output_dtype=_get_node_arg(qlinear_users[0], "output_dtype", 9),
-                            postop_name=_get_node_arg(qlinear_users[0], "postop_name", 10),
-                            postop_args=_get_node_arg(qlinear_users[0], "postop_args", 11),
-                            postop_algorithm=_get_node_arg(qlinear_users[0], "postop_algorithm", 12),
+                            output_dtype=_get_node_arg(
+                                qlinear_users[0], "output_dtype", 9
+                            ),
+                            postop_name=_get_node_arg(
+                                qlinear_users[0], "postop_name", 10
+                            ),
+                            postop_args=_get_node_arg(
+                                qlinear_users[0], "postop_args", 11
+                            ),
+                            postop_algorithm=_get_node_arg(
+                                qlinear_users[0], "postop_algorithm", 12
+                            ),
                         )
 
                     with graph.inserting_after(new_qlinear_node):
@@ -412,7 +422,9 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                             delayed_erase_nodes.append(user)
 
                     for split_out in split_outputs:
-                        dequant_node = _collect_first_dequant_on_single_user_chain(split_out)
+                        dequant_node = _collect_first_dequant_on_single_user_chain(
+                            split_out
+                        )
                         if dequant_node is not None:
                             dequant_node.args = (
                                 dequant_node.args[0],
@@ -423,15 +435,21 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
                                 dequant_node.args[5],
                             )
 
-                        qdq_pair = _collect_quant_dequant_pair_on_single_user_chain(split_out)
+                        qdq_pair = _collect_quant_dequant_pair_on_single_user_chain(
+                            split_out
+                        )
                         if qdq_pair is not None:
                             quant_node, dequant_node = qdq_pair
-                            dequant_node.replace_input_with(quant_node, quant_node.args[0])
+                            dequant_node.replace_input_with(
+                                quant_node, quant_node.args[0]
+                            )
                             delayed_erase_nodes.append(quant_node)
 
                     if len(split_outputs) == 3:
                         qparam_nodes = [
-                            _find_node_with_qparam_kwargs_on_single_user_chain(split_out)
+                            _find_node_with_qparam_kwargs_on_single_user_chain(
+                                split_out
+                            )
                             for split_out in split_outputs
                         ]
                         if (
@@ -452,4 +470,5 @@ def _concat_linear_int8_cpu(graph: torch.fx.Graph):
 
 def register_int8_concat_linear_cpu_pass():
     from torch._inductor import config as inductor_config
+
     inductor_config.post_grad_custom_post_pass = _concat_linear_int8_cpu


### PR DESCRIPTION
This PR add qkv-fusion pass on x86 CPU. It added a manually registered qkv-usion pass. This fusion pass fuse 3 gemm(qkv) and SDPA to a gemm kernel and a SPDA kernel in int8.

The current fp8 mkl tensor does not support unpack. Thus, fp8 qkv-fusion will be add until pytorch updated.