### PR TITLE
install torchvision to resolve ci issue

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -25,12 +25,12 @@ jobs:
         include:
           - name: CUDA Nightly
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
           - name: CPU Nightly
             runs-on: linux.4xlarge
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cpu'
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
 
@@ -61,38 +61,38 @@ jobs:
         include:
           - name: CUDA 2.8
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.8.0'
+            torch-spec: 'torch==2.8.0 torchvision==0.23.0'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
             dev-requirements-overrides: ""
           - name: CUDA 2.9
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.9.1'
+            torch-spec: 'torch==2.9.1 torchvision==0.24.1'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
             dev-requirements-overrides: ""
           - name: CUDA 2.10
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.10.0'
+            torch-spec: 'torch==2.10.0 torchvision==0.25.0'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
             dev-requirements-overrides: ""
 
           - name: CPU 2.8
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.8.0 --index-url https://download.pytorch.org/whl/cpu'
+            torch-spec: 'torch==2.8.0 torchvision==0.23.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
             dev-requirements-overrides: ""
           - name: CPU 2.9
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu'
+            torch-spec: 'torch==2.9.1 torchvision==0.24.1 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
             dev-requirements-overrides: ""
           - name: CPU 2.10
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu'
+            torch-spec: 'torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
             dev-requirements-overrides: ""


### PR DESCRIPTION
## Summary
transformers lib is now using torchvision, and torchao CI jobs without torchvision installed are failing ([example](https://github.com/pytorch/ao/actions/runs/23771947123/job/69265231043)):
```
->   from torchvision.transforms.v2 import functional as tvF
E   ModuleNotFoundError: No module named 'torchvision'

/opt/conda/envs/venv/lib/python3.10/site-packages/transformers/models/beit/image_processing_pil_beit.py:19: ModuleNotFoundError
```

Set torchvision versions based on: https://pytorch.org/get-started/previous-versions/