### PR TITLE
[training] skip Dtensor/TP integration test pending solution

### DIFF
--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -47,6 +47,4 @@ jobs:
         uv pip install -r dev-requirements.txt
         pip install . --no-build-isolation
         ./test/float8/test_everything_multi_gpu.sh
-        ./test/prototype/mx_formats/test_mx_dtensor.sh
         ./test/prototype/mx_formats/test_mxfp8_allgather.sh
-        ./test/prototype/moe_training/test_distributed.sh


### PR DESCRIPTION
## Summary
- Dtensor handling for mxfp8 linear training is in progress but may take ~days, let's skip the test for now so get cleaner signal in CI
    - discussing and iterating on ideas with Pian here https://github.com/pytorch/ao/pull/3985 and here https://github.com/pytorch/ao/pull/4010  