### PR TITLE
[xpu][test] Enable MoE tests for Intel XPU

### DIFF
--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -14,7 +14,9 @@ _is_incompatible_cuda = torch.cuda.is_available() and not (
     is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
 )
 if not _is_xpu and _is_incompatible_cuda:
-    pytest.skip("Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True)
+    pytest.skip(
+        "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
+    )
 
 from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
 from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd

--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -9,15 +9,21 @@ import torch
 
 from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
 
-if not (
-    torch.cuda.is_available()
-    and is_sm_at_least_100()
-    and is_cuda_version_at_least(12, 8)
+if torch.cuda.is_available() and not (
+    is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
 ):
     pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
 
 from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
 from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize(
@@ -41,10 +47,8 @@ from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
     ],
 )
 def test_triton_permute_bwd(
-    num_tokens, hidden_dim, num_local_experts, ep_degree, alignment
+    num_tokens, hidden_dim, num_local_experts, ep_degree, alignment, device
 ):
-    device = "cuda"
-
     # Generate realistic permutation indices using generate_permute_indices
     # Simulate token distribution across experts
     tokens_per_expert_group = torch.randint(

--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -9,10 +9,12 @@ import torch
 
 from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
 
-if torch.cuda.is_available() and not (
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
     is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
-):
-    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+)
+if not _is_xpu and _is_incompatible_cuda:
+    pytest.skip("Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True)
 
 from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
 from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd

--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -7,13 +7,16 @@
 import pytest
 import torch
 
-from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100, is_XPU
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not (
-    is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
+_is_xpu = is_XPU()
+_is_compatible_cuda = (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
 )
-if not _is_xpu and _is_incompatible_cuda:
+
+if not (_is_xpu or _is_compatible_cuda):
     pytest.skip(
         "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
     )

--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -3,10 +3,14 @@ import torch
 
 from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
 
-if torch.cuda.is_available() and not (
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
     is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
-):
-    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+)
+if not _is_xpu and _is_incompatible_cuda:
+    pytest.skip(
+        "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
+    )
 
 from torchao.prototype.moe_training.ep import permute_mxfp8_fwd_hp_bwd
 from torchao.prototype.moe_training.ep.permute import permute_and_pad

--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -3,10 +3,8 @@ import torch
 
 from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
 
-if not (
-    torch.cuda.is_available()
-    and is_sm_at_least_100()
-    and is_cuda_version_at_least(12, 8)
+if torch.cuda.is_available() and not (
+    is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
 ):
     pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
 
@@ -14,10 +12,17 @@ from torchao.prototype.moe_training.ep import permute_mxfp8_fwd_hp_bwd
 from torchao.prototype.moe_training.ep.permute import permute_and_pad
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.quantization.utils import compute_error
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
 
 
-def test_mxfp8_permute_forward():
-    device = "cuda"
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
+
+def test_mxfp8_permute_forward(device: str):
     tokens = 64
     dim = 128
     num_experts = 8

--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -1,13 +1,16 @@
 import pytest
 import torch
 
-from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100, is_XPU
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not (
-    is_sm_at_least_100() and is_cuda_version_at_least(12, 8)
+_is_xpu = is_XPU()
+_is_compatible_cuda = (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
 )
-if not _is_xpu and _is_incompatible_cuda:
+
+if not (_is_xpu or _is_compatible_cuda):
     pytest.skip(
         "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
     )

--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -15,9 +15,8 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
-if not (
+if torch.cuda.is_available() and not (
     torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
 ):
     pytest.skip(
@@ -41,16 +40,24 @@ from torchao.prototype.moe_training.config import (
 from torchao.prototype.moe_training.fp8_grouped_mm import (
     _to_fp8_rowwise_then_scaled_grouped_mm,
 )
-from torchao.utils import is_MI300, is_MI350, is_ROCM
+from torchao.utils import get_available_devices, is_MI300, is_MI350, is_ROCM
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.skipif(
     True,
     reason="Skipping FP8 rowwise test pending fix for https://github.com/pytorch/ao/issues/3957",
 )
+@pytest.mark.skipif(torch.xpu.is_available(), reason="XPU support not yet available")
 @pytest.mark.parametrize("m", [4096])
 @pytest.mark.parametrize("n", [8192])
 @pytest.mark.parametrize("k", [5120])
@@ -91,7 +98,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
         b_t,
         offs=offs,
         out_dtype=config.out_dtype,
-        float8_dtyep=config.float8_dtype,
+        float8_dtype=config.float8_dtype,
     )
 
     # Validate result.
@@ -130,7 +137,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
 @pytest.mark.parametrize("m", [16, 17])
 @pytest.mark.parametrize("k", [16, 18])
 @pytest.mark.parametrize("n", [32, 33])
-def test_K_or_N_dim_not_multiple_of_16(m, n, k):
+def test_K_or_N_dim_not_multiple_of_16(m, n, k, device):
     # - Leading dim of A doesn't have to be divisible by 16, since it will be
     # divided up into groups based on offset anyway.
     # - Trailing dim of A must be divisible by 16.
@@ -138,7 +145,6 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     # - Last 2 dims of B must be divisible by 16.
     if n % 16 == 0 and k % 16 == 0:
         return
-    device = "cuda"
     n_groups = 4
     a = torch.randn(
         m * n_groups,
@@ -161,7 +167,7 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     b_t = b_t.transpose(-2, -1).contiguous().transpose(-2, -1)
 
     config = Float8TrainingOpConfig.from_recipe(Float8TrainingRecipe.FP8_ROWWISE)
-    offs = torch.arange(m, n_groups * m + 1, m, device="cuda", dtype=torch.int32)
+    offs = torch.arange(m, n_groups * m + 1, m, device=device, dtype=torch.int32)
 
     # Compute output.
     with pytest.raises(AssertionError):

--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -15,12 +15,14 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
-if torch.cuda.is_available() and not (
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
     torch_version_at_least("2.7.0")
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
-):
+)
+if not _is_xpu and _is_incompatible_cuda:
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350 or Intel XPU)",
         allow_module_level=True,
     )
 

--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -12,15 +12,15 @@ from torchao.utils import (
     is_MI350,
     is_sm_at_least_90,
     is_sm_version,
+    is_XPU,
     torch_version_at_least,
 )
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not (
-    torch_version_at_least("2.7.0")
-    and (is_sm_at_least_90() or is_MI300() or is_MI350())
+_is_xpu = is_XPU()
+_is_compatible_cuda = torch.cuda.is_available() and (
+    is_sm_at_least_90() or is_MI300() or is_MI350()
 )
-if not _is_xpu and _is_incompatible_cuda:
+if not ((_is_xpu or _is_compatible_cuda) and torch_version_at_least("2.7.0")):
     pytest.skip(
         "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350 or Intel XPU)",
         allow_module_level=True,

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -82,6 +82,7 @@ def device(request):
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 @skip_if_rocm("jagged rowwise scales kernel vs torch reference mismatch on ROCm")
+@skip_if_xpu("XPU numerical mismatch with torch reference")
 def test_row_major_with_jagged_rowwise_scales(
     round_scales_to_power_of_2: bool, device: str
 ):
@@ -728,6 +729,7 @@ def test_triton_fp8_rowwise_2d_scale_and_cast(
     "e,n,k",
     [(1, 8192, 5120), (2, 5120, 8192), (8, 8192, 5120)],
 )
+@skip_if_xpu("XPU support not yet available")
 def test_triton_fp8_colwise_3d_scale_and_cast(
     e: int, n: int, k: int, round_scales_to_power_of_2: bool
 ):

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -15,9 +15,13 @@ def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-if torch.cuda.is_available and not (_is_sm_10x() or is_MI300() or is_MI350()):
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
+    _is_sm_10x() or is_MI300() or is_MI350()
+)
+if not _is_xpu and _is_incompatible_cuda:
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, MI350 or Intel XPU)",
         allow_module_level=True,
     )
 
@@ -681,6 +685,7 @@ def test_cuda_fused_unpad_token_groups(
     )
 
 
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 @pytest.mark.parametrize(
     "m,k",

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -8,18 +8,18 @@ import pytest
 import torch
 
 # FP8 MoE kernels require FP8-capable hardware (SM 10.x on CUDA, MI300+ on ROCm)
-from torchao.utils import is_MI300, is_MI350
+from torchao.utils import is_MI300, is_MI350, is_XPU
 
 
 def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not (
+_is_compatible_cuda = torch.cuda.is_available() and (
     _is_sm_10x() or is_MI300() or is_MI350()
 )
-if not _is_xpu and _is_incompatible_cuda:
+
+if not (is_XPU() or _is_compatible_cuda):
     pytest.skip(
         "Requires FP8-capable GPU (CUDA SM 10.x, MI300, MI350 or Intel XPU)",
         allow_module_level=True,

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -15,7 +15,7 @@ def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-if not (torch.cuda.is_available() and (_is_sm_10x() or is_MI300() or is_MI350())):
+if torch.cuda.is_available and not (_is_sm_10x() or is_MI300() or is_MI350()):
     pytest.skip(
         "Requires FP8-capable GPU (CUDA SM 10.x, MI300, or MI350)",
         allow_module_level=True,
@@ -65,15 +65,24 @@ from torchao.prototype.moe_training.utils import (
 from torchao.prototype.mx_formats.kernels import triton_mx_block_rearrange
 from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
 from torchao.prototype.mx_formats.utils import from_blocked
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 @skip_if_rocm("jagged rowwise scales kernel vs torch reference mismatch on ROCm")
-def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
+def test_row_major_with_jagged_rowwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # Tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(k, m * n_groups, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -102,10 +111,10 @@ def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 def test_row_major_with_jagged_rowwise_scales_transpose_method(
     round_scales_to_power_of_2: bool,
+    device: str,
 ):
     # tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     grad_out = torch.randn(m * n_groups, k, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -137,10 +146,11 @@ def test_row_major_with_jagged_rowwise_scales_transpose_method(
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: bool):
+def test_column_major_with_jagged_colwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # tests case where colwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end row indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(m * n_groups, k, device=device).t().contiguous().t()
     rowwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -164,8 +174,9 @@ def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: boo
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_atomic(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -198,8 +209,9 @@ def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_reduction(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -236,11 +248,8 @@ def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool
     "m,k,n_groups", [(256, 256, 4), (16640, 5120, 16), (16640, 8192, 16)]
 )
 def test_triton_mx_block_rearrange_2d_M_groups(
-    m: int,
-    k: int,
-    n_groups: int,
+    m: int, k: int, n_groups: int, device: str
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, k, device=device)
     e8m0_scales, _ = to_mx(
@@ -270,6 +279,7 @@ def test_triton_mx_block_rearrange_2d_M_groups(
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize(
     "m,k,n_groups,chunks_per_tb",
     [
@@ -326,8 +336,8 @@ def test_mxfp8_per_group_blocked_scales_3d(
     e: int,
     n: int,
     k: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     weights = torch.randn(e, n, k // block_size, device=device)
     weight_scales, _ = to_mx(
@@ -352,8 +362,8 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     m: int,
     total_k: int,
     n_groups: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, total_k, device=device)
 
@@ -385,6 +395,7 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("E", (1, 2, 4, 8))
 @pytest.mark.parametrize("N", (32, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("K", (32, 1536, 5120, 7168, 8192))

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -15,9 +15,13 @@ def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-if torch.cuda.is_available and not (_is_sm_10x() or is_MI300() or is_MI350()):
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
+    _is_sm_10x() or is_MI300() or is_MI350()
+)
+if not _is_xpu and _is_incompatible_cuda:
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, MI350 or Intel XPU)",
         allow_module_level=True,
     )
 
@@ -680,6 +684,7 @@ def test_cuda_fused_unpad_token_groups(
     )
 
 
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 @pytest.mark.parametrize(
     "m,k",

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -15,7 +15,7 @@ def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-if not (torch.cuda.is_available() and (_is_sm_10x() or is_MI300() or is_MI350())):
+if torch.cuda.is_available and not (_is_sm_10x() or is_MI300() or is_MI350()):
     pytest.skip(
         "Requires FP8-capable GPU (CUDA SM 10.x, MI300, or MI350)",
         allow_module_level=True,
@@ -63,14 +63,23 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
 from torchao.prototype.mx_formats.utils import from_blocked
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
+def test_row_major_with_jagged_rowwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # Tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(k, m * n_groups, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -99,10 +108,10 @@ def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 def test_row_major_with_jagged_rowwise_scales_transpose_method(
     round_scales_to_power_of_2: bool,
+    device: str,
 ):
     # tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     grad_out = torch.randn(m * n_groups, k, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -134,10 +143,11 @@ def test_row_major_with_jagged_rowwise_scales_transpose_method(
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: bool):
+def test_column_major_with_jagged_colwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # tests case where colwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end row indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(m * n_groups, k, device=device).t().contiguous().t()
     rowwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -161,8 +171,9 @@ def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: boo
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_atomic(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -195,8 +206,9 @@ def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_reduction(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -233,11 +245,8 @@ def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool
     "m,k,n_groups", [(256, 256, 4), (16640, 5120, 16), (16640, 8192, 16)]
 )
 def test_triton_mx_block_rearrange_2d_M_groups(
-    m: int,
-    k: int,
-    n_groups: int,
+    m: int, k: int, n_groups: int, device: str
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, k, device=device)
     e8m0_scales, _ = to_mx(
@@ -267,6 +276,7 @@ def test_triton_mx_block_rearrange_2d_M_groups(
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize(
     "m,k,n_groups,chunks_per_tb",
     [
@@ -323,8 +333,8 @@ def test_mxfp8_per_group_blocked_scales_3d(
     e: int,
     n: int,
     k: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     weights = torch.randn(e, n, k // block_size, device=device)
     weight_scales, _ = to_mx(
@@ -349,8 +359,8 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     m: int,
     total_k: int,
     n_groups: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, total_k, device=device)
 
@@ -382,6 +392,7 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("E", (1, 2, 4, 8))
 @pytest.mark.parametrize("N", (32, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("K", (32, 1536, 5120, 7168, 8192))

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -17,9 +17,8 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
-if not (
+if torch.cuda.is_available() and not (
     torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
 ):
     pytest.skip(
@@ -42,7 +41,16 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
@@ -51,10 +59,10 @@ torch._dynamo.config.cache_size_limit = 1000
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
 @pytest.mark.parametrize("num_experts", (1, 8, 16))
-def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M)
+def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts, device):
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, device=device)
     x_ref, w_ref, offs_ref = x.clone(), w.clone(), offs.clone()
 
     # Quantize inputs to mxpf8 for emulated mxfp8 scaled grouped mm
@@ -84,13 +92,13 @@ def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
 @pytest.mark.parametrize("M", (1024, 4096))
 @pytest.mark.parametrize("N", (1024, 4096))
 @pytest.mark.parametrize("num_experts", (8, 16))
-def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
+def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts, device):
     # Simluate 2d-2d grouped gemm grad_weight = grad_output_t @ x
     block_size = 32
-    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device=device)
     grad_out_t = grad_out.t().contiguous()
-    x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size, device=device)
     x_ref, grad_out_t_ref, offs_ref = x.clone(), grad_out_t.clone(), offs.clone()
 
     # bf16 reference grouped gemm
@@ -129,6 +137,7 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (1, 8))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
@@ -150,9 +159,14 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     kernel_preference,
     scale_mode,
     pad_token_groups_for_grouped_mm,
+    device,
 ):
     # MXFP8 hardware path requires SM100
-    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+    if (
+        torch.cuda.is_available()
+        and kernel_preference != KernelPreference.EMULATED
+        and not is_sm_version(10, 0)
+    ):
         pytest.skip(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
@@ -165,18 +179,18 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
             "torch native dynamic per group pad/unpad functions do not work with torch.compile yet: https://github.com/pytorch/pytorch/issues/176770"
         )
 
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
 
     multiple_of = 1 if pad_token_groups_for_grouped_mm else 32
-    offs = generate_jagged_offs(num_experts, M, multiple_of=multiple_of)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=multiple_of, device=device)
     x_ref, w_t_ref, offs_ref = (
         x.clone().detach().requires_grad_(True),
         w_t.clone().detach().requires_grad_(True),
@@ -226,6 +240,7 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
@@ -299,19 +314,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
+def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward(device):
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size, device=device)
 
     x_scale, x_qdata = to_mx(
         x.detach(),
@@ -353,19 +368,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
+def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp(device):
     block_size = 32
     M, K, N, num_experts = 1024, 1024, 2048, 4
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size, device=device)
 
     x_scale, x_qdata = to_mx(
         x,

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -17,12 +17,14 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
-if torch.cuda.is_available() and not (
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not (
     torch_version_at_least("2.7.0")
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
-):
+)
+if not _is_xpu and _is_incompatible_cuda:
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350 or Intel XPU)",
         allow_module_level=True,
     )
 

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -14,15 +14,16 @@ from torchao.utils import (
     is_MI350,
     is_sm_at_least_90,
     is_sm_version,
+    is_XPU,
     torch_version_at_least,
 )
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not (
-    torch_version_at_least("2.7.0")
-    and (is_sm_at_least_90() or is_MI300() or is_MI350())
+_is_xpu = is_XPU()
+_is_compatible_cuda = torch.cuda.is_available() and (
+    is_sm_at_least_90() or is_MI300() or is_MI350()
 )
-if not _is_xpu and _is_incompatible_cuda:
+
+if not ((_is_xpu or _is_compatible_cuda) and torch_version_at_least("2.7.0")):
     pytest.skip(
         "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350 or Intel XPU)",
         allow_module_level=True,

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -17,9 +17,8 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
-if not (
+if torch.cuda.is_available() and not (
     torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
     and (is_sm_at_least_90() or is_MI300() or is_MI350())
 ):
     pytest.skip(
@@ -42,7 +41,16 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
@@ -51,10 +59,10 @@ torch._dynamo.config.cache_size_limit = 1000
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
 @pytest.mark.parametrize("num_experts", (1, 8, 16))
-def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M)
+def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts, device):
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, device=device)
     x_ref, w_ref, offs_ref = x.clone(), w.clone(), offs.clone()
 
     # Quantize inputs to mxpf8 for emulated mxfp8 scaled grouped mm
@@ -84,13 +92,13 @@ def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
 @pytest.mark.parametrize("M", (1024, 4096))
 @pytest.mark.parametrize("N", (1024, 4096))
 @pytest.mark.parametrize("num_experts", (8, 16))
-def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
+def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts, device):
     # Simluate 2d-2d grouped gemm grad_weight = grad_output_t @ x
     block_size = 32
-    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device=device)
     grad_out_t = grad_out.t().contiguous()
-    x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size, device=device)
     x_ref, grad_out_t_ref, offs_ref = x.clone(), grad_out_t.clone(), offs.clone()
 
     # bf16 reference grouped gemm
@@ -129,6 +137,7 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (1, 8))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
@@ -148,9 +157,14 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     use_compile,
     kernel_preference,
     scale_mode,
+    device,
 ):
     # MXFP8 hardware path requires SM100
-    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+    if (
+        torch.cuda.is_available()
+        and kernel_preference != KernelPreference.EMULATED
+        and not is_sm_version(10, 0)
+    ):
         pytest.skip(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
@@ -159,17 +173,17 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
             "torch native dynamic per group pad/unpad functions do not work with torch.compile yet: https://github.com/pytorch/pytorch/issues/176770"
         )
 
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
 
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
     x_ref, w_t_ref, offs_ref = (
         x.clone().detach().requires_grad_(True),
         w_t.clone().detach().requires_grad_(True),
@@ -219,6 +233,7 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
@@ -292,19 +307,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
+def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward(device):
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
 
     x_scale, x_qdata = to_mx(
         x.detach(),
@@ -346,19 +361,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
+def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp(device):
     block_size = 32
     M, K, N, num_experts = 1024, 1024, 2048, 4
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
 
     x_scale, x_qdata = to_mx(
         x,

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -10,9 +10,12 @@ import torch.nn.functional as F
 
 from torchao.utils import torch_version_at_least
 
-# Skip module if basic requirements aren't met
-if torch.cuda.is_available() and not torch_version_at_least("2.7.0"):
-    pytest.skip("CUDA and PyTorch 2.7.0+ required", allow_module_level=True)
+_is_xpu = torch.xpu.is_available()
+_is_incompatible_cuda = torch.cuda.is_available() and not torch_version_at_least(
+    "2.7.0"
+)
+if not _is_xpu and _is_incompatible_cuda:
+    pytest.skip("CUDA or XPU with PyTorch 2.7.0+ required", allow_module_level=True)
 
 from torchao.prototype.moe_training.config import (
     MXFP8TrainingOpConfig,

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -8,8 +8,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from torchao.utils import torch_version_at_least, is_XPU
-
+from torchao.utils import is_XPU, torch_version_at_least
 
 if not ((is_XPU() or torch.cuda.is_available()) and torch_version_at_least("2.7.0")):
     pytest.skip("CUDA or XPU with PyTorch 2.7.0+ required", allow_module_level=True)

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -29,6 +29,7 @@ from torchao.prototype.mx_formats.kernels import (
     _triton_kernels_available,
 )
 from torchao.quantization.utils import compute_error
+from torchao.testing.utils import skip_if_xpu
 from torchao.utils import get_available_devices, is_sm_at_least_100
 
 _DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
@@ -49,10 +50,11 @@ def device(request):
     "cast_kernel_choice",
     [MXFP8Dim1CastKernelChoice.CUDA, MXFP8Dim1CastKernelChoice.CUTEDSL],
 )
+@skip_if_xpu("XPU support not yet available")
 def test_mxfp8_training_tensor_ops_fwd_bwd(
     op_name, batch_size, recipe, cast_kernel_choice, device
 ):
-    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL and device == "cuda":
+    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
         if not is_sm_at_least_100() or not _triton_kernels_available:
             pytest.skip("SM 100+ required for real MXFP8 support")
         if (

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -8,13 +8,10 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from torchao.utils import torch_version_at_least
+from torchao.utils import torch_version_at_least, is_XPU
 
-_is_xpu = torch.xpu.is_available()
-_is_incompatible_cuda = torch.cuda.is_available() and not torch_version_at_least(
-    "2.7.0"
-)
-if not _is_xpu and _is_incompatible_cuda:
+
+if not ((is_XPU() or torch.cuda.is_available()) and torch_version_at_least("2.7.0")):
     pytest.skip("CUDA or XPU with PyTorch 2.7.0+ required", allow_module_level=True)
 
 from torchao.prototype.moe_training.config import (

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from torchao.utils import torch_version_at_least
 
 # Skip module if basic requirements aren't met
-if not (torch_version_at_least("2.7.0") and torch.cuda.is_available()):
+if torch.cuda.is_available() and not torch_version_at_least("2.7.0"):
     pytest.skip("CUDA and PyTorch 2.7.0+ required", allow_module_level=True)
 
 from torchao.prototype.moe_training.config import (
@@ -30,7 +30,14 @@ from torchao.prototype.mx_formats.kernels import (
     _triton_kernels_available,
 )
 from torchao.quantization.utils import compute_error
-from torchao.utils import is_sm_at_least_100
+from torchao.utils import get_available_devices, is_sm_at_least_100
+
+_DEVICES = get_available_devices()[1:]  # Exclude CPU since this test is for GPU kernels
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize("op_name", ["mm", "matmul", "linear"])
@@ -44,9 +51,9 @@ from torchao.utils import is_sm_at_least_100
     [MXFP8Dim1CastKernelChoice.CUDA, MXFP8Dim1CastKernelChoice.CUTEDSL],
 )
 def test_mxfp8_training_tensor_ops_fwd_bwd(
-    op_name, batch_size, recipe, cast_kernel_choice
+    op_name, batch_size, recipe, cast_kernel_choice, device
 ):
-    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
+    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL and device == "cuda":
         if not is_sm_at_least_100() or not _triton_kernels_available:
             pytest.skip("SM 100+ required for real MXFP8 support")
         if (
@@ -75,10 +82,10 @@ def test_mxfp8_training_tensor_ops_fwd_bwd(
     else:
         A_shape = (batch_size, M, K)
 
-    A = torch.randn(*A_shape, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-    B = torch.randn(N, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    A = torch.randn(*A_shape, dtype=torch.bfloat16, device=device, requires_grad=True)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     bias = (
-        torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        torch.randn(N, dtype=torch.bfloat16, device=device)
         if op_name == "linear"
         else None
     )
@@ -148,10 +155,10 @@ def test_mxfp8_training_tensor_ops_fwd_bwd(
     )
 
 
-def test_mxfp8_training_tensor_ops_preserve_subclass():
+def test_mxfp8_training_tensor_ops_preserve_subclass(device):
     config = MXFP8TrainingOpConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL)
 
-    B = torch.randn(64, 32, dtype=torch.bfloat16, device="cuda")
+    B = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
     B_mxfp8 = MXFP8TrainingWeightWrapperTensor(B, config)
 
     # view

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1198,6 +1198,10 @@ def is_Navi4():
     return False
 
 
+def is_XPU():
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
+
+
 def is_sm_version(major: int, minor: int) -> bool:
     """Check if the CUDA version is exactly major.minor"""
     is_cuda = torch.cuda.is_available() and torch.version.cuda

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1128,6 +1128,10 @@ def is_Navi4():
     return False
 
 
+def is_XPU():
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
+
+
 def is_sm_version(major: int, minor: int) -> bool:
     """Check if the CUDA version is exactly major.minor"""
     is_cuda = torch.cuda.is_available() and torch.version.cuda


### PR DESCRIPTION
The PR enables a subset of MoE tests for Intel XPU and is part of the [XPU Enabling Plan for TorchAO](https://github.com/pytorch/ao/issues/3576).

Details:
- The PR doesn’t introduce any new logic to the tests.
- Adds a device parameter to be able to run the tests on the XPU.
- Skips not yet supported scenarios.