### PR TITLE
Fix _is_128_128_scaled false positive for PerTensor on 128x128 linears

### DIFF
--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -210,7 +210,7 @@ def _is_128_128_scaled(x: torch.Tensor) -> bool:
     """
     assert hasattr(x, "block_size"), "Expecting input to have `block_size` attribute"
     b = x.block_size
-    return len(b) == 2 and b[0] == 128 and b[1] == 128
+    return len(b) == 2 and b[0] == 128 and b[1] == 128 and not _is_tensorwise_scaled(x)
 
 
 def _granularity_is_a_1_128_w_128_128(


### PR DESCRIPTION
`_is_128_128_scaled` checks whether `block_size == (128, 128)`, but for PerTensor granularity, `block_size` is set to the full tensor shape. On a 128x128 weight this means `block_size = (128, 128)`, so the function returns True and routes to `blockwise_fp8_gemm` instead of the standard path.

The fix excludes the tensorwise case (`block_size == shape`) so only actual blockwise 128x128 scaling matches. PerRow is unaffected since its block_size is `(1, K)`.

Found while enabling Float8 inference tests on ROCm (#4044) — the test model (`ToyLinearModel`) has a 128x128 linear, and `Float8DynamicActivationFloat8WeightConfig()` with default PerTensor granularity was hitting this.

Fixes #4089