### PR TITLE
[ROCm] Enable FP8 QAT test on MI300/MI350

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -100,6 +100,8 @@ from torchao.utils import (
     _is_mslk_available,
     get_current_accelerator_device,
     is_fbcode,
+    is_MI300,
+    is_MI350,
     is_sm_at_least_89,
     torch_version_at_least,
 )
@@ -1834,7 +1836,10 @@ class TestQAT(TestCase):
 
     @parametrize("granularity", [PerTensor(), PerRow()])
     @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
-    @unittest.skipIf(not is_sm_at_least_89(), "Need sm89+")
+    @unittest.skipIf(
+        not (is_sm_at_least_89() or is_MI300() or is_MI350()),
+        "Need sm89+ or MI300/MI350",
+    )
     def test_quantize_api_fp8_fp8(self, granularity: Granularity):
         """
         Test the following:


### PR DESCRIPTION
The FP8 QAT test (`test_quantize_api_fp8_fp8`) was gated on `is_sm_at_least_89()`, which excluded AMD GPUs. MI300 and MI350 both support FP8 dynamic activation + FP8 weight quantization with PerTensor and PerRow granularity, so this updates the skip condition to also allow MI300/MI350.

Tested locally on MI300X -- both PerTensor and PerRow variants pass.