### PR TITLE
Fix rocm CI

### DIFF
--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
 import copy
 
 import pytest
@@ -10,6 +16,11 @@ if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
     pytest.skip(
         "CUDA not available or compute capability < 8.9", allow_module_level=True
     )
+
+from torchao.utils import is_ROCM
+
+if is_ROCM():
+    pytest.skip("MXFP8 MoE training is not supported on ROCm", allow_module_level=True)
 
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.config import (

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -30,18 +30,15 @@ def _get_tensor_cls_for_config(
     )
 
     if isinstance(config, MXFP8TrainingOpConfig):
-        from torchao.quantization.quantize_.common import KernelPreference
+        from torch.distributed.tensor import _dispatch, _ops
 
-        if config.kernel_preference != KernelPreference.EMULATED:
-            from torch.distributed.tensor import _dispatch, _ops
+        pytorch_version_supported = hasattr(
+            _ops, "scaled_mm_single_dim_strategy"
+        ) and hasattr(_dispatch, "is_pinned_handler")
 
-            pytorch_version_supported = hasattr(
-                _ops, "scaled_mm_single_dim_strategy"
-            ) and hasattr(_dispatch, "is_pinned_handler")
-
-            assert pytorch_version_supported, (
-                "Please install the latest torch nightly build to use MXFP8 training"
-            )
+        assert pytorch_version_supported, (
+            "Please install the latest torch nightly build to use MXFP8 training"
+        )
 
         return MXFP8TrainingWeightWrapperTensor
     elif isinstance(config, Float8TrainingOpConfig):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4167

Summary:
The fix skips the pytorch version check when kernel_preference is EMULATED, since the emulated mode doesn't need scaled_mm_single_dim_strategy or is_pinned_handler from torch.distributed.tensor. The hardware
MXFP8 paths (AUTO kernel preference) still get the version check.

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: