### PR TITLE
Fix aten._has_compatible_shallow_copy_type', overload='default' dispatcher failed for LinearActivationQuantizedTensor in inference mode

### DIFF
--- a/torchao/quantization/linear_activation_quantized_tensor.py
+++ b/torchao/quantization/linear_activation_quantized_tensor.py
@@ -301,6 +301,12 @@ def _(func, types, args, kwargs):
     )
 
 
+@implements_torch_function(torch._has_compatible_shallow_copy_type)
+def _(func, types, args, kwargs):
+    assert len(args) == 2
+    return type(args[0]) == type(args[1]) and args[0].shape == args[1].shape
+
+
 to_linear_activation_quantized = LinearActivationQuantizedTensor.from_float  # Converts a float tensor to LinearActivationQuantizedTensor for dynamic activation quantization
 
 # Allow a model with LinearActivationQuantizedTensor weights to be loaded with `weights_only=True`


### PR DESCRIPTION
Fixes https://github.com/pytorch/ao/issues/4097
### Summary
This PR fixes a bug in torchao/quantization/linear_activation_quantized_tensor.py where LinearActivationQuantizedTensor without dispatch of aten._has_compatible_shallow_copy_type.