### PR TITLE
[ROCm] Enable SmoothQuant tests on ROCm

### DIFF
--- a/test/prototype/test_smoothquant.py
+++ b/test/prototype/test_smoothquant.py
@@ -69,7 +69,6 @@ if torch.xpu.is_available():
     device_list.append("xpu")
 
 
-@unittest.skipIf(torch.version.hip is not None, "Skipping tests in ROCm")
 class TestSmoothQuant(unittest.TestCase):
     """SmoothQuant tests using only supported quantization configs."""
 


### PR DESCRIPTION
Remove the blanket ROCm skip on TestSmoothQuant. The SmoothQuant implementation uses only standard PyTorch ops -- Int8 quantization via `Int8DynamicActivationInt8WeightConfig` and `Int8StaticActivationInt8WeightConfig`, `torch.nn.Linear`, and `int_scaled_matmul` which falls back to `aten.mm` (rocBLAS on ROCm). There are no FP8, CUDA-specific, or Triton kernel dependencies anywhere in the code path.

The `device_list` already correctly includes `"cuda"` on ROCm/HIP builds, so the tests were only being held back by this blanket skip.

## Verification

All 14 test cases pass on MI300X (ROCm 6.3, gfx942):

```
test_observer_insertion_base_config0                                                  PASSED
test_prepare_for_loading_base_config0                                                 PASSED
test_smoothquant_accuracy_alpha_0_5_base_config0_device_cpu_bfloat16                  PASSED
test_smoothquant_accuracy_alpha_0_5_base_config0_device_cuda_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_5_base_config1_device_cpu_bfloat16                  PASSED
test_smoothquant_accuracy_alpha_0_5_base_config1_device_cuda_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_5_base_config2_device_cpu_bfloat16                  PASSED
test_smoothquant_accuracy_alpha_0_5_base_config2_device_cuda_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_75_base_config0_device_cpu_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_75_base_config0_device_cuda_bfloat16                PASSED
test_smoothquant_accuracy_alpha_0_75_base_config1_device_cpu_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_75_base_config1_device_cuda_bfloat16                PASSED
test_smoothquant_accuracy_alpha_0_75_base_config2_device_cpu_bfloat16                 PASSED
test_smoothquant_accuracy_alpha_0_75_base_config2_device_cuda_bfloat16                PASSED
```

Covers all three base configs (`Int8DynamicActivationInt8WeightConfig(version=2)`, `Int8StaticActivationInt8WeightConfig(granularity=PerRow())`, `Int8StaticActivationInt8WeightConfig(granularity=PerTensor())`), both alpha values (0.5, 0.75), and both CPU and CUDA devices. The accuracy tests verify that SmoothQuant loss < basic quantization loss and SQNR > 20 dB for all configurations.

cc: @danielvegamyhre