### PR TITLE
[mxfp8 training] require torch nightly and cuda 12.8+

### DIFF
--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -30,6 +30,16 @@ def _get_tensor_cls_for_config(
     )
 
     if isinstance(config, MXFP8TrainingOpConfig):
+        from torch.distributed.tensor import _dispatch, _ops
+
+        pytorch_version_supported = hasattr(
+            _ops, "scaled_mm_single_dim_strategy"
+        ) and hasattr(_dispatch, "is_pinned_handler")
+
+        assert pytorch_version_supported, (
+            "Please install the latest torch nightly build to use MXFP8 training"
+        )
+
         return MXFP8TrainingWeightWrapperTensor
     elif isinstance(config, Float8TrainingOpConfig):
         return Float8TrainingWeightWrapperTensor


### PR DESCRIPTION
## Summary
- #4010 depends on changes in pytorch core that recently landed, so we need to assert the user has torch nightly installed for MXFP8 training