### PR TITLE
Skip test_comm for nf4

### DIFF
--- a/test/dtypes/test_nf4.py
+++ b/test/dtypes/test_nf4.py
@@ -771,6 +771,9 @@ class TestComm(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @unittest.skip(
+        "Skipped due to PyTorch autograd metadata issue with DTensor redistribute"
+    )
     def test_comm(self):
         self.run_subtests(
             {"input_size": [512, 2048]},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4210

Summary:
Getting error: RuntimeError: Attempted to make a tensor into a differentiable view, but the tensor already had autograd metadata associated with it.  If you are using a __torch_dispatch__ mode, the most common cause for this
problem is that you used torch.overrides.enable_reentrant_dispatch() improperly; tensors created within the extent of reentrant dispatch MUST NOT be directly returned from __torch_dispatch__; instead, they must be
 wrapped into fresh tensors that serve as the output.  If you are not using wrappers, you probably don't need reentrant dispatch.  If this doesn't seem applicable, please file a bug to PyTorch.

The test fails due to a PyTorch-side issue with autograd metadata in DTensor redistribute — not something fixable on the torchao side.

Skipping for now, can enable after we figure out a proper fix

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: