### PR TITLE
Lazy load x86 import

### DIFF
--- a/torchao/testing/pt2e/utils.py
+++ b/torchao/testing/pt2e/utils.py
@@ -24,7 +24,6 @@ from torch.testing._internal.common_utils import TestCase
 from torch.testing._internal.inductor_utils import clone_preserve_strides_offset
 
 import torchao
-import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
 from torchao.quantization.pt2e import FROM_NODE_KEY
 from torchao.quantization.pt2e._numeric_debugger import _extract_node_source_debug_info
 from torchao.quantization.pt2e.graph_utils import bfs_trace_with_node_process
@@ -32,9 +31,6 @@ from torchao.quantization.pt2e.quantize_pt2e import (
     convert_pt2e,
     prepare_pt2e,
     prepare_qat_pt2e,
-)
-from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import (
-    X86InductorQuantizer,
 )
 from torchao.utils import torch_version_at_least
 
@@ -226,6 +222,11 @@ def get_default_x86_quantizer(is_qat, is_dynamic):
     """
     Create a default X86InductorQuantizer configured for the given mode (QAT and dynamic quant).
     """
+    import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
+    from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import (
+        X86InductorQuantizer,
+    )
+
     quantizer = X86InductorQuantizer()
     quantizer.set_global(
         xiq.get_default_x86_inductor_quantization_config(


### PR DESCRIPTION
This is breaking executorch ci, see https://hud.pytorch.org/hud/pytorch/executorch/main/1?per_page=50&name_filter=unittest%20%2F%20macos

Error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lfq/executorch/third-party/ao/torchao/testing/pt2e/utils.py", line 27, in <module>
    import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer as xiq
  File "/Users/lfq/executorch/third-party/ao/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py", line 1644, in <module>
    _register_quantization_weight_pack_pass()
  File "/Users/lfq/executorch/third-party/ao/torchao/quantization/pt2e/inductor_passes/x86.py", line 3221, in _register_quantization_weight_pack_pass
    if not torch.ops.mkldnn._is_mkldnn_acl_supported():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lfq/miniconda3/envs/executorch/lib/python3.12/site-packages/torch/_ops.py", line 1353, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' 'mkldnn' object has no attribute '_is_mkldnn_acl_supported'
```

Lazy load the x86 import, as macos doesnt have mkldnn

Test locally in executorch
```
(executorch) lfq@lfq-mac executorch % pytest --collect-only backends/xnnpack/test/quantizer/test_pt2e_quantization.py

```