### PR TITLE
Move `_module_extra_repr` to `torchao/quantization/utils.py`

### DIFF
--- a/torchao/prototype/float8_opaque_tensor/inference_workflow.py
+++ b/torchao/prototype/float8_opaque_tensor/inference_workflow.py
@@ -22,12 +22,11 @@ FP8Granularity = Union["PerTensor", "PerRow", "PerGroup"]
 import types
 from functools import partial
 
-from torchao.quantization.quant_api import _module_extra_repr
 from torchao.quantization.quantize_.workflows import QuantizeTensorToFloat8Kwargs
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
-from torchao.quantization.utils import get_block_size
+from torchao.quantization.utils import _module_extra_repr, get_block_size
 
 from .float8_opaque_tensor import Float8OpaqueTensor
 

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -24,10 +24,9 @@ from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_api import (
     Int4WeightOnlyConfig,
     Int8WeightOnlyConfig,
-    _module_extra_repr,
 )
 from torchao.quantization.transform_module import register_quantize_module_handler
-from torchao.quantization.utils import get_block_size
+from torchao.quantization.utils import _module_extra_repr, get_block_size
 
 from .observer import GPTQObserverTensor
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -25,12 +25,12 @@ from torchao.prototype.mx_formats.nvfp4_tensor import (
     QuantizeTensorToNVFP4Kwargs,
     per_tensor_amax_to_scale,
 )
-from torchao.quantization.quant_api import _module_extra_repr, _quantization_type
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
 from torchao.quantization.quantize_.common.quantization_step import QuantizationStep
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
+from torchao.quantization.utils import _module_extra_repr, _quantization_type
 from torchao.utils import (
     is_sm_at_least_100,
     torch_version_at_least,

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -97,6 +97,7 @@ from torchao.quantization.transform_module import (
 from torchao.quantization.utils import (
     _fp8_mm_compat,
     _linear_extra_repr,
+    _module_extra_repr,
     _quantization_type,
     get_block_size,
 )
@@ -393,19 +394,6 @@ def insert_observers_(
 
 def _embedding_extra_repr(self):
     return f"num_embeddings={self.weight.shape[0]}, embedding_dim={self.weight.shape[1]}, weight={_quantization_type(self.weight)}"
-
-
-def _module_extra_repr(self, original_extra_repr, parameter_name):
-    module_torchao_extra_repr = []
-
-    original_extra_repr_str = original_extra_repr()
-    if len(original_extra_repr_str) > 0:
-        module_torchao_extra_repr.append(original_extra_repr_str)
-
-    module_torchao_extra_repr.append(
-        f"{parameter_name}={_quantization_type(getattr(self, parameter_name))}"
-    )
-    return ", ".join(module_torchao_extra_repr)
 
 
 def _get_linear_subclass_inserter(

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -766,6 +766,19 @@ def _linear_extra_repr(self):
     return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={_quantization_type(self.weight)}"
 
 
+def _module_extra_repr(self, original_extra_repr, parameter_name):
+    module_torchao_extra_repr = []
+
+    original_extra_repr_str = original_extra_repr()
+    if len(original_extra_repr_str) > 0:
+        module_torchao_extra_repr.append(original_extra_repr_str)
+
+    module_torchao_extra_repr.append(
+        f"{parameter_name}={_quantization_type(getattr(self, parameter_name))}"
+    )
+    return ", ".join(module_torchao_extra_repr)
+
+
 def _fp8_mm_compat(weight: torch.Tensor) -> bool:
     """
     Check if a weight tensor meets float8 quantization requirements.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4082
* __->__ #4093

Summary:
Moving to utils.py so we can use this both in non-prototype and prototype quant_api.py

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: