### PR TITLE
Fix deprecated TorchAO dtype imports

### DIFF
--- a/torchao/dtypes/__init__.py
+++ b/torchao/dtypes/__init__.py
@@ -20,9 +20,11 @@ from .uintx import (
     SemiSparseLayout,
     TensorCoreTiledLayout,
 )
-from .uintx.block_sparse_layout import BlockSparseLayout
-from .uintx.dyn_int8_act_int4_wei_cpu_layout import Int8DynamicActInt4WeightCPULayout
-from .uintx.uintx_layout import UintxLayout
+from torchao.prototype.dtypes import (
+    BlockSparseLayout,
+    Int8DynamicActInt4WeightCPULayout,
+    UintxLayout,
+)
 from .utils import (
     Layout,
     PlainLayout,

--- a/torchao/dtypes/uintx/__init__.py
+++ b/torchao/dtypes/uintx/__init__.py
@@ -1,5 +1,6 @@
-from .dyn_int8_act_int4_wei_cpu_layout import (
+from torchao.prototype.dtypes import (
     Int8DynamicActInt4WeightCPULayout,
+    UintxLayout,
 )
 from .int4_cpu_layout import (
     Int4CPULayout,
@@ -18,9 +19,6 @@ from .semi_sparse_layout import (
 )
 from .tensor_core_tiled_layout import (
     TensorCoreTiledLayout,
-)
-from .uintx_layout import (
-    UintxLayout,
 )
 
 __all__ = [


### PR DESCRIPTION
This PR resolves `DeprecationWarnings` caused by deprecated `dtype` import paths in TorchAO.
```
/usr/local/lib/python3.12/dist-packages/torchao/dtypes/uintx/__init__.py:1: DeprecationWarning: Importing 
from torchao.dtypes.uintx.dyn_int8_act_int4_wei_cpu_layout is deprecated. Please use 
'from torchao.prototype.dtypes import Int8DynamicActInt4WeightCPULayout' instead. 
This import path will be removed in a future release of torchao. See https://github.com/pytorch/ao/issues/2752 
for more details.
    from .dyn_int8_act_int4_wei_cpu_layout import (

  /usr/local/lib/python3.12/dist-packages/torchao/dtypes/uintx/__init__.py:22: DeprecationWarning: Importing 
from torchao.dtypes.uintx.uintx_layout is deprecated. Please use 
'from torchao.prototype.dtypes import UintxLayout, UintxTensor' instead. 
This import path will be removed in a future release of torchao. See https://github.com/pytorch/ao/issues/2752
 for more details. 
    from .uintx_layout import (
  /usr/local/lib/python3.12/dist-packages/torchao/dtypes/__init__.py:23: DeprecationWarning: Importing
 BlockSparseLayout from torchao.dtypes is deprecated. Please use 
'from torchao.prototype.dtypes import BlockSparseLayout' instead. This import path will be removed 
in a future torchao release. Please check issue: https://github.com/pytorch/ao/issues/2752 for more details.
    from .uintx.block_sparse_layout import BlockSparseLayout
```

Recent changes in PyTorch's TorchAO moved several dtype definitions from `torchao.dtypes` to `torchao.prototype.dtypes` (see [pytorch/ao#2752](https://github.com/pytorch/ao/issues/2752)).

The deprecated imports are replaced with the corresponding symbols from `torchao.prototype.dtypes`.

**Result**

- Eliminates runtime DeprecationWarnings.
- Ensures compatibility with upcoming TorchAO releases, where the old import paths will be removed.
- No functional behavior changes are introduced.