### PR TITLE
[xpu][test]Skip distributed test in test/dtypes/test_nf4.py for Intel GPU

### DIFF
--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -43,7 +43,7 @@ from torchao.dtypes.nf4tensor import (
 )
 from torchao.prototype._nf4tensor_api import nf4_weight_only
 from torchao.testing.utils import skip_if_rocm
-from torchao.utils import get_current_accelerator_device, torch_version_at_least
+from torchao.utils import get_available_devices, torch_version_at_least
 
 bnb_available = False
 
@@ -127,10 +127,12 @@ class TestNF4Linear(TestCase):
     )  # TODO: fix this
     @skip_if_rocm("ROCm enablement in progress")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_reconstruction_qlora_vs_bnb(self, dtype: torch.dtype):
+    @parametrize("device", get_available_devices())
+    def test_reconstruction_qlora_vs_bnb(
+        self, dtype: torch.dtype, device: torch.device
+    ):
         # From https://github.com/drisspg/transformer_nuggets/blob/f05afad68ad9086d342268f46a7f344617a02314/test/test_qlora.py#L65C1-L81C47
         torch.manual_seed(0)
-        device = get_current_accelerator_device()
         embed_dim = 512
         input_weight = _build_input_weight(embed_dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
@@ -153,14 +155,14 @@ class TestNF4Linear(TestCase):
         torch_version_at_least("2.7.0"), reason="Failing in CI"
     )  # TODO: fix this
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_nf4_bnb_linear(self, dtype: torch.dtype):
+    @parametrize("device", get_available_devices())
+    def test_nf4_bnb_linear(self, dtype: torch.dtype, device: torch.device):
         """
         This test ensures that nf4_linear is "no worse" than BNB by ensuring the
         error compared to a bf16 linear is not more than BNB's implementation.
         """
         torch.manual_seed(0)
         dim = 512
-        device = get_current_accelerator_device()
         input_weight = _build_input_weight(dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
         bnb_linear = _build_bnb_linear(input_weight, device)
@@ -178,9 +180,9 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU for test")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_load_from_state_dicts(self, dtype: torch.dtype):
+    @parametrize("device", get_available_devices())
+    def test_load_from_state_dicts(self, dtype: torch.dtype, device: torch.device):
         """Tests loading to and from different module state dicts"""
-        device = get_current_accelerator_device()
         input_tensor = torch.rand(64, device=device, dtype=dtype)
         base_mod = self.TestMod(input_tensor, 32, 2)
 
@@ -217,14 +219,14 @@ class TestNF4Linear(TestCase):
         assert other_mod.param.scaler_block_size == 1
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_to_copy(self, dtype: torch.dtype):
+    @parametrize("device", get_available_devices())
+    def test_to_copy(self, dtype: torch.dtype, device: torch.device):
         input_tensor = torch.rand(128, device="cpu")
         input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
         nf4_to_dtype = input_tensor_nf4.to(dtype)
         torch.testing.assert_allclose(input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
 
         if torch.accelerator.is_available():
-            device = get_current_accelerator_device()
             input_tensor = torch.rand(128, device=device)
             input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
             nf4_to_dtype = input_tensor_nf4.to(dtype)
@@ -233,19 +235,19 @@ class TestNF4Linear(TestCase):
             )
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need gpu for test")
-    def test_to_copy_device(self):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_to_copy_device(self, device: torch.device):
         input_tensor = torch.rand(128, device="cpu")
         t = to_nf4(input_tensor, 32, 2)
         assert t.device == torch.device("cpu")
         z = t.to(device)
-        assert z.device.type == device.type  # Because the device could be cuda:0
+        assert z.device.type == device  # Because the device could be cuda:0
         x = z.cpu()
         assert x.device == torch.device("cpu")
 
         input_tensor = torch.rand(128, device=device)
         t = to_nf4(input_tensor, 32, 2)
-        assert t.device.type == device.type
+        assert t.device.type == device
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_to_dtype(self, dtype: torch.dtype):
@@ -257,17 +259,18 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear(self, dtype: torch.dtype):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_smoketest_linear(self, dtype: torch.dtype, device: torch.device):
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = torchao.dtypes.to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
         _ = torch.nn.functional.linear(inp, a)
         _ = torch.nn.functional.linear(inp, a_nf4)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear_compile(self, dtype: torch.dtype):
+    @parametrize("device", get_available_devices())
+    def test_smoketest_linear_compile(self, dtype: torch.dtype, device: torch.device):
         if (
             torch.cuda.is_available()
             and torch.cuda.get_device_capability() < (8, 0)
@@ -276,7 +279,6 @@ class TestNF4Linear(TestCase):
             self.skipTest("test requires SM capability of at least (8, 0).")
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest("test requires 2.3.0 and above for tracing NF4Tensor")
-        device = get_current_accelerator_device()
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = torchao.dtypes.to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
@@ -284,10 +286,12 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("device", get_available_devices())
     @parametrize("shape", [(16, 16), (32, 16)])
     @parametrize("chunk_size", [8, 16, 32])
-    def test_chunk_size_equivalence(self, dtype: torch.dtype, shape, chunk_size):
-        device = get_current_accelerator_device()
+    def test_chunk_size_equivalence(
+        self, dtype: torch.dtype, shape, chunk_size, device: torch.device
+    ):
         a = torch.randn(shape, device=device, dtype=dtype)
         with unittest.mock.patch("torchao.dtypes.nf4tensor.CHUNK_SIZE", chunk_size):
             nf4_patched = to_nf4(a, 16, 2)
@@ -298,8 +302,8 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("input_size", [(512 * 512,), (512, 512)])
-    def test_empty_like(self, input_size: Union[Tuple[int], int]):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_empty_like(self, input_size: Union[Tuple[int], int], device: torch.device):
         nf4_tensor = to_nf4(torch.rand(input_size, device=device))
         new_tensor = torch.empty_like(nf4_tensor, device="cpu")
         self.assertTrue(isinstance(new_tensor, NF4Tensor))
@@ -308,8 +312,8 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("compile", [False, True])
-    def test_quantize_api(self, compile):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_quantize_api(self, compile, device: torch.device):
         nf4_linear = nn.Linear(512, 512, device=device)
         torchao.quantize_(nf4_linear, nf4_weight_only())
         assert isinstance(nf4_linear.weight, NF4Tensor)
@@ -520,44 +524,44 @@ class TestFSDPOps(TestCase):
                 )
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPu available")
-    def test_pin_memory(self):
+    @parametrize("device", get_available_devices())
+    def test_pin_memory(self, device: torch.device):
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertFalse(nf4_tensor.is_pinned())
 
         nf4_tensor = nf4_tensor.pin_memory()
         self.assertTrue(nf4_tensor.is_pinned())
 
-        device = get_current_accelerator_device()
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         self.assertFalse(nf4_tensor.is_pinned())
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_cuda(self):
+    @parametrize("device", get_available_devices())
+    def test_to_cuda(self, device: torch.device):
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
-        device = get_current_accelerator_device()
         nf4_tensor = nf4_tensor.to(device, non_blocking=True)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device, torch.bfloat16)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(nf4_tensor.dtype, torch.bfloat16)
         self.assertEqual(type(nf4_tensor), torch.Tensor)  # dequantized
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_cpu(self):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_to_cpu(self, device: torch.device):
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         nf4_tensor = nf4_tensor.cpu()
         self.assertEqual(nf4_tensor.device.type, "cpu")
@@ -567,16 +571,16 @@ class TestFSDPOps(TestCase):
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_module(self):
+    @parametrize("device", get_available_devices())
+    def test_to_module(self, device: torch.device):
         linear = nn.Linear(512, 512, bias=False)
         linear.weight = nn.Parameter(
             to_nf4(linear.weight.detach()), requires_grad=False
         )
-        device = get_current_accelerator_device()
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device.type)
+        self.assertEqual(linear.weight.device.type, device)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device.type)
+        self.assertEqual(weight.device.type, device)
 
         linear.cpu()
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -588,9 +592,9 @@ class TestFSDPOps(TestCase):
             to_nf4(linear.weight.detach()), requires_grad=False
         )
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device.type)
+        self.assertEqual(linear.weight.device.type, device)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device.type)
+        self.assertEqual(weight.device.type, device)
 
         linear.to("cpu")
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -599,8 +603,10 @@ class TestFSDPOps(TestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
-    def test_tensor_deepcopy(self, input_size: Union[Tuple[int], int]):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_tensor_deepcopy(
+        self, input_size: Union[Tuple[int], int], device: torch.device
+    ):
         nf4_orig = to_nf4(torch.randn(input_size, device=device))
         nf4_clone = copy.deepcopy(nf4_orig)
         self.assertEqual(
@@ -656,6 +662,7 @@ class TestQLoRA(FSDPTest):
         self.run_subtests(
             {
                 "enable_activation_checkpointing": [False, True],
+                "device": get_available_devices(),
                 "offload_policy": [
                     OffloadPolicy(),
                     CPUOffloadPolicy(pin_memory=True),
@@ -668,6 +675,7 @@ class TestQLoRA(FSDPTest):
     def _test_qlora_fsdp2(
         self,
         enable_activation_checkpointing: bool,
+        device: torch.device,
         offload_policy: "OffloadPolicy",  # noqa: F821
     ):
         from torch.distributed._composable.fsdp import fully_shard
@@ -691,7 +699,6 @@ class TestQLoRA(FSDPTest):
             dropout_p=0,
         )
         torch.manual_seed(42)
-        device = get_current_accelerator_device()
         with torch.device(device):
             base_model = Transformer(model_args)
             for layer in base_model.layers:
@@ -770,7 +777,7 @@ class TestComm(FSDPTest):
         return 2
 
     @skip_if_lt_x_gpu(2)
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @unittest.skipIf(not torch.cuda.is_available(), "Need GPU available")
     def test_comm(self):
         self.run_subtests(
             {"input_size": [512, 2048]},
@@ -781,8 +788,7 @@ class TestComm(FSDPTest):
         from torch.distributed._composable.fsdp import fully_shard
         from torch.distributed._tensor import distribute_tensor
 
-        device = get_current_accelerator_device()
-        model = nn.Linear(input_size, input_size, device=device)
+        model = nn.Linear(input_size, input_size, device="cuda")
         origin_tensor = model.weight
         origin_nf4_tensor = to_nf4(origin_tensor)
         model = fully_shard(model)

--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -662,7 +662,6 @@ class TestQLoRA(FSDPTest):
         self.run_subtests(
             {
                 "enable_activation_checkpointing": [False, True],
-                "device": get_available_devices(),
                 "offload_policy": [
                     OffloadPolicy(),
                     CPUOffloadPolicy(pin_memory=True),
@@ -675,7 +674,6 @@ class TestQLoRA(FSDPTest):
     def _test_qlora_fsdp2(
         self,
         enable_activation_checkpointing: bool,
-        device: torch.device,
         offload_policy: "OffloadPolicy",  # noqa: F821
     ):
         from torch.distributed._composable.fsdp import fully_shard
@@ -699,7 +697,7 @@ class TestQLoRA(FSDPTest):
             dropout_p=0,
         )
         torch.manual_seed(42)
-        with torch.device(device):
+        with torch.device("cuda"):
             base_model = Transformer(model_args)
             for layer in base_model.layers:
                 # attention with lora adapters
@@ -753,7 +751,7 @@ class TestQLoRA(FSDPTest):
 
         torch.manual_seed(42 + self.rank + 1)
         for iter_idx in range(5):
-            inp = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+            inp = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
             fsdp_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
             fsdp_loss = fsdp_model(inp).sum()
             fsdp_loss.backward()


### PR DESCRIPTION
For https://github.com/pytorch/ao/issues/2917, This PR is targeted to 
- Skip distributed test in test/dtypes/test_nf4.py for Intel GPU.
- Refactor the device generalization to use ```get_available_devices``` in test/dtypes/test_nf4.py