### PR TITLE
[mxfp8 moe training] permute support for alignment=0

### DIFF
--- a/torchao/prototype/moe_training/ep/kernels.py
+++ b/torchao/prototype/moe_training/ep/kernels.py
@@ -182,9 +182,12 @@ def generate_permute_indices(
     total_tokens_per_expert = torch.clamp_min(total_tokens_per_expert, alignment)
 
     # align the chunk sizes (cdiv)
-    m_sizes = ((total_tokens_per_expert + alignment - 1) // alignment * alignment).to(
-        torch.int32
-    )
+    if alignment > 0:
+        m_sizes = (
+            (total_tokens_per_expert + alignment - 1) // alignment * alignment
+        ).to(torch.int32)
+    else:
+        m_sizes = total_tokens_per_expert.to(torch.int32)
 
     # additional prefix sum to get write offset of each expert in permuted_indices
     # write offsets is per local expert, not global

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -17,6 +17,8 @@ from .kernels import generate_permute_indices
 
 def _round_up(x: int, y: int) -> int:
     """Round up x to the nearest multiple of y."""
+    if y == 0:
+        return x
     x_ceil_div_y = (x + y - 1) // y
     return x_ceil_div_y * y
 


### PR DESCRIPTION
## Summary
- For bf16 moe training in torchtitan with EP, token groups need to be permuted to be grouped by expert instead of by source rank, but don't need padding.
- We may use this torchao function to permute and optionally pad for both bf16 and mxfp8. (definitely for mxfp8, tbd about bf16, but still we should fix/update our code to handle this case)