### PR TITLE
[xpu][mx][test] Enable test_mx_tensor on xpu

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -78,45 +78,65 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_hello_world(elem_dtype):
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    data = torch.randn(
+        8, 8, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_realistic_numerics(elem_dtype, scale_calculation_mode):
-    data = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    data = torch.randn(
+        128, 128, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_all_zeros(elem_dtype):
-    data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
+    data = torch.zeros(
+        4, 4, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_some_zeros(elem_dtype):
-    data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    data = torch.randn(
+        4, 4, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     data[0, :] = 0.0
     data[:, 2] = 0.0
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 def test_to_mx_rceil():
     # nan
     # fmt: off
+
+    device = torch.accelerator.current_accelerator()
     data_hp = torch.tensor(
         [
         2143289344, 1054459450, 1060527345, 1045656552, 1058239340, 1045057552, 1061158006, 1049626606,
@@ -124,6 +144,7 @@ def test_to_mx_rceil():
         1036491424, 1063542041, 1057099838, 1058731224, 1050189482, 1049114228, 1058347802, 1060065968,
         1058846156, 1048878912, 1065109089, 1054494928, 1044803976, 1049117692, 1065222528, 1056965012,
         ],
+        device=device,
         dtype=torch.uint32,
     ).view(torch.float32)
 
@@ -164,11 +185,14 @@ def test_to_mx_rceil():
         18, 42, 98, 58, 3, 26, 64, 86,
         60, 86, 52, 23, 61, 70, 59, 74,
         ],
+        device=device,
         dtype=torch.uint16,
     ).view(torch.bfloat16)
     # fmt: on
-    ground_truth_scale = torch.tensor([0], dtype=torch.uint8).view(torch.float8_e8m0fnu)
-    ground_truth_fp8 = torch.tensor([0] * 32, dtype=torch.uint8).view(
+    ground_truth_scale = torch.tensor([0], device=device, dtype=torch.uint8).view(
+        torch.float8_e8m0fnu
+    )
+    ground_truth_fp8 = torch.tensor([0] * 32, device=device, dtype=torch.uint8).view(
         torch.float8_e4m3fn
     )
     data_mx = MXTensor.to_mx(
@@ -185,10 +209,11 @@ def test_to_mx_rceil():
         1051852994, 1059794063, 1054011102, 1062023602, 1059467900, 1062276774, 1059155029, 1053287574,
         1064378711, 1055768540, 1045266076, 1059575077, 1054928758, 1040468200, 1058061961, 1053066436,
         ],
+        device=device,
         dtype=torch.uint32,
     ).view(torch.float32)
     # fmt: on
-    ground_truth_scale = torch.tensor([119], dtype=torch.uint8).view(
+    ground_truth_scale = torch.tensor([119], device=device, dtype=torch.uint8).view(
         torch.float8_e8m0fnu
     )
     # fmt: off
@@ -199,6 +224,7 @@ def test_to_mx_rceil():
         107, 115, 109, 117, 114, 117, 114, 108,
         119, 111, 101, 114, 110, 96, 113, 108,
         ],
+        device=device,
         dtype=torch.uint8,
     ).view(torch.float8_e4m3fn)
     # fmt: on
@@ -216,10 +242,11 @@ def test_to_mx_rceil():
         16135, 16214, 16205, 16110, 16122, 15960, 15824, 16106,
         16220, 16230, 15952, 15896, 16000, 16144, 16232, 16157,
         ],
+        device=device,
         dtype=torch.uint16,
     ).view(torch.bfloat16)
     # fmt: on
-    ground_truth_scale = torch.tensor([119], dtype=torch.uint8).view(
+    ground_truth_scale = torch.tensor([119], device=device, dtype=torch.uint8).view(
         torch.float8_e8m0fnu
     )
     # fmt: off
@@ -230,6 +257,7 @@ def test_to_mx_rceil():
         112, 117, 117, 111, 112, 102, 93, 111,
         118, 118, 101, 98, 104, 113, 118, 114,
         ],
+        device=device,
         dtype=torch.uint8,
     ).view(torch.float8_e4m3fn)
     # fmt: on
@@ -239,9 +267,13 @@ def test_to_mx_rceil():
     torch.testing.assert_close(data_mx.scale, ground_truth_scale)
     torch.testing.assert_close(data_mx.qdata, ground_truth_fp8)
     # zero
-    data_hp = torch.tensor([0] * 32, dtype=torch.uint32).view(torch.float32)
-    ground_truth_scale = torch.tensor([0], dtype=torch.uint8).view(torch.float8_e8m0fnu)
-    ground_truth_fp8 = torch.tensor([0] * 32, dtype=torch.uint8).view(
+    data_hp = torch.tensor([0] * 32, device=device, dtype=torch.uint32).view(
+        torch.float32
+    )
+    ground_truth_scale = torch.tensor([0], device=device, dtype=torch.uint8).view(
+        torch.float8_e8m0fnu
+    )
+    ground_truth_fp8 = torch.tensor([0] * 32, device=device, dtype=torch.uint8).view(
         torch.float8_e4m3fn
     )
     data_mx = MXTensor.to_mx(
@@ -258,10 +290,11 @@ def test_to_mx_rceil():
         1057854101, 1053562724, 1027482352, 1060498324, 1063238522, 1060472055, 1054346794, 1029092912,
         1056687298, 1059146141, 1037992128, 1064097772, 1056522806, 1059255744, 1064364912, 1060606252,
         ],
+        device=device,
         dtype=torch.uint32,
     ).view(torch.float32)
     # fmt: on
-    ground_truth_scale = torch.tensor([119], dtype=torch.uint8).view(
+    ground_truth_scale = torch.tensor([119], device=device, dtype=torch.uint8).view(
         torch.float8_e8m0fnu
     )
     # fmt: off
@@ -272,6 +305,7 @@ def test_to_mx_rceil():
         113, 109, 84, 115, 118, 115, 110, 85,
         112, 114, 94, 119, 112, 114, 119, 115,
         ],
+        device=device,
         dtype=torch.uint8,
     ).view(torch.float8_e4m3fn)
     # fmt: on
@@ -289,10 +323,11 @@ def test_to_mx_rceil():
         16210, 16024, 16248, 16187, 16050, 15696, 16060, 15956,
         16131, 16251, 15896, 16014, 15808, 16024, 16159, 16186,
         ],
+        device=device,
         dtype=torch.uint16,
     ).view(torch.bfloat16)
     # fmt: on
-    ground_truth_scale = torch.tensor([119], dtype=torch.uint8).view(
+    ground_truth_scale = torch.tensor([119], device=device, dtype=torch.uint8).view(
         torch.float8_e8m0fnu
     )
     # fmt: off
@@ -303,6 +338,7 @@ def test_to_mx_rceil():
         117, 106, 120, 116, 107, 85, 108, 101,
         112, 120, 98, 105, 92, 106, 114, 116,
         ],
+        device=device,
         dtype=torch.uint8,
     ).view(torch.float8_e4m3fn)
     # fmt: on
@@ -313,15 +349,19 @@ def test_to_mx_rceil():
     torch.testing.assert_close(data_mx.qdata, ground_truth_fp8)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_exponent_nan_in(elem_dtype):
     """
     If high precision block values has a NaN, the exponent block
     value is set to is NaN
     """
     tensor_hp = torch.tensor(
-        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device="cuda", dtype=torch.bfloat16
+        [float("nan"), 1, 2, 3, 4, 5, 6, 7],
+        device=torch.accelerator.current_accelerator(),
+        dtype=torch.bfloat16,
     )
     block_size = 4
     tensor_mx = MXTensor.to_mx(tensor_hp, elem_dtype, block_size)
@@ -329,7 +369,9 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
     """
@@ -337,12 +379,13 @@ def test_all_nan_blocks(elem_dtype):
     - Mixed real + NaN: scale = NaN
     - All NaN: scale = NaN
     """
+    device = torch.accelerator.current_accelerator()
     block_size = 4
 
     # Test case 1: Mixed NaN + real values
     mixed_tensor = torch.tensor(
         [float("nan"), 2.0, float("nan"), 4.0, 1.0, 3.0, 5.0, 2.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     mixed_mx = MXTensor.to_mx(mixed_tensor, elem_dtype, block_size)
@@ -358,7 +401,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 2: All NaN blocks (should return NaN scale)
     all_nan_tensor = torch.tensor(
         [float("nan"), float("nan"), float("nan"), float("nan"), 1.0, 2.0, 3.0, 4.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     all_nan_mx = MXTensor.to_mx(all_nan_tensor, elem_dtype, block_size)
@@ -384,7 +427,7 @@ def test_all_nan_blocks(elem_dtype):
             float("nan"),
             float("nan"),
         ],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     completely_nan_mx = MXTensor.to_mx(completely_nan_tensor, elem_dtype, block_size)
@@ -395,34 +438,38 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
+    device = torch.accelerator.current_accelerator()
+
     scale_e8m0 = torch.tensor(
-        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device="cuda"
+        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
 
     block_size = 4
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device=device
         )  # noqa: E501
     elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
     elif elem_dtype == torch.float4_e2m1fn_x2:
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
         data_bits = pack_uint4(data_bits)
     else:
         raise AssertionError("unsupported")
-    block_size = 4
+
     tensor_mx = MXTensor(
         data_bits,
         scale_e8m0,
@@ -438,8 +485,10 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
@@ -447,13 +496,17 @@ def test_ranks(elem_dtype):
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
-        tensor_hp = torch.randn(*s, device="cuda", dtype=torch.bfloat16)
+        tensor_hp = torch.randn(
+            *s, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+        )
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("B", [1, 4, 32])
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
+@pytest.mark.parametrize("B", [1, 4, 32], ids=lambda x: f"block_size_{x}")
 def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
@@ -462,13 +515,19 @@ def test_block_sizes(elem_dtype, B):
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
         pytest.skip("unsupported configuration")
-    tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(
+        B, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 def test_from_qdata_and_scales_round_trip():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(
+        128, 128, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -490,9 +549,13 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(
+        128, 128, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -508,9 +571,13 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(
+        128, 128, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -526,15 +593,19 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
     M, K = 128, 256
     block_size = 32
-    tensor_hp = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(
+        M, K, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         elem_dtype,
@@ -549,18 +620,24 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: str(x))
 def test_view(elem_dtype):
-    x = torch.randn(1, 2, 4, device="cuda")
+    x = torch.randn(1, 2, 4, device=torch.accelerator.current_accelerator())
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 def test_clone():
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    data = torch.randn(
+        8, 8, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
     data_mx_c = data_mx.clone()
@@ -572,24 +649,32 @@ def test_clone():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-@pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.parametrize("all_zeros", [False, True])
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize(
+    "elem_dtype", SUPPORTED_ELEM_DTYPES, ids=lambda x: f"elem_dtype_{x}"
+)
+@pytest.mark.parametrize(
+    "hp_dtype", [torch.float32, torch.bfloat16], ids=lambda x: f"hp_dtype_{x}"
+)
+@pytest.mark.parametrize("all_zeros", [False, True], ids=lambda x: f"all_zeros_{x}")
 def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
+    device = torch.accelerator.current_accelerator()
+
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if torch.cuda.is_available() and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:
-        x = torch.randn(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.randn(*shape, dtype=hp_dtype, device=device)
     else:
-        x = torch.zeros(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.zeros(*shape, dtype=hp_dtype, device=device)
     block_size = 4
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
 
@@ -622,9 +707,11 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     torch.testing.assert_close(x_mx_dq, x_mx_c_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 def test_to_mx_inductor_single_kernel():
@@ -634,15 +721,22 @@ def test_to_mx_inductor_single_kernel():
     """
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
-    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(
+        2048, 2048, dtype=torch.bfloat16, device=torch.accelerator.current_accelerator()
+    )
     block_size = 32
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
-    out, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
+    _, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
     FileCheck().check("def call(").check_count(".run(", 1, exactly=True).run(code[0])
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Need sm90+")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    reason="sm90+ required for CUDA",
+)
 def test_index_select():
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
@@ -652,7 +746,9 @@ def test_index_select():
     """
 
     E, K, N = 128, 256, 512
-    x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(
+        E, N, K, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
 
     x_mx_1 = x_mx[1]
@@ -661,9 +757,11 @@ def test_index_select():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
@@ -680,7 +778,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
             -1 * max_val,
         ],
         dtype=torch.bfloat16,
-        device="cuda",
+        device=torch.accelerator.current_accelerator(),
     )
 
     # create example data outside the representable range
@@ -690,7 +788,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
             -1 * (max_val * 2),
         ],
         dtype=torch.bfloat16,
-        device="cuda",
+        device=torch.accelerator.current_accelerator(),
     )
 
     # PyTorch core saturates finite-overflow e4m3fn casts as of
@@ -727,13 +825,20 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
         (50, 10),
         (384, 12),
     ],
+    ids=lambda x: f"{x[0]}x{x[1]}",
 )
 @pytest.mark.parametrize(
-    "use_triton_kernel", [False, True] if torch.cuda.is_available() else [False]
+    "use_triton_kernel",
+    [False, True] if torch.accelerator.is_available() else [False],
+    ids=lambda x: f"triton_kernel_{x}",
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = (
+        torch.accelerator.current_accelerator()
+        if torch.accelerator.is_available()
+        else "cpu"
+    )
 
     original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 
@@ -749,13 +854,15 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("transpose", [False, True])
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize("transpose", [False, True], ids=lambda x: f"transpose_{x}")
 @pytest.mark.parametrize(
     "shape",
     (
-        (128, 64),
-        (1, 128, 64),
+        pytest.param((128, 64), id="2D"),
+        pytest.param((1, 128, 64), id="3D"),
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
@@ -764,7 +871,7 @@ def test_scale_shape_matches_qdata(transpose, shape):
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=torch.accelerator.current_accelerator())
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -802,9 +909,13 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
-@pytest.mark.parametrize("transpose", [False, True])
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.parametrize(
+    "elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2), ids=lambda x: str(x)
+)
+@pytest.mark.parametrize("transpose", [False, True], ids=lambda x: f"transpose_{x}")
 @pytest.mark.parametrize(
     "shape",
     (
@@ -818,7 +929,7 @@ def test_swizzle(elem_dtype, transpose, shape):
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=torch.accelerator.current_accelerator())
     x = MXTensor.to_mx(
         x_hp,
         elem_dtype,
@@ -866,10 +977,14 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+    x_hp = torch.randn(
+        128, 256, device=torch.accelerator.current_accelerator(), dtype=torch.bfloat16
+    )
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()
 


### PR DESCRIPTION
In the context of https://github.com/pytorch/ao/issues/3576 - enable mx tensor tests on xpu.

Parametrize mx tensor tests with device to include xpu.
Add ids to existing test parameters for clearer test names.
