### PR TITLE
Enable TestSemiStructuredSparse.test_sparse for ROCm 7.0+ (#4065)

### DIFF
--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -10,6 +10,7 @@ import unittest
 import torch
 from torch import nn
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_utils import skipIfRocmVersionLessThan
 
 from torchao.dtypes import SemiSparseLayout
 from torchao.quantization.quant_api import (
@@ -26,6 +27,7 @@ logging.basicConfig(
 
 class TestSemiStructuredSparse(common_utils.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @skipIfRocmVersionLessThan((7, 0))
     def test_sparse(self):
         input = torch.rand((128, 128)).half().cuda()
         model = (


### PR DESCRIPTION
Summary:

What: Update guards on `TestSemiStructuredSparse.test_sparse` so the test runs on CUDA and ROCm/hipSPARSELt), but skips CPU only environments.

Why: Semi-structured sparsity now works on ROCm 7.0+ with hipSPARSELt.

Reviewed By: RandySheriff

Differential Revision: D96206508
