### PR TITLE
[CPU] Add software prefetch to overlap bandwidth for scaled_embedding_bag

### DIFF
--- a/torchao/csrc/cpu/aten_kernels/scaled_embedding_bag.cpp
+++ b/torchao/csrc/cpu/aten_kernels/scaled_embedding_bag.cpp
@@ -191,11 +191,11 @@ inline void _scaled_embedding_bag_krnl(
     const int64_t emb_dim, const index_t last_offset, const index_t *indices,
     const index_t *offsets, const data_t *weight, const double scale,
     output_t *result, const int64_t num_batch) {
+#if defined(CPU_CAPABILITY_AVX512)
   // How many batch entries ahead to prefetch. Each entry has ~3 rows to fetch
   // from a 40M-row table; DRAM latency ~100 ns means we must keep enough
   // in-flight requests to hide latency.
   constexpr int64_t PREFETCH_DIST = 8;
-#if defined(CPU_CAPABILITY_AVX512)
   if (kHasAVX512 && emb_dim % 128 == 0) {
     constexpr int64_t block_dim = 128;
     const int64_t num_blocks = emb_dim / block_dim;


### PR DESCRIPTION
This PR is to add software prefetch to overlap bandwidth for scaled_embedding_bag.

The embedding table (e.g, 40M rows × 128 dims = 5 GB for fp8) in scaled_embedding_bag far exceeds the CPU's L3 cache, so every unique index access results in a DRAM miss that the hardware prefetcher cannot predict due to the random access pattern. Without software prefetching, each of the ~218 unique DRAM fetches per batch must be served serially at ~100 ns latency, making the kernel latency-bound (22 µs) rather than bandwidth-bound (~8 µs).