### PR TITLE
Deprecate TorchAODType

### DIFF
--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from enum import Enum, auto
+import warnings
+from enum import Enum, EnumMeta, auto
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -88,7 +89,17 @@ class ZeroPointDomain(Enum):
     NONE = auto()
 
 
-class TorchAODType(Enum):
+class _TorchAODTypeMeta(EnumMeta):
+    def __getattribute__(cls, name):
+        result = super().__getattribute__(name)
+        warnings.warn(
+            "Deprecation: TorchAODType is deprecated, please use the torch.intN dtype instead "
+            "(e.g. TorchAODType.INT4 -> torch.int4)"
+        )
+        return result
+
+
+class TorchAODType(Enum, metaclass=_TorchAODTypeMeta):
     """
     Placeholder for dtypes that do not exist in PyTorch core yet.
     """


### PR DESCRIPTION
**Summary:** This was added for torch 2.5 as a placeholder for torch.int4. Now all torch versions we support have these dtypes, so this class is no longer needed and should not be used by anyone. We will remove it next release (0.18.0).

**Test Plan:** Manual testing

**Deprecation notes:**

Before:
```
TorchAODType.INT1
TorchAODType.INT2
TorchAODType.INT3
TorchAODType.INT4
TorchAODType.INT5
TorchAODType.INT6
TorchAODType.INT7
```

After:
```
torch.int1
torch.int2
torch.int3
torch.int4
torch.int5
torch.int6
torch.int7
```