### PR TITLE
[ROCm] Enable MoE FP8 kernel and grouped MM tests on ROCm

### DIFF
--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -20,7 +20,10 @@ if not (
     and torch.cuda.is_available()
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
 ):
-    pytest.skip("Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)", allow_module_level=True)
+    pytest.skip(
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        allow_module_level=True,
+    )
 
 pytest.importorskip("triton", reason="Triton required to run this test")
 

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -10,8 +10,13 @@ import torch
 # FP8 MoE kernels require FP8-capable hardware (SM90+ on CUDA, MI300+ on ROCm)
 from torchao.utils import is_MI300, is_MI350, is_sm_at_least_90
 
-if not (torch.cuda.is_available() and (is_sm_at_least_90() or is_MI300() or is_MI350())):
-    pytest.skip("Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)", allow_module_level=True)
+if not (
+    torch.cuda.is_available() and (is_sm_at_least_90() or is_MI300() or is_MI350())
+):
+    pytest.skip(
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        allow_module_level=True,
+    )
 
 from torchao.float8.config import e4m3_dtype
 from torchao.prototype.moe_training.kernels.float8_rowwise import (


### PR DESCRIPTION
Fix module-level capability gates in test_kernels.py and test_fp8_grouped_mm.py that used raw get_device_capability() >= (9, 0). This incorrectly passes on MI250X (gfx90a reports capability 9.0 despite lacking FP8 support) and incorrectly skips on MI300/MI350. Replace with is_sm_at_least_90() || is_MI300() || is_MI350().

test_kernels.py:
- Enable 5 FP8 kernel tests on MI300/MI350: jagged rowwise scales, jagged rowwise scales via transpose, jagged colwise scales, 3D rowwise transpose-rhs (atomic), and 3D rowwise transpose-rhs (reduction). These kernels already have AMD-specific autotune configs on main.
- Use e4m3_dtype from config instead of hardcoded torch.float8_e4m3fn since MI300 uses float8_e4m3fnuz.
- MXFP8 tests remain skipped on ROCm since MXFP8 format is not yet supported.

test_fp8_grouped_mm.py:
- Fix module-level gate so the file loads on FP8-capable ROCm hardware. The main test (test_fp8_rowwise_scaled_grouped_mm) already has proper per-test MI300/MI350 gating and ROCm-specific tolerances.
- Enable test_K_or_N_dim_not_multiple_of_16 on ROCm since it validates dimension assertions and uses Float8TrainingOpConfig which already resolves to the correct platform FP8 dtype.