### PR TITLE
Unskip TestSemiStructuredSparse.test_sparse (#4064)

### DIFF
--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -26,7 +26,6 @@ logging.basicConfig(
 
 class TestSemiStructuredSparse(common_utils.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    @unittest.skip("Temporarily skipping to unpin nightlies")
     def test_sparse(self):
         input = torch.rand((128, 128)).half().cuda()
         model = (


### PR DESCRIPTION
Summary:

What: Remove temporary skip on `TestSemiStructuredSparse.test_sparse`

Why: The existing TorchAO sparsity test now passes locally again on the CUDA cuSPARSELt path, so the temporary skip is no longer needed.

Reviewed By: RandySheriff

Differential Revision: D96172407
