### PR TITLE
[mxfp8 moe training] remove unnecessary memory fences in cutedsl kernel; unify redundant conditionals

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_3d.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_3d.py
@@ -631,6 +631,9 @@ def _compile_mxfp8_quantize_3d_cutedsl(
                         )
 
                 if warp_idx >= 1 and warp_idx <= compute_warps:
+                    # wait for tma load to complete
+                    # (no explicit memory fence necessary, it is implicit after mbarrier completion)
+                    # see PTX docs: https://docs.nvidia.com/cuda/parallel-thread-execution/#async-proxy
                     cute.arch.mbarrier_wait(tma_mbar_ptr, tma_phase)
                     lane = tidx % 32
                     k_lane = (warp_idx - 1) * 32 + lane


### PR DESCRIPTION
## Summary
- Remove unnecessary memory fences
    - Explicit memory fences are only necessary to enforce generic proxy's smem writes are visible to the async proxy (TMA in this case), not vice versa. 
    - For async proxy writes to smem (TMA load) visibility to the generic proxy, the mbarrier wait acts as both a completion event *and* visibility boundary (fence is implicit).
- Simplify/unify conditional statements

## Tests
- `pytest test/prototype/moe_training/test_kernels.py -k 3d_numerics    `
- `pytest test/prototype/moe_training/test_mxfp8_grouped_mm.py -k dq_fwd_bwd`

## Benchmarks
- Zero or slight perf boost for some shapes, (+0 - 2.8% memory bandwidth utilization)

Before:
```
input_shape       scaling_mode                  cuda_2d_us    cutedsl_3d_us    to_mx_us    cuda_2d_gbps    cutedsl_3d_gbps    to_mx_gbps
----------------  --------------------------  ------------  ---------------  ----------  --------------  -----------------  ------------
(1, 8192, 5120)   ScaleCalculationMode.FLOOR        31.776           31.744     117.76         4001.13             4005.16      1079.65
(1, 8192, 5120)   ScaleCalculationMode.RCEIL        29.728           29.824     117.76         4276.77             4263         1079.65
(1, 7168, 2048)   ScaleCalculationMode.FLOOR        17.888           17.408      82.912        2487.64             2556.24       536.701
(1, 7168, 2048)   ScaleCalculationMode.RCEIL        17.632           17.408      82.912        2523.76             2556.24       536.701
(8, 8192, 5120)   ScaleCalculationMode.FLOOR      1530.85           181.248    1725.38          664.415            5611.75       589.506
(8, 8192, 5120)   ScaleCalculationMode.RCEIL      1511.54           173.056    1725.46          672.904            5877.4        589.478
(8, 7168, 2048)   ScaleCalculationMode.FLOOR       543.744           70.656     613.28          654.704            5038.38       580.471
(8, 7168, 2048)   ScaleCalculationMode.RCEIL       537.536           68.48      612.288         662.265            5198.48       581.412
(32, 7168, 2048)  ScaleCalculationMode.FLOOR      2137.06           248.8      2410.43          666.321            5723.34       590.751
(32, 7168, 2048)  ScaleCalculationMode.RCEIL      2108.45           234.496    2410.37          675.362            6072.45       590.767
(32, 8192, 5120)  ScaleCalculationMode.FLOOR      6083.6            692.096    6859.84          668.761            5878.48       593.086
(32, 8192, 5120)  ScaleCalculationMode.RCEIL      6005.22           656.384    6860.64          677.49             6198.31       593.017
```


After:
```
input_shape       scaling_mode                  cuda_2d_us    cutedsl_3d_us    to_mx_us    cuda_2d_gbps    cutedsl_3d_gbps    to_mx_gbps
----------------  --------------------------  ------------  ---------------  ----------  --------------  -----------------  ------------
(1, 8192, 5120)   ScaleCalculationMode.FLOOR        31.776           31.744     117.792        4001.13             4005.16      1079.36
(1, 8192, 5120)   ScaleCalculationMode.RCEIL        29.728           29.728     117.792        4276.77             4276.77      1079.36
(1, 7168, 2048)   ScaleCalculationMode.FLOOR        18.816           17.44       82.944        2364.95             2551.55       536.494
(1, 7168, 2048)   ScaleCalculationMode.RCEIL        18.656           17.408      82.912        2385.24             2556.24       536.701
(8, 8192, 5120)   ScaleCalculationMode.FLOOR      1530.88           181.248    1725.41          664.401            5611.75       589.495
(8, 8192, 5120)   ScaleCalculationMode.RCEIL      1511.55           171.104    1725.44          672.897            5944.45       589.484
(8, 7168, 2048)   ScaleCalculationMode.FLOOR       543.744           70.656     612.384         654.704            5038.38       581.321
(8, 7168, 2048)   ScaleCalculationMode.RCEIL       537.6             66.592     612.32          662.187            5345.86       581.382
(32, 7168, 2048)  ScaleCalculationMode.FLOOR      2137.09           246.816    2410.43          666.311            5769.34       590.751
(32, 7168, 2048)  ScaleCalculationMode.RCEIL      2108.45           232.448    2409.41          675.362            6125.96       591.003
(32, 8192, 5120)  ScaleCalculationMode.FLOOR      6083.62           687.136    6859.78          668.759            5920.92       593.092
(32, 8192, 5120)  ScaleCalculationMode.RCEIL      6005.78           652.288    6860.8           677.427            6237.24       593.003
```