### PR TITLE
fix undefined values for tail elements in act quant kernels

### DIFF
--- a/torchao/prototype/blockwise_fp8_training/kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/kernels.py
@@ -318,7 +318,7 @@ def triton_fp8_blockwise_act_quant_lhs_kernel(
     k_offs = pid_k * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     x_offs = m_offs[:, None] * x_stride_dim_0 + k_offs[None, :] * x_stride_dim_1
     x_mask = (m_offs[:, None] < M) & (k_offs[None, :] < K)
-    x = tl.load(x_ptr + x_offs, mask=x_mask)
+    x = tl.load(x_ptr + x_offs, mask=x_mask, other=0.0)
 
     # Scales for (1 x block_size) groups, shape will be (NUM_GROUPS, 1)
     amax = tl.clamp(tl.max(tl.abs(x), axis=1), min=EPS, max=float("inf")).to(tl.float64)
@@ -333,7 +333,8 @@ def triton_fp8_blockwise_act_quant_lhs_kernel(
 
     # Write reciprocal scales
     scale_offs = m_offs[:, None] * s_stride_dim_0 + pid_k * s_stride_dim_1
-    tl.store(s_ptr + scale_offs, tl.div_rn(1.0, scale))
+    scale_mask = m_offs[:, None] < M
+    tl.store(s_ptr + scale_offs, tl.div_rn(1.0, scale), mask=scale_mask)
 
 
 @triton_op("torchao::triton_fp8_blockwise_act_quant_lhs", mutates_args={})
@@ -412,7 +413,7 @@ def triton_fp8_blockwise_act_quant_rhs_kernel(
     k_offs = pid_k * NUM_GROUPS + tl.arange(0, NUM_GROUPS)
     x_offs = m_offs[:, None] * x_stride_dim_0 + k_offs[None, :] * x_stride_dim_1
     x_mask = (m_offs[:, None] < M) & (k_offs[None, :] < K)
-    x = tl.load(x_ptr + x_offs, mask=x_mask)
+    x = tl.load(x_ptr + x_offs, mask=x_mask, other=0.0)
 
     # Column-wise scales for RHS operand, shape (1, block_size)
     amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(tl.float64)
@@ -427,7 +428,8 @@ def triton_fp8_blockwise_act_quant_rhs_kernel(
 
     # Write scales
     scale_offs = pid_m * s_stride_dim_0 + k_offs[None, :] * s_stride_dim_1
-    tl.store(s_ptr + scale_offs, tl.div_rn(1.0, scale))
+    scale_mask = k_offs[None, :] < K
+    tl.store(s_ptr + scale_offs, tl.div_rn(1.0, scale), mask=scale_mask)
 
 
 @triton_op("torchao::triton_fp8_blockwise_act_quant_rhs", mutates_args={})


### PR DESCRIPTION
### Summary
Fixed a tail-handling bug in the blockwise FP8 activation quantization kernels that was corrupting reciprocal scale tensors and causing ```test_triton_fp8_gemm_1x128_128x128``` to fail on ragged shapes. 

The GEMM consumes a_s / b_s scale tensors produced by the quantization kernels, and those scale tensors could be corrupted at the tensor edges. In the LHS activation quant kernel, masked tail lanes were still storing scales into a compact column-major as_strided buffer. Because that buffer has no padding, logically invalid row writes could alias valid scale entries from the next column. The GEMM then used those corrupted scales and SQNR collapsed on small or ragged M.

Updated RHS and LHS blockwise quant kernels with ```tl.load(..., other=0.0)``` for masked tail loads. And masked reciprocral scale ```tl.store``` calls so invalid lanes don't write to scale buffers.

Failures before fix:
<img width="1112" height="153" alt="image" src="https://github.com/user-attachments/assets/b8f2ee79-f405-4304-8048-bf1d95a82015" />

### Testing
  - ```pytest -q test/prototype/blockwise_fp8_training/test_blockwise_kernels.py -k test_triton_fp8_gemm_1x128_128x128```
  - ```pytest -q test/prototype/blockwise_fp8_training/test_blockwise_kernels.py``` 
     - now passes entirely (42 passed)