### PR TITLE
Fix #4106: ./test/float8/test_everything_multi_gpu.sh failing in 4xH1...

### DIFF
--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -41,8 +41,6 @@ from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 from torchao.testing.training.dtensor_utils import (
     _test_lowp_mlp_tensor_parallelism_base,
 )
-from torchao.utils import torch_version_at_least
-
 torch.set_float32_matmul_precision("high")
 
 
@@ -141,10 +139,6 @@ def _test_dtensor_cast_to_fp8(mesh: DeviceMesh, size=16):
 
 
 def _test_dtensor_fp8_autograd(mesh: DeviceMesh, size=16):
-    # TODO: re-enable after fixing https://github.com/pytorch/ao/issues/4106
-    if torch_version_at_least("2.11.0.dev"):
-        print("skipping _test_dtensor_fp8_autograd for torch >= 2.11.0.dev")
-        return
     device = mesh.device_type
     fp8_dtype = e4m3_dtype
 

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -332,10 +332,10 @@ def preprocess_addmm(a: Float8TrainingTensor, b: Float8TrainingTensor):
         b._linear_mm_config,
     )
 
-    if scaled_mm_config.pad_inner_dim:
-        assert a._data.size(1) == b._data.size(0), (
-            f"Inner dims must match for mm, got {a._data.size(1)} and {b._data.size(0)}"
-        )
+    assert a._data.size(1) == b._data.size(0), (
+        f"Inner dims must match for mm, got {a._data.size(1)} and {b._data.size(0)}"
+    )
+    if scaled_mm_config.pad_inner_dim or a_data.size(1) % 16 != 0:
         a_data = pad_tensor_for_matmul(a_data, dims=1)
         b_data = pad_tensor_for_matmul(b_data, dims=0)
 


### PR DESCRIPTION
Closes #4106

## Before

`_test_dtensor_fp8_autograd` in `test/float8/test_dtensor.py` was crashing in CI on 4xH100 with:

```
RuntimeError: Expected trailing dimension of mat1 to be divisible by 16 but got mat1 shape: (32x8).
```

The failure occurred during backward pass inside `addmm_float8_unwrapped` (`torchao/float8/float8_ops.py`, line 73) when calling `torch._scaled_mm`, which requires the inner matmul dimension to be divisible by 16. When tensor parallelism shards the weight across GPUs, the local inner dimension can fall below 16 (e.g., `8` with 4-way TP on a small test tensor), violating this hardware requirement.

As a workaround, `_test_dtensor_fp8_autograd` was skipped entirely for `torch >= 2.11.0.dev` in `test/float8/test_dtensor.py` (lines 143–146), masking the bug rather than fixing it.

## After

`preprocess_addmm` in `torchao/float8/float8_ops.py` now pads `a_data` and `b_data` when the inner dimension is not divisible by 16, regardless of the `scaled_mm_config.pad_inner_dim` flag. The condition changes from:

```python
if scaled_mm_config.pad_inner_dim:
```

to:

```python
if scaled_mm_config.pad_inner_dim or a_data.size(1) % 16 != 0:
```

The inner-dim assertion (`a._data.size(1) == b._data.size(0)`) is now unconditional — it was previously gated inside `if scaled_mm_config.pad_inner_dim`, which was incorrect since the check is always valid regardless of padding config.

The test skip in `test/float8/test_dtensor.py` is removed, restoring full coverage of `_test_dtensor_fp8_autograd`.

## Changes

- **`torchao/float8/float8_ops.py`, `preprocess_addmm`**: Inner-dim assertion moved outside the `pad_inner_dim` guard. Padding is now triggered by `pad_inner_dim=True` **or** `a_data.size(1) % 16 != 0`, covering cases where TP sharding produces sub-16 inner dims.
- **`test/float8/test_dtensor.py`**: Removed the `torch_version_at_least("2.11.0.dev")` early-return skip in `_test_dtensor_fp8_autograd` (lines 143–146) and the now-unused `torch_version_at_least` import.

## Testing

`test/float8/test_everything_multi_gpu.sh` (which runs `test/float8/test_dtensor.py`) should now pass on 4xH100 CI without hitting the `Expected trailing dimension of mat1 to be divisible by 16` error. The test that was previously skipped for `torch >= 2.11.0.dev` now executes fully and exercises the backward pass through `float8_mm` with tensor-parallel sharded weights.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*