### PR TITLE
Fix Android ARM64 build for torchao lowbit kernels

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/internal/memory.h
+++ b/torchao/csrc/cpu/shared_kernels/internal/memory.h
@@ -19,7 +19,15 @@ inline aligned_byte_ptr make_aligned_byte_ptr(size_t alignment, size_t size) {
   // Adjust size to next multiple of alignment >= size
   size_t adjusted_size = ((size + alignment - 1) / alignment) * alignment;
 
+#if defined(__ANDROID__) && __ANDROID_API__ < 28
+  void* raw_ptr = nullptr;
+  if (::posix_memalign(&raw_ptr, alignment, adjusted_size) != 0) {
+    raw_ptr = nullptr;
+  }
+  char* ptr = static_cast<char*>(raw_ptr);
+#else
   char* ptr = static_cast<char*>(std::aligned_alloc(alignment, adjusted_size));
+#endif
   if (!ptr) {
     throw std::runtime_error(
         "Failed to allocate memory. Requested size: " + std::to_string(size) +


### PR DESCRIPTION
Summary:
D95224222 added torchao ARM lowbit kernel dependencies to the ExecuTorch
llama runner for ARM64 builds, but the Buck targets had two issues that
prevented the Android ARM64 build from succeeding.

1. `std::aligned_alloc` is not available on Android API < 28.
   Android's Bionic libc only added `aligned_alloc` in API 28 (Android 9 Pie).
   The NDK's libc++ declares `using ::aligned_alloc _LIBCPP_USING_IF_EXISTS`
   which silently becomes unresolved when targeting API < 28 (the default
   `app_platform` is android-21). This caused a compile error in
   `shared_kernels/internal/memory.h`. Fixed by using `posix_memalign` (which
   is available since API 16) as a fallback when `__ANDROID_API__ < 28`.

2. The aarch64 `linear` kernels use ARM dot product intrinsics (`vdotq_s32`)
   which require the `+dotprod` architecture feature. The CMake build already
   passed `-march=armv8.4-a+dotprod`, but the Buck targets were missing this
   flag for Android builds. Fixed by adding `-march=armv8.2-a+dotprod` to
   `fbandroid_compiler_flags` in both the `aarch64/linear` target and the
   `op_linear_8bit_act_xbit_weight_executorch` target.

Reviewed By: tanvirislam-meta

Differential Revision: D95832860


