### PR TITLE
Add flag for users to silence version compatibility warning

### DIFF
--- a/torchao/__init__.py
+++ b/torchao/__init__.py
@@ -76,11 +76,13 @@ elif not ("+git" in __version__) and not ("unknown" in __version__):
         skip_loading_so_files = True
         _skip_reason = (
             f"Skipping import of cpp extensions due to incompatible torch version. "
-            f"Please upgrade to torch >= 2.11.0 (found {torch.__version__})."
+            f"Please upgrade to torch >= 2.11.0 (found {torch.__version__}). "
+            f"Set TORCHAO_SILENCE_VERSION_COMPATIBILITY_WARNING=1 to silence this warning."
         )
 
 if skip_loading_so_files:
-    logger.warning(_skip_reason)
+    if not os.getenv("TORCHAO_SILENCE_VERSION_COMPATIBILITY_WARNING", "0") == "1":
+        logger.warning(_skip_reason)
 else:
     try:
         from pathlib import Path


### PR DESCRIPTION
**Summary:** Many users wish to just use the python only APIs but still see this warning when they import torchao, e.g.

https://github.com/pytorch/ao/issues/2919#issuecomment-3821689925 https://github.com/pytorch/ao/issues/2919#issuecomment-3849920557

For example, this warning still triggers when they use torchao 0.17.0 with torch 2.10, which is within the 3 most recent torch versions that we support for python only APIs. This commit adds an optional env var users can explicitly set to disable this warning.

**Test Plan:** Manual testing.