### PR TITLE
[xpu][mx][test] Enable test_kernels on xpu

### DIFF
--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -44,6 +44,7 @@ from torchao.prototype.mx_formats.kernels import (
 from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_dtype, to_mx
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import (
+    get_available_devices,
     is_cuda_version_at_least,
     is_MI350,
     is_sm_at_least_100,
@@ -388,26 +389,15 @@ def test_fp6_values(dtype_name):
         torch.testing.assert_close(f32, f32_ref, rtol=0, atol=0)
 
 
-@pytest.mark.parametrize(
-    "device",
-    [
-        "cpu",
-        pytest.param(
-            "cuda",
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available(), reason="CUDA not available"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("device", get_available_devices())
 @pytest.mark.parametrize(
     "f32_val,f6_e3m2_enc",
     [
-        (29.0, 0b011111),  # normal round down
-        (26.0, 0b011110),  # normal round to nearest even
-        (0.1251, 0b000010),  # subnormal round down
-        (0.0314, 0b000001),  # subnormal round up
-        (0.03, 0b000000),  # underflow
+        pytest.param(29.0, 0b011111, id="normal_round_down"),
+        pytest.param(26.0, 0b011110, id="normal_round_to_nearest_even"),
+        pytest.param(0.1251, 0b000010, id="subnormal_round_down"),
+        pytest.param(0.0314, 0b000001, id="subnormal_round_up"),
+        pytest.param(0.03, 0b000000, id="underflow"),
     ],
 )
 def test_fp6_e3m2_rounding(f32_val, f6_e3m2_enc, device):
@@ -441,16 +431,18 @@ def triton_to_mxfp8_dim0_reference(
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
-@pytest.mark.parametrize("M", (128, 256))
-@pytest.mark.parametrize("K", (128, 256))
+@pytest.mark.parametrize("M", (128, 256), ids=lambda x: f"M={x}")
+@pytest.mark.parametrize("K", (128, 256), ids=lambda x: f"K={x}")
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 def test_triton_mxfp8_dim1_randn(M, K, scaling_mode):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(
+        M, K, dtype=torch.bfloat16, device=torch.accelerator.current_accelerator()
+    )
     x_mx_ref, x_s_ref = triton_to_mxfp8_dim1_reference(
         x, block_size=32, scaling_mode=scaling_mode
     )
@@ -463,16 +455,18 @@ def test_triton_mxfp8_dim1_randn(M, K, scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
-@pytest.mark.parametrize("M", (128, 256))
-@pytest.mark.parametrize("K", (128, 256))
+@pytest.mark.parametrize("M", (128, 256), ids=lambda x: f"M={x}")
+@pytest.mark.parametrize("K", (128, 256), ids=lambda x: f"K={x}")
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 def test_triton_mxfp8_dim0_randn(M, K, scaling_mode):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(
+        M, K, dtype=torch.bfloat16, device=torch.accelerator.current_accelerator()
+    )
     x_mx_ref, x_s_ref = triton_to_mxfp8_dim0_reference(
         x, block_size=32, scaling_mode=scaling_mode
     )
@@ -487,14 +481,16 @@ def test_triton_mxfp8_dim0_randn(M, K, scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 def test_triton_mxfp8_dim0_zeros(scaling_mode):
-    x = torch.zeros(128, 256, dtype=torch.bfloat16, device="cuda")
+    x = torch.zeros(
+        128, 256, dtype=torch.bfloat16, device=torch.accelerator.current_accelerator()
+    )
     x_mx_ref, x_s_ref = triton_to_mxfp8_dim0_reference(
         x, block_size=32, scaling_mode=scaling_mode
     )
@@ -510,14 +506,22 @@ def test_triton_mxfp8_dim0_zeros(scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
-@pytest.mark.parametrize("M", (128, 256))
-@pytest.mark.parametrize("K", (128, 256))
-@pytest.mark.parametrize("orig_dtype", (torch.float32, torch.bfloat16))
+@pytest.mark.parametrize("M", (128, 256), ids=lambda x: f"M={x}")
+@pytest.mark.parametrize("K", (128, 256), ids=lambda x: f"K={x}")
+@pytest.mark.parametrize(
+    "orig_dtype",
+    [
+        pytest.param(torch.float32, id="float32"),
+        pytest.param(torch.bfloat16, id="bfloat16"),
+    ],
+)
 def test_triton_mxfp8_dequant_dim0(M, K, orig_dtype):
-    x = torch.zeros(M, K, dtype=orig_dtype, device="cuda")
+    x = torch.zeros(
+        M, K, dtype=orig_dtype, device=torch.accelerator.current_accelerator()
+    )
     block_size = 32
     x_data, x_scales = triton_to_mxfp8_dim0_reference(x, block_size=32)
     hp_ref = to_dtype(
@@ -531,7 +535,9 @@ def test_triton_mxfp8_dequant_dim0(M, K, orig_dtype):
     torch.testing.assert_close(hp_t, hp_ref, rtol=0, atol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 @pytest.mark.parametrize(
     "shape",
     [
@@ -544,9 +550,15 @@ def test_triton_mxfp8_dequant_dim0(M, K, orig_dtype):
         (528, 512),
         (128, 1),
     ],
+    ids=lambda x: f"{x[0]}x{x[1]}",
 )
 def test_rearrange(shape):
-    scales = torch.randint(256, size=shape, device="cuda", dtype=torch.uint8)
+    scales = torch.randint(
+        256,
+        size=shape,
+        device=torch.accelerator.current_accelerator(),
+        dtype=torch.uint8,
+    )
     eager = to_blocked(scales, False)
     triton = to_blocked(scales, True)
     torch.testing.assert_close(eager, triton, atol=0, rtol=0)
@@ -560,9 +572,15 @@ def test_rearrange(shape):
     not is_cuda_version_at_least(12, 8),
     reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
 )
-@pytest.mark.parametrize("M", (32, 256))
-@pytest.mark.parametrize("K", (32, 256))
-@pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
+@pytest.mark.parametrize("M", (32, 256), ids=lambda x: f"M={x}")
+@pytest.mark.parametrize("K", (32, 256), ids=lambda x: f"K={x}")
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        pytest.param(torch.float32, id="float32"),
+        pytest.param(torch.bfloat16, id="bfloat16"),
+    ],
+)
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
@@ -625,18 +643,23 @@ def test_cuda_mx_dim0_not_supported():
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8),
+    torch.cuda.is_available() and not is_cuda_version_at_least(12, 8),
     reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
 )
 @pytest.mark.parametrize("scaling_mode", (ScaleCalculationMode.RCEIL,))
 def test_triton_mxfp8_dim0_special_values(scaling_mode: ScaleCalculationMode):
     # Create tensor with special values - make it compatible with block_size=32
     block_size = 32
-    special_vals = torch.zeros(2, block_size, dtype=torch.bfloat16, device="cuda")
+    special_vals = torch.zeros(
+        2,
+        block_size,
+        dtype=torch.bfloat16,
+        device=torch.accelerator.current_accelerator(),
+    )
 
     # Fill first few elements of each row with special values
     special_vals[0, :4] = torch.tensor(
@@ -718,11 +741,11 @@ def test_triton_mxfp8_dim0_special_values(scaling_mode: ScaleCalculationMode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8),
+    torch.cuda.is_available() and not is_cuda_version_at_least(12, 8),
     reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
 )
 @pytest.mark.parametrize("scaling_mode", (ScaleCalculationMode.RCEIL,))
@@ -732,7 +755,12 @@ def test_triton_mxfp8_dim0_overflow_underflow(scaling_mode):
     fp8_subnormal_min = 2e-9  # smallest positive subnormal for e4m3: https://www.emergentmind.com/topics/mxfp8-e4m3-floating-point-format
     block_size = 32
 
-    test_vals = torch.zeros(4, block_size, dtype=torch.bfloat16, device="cuda")
+    test_vals = torch.zeros(
+        4,
+        block_size,
+        dtype=torch.bfloat16,
+        device=torch.accelerator.current_accelerator(),
+    )
 
     # Row 0: elem 0 is near max, elems 1-3 are above max
     test_vals[0, :4] = torch.tensor(
@@ -811,12 +839,13 @@ def test_triton_mxfp8_dim0_overflow_underflow(scaling_mode):
 
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8), reason="CUDA version >= 12.8 required"
+    torch.cuda.is_available() and not is_cuda_version_at_least(12, 8),
+    reason="CUDA version >= 12.8 required",
 )
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability 10.0 or greater required"
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability 10.0 or greater required",
 )
 @pytest.mark.parametrize("scaling_mode", (ScaleCalculationMode.RCEIL,))
 def test_all_nan_block_scale_behavior(scaling_mode):
@@ -832,7 +861,11 @@ def test_all_nan_block_scale_behavior(scaling_mode):
     # First 32 elements: mixed NaN + real values
     # Second 32 elements: all NaN values
     # Third 32 elements: normal values for reference
-    test_vals = torch.zeros(3 * block_size, dtype=torch.bfloat16, device="cuda")
+    test_vals = torch.zeros(
+        3 * block_size,
+        dtype=torch.bfloat16,
+        device=torch.accelerator.current_accelerator(),
+    )
 
     # Block 1: Mixed NaN + real values [NaN, 1.0, NaN, 5.0, NaN, 3.0, ...]
     test_vals[:block_size:3] = float("nan")  # Every 3rd element is NaN
@@ -912,11 +945,11 @@ def test_all_nan_block_scale_behavior(scaling_mode):
 
 @pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
 @pytest.mark.skipif(
-    not is_sm_at_least_100() and not is_MI350(),
+    torch.cuda.is_available() and not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
 @pytest.mark.skipif(
-    not is_cuda_version_at_least(12, 8),
+    torch.cuda.is_available() and not is_cuda_version_at_least(12, 8),
     reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
 )
 @pytest.mark.parametrize(
@@ -924,7 +957,11 @@ def test_all_nan_block_scale_behavior(scaling_mode):
 )
 def test_triton_mxfp8_dim0_large_tensor_offset_no_overflow(scaling_mode):
     """Test with large tensor whose offsets exceeds the max int32 value."""
-    x = torch.randn((184320, 14336), dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(
+        (184320, 14336),
+        dtype=torch.bfloat16,
+        device=torch.accelerator.current_accelerator(),
+    )
     block_size = 32
     x_mx_ref, x_s_ref = triton_to_mxfp8_dim0_reference(
         x, block_size=block_size, scaling_mode=scaling_mode

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -514,12 +514,9 @@ if _triton_kernels_available:
         max_abs = tl.max(x, axis=axis)
 
         # Check for NaN presence: if ANY element in each row is NaN,
-        # set that row's max_abs to NaN (per-axis NaN detection)
+        # flag that row for post-chain correction (see below).
         nan_mask = x != x
         has_nan_per_axis = tl.max(nan_mask, axis=axis)
-
-        # If any element in a row was NaN, set that row's max_abs to NaN
-        max_abs = tl.where(has_nan_per_axis > 0, float("nan"), max_abs)
 
         F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
 
@@ -546,6 +543,15 @@ if _triton_kernels_available:
             scale_e8m0_biased = (scale_e8m0_unbiased + 127).to(tl.uint8)
 
         descale_fp = _calculate_reciprocal_scale(scale_e8m0_biased)
+
+        # Overwrite scale and descale for NaN rows. This is done after the
+        # chain rather than by injecting NaN into max_abs, because .to(uint8)
+        # silently destroys NaN on SPIR-V backends (XPU):  fptoui(NaN) is
+        # undefined behavior per LLVM spec, returning 0 on XPU instead of
+        # the expected 255. 255 is the E8M0 NaN encoding; NaN descale ensures
+        # NaN propagation.
+        scale_e8m0_biased = tl.where(has_nan_per_axis > 0, 255, scale_e8m0_biased)
+        descale_fp = tl.where(has_nan_per_axis > 0, float("nan"), descale_fp)
 
         return descale_fp, scale_e8m0_biased
 

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -25,6 +25,7 @@ from torchao.utils import (
     is_mslk_version_at_least,
     is_ROCM,
     is_sm_at_least_100,
+    is_XPU,
 )
 
 logger = logging.getLogger(__name__)
@@ -455,11 +456,13 @@ else:
         raise AssertionError("needs triton")
 
 
-_triton_kernels_available = (
-    has_triton()
-    and torch.cuda.is_available()
-    and (is_sm_at_least_100() and is_cuda_version_at_least(12, 8))
+_triton_kernels_available = has_triton() and (
+    (
+        torch.cuda.is_available()
+        and (is_sm_at_least_100() and is_cuda_version_at_least(12, 8))
+    )
     or (is_ROCM() and is_MI350())
+    or is_XPU()
 )
 
 if _triton_kernels_available:
@@ -468,6 +471,7 @@ if _triton_kernels_available:
     from torch.library import triton_op, wrap_triton
 
     IS_ROCM = tl.constexpr(is_ROCM())
+    IS_XPU = tl.constexpr(is_XPU())
 
     @triton.jit
     def _calculate_reciprocal_scale(scale_e8m0_biased):
@@ -689,7 +693,7 @@ if _triton_kernels_available:
             col_rcp_scale_fp32, col_scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_t_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=(not IS_ROCM and not IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")
@@ -800,7 +804,7 @@ if _triton_kernels_available:
             descale_fp32_r, scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=(not IS_ROCM and not IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1185,6 +1185,10 @@ def _cpu_is_amx_tile_supported() -> bool:
     return False
 
 
+def is_XPU():
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
+
+
 def _cpu_is_vnni_supported() -> bool:
     """
     Safely query AVX512_VNNI support, guarding against private API absence.


### PR DESCRIPTION
In the context of https://github.com/pytorch/ao/issues/3576.

This PR contains 3 commits necessary for enabling mx kernels tests on xpu:

### 1. Triton RCEIL rounding for non-CUDA backends
The `USE_PTX` flag in MXFP8 triton kernels was gated by `not IS_ROCM`, which assumed only CUDA and ROCm backends exist. On any other non-CUDA device (e.g. XPU), this incorrectly enabled CUDA PTX inline assembly (`cvt.rp.satfinite.ue8m0x2.f32`), causing errors.

### 2. Fix NaN scale propagation in RCEIL triton kernel for SPIR-V backends
On XPU's SPIR-V backend, `.to(uint8)` silently destroys NaN values: 

`fptoui(NaN)`, used by `.to(uint8)` is undefined behavior per the LLVM spec (returning 0 instead of 255) - see [The LLVM LangRef `fptoui` semantics section](https://llvm.org/docs/LangRef.html#fptoui-to-instruction)
The existing NaN workaround in `_triton_calculate_scale_rceil` correctly detects NaN blocks via `x != x + tl.max(nan_mask)`, but then the NaN injected into `max_abs` is subsequently killed by `.to(uint8)` further down the chain.

The proposed solution is to move the NaN correction after the `log2 -> ceil -> clamp -> +127 -> to(uint8)` chain.

### 3. Enable tests to run on xpu
Remove hardcoded `device="cuda"` and use `current_accelerator`. 
Add ids to existing test parameters for clearer test names.
