### PR TITLE
[ROCm] Fix BlockwiseQuantLinear FP8 dtype handling for AMD GPUs

### DIFF
--- a/torchao/prototype/blockwise_fp8_inference/blockwise_linear.py
+++ b/torchao/prototype/blockwise_fp8_inference/blockwise_linear.py
@@ -7,25 +7,33 @@
 import torch
 from torch import nn
 
+from torchao.float8.config import e4m3_dtype
 from torchao.kernel.blockwise_quantization import (
     blockwise_fp8_gemm,
     fp8_blockwise_act_quant,
 )
 
+_SUPPORTED_FP8_DTYPES = [
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+    torch.float8_e5m2fnuz,
+]
+
 
 class BlockwiseQuantLinear(nn.Module):
     """
-    Custom linear layer with support for quantized weights and optional bias.
+    Custom linear layer with support for blockwise FP8 quantized weights.
 
     Args:
         in_features (int): Number of input features.
         out_features (int): Number of output features.
         bias (bool): Whether to include a bias term. Defaults to False.
         block_size (int): Block size for quantization. Defaults to 128.
-        dtype (torch.dtype): Data type for the weights. Defaults to torch.float8_e4m3fn.
+        dtype (torch.dtype): FP8 data type for quantized weights.
+            Defaults to the hardware-appropriate e4m3 variant
+            (e4m3fn on NVIDIA, e4m3fnuz on MI300).
     """
-
-    dtype = torch.bfloat16
 
     def __init__(
         self,
@@ -33,15 +41,11 @@ class BlockwiseQuantLinear(nn.Module):
         out_features: int,
         bias: bool = False,
         block_size: int = 128,
-        dtype: torch.dtype = torch.float8_e4m3fn,
+        dtype: torch.dtype = e4m3_dtype,
     ):
         super().__init__()
-        supported_dtypes = [
-            torch.float8_e4m3fn,
-            torch.float8_e5m2,
-        ]
-        assert dtype in supported_dtypes, (
-            f"Unsupported dtype: {dtype}. Supported dtypes: {supported_dtypes}"
+        assert dtype in _SUPPORTED_FP8_DTYPES, (
+            f"Unsupported dtype: {dtype}. Supported dtypes: {_SUPPORTED_FP8_DTYPES}"
         )
         scale_in_features = (in_features + block_size - 1) // block_size
         scale_out_features = (out_features + block_size - 1) // block_size
@@ -50,7 +54,7 @@ class BlockwiseQuantLinear(nn.Module):
             torch.empty(scale_out_features, scale_in_features, dtype=torch.float32)
         )
         self.block_size = block_size
-        self.dtype
+        self.fp8_dtype = dtype
 
         if bias:
             self.bias = nn.Parameter(torch.empty(out_features))
@@ -67,7 +71,7 @@ class BlockwiseQuantLinear(nn.Module):
         Returns:
             torch.Tensor: Transformed tensor after linear computation.
         """
-        x, scale = fp8_blockwise_act_quant(x, self.block_size, self.dtype)
+        x, scale = fp8_blockwise_act_quant(x, self.block_size, self.fp8_dtype)
         y = blockwise_fp8_gemm(
             x, scale, self.weight, self.weight.scale, self.block_size
         )


### PR DESCRIPTION
`BlockwiseQuantLinear` doesn't work on MI300 — the dtype whitelist rejects fnuz variants, the default is hardcoded to `e4m3fn`, and there's a bug where `self.dtype` reads the class attribute (`bfloat16`) instead of storing the constructor arg, so the forward pass would always blow up in `fp8_blockwise_act_quant`.

Fixed by adding fnuz dtypes to the accepted set, defaulting to `e4m3_dtype` from config (picks the right variant per hardware), and storing the dtype properly as `self.fp8_dtype`.

Tested on MI300X — all four FP8 dtype variants construct fine, invalid dtypes get rejected, forward pass works.