### PR TITLE
Add aten.view.dtype dispatch to optim state subclasses

### DIFF
--- a/torchao/optim/subclass_4bit.py
+++ b/torchao/optim/subclass_4bit.py
@@ -195,10 +195,10 @@ def _(func, types, args, kwargs):
     x, shape = args
 
     if tuple(x.shape) == tuple(shape):
-        return OptimState4bit(x.codes, x.scale, x.qmap, x.signed, x._shape)
+        return OptimState4bit(x.codes, x.scale, x.qmap, x.signed, x._shape, dtype=x.dtype)
 
     if len(shape) == 1 and shape[0] == -1:
-        return OptimState4bit(x.codes, x.scale, x.qmap, x.signed, (x.numel(),))
+        return OptimState4bit(x.codes, x.scale, x.qmap, x.signed, (x.numel(),), dtype=x.dtype)
 
     raise ValueError(
         f"{x.__class__.__name__} only supports .view() with same shape or shape=[-1]"

--- a/torchao/optim/subclass_8bit.py
+++ b/torchao/optim/subclass_8bit.py
@@ -174,7 +174,7 @@ def _(func, types, args, kwargs):
 @OptimState8bit.implements(aten.view.default)
 def _(func, types, args, kwargs):
     x, shape = args
-    return OptimState8bit(x.codes.view(shape), x.scale, x.qmap, x.signed)
+    return OptimState8bit(x.codes.view(shape), x.scale, x.qmap, x.signed, dtype=x.dtype)
 
 
 # this is needed for torch.compile fake tensor creation when appearance dtype

--- a/torchao/optim/subclass_fp8.py
+++ b/torchao/optim/subclass_fp8.py
@@ -149,7 +149,7 @@ def _(func, types, args, kwargs):
 @OptimStateFp8.implements(aten.view.default)
 def _(func, types, args, kwargs):
     x, shape = args
-    return OptimStateFp8(x.codes.view(shape), x.scale)
+    return OptimStateFp8(x.codes.view(shape), x.scale, dtype=x.dtype)
 
 
 # this is needed for torch.compile fake tensor creation when appearance dtype


### PR DESCRIPTION
PR #3934 added an "appearance dtype" to OptimState8bit (e.g. bf16 wrapper over uint8 codes), but didn't implement aten.view.dtype. 

torch.compile'd 8bit Adam optimizer (e.g. adamw_torch_8bit in HuggingFace transformers) crashes on PyTorch 2.9.1+

fix: register aten.view.dtype for all three optim subclasses, updating only the appearance dtype (consistent with existing aten._to_copy.default behavior).