### PR TITLE
[xpu][feat] Add XPU support for blockwise FP8

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -321,8 +321,6 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
                 return unittest.skip("PerGroup not supported for dynamic mode")
 
         elif granularity == (PerBlock([1, 128]), PerBlock([128, 128])):
-            if torch.xpu.is_available():
-                return unittest.skip("PerBlock granularity not supported on XPU")
             if dtype is not torch.bfloat16:
                 return unittest.skip("unimplemented")
             elif mode != "dynamic":

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -60,11 +60,8 @@ def preprocess_data(
         b_data = pad_tensor_for_matmul(b_data, dims=0)
     if not is_row_major(a_data.stride()):
         a_data = a_data.contiguous()
-    if not is_row_major(b_data.stride()):
-        b_data = b_data.contiguous()
-
-    # if is_row_major(b_data.stride()) and not torch.xpu.is_available():
-    #     b_data = b_data.t().contiguous().t()
+    if is_row_major(b_data.stride()):
+        b_data = b_data.t().contiguous().t()
     return a_data, b_data
 
 

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -60,8 +60,11 @@ def preprocess_data(
         b_data = pad_tensor_for_matmul(b_data, dims=0)
     if not is_row_major(a_data.stride()):
         a_data = a_data.contiguous()
-    if is_row_major(b_data.stride()):
-        b_data = b_data.t().contiguous().t()
+    if not is_row_major(b_data.stride()):
+        b_data = b_data.contiguous()
+
+    # if is_row_major(b_data.stride()) and not torch.xpu.is_available():
+    #     b_data = b_data.t().contiguous().t()
     return a_data, b_data
 
 

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -305,8 +305,8 @@ def _check_hardware_support(
         )
     elif is_a_1_128_w_128_128:
         # TODO(future PR): look into AMD support
-        assert is_sm_at_least_89(), (
-            "Float8 1x128 activation and 128x128 weight scaling requires CUDA compute capability ≥8.9."
+        assert torch.xpu.is_available() or is_sm_at_least_89(), (
+            "Float8 1x128 activation and 128x128 weight scaling requires CUDA compute capability ≥8.9 or XPU."
         )
     else:
         raise ValueError(f"Invalid granularities {granularities}.")


### PR DESCRIPTION
This PR enables the fp8 blockwise for XPU device. The `torch.scaled_mm` is enabled by https://github.com/pytorch/pytorch/pull/173630

**Test Status:**
UT pass.
Model: LLama3.1-8B tested.


**cc:** @liangan1 
