### PR TITLE
Add PerGroup granularity for Float8WeightOnly config

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -22,6 +22,7 @@ from torchao.quantization import (
     Float8WeightOnlyConfig,
     Granularity,
     PerBlock,
+    PerGroup,
     PerRow,
     PerTensor,
     quantize_,
@@ -65,6 +66,10 @@ class ToyLinearModel(torch.nn.Module):
         elif granularity == PerRow():
             assert qs1.shape == (N, 1)
             assert qs2.shape == (K, 1)
+        elif isinstance(granularity, PerGroup):
+            group_size = granularity.group_size
+            assert qs1.shape == (N, K // group_size)
+            assert qs2.shape == (K, N // group_size)
         else:
             assert granularity == (PerBlock([1, 128]), PerBlock([128, 128]))
             assert qs1.shape == (N // 128, K // 128)
@@ -167,6 +172,9 @@ class ToyLoRAModel(torch.nn.Module):
             assert qs.shape == (1, 1)
         elif granularity == PerRow():
             assert qs.shape == (N, 1)
+        elif isinstance(granularity, PerGroup):
+            group_size = granularity.group_size
+            assert qs.shape == (N, K // group_size)
         else:
             assert granularity == (PerBlock((1, 128)), PerBlock((128, 128)))
             assert qs.shape == (N // 128, K // 128)
@@ -194,7 +202,12 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
     @common_utils.parametrize("compile", [True, False])
     @common_utils.parametrize(
         "granularity",
-        [PerTensor(), PerRow(), (PerBlock([1, 128]), PerBlock([128, 128]))],
+        [
+            PerTensor(),
+            PerRow(),
+            PerGroup(64),
+            (PerBlock([1, 128]), PerBlock([128, 128])),
+        ],
     )
     @common_utils.parametrize(
         "kernel_preference",
@@ -291,6 +304,10 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
             if mode == "weight-only":
                 return unittest.skip("unimplemented")
 
+        elif isinstance(granularity, PerGroup):
+            if mode == "dynamic":
+                return unittest.skip("PerGroup not supported for dynamic mode")
+
         elif granularity == (PerBlock([1, 128]), PerBlock([128, 128])):
             if torch.xpu.is_available():
                 return unittest.skip("PerBlock granularity not supported on XPU")
@@ -351,7 +368,7 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
                 )
             else:
                 assert mode == "weight-only", f"Unsupported mode: {mode}"
-                config = Float8WeightOnlyConfig()
+                config = Float8WeightOnlyConfig(granularity=granularity)
 
             quantize_(quantized_model, config)
 

--- a/torchao/float8/types.py
+++ b/torchao/float8/types.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from torchao.quantization.granularity import PerRow, PerTensor
+    from torchao.quantization.granularity import PerGroup, PerRow, PerTensor
 
 
 # Define FP8Granularity type alias to break circular import dependencies
-FP8Granularity = Union["PerTensor", "PerRow"]
+FP8Granularity = Union["PerTensor", "PerRow", "PerGroup"]

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1307,12 +1307,13 @@ def _int8_static_activation_int8_weight_transform(
 @dataclass
 class Float8WeightOnlyConfig(AOBaseConfig):
     """
-    Configuration for applying float8 weight-only symmetric per-channel quantization to linear layers.
+    Configuration for applying float8 weight-only symmetric quantization to linear layers.
 
     Args:
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m3fn.
         set_inductor_config (bool): if True, adjusts `torchinductor` settings to recommended values.
         version (int): the version of the config, version 1 is deprecated, version 2 is using Float8Tensor (default)
+        granularity (Granularity): quantization granularity. Supported: PerTensor, PerRow (default), PerGroup.
 
     Note:
         The actual matmul will be computed in original precision of the weight tensor.
@@ -1326,8 +1327,14 @@ class Float8WeightOnlyConfig(AOBaseConfig):
     weight_dtype: torch.dtype = e4m3_dtype
     set_inductor_config: bool = True
     version: int = 2
+    granularity: Granularity = None  # type: ignore[assignment]
 
     def __post_init__(self):
+        if self.granularity is None:
+            self.granularity = PerRow()
+        assert isinstance(self.granularity, (PerTensor, PerRow, PerGroup)), (
+            f"granularity must be PerTensor, PerRow, or PerGroup, got {type(self.granularity)}"
+        )
         torch._C._log_api_usage_once("torchao.quantization.Float8WeightOnlyConfig")
 
 
@@ -1335,7 +1342,7 @@ def _float8_weight_only_quant_tensor(weight, config):
     assert config.version == 2, f"Unexpected version: {config.version}"
     weight_dtype = config.weight_dtype
     new_weight = Float8Tensor.from_hp(
-        weight, float8_dtype=weight_dtype, granularity=PerRow()
+        weight, float8_dtype=weight_dtype, granularity=config.granularity
     )
     return new_weight
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #4175
* __->__ #4174

Summary:
This is to support a internal use case for per group embedding quantization that usings `QDQLayout` which is deprecated now

- Add granularity field to Float8WeightOnlyConfig supporting PerTensor, PerRow (default), and PerGroup
- Previously hardcoded to PerRow(); now users can pass e.g. Float8WeightOnlyConfig(granularity=PerGroup(64)) for per-group float8 weight quantization
- Update FP8Granularity type alias to include PerGroup

Test Plan:

- Added PerGroup(64) to existing test_fp8_linear_variants parametrization
- Updated check_weight_scaling helpers to verify PerGroup scale shapes (N, K // group_size)
- Existing weight-only tests now pass granularity to config instead of ignoring it
- Run: python -m pytest test/quantization/quantize_/workflows/float8/test_float8_tensor.py -xvs -k "Float8WeightOnly"

Reviewers:

Subscribers:

Tasks:

Tags: