### PR TITLE
Deprecate AQT and related classes

### DIFF
--- a/torchao/dtypes/affine_quantized_tensor.py
+++ b/torchao/dtypes/affine_quantized_tensor.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import torch
@@ -112,6 +113,9 @@ class AffineQuantizedTensor(TorchAOBaseTensor):
         if zero_point_domain is _DEFAULT_ZPD:
             zero_point_domain = ZeroPointDomain.INT
         torch._C._log_api_usage_once(str(type(self)))
+        warnings.warn(
+            "Deprecation: AffineQuantizedTensor is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         self.tensor_impl = tensor_impl
         self.block_size = block_size
         self.quant_min = quant_min

--- a/torchao/dtypes/floatx/cutlass_semi_sparse_layout.py
+++ b/torchao/dtypes/floatx/cutlass_semi_sparse_layout.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -42,6 +43,12 @@ def _same_metadata(
 class CutlassSemiSparseLayout(Layout):
     """Layout class for float8 2:4 sparsity layout for affine quantized tensor, for cutlass kernel."""
 
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: CutlassSemiSparseLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+
     def pre_process(self, dense: torch.Tensor) -> torch.Tensor:
         # prune to 2:4 if not already
         from torchao.sparsity.utils import mask_creator
@@ -76,6 +83,9 @@ class CutlassSemiSparseTensorImpl(AQTTensorImpl):
         scale: torch.Tensor,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: CutlassSemiSparseTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         self.sparse = sparse
         self.meta = meta
         self.scale = scale

--- a/torchao/dtypes/floatx/float8_layout.py
+++ b/torchao/dtypes/floatx/float8_layout.py
@@ -69,6 +69,12 @@ class Float8Layout(Layout):
 
     mm_config: Optional[Float8MMConfig] = None
 
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: Float8Layout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+
 
 _fallback_warning_shown = False
 
@@ -110,6 +116,9 @@ class Float8AQTTensorImpl(AQTTensorImpl):
         transposed: bool,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: Float8AQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         warnings.warn(
             "Models quantized with version 1 of Float8DynamicActivationFloat8WeightConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2649 for more details"
         )

--- a/torchao/dtypes/uintx/int4_cpu_layout.py
+++ b/torchao/dtypes/uintx/int4_cpu_layout.py
@@ -29,7 +29,11 @@ class Int4CPULayout(Layout):
     Only for PyTorch version at least 2.6
     """
 
-    pass
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: Int4CPULayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
 
 
 @register_layout(Int4CPULayout)
@@ -75,6 +79,9 @@ class Int4CPUAQTTensorImpl(AQTTensorImpl):
         transposed: bool,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: Int4CPUAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         warnings.warn(
             "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
         )

--- a/torchao/dtypes/uintx/int4_xpu_layout.py
+++ b/torchao/dtypes/uintx/int4_xpu_layout.py
@@ -158,7 +158,11 @@ def _linear_fp_act_uint4_weight_int8_zero_impl(input_tensor, weight_tensor, bias
 class Int4XPULayout(Layout):
     """Only for PyTorch version at least 2.7"""
 
-    pass
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: Int4XPULayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
 
 
 @register_layout(Int4XPULayout)
@@ -211,6 +215,9 @@ class Int4XPUAQTTensorImpl(AQTTensorImpl):
         scale: torch.Tensor = None,
         zero: torch.Tensor = None,
     ):
+        warnings.warn(
+            "Deprecation: Int4XPUAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         warnings.warn(
             "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
         )

--- a/torchao/dtypes/uintx/packed_linear_int8_dynamic_activation_intx_weight_layout.py
+++ b/torchao/dtypes/uintx/packed_linear_int8_dynamic_activation_intx_weight_layout.py
@@ -71,6 +71,9 @@ class PackedLinearInt8DynamicActivationIntxWeightLayout(Layout):
         target: Union[str, Target] = "auto",
     ):
         warnings.warn(
+            "Deprecation: PackedLinearInt8DynamicActivationIntxWeightLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+        warnings.warn(
             "Models quantized with version 1 of IntxWeightOnlyConfig/Int8DynamicActivationIntxWeightConfig are deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2967 for more details"
         )
         if isinstance(target, str):
@@ -130,6 +133,9 @@ class PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl(AQTTensorImpl):
         packed_weight: torch.Tensor,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         assert isinstance(_layout, PackedLinearInt8DynamicActivationIntxWeightLayout)
         self.packed_weight = packed_weight
         self._layout = _layout

--- a/torchao/dtypes/uintx/plain_layout.py
+++ b/torchao/dtypes/uintx/plain_layout.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -77,6 +78,10 @@ class PlainAQTTensorImpl(AQTTensorImpl):
         zero_point: Optional[torch.Tensor],
         _layout: Layout,
     ):
+        if type(self) is PlainAQTTensorImpl:
+            warnings.warn(
+                "Deprecation: PlainAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+            )
         self.int_data = int_data
         self.scale = scale
         self.zero_point = zero_point

--- a/torchao/dtypes/uintx/q_dq_layout.py
+++ b/torchao/dtypes/uintx/q_dq_layout.py
@@ -40,7 +40,11 @@ aten = torch.ops.aten
 
 @dataclass(frozen=True)
 class QDQLayout(Layout):
-    pass
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: QDQLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
 
 
 def _same_metadata(self: "QDQTensorImpl", src: "QDQTensorImpl") -> bool:
@@ -96,6 +100,9 @@ class QDQTensorImpl(AQTTensorImpl):
         zero_point: Optional[torch.Tensor],
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: QDQTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         warnings.warn(
             "Models quantized with version 1 of IntxWeightOnlyConfig/Int8DynamicActivationIntxWeightConfig are deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2967 for more details"
         )

--- a/torchao/dtypes/uintx/semi_sparse_layout.py
+++ b/torchao/dtypes/uintx/semi_sparse_layout.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -78,6 +79,12 @@ class SemiSparseLayout(Layout):
     tensors to conform to this sparsity pattern.
     """
 
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: SemiSparseLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+
     def pre_process(self, input: torch.Tensor) -> torch.Tensor:
         # prune to 2:4 if not already
         temp = input.detach()
@@ -91,6 +98,18 @@ class SemiSparseAQTTensorImpl(PlainAQTTensorImpl):
     """
     TensorImpl for semi_sparse_cusparselt layout for affine quantized tensor
     """
+
+    def __init__(
+        self,
+        int_data: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: Optional[torch.Tensor],
+        _layout: Layout,
+    ):
+        warnings.warn(
+            "Deprecation: SemiSparseAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+        super().__init__(int_data, scale, zero_point, _layout)
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs):

--- a/torchao/dtypes/uintx/tensor_core_tiled_layout.py
+++ b/torchao/dtypes/uintx/tensor_core_tiled_layout.py
@@ -188,6 +188,12 @@ class TensorCoreTiledLayout(Layout):
         )
         return input, scale, zero_point
 
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: TensorCoreTiledLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
+
     def extra_repr(self):
         return f"inner_k_tiles={self.inner_k_tiles}"
 
@@ -241,6 +247,9 @@ class TensorCoreTiledAQTTensorImpl(AQTTensorImpl):
         transposed: bool,
         _layout: Layout,
     ):
+        warnings.warn(
+            "Deprecation: TensorCoreTiledAQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
         warnings.warn(
             "Models quantized with version 1 of Int4WeightOnlyConfig is deprecated and will no longer be supported in a future release, please upgrade torchao and quantize again, or download a newer torchao checkpoint, see https://github.com/pytorch/ao/issues/2948 for more details"
         )

--- a/torchao/dtypes/utils.py
+++ b/torchao/dtypes/utils.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -70,6 +71,10 @@ class Layout:
 
     def __post_init__(self):
         torch._C._log_api_usage_once(str(type(self)))
+        if type(self) is Layout:
+            warnings.warn(
+                "Deprecation: Layout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+            )
 
 
 @dataclass(frozen=True)
@@ -79,7 +84,11 @@ class PlainLayout(Layout):
     Typically, this layout is used as the default when no specific layout is required.
     """
 
-    pass
+    def __post_init__(self):
+        super().__post_init__()
+        warnings.warn(
+            "Deprecation: PlainLayout is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+        )
 
 
 def is_device(target_device_str: str, device: Union[str, torch.device]):
@@ -109,6 +118,12 @@ class AQTTensorImpl(TorchAOBaseTensor):
     Note: This is not a user facing API, it's used by AffineQuantizedTensor to construct
     the underlying implementation of a AQT based on layout
     """
+
+    def __init__(self, *args, **kwargs):
+        if type(self) is AQTTensorImpl:
+            warnings.warn(
+                "Deprecation: AQTTensorImpl is deprecated and will be removed in a future release of torchao, see https://github.com/pytorch/ao/issues/2752 for more details"
+            )
 
     def get_plain(self) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """Get the plain (unpacked) Tensor for the tensor impl


### PR DESCRIPTION
**Summary:** Deprecate AffineQuantizedTensor, AQTTensorImpl, Layout, and all subclasses of the above in torchao.dtypes. We are planning to remove these classes in the future, so we deprecate them here in advance.

```
● Here are all the classes that now have new deprecation warnings:

  Base classes (torchao/dtypes/utils.py):
  1. Layout
  2. PlainLayout
  3. AQTTensorImpl

  torchao/dtypes/affine_quantized_tensor.py:
  4. AffineQuantizedTensor

  torchao/dtypes/floatx/:
  5. Float8Layout
  6. Float8AQTTensorImpl
  7. CutlassSemiSparseLayout
  8. CutlassSemiSparseTensorImpl

  torchao/dtypes/uintx/:
  9. TensorCoreTiledLayout
  10. TensorCoreTiledAQTTensorImpl
  11. SemiSparseLayout
  12. SemiSparseAQTTensorImpl
  13. Int4CPULayout
  14. Int4CPUAQTTensorImpl
  15. Int4XPULayout
  16. Int4XPUAQTTensorImpl
  17. QDQLayout
  18. QDQTensorImpl
  19. PlainAQTTensorImpl
  20. PackedLinearInt8DynamicActivationIntxWeightLayout
  21. PackedLinearInt8DynamicActivationIntxWeightAQTTensorImpl
```

More context here: https://github.com/pytorch/ao/issues/2752

**Test Plan:**
Manual testing