### PR TITLE
[X86] Enable FP8 patterns for AOT Inductor

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -8,9 +8,12 @@
 import contextlib
 import copy
 import functools
+import glob
 import itertools
+import os
 import unittest
 from typing import NamedTuple
+import tempfile
 
 import torch
 from torch._dynamo import config as dynamo_config
@@ -168,6 +171,7 @@ class TestPatternMatcherBase(TestCase):
         quantizer=None,
         compile_options={},  # noqa: B006
         is_fp8=False,
+        is_aoti=False,
     ):
         if not hasattr(self, "device"):
             has_xpu = any(
@@ -207,7 +211,20 @@ class TestPatternMatcherBase(TestCase):
             with torch.no_grad(), maybe_autocast:
                 clone_inputs = self._clone_inputs(inputs)
                 expected = mod(*inputs)
-                actual = torch.compile(mod, **compile_options)(*clone_inputs)
+                if is_aoti:
+                    exported = torch.export.export(mod, clone_inputs)
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        package_path = os.path.join(tmpdir, "model.pt2")
+                        with config.patch({"aot_inductor.output_path": tmpdir}):
+                            torch._inductor.aoti_compile_and_package(
+                                exported,
+                                package_path=package_path,
+                            )
+
+                        compiled_mod = torch._inductor.aoti_load_package(package_path)
+                        actual = compiled_mod(*clone_inputs)
+                else:
+                    actual = torch.compile(mod, **compile_options)(*clone_inputs)
                 torch.testing.assert_close(
                     actual.float(), expected.float(), atol=atol, rtol=rtol
                 )
@@ -226,6 +243,7 @@ class TestPatternMatcherBase(TestCase):
         num_include_ops=None,
         quantizer=None,
         is_fp8=False,
+        is_aoti=False,
     ):
         with torch.no_grad():
             clone_inputs = self._clone_inputs(inputs)
@@ -234,10 +252,28 @@ class TestPatternMatcherBase(TestCase):
                     mod, inputs, quantizer=quantizer, is_fp8=is_fp8
                 )
             expected = mod(*inputs)
-            actual, (source_code,) = run_and_get_code(
-                torch.compile(mod, fullgraph=True, dynamic=check_dynamic),
-                *clone_inputs,
-            )
+            if is_aoti:
+                exported = torch.export.export(mod, clone_inputs)
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    package_path = os.path.join(tmpdir, "model.pt2")
+                    with config.patch({"aot_inductor.output_path": tmpdir}):
+                        torch._inductor.aoti_compile_and_package(
+                            exported,
+                            package_path=package_path,
+                        )
+
+                    cpp_paths = glob.glob(os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True)
+                    assert cpp_paths, "Failed to find generated .wrapper.cpp"
+                    with open(cpp_paths[0], "r") as f:
+                        source_code = f.read()
+
+                    compiled_mod = torch._inductor.aoti_load_package(package_path)
+                    actual = compiled_mod(*clone_inputs)
+            else:
+                actual, (source_code,) = run_and_get_code(
+                    torch.compile(mod, fullgraph=True, dynamic=check_dynamic),
+                    *clone_inputs,
+                )
             for op in include_ops:
                 self.assertIn(op, source_code)
             if num_include_ops is not None:
@@ -1494,6 +1530,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         is_dynamic=False,
         is_qat=False,
         is_fp8=False,
+        is_aoti=False,
     ):
         class M(torch.nn.Module):
             def __init__(self, use_bias, do_permute=False):
@@ -1545,6 +1582,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
                 ],
                 check_quantization=True,
                 is_fp8=is_fp8,
+                is_aoti=is_aoti,
             )
 
     @skipIfNoDynamoSupport
@@ -1563,8 +1601,18 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize a single Linear Moduel.
         """
-        for bias in [True, False]:
-            self._qlinear_test_helper((torch.randn((2, 4)),), bias=bias, is_fp8=True)
+        aoti_options = [False,]
+        try:
+            import torch._inductor.constant_folding as cf
+            if hasattr(cf, "add_dont_constant_fold"):
+                cf.add_dont_constant_fold(torch.ops.torchao.dequantize_affine_float8_non_decomposed.default)
+                aoti_options = [False, True]
+        finally:
+            pass
+
+        for is_aoti in aoti_options:
+            for bias in [True, False]:
+                self._qlinear_test_helper((torch.randn((2, 4)),), bias=bias, is_fp8=True, is_aoti=is_aoti)
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
@@ -3108,7 +3156,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 annotate_matmul=annotate_matmul, is_fp8=True
             )
 
-    def _test_scaled_embedding_bag_helper(self, dtype, with_output_quant=False):
+    def _test_scaled_embedding_bag_helper(self, dtype, with_output_quant=False, is_aoti=False):
         class FP8QDQEmbeddingBag(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -3203,6 +3251,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                     mod,
                     (weight, indices, offsets),
                     matcher_check_fn,
+                    is_aoti=is_aoti,
                 )
 
     @skipIfNoDynamoSupport
@@ -3213,7 +3262,17 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         reason="cpp kernels not built",
     )
     def test_fp8_scaled_embedding_bag(self):
-        self._test_scaled_embedding_bag_helper(torch.float8_e4m3fn)
+        aoti_options = [False,]
+        try:
+            import torch._inductor.constant_folding as cf
+            if hasattr(cf, "add_dont_constant_fold"):
+                cf.add_dont_constant_fold(torch.ops.torchao.dequantize_affine_float8_non_decomposed.default)
+                aoti_options = [False, True]
+        finally:
+            pass
+
+        for is_aoti in aoti_options:
+            self._test_scaled_embedding_bag_helper(torch.float8_e4m3fn, is_aoti=is_aoti)
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -173,6 +173,19 @@ class TestPatternMatcherBase(TestCase):
         is_fp8=False,
         is_aoti=False,
     ):
+        def aoti_compile(model, inputs):
+            exported = torch.export.export(model, inputs)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                package_path = os.path.join(tmpdir, "model.pt2")
+                with config.patch({"aot_inductor.output_path": tmpdir}):
+                    torch._inductor.aoti_compile_and_package(
+                        exported,
+                        package_path=package_path,
+                    )
+
+                compiled_mod = torch._inductor.aoti_load_package(package_path)
+            return compiled_mod
+
         if not hasattr(self, "device"):
             has_xpu = any(
                 isinstance(input, torch.Tensor) and input.device.type == "xpu"
@@ -205,24 +218,18 @@ class TestPatternMatcherBase(TestCase):
                 mod, inputs, is_qat, is_dynamic, quantizer, is_fp8
             )
             with torch.no_grad(), maybe_autocast:
-                _ = torch.compile(convert_model)(*inputs)
+                if is_aoti:
+                    _ = aoti_compile(convert_model, inputs)(*inputs)
+                else:
+                    _ = torch.compile(convert_model)(*inputs)
                 matcher_check_fn()
         else:
             with torch.no_grad(), maybe_autocast:
                 clone_inputs = self._clone_inputs(inputs)
                 expected = mod(*inputs)
                 if is_aoti:
-                    exported = torch.export.export(mod, clone_inputs)
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        package_path = os.path.join(tmpdir, "model.pt2")
-                        with config.patch({"aot_inductor.output_path": tmpdir}):
-                            torch._inductor.aoti_compile_and_package(
-                                exported,
-                                package_path=package_path,
-                            )
-
-                        compiled_mod = torch._inductor.aoti_load_package(package_path)
-                        actual = compiled_mod(*clone_inputs)
+                    compiled_mod = aoti_compile(mod, clone_inputs)
+                    actual = compiled_mod(*clone_inputs)
                 else:
                     actual = torch.compile(mod, **compile_options)(*clone_inputs)
                 torch.testing.assert_close(
@@ -1570,6 +1577,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             is_qat=is_qat,
             is_dynamic=is_dynamic,
             is_fp8=is_fp8,
+            is_aoti=is_aoti,
         )
         if is_fp8:
             # ensure quantize_affine_float8_non_decomposed is lowered

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3133,13 +3133,13 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             def _dequantize(self, weight):
                 if dtype == torch.float8_e4m3fn:
                     res = torch.ops.torchao.dequantize_affine_float8_non_decomposed.default(
-                        tensor=weight.data,
+                        tensor=weight,
                         scale=torch.tensor([self.weight_scale]),
                         output_dtype=torch.float,
                     )
                 else:
                     res = torch.ops.quantized_decomposed.dequantize_per_tensor.default(
-                        weight.data,
+                        weight,
                         self.weight_scale,
                         0,
                         -128,
@@ -3323,6 +3323,65 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 (int8_inputs,),
                 matcher_check_fn,
             )
+
+    @skipIfNoDynamoSupport
+    @skipIfNoONEDNN
+    @skipIfNoFloat8Support
+    @unittest.skipIf(
+        "CPU" not in torch._C._dispatch_dump("torchao::_scaled_embedding_bag"),
+        reason="cpp kernels not built",
+    )
+    def test_fp8_concat_dequant_quant(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = 0.5
+
+            def forward(self, fp8_inputs):
+                res = torch.cat(fp8_inputs, dim=1)
+                res = torch.ops.torchao.dequantize_affine_float8_non_decomposed.default(
+                    tensor=res,
+                    scale=torch.tensor([self.scale]),
+                    output_dtype=torch.float32,
+                )
+                res = torch.ops.torchao.quantize_affine_float8_non_decomposed.default(
+                    tensor=res,
+                    scale=torch.tensor([self.scale]),
+                    float8_dtype=torch.float8_e4m3fn,
+                )
+                return res
+
+        def quant_input(x):
+            scale = x.abs().max() / 448.0
+            return (x / scale).to(torch.float8_e4m3fn)
+
+        def matcher_check_fn():
+            self.assertEqual(counters["inductor"]["concat_dq_q_matcher_count"], 1)
+
+        aoti_options = [False]
+        try:
+            import torch._inductor.constant_folding as cf
+
+            if hasattr(cf, "add_dont_constant_fold"):
+                cf.add_dont_constant_fold(
+                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+                )
+                aoti_options = [False, True]
+        finally:
+            pass
+
+        shape = (128, 3)
+        mod = Mod()
+        for is_aoti in aoti_options:
+            for length in [2, 3]:
+                inputs = [torch.randn(shape) for _ in range(length)]
+                fp8_inputs = [quant_input(x) for x in inputs]
+                self._test_common(
+                    mod,
+                    (fp8_inputs,),
+                    matcher_check_fn,
+                    is_aoti=is_aoti,
+                )
 
 
 @unittest.skipIf(not torch_version_at_least("2.8.0"), "Requires torch 2.8+")

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -16,6 +16,7 @@ import unittest
 from typing import NamedTuple
 
 import torch
+import torch._export.utils as eu
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.testing import make_test_cls_with_patches
 from torch._dynamo.utils import counters
@@ -174,7 +175,8 @@ class TestPatternMatcherBase(TestCase):
         is_aoti=False,
     ):
         def aoti_compile(model, inputs):
-            exported = torch.export.export(model, inputs)
+            with eu._disable_aten_to_metadata_assertions():
+                exported = torch.export.export(model, inputs)
             with tempfile.TemporaryDirectory() as tmpdir:
                 package_path = os.path.join(tmpdir, "model.pt2")
                 with config.patch({"aot_inductor.output_path": tmpdir}):
@@ -260,7 +262,8 @@ class TestPatternMatcherBase(TestCase):
                 )
             expected = mod(*inputs)
             if is_aoti:
-                exported = torch.export.export(mod, clone_inputs)
+                with eu._disable_aten_to_metadata_assertions():
+                    exported = torch.export.export(mod, clone_inputs)
                 with tempfile.TemporaryDirectory() as tmpdir:
                     package_path = os.path.join(tmpdir, "model.pt2")
                     with config.patch({"aot_inductor.output_path": tmpdir}):

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -8,6 +8,7 @@
 import contextlib
 import copy
 import functools
+import glob
 import itertools
 import os
 import tempfile
@@ -104,6 +105,34 @@ skipIfNoQConvFp8Support = unittest.skipIf(
 )
 
 
+def _get_fp8_aoti_options():
+    """
+    Detect whether AOTI can exercise the FP8 fusion path.
+
+    AOTI constant-folds lifted tensors by default, which folds away the
+    dequant scale and breaks pattern matching.  We need to call
+    ``add_dont_constant_fold`` on the FP8 dequant op so that the scale
+    survives into the inductor graph and the fusion pattern can still be
+    matched.  If the API is not yet available we fall back to compile-only
+    testing.
+
+    Returns ``[False]`` when AOTI is not exercisable, ``[False, True]``
+    when it is.
+    """
+    aoti_options = [False]
+    try:
+        import torch._inductor.constant_folding as cf
+
+        if hasattr(cf, "add_dont_constant_fold"):
+            cf.add_dont_constant_fold(
+                torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+            )
+            aoti_options = [False, True]
+    except ImportError:
+        pass
+    return aoti_options
+
+
 def cal_conv_generated_kernel_number(mod, input, dtype, dim=4, device="cpu"):
     # this function is to decide how many kernels are generated
     # while testing conv2d/3d/deconv2d
@@ -171,7 +200,7 @@ class TestPatternMatcherBase(TestCase):
         quantizer=None,
         compile_options={},  # noqa: B006
         is_fp8=False,
-        is_aoti=False,
+        use_aoti=False,
         include_ops=None,
         exclude_ops=None,
         check_dynamic=None,
@@ -190,7 +219,11 @@ class TestPatternMatcherBase(TestCase):
         counters.clear()
         torch._dynamo.reset()
 
-        def aoti_compile(model, inputs):
+        def aoti_compile(model, inputs, compile_options=None, get_source_code=False):
+            # compile_options (e.g. dynamic=True) are torch.compile() kwargs and do not
+            # directly apply to the AOTI path — they are ignored for now.
+            # Support can be added in the future if needed (e.g. via dynamic_shapes in
+            # torch.export.export for the dynamic case).
             with eu._disable_aten_to_metadata_assertions():
                 exported = torch.export.export(model, inputs)
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -201,7 +234,17 @@ class TestPatternMatcherBase(TestCase):
                         package_path=package_path,
                     )
 
+                if get_source_code:
+                    cpp_paths = glob.glob(
+                        os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True
+                    )
+                    assert cpp_paths, "Failed to find generated .wrapper.cpp"
+                    with open(cpp_paths[0]) as f:
+                        source_code = f.read()
+
                 compiled_mod = torch._inductor.aoti_load_package(package_path)
+                if get_source_code:
+                    return compiled_mod, source_code
                 return compiled_mod
 
         if check_autocast == torch.bfloat16 and (
@@ -232,16 +275,29 @@ class TestPatternMatcherBase(TestCase):
                 mod, inputs, is_qat, is_dynamic, quantizer, is_fp8
             )
 
+        # Dynamic aoti check is not supported for now.
+        # Support can be added in the future if needed (e.g. via dynamic_shapes in
+        # torch.export.export for the dynamic case).
+        assert not (
+            use_aoti and (check_dynamic is not None or compile_options.get("dynamic"))
+        ), "Dynamic AOTI check is not supported for now"
+
         with torch.no_grad(), maybe_autocast:
             if check_code:
-                expected = mod(*inputs)
-                code_compile_options = dict(compile_options)
-                if check_dynamic is not None:
-                    code_compile_options["dynamic"] = check_dynamic
-                actual, (source_code,) = run_and_get_code(
-                    torch.compile(mod, **code_compile_options),
-                    *inputs,
-                )
+                if use_aoti:
+                    compiled_mod, source_code = aoti_compile(
+                        mod, inputs, compile_options, get_source_code=True
+                    )
+                    actual = compiled_mod(*inputs)
+                else:
+                    expected = mod(*inputs)
+                    code_compile_options = dict(compile_options)
+                    if check_dynamic is not None:
+                        code_compile_options["dynamic"] = check_dynamic
+                    actual, (source_code,) = run_and_get_code(
+                        torch.compile(mod, **code_compile_options),
+                        *inputs,
+                    )
                 for op in include_ops:
                     self.assertIn(op, source_code)
                 if num_include_ops is not None:
@@ -258,14 +314,14 @@ class TestPatternMatcherBase(TestCase):
                     # Skip due to reduce range setting for Quantization on preCI system.
                     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
             elif check_quantization:
-                if is_aoti:
-                    _ = aoti_compile(mod, inputs)(*inputs)
+                if use_aoti:
+                    _ = aoti_compile(mod, inputs, compile_options)(*inputs)
                 else:
                     _ = torch.compile(mod, **compile_options)(*inputs)
             else:
                 expected = mod(*inputs)
-                if is_aoti:
-                    compiled_mod = aoti_compile(mod, inputs)
+                if use_aoti:
+                    compiled_mod = aoti_compile(mod, inputs, compile_options)
                     actual = compiled_mod(*inputs)
                 else:
                     actual = torch.compile(mod, **compile_options)(*inputs)
@@ -1514,7 +1570,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         is_dynamic=False,
         is_qat=False,
         is_fp8=False,
-        is_aoti=False,
+        use_aoti=False,
     ):
         class M(torch.nn.Module):
             def __init__(self, use_bias, do_permute=False):
@@ -1554,7 +1610,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             is_qat=is_qat,
             is_dynamic=is_dynamic,
             is_fp8=is_fp8,
-            is_aoti=is_aoti,
+            use_aoti=use_aoti,
             include_ops=[] if is_fp8 else None,
             # ensure quantize_affine_float8_non_decomposed is lowered
             exclude_ops=[
@@ -1580,24 +1636,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize a single Linear Moduel.
         """
-        aoti_options = [
-            False,
-        ]
-        try:
-            import torch._inductor.constant_folding as cf
-
-            if hasattr(cf, "add_dont_constant_fold"):
-                cf.add_dont_constant_fold(
-                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
-                )
-                aoti_options = [False, True]
-        finally:
-            pass
-
-        for is_aoti in aoti_options:
+        for use_aoti in _get_fp8_aoti_options():
             for bias in [True, False]:
                 self._qlinear_test_helper(
-                    (torch.randn((2, 4)),), bias=bias, is_fp8=True, is_aoti=is_aoti
+                    (torch.randn((2, 4)),), bias=bias, is_fp8=True, use_aoti=use_aoti
                 )
 
     @skipIfNoDynamoSupport
@@ -3122,7 +3164,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             )
 
     def _test_scaled_embedding_bag_helper(
-        self, dtype, with_output_quant=False, is_aoti=False
+        self, dtype, with_output_quant=False, use_aoti=False
     ):
         class FP8QDQEmbeddingBag(torch.nn.Module):
             def __init__(self):
@@ -3133,6 +3175,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             def _dequantize(self, weight):
                 if dtype == torch.float8_e4m3fn:
                     res = torch.ops.torchao.dequantize_affine_float8_non_decomposed.default(
+                        # use weight instead of weight.data for tracing/export compatibility
                         tensor=weight,
                         scale=torch.tensor([self.weight_scale]),
                         output_dtype=torch.float,
@@ -3218,7 +3261,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                     mod,
                     (weight, indices, offsets),
                     matcher_check_fn,
-                    is_aoti=is_aoti,
+                    use_aoti=use_aoti,
                 )
 
     @skipIfNoDynamoSupport
@@ -3229,22 +3272,10 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         reason="cpp kernels not built",
     )
     def test_fp8_scaled_embedding_bag(self):
-        aoti_options = [
-            False,
-        ]
-        try:
-            import torch._inductor.constant_folding as cf
-
-            if hasattr(cf, "add_dont_constant_fold"):
-                cf.add_dont_constant_fold(
-                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
-                )
-                aoti_options = [False, True]
-        finally:
-            pass
-
-        for is_aoti in aoti_options:
-            self._test_scaled_embedding_bag_helper(torch.float8_e4m3fn, is_aoti=is_aoti)
+        for use_aoti in _get_fp8_aoti_options():
+            self._test_scaled_embedding_bag_helper(
+                torch.float8_e4m3fn, use_aoti=use_aoti
+            )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
@@ -3315,8 +3346,8 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         shape = (128, 3)
 
         mod = Mod()
-        for len in input_len_list:
-            inputs = [torch.randn(shape) for _ in range(len)]
+        for length in input_len_list:
+            inputs = [torch.randn(shape) for _ in range(length)]
             int8_inputs = [quant_input(x) for x in inputs]
             self._test_common(
                 mod,
@@ -3358,21 +3389,9 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         def matcher_check_fn():
             self.assertEqual(counters["inductor"]["concat_dq_q_matcher_count"], 1)
 
-        aoti_options = [False]
-        try:
-            import torch._inductor.constant_folding as cf
-
-            if hasattr(cf, "add_dont_constant_fold"):
-                cf.add_dont_constant_fold(
-                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
-                )
-                aoti_options = [False, True]
-        finally:
-            pass
-
         shape = (128, 3)
         mod = Mod()
-        for is_aoti in aoti_options:
+        for use_aoti in _get_fp8_aoti_options():
             for length in [2, 3]:
                 inputs = [torch.randn(shape) for _ in range(length)]
                 fp8_inputs = [quant_input(x) for x in inputs]
@@ -3380,7 +3399,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                     mod,
                     (fp8_inputs,),
                     matcher_check_fn,
-                    is_aoti=is_aoti,
+                    use_aoti=use_aoti,
                 )
 
 

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -219,11 +219,7 @@ class TestPatternMatcherBase(TestCase):
         counters.clear()
         torch._dynamo.reset()
 
-        def aoti_compile(model, inputs, compile_options=None, get_source_code=False):
-            # compile_options (e.g. dynamic=True) are torch.compile() kwargs and do not
-            # directly apply to the AOTI path — they are ignored for now.
-            # Support can be added in the future if needed (e.g. via dynamic_shapes in
-            # torch.export.export for the dynamic case).
+        def aoti_compile(model, inputs, get_source_code=False):
             with eu._disable_aten_to_metadata_assertions():
                 exported = torch.export.export(model, inputs)
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -285,8 +281,12 @@ class TestPatternMatcherBase(TestCase):
         with torch.no_grad(), maybe_autocast:
             if check_code:
                 if use_aoti:
+                    # compile_options (e.g. dynamic=True) are torch.compile() kwargs and do not
+                    # directly apply to the AOTI path — they are ignored for now.
+                    # Support can be added in the future if needed (e.g. via dynamic_shapes in
+                    # torch.export.export for the dynamic case).
                     compiled_mod, source_code = aoti_compile(
-                        mod, inputs, compile_options, get_source_code=True
+                        mod, inputs, get_source_code=True
                     )
                     actual = compiled_mod(*inputs)
                 else:
@@ -315,13 +315,13 @@ class TestPatternMatcherBase(TestCase):
                     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
             elif check_quantization:
                 if use_aoti:
-                    _ = aoti_compile(mod, inputs, compile_options)(*inputs)
+                    _ = aoti_compile(mod, inputs)(*inputs)
                 else:
                     _ = torch.compile(mod, **compile_options)(*inputs)
             else:
                 expected = mod(*inputs)
                 if use_aoti:
-                    compiled_mod = aoti_compile(mod, inputs, compile_options)
+                    compiled_mod = aoti_compile(mod, inputs)
                     actual = compiled_mod(*inputs)
                 else:
                     actual = torch.compile(mod, **compile_options)(*inputs)
@@ -1636,11 +1636,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize a single Linear Moduel.
         """
-        for use_aoti in _get_fp8_aoti_options():
-            for bias in [True, False]:
-                self._qlinear_test_helper(
-                    (torch.randn((2, 4)),), bias=bias, is_fp8=True, use_aoti=use_aoti
-                )
+        for use_aoti, bias in itertools.product(_get_fp8_aoti_options(), [True, False]):
+            self._qlinear_test_helper(
+                (torch.randn((2, 4)),), bias=bias, is_fp8=True, use_aoti=use_aoti
+            )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
@@ -3175,7 +3174,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
             def _dequantize(self, weight):
                 if dtype == torch.float8_e4m3fn:
                     res = torch.ops.torchao.dequantize_affine_float8_non_decomposed.default(
-                        # use weight instead of weight.data for tracing/export compatibility
                         tensor=weight,
                         scale=torch.tensor([self.weight_scale]),
                         output_dtype=torch.float,
@@ -3391,16 +3389,15 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
 
         shape = (128, 3)
         mod = Mod()
-        for use_aoti in _get_fp8_aoti_options():
-            for length in [2, 3]:
-                inputs = [torch.randn(shape) for _ in range(length)]
-                fp8_inputs = [quant_input(x) for x in inputs]
-                self._test_common(
-                    mod,
-                    (fp8_inputs,),
-                    matcher_check_fn,
-                    use_aoti=use_aoti,
-                )
+        for use_aoti, length in itertools.product(_get_fp8_aoti_options(), [2, 3]):
+            inputs = [torch.randn(shape) for _ in range(length)]
+            fp8_inputs = [quant_input(x) for x in inputs]
+            self._test_common(
+                mod,
+                (fp8_inputs,),
+                matcher_check_fn,
+                use_aoti=use_aoti,
+            )
 
 
 @unittest.skipIf(not torch_version_at_least("2.8.0"), "Requires torch 2.8+")

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -219,29 +219,31 @@ class TestPatternMatcherBase(TestCase):
         counters.clear()
         torch._dynamo.reset()
 
-        def aoti_compile(model, inputs, get_source_code=False):
-            with eu._disable_aten_to_metadata_assertions():
-                exported = torch.export.export(model, inputs)
-            with tempfile.TemporaryDirectory() as tmpdir:
-                package_path = os.path.join(tmpdir, "model.pt2")
-                with config.patch({"aot_inductor.output_path": tmpdir}):
-                    torch._inductor.aoti_compile_and_package(
-                        exported,
-                        package_path=package_path,
-                    )
+        if use_aoti:
 
-                if get_source_code:
-                    cpp_paths = glob.glob(
-                        os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True
-                    )
-                    assert cpp_paths, "Failed to find generated .wrapper.cpp"
-                    with open(cpp_paths[0]) as f:
-                        source_code = f.read()
+            def aoti_compile(model, inputs, get_source_code=False):
+                with eu._disable_aten_to_metadata_assertions():
+                    exported = torch.export.export(model, inputs)
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    package_path = os.path.join(tmpdir, "model.pt2")
+                    with config.patch({"aot_inductor.output_path": tmpdir}):
+                        torch._inductor.aoti_compile_and_package(
+                            exported,
+                            package_path=package_path,
+                        )
 
-                compiled_mod = torch._inductor.aoti_load_package(package_path)
-                if get_source_code:
-                    return compiled_mod, source_code
-                return compiled_mod
+                    if get_source_code:
+                        cpp_paths = glob.glob(
+                            os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True
+                        )
+                        assert cpp_paths, "Failed to find generated .wrapper.cpp"
+                        with open(cpp_paths[0]) as f:
+                            source_code = f.read()
+
+                    compiled_mod = torch._inductor.aoti_load_package(package_path)
+                    if get_source_code:
+                        return compiled_mod, source_code
+                    return compiled_mod
 
         if check_autocast == torch.bfloat16 and (
             torch.ops.mkldnn._is_mkldnn_bf16_supported() or device == "xpu"
@@ -280,13 +282,13 @@ class TestPatternMatcherBase(TestCase):
 
         with torch.no_grad(), maybe_autocast:
             if check_code:
+                expected = mod(*inputs)
                 if use_aoti:
                     compiled_mod, source_code = aoti_compile(
                         mod, inputs, get_source_code=True
                     )
                     actual = compiled_mod(*inputs)
                 else:
-                    expected = mod(*inputs)
                     code_compile_options = dict(compile_options)
                     if check_dynamic is not None:
                         code_compile_options["dynamic"] = check_dynamic

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -11,9 +11,9 @@ import functools
 import glob
 import itertools
 import os
+import tempfile
 import unittest
 from typing import NamedTuple
-import tempfile
 
 import torch
 from torch._dynamo import config as dynamo_config

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -9,10 +9,13 @@ import contextlib
 import copy
 import functools
 import itertools
+import os
+import tempfile
 import unittest
 from typing import NamedTuple
 
 import torch
+import torch._export.utils as eu
 from torch._dynamo import config as dynamo_config
 from torch._dynamo.testing import make_test_cls_with_patches
 from torch._dynamo.utils import counters
@@ -168,6 +171,7 @@ class TestPatternMatcherBase(TestCase):
         quantizer=None,
         compile_options={},  # noqa: B006
         is_fp8=False,
+        is_aoti=False,
         include_ops=None,
         exclude_ops=None,
         check_dynamic=None,
@@ -185,6 +189,21 @@ class TestPatternMatcherBase(TestCase):
         mod = mod.to(device=device)
         counters.clear()
         torch._dynamo.reset()
+
+        def aoti_compile(model, inputs):
+            with eu._disable_aten_to_metadata_assertions():
+                exported = torch.export.export(model, inputs)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                package_path = os.path.join(tmpdir, "model.pt2")
+                with config.patch({"aot_inductor.output_path": tmpdir}):
+                    torch._inductor.aoti_compile_and_package(
+                        exported,
+                        package_path=package_path,
+                    )
+
+                compiled_mod = torch._inductor.aoti_load_package(package_path)
+                return compiled_mod
+
         if check_autocast == torch.bfloat16 and (
             torch.ops.mkldnn._is_mkldnn_bf16_supported() or device == "xpu"
         ):
@@ -239,10 +258,17 @@ class TestPatternMatcherBase(TestCase):
                     # Skip due to reduce range setting for Quantization on preCI system.
                     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
             elif check_quantization:
-                _ = torch.compile(mod, **compile_options)(*inputs)
+                if is_aoti:
+                    _ = aoti_compile(mod, inputs)(*inputs)
+                else:
+                    _ = torch.compile(mod, **compile_options)(*inputs)
             else:
                 expected = mod(*inputs)
-                actual = torch.compile(mod, **compile_options)(*inputs)
+                if is_aoti:
+                    compiled_mod = aoti_compile(mod, inputs)
+                    actual = compiled_mod(*inputs)
+                else:
+                    actual = torch.compile(mod, **compile_options)(*inputs)
                 torch.testing.assert_close(
                     actual.float(), expected.float(), atol=atol, rtol=rtol
                 )
@@ -1488,6 +1514,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
         is_dynamic=False,
         is_qat=False,
         is_fp8=False,
+        is_aoti=False,
     ):
         class M(torch.nn.Module):
             def __init__(self, use_bias, do_permute=False):
@@ -1527,6 +1554,7 @@ class TestPatternMatcher(TestPatternMatcherBase):
             is_qat=is_qat,
             is_dynamic=is_dynamic,
             is_fp8=is_fp8,
+            is_aoti=is_aoti,
             include_ops=[] if is_fp8 else None,
             # ensure quantize_affine_float8_non_decomposed is lowered
             exclude_ops=[
@@ -1552,8 +1580,25 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize a single Linear Moduel.
         """
-        for bias in [True, False]:
-            self._qlinear_test_helper((torch.randn((2, 4)),), bias=bias, is_fp8=True)
+        aoti_options = [
+            False,
+        ]
+        try:
+            import torch._inductor.constant_folding as cf
+
+            if hasattr(cf, "add_dont_constant_fold"):
+                cf.add_dont_constant_fold(
+                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+                )
+                aoti_options = [False, True]
+        finally:
+            pass
+
+        for is_aoti in aoti_options:
+            for bias in [True, False]:
+                self._qlinear_test_helper(
+                    (torch.randn((2, 4)),), bias=bias, is_fp8=True, is_aoti=is_aoti
+                )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
@@ -3076,7 +3121,9 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 annotate_matmul=annotate_matmul, is_fp8=True
             )
 
-    def _test_scaled_embedding_bag_helper(self, dtype, with_output_quant=False):
+    def _test_scaled_embedding_bag_helper(
+        self, dtype, with_output_quant=False, is_aoti=False
+    ):
         class FP8QDQEmbeddingBag(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -3171,6 +3218,7 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                     mod,
                     (weight, indices, offsets),
                     matcher_check_fn,
+                    is_aoti=is_aoti,
                 )
 
     @skipIfNoDynamoSupport
@@ -3181,7 +3229,22 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         reason="cpp kernels not built",
     )
     def test_fp8_scaled_embedding_bag(self):
-        self._test_scaled_embedding_bag_helper(torch.float8_e4m3fn)
+        aoti_options = [
+            False,
+        ]
+        try:
+            import torch._inductor.constant_folding as cf
+
+            if hasattr(cf, "add_dont_constant_fold"):
+                cf.add_dont_constant_fold(
+                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+                )
+                aoti_options = [False, True]
+        finally:
+            pass
+
+        for is_aoti in aoti_options:
+            self._test_scaled_embedding_bag_helper(torch.float8_e4m3fn, is_aoti=is_aoti)
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -269,7 +269,9 @@ class TestPatternMatcherBase(TestCase):
                             package_path=package_path,
                         )
 
-                    cpp_paths = glob.glob(os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True)
+                    cpp_paths = glob.glob(
+                        os.path.join(tmpdir, "**/*.wrapper.cpp"), recursive=True
+                    )
                     assert cpp_paths, "Failed to find generated .wrapper.cpp"
                     with open(cpp_paths[0], "r") as f:
                         source_code = f.read()
@@ -1609,18 +1611,25 @@ class TestPatternMatcher(TestPatternMatcherBase):
         r"""
         This testcase will quantize a single Linear Moduel.
         """
-        aoti_options = [False,]
+        aoti_options = [
+            False,
+        ]
         try:
             import torch._inductor.constant_folding as cf
+
             if hasattr(cf, "add_dont_constant_fold"):
-                cf.add_dont_constant_fold(torch.ops.torchao.dequantize_affine_float8_non_decomposed.default)
+                cf.add_dont_constant_fold(
+                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+                )
                 aoti_options = [False, True]
         finally:
             pass
 
         for is_aoti in aoti_options:
             for bias in [True, False]:
-                self._qlinear_test_helper((torch.randn((2, 4)),), bias=bias, is_fp8=True, is_aoti=is_aoti)
+                self._qlinear_test_helper(
+                    (torch.randn((2, 4)),), bias=bias, is_fp8=True, is_aoti=is_aoti
+                )
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
@@ -3164,7 +3173,9 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
                 annotate_matmul=annotate_matmul, is_fp8=True
             )
 
-    def _test_scaled_embedding_bag_helper(self, dtype, with_output_quant=False, is_aoti=False):
+    def _test_scaled_embedding_bag_helper(
+        self, dtype, with_output_quant=False, is_aoti=False
+    ):
         class FP8QDQEmbeddingBag(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -3270,11 +3281,16 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
         reason="cpp kernels not built",
     )
     def test_fp8_scaled_embedding_bag(self):
-        aoti_options = [False,]
+        aoti_options = [
+            False,
+        ]
         try:
             import torch._inductor.constant_folding as cf
+
             if hasattr(cf, "add_dont_constant_fold"):
-                cf.add_dont_constant_fold(torch.ops.torchao.dequantize_affine_float8_non_decomposed.default)
+                cf.add_dont_constant_fold(
+                    torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+                )
                 aoti_options = [False, True]
         finally:
             pass

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -281,10 +281,6 @@ class TestPatternMatcherBase(TestCase):
         with torch.no_grad(), maybe_autocast:
             if check_code:
                 if use_aoti:
-                    # compile_options (e.g. dynamic=True) are torch.compile() kwargs and do not
-                    # directly apply to the AOTI path — they are ignored for now.
-                    # Support can be added in the future if needed (e.g. via dynamic_shapes in
-                    # torch.export.export for the dynamic case).
                     compiled_mod, source_code = aoti_compile(
                         mod, inputs, get_source_code=True
                     )

--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -117,9 +117,12 @@ def _get_fp8_aoti_options():
     testing.
 
     Returns ``[False]`` when AOTI is not exercisable, ``[False, True]``
-    when it is.
+    when it is. Float8 AOTI execution is additionally gated on torch >= 2.13.
     """
     aoti_options = [False]
+    if not torch_version_at_least("2.13.0"):
+        return aoti_options
+
     try:
         import torch._inductor.constant_folding as cf
 

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -1041,8 +1041,6 @@ def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contigu
         # Allow dequant has multi users including _assert_tensor_metadata introduced by AOT Inductor.
         if len(_get_non_assert_users(dequant_node)) != 1:
             return False
-            # Ensure the dequant pattern only has 1 effective user
-            # since we will delete the dequant pattern here
 
         # Extra check for bmm pattern
         if input_dim_exceeds_two and not input_contiguous:

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -148,7 +148,7 @@ def _unary_fusion_pattern(unary_fusion, call_fn, users, is_bf16):
 
 
 def get_dequantize_per_tensor_activation_pattern(
-    is_tensor_overload=False, is_fp8=False
+    is_tensor_overload=False, is_fp8=False, users=1
 ):
     if is_fp8:
         dequantize_per_tensor_activation_pattern = CallFunction(
@@ -156,6 +156,7 @@ def get_dequantize_per_tensor_activation_pattern(
             KeywordArg("x"),
             KeywordArg("x_scale"),
             output_dtype=KeywordArg("x_dq_dtype"),
+            _users=users,
         )
     else:
         dequantize_per_tensor_activation_pattern = CallFunction(
@@ -168,6 +169,7 @@ def get_dequantize_per_tensor_activation_pattern(
             KeywordArg("x_quant_min"),
             KeywordArg("x_quant_max"),
             KeywordArg("x_dq_dtype"),
+            _users=users,
         )
     return dequantize_per_tensor_activation_pattern
 
@@ -991,6 +993,26 @@ def _get_linear_dq_node(
     return dequant_node, act_reshape_node, activation_to_bf16_node, act_expand_node
 
 
+def _is_assert_tensor_metadata_node(node: Any) -> bool:
+    return (
+        isinstance(node, torch.fx.Node)
+        and node.op == "call_function"
+        and node.target == torch.ops.aten._assert_tensor_metadata.default
+    )
+
+
+def _get_non_assert_users(node: torch.fx.Node) -> list[torch.fx.Node]:
+    return [user for user in node.users if not _is_assert_tensor_metadata_node(user)]
+
+
+def _erase_assert_tensor_metadata_users(
+    graph: torch.fx.Graph, node: torch.fx.Node
+) -> None:
+    for user in list(node.users):
+        if _is_assert_tensor_metadata_node(user):
+            graph.erase_node(user)
+
+
 def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contiguous):
     def _inner(match):
         # Check dequant pattern has only 1 user.
@@ -1016,10 +1038,11 @@ def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contigu
             torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
         ]
 
-        if len(list(dequant_node.users)) != 1:
-            # Ensure the dequant pattern only has 1 user
-            # since we will delete the dequant pattern here
+        # Allow dequant has multi users including _assert_tensor_metadata introduced by AOT Inductor.
+        if len(_get_non_assert_users(dequant_node)) != 1:
             return False
+            # Ensure the dequant pattern only has 1 effective user
+            # since we will delete the dequant pattern here
 
         # Extra check for bmm pattern
         if input_dim_exceeds_two and not input_contiguous:
@@ -1202,6 +1225,10 @@ def _register_qlinear_weight_prepack_pass(
                 linear_node.replace_all_uses_with(new_linear_node)
                 new_linear_node.meta.update(linear_node.meta)
 
+            # Erase assert users first so dequant nodes become erasable.
+            _erase_assert_tensor_metadata_users(graph, dequant_node)
+            _erase_assert_tensor_metadata_users(graph, dequant)
+
             # Erase the original linear node
             if input_dim_exceeds_two:
                 if input_contiguous:
@@ -1237,6 +1264,7 @@ def _generate_dequant_linear_node_pattern(
     input_dim_exceeds_two=False,
     is_tensor_overload=False,
     is_fp8=False,
+    users=1,
 ):
     assert dtype in [torch.float32, torch.bfloat16]
     t_pattern = _generate_linear_t_pattern(_dequant_per_channel_pattern, dtype)
@@ -1247,7 +1275,7 @@ def _generate_dequant_linear_node_pattern(
             _may_generate_pattern_with_reshape(
                 _may_generate_pattern_with_dtype_convert(
                     get_dequantize_per_tensor_activation_pattern(
-                        is_tensor_overload, is_fp8
+                        is_tensor_overload, is_fp8, users
                     ),
                     KeywordArg("autocast_act_dtype"),
                     dtype == torch.bfloat16,
@@ -1266,7 +1294,7 @@ def _generate_dequant_linear_node_pattern(
             _may_generate_pattern_with_reshape(
                 _may_generate_pattern_with_dtype_convert(
                     get_dequantize_per_tensor_activation_pattern(
-                        is_tensor_overload, is_fp8
+                        is_tensor_overload, is_fp8, users
                     ),
                     KeywordArg("autocast_act_dtype"),
                     dtype == torch.bfloat16,
@@ -1288,6 +1316,7 @@ def _generate_dequant_bmm_node_pattern(
     with_bias=False,
     is_tensor_overload=False,
     is_fp8=False,
+    users=1,
 ):
     # When activation of linear dim exceed 2 and not contiguous
     t_pattern = _generate_linear_t_pattern(_dequant_per_channel_pattern, dtype)
@@ -1299,7 +1328,7 @@ def _generate_dequant_bmm_node_pattern(
             aten.expand.default,
             _may_generate_pattern_with_dtype_convert(
                 get_dequantize_per_tensor_activation_pattern(
-                    is_tensor_overload, is_fp8
+                    is_tensor_overload, is_fp8, users
                 ),
                 KeywordArg("autocast_act_dtype"),
                 dtype == torch.bfloat16,
@@ -1333,9 +1362,17 @@ def _generate_qlinear_weight_prepack_patterns(
     with_bias=False,
     is_tensor_overload=False,
     is_fp8=False,
+    users=1,
 ):
     if is_fp8:
-        dequant_wgt_pattern = dequantize_fp8_weight_pattern
+        # dequant_wgt_pattern = dequantize_fp8_weight_pattern
+        dequant_wgt_pattern = CallFunction(
+            torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
+            KeywordArg("q_weight"),
+            KeywordArg("w_scale"),
+            output_dtype=KeywordArg("w_dtype"),
+            _users=users,
+        )
     else:
         dequant_wgt_pattern = dequantize_per_channel_weight_pattern
     if input_dim_exceeds_two and not input_contiguous:
@@ -1345,6 +1382,7 @@ def _generate_qlinear_weight_prepack_patterns(
             with_bias,
             is_tensor_overload,
             is_fp8=is_fp8,
+            users=users,
         )
     else:
         return _generate_dequant_linear_node_pattern(
@@ -1353,6 +1391,7 @@ def _generate_qlinear_weight_prepack_patterns(
             input_dim_exceeds_two,
             is_tensor_overload,
             is_fp8=is_fp8,
+            users=users,
         )
 
 
@@ -1526,7 +1565,7 @@ def _register_qlinear_weight_prepack():
     #   |            OPT(add)               |
 
     linear_weight_prepack_cases = itertools.product(
-        [torch.float32, torch.bfloat16], [True, False], [True, False], [True, False]
+        [torch.float32, torch.bfloat16], [True, False], [True, False], [True, False], [1, 2]
     )
 
     # Step 1: register patterns from mm and addmm
@@ -1535,6 +1574,7 @@ def _register_qlinear_weight_prepack():
         input_dim_exceeds_two,
         is_tensor_overload,
         is_fp8,
+        users,
     ) in linear_weight_prepack_cases:
         if is_fp8 and not is_tensor_overload:
             continue
@@ -1543,6 +1583,7 @@ def _register_qlinear_weight_prepack():
             input_dim_exceeds_two,
             is_tensor_overload=is_tensor_overload,
             is_fp8=is_fp8,
+            users=users,
         )
         for weight_prepack_pattern in weight_prepack_patterns:
             # Register to pass_number 1, so we can do dequant promotion in pass_number 0.
@@ -2458,6 +2499,40 @@ def _register_qconv_binary_fusion():
             )
 
 
+def _extract_const_float_from_node(v: Any) -> float | None:
+    if isinstance(v, (int, float)):
+        return float(v)
+
+    if isinstance(v, torch.fx.Node):
+        # case 1: aten.full([1], c)
+        if v.op == "call_function" and v.target is torch.ops.aten.full.default:
+            if len(v.args) >= 2 and isinstance(v.args[1], (int, float)):
+                return float(v.args[1])
+
+        # case 2: get_attr(lifted_tensor)
+        if v.op == "get_attr":
+            obj = v.graph.owning_module
+            for atom in str(v.target).split("."):
+                if not hasattr(obj, atom):
+                    obj = None
+                    break
+                obj = getattr(obj, atom)
+
+            if isinstance(obj, (int, float)):
+                return float(obj)
+            if isinstance(obj, torch.Tensor) and obj.numel() == 1:
+                return float(obj.item())
+
+        # case 3: meta val fallback
+        mv = v.meta.get("val", None)
+        if isinstance(mv, (int, float)):
+            return float(mv)
+        if isinstance(mv, torch.Tensor) and mv.numel() == 1:
+            return float(mv.item())
+
+    return None
+
+
 def _register_qlinear_post_op_fusion_pass(
     pattern,
     pass_number,
@@ -2495,10 +2570,10 @@ def _register_qlinear_post_op_fusion_pass(
 
         # Output QParams
         if output_dtype == torch.float8_e4m3fn:
-            # For float8, we assume the scale is from aten.full.default instead of
-            # a constant buffer to avoid constant folding of q/dq before fusion passes.
-            assert kwargs["o_inv_scale"].target is torch.ops.aten.full.default
-            o_inv_scale = kwargs["o_inv_scale"].args[1]
+            o_inv_scale = _extract_const_float_from_node(kwargs["o_inv_scale"])
+            assert o_inv_scale is not None, (
+                f"Unsupported fp8 o_inv_scale node: {kwargs['o_inv_scale']}"
+            )
         else:
             o_inv_scale = (
                 kwargs["o_inv_scale"]
@@ -2979,31 +3054,7 @@ def _register_scaled_embedding_bag_pass(pattern, pass_number, dtype=torch.float3
             normalized_o_dtype = _normalize_dtype(kwargs["o_dtype"])
             output_type = normalized_o_dtype
 
-            def _extract_const_float(val) -> float | None:
-                # Prefer extracting from python scalars and FX node structure
-                if isinstance(val, (int, float)):
-                    return float(val)
-                if isinstance(val, torch.fx.Node):
-                    meta_val = val.meta.get("val", None)
-                    if isinstance(meta_val, (int, float)):
-                        return float(meta_val)
-                    # Common pattern: aten.full([1], fill_value, dtype=float)
-                    if val.target is torch.ops.aten.full.default and len(val.args) >= 2:
-                        fill_value = val.args[1]
-                        if isinstance(fill_value, (int, float)):
-                            return float(fill_value)
-                    # Common pattern in user code: torch.tensor([scalar])
-                    if val.target is torch.tensor and len(val.args) >= 1:
-                        data = val.args[0]
-                        if (
-                            isinstance(data, (list, tuple))
-                            and len(data) == 1
-                            and isinstance(data[0], (int, float))
-                        ):
-                            return float(data[0])
-                return None
-
-            o_scale = _extract_const_float(kwargs["o_inv_scale"])
+            o_scale = _extract_const_float_from_node(kwargs["o_inv_scale"])
             assert o_scale is not None, "Output scale is not a constant float."
 
         graph = match.graph

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -2464,11 +2464,21 @@ def _extract_const_float_from_node(v: Any) -> float | None:
 
     if isinstance(v, torch.fx.Node):
         # case 1: aten.full([1], c)
-        if v.op == "call_function" and v.target is torch.ops.aten.full.default:
+        if v.target is torch.ops.aten.full.default:
             if len(v.args) >= 2 and isinstance(v.args[1], (int, float)):
                 return float(v.args[1])
 
-        # case 2: get_attr(lifted_tensor)
+        # case 2: aten.tensor
+        if v.target is torch.tensor and len(v.args) >= 1:
+            data = v.args[0]
+            if (
+                isinstance(data, (list, tuple))
+                and len(data) == 1
+                and isinstance(data[0], (int, float))
+            ):
+                return float(data[0])
+
+        # case 3: get_attr(lifted_tensor)
         if v.op == "get_attr":
             obj = v.graph.owning_module
             for atom in str(v.target).split("."):
@@ -2482,7 +2492,7 @@ def _extract_const_float_from_node(v: Any) -> float | None:
             if isinstance(obj, torch.Tensor) and obj.numel() == 1:
                 return float(obj.item())
 
-        # case 3: meta val fallback
+        # case 4: meta val fallback
         mv = v.meta.get("val", None)
         if isinstance(mv, (int, float)):
             return float(mv)

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -3116,37 +3116,46 @@ def _register_quantization_embeddingbag_pass():
             )
 
 
-def _is_valid_concat_dq_q_pattern():
+def _is_valid_concat_dq_q_pattern(is_fp8=False):
     def _inner(match):
-        q_pattern_node = match.output_node()
-        dq_pattern_node = q_pattern_node.args[0]
-        assert q_pattern_node.target is quantized_decomposed.quantize_per_tensor.default
-        assert (
-            dq_pattern_node.target is quantized_decomposed.dequantize_per_tensor.default
-        )
-        # dq/q pattern_node args: (node, scale, zp, min, max, dtype)
-        for i in range(2, len(q_pattern_node.args)):
-            if not q_pattern_node.args[i] == dq_pattern_node.args[i]:
+        q_node = match.output_node()
+        dq_node = q_node.args[0]
+        if is_fp8:
+            assert (
+                q_node.target
+                is torch.ops.torchao.quantize_affine_float8_non_decomposed.default
+            )
+            assert (
+                dq_node.target
+                is torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+            )
+            dq_scale = _extract_const_float_from_node(dq_node.args[1])
+            q_scale = _extract_const_float_from_node(q_node.args[1])
+            if dq_scale is None or q_scale is None:
                 return False
-
-        q_scale = q_pattern_node.args[1]
-        dq_scale = dq_pattern_node.args[1]
+        else:
+            assert q_node.target is quantized_decomposed.quantize_per_tensor.default
+            assert dq_node.target is quantized_decomposed.dequantize_per_tensor.default
+            # dq/q pattern_node args: (node, scale, zp, min, max, dtype)
+            for i in range(2, len(q_node.args)):
+                if q_node.args[i] != dq_node.args[i]:
+                    return False
+            dq_scale = dq_node.args[1]
+            q_scale = q_node.args[1]
         if not math.isclose(q_scale, dq_scale, rel_tol=1e-5, abs_tol=1e-5):
             return False
-
-        cat_node = dq_pattern_node.args[0]
-        if not cat_node.target is torch.ops.aten.cat.default:
-            return False
-
-        return True
+        return dq_node.args[0].target is torch.ops.aten.cat.default
 
     return _inner
 
 
-def _register_concat_dequant_quant_pass(pattern, pass_number=3):
+def _register_concat_dequant_quant_pass(pattern, pass_number=3, extra_check=None):
+    if extra_check is None:
+        extra_check = _is_valid_concat_dq_q_pattern()
+
     @register_freezing_graph_pattern(
         pattern,
-        extra_check=_is_valid_concat_dq_q_pattern(),
+        extra_check=extra_check,
         pass_number=pass_number,
     )
     def concat_dq_q_fusion(match: Match, *args, **kwargs):
@@ -3210,6 +3219,25 @@ def _register_concat_dq_q_pattern():
         KeywordArg("o_dtype"),
     )
     _register_concat_dequant_quant_pass(quantized_op_output_pattern_pt2e)
+
+    # FP8 version: cat(fp8) -> dequant_fp8 -> quant_fp8 -> users
+    # Eliminates the redundant dq/q when both use the same scale tensor node.
+    dequantize_fp8_activation_pattern = CallFunction(
+        torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
+        Arg(),
+        KeywordArg("fp8_dq_scale"),
+        output_dtype=Arg(),
+    )
+    quantize_fp8_output_pattern = CallFunction(
+        torch.ops.torchao.quantize_affine_float8_non_decomposed.default,
+        dequantize_fp8_activation_pattern,
+        KeywordArg("fp8_q_scale"),
+        float8_dtype=KeywordArg("fp8_q_dtype"),
+    )
+    _register_concat_dequant_quant_pass(
+        quantize_fp8_output_pattern,
+        extra_check=_is_valid_concat_dq_q_pattern(is_fp8=True),
+    )
 
 
 @functools.lru_cache(None)

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -3131,21 +3131,25 @@ def _is_valid_concat_dq_q_pattern(is_fp8=False):
         q_node = match.output_node()
         dq_node = q_node.args[0]
         if is_fp8:
-            assert (
+            if (
                 q_node.target
-                is torch.ops.torchao.quantize_affine_float8_non_decomposed.default
-            )
-            assert (
+                is not torch.ops.torchao.quantize_affine_float8_non_decomposed.default
+            ):
+                return False
+            if (
                 dq_node.target
-                is torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
-            )
+                is not torch.ops.torchao.dequantize_affine_float8_non_decomposed.default
+            ):
+                return False
             dq_scale = _extract_const_float_from_node(dq_node.args[1])
             q_scale = _extract_const_float_from_node(q_node.args[1])
             if dq_scale is None or q_scale is None:
                 return False
         else:
-            assert q_node.target is quantized_decomposed.quantize_per_tensor.default
-            assert dq_node.target is quantized_decomposed.dequantize_per_tensor.default
+            if q_node.target is not quantized_decomposed.quantize_per_tensor.default:
+                return False
+            if dq_node.target is not quantized_decomposed.dequantize_per_tensor.default:
+                return False
             # dq/q pattern_node args: (node, scale, zp, min, max, dtype)
             for i in range(2, len(q_node.args)):
                 if q_node.args[i] != dq_node.args[i]:

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -1563,7 +1563,11 @@ def _register_qlinear_weight_prepack():
     #   |            OPT(add)               |
 
     linear_weight_prepack_cases = itertools.product(
-        [torch.float32, torch.bfloat16], [True, False], [True, False], [True, False], [1, 2]
+        [torch.float32, torch.bfloat16],
+        [True, False],
+        [True, False],
+        [True, False],
+        [1, 2],
     )
 
     # Step 1: register patterns from mm and addmm

--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -148,7 +148,7 @@ def _unary_fusion_pattern(unary_fusion, call_fn, users, is_bf16):
 
 
 def get_dequantize_per_tensor_activation_pattern(
-    is_tensor_overload=False, is_fp8=False, users=1
+    is_tensor_overload=False, is_fp8=False
 ):
     if is_fp8:
         dequantize_per_tensor_activation_pattern = CallFunction(
@@ -156,7 +156,6 @@ def get_dequantize_per_tensor_activation_pattern(
             KeywordArg("x"),
             KeywordArg("x_scale"),
             output_dtype=KeywordArg("x_dq_dtype"),
-            _users=users,
         )
     else:
         dequantize_per_tensor_activation_pattern = CallFunction(
@@ -169,7 +168,6 @@ def get_dequantize_per_tensor_activation_pattern(
             KeywordArg("x_quant_min"),
             KeywordArg("x_quant_max"),
             KeywordArg("x_dq_dtype"),
-            _users=users,
         )
     return dequantize_per_tensor_activation_pattern
 
@@ -993,26 +991,6 @@ def _get_linear_dq_node(
     return dequant_node, act_reshape_node, activation_to_bf16_node, act_expand_node
 
 
-def _is_assert_tensor_metadata_node(node: Any) -> bool:
-    return (
-        isinstance(node, torch.fx.Node)
-        and node.op == "call_function"
-        and node.target == torch.ops.aten._assert_tensor_metadata.default
-    )
-
-
-def _get_non_assert_users(node: torch.fx.Node) -> list[torch.fx.Node]:
-    return [user for user in node.users if not _is_assert_tensor_metadata_node(user)]
-
-
-def _erase_assert_tensor_metadata_users(
-    graph: torch.fx.Graph, node: torch.fx.Node
-) -> None:
-    for user in list(node.users):
-        if _is_assert_tensor_metadata_node(user):
-            graph.erase_node(user)
-
-
 def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contiguous):
     def _inner(match):
         # Check dequant pattern has only 1 user.
@@ -1038,8 +1016,9 @@ def _is_valid_dequant_linear_pattern(dtype, input_dim_exceeds_two, input_contigu
             torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
         ]
 
-        # Allow dequant has multi users including _assert_tensor_metadata introduced by AOT Inductor.
-        if len(_get_non_assert_users(dequant_node)) != 1:
+        if len(list(dequant_node.users)) != 1:
+            # Ensure the dequant pattern only has 1 user
+            # since we will delete the dequant pattern here
             return False
 
         # Extra check for bmm pattern
@@ -1223,10 +1202,6 @@ def _register_qlinear_weight_prepack_pass(
                 linear_node.replace_all_uses_with(new_linear_node)
                 new_linear_node.meta.update(linear_node.meta)
 
-            # Erase assert users first so dequant nodes become erasable.
-            _erase_assert_tensor_metadata_users(graph, dequant_node)
-            _erase_assert_tensor_metadata_users(graph, dequant)
-
             # Erase the original linear node
             if input_dim_exceeds_two:
                 if input_contiguous:
@@ -1262,7 +1237,6 @@ def _generate_dequant_linear_node_pattern(
     input_dim_exceeds_two=False,
     is_tensor_overload=False,
     is_fp8=False,
-    users=1,
 ):
     assert dtype in [torch.float32, torch.bfloat16]
     t_pattern = _generate_linear_t_pattern(_dequant_per_channel_pattern, dtype)
@@ -1273,7 +1247,7 @@ def _generate_dequant_linear_node_pattern(
             _may_generate_pattern_with_reshape(
                 _may_generate_pattern_with_dtype_convert(
                     get_dequantize_per_tensor_activation_pattern(
-                        is_tensor_overload, is_fp8, users
+                        is_tensor_overload, is_fp8
                     ),
                     KeywordArg("autocast_act_dtype"),
                     dtype == torch.bfloat16,
@@ -1292,7 +1266,7 @@ def _generate_dequant_linear_node_pattern(
             _may_generate_pattern_with_reshape(
                 _may_generate_pattern_with_dtype_convert(
                     get_dequantize_per_tensor_activation_pattern(
-                        is_tensor_overload, is_fp8, users
+                        is_tensor_overload, is_fp8
                     ),
                     KeywordArg("autocast_act_dtype"),
                     dtype == torch.bfloat16,
@@ -1314,7 +1288,6 @@ def _generate_dequant_bmm_node_pattern(
     with_bias=False,
     is_tensor_overload=False,
     is_fp8=False,
-    users=1,
 ):
     # When activation of linear dim exceed 2 and not contiguous
     t_pattern = _generate_linear_t_pattern(_dequant_per_channel_pattern, dtype)
@@ -1326,7 +1299,7 @@ def _generate_dequant_bmm_node_pattern(
             aten.expand.default,
             _may_generate_pattern_with_dtype_convert(
                 get_dequantize_per_tensor_activation_pattern(
-                    is_tensor_overload, is_fp8, users
+                    is_tensor_overload, is_fp8
                 ),
                 KeywordArg("autocast_act_dtype"),
                 dtype == torch.bfloat16,
@@ -1360,17 +1333,9 @@ def _generate_qlinear_weight_prepack_patterns(
     with_bias=False,
     is_tensor_overload=False,
     is_fp8=False,
-    users=1,
 ):
     if is_fp8:
-        # dequant_wgt_pattern = dequantize_fp8_weight_pattern
-        dequant_wgt_pattern = CallFunction(
-            torch.ops.torchao.dequantize_affine_float8_non_decomposed.default,
-            KeywordArg("q_weight"),
-            KeywordArg("w_scale"),
-            output_dtype=KeywordArg("w_dtype"),
-            _users=users,
-        )
+        dequant_wgt_pattern = dequantize_fp8_weight_pattern
     else:
         dequant_wgt_pattern = dequantize_per_channel_weight_pattern
     if input_dim_exceeds_two and not input_contiguous:
@@ -1380,7 +1345,6 @@ def _generate_qlinear_weight_prepack_patterns(
             with_bias,
             is_tensor_overload,
             is_fp8=is_fp8,
-            users=users,
         )
     else:
         return _generate_dequant_linear_node_pattern(
@@ -1389,7 +1353,6 @@ def _generate_qlinear_weight_prepack_patterns(
             input_dim_exceeds_two,
             is_tensor_overload,
             is_fp8=is_fp8,
-            users=users,
         )
 
 
@@ -1563,11 +1526,7 @@ def _register_qlinear_weight_prepack():
     #   |            OPT(add)               |
 
     linear_weight_prepack_cases = itertools.product(
-        [torch.float32, torch.bfloat16],
-        [True, False],
-        [True, False],
-        [True, False],
-        [1, 2],
+        [torch.float32, torch.bfloat16], [True, False], [True, False], [True, False]
     )
 
     # Step 1: register patterns from mm and addmm
@@ -1576,7 +1535,6 @@ def _register_qlinear_weight_prepack():
         input_dim_exceeds_two,
         is_tensor_overload,
         is_fp8,
-        users,
     ) in linear_weight_prepack_cases:
         if is_fp8 and not is_tensor_overload:
             continue
@@ -1585,7 +1543,6 @@ def _register_qlinear_weight_prepack():
             input_dim_exceeds_two,
             is_tensor_overload=is_tensor_overload,
             is_fp8=is_fp8,
-            users=users,
         )
         for weight_prepack_pattern in weight_prepack_patterns:
             # Register to pass_number 1, so we can do dequant promotion in pass_number 0.

--- a/torchao/testing/pt2e/utils.py
+++ b/torchao/testing/pt2e/utils.py
@@ -255,7 +255,7 @@ class FP8QDQLinear(torch.nn.Module):
 
     def forward(self, input):
         weight = torch.ops.torchao.dequantize_affine_float8_non_decomposed.default(
-            tensor=self.weight.data,
+            tensor=self.weight,
             scale=torch.tensor([self.weight_scale]),
             output_dtype=torch.float,
         )


### PR DESCRIPTION
The graph obtained by AOT Inductor differs from that obtained by the regular torch.compile:
1) Add fp8 support for `concat_dequant_quant`. 
2) The scale may be lifted to a lifted_tensor. Therefore, the fp8 pattern needs to be extended to adapt to AOTI.