### PR TITLE
[ROCm] Enable test_flatten_unflatten on ROCm

### DIFF
--- a/test/dtypes/test_affine_quantized.py
+++ b/test/dtypes/test_affine_quantized.py
@@ -254,7 +254,6 @@ class TestAffineQuantizedBasic(TestCase):
 
     @common_utils.parametrize("device", COMMON_DEVICES)
     @common_utils.parametrize("dtype", COMMON_DTYPES)
-    @skip_if_rocm("ROCm enablement in progress")
     def test_flatten_unflatten(self, device, dtype):
         if device == "cuda" and dtype == torch.bfloat16 and is_fbcode():
             raise unittest.SkipTest("TODO: Failing for cuda + bfloat16 in fbcode")


### PR DESCRIPTION
The test_flatten_unflatten test was skipped on ROCm with the message "ROCm enablement in progress." All three quantization configs it exercises (Int8WeightOnlyConfig, Int8DynamicActivationInt8WeightConfig symmetric, Int8DynamicActivationInt8WeightConfig asymmetric) now pass on MI300X for both CPU and CUDA devices. Removes the skip.