### PR TITLE
[CPU] Skip the failing test_fp8_q_attention_block UT

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3106,7 +3106,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 # TODO(Weiwen)
                 # It's failing due to https://github.com/pytorch/pytorch/commit/6a91cdc0302aa3353d773f292d24df787961f4a5
                 # Now we skip the failing case and will re-enable it after the issue is fixed.
-                return
+                continue
             self._test_q_attention_block_helper(
                 annotate_matmul=annotate_matmul, is_fp8=True
             )


### PR DESCRIPTION
The UT is failing due to the commit https://github.com/pytorch/pytorch/commit/6a91cdc0302aa3353d773f292d24df787961f4a5 in pytorch. We skip this UT for now and will re-enable it after the fix.

Related issue: https://github.com/pytorch/ao/issues/4070