### PR TITLE
flux benchmark: gate out small activations

### DIFF
--- a/benchmarks/quantization/eval_accuracy_and_perf_of_flux.py
+++ b/benchmarks/quantization/eval_accuracy_and_perf_of_flux.py
@@ -545,6 +545,10 @@ def run(
                 continue
             elif fqn == "proj_out":
                 continue
+            elif "norm.linear" in fqn:
+                # activations here have shape [batch_size, 3072], so
+                # too small to see speedups from activation quantization
+                continue
             elif weight_shape[0] < 1024 or weight_shape[1] < 1024:
                 continue
             fqn_to_config_dict[fqn] = config_obj


### PR DESCRIPTION
Summary:

Using the logs from https://github.com/pytorch/ao/pull/3987, we now know
that FQNs that look like
`single_transformer_blocks.37.norm.linear.weight` have small shapes,
gate them out.

Test Plan:

TODO run new perf/accuracy bench after this