### PR TITLE
[xpu][test] Add weekly test for Intel GPU

### DIFF
--- a/.github/workflows/xpu_test.yml
+++ b/.github/workflows/xpu_test.yml
@@ -8,6 +8,10 @@ on:
   push:
     tags:
       - ciflow/xpu/*
+  workflow_dispatch:
+  schedule:
+    # Every Saturday at 4 PM UTC
+    - cron: '0 16 * * 6'
 
 permissions:
   id-token: write


### PR DESCRIPTION
For https://github.com/pytorch/ao/issues/2917, This PR is targeted to enable weekly test for Intel GPU, it will run on every Saturday at 4 PM UTC