### PR TITLE
Patch AArch64 detection and enable Python 3.12 in Linux AArch64 nightly wheels build

### DIFF
--- a/.github/workflows/build_wheels_linux_aarch64.yml
+++ b/.github/workflows/build_wheels_linux_aarch64.yml
@@ -30,7 +30,7 @@ jobs:
       with-cpu: enable
       with-cuda: disable
       # Note: if free-threaded python is required add py3.13t here
-      python-versions: '["3.10"]'
+      python-versions: '["3.10", "3.12"]'
 
   build:
     needs: generate-matrix

--- a/packaging/env_var_script_linux.sh
+++ b/packaging/env_var_script_linux.sh
@@ -20,7 +20,8 @@ if [[ ${CU_VERSION:-} == "cu124" ]]; then
 fi
 
 # Enable C++ kernels + kleidiai in aarch64 build
-if [[ "$(uname -m)" =~ "^(aarch64|arm64)$" ]]; then
+MACHINE_HW="$(uname -m)"
+if [[ "${MACHINE_HW}" == "aarch64" || "${MACHINE_HW}" == "arm64" ]]; then
     echo "Enabling aarch64-specific build"
     export USE_CPP=1
     export USE_CPU_KERNELS=1


### PR DESCRIPTION
## Summary

This PR patches the machine checks in the Linux packaging env script (for gating AArch64-specific build flags) and updates the Linux AArch64 wheel build to include Python 3.12.

## Changes

- Add Python 3.12 to `.github/workflows/build_wheels_linux_aarch64.yml`
- Replace the regex-based `uname -m` check in `packaging/env_var_script_linux.sh` with explicit `aarch64` and `arm64` comparisons
- Keep the AArch64-only build flags gated to ARM machines while making the detection logic more predictable in CI

## Why

We attempted to sort the CI out with [this PR](https://github.com/pytorch/ao/pull/3954), but the [CI runs after it](https://github.com/pytorch/ao/actions/runs/23396440823/job/68060457170) indicate that the machine detection was not done correctly which this patch detects.

Additionally, it is important for our library [Tool Solutions](https://github.com/ARM-software/Tool-Solutions) to have Python 3.12 wheels of `torch` so we don't need to build it from source, which is why I've added that to the CI.

## Testing

- I ran the same tests as I did for the previous PR and they passed.