### PR TITLE
Fix deprecated TreeSpec CTOR

### DIFF
--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -29,6 +29,9 @@ from torch.fx import Graph, GraphModule, Node
 from torch.nn.utils.fusion import fuse_conv_bn_weights, fuse_linear_bn_weights
 from torch.nn.utils.parametrize import is_parametrized
 
+# treespec_leaf() was added in newer PyTorch to replace LeafSpec(), which is
+# now deprecated and triggers a FutureWarning on instantiation. Fall back to
+# LeafSpec() for older PyTorch versions that don't have treespec_leaf yet.
 try:
     from torch.utils._pytree import treespec_leaf
 except ImportError:


### PR DESCRIPTION
Getting absolutely spammed with "/Users/jakeszwe/anaconda3/envs/opt/lib/python3.12/copyreg.py:99: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead." 

when lowering models in ET. Seeing if this fixes.