### PR TITLE
Upgrade torchao build configs to C++20 (#4025)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -523,12 +523,12 @@ def get_extensions():
         "-DNDEBUG" if not debug_mode else "-DDEBUG",
         "-O3" if not debug_mode else "-O0",
         "-t=0",
-        "-std=c++17",
+        "-std=c++20",
     ]
     rocm_args = [
         "-DNDEBUG" if not debug_mode else "-DDEBUG",
         "-O3" if not debug_mode else "-O0",
-        "-std=c++17",
+        "-std=c++20",
     ]
     maybe_hipify_v2_flag = []
     if use_rocm and detect_hipify_v2():
@@ -773,7 +773,7 @@ def get_extensions():
                     extra_compile_args={
                         "cxx": [
                             f"-DPy_LIMITED_API={min_supported_cpython_hexcode}",
-                            "-std=c++17",
+                            "-std=c++20",
                             "-O3",
                         ],
                         "nvcc": nvcc_args

--- a/torchao/csrc/cpu/CMakeLists.txt
+++ b/torchao/csrc/cpu/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CMakeDependentOption)
 
 project(torchao)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/torchao/experimental/CMakeLists.txt
+++ b/torchao/experimental/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CMakeDependentOption)
 
 project(torchao)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/torchao/experimental/kernels/mps/test/Makefile
+++ b/torchao/experimental/kernels/mps/test/Makefile
@@ -1,7 +1,7 @@
 all: test_lowbit
 
 test_lowbit: test_lowbit.mm ../src/OperationUtils.mm
-	clang++ -I${TORCHAO_ROOT} -O3 -std=c++17  -Wall -Wextra -o $@ $^ -framework Metal -framework Foundation
+	clang++ -I${TORCHAO_ROOT} -O3 -std=c++20  -Wall -Wextra -o $@ $^ -framework Metal -framework Foundation
 
 run: test_lowbit
 	./test_lowbit

--- a/torchao/experimental/ops/mps/CMakeLists.txt
+++ b/torchao/experimental/ops/mps/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.19)
 
 project(torchao_ops_mps_linear_fp_act_xbit_weight)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Summary:

Update CMAKE_CXX_STANDARD and compiler flags from c++17 to c++20
in torchao's setup.py, CMakeLists.txt, and Makefile files.

Reviewed By: andrewor14

Differential Revision: D95103084


