### PR TITLE
[RELEASE TEST] Remove unnecessary Torch dependency from ExecuTorch ops build

### DIFF
--- a/torchao/csrc/cpu/CMakeLists.txt
+++ b/torchao/csrc/cpu/CMakeLists.txt
@@ -197,7 +197,6 @@ endif()
 
 # Build ExecuTorch ops
 if(TORCHAO_BUILD_EXECUTORCH_OPS)
-    find_package(Torch REQUIRED)
     # ExecuTorch package is not required, but EXECUTORCH_INCLUDE_DIRS and EXECUTORCH_LIBRARIES must
     # be defined and EXECUTORCH_LIBRARIES must include the following libraries installed by ExecuTorch:
     # libexecutorch.a
@@ -230,5 +229,4 @@ if(TORCHAO_BUILD_EXECUTORCH_OPS)
         endif()
     endif()
     target_link_libraries(torchao_ops_executorch PRIVATE cpuinfo)
-    target_include_directories(torchao_ops_executorch PRIVATE "${TORCH_INCLUDE_DIRS}")
 endif()


### PR DESCRIPTION
The ExecuTorch ops target defines TORCHAO_SHARED_KERNELS_BUILD_EXECUTORCH=1, which means shared kernel headers use ExecuTorch includes, not Torch includes. The find_package(Torch) and TORCH_INCLUDE_DIRS were therefore unnecessary and caused CMake configure failures in standalone ExecuTorch builds where PyTorch is not discoverable via find_package.