### PR TITLE
add torch.compile test for Float8BlockwiseLinear

### DIFF
--- a/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
+++ b/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
@@ -109,7 +109,8 @@ def test_triton_quantize_fp8_act_quant_lhs(block_size):
     x[0, :block_size] = 0.0
 
     triton_fp8, triton_scale = triton_fp8_blockwise_act_quant_lhs(
-        x, block_size=block_size
+        x,
+        block_size=block_size,
     )
 
     ref_fp8, ref_scale = torch_blockwise_scale_act_quant_lhs(x, tile_size=block_size)
@@ -151,7 +152,8 @@ def test_triton_quantize_fp8_act_quant_rhs(block_size: int):
     x[:block_size, :block_size] = 0.0
 
     triton_fp8, triton_scale = triton_fp8_blockwise_act_quant_rhs(
-        x, block_size=block_size
+        x,
+        block_size=block_size,
     )
 
     ref_fp8, ref_scale = torch_blockwise_scale_act_quant_rhs(x, block_size=block_size)
@@ -186,16 +188,15 @@ def test_triton_quantize_fp8_act_quant_rhs(block_size: int):
 )
 @pytest.mark.parametrize("block_size", [128, 256])
 @pytest.mark.parametrize("M,K", [(4096, 1024), (4096, 4 * 4096)])
-def test_triton_quantize_fp8_act_quant_transposed_lhs(
-    M, K, block_size: int
-):
+def test_triton_quantize_fp8_act_quant_transposed_lhs(M, K, block_size: int):
     device = "cuda"
     x = torch.randn(M, K, device=device)
 
     x[0, :block_size] = 0.0
 
     triton_fp8, triton_scale = triton_fp8_blockwise_act_quant_transposed_lhs(
-        x, block_size=block_size
+        x,
+        block_size=block_size,
     )
 
     ref_fp8, ref_scale = torch_blockwise_scale_act_quant_lhs(
@@ -239,7 +240,8 @@ def test_triton_quantize_fp8_weight_quant_rhs(M, K, block_size: int):
     x[:block_size, :block_size] = 0.0
 
     triton_fp8, triton_scale = triton_fp8_blockwise_weight_quant_rhs(
-        x, block_size=block_size
+        x,
+        block_size=block_size,
     )
     ref_fp8, ref_scale = torch_blockwise_scale_weight_quant(x, tile_size=block_size)
 
@@ -281,7 +283,8 @@ def test_triton_quantize_fp8_weight_quant_transposed_rhs(block_size: int):
     x[:block_size, :block_size] = 0.0
 
     triton_fp8, triton_scale = triton_fp8_blockwise_weight_quant_transposed_rhs(
-        x, block_size=block_size
+        x,
+        block_size=block_size,
     )
     ref_fp8, ref_scale = torch_blockwise_scale_weight_quant(
         x.t().contiguous(), tile_size=block_size


### PR DESCRIPTION
## Summary
- Add `torch.compile` testing to `Float8BlockwiseLinear` forward and backward passes, verifying fullgraph compilation, numerical correctness, and no recompilation across repeated calls with the same shapes
- Refactored existing `test_blockwise_quant_linear_fwd_bwd` into a shared `_run_blockwise_quant_linear_fwd_bwd` helper that supports both eager and compiled execution paths
- Fixes backward pass assertions to correctly compare gradients (input grad vs input grad, weight grad vs weight grad)

## Testing

```
pytest test/prototype/blockwise_fp8_training/test_blockwise_linear.py
```

- **Eager mode (`test_blockwise_quant_linear_fwd_bwd`)**: Parametrized across `in_features=[4096]`, `out_features=[128256]`, `batch_size=[1, 8]`, `block_size=[128]` — validates forward SQNR >= 25.0 and backward grad SQNR >= 30.0 against a reference `nn.Linear`
- **Compile mode (`test_blockwise_quant_linear_compile_fullgraph_fwd_bwd`)**: Runs with `torch.compile(fullgraph=True)` using `CompileCounterWithBackend("inductor")` to assert:
  - The model traces into a **single compiled frame** (no graph breaks)
  - **No recompilation** on a second forward/backward call with the same input shapes
  - Numerical correctness matches the eager reference (same SQNR thresholds)
- Both paths check for NaN-free outputs and gradients