### PR TITLE
update b200 peak memory bandwidth

### DIFF
--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -33,9 +33,13 @@ gpu_name_to_specs = {
         "bf16_peak_tops": 2.25e15,
         "fp8_peak_tops": 4.5e15,
         "fp4_peak_tops": 9.0e15,
-        # https://resources.nvidia.com/en-us-blackwell-architecture, page 20
-        # 8.0 TB per second
-        "peak_mem_bw_bytes_sec": 8.0e12,
+        # Original source for mem bw: # https://resources.nvidia.com/en-us-blackwell-architecture, page 20
+        # This 8 TB/s number is based on a memory bus bitwidth 8192 bits.
+        # However, as of CUDA 13.0, the memory bus bitwidth is now reported by driver API as 7680 bits.
+        # This was flagged by this twitter user: https://x.com/PV90169/status/2027746935843832044?s=20
+        # We confirmed via CUDA C++ file querying device properties.
+        # (7680 memory bus bitwdith / 8 bits per byte) * (3996 MHz memory clock) * 2 DDR
+        "peak_mem_bw_bytes_sec": (7680 / 8) * (3.996e9) * 2,  # ~7.672 TB/s
         # for now, copy over from H100
         # TODO(future): measure once we have the hardware
         "pct_achievable_gemm_tops": 0.78,


### PR DESCRIPTION
This [twitter post ](https://x.com/PV90169/status/2027746935843832044?s=20) claimed B200 memory bandwidth is actually 7680gbps, not 8192gbps, as the original bitwidth of the memory bus reported by CUDA drivers has been updated/corrected from 8192 bits to 7680 bits.

I confirmed this claim using Claude to write a simple CUDA C++ file to query the device driver:

```
=== Device 0: NVIDIA B200 ===
Memory Bus Width: 7680 bits
Total Global Memory: 178.35 GB
L2 Cache Size: 126.50 MB
Compute Capability: 10.0
Number of SMs: 148
Warp Size: 32
Max Threads per Block: 1024
Max Threads per SM: 2048
Shared Memory per Block: 48.00 KB
Shared Memory per SM: 228.00 KB
Registers per Block: 65536
Registers per SM: 65536
ECC Enabled: Yes
```

And nvidia-smi to get the memory clock frequency:
```
nvidia-smi --query-gpu=clocks.mem,clocks.max.mem --format=csv

clocks.current.memory [MHz], clocks.max.memory [MHz]
3996 MHz, 3996 MHz
```
Bandwidth = (7680bits/8bits per byte)*(3996 MHz memory clock) * 2 DDR / 1e12 = 7.672 TB/s

This PR updates our benchmark/roofline utils accordingly.

