### PR TITLE
Add __init__.py to quant_logger to make it a proper Python package

### DIFF
--- a/test/prototype/quant_logger/test_quant_logger.py
+++ b/test/prototype/quant_logger/test_quant_logger.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import csv
 import importlib
 import pathlib

--- a/torchao/prototype/quant_logger/__init__.py
+++ b/torchao/prototype/quant_logger/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchao/prototype/quant_logger/quant_logger.py
+++ b/torchao/prototype/quant_logger/quant_logger.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import csv
 import os
 


### PR DESCRIPTION
This fixes ImportError on CPU CI runners where the module couldn't be
imported before skip decorators could be evaluated.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>