### PR TITLE
Prevent folding of mutable input to copy_ and put_ operators

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -3266,6 +3266,74 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         result = m(*example_inputs)
         self.assertIsNotNone(result)
 
+    def test_quantize_in_place_index_put(self):
+        class IndexPutQuantizer(Quantizer):
+            def __init__(self) -> None:
+                super().__init__()
+                self.qspec = QuantizationSpec(
+                    dtype=torch.int8,
+                    observer_or_fake_quant_ctr=observer.default_observer,
+                    quant_min=-128,
+                    quant_max=127,
+                    qscheme=torch.per_tensor_symmetric,
+                )
+
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                for node in model.graph.nodes:
+                    if node.op != "call_function":
+                        continue
+                    if node.target != torch.ops.aten.index_put_.default:
+                        continue
+
+                    dst = node.args[0]
+                    value = node.args[2]
+                    node.meta["quantization_annotation"] = QuantizationAnnotation(
+                        input_qspec_map={
+                            dst: self.qspec,
+                            value: SharedQuantizationSpec((dst, node)),
+                        },
+                        output_qspec=SharedQuantizationSpec((dst, node)),
+                        _annotated=True,
+                    )
+                return model
+
+            def transform_for_annotation(
+                self, model: torch.fx.GraphModule
+            ) -> torch.fx.GraphModule:
+                return model
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                return None
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(4, dtype=torch.float32))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put_((idx,), x)
+                return updated.clone()
+
+        m = M().eval()
+        quantizer = IndexPutQuantizer()
+        example_inputs = (
+            torch.tensor([1.0, 2.0], dtype=torch.float32),
+            torch.tensor([1, 3], dtype=torch.int64),
+        )
+        m = torch.export.export(m, example_inputs, strict=True).module()
+
+        m = prepare_pt2e(m, quantizer)
+        m(*example_inputs)
+        m = convert_pt2e(m, fold_quantize=True)
+
+        # Check that the named buffer is not folded
+        # If it folded it will be named _frozen_param0
+        self.assertTrue("buf" in dict(m.named_buffers()))
+
+        # Verify the quantized model works
+        result = m(*example_inputs)
+        self.assertIsNotNone(result)
+
     def test_scan_op_quantization(self):
         """Test that prepare_pt2e and convert_pt2e correctly quantize ops
         inside the combine_fn subgraph of torch._higher_order_ops.scan.

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -94,19 +94,66 @@ class ConstantFolder(torch.fx.Interpreter):
         # Identify mutable buffers by finding copy_ operations
         self.mutable_buffers = self._find_mutable_buffers()
 
+    def _is_mutable_buffer(self, node: torch.fx.Node) -> bool:
+        """Check if a node is a mutable buffer."""
+        named_buffers = dict(self.module.named_buffers())
+        if node.op == "placeholder":
+            return True
+
+        if node.op == "get_attr" and str(node.target) in named_buffers:
+            return True
+
+        return False
+
+    def _collect_mutable_chain(self, start: torch.fx.Node) -> set[torch.fx.Node]:
+        """Collects all nodes that lead to a mutable buffer."""
+        stack = [start]
+        node_parents: dict[torch.fx.Node, list[torch.fx.Node]] = {}
+
+        # Generate a map from a node to its parents
+        while stack:
+            node = stack.pop()
+            if node in node_parents:
+                continue
+
+            parents = [
+                arg
+                for arg in pytree.arg_tree_leaves(*node.args, **node.kwargs)
+                if isinstance(arg, torch.fx.Node)
+            ]
+            node_parents[node] = parents
+            stack.extend(parents)
+
+        # Visit the graph in topological order and trace from the buffer to the start node
+        connected = set()
+        for node in self.graph.nodes:
+            if node not in node_parents:
+                continue
+            if self._is_mutable_buffer(node) or any(
+                parent in connected for parent in node_parents[node]
+            ):
+                connected.add(node)
+
+        return connected if start in connected else set()
+
     def _find_mutable_buffers(self) -> set[torch.fx.Node]:
-        """Find mutable buffers by identifying copy_ operations.
-        The first argument of copy_ op is the mutable buffer."""
+        """Find mutable buffers by identifying copy_ or put_ operations.
+        The graph then traces all nodes that lead to a mutable buffer."""
         mutable_buffers = set()
         for node in self.module.graph.nodes:
             if (
                 node.op == "call_function"
                 and hasattr(node.target, "_schema")
-                and "copy_" in str(node.target)
+                and ("copy_" in str(node.target) or "put_" in str(node.target))
             ):
-                # The first argument of copy_ is the mutable buffer
+                # The first argument of copy_ or put_ is the mutable input
+                # Work through the graph to find all nodes that lead to a mutable buffer
                 if len(node.args) > 0 and isinstance(node.args[0], torch.fx.Node):
-                    mutable_buffers.add(node.args[0])
+                    mutable_chain = self._collect_mutable_chain(node.args[0])
+
+                    if mutable_chain:
+                        mutable_buffers.update(mutable_chain)
+
         return mutable_buffers
 
     def _support_dynamic_shape(self) -> bool:

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional
 import torch
 import torch.utils._pytree as pytree
 from torch._inductor.freezing_utils import maybe_set_is_frozen_param
+from torch.ao.quantization.fx.utils import collect_producer_nodes
 from torch.utils._ordered_set import OrderedSet
 
 aten = torch.ops.aten
@@ -105,37 +106,6 @@ class ConstantFolder(torch.fx.Interpreter):
 
         return False
 
-    def _collect_mutable_chain(self, start: torch.fx.Node) -> set[torch.fx.Node]:
-        """Collects all nodes that lead to a mutable buffer."""
-        stack = [start]
-        node_parents: dict[torch.fx.Node, list[torch.fx.Node]] = {}
-
-        # Generate a map from a node to its parents
-        while stack:
-            node = stack.pop()
-            if node in node_parents:
-                continue
-
-            parents = [
-                arg
-                for arg in pytree.arg_tree_leaves(*node.args, **node.kwargs)
-                if isinstance(arg, torch.fx.Node)
-            ]
-            node_parents[node] = parents
-            stack.extend(parents)
-
-        # Visit the graph in topological order and trace from the buffer to the start node
-        connected = set()
-        for node in self.graph.nodes:
-            if node not in node_parents:
-                continue
-            if self._is_mutable_buffer(node) or any(
-                parent in connected for parent in node_parents[node]
-            ):
-                connected.add(node)
-
-        return connected if start in connected else set()
-
     def _find_mutable_buffers(self) -> set[torch.fx.Node]:
         """Find mutable buffers by identifying copy_ or put_ operations.
         The graph then traces all nodes that lead to a mutable buffer."""
@@ -146,13 +116,15 @@ class ConstantFolder(torch.fx.Interpreter):
                 and hasattr(node.target, "_schema")
                 and ("copy_" in str(node.target) or "put_" in str(node.target))
             ):
-                # The first argument of copy_ or put_ is the mutable input
-                # Work through the graph to find all nodes that lead to a mutable buffer
+                # The first argument of copy_ or put_ is the mutable input.
+                # If any producer in the chain is a mutable buffer, mark
+                # all producers as mutable to prevent constant folding.
                 if len(node.args) > 0 and isinstance(node.args[0], torch.fx.Node):
-                    mutable_chain = self._collect_mutable_chain(node.args[0])
-
-                    if mutable_chain:
-                        mutable_buffers.update(mutable_chain)
+                    producer_nodes = collect_producer_nodes(node.args[0])
+                    if producer_nodes is not None and any(
+                        self._is_mutable_buffer(p) for p in producer_nodes
+                    ):
+                        mutable_buffers.update(producer_nodes)
 
         return mutable_buffers
 


### PR DESCRIPTION
* Find mutable buffers for put_ operations as well as copy_.
* Trace the graph to the buffer and mark nodes found as mutable to prevent folding.