### PR TITLE
[float8] fix `cc1` typo in `Float8LinearConfig.__post_init__` operand-precision assertion

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 
 from torchao.float8.config import (
+    CastConfig,
     Float8LinearConfig,
     Float8LinearRecipeName,
     ScalingGranularity,
@@ -453,6 +454,16 @@ class TestFloat8Linear:
         )
         s = m.__repr__()
         assert "i:dyn_ten_e4m3,w:dyn_ten_e4m3,go:dyn_ten_e5m2" in s
+
+    def test_mixed_precision_operands_raise(self):
+        with pytest.raises(
+            AssertionError,
+            match="incompatible operand precision for output",
+        ):
+            Float8LinearConfig(
+                cast_config_input=CastConfig(scaling_type=ScalingType.DISABLED),
+                cast_config_weight=CastConfig(scaling_type=ScalingType.DYNAMIC),
+            )
 
     @unittest.skipIf(not is_sm_at_least_89(), "CUDA 8.9 not available")
     def test_inference_mode(self):

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -289,7 +289,7 @@ class Float8LinearConfig:
             (cc_i_gw, cc_go_gw, "grad_weight"),
         ):
             is_disabled_1 = cc1.scaling_type is ScalingType.DISABLED
-            is_disabled_2 = cc1.scaling_type is ScalingType.DISABLED
+            is_disabled_2 = cc2.scaling_type is ScalingType.DISABLED
             assert is_disabled_1 == is_disabled_2, (
                 f"incompatible operand precision for {gemm_name}"
             )


### PR DESCRIPTION
Fixes #4445.

## Summary

In `torchao/float8/config.py::Float8LinearConfig.__post_init__`, the loop that validates "both operands of a GEMM must share the same DISABLED status" reads `cc1` twice instead of comparing `cc1` against `cc2`:

```python
for cc1, cc2, gemm_name in (
    (cc_i, cc_w, "output"),
    (cc_go, cc_w_gi, "grad_input"),
    (cc_i_gw, cc_go_gw, "grad_weight"),
):
    is_disabled_1 = cc1.scaling_type is ScalingType.DISABLED
    is_disabled_2 = cc1.scaling_type is ScalingType.DISABLED   # ← reads cc1 twice
    assert is_disabled_1 == is_disabled_2, (
        f"incompatible operand precision for {gemm_name}"
    )
```

So the comparison is always `True == True` or `False == False` → the `assert` never fires → misconfigured `Float8LinearConfig` (one operand DISABLED, the other DYNAMIC) is silently accepted and then fails later in the matmul path with a much harder-to-debug error.

Verified the bug still exists on `main` at `b4805e2e8`.

## Fix

Change the second `cc1` to `cc2` (1 character). This restores the intended "both operands share the same DISABLED status" semantics that the loop and the comment immediately above it already assume.

## Test Plan

Adds `test_mixed_precision_operands_raise` that constructs a `Float8LinearConfig` with `cast_config_input=DISABLED` and `cast_config_weight=DYNAMIC`, then verifies the corresponding `AssertionError("incompatible operand precision for output")` is raised.

```bash
pytest test/float8/test_base.py -k mixed_precision_operands_raise -v
```

The new test fails on `main` (config silently constructs) and passes after the fix.

## Related

- Sibling typo bug + PR: #4444 / #4038