### PR TITLE
speed up mxfp8 rceil quantization kernel

### DIFF
--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -147,7 +147,17 @@ def _to_mx_rceil(
     )
 
     # scale and saturated cast the data elements to max of target dtype
-    data_lp = torch.clamp(data_hp * descale_fp, min=-1 * max_pos, max=max_pos)
+    data_lp = data_hp * descale_fp
+    if not torch._dynamo.is_compiling():
+        # As of 20250317, the Pytorch eager mode cast to `torch.float8_e4m3fn`
+        # is unsaturated. This cast is saturated in triton. If we are compute bound,
+        # we see a speedup if we remove this redundant clamp if we are compiling
+        # to triton.
+        # TODO(#1912): make the saturated cast work in eager mode and remove this
+        # workaround.
+        # TODO(future PR): unify this code between the FLOOR and RCEIL scaling
+        # methods
+        data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
     return exponent, data_lp
 
 


### PR DESCRIPTION
Summary:

Ensure we don't clamp in inductor, as triton does it for us.
This optimization is already there for FLOOR, also adding it
to the RCEIL path.

copy-pasting as we need to unify the scaling anyways so it will be
faster do that as a separate PR.

For large shapes, this brings us from 3.7 TB/s to 6.1 TB/s on B200.

```bash
> python benchmarks/mx_formats/cast_bench.py --mode dim0_mxfp8_rceil
...
// before
time_us 220.12799978256226                                                                                                                                                                                                       
mem_bw_gbps 3696.4628616248297
// after
time_us 134.17600095272064                                                                                                                                                                                                       
mem_bw_gbps 6064.385361184824 
```

Test Plan: