### PR TITLE
Make QuantizeTensorToFloat8Kwargs a frozen Dataclass to enable torch export

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -58,7 +58,7 @@ __all__ = [
 aten = torch.ops.aten
 
 
-@dataclass
+@dataclass(frozen=True)
 class QuantizeTensorToFloat8Kwargs(QuantizeTensorKwargs):
     """Tensor kwargs for creating float8 tensor (either activation or weight)
 


### PR DESCRIPTION
Regular Dataclasses are not supported by the Dynamo Tracer as they're dispatched to `UserDefinedObjectVariable` which doesn't have an implementation for `as_proxy`. However, Frozen Dataclasses are supported by the Dynamo Tracer as the `as_proxy` method is defined for them ([source](https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/variables/user_defined.py#L2253)).

Marking `QuantizeTensorToFloat8Kwargs` as a frozen dataclass enables torch.export on the `Float8Tensor` subclass.

Fixes https://github.com/pytorch/ao/issues/3928