### PR TITLE
[sam2] Replace complex-number RoPE with PyTorch F.apply_rotary_emb

### DIFF
--- a/test_sam2_rope_equivalence.py
+++ b/test_sam2_rope_equivalence.py
@@ -1,0 +1,248 @@
+"""
+Numerical equivalence test: original SAM2 complex RoPE vs new F.apply_rotary_emb.
+
+Verifies that compute_2d_axial_rope_frequencies + F.apply_rotary_emb(interleaved=True)
+produces identical results to the original compute_axial_cis + apply_rotary_enc.
+"""
+import sys
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+# Shim F.apply_rotary_emb for PyTorch versions that don't include it yet
+if not hasattr(F, "apply_rotary_emb"):
+    def _rotate_half(x, interleaved=False):
+        if interleaved:
+            x1 = x[..., ::2]
+            x2 = x[..., 1::2]
+            return torch.stack((-x2, x1), dim=-1).flatten(-2)
+        else:
+            x1, x2 = x.chunk(2, dim=-1)
+            return torch.cat((-x2, x1), dim=-1)
+
+    def _apply_rotary_emb(query, key, cos, sin, seq_dim=1, interleaved=False):
+        cos = cos.narrow(0, 0, query.size(seq_dim))
+        sin = sin.narrow(0, 0, query.size(seq_dim))
+        if seq_dim == 1:
+            cos_b = cos.unsqueeze(0).unsqueeze(2)
+            sin_b = sin.unsqueeze(0).unsqueeze(2)
+        elif seq_dim == 2:
+            cos_b = cos.unsqueeze(0).unsqueeze(0)
+            sin_b = sin.unsqueeze(0).unsqueeze(0)
+        else:
+            raise ValueError(f"seq_dim must be 1 or 2, got {seq_dim}")
+        query_rot = query * cos_b + _rotate_half(query, interleaved) * sin_b
+        key_rot = key * cos_b + _rotate_half(key, interleaved) * sin_b
+        return query_rot, key_rot
+
+    F.apply_rotary_emb = _apply_rotary_emb
+
+from torchao._models.sam2.modeling.position_encoding import (
+    compute_2d_axial_rope_frequencies,
+)
+
+
+# ── Original SAM2 implementations (copied from before our changes) ──
+
+def orig_init_t_xy(end_x, end_y, device=None):
+    t = torch.arange(end_x * end_y, dtype=torch.float32, device=device)
+    t_x = (t % end_x).float()
+    t_y = torch.div(t, end_x, rounding_mode="floor").float()
+    return t_x, t_y
+
+
+def orig_compute_axial_cis(dim, end_x, end_y, theta=10000.0, device=None):
+    freqs_x = 1.0 / (
+        theta ** (torch.arange(0, dim, 4, device=device)[: (dim // 4)].float() / dim)
+    )
+    freqs_y = 1.0 / (
+        theta ** (torch.arange(0, dim, 4, device=device)[: (dim // 4)].float() / dim)
+    )
+    t_x, t_y = orig_init_t_xy(end_x, end_y, device=device)
+    freqs_x = torch.outer(t_x, freqs_x)
+    freqs_y = torch.outer(t_y, freqs_y)
+    freqs_cis_x = torch.polar(torch.ones_like(freqs_x), freqs_x)
+    freqs_cis_y = torch.polar(torch.ones_like(freqs_y), freqs_y)
+    return torch.cat([freqs_cis_x, freqs_cis_y], dim=-1)
+
+
+def orig_reshape_for_broadcast(freqs_cis, x):
+    ndim = x.ndim
+    shape = [d if i >= ndim - 2 else 1 for i, d in enumerate(x.shape)]
+    return freqs_cis.view(*shape)
+
+
+def orig_apply_rotary_enc(xq, xk, freqs_cis, repeat_freqs_k=False):
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = (
+        torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+        if xk.shape[-2] != 0
+        else None
+    )
+    freqs_cis = orig_reshape_for_broadcast(freqs_cis, xq_)
+    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
+    if xk_ is None:
+        return xq_out.type_as(xq).to(xq.device), xk
+    if repeat_freqs_k:
+        r = xk_.shape[-2] // xq_.shape[-2]
+        freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
+    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
+    return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
+
+
+# ── Tests ──
+
+def check(name, a, b, atol=1e-5):
+    diff = (a - b).abs().max().item()
+    ok = diff < atol
+    print(f"  {'PASS' if ok else 'FAIL'}: {name} (max diff: {diff:.2e})")
+    return ok
+
+
+def test_basic_attention():
+    """SAM2 default: 32x32 features, dim=32."""
+    print("=== test_basic_attention (SAM2 decoder) ===")
+    device = "cuda"
+    B, heads, dim = 2, 8, 32
+    L_x, L_y = 32, 32
+    L = L_x * L_y
+
+    q = torch.randn(B, heads, L, dim, device=device)
+    k = torch.randn(B, heads, L, dim, device=device)
+
+    freqs_cis = orig_compute_axial_cis(dim, L_x, L_y, device=device)
+    q_orig, k_orig = orig_apply_rotary_enc(q, k, freqs_cis)
+
+    cos, sin = compute_2d_axial_rope_frequencies(dim, L_x, L_y)
+    cos, sin = cos.to(device), sin.to(device)
+    q_new, k_new = F.apply_rotary_emb(q, k, cos, sin, seq_dim=2, interleaved=True)
+
+    ok = check("basic q", q_orig, q_new)
+    ok &= check("basic k", k_orig, k_new)
+    return ok
+
+
+def test_k_repeat():
+    """Cross-attention with rope_k_repeat."""
+    print("\n=== test_k_repeat (cross-attention to memories) ===")
+    device = "cuda"
+    B, heads, dim = 2, 8, 32
+    L_x, L_y = 32, 32
+    L_q = L_x * L_y
+    L_k = L_q * 3
+
+    q = torch.randn(B, heads, L_q, dim, device=device)
+    k = torch.randn(B, heads, L_k, dim, device=device)
+
+    freqs_cis = orig_compute_axial_cis(dim, L_x, L_y, device=device)
+    q_orig, k_orig = orig_apply_rotary_enc(q, k, freqs_cis, repeat_freqs_k=True)
+
+    cos, sin = compute_2d_axial_rope_frequencies(dim, L_x, L_y)
+    cos, sin = cos.to(device), sin.to(device)
+    q_new, _ = F.apply_rotary_emb(q, q, cos, sin, seq_dim=2, interleaved=True)
+    r = L_k // L_q
+    cos_k = cos.repeat(r, 1)
+    sin_k = sin.repeat(r, 1)
+    _, k_new = F.apply_rotary_emb(k, k, cos_k, sin_k, seq_dim=2, interleaved=True)
+
+    ok = check("k_repeat q", q_orig, q_new)
+    ok &= check("k_repeat k", k_orig, k_new)
+    return ok
+
+
+def test_exclude_rope():
+    """RoPE with num_k_exclude_rope."""
+    print("\n=== test_exclude_rope ===")
+    device = "cuda"
+    B, heads, dim = 2, 8, 32
+    L_x, L_y = 32, 32
+    L_q = L_x * L_y
+    num_exclude = 4
+    L_k = L_q + num_exclude
+
+    q = torch.randn(B, heads, L_q, dim, device=device)
+    k = torch.randn(B, heads, L_k, dim, device=device)
+
+    freqs_cis = orig_compute_axial_cis(dim, L_x, L_y, device=device)
+    num_k_rope = L_k - num_exclude
+    q_orig, k_rope_orig = orig_apply_rotary_enc(q, k[:, :, :num_k_rope], freqs_cis)
+
+    cos, sin = compute_2d_axial_rope_frequencies(dim, L_x, L_y)
+    cos, sin = cos.to(device), sin.to(device)
+    q_new, k_rope_new = F.apply_rotary_emb(
+        q, k[:, :, :num_k_rope], cos, sin, seq_dim=2, interleaved=True
+    )
+
+    ok = check("exclude q", q_orig, q_new)
+    ok &= check("exclude k_rope", k_rope_orig, k_rope_new)
+    return ok
+
+
+def test_compile_fullgraph():
+    """Verify F.apply_rotary_emb compiles fullgraph."""
+    print("\n=== test_compile_fullgraph ===")
+    device = "cuda"
+    B, heads, dim = 2, 8, 32
+    L_x, L_y = 32, 32
+    L = L_x * L_y
+
+    cos, sin = compute_2d_axial_rope_frequencies(dim, L_x, L_y)
+    cos, sin = cos.to(device), sin.to(device)
+
+    def rope_fn(q, k, cos, sin):
+        return F.apply_rotary_emb(q, k, cos, sin, seq_dim=2, interleaved=True)
+
+    q = torch.randn(B, heads, L, dim, device=device)
+    k = torch.randn(B, heads, L, dim, device=device)
+
+    q_eager, k_eager = rope_fn(q, k, cos, sin)
+    compiled_fn = torch.compile(rope_fn, fullgraph=True)
+    q_compiled, k_compiled = compiled_fn(q, k, cos, sin)
+
+    ok = check("compile q", q_compiled, q_eager)
+    ok &= check("compile k", k_compiled, k_eager)
+    return ok
+
+
+def test_bfloat16():
+    """Test with bfloat16 (SAM2's typical inference dtype)."""
+    print("\n=== test_bfloat16 ===")
+    device = "cuda"
+    B, heads, dim = 1, 8, 32
+    L_x, L_y = 32, 32
+    L = L_x * L_y
+
+    q = torch.randn(B, heads, L, dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn(B, heads, L, dim, device=device, dtype=torch.bfloat16)
+
+    freqs_cis = orig_compute_axial_cis(dim, L_x, L_y, device=device)
+    q_orig, k_orig = orig_apply_rotary_enc(q, k, freqs_cis)
+
+    cos, sin = compute_2d_axial_rope_frequencies(dim, L_x, L_y)
+    cos, sin = cos.to(device), sin.to(device)
+    q_new, k_new = F.apply_rotary_emb(
+        q.float(), k.float(), cos, sin, seq_dim=2, interleaved=True
+    )
+    q_new, k_new = q_new.to(torch.bfloat16), k_new.to(torch.bfloat16)
+
+    ok = check("bf16 q", q_orig, q_new, atol=5e-2)
+    ok &= check("bf16 k", k_orig, k_new, atol=5e-2)
+    return ok
+
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+    all_ok = True
+    all_ok &= test_basic_attention()
+    all_ok &= test_k_repeat()
+    all_ok &= test_exclude_rope()
+    all_ok &= test_compile_fullgraph()
+    all_ok &= test_bfloat16()
+
+    print("\n" + "=" * 50)
+    if all_ok:
+        print("ALL TESTS PASSED")
+    else:
+        print("SOME TESTS FAILED")
+    sys.exit(0 if all_ok else 1)

--- a/torchao/_models/sam2/modeling/position_encoding.py
+++ b/torchao/_models/sam2/modeling/position_encoding.py
@@ -163,64 +163,27 @@ class PositionEmbeddingRandom(nn.Module):
 # 3. https://github.com/lucidrains/rotary-embedding-torch
 
 
-def init_t_xy(end_x: int, end_y: int, device=None):
-    t = torch.arange(end_x * end_y, dtype=torch.float32, device=device)
+def compute_2d_axial_rope_frequencies(
+    dim: int,
+    end_x: int,
+    end_y: int,
+    theta: float = 10000.0,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute 2D axial RoPE cos/sin for use with F.apply_rotary_emb(interleaved=True).
+
+    Head dimension is split in half: first half encodes x-position, second half
+    encodes y-position. Returns cos/sin of shape [end_x * end_y, dim] with values
+    repeat-interleaved for the interleaved pair layout.
+    """
+    inv_freq = 1.0 / (
+        theta ** (torch.arange(0, dim, 4, dtype=torch.float32)[: dim // 4] / dim)
+    )
+    t = torch.arange(end_x * end_y, dtype=torch.float32)
     t_x = (t % end_x).float()
     t_y = torch.div(t, end_x, rounding_mode="floor").float()
-    return t_x, t_y
-
-
-def compute_axial_cis(
-    dim: int, end_x: int, end_y: int, theta: float = 10000.0, device=None
-):
-    freqs_x = 1.0 / (
-        theta ** (torch.arange(0, dim, 4, device=device)[: (dim // 4)].float() / dim)
-    )
-    freqs_y = 1.0 / (
-        theta ** (torch.arange(0, dim, 4, device=device)[: (dim // 4)].float() / dim)
-    )
-
-    t_x, t_y = init_t_xy(end_x, end_y, device=device)
-    freqs_x = torch.outer(t_x, freqs_x)
-    freqs_y = torch.outer(t_y, freqs_y)
-    freqs_cis_x = torch.polar(torch.ones_like(freqs_x), freqs_x)
-    freqs_cis_y = torch.polar(torch.ones_like(freqs_y), freqs_y)
-    return torch.cat([freqs_cis_x, freqs_cis_y], dim=-1)
-
-
-def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[-2], x.shape[-1])
-    shape = [d if i >= ndim - 2 else 1 for i, d in enumerate(x.shape)]
-    return freqs_cis.view(*shape)
-
-
-def apply_rotary_enc(
-    xq: torch.Tensor,
-    xk: torch.Tensor,
-    freqs_cis: torch.Tensor,
-    repeat_freqs_k: bool = False,
-):
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = (
-        torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
-        if xk.shape[-2] != 0
-        else None
-    )
-    freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(3)
-    if xk_ is None:
-        # no keys to rotate, due to dropout
-        return xq_out.type_as(xq).to(xq.device), xk
-    # repeat freqs along seq_len dim to match k seq_len
-    if repeat_freqs_k:
-        r = xk_.shape[-2] // xq_.shape[-2]
-        if freqs_cis.is_cuda:
-            freqs_cis = freqs_cis.repeat(*([1] * (freqs_cis.ndim - 2)), r, 1)
-        else:
-            # torch.repeat on complex numbers may not be supported on non-CUDA devices
-            # (freqs_cis has 4 dims and we repeat on dim 2) so we use expand + flatten
-            freqs_cis = freqs_cis.unsqueeze(2).expand(-1, -1, r, -1, -1).flatten(2, 3)
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(3)
-    return xq_out.type_as(xq).to(xq.device), xk_out.type_as(xk).to(xk.device)
+    freqs_x = torch.outer(t_x, inv_freq)
+    freqs_y = torch.outer(t_y, inv_freq)
+    freqs = torch.cat([freqs_x, freqs_y], dim=-1)
+    cos = freqs.cos().repeat_interleave(2, dim=-1)
+    sin = freqs.sin().repeat_interleave(2, dim=-1)
+    return cos, sin

--- a/torchao/_models/sam2/modeling/sam/transformer.py
+++ b/torchao/_models/sam2/modeling/sam/transformer.py
@@ -15,8 +15,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 
 from torchao._models.sam2.modeling.position_encoding import (
-    apply_rotary_enc,
-    compute_axial_cis,
+    compute_2d_axial_rope_frequencies,
 )
 from torchao._models.sam2.modeling.sam2_utils import MLP
 from torchao._models.sam2.utils.misc import get_sdpa_settings
@@ -307,12 +306,15 @@ class RoPEAttention(Attention):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-
-        self.compute_cis = partial(
-            compute_axial_cis, dim=self.internal_dim // self.num_heads, theta=rope_theta
+        head_dim = self.internal_dim // self.num_heads
+        self.compute_rope_freqs = partial(
+            compute_2d_axial_rope_frequencies, dim=head_dim, theta=rope_theta
         )
-        freqs_cis = self.compute_cis(end_x=feat_sizes[0], end_y=feat_sizes[1])
-        self.freqs_cis = freqs_cis
+        cos, sin = self.compute_rope_freqs(
+            end_x=feat_sizes[0], end_y=feat_sizes[1],
+        )
+        self.rope_cos = cos
+        self.rope_sin = sin
         self.rope_k_repeat = rope_k_repeat
 
     def forward(
@@ -328,40 +330,43 @@ class RoPEAttention(Attention):
         k = self._separate_heads(k, self.num_heads)
         v = self._separate_heads(v, self.num_heads)
 
-        # Apply rotary position encoding
+        # Recompute frequencies if spatial resolution changed
         w = h = math.sqrt(q.shape[-2])
-        # NOTE: Disabling this.
-        # self.freqs_cis = self.freqs_cis.to(q.device)
-        if self.freqs_cis.shape[0] != q.shape[-2]:
-            self.freqs_cis = self.compute_cis(
-                end_x=w, end_y=h, device=q.device
-            )  # .to(q.device)
-        if q.shape[-2] != k.shape[-2]:
-            assert self.rope_k_repeat
+        if self.rope_cos.shape[0] != q.shape[-2]:
+            self.rope_cos, self.rope_sin = self.compute_rope_freqs(
+                end_x=int(w), end_y=int(h),
+            )
+            self.rope_cos = self.rope_cos.to(device=q.device)
+            self.rope_sin = self.rope_sin.to(device=q.device)
 
         num_k_rope = k.size(-2) - num_k_exclude_rope
-        q, k[:, :, :num_k_rope] = apply_rotary_enc(
-            q,
-            k[:, :, :num_k_rope],
-            freqs_cis=self.freqs_cis,
-            repeat_freqs_k=self.rope_k_repeat,
-        )
+        if q.shape[-2] != num_k_rope:
+            assert self.rope_k_repeat
+
+        cos, sin = self.rope_cos, self.rope_sin
+
+        if self.rope_k_repeat:
+            q, _ = F.apply_rotary_emb(
+                q, q, cos, sin, seq_dim=2, interleaved=True
+            )
+            r = num_k_rope // q.shape[-2]
+            cos_k = cos.repeat(r, 1)
+            sin_k = sin.repeat(r, 1)
+            _, k_rope = F.apply_rotary_emb(
+                k[:, :, :num_k_rope], k[:, :, :num_k_rope],
+                cos_k, sin_k, seq_dim=2, interleaved=True
+            )
+        else:
+            q, k_rope = F.apply_rotary_emb(
+                q, k[:, :, :num_k_rope], cos, sin, seq_dim=2, interleaved=True
+            )
+
+        if num_k_exclude_rope > 0:
+            k = torch.cat([k_rope, k[:, :, num_k_rope:]], dim=2)
+        else:
+            k = torch.cat([k_rope], dim=2) if num_k_rope < k.size(2) else k_rope
 
         dropout_p = self.dropout_p if self.training else 0.0
-        # # Attention
-        # try:
-        #     with sdp_kernel_context(dropout_p):
-        #         out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
-        # except Exception as e:
-        #     # Fall back to all kernels if the Flash attention kernel fails
-        #     warnings.warn(
-        #         f"Flash Attention kernel failed due to: {e}\nFalling back to all available "
-        #         f"kernels for scaled_dot_product_attention (which may have a slower speed).",
-        #         category=UserWarning,
-        #         stacklevel=2,
-        #     )
-        #     global ALLOW_ALL_KERNELS
-        #     ALLOW_ALL_KERNELS = True
         # TODO: This scale should not be needed. But without it compile causes a NaN.
         out = F.scaled_dot_product_attention(
             q, k, v, dropout_p=dropout_p, scale=(1.0 / math.sqrt(q.size(-1)))


### PR DESCRIPTION
## [sam2] Replace complex-number RoPE with PyTorch functional API (`F.apply_rotary_emb`)

Replaces SAM2's custom complex-number RoPE implementation with PyTorch's new
`F.apply_rotary_emb` functional API ([pytorch/pytorch#176223](https://github.com/pytorch/pytorch/pull/176223)).
This eliminates `view_as_complex`/`view_as_real` overhead and enables kernel
fusion under `torch.compile`.

### Changes

- `torchao/_models/sam2/modeling/position_encoding.py`: Replace
  `compute_axial_cis`, `init_t_xy`, `reshape_for_broadcast`, `apply_rotary_enc`
  (~65 lines of complex arithmetic) with `compute_2d_axial_rope_frequencies`
  (~20 lines returning real cos/sin).
- `torchao/_models/sam2/modeling/sam/transformer.py`: Update `RoPEAttention` to
  use `F.apply_rotary_emb(..., interleaved=True)` for both basic and
  `rope_k_repeat` cases.
- `test_sam2_rope_equivalence.py`: Numerical equivalence tests covering basic
  attention, k_repeat, exclude_rope, compile fullgraph, and bfloat16.

### Equivalence Test Results

All 10 tests pass with max diff 4.77e-07 (fp32):
```
=== test_basic_attention (SAM2 decoder) ===
  PASS: basic q (max diff: 4.77e-07)
  PASS: basic k (max diff: 4.77e-07)
=== test_k_repeat (cross-attention to memories) ===
  PASS: k_repeat q (max diff: 4.77e-07)
  PASS: k_repeat k (max diff: 4.77e-07)
=== test_exclude_rope ===
  PASS: exclude q (max diff: 4.77e-07)
  PASS: exclude k_rope (max diff: 4.77e-07)
=== test_compile_fullgraph ===
  PASS: compile q (max diff: 4.77e-07)
  PASS: compile k (max diff: 4.77e-07)
=== test_bfloat16 ===
  PASS: bf16 q (max diff: 3.91e-03)
  PASS: bf16 k (max diff: 3.91e-03)
```

### How to Reproduce

**1. Install PyTorch from the RoPE branch:**

```bash
git clone https://github.com/pytorch/pytorch.git
cd pytorch
git checkout rope-functional-api-v2
git submodule sync && git submodule update --init --recursive
pip install -e . -v --no-build-isolation
```

Or, use the inline shim in `test_sam2_rope_equivalence.py` which patches
`F.apply_rotary_emb` for PyTorch versions that don't include it yet.

**2. Clone torchao and checkout the branch:**

```bash
git clone https://github.com/pytorch/ao.git
cd ao
git checkout rope-pytorch-functional-api
pip install -e .
```

**3. Run equivalence tests:**

```bash
python test_sam2_rope_equivalence.py
```

### Related PRs

- PyTorch core: [pytorch/pytorch#176223](https://github.com/pytorch/pytorch/pull/176223) — adds `F.rotary_embedding_frequencies`, `F.apply_rotary_emb`, `F.rotate_half`
- SAM3: [jainapurva/sam3](https://github.com/jainapurva/sam3/tree/rope-pytorch-functional-api) — same replacement with full E2E kernel/memory traces