### PR TITLE
[float8] fix `==` typo in `float8_transpose` axiswise dim remapping

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -144,11 +144,16 @@ class TestFloat8TrainingTensor:
 
             fp8_a_transposed = fp8_a.transpose(0, 1)
             fp8_b_t = fp8_b.t()
+            expected_axiswise_dim = (
+                None if axiswise_dim is None else (-1 if axiswise_dim == 0 else 0)
+            )
 
             torch.testing.assert_close(
                 (fp8_a_transposed._data, fp8_a_transposed._scale),
                 (fp8_b_t._data, fp8_b_t._scale),
             )
+            assert fp8_a_transposed._axiswise_dim == expected_axiswise_dim
+            assert fp8_b_t._axiswise_dim == expected_axiswise_dim
 
     @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
     @pytest.mark.parametrize("axiswise_dim", [0, -1])

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -174,9 +174,9 @@ def float8_transpose(aten_op, args, kwargs=None):
     new_axiswise_dim = old_axiswise_dim
     if old_axiswise_dim is not None:
         if old_axiswise_dim == 0:
-            new_axiswise_dim == -1
+            new_axiswise_dim = -1
         else:
-            new_axiswise_dim == 0
+            new_axiswise_dim = 0
 
     return Float8TrainingTensor(
         new_data,


### PR DESCRIPTION
Fixes #4444.

## Summary

In `torchao/float8/float8_ops.py::float8_transpose`, the lines that remap `_axiswise_dim` after transpose use `==` (comparison) instead of `=` (assignment), so the comparison result is discarded and `new_axiswise_dim` is never updated:

```python
if old_axiswise_dim is not None:
    if old_axiswise_dim == 0:
        new_axiswise_dim == -1   # no-op comparison
    else:
        new_axiswise_dim == 0    # no-op comparison
```

After this patch `Float8TrainingTensor.transpose(0, 1)` and `.t()` correctly flip the axiswise dim (`0` ↔ `-1`), matching what `float8_view` (lines 213-239 in the same file) already assumes for reshape.

Verified the bug still exists on `main` at `b4805e2e8` (HEAD as of this rebase).

## Test Plan

Extends the existing `TestFloat8TrainingTensor.test_transpose` (which previously only asserted `_data` / `_scale` on the transposed tensor) to also assert `_axiswise_dim` on both `transpose(0, 1)` and `.t()` outputs, for all parametrized `axiswise_dim` values (`None`, `0`, `-1`).

```bash
pytest test/float8/test_base.py -k 'TestFloat8TrainingTensor and transpose' -v
```

The new assertions fail on `main` (the bug) and pass after the fix.

## Changes since the previous version of this PR

The previous version of this PR also touched two other files. Both have been **split out**:

1. **`torchao/quantization/linear_activation_quantized_tensor.py`** (`tensor_impl` property passthrough)
   — the file was deleted from upstream `main` in the interim (class `LinearActivationQuantizedTensor` no longer exists anywhere in the repo per code search), so this hunk is obsolete.

2. **`torchao/optim/adam.py`** (DTensor branch around `torch.compile(single_param_adam)`)
   — this is a separate functional concern that deserves its own PR with a clearer FSDP2 reproducer. Will file separately if still needed after verification on current `main`.

This PR is now **only** the one-line typo fix plus the regression test that locks it in (+7/-2 lines).

Addresses @vkuzo's earlier ask for a test plan.

## Related

- Sibling typo bug + PR: #4445 / #4115