### PR TITLE
[CPU] Re-enable the previously failing test_fp8_q_attention_block UT

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3093,9 +3093,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
 
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
-    @unittest.skipIf(
-        torch_version_at_least("2.11.0.dev"), "Doesn't work with torch 2.11.0.dev+"
-    )
     @unittest.skipIf(torch.xpu.is_available(), "Doesn't work with XPU")
     def test_q_attention_block(self):
         for annotate_matmul in [True, False]:
@@ -3104,9 +3101,6 @@ class TestDynamicPatternMatcher(TestPatternMatcherBase):
     @skipIfNoDynamoSupport
     @skipIfNoONEDNN
     @skipIfNoFloat8Support
-    @unittest.skipIf(
-        torch_version_at_least("2.11.0.dev"), "Doesn't work with torch 2.11.0.dev+"
-    )
     @unittest.skipIf(torch.xpu.is_available(), "Doesn't work with XPU")
     def test_fp8_q_attention_block(self):
         for annotate_matmul in [True, False]:


### PR DESCRIPTION
The test_fp8_q_attention_block unit test, which previously failed due to commit https://github.com/pytorch/pytorch/commit/6a91cdc0302aa3353d773f292d24df787961f4a5 in pytorch, was skipped in https://github.com/pytorch/ao/pull/4085. Since the issue has been fixed in https://github.com/pytorch/pytorch/pull/177805, this PR re-enable test_fp8_q_attention_block UT.