### PR TITLE
Add WAN style rope detection pattern for low precision attention API

### DIFF
--- a/torchao/prototype/attention/shared_utils/fusion_utils.py
+++ b/torchao/prototype/attention/shared_utils/fusion_utils.py
@@ -692,6 +692,23 @@ def _detect_neox_rope(node: Node) -> Optional[RoPEMatch]:
     return _try_match(right, left)
 
 
+def _parse_stride2_index(idx) -> Optional[int]:
+    """Parse ``(..., slice(start, None, 2))`` index tuples.
+
+    Returns the slice ``start`` value (defaulting to 0), or None if the
+    index does not match the expected stride-2 pattern.
+    """
+    if not isinstance(idx, tuple) or len(idx) < 1:
+        return None
+    last = idx[-1]
+    if not isinstance(last, slice) or last.step != 2:
+        return None
+    for entry in idx[:-1]:
+        if entry is not Ellipsis and entry != slice(None):
+            return None
+    return last.start if last.start is not None else 0
+
+
 def _get_setitem_stride2_slice(node: Node) -> Optional[Tuple[int, Node]]:
     """Check if node is ``operator.setitem(tensor, (..., slice(start, None, 2)), value)``.
 
@@ -701,21 +718,12 @@ def _get_setitem_stride2_slice(node: Node) -> Optional[Tuple[int, Node]]:
         return None
     if len(node.args) < 3:
         return None
-    idx = node.args[1]
     value = node.args[2]
     if not isinstance(value, Node):
         return None
-    # idx should be (Ellipsis, slice(start, None, 2))
-    if not isinstance(idx, tuple) or len(idx) < 1:
+    start = _parse_stride2_index(node.args[1])
+    if start is None:
         return None
-    last = idx[-1]
-    if not isinstance(last, slice) or last.step != 2:
-        return None
-    # Check preceding entries are Ellipsis or slice(None)
-    for entry in idx[:-1]:
-        if entry is not Ellipsis and entry != slice(None):
-            return None
-    start = last.start if last.start is not None else 0
     return start, value
 
 
@@ -729,18 +737,11 @@ def _get_getitem_stride2_slice(node: Node) -> Optional[Tuple[int, Node]]:
     if len(node.args) < 2:
         return None
     source = node.args[0]
-    idx = node.args[1]
     if not isinstance(source, Node):
         return None
-    if not isinstance(idx, tuple) or len(idx) < 1:
+    start = _parse_stride2_index(node.args[1])
+    if start is None:
         return None
-    last = idx[-1]
-    if not isinstance(last, slice) or last.step != 2:
-        return None
-    for entry in idx[:-1]:
-        if entry is not Ellipsis and entry != slice(None):
-            return None
-    start = last.start if last.start is not None else 0
     return start, source
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #4173

## Quick Summary
- Added rope fusion detection for WAN style models that use RoPE. This is for the low precision attention API, to enable rope fusion.
- Previously, the fallback path would work, allowing for torch.compile to work with the monkey patched F.SDPA. However, the RoPE operation was not fused into a single kernel with the quantization to fp8.

## Results
Previous results on WAN model:
| Config | Median Time (s) | Speedup |
| --- | --- | --- |
| bf16 baseline | 100.85 | 1.00x |
| fp8_attn | 67.15 | **1.50x** |
| bf16 baseline + torch.compile | 81.32 | 1.00x |
| fp8_attn + compile | 46.88 | **1.73x** |

New results with rope fusion:
| Config | Median Time (s) | Speedup |
| --- | --- | --- |
| fp8_attn + rope fusion + compile | 44.24 | **1.84x** |
