### PR TITLE
[mxfp8 moe training] add cuda kernel for per group padding

### DIFF
--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -65,31 +65,14 @@ class Experiment:
 
 def get_configs() -> List[ExperimentConfig]:
     MNKG_list = [
-        # Llama4 16e with various experts per device (i.e., different EP degrees)
-        (16384, 8192, 5120, 1),
-        (16384, 8192, 5120, 2),
-        (16384, 8192, 5120, 4),
-        (16384, 8192, 5120, 8),
+        # Llama4 16e with various experts per device (i.e., EP degree=8 or 16
+        (32768, 8192, 5120, 1),
+        (32768, 8192, 5120, 2),
         (128000, 8192, 5120, 1),
         (128000, 8192, 5120, 2),
-        (128000, 8192, 5120, 4),
-        (128000, 8192, 5120, 8),
-        # DSV3 236B with various experts per device (i.e., different EP degrees)
-        (16384, 1536, 5120, 1),
-        (16384, 1536, 5120, 2),
-        (16384, 1536, 5120, 4),
-        (16384, 1536, 5120, 8),
-        (128000, 1536, 5120, 1),
-        (128000, 1536, 5120, 2),
-        (128000, 1536, 5120, 4),
-        (128000, 1536, 5120, 8),
-        # DSV3 671B with various experts per device (i.e., different EP degrees)
-        (16384, 2048, 7168, 1),
-        (16384, 2048, 7168, 2),
-        (16384, 2048, 7168, 4),
-        (16384, 2048, 7168, 8),
-        (128000, 2048, 7168, 1),
-        (128000, 2048, 7168, 2),
+        # DSV3 671B with various experts per device (i.e., EP degree=32 or 64
+        (32768, 2048, 7168, 4),
+        (32768, 2048, 7168, 8),
         (128000, 2048, 7168, 4),
         (128000, 2048, 7168, 8),
     ]
@@ -133,20 +116,7 @@ def run_experiment(
         requires_grad=True,
     ).transpose(-2, -1)
 
-    # - configure input to be row-major with groups divided along the column dimension,
-    #   representing the left operand of grad_weight = grad_output_t @ input
-    #   that occurs in the backward pass of the differentiable scaled grouped mm.
-    # - the transposed tensor in col-major format with groups along the row dimension,
-    #    which represents the right operand.
-    token_group_alignment_size = (
-        16 if config.recipe == Float8TrainingRecipe.FP8_ROWWISE else 32
-    )
-
-    offs = generate_jagged_offs(G, total_M, multiple_of=token_group_alignment_size)
-
-    labels = torch.ones(
-        (A.shape[0], B_t.shape[-1]), device=device, dtype=torch.bfloat16
-    )
+    offs = generate_jagged_offs(G, total_M, multiple_of=1)
 
     # fwd_bwd bf16 benchmark + profiling
     bf16_fwd_bwd_us = bench_fwd_bwd_microseconds(
@@ -154,7 +124,6 @@ def run_experiment(
         A,
         B_t,
         offs,
-        labels=labels,
         use_compile=args.compile,
         fullgraph=False,
     )
@@ -164,7 +133,6 @@ def run_experiment(
             A,
             B_t,
             offs,
-            labels=labels,
             use_compile=args.compile,
             fullgraph=False,
             profile_name="bf16_profile",
@@ -183,7 +151,6 @@ def run_experiment(
         B_t,
         quant_config,
         offs,
-        labels=labels,
         use_compile=args.compile,
         fullgraph=False,
     )
@@ -194,7 +161,6 @@ def run_experiment(
             B_t,
             quant_config,
             offs,
-            labels=labels,
             use_compile=args.compile,
             profile_name="scaled_profile",
             fullgraph=False,

--- a/benchmarks/prototype/moe_training/mxfp8/bench_pad_token_groups.py
+++ b/benchmarks/prototype/moe_training/mxfp8/bench_pad_token_groups.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+# this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
+
+import argparse
+import itertools
+import time
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+from benchmarks.utils import profile_fn
+from torchao.prototype.moe_training.kernels.mxfp8 import (
+    _mxfp8_cuda_kernels_available,
+    fused_pad_token_groups_cuda,
+    torch_pad_token_groups,
+)
+from torchao.prototype.moe_training.utils import generate_jagged_offs
+
+device = torch.device("cuda")
+
+# Needed since changing args to function causes recompiles
+torch._dynamo.config.cache_size_limit = 1000
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    num_tokens: int
+    dim: int
+    num_groups: int
+    alignment_size: int
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    torch_eager_time_us: float
+    cuda_time_us: float
+    torch_mem_bw_gbps: float
+    cuda_mem_bw_gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    # Various token group sizes and dimensions
+    num_tokens_list = [16384]
+    dim_list = [1536, 2048, 5120, 7168]
+    num_groups_list = [1, 4, 8, 16]
+    alignment_size_list = [32]
+
+    configs = []
+    for num_tokens, dim, num_groups, alignment_size in itertools.product(
+        num_tokens_list, dim_list, num_groups_list, alignment_size_list
+    ):
+        configs.append(
+            ExperimentConfig(
+                num_tokens=num_tokens,
+                dim=dim,
+                num_groups=num_groups,
+                alignment_size=alignment_size,
+            )
+        )
+    return configs
+
+
+def benchmark_host_side_in_microseconds(fn, *args, num_iters=100, **kwargs):
+    """
+    Benchmark using host-side timing, includes buffer allocation overhead.
+    """
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(num_iters):
+        fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    end = time.perf_counter()
+    return ((end - start) / num_iters) * 1e6  # Convert to microseconds
+
+
+def run_experiment(
+    config: ExperimentConfig, args: argparse.Namespace
+) -> ExperimentResult:
+    num_tokens, dim, num_groups, alignment_size = (
+        config.num_tokens,
+        config.dim,
+        config.num_groups,
+        config.alignment_size,
+    )
+
+    inputs = torch.randn(num_tokens, dim, dtype=torch.bfloat16, device=device)
+
+    def torch_eager_with_offsets():
+        group_offsets = generate_jagged_offs(
+            num_groups, num_tokens, multiple_of=1, device=device
+        )
+        return torch_pad_token_groups(inputs, group_offsets, alignment_size)
+
+    def warmup(fn):
+        for _ in range(5):
+            fn()
+
+    # bench torch eager (includes buffer allocation overhead)
+    warmup(torch_eager_with_offsets)
+    torch_eager_time_us = benchmark_host_side_in_microseconds(torch_eager_with_offsets)
+    if args.profile:
+        group_offsets = generate_jagged_offs(
+            num_groups, num_tokens, multiple_of=1, device=device
+        )
+        profile_fn(
+            torch_pad_token_groups,
+            inputs,
+            group_offsets,
+            alignment_size,
+            profile_name="torch_pad_token_groups_eager",
+        )
+
+    # bench CUDA kernel if available
+    if _mxfp8_cuda_kernels_available:
+
+        def cuda_with_offsets():
+            group_offsets = generate_jagged_offs(
+                num_groups, num_tokens, multiple_of=1, device=device
+            )
+            return fused_pad_token_groups_cuda(inputs, group_offsets, alignment_size)
+
+        warmup(cuda_with_offsets)
+        cuda_time_us = benchmark_host_side_in_microseconds(cuda_with_offsets)
+        if args.profile:
+            group_offsets = generate_jagged_offs(
+                num_groups, num_tokens, multiple_of=1, device=device
+            )
+            profile_fn(
+                fused_pad_token_groups_cuda,
+                inputs,
+                group_offsets,
+                alignment_size,
+                profile_name="fused_pad_token_groups_cuda",
+            )
+    else:
+        cuda_time_us = float("inf")  # Not available
+
+    # mem bw calculations - run once to get output sizes
+    group_offsets = generate_jagged_offs(
+        num_groups, num_tokens, multiple_of=1, device=device
+    )
+    torch_padded_tokens, torch_padded_offsets = torch_pad_token_groups(
+        inputs, group_offsets, alignment_size
+    )
+
+    bytes_per_el = torch.finfo(torch.bfloat16).bits / 8
+
+    read_bytes = (
+        inputs.numel() * bytes_per_el  # Read input tokens
+        + group_offsets.numel() * 4  # Read group offsets (int32)
+    )
+
+    write_bytes = (
+        torch_padded_tokens.numel() * bytes_per_el  # Write zeros (entire buffer)
+        + inputs.numel() * bytes_per_el  # Write actual data (overwrites part of zeros)
+        + torch_padded_offsets.numel() * 4  # Write output offsets (int32)
+    )
+
+    total_bytes = read_bytes + write_bytes
+
+    torch_mem_bw_gbps = (total_bytes / 1e9) / (torch_eager_time_us / 1e6)
+
+    if _mxfp8_cuda_kernels_available and cuda_time_us != float("inf"):
+        cuda_mem_bw_gbps = (total_bytes / 1e9) / (cuda_time_us / 1e6)
+    else:
+        cuda_mem_bw_gbps = 0.0
+
+    return ExperimentResult(
+        torch_eager_time_us=torch_eager_time_us,
+        cuda_time_us=cuda_time_us,
+        torch_mem_bw_gbps=torch_mem_bw_gbps,
+        cuda_mem_bw_gbps=cuda_mem_bw_gbps,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "num_tokens",
+        "dim",
+        "num_groups",
+        "torch_us",
+        "cuda_us",
+        "torch_mem_bw_gbps",
+        "cuda_mem_bw_gbps",
+        "cuda_vs_torch",
+    ]
+    rows = []
+    for experiment in experiments:
+        cuda_time = experiment.result.cuda_time_us
+        cuda_vs_torch = (
+            f"{experiment.result.torch_eager_time_us / cuda_time:.2f}x"
+            if cuda_time != float("inf") and cuda_time > 0
+            else "N/A"
+        )
+        cuda_bw_str = (
+            f"{experiment.result.cuda_mem_bw_gbps:.2f}"
+            if experiment.result.cuda_mem_bw_gbps > 0
+            else "N/A"
+        )
+
+        rows.append(
+            [
+                experiment.config.num_tokens,
+                experiment.config.dim,
+                experiment.config.num_groups,
+                experiment.result.torch_eager_time_us,
+                experiment.result.cuda_time_us,
+                f"{experiment.result.torch_mem_bw_gbps:.2f}",
+                cuda_bw_str,
+                cuda_vs_torch,
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def main(args: argparse.Namespace):
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config, args)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profile", action="store_true", help="Enable profiling with PyTorch profiler"
+    )
+    args = parser.parse_args()
+    main(args)

--- a/setup.py
+++ b/setup.py
@@ -756,6 +756,7 @@ def get_extensions():
             os.path.join(mxfp8_extension_dir, "mxfp8_extension.cpp"),
             os.path.join(mxfp8_extension_dir, "mxfp8_cuda.cu"),
             os.path.join(mxfp8_extension_dir, "mx_block_rearrange_2d_M_groups.cu"),
+            os.path.join(mxfp8_extension_dir, "fused_pad_token_groups.cu"),
         ]
 
         # Only add the extension if the source files exist AND we are building for sm100

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -21,8 +21,11 @@ from torchao.prototype.moe_training.kernels.jagged_float8_scales import (
     triton_fp8_per_group_rowwise_scales,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    _mxfp8_cuda_kernels_available,
+    fused_pad_token_groups_cuda,
     mx_block_rearrange_2d_M_groups_cuda,
     mxfp8_quantize_cuda_3d,
+    torch_pad_token_groups,
     torch_to_blocked_2d_K_groups,
     torch_to_blocked_2d_M_groups,
     torch_to_blocked_per_group_3d,
@@ -405,3 +408,47 @@ def test_cuda_mx_dim1_3d_numerics(E, N, K, input_dtype, scaling_mode):
     # Check quantized values
     torch.testing.assert_close(y_d1, y_d1_ref, rtol=0, atol=0)
     assert y_d1.stride() == y_d1_ref.stride(), "quantized tensor strides do not match"
+
+
+@pytest.mark.skipif(
+    not _mxfp8_cuda_kernels_available,
+    reason="CUDA kernel requires sm_100 and CUDA 12.8+",
+)
+@skip_if_rocm("ROCm enablement in progress")
+@pytest.mark.parametrize("num_tokens", [128, 157, 4096])
+@pytest.mark.parametrize("dim", [7168])
+@pytest.mark.parametrize("num_groups", [1, 2, 4, 8])
+@pytest.mark.parametrize("alignment_size", [32])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_cuda_fused_pad_token_groups(
+    num_tokens: int, dim: int, num_groups: int, alignment_size: int, dtype: torch.dtype
+):
+    """Test fused_pad_token_groups_cuda kernel for padding token groups to alignment."""
+    device = "cuda"
+
+    # Create input activations
+    inputs = torch.randn(num_tokens, dim, dtype=dtype, device=device)
+
+    # Generate group offsets (end indices for each group)
+    group_offsets = generate_jagged_offs(
+        num_groups, num_tokens, multiple_of=1, device=device
+    )
+
+    # Get reference output
+    ref_padded_tokens, ref_padded_offsets = torch_pad_token_groups(
+        inputs, group_offsets, alignment_size
+    )
+
+    # Run CUDA kernel
+    kernel_padded_tokens, kernel_padded_offsets = fused_pad_token_groups_cuda(
+        inputs, group_offsets, alignment_size
+    )
+
+    # All implementations now use the same upper bound output size
+    # Verify outputs match
+    assert torch.allclose(ref_padded_tokens, kernel_padded_tokens, rtol=0, atol=1e-5), (
+        "Padded tokens do not match"
+    )
+    assert torch.equal(ref_padded_offsets, kernel_padded_offsets), (
+        "Padded group offsets do not match"
+    )

--- a/torchao/csrc/cuda/mx_kernels/fused_pad_token_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/fused_pad_token_groups.cu
@@ -1,0 +1,160 @@
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+#include <cstdio>
+
+#define CUDA_CHECK(call) \
+    do { \
+        cudaError_t error = call; \
+        if (error != cudaSuccess) { \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__, \
+                    cudaGetErrorString(error)); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while(0)
+
+__host__ __device__ __forceinline__ int ceil_div(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+__device__ __forceinline__ int find_group_id(
+    int row_idx,
+    const int32_t* __restrict__ group_end_offsets,
+    int num_groups
+) {
+    // linear prefix sum lookup (same or faster than binary search for small num groups, which ours are <= 32)
+    int group_id = 0;
+    while (group_id < num_groups - 1 && row_idx >= group_end_offsets[group_id]) {
+        ++group_id;
+    }
+    return group_id;
+}
+
+__global__ void fused_pad_token_groups_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const int32_t* __restrict__ group_end_offsets,
+    const int32_t* __restrict__ padded_group_start_offsets,
+    __nv_bfloat16* __restrict__ output,
+    int num_tokens,
+    int dim,
+    int num_groups
+) {
+    constexpr int WARP_SIZE = 32;
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    const int warp_id_in_block = threadIdx.x / WARP_SIZE;
+    const int warps_per_block = blockDim.x / WARP_SIZE;
+    const int global_row_idx = blockIdx.x * warps_per_block + warp_id_in_block;
+
+    if (global_row_idx >= num_tokens) return;
+
+    // one thread finds which group this row belongs to, then broadcasts to other lanes via warp shuffle
+    int group_id;
+    if (lane_id == 0) {
+        group_id = find_group_id(global_row_idx, group_end_offsets, num_groups);
+    }
+    group_id = __shfl_sync(0xffffffff, group_id, 0);
+
+    int group_start = (group_id > 0) ? group_end_offsets[group_id - 1] : 0;
+    int padded_start = padded_group_start_offsets[group_id];
+    int offset_in_group = global_row_idx - group_start;
+    int output_row = padded_start + offset_in_group;
+
+    const __nv_bfloat16* row_in = input + global_row_idx * dim;
+    __nv_bfloat16* row_out = output + output_row * dim;
+
+    // vectorized copy for all complete float4 chunks (8 bf16 elements each)
+    int num_vecs = dim / 8;
+    if (num_vecs > 0) {
+        const float4* in_vec = reinterpret_cast<const float4*>(row_in);
+        float4* out_vec = reinterpret_cast<float4*>(row_out);
+
+        for (int i = lane_id; i < num_vecs; i += 32) {
+            out_vec[i] = in_vec[i];
+        }
+    }
+
+    // scalar copy for remaining elems
+    int elems_covered = num_vecs * 8;
+    for (int i = elems_covered + lane_id; i < dim; i += 32) {
+        row_out[i] = row_in[i];
+    }
+}
+
+__global__ void compute_padded_offsets_kernel(
+    const int32_t* __restrict__ group_end_offsets,
+    int32_t* __restrict__ padded_group_start_offsets,
+    int32_t* __restrict__ padded_group_end_offsets,
+    int num_groups,
+    int alignment_size
+) {
+    if (threadIdx.x == 0) {
+        int cumulative = 0;
+
+        for (int g = 0; g < num_groups; g++) {
+            int group_start = (g > 0) ? group_end_offsets[g - 1] : 0;
+            int group_end = group_end_offsets[g];
+            int group_size = group_end - group_start;
+
+            int padded_size = ((group_size + alignment_size - 1) / alignment_size) * alignment_size;
+
+            padded_group_start_offsets[g] = cumulative;
+            cumulative += padded_size;
+            padded_group_end_offsets[g] = cumulative;
+        }
+    }
+}
+
+namespace mxfp8 {
+
+void launch_compute_padded_offsets_cuda(
+    const int32_t* group_end_offsets_ptr,
+    int32_t* padded_group_start_offsets_ptr,
+    int32_t* padded_group_end_offsets_ptr,
+    int num_groups,
+    int alignment_size,
+    cudaStream_t stream
+) {
+    // Single warp is enough for num_groups <= 32
+    compute_padded_offsets_kernel<<<1, 32, 0, stream>>>(
+        group_end_offsets_ptr,
+        padded_group_start_offsets_ptr,
+        padded_group_end_offsets_ptr,
+        num_groups,
+        alignment_size
+    );
+
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void launch_fused_pad_token_groups_cuda(
+    const void* input_ptr,
+    const int32_t* group_end_offsets_ptr,
+    const int32_t* padded_group_start_offsets_ptr,
+    void* output_ptr,
+    int num_tokens,
+    int dim,
+    int num_groups,
+    int dtype_size,
+    int dtype_enum,
+    cudaStream_t stream
+) {
+    const int WARPS_PER_BLOCK = 8;
+    const int THREADS_PER_WARP = 32;
+    const int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;  // 256 threads
+
+    const int num_blocks = ceil_div(num_tokens, WARPS_PER_BLOCK);
+
+    fused_pad_token_groups_kernel<<<num_blocks, THREADS_PER_BLOCK, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(input_ptr),
+        group_end_offsets_ptr,
+        padded_group_start_offsets_ptr,
+        reinterpret_cast<__nv_bfloat16*>(output_ptr),
+        num_tokens,
+        dim,
+        num_groups
+    );
+
+    CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace mxfp8

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_extension.cpp
@@ -49,6 +49,26 @@ void launch_mx_block_rearrange_2d_simple_cuda(
     int chunk_width,
     cudaStream_t stream);
 
+void launch_compute_padded_offsets_cuda(
+    const int32_t* group_end_offsets_ptr,
+    int32_t* padded_group_start_offsets_ptr,
+    int32_t* padded_group_end_offsets_ptr,
+    int num_groups,
+    int alignment_size,
+    cudaStream_t stream);
+
+void launch_fused_pad_token_groups_cuda(
+    const void* input_ptr,
+    const int32_t* group_end_offsets_ptr,
+    const int32_t* padded_group_start_offsets_ptr,
+    void* output_ptr,
+    int num_tokens,
+    int dim,
+    int num_groups,
+    int dtype_size,
+    int dtype_enum,
+    cudaStream_t stream);
+
 // Helper for tensor validation
 void check_cuda_tensor(const at::Tensor &t, const char *name) {
   TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
@@ -296,6 +316,77 @@ at::Tensor mx_block_rearrange_2d_M_groups(
   return output;
 }
 
+std::tuple<at::Tensor, at::Tensor> fused_pad_token_groups(
+    at::Tensor inputs,
+    at::Tensor group_end_offsets,
+    int64_t alignment_size) {
+
+  // Validate inputs
+  check_cuda_tensor(inputs, "inputs");
+  check_cuda_tensor(group_end_offsets, "group_end_offsets");
+
+  TORCH_CHECK(inputs.dim() == 2, "inputs must be 2D, got: ", inputs.dim());
+  TORCH_CHECK(inputs.is_contiguous(), "inputs must be contiguous");
+  TORCH_CHECK(group_end_offsets.dim() == 1, "group_end_offsets must be 1D");
+  TORCH_CHECK(group_end_offsets.scalar_type() == at::kInt,
+              "group_end_offsets must be int32");
+  TORCH_CHECK(inputs.scalar_type() == at::kFloat ||
+                  inputs.scalar_type() == at::kBFloat16,
+              "inputs must be float32 or bfloat16");
+
+  c10::cuda::CUDAGuard device_guard(inputs.device());
+
+  const int num_tokens = inputs.size(0);
+  const int dim = inputs.size(1);
+  const int num_groups = group_end_offsets.size(0);
+
+  TORCH_CHECK(num_groups <= 32, "num_groups must be <= 32, got: ", num_groups);
+  TORCH_CHECK(alignment_size == 32, "alignment_size must be 32 for now");
+
+  // Allocate tensors for padded group offsets
+  at::Tensor padded_group_start_offsets = at::empty({num_groups}, group_end_offsets.options());
+  at::Tensor padded_group_end_offsets = at::empty({num_groups}, group_end_offsets.options());
+
+  // Launch GPU kernel to compute padded offsets (avoids multiple torch op launches)
+  launch_compute_padded_offsets_cuda(
+      group_end_offsets.data_ptr<int32_t>(),
+      padded_group_start_offsets.data_ptr<int32_t>(),
+      padded_group_end_offsets.data_ptr<int32_t>(),
+      num_groups,
+      static_cast<int>(alignment_size),
+      at::cuda::getCurrentCUDAStream()
+  );
+
+  // Calculate output size with upper bound padding
+  const int output_rows = num_tokens + num_groups * alignment_size;
+
+  // Allocate zero-initialized output (zeros for padding required by quantization)
+  at::Tensor output = at::zeros({output_rows, dim}, inputs.options());
+
+  // Determine dtype parameters
+  int dtype_size = inputs.element_size();
+  int dtype_enum = 0; // 0=fp32, 1=bf16
+  if (inputs.scalar_type() == at::kBFloat16) {
+    dtype_enum = 1;
+  }
+
+  // Launch copy kernel (overwrites zeros with real data)
+  launch_fused_pad_token_groups_cuda(
+      inputs.data_ptr(),
+      group_end_offsets.data_ptr<int32_t>(),
+      padded_group_start_offsets.data_ptr<int32_t>(),
+      output.data_ptr(),
+      num_tokens,
+      dim,
+      num_groups,
+      dtype_size,
+      dtype_enum,
+      at::cuda::getCurrentCUDAStream()
+  );
+
+  return std::make_tuple(output, padded_group_end_offsets);
+}
+
 
 } // namespace mxfp8
 
@@ -305,4 +396,5 @@ TORCH_LIBRARY_IMPL(torchao, CUDA, m) {
   m.impl("mxfp8_quantize", &mxfp8::mxfp8_quantize);
   m.impl("mxfp8_quantize_3d", &mxfp8::mxfp8_quantize_3d);
   m.impl("mx_block_rearrange_2d_M_groups", &mxfp8::mx_block_rearrange_2d_M_groups);
+  m.impl("fused_pad_token_groups", &mxfp8::fused_pad_token_groups);
 }

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -1,7 +1,9 @@
 from torchao.prototype.moe_training.kernels.mxfp8.quant import (
     _mxfp8_cuda_kernels_available,  # noqa: F401
+    fused_pad_token_groups_cuda,  # noqa: F401
     mx_block_rearrange_2d_M_groups_cuda,  # noqa: F401
     mxfp8_quantize_cuda_3d,  # noqa: F401
+    torch_pad_token_groups,  # noqa: F401
     torch_to_blocked_2d_K_groups,  # noqa: F401
     torch_to_blocked_2d_M_groups,  # noqa: F401
     torch_to_blocked_per_group_3d,  # noqa: F401

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -245,6 +245,76 @@ def compute_blocked_scale_offsets_for_K_groups(
     return group_sizes, starting_col_after_padding
 
 
+def torch_pad_token_groups(
+    inputs: torch.Tensor, group_offsets: torch.Tensor, alignment_size: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reference PyTorch implementation for padding token groups to alignment.
+
+    Uses upper bound allocation to match Triton implementations and avoid D2H sync
+    for size computation.
+
+    Args:
+        inputs: Input tensor of shape (num_tokens, dim)
+        group_offsets: Group end offsets of shape (num_groups,)
+        alignment_size: Alignment size to pad each group to
+
+    Returns:
+        padded_tokens: Padded tokens tensor (with upper bound size)
+        padded_group_offsets: New group offsets after padding
+    """
+    num_tokens, dim = inputs.shape
+    num_groups = group_offsets.shape[0]
+
+    # Upper bound allocation (same as Triton implementations)
+    output_size = num_tokens + num_groups * alignment_size
+    padded_tokens = torch.zeros(
+        output_size, dim, dtype=inputs.dtype, device=inputs.device
+    )
+
+    # Compute group sizes using torch operations (no D2H sync)
+    group_sizes = torch.diff(
+        group_offsets,
+        prepend=torch.zeros(1, dtype=group_offsets.dtype, device=group_offsets.device),
+    )
+
+    # Compute padded sizes (align to alignment_size)
+    padded_sizes = (
+        (group_sizes + alignment_size - 1) // alignment_size
+    ) * alignment_size
+
+    # Compute padded offsets using cumsum
+    padded_group_end_offsets = torch.cumsum(padded_sizes, 0, dtype=torch.int32)
+    padded_group_start_offsets = padded_group_end_offsets - padded_sizes
+
+    # Copy data group by group
+    group_start_offsets = torch.cat(
+        [
+            torch.zeros(1, dtype=group_offsets.dtype, device=group_offsets.device),
+            group_offsets[:-1],
+        ]
+    )
+
+    # Convert tensors to lists once to avoid repeated device-to-host syncs
+    group_start_list = group_start_offsets.tolist()
+    group_end_list = group_offsets.tolist()
+    padded_start_list = padded_group_start_offsets.tolist()
+
+    for i in range(num_groups):
+        group_start = group_start_list[i]
+        group_end = group_end_list[i]
+        padded_start = padded_start_list[i]
+
+        # Copy group tokens to padded output
+        group_size = group_end - group_start
+        padded_tokens[padded_start : padded_start + group_size] = inputs[
+            group_start:group_end
+        ]
+        # Zeros already in buffer, no need to explicitly pad
+
+    return padded_tokens, padded_group_end_offsets
+
+
 if torch_version_at_least("2.7.0") and has_triton():
     import triton
     import triton.language as tl
@@ -346,7 +416,7 @@ if torch_version_at_least("2.7.0") and has_triton():
 
         # Calculate this group's start row after blocked format padding, by doing a prefix sum
         # of each previous group's padded size.
-        output_group_start_row = _blocked_group_start_idx(
+        output_group_start_row = _start_index_after_padding(
             group_pid, orig_offsets, num_groups, 128
         )
 
@@ -608,7 +678,7 @@ if torch_version_at_least("2.7.0") and has_triton():
 
         # Calculate this group's start row after blocked format padding, by doing a prefix sum
         # of each previous group's padded size.
-        output_group_start_col = _blocked_group_start_idx(
+        output_group_start_col = _start_index_after_padding(
             group_pid, orig_offsets, num_groups, 4
         )
 
@@ -684,7 +754,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         return dest_indices_flat
 
     @triton.jit
-    def _blocked_group_start_idx(
+    def _start_index_after_padding(
         group_pid,
         orig_offsets,
         num_groups: tl.constexpr,
@@ -860,6 +930,75 @@ if _mxfp8_cuda_kernels_available:
 
         return scales_tensor.new_empty((padded_rows, padded_cols))
 
+    # CUDA kernel for fused padding of token groups
+    lib.define(
+        "fused_pad_token_groups(Tensor inputs, Tensor group_end_offsets, int alignment_size) -> (Tensor, Tensor)",
+        tags=[torch._C.Tag.needs_fixed_stride_order],
+    )
+
+    def fused_pad_token_groups_cuda(
+        inputs: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        alignment_size: int = 32,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        CUDA implementation of fused padding for token groups.
+
+        This function pads token groups to alignment boundaries in a single fused operation.
+        Each group is padded to a multiple of alignment_size (typically 32).
+
+        Args:
+            inputs: Input tensor of shape (num_tokens, dim)
+            group_end_offsets: Group end offsets of shape (num_groups,)
+            alignment_size: Alignment size to pad each group to
+
+        Returns:
+            padded_tokens: Padded tokens tensor
+            padded_group_end_offsets: New group offsets after padding
+        """
+        assert inputs.ndim == 2, "input activations must be 2d"
+        assert inputs.dtype in (
+            torch.float32,
+            torch.bfloat16,
+        ), "inputs must be float32 or bfloat16"
+        assert group_end_offsets.dtype == torch.int32, "group_end_offsets must be int32"
+
+        return torch.ops.torchao.fused_pad_token_groups.default(
+            inputs,
+            group_end_offsets,
+            alignment_size,
+        )
+
+    @torch.library.register_fake("torchao::fused_pad_token_groups")
+    def _fake_fused_pad_token_groups_cuda(
+        inputs: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        alignment_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fake/meta implementation for fused_pad_token_groups."""
+        num_tokens, dim = inputs.shape
+        num_groups = group_end_offsets.shape[0]
+
+        # Calculate output size with upper bound padding
+        output_rows = num_tokens + num_groups * alignment_size
+
+        # Create fake output tensors
+        padded_tokens = inputs.new_empty((output_rows, dim))
+
+        # Compute fake padded offsets
+        group_sizes = torch.diff(
+            group_end_offsets,
+            prepend=torch.zeros(
+                1, dtype=group_end_offsets.dtype, device=group_end_offsets.device
+            ),
+        )
+        padded_sizes = (
+            (group_sizes + alignment_size - 1) // alignment_size
+        ) * alignment_size
+        padded_group_end_offsets = torch.cumsum(padded_sizes, 0, dtype=torch.int32)
+
+        return padded_tokens, padded_group_end_offsets
+
 else:
 
     def mxfp8_quantize_cuda_3d(
@@ -878,4 +1017,13 @@ else:
     ) -> torch.Tensor:
         raise NotImplementedError(
             "mx_block_rearrange_2d_M_groups_cuda is not implemented on this device"
+        )
+
+    def fused_pad_token_groups_cuda(
+        inputs: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        alignment_size: int = 32,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError(
+            "fused_pad_token_groups_cuda is not implemented on this device"
         )

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -13,8 +13,10 @@ from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
+    fused_pad_token_groups_cuda,
     mx_block_rearrange_2d_M_groups_cuda,
     mxfp8_quantize_cuda_3d,
+    torch_pad_token_groups,
     triton_mx_block_rearrange_2d_K_groups,
     triton_mx_block_rearrange_per_group_3d,
 )
@@ -59,6 +61,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
     kernel_preference: KernelPreference = KernelPreference.AUTO,
     wgrad_with_hp: bool = False,
     scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
+    pad_token_groups: bool = True,
 ) -> torch.Tensor:
     """
     Differentiable mxfp8 grouped gemm with dynamic mxfp8 quantization.
@@ -76,6 +79,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
         kernel_preference (KernelPreference): Kernel preference (AUTO uses CUDA/Triton, EMULATED uses to_mx). Defaults to KernelPreference.AUTO.
         wgrad_with_hp (bool): Whether to compute weight gradient in high precision. Defaults to False.
         scale_calculation_mode (ScaleCalculationMode): Mode for scale calculation (RCEIL, FLOOR, etc.). Defaults to ScaleCalculationMode.RCEIL.
+        pad_token_groups (bool): Whether to pad token groups to the next multiple of 32 (requirement for MXFP8 grouped GEMM). If your tokens are already padded, set to False.
 
     Returns:
         out (torch.Tensor): The result of the mxfp8 scaled grouped gemm.
@@ -91,6 +95,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
         kernel_preference,
         wgrad_with_hp,
         scale_calculation_mode,
+        pad_token_groups,
     )
 
 
@@ -114,6 +119,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         kernel_preference: KernelPreference = KernelPreference.AUTO,
         wgrad_with_hp: bool = False,
         scale_calculation_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
+        pad_token_groups: bool = False,
     ) -> torch.Tensor:
         """
         Forward pass: Quantize inputs and perform grouped GEMM.
@@ -157,6 +163,18 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         if isinstance(input_act, MXTensor):
             assert wgrad_with_hp, (
                 "only `wgrad_with_hp` recipe is supported for pre-quantized inputs, support for other recipes is still in progress"
+            )
+
+        # Save original M before padding
+        original_M = input_act.shape[0]
+
+        # Conditionally pad token groups if not aligned to block_size
+        if pad_token_groups:
+            input_act, group_offsets = pad_token_groups_func(
+                input_act,
+                group_offsets,
+                alignment_size=block_size,
+                kernel_preference=kernel_preference,
             )
 
         # Quantize input activations along dim0
@@ -216,6 +234,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         ctx.kernel_preference = kernel_preference
         ctx.wgrad_with_hp = wgrad_with_hp
         ctx.scale_calculation_mode = scale_calculation_mode
+        ctx.original_M = original_M
 
         return output
 
@@ -237,6 +256,7 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         kernel_preference = ctx.kernel_preference
         wgrad_with_hp = ctx.wgrad_with_hp
         scale_calculation_mode = ctx.scale_calculation_mode
+        original_M = ctx.original_M
 
         # Check SM100 kernel availability when not using emulated mode
         emulated = kernel_preference == KernelPreference.EMULATED
@@ -267,7 +287,12 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             wgrad_with_hp,
             kernel_preference,
         )
-        return grad_input, grad_weight_t, None, None, None, None, None, None
+
+        # Unpad grad_input to original shape
+        if grad_input.shape[0] > original_M:
+            grad_input = grad_input[:original_M]
+
+        return grad_input, grad_weight_t, None, None, None, None, None, None, None
 
 
 def _compute_dgrad(
@@ -714,6 +739,23 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
         A_dequant, B_dequant.transpose(-2, -1), offs=offs, out_dtype=out_dtype
     )
     return out
+
+
+def pad_token_groups_func(
+    input_act: torch.Tensor,
+    group_offsets: torch.Tensor,
+    alignment_size: int = 32,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if kernel_preference == KernelPreference.EMULATED:
+        padded_input_act, padded_group_offsets = torch_pad_token_groups(
+            input_act, group_offsets, alignment_size=alignment_size
+        )
+    else:
+        padded_input_act, padded_group_offsets = fused_pad_token_groups_cuda(
+            input_act, group_offsets, alignment_size=alignment_size
+        )
+    return padded_input_act, padded_group_offsets
 
 
 def round_up(x, y):

--- a/torchao/quantization/quantize_/common/kernel_preference.py
+++ b/torchao/quantization/quantize_/common/kernel_preference.py
@@ -8,9 +8,12 @@ from enum import Enum
 
 import torch
 
+from torchao.utils import register_as_pytree_constant
+
 
 # can switch to StrEnum (https://docs.python.org/3/library/enum.html#enum.StrEnum)
 # after python 3.10 is end of life (https://devguide.python.org/versions/)
+@register_as_pytree_constant
 class KernelPreference(str, Enum):
     """Enum for specifying the groups of kernels that's used for quantization, matrix multiplication
     or other compute ops for quantized tensor


### PR DESCRIPTION
Stacked PRs:
 * #4021
 * __->__#3998


--- --- ---

## Motivation
- Torchtitan is removing the token group padding logic since it is now only needed for fp8/mxfp8, not bf16 grouped mm
- We have also received [user feedback](https://github.com/pytorch/ao/issues/3287#issuecomment-3493036157) that torchao should handle this token group padding / data movement as it is tricky to do efficiently and many users won't be able to get a speedup using TorchAO MXFP8 without an optimized implementation of it.

## Summary
- For emulated mode, use a torch native token group padding impl with d2h sync
- For non-emulated mode, I prototyped the following:
    - Add 3 prototype kernels to do this padding with different approaches, with tests and benchmarks
       - Approach 1: Triton two stage approach;
           -  Add padding row to inputs with torch.vstack
           - Triton kernel generates indexes with padding index of -1, avoiding d2h sync
           - Torch code uses those indexes like `inputs[padded_indexes, :]` where the -1 index will select a padding row every time it appears.
       - Approach 2: Triton fused approach (do copy tokens and write padding data in one kernel )
       - Approach 3: CUDA kernel with 2 stage approach (precompute padded offsets in tiny kernel instead of several torch ops, then dispatch padding kernel)

## Tests
- `pytest test/prototype/moe_training/test_kernels.py -k pad`

## Benchmarks
 CUDA is the best across all shapes:
```
  num_tokens    dim    num_groups    torch_us    triton_us    fused_triton_us    cuda_us    torch_mem_bw_gbps    triton_mem_bw_gbps    triton_fused_mem_bw_gbps    cuda_mem_bw_gbps  triton_vs_torch    fused_triton_vs_torch    cuda_vs_torch
------------  -----  ------------  ----------  -----------  -----------------  ---------  -------------------  --------------------  --------------------------  ------------------  -----------------  -----------------------  ---------------
       16384   1536             1     436.458      439.953            417.303    320.444               346.18                343.43                      362.07              471.51  0.99x              1.05x                    1.36x
       16384   1536             4     517.7        452.393            383.254    292.423               292.42                334.64                      395.01              517.7   1.14x              1.35x                    1.77x
       16384   1536             8     536.612      466.062            368.165    286.548               282.85                325.67                      412.27              529.69  1.15x              1.46x                    1.87x
       16384   1536            16     598          465.822            367.509    286.343               255.13                327.52                      415.14              532.81  1.28x              1.63x                    2.09x
       16384   2048             1     441.902      449.814            382.631    292.373               455.89                447.87                      526.51              689.04  0.98x              1.15x                    1.51x
       16384   2048             4     484.005      461.893            401.875    309.171               417.04                437.01                      502.27              652.88  1.05x              1.20x                    1.57x
       16384   2048             8     541.357      473.953            392.233    298.03                373.83                426.99                      515.96              679.04  1.14x              1.38x                    1.82x
       16384   2048            16     585.292      460.7              390.033    293.395               347.56                441.55                      521.56              693.34  1.27x              1.50x                    1.99x
       16384   5120             1     460.036      464.683            567.816    299.987              1094.79               1083.85                      886.98             1678.89  0.99x              0.81x                    1.53x
       16384   5120             4     497.396      449.034            575.571    286.81               1014.54               1123.81                      876.74             1759.45  1.11x              0.86x                    1.73x
       16384   5120             8     526.011      455.096            612.969    300.776               961.84               1111.72                      825.39             1682.11  1.16x              0.86x                    1.75x
       16384   5120            16     607.179      484.409            630.304    296.039               837.58               1049.86                      806.85             1717.88  1.25x              0.96x                    2.05x
       16384   7168             1     465.052      459.34             613.543    295.84               1516.18               1535.03                     1149.23             2383.39  1.01x              0.76x                    1.57x
       16384   7168             4     492.211      456.083            623.67     293.7                1435.31               1549.01                     1132.77             2405.44  1.08x              0.79x                    1.68x
       16384   7168             8     533.49       465.685            665.016    293.333              1327.7                1521.01                     1065.11             2414.71  1.15x              0.80x                    1.82x
       16384   7168            16     609.1        469.449            677.495    298.956              1168.91               1516.64                     1050.91             2381.56  1.30x              0.90x                    2.04x
```
## Limitations
- We should update the docs to recommend Torchtitan users use HybridEP which fuses the padding into the dispatch step to avoid this extra copy (which is expensive since input activations are huge).
- For non-torchtitan users, we can modify our [Triton+Symmetric memory all2all](https://github.com/pytorch/ao/blob/d6d423e0322b760cf8c5d69934915a837f319a99/torchao/prototype/moe_training/kernels/mxfp8/comms.py#L25) impl to fuse padding this way as well, but it is a larger project.


## MXFP8 grouped mm autograd func fwd + bwd new benchmarks

We lose about 25% of the speedup for Llama4 and 50% of the speedup for DSV3 671b. Need to do the all2all dispatch padding approach to avoid this.

```
M,N,K,G                  recipe                             bf16_fwd_bwd_us    scaled_fwd_bwd_us  scaled_fwd_bwd_speedup      bf16_fwd_us    scaled_fwd_us  scaled_fwd_speedup
-----------------------  -------------------------------  -----------------  -------------------  ------------------------  -------------  ---------------  --------------------
(32768, 8192, 5120, 1)   MXFP8TrainingRecipe.MXFP8_RCEIL            7274.69              4548.62  1.599x                         2033.6           1249.18   1.628x
(32768, 8192, 5120, 2)   MXFP8TrainingRecipe.MXFP8_RCEIL            7264.42              4645.89  1.564x                         2171.97          1318.75   1.647x
(128000, 8192, 5120, 1)  MXFP8TrainingRecipe.MXFP8_RCEIL           28025.1              17680.4   1.585x                         9683.04          4871.17   1.988x
(128000, 8192, 5120, 2)  MXFP8TrainingRecipe.MXFP8_RCEIL           27889.7              17515.6   1.592x                         9126.48          4927.33   1.852x
(32768, 2048, 7168, 4)   MXFP8TrainingRecipe.MXFP8_RCEIL            2493.47              2234.4   1.116x                          733.216          758.752  0.966x
(32768, 2048, 7168, 8)   MXFP8TrainingRecipe.MXFP8_RCEIL            2519.04              2359.2   1.068x                          708.544          807.872  0.877x
(128000, 2048, 7168, 4)  MXFP8TrainingRecipe.MXFP8_RCEIL           10091.2               8602.66  1.173x                         2898.9           2812.06   1.031x
(128000, 2048, 7168, 8)  MXFP8TrainingRecipe.MXFP8_RCEIL            9958.98              8097.26  1.23x                          3020.8           2861.15   1.056x
```