### PR TITLE
Skip `test_q_attention_block` for torch >= 2.11.0.dev

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3093,7 +3093,9 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @unittest.skipIf(torch_version_at_least("2.11.0.dev"), "Requires torch 2.11.0.dev+")
+    @unittest.skipIf(
+        torch_version_at_least("2.11.0.dev"), "Doesn't work with torch 2.11.0.dev+"
+    )
     def test_q_attention_block(self):
         for annotate_matmul in [True, False]:
             self._test_q_attention_block_helper(annotate_matmul=annotate_matmul)
@@ -3101,6 +3103,9 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfNoFloat8Support
+    @unittest.skipIf(
+        torch_version_at_least("2.11.0.dev"), "Doesn't work with torch 2.11.0.dev+"
+    )
     def test_fp8_q_attention_block(self):
         for annotate_matmul in [True, False]:
             self._test_q_attention_block_helper(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4085

Summary:
Currently failing in CI, probably due to changes in compile, need a fix
current failing example: https://github.com/pytorch/ao/actions/runs/23070569120/job/67019856617?pr=4082

cc @Xia-Weiwen

Test Plan:
CI nightly regression tests

Reviewers:

Subscribers:

Tasks:

Tags: