### PR TITLE
Fix NF4Tensor narrow() crash with recent PyTorch nightly

### DIFF
--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -771,9 +771,6 @@ class TestComm(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skip(
-        "Skipped due to PyTorch autograd metadata issue with DTensor redistribute"
-    )
     def test_comm(self):
         self.run_subtests(
             {"input_size": [512, 2048]},

--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -1153,6 +1153,33 @@ def _(*args, **kwargs):
     return out
 
 
+@implements_torch_function(torch.Tensor.narrow)
+def function_narrow(*args, **kwargs):
+    """Handle narrow for NF4Tensor.
+
+    When narrow is called (e.g. by DTensor's redistribute for unpadding),
+    we need to return a fresh NF4Tensor without autograd metadata to avoid
+    the 'differentiable view with existing autograd metadata' error.
+    """
+    tensor = args[0]
+    dim = args[1] if len(args) > 1 else kwargs["dim"]
+    start = args[2] if len(args) > 2 else kwargs["start"]
+    length = args[3] if len(args) > 3 else kwargs["length"]
+
+    if start != 0 or length != tensor.size(dim):
+        raise NotImplementedError(
+            f"NF4Tensor.narrow only supports no-op narrow (start=0, length=size[dim]), "
+            f"got start={start}, length={length}, size[{dim}]={tensor.size(dim)}"
+        )
+
+    updated_attrs = {}
+    tensor_attrs, _ = tensor.__tensor_flatten__()
+    for attr in tensor_attrs:
+        updated_attrs[attr] = getattr(tensor, attr).detach()
+
+    return NF4Tensor(*construct_nf4_args(tensor, updated_attrs))
+
+
 @implements_torch_function(torch.Tensor.view_as)
 def function_view_as(*args, **kwargs):
     """Handle view_as for NF4Tensor.


### PR DESCRIPTION
(95% claude)

Recent PyTorch nightly added a stricter check that prevents creating differentiable views on tensors that already have autograd metadata. When DTensor's _maybe_unpad_tensor calls narrow() on an NF4Tensor (after detach()), it fell through to the default __torch_function__ fallback path, which triggered a RuntimeError:

  "Attempted to make a tensor into a differentiable view, but the
   tensor already had autograd metadata associated with it."

This adds a torch.Tensor.narrow handler in __torch_function__ for NF4Tensor (similar to the existing view_as handler) that returns a fresh NF4Tensor with detached inner tensors, avoiding the autograd metadata conflict. It currently only supports identity narrows (start=0, length=size[dim]), which covers DTensor's redistribute unpadding path when tensor dimensions evenly divide across the mesh.