### PR TITLE
[ROCm] Fix module-level capability gates in MoE distributed and MXFP8 tests

### DIFF
--- a/test/prototype/moe_training/test_distributed.py
+++ b/test/prototype/moe_training/test_distributed.py
@@ -19,9 +19,12 @@ import torch
 
 from torchao.utils import is_MI300, is_MI350, is_sm_at_least_89
 
-if not torch.cuda.is_available() or not (is_sm_at_least_89() or is_MI300() or is_MI350()):
+if not torch.cuda.is_available() or not (
+    is_sm_at_least_89() or is_MI300() or is_MI350()
+):
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM89+, MI300, or MI350)", allow_module_level=True
+        "Requires FP8-capable GPU (CUDA SM89+, MI300, or MI350)",
+        allow_module_level=True,
     )
 
 from torch import distributed as dist

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -22,7 +22,10 @@ if not (
     and torch.cuda.is_available()
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
 ):
-    pytest.skip("Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)", allow_module_level=True)
+    pytest.skip(
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        allow_module_level=True,
+    )
 
 pytest.importorskip("triton", reason="Triton required to run this test")
 


### PR DESCRIPTION
Fix module-level capability gates in test_distributed.py and test_mxfp8_grouped_mm.py that used raw get_device_capability() checks. On ROCm, MI250X (gfx90a) reports capability (9, 0) despite lacking FP8 support, causing these modules to load incorrectly instead of being skipped.

test_distributed.py:
- Collapse the blanket ROCm skip and the raw get_device_capability() < (8, 9) check into a single gate using is_sm_at_least_89() || is_MI300() || is_MI350(). The is_sm_at_least_* helpers short-circuit on torch.version.cuda, avoiding the false positive on MI250X. Individual MXFP8 tests still skip on ROCm via @skip_if_rocm until MXFP8 format support is available.

test_mxfp8_grouped_mm.py:
- Replace get_device_capability()[0] >= 9 with the same proper gate. Individual tests remain gated by @skip_if_rocm.