### PR TITLE
[ROCm] Enable float8 numerics integration and quant API e2e tests

### DIFF
--- a/test/float8/test_numerics_integration.py
+++ b/test/float8/test_numerics_integration.py
@@ -22,9 +22,11 @@ from torchao.float8.config import (
 from torchao.float8.float8_linear_utils import (
     convert_to_float8_training,
 )
-from torchao.float8.float8_utils import IS_ROCM, compute_error
+from torchao.float8.float8_utils import compute_error
 from torchao.testing.training.test_utils import get_test_float8_linear_config
 from torchao.utils import (
+    is_MI300,
+    is_MI350,
     is_sm_at_least_89,
     is_sm_at_least_90,
 )
@@ -154,9 +156,9 @@ class TestFloat8NumericsIntegrationTest:
         [ScalingType.DYNAMIC],
     )
     @pytest.mark.skipif(
-        not is_sm_at_least_89(), reason="requires SM89 compatible machine"
+        not (is_sm_at_least_89() or is_MI300() or is_MI350()),
+        reason="requires SM89+ or MI300/MI350",
     )
-    @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_config_params(
         self,
         scaling_type_input: ScalingType,
@@ -179,9 +181,9 @@ class TestFloat8NumericsIntegrationTest:
         ],
     )
     @pytest.mark.skipif(
-        not is_sm_at_least_90(), reason="requires SM90 compatible machine"
+        not (is_sm_at_least_90() or is_MI300() or is_MI350()),
+        reason="requires SM90+ or MI300/MI350",
     )
-    @pytest.mark.skipif(IS_ROCM, reason="test doesn't currently work on the ROCm stack")
     def test_encoder_fw_bw_from_recipe(
         self,
         recipe_name: str,

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -57,7 +57,7 @@ from torchao.testing.pt2e._xnnpack_quantizer import (
     XNNPACKQuantizer,
     get_symmetric_quantization_config,
 )
-from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.testing.utils import skip_if_xpu
 from torchao.utils import (
     get_current_accelerator_device,
     is_sm_at_least_89,
@@ -358,7 +358,6 @@ class TestQuantFlow(TestCase):
         ],
     )
     @skip_if_xpu("XPU enablement in progress")
-    @skip_if_rocm("ROCm enablement in progress")
     def test_workflow_e2e_numerics(self, config):
         """
         Simple test of e2e Int4WeightOnlyConfig workflow, comparing numerics


### PR DESCRIPTION
Removes ROCm skip guards from two test files that now pass on MI300X.

In `test/float8/test_numerics_integration.py`, the `IS_ROCM` skip was added when the float8 training path didn't work on ROCm. It does now — both the dynamic scaling config and the rowwise recipes (ROWWISE, ROWWISE_WITH_GW_HP) produce correct forward/backward numerics (SQNR > 20) on MI300X. Updated the `is_sm_at_least` checks to also allow MI300/MI350.

In `test/quantization/test_quant_api.py`, removed `@skip_if_rocm` from `test_workflow_e2e_numerics`. The individual config-level checks already handle unsupported cases: `Float8DynamicActivationFloat8WeightConfig` is skipped when `not is_sm_at_least_89()`, and `GemliteUIntXWeightOnlyConfig` is skipped when gemlite is unavailable. The remaining configs (Float8WeightOnly, Int8DynActInt8Wt, Int8WeightOnly) all pass on MI300X.

Tested locally: 3/3 numerics integration tests pass, 5/5 quant API e2e tests pass (3 run + 2 gracefully skipped) on MI300X with ROCm 7.2.