### PR TITLE
fix blockwise FP8 scaled_mm scale layout in Float8BlockwiseLinear

### DIFF
--- a/torchao/prototype/blockwise_fp8_training/linear.py
+++ b/torchao/prototype/blockwise_fp8_training/linear.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from torchao.core.config import AOBaseConfig
@@ -21,6 +22,55 @@ from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
 from torchao.utils import is_sm_at_least_90
+
+
+def _pad_blockwise_128x128_scale_k_major(scale: torch.Tensor) -> torch.Tensor:
+    # cuBLASLt requires BLK128x128 scales to be K-major with the K stride padded to a multiple of 4.
+    padded_k_blocks = (scale.shape[0] + 3) // 4 * 4
+    if padded_k_blocks == scale.shape[0]:
+        return scale
+
+    padded_scale = scale.new_full((scale.shape[1], padded_k_blocks), 1.0).transpose(
+        0, 1
+    )
+    padded_scale[: scale.shape[0], :] = scale
+    return padded_scale
+
+
+def _scaled_mm(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_recipe_a,
+    scale_b: torch.Tensor,
+    scale_recipe_b,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    if torch.compiler.is_compiling():
+        return torch.ops.aten._scaled_mm_v2.default(
+            mat_a,
+            mat_b,
+            [scale_a],
+            [scale_recipe_a.value],
+            [],
+            [scale_b],
+            [scale_recipe_b.value],
+            [],
+            None,
+            out_dtype,
+            [],
+            False,
+        )
+
+    return F.scaled_mm(
+        mat_a,
+        mat_b,
+        scale_a=scale_a,
+        scale_recipe_a=scale_recipe_a,
+        scale_b=scale_b,
+        scale_recipe_b=scale_recipe_b,
+        output_dtype=out_dtype,
+    )
 
 
 class fp8_blockwise_mm(torch.autograd.Function):
@@ -42,14 +92,24 @@ class fp8_blockwise_mm(torch.autograd.Function):
         )
 
         # out = input @ weight.T
-        fp8_gemm = triton_fp8_gemm_1x128_128x128 if use_triton else torch._scaled_mm
-        out = fp8_gemm(
-            x_fp8,
-            weight_t_fp8,
-            x_scale,
-            weight_t_scale,
-            out_dtype=out_dtype,
-        )
+        if use_triton:
+            out = triton_fp8_gemm_1x128_128x128(
+                x_fp8,
+                weight_t_fp8,
+                x_scale,
+                weight_t_scale,
+                out_dtype=out_dtype,
+            )
+        else:
+            out = _scaled_mm(
+                x_fp8,
+                weight_t_fp8,
+                x_scale,
+                F.ScalingType.BlockWise1x128,
+                _pad_blockwise_128x128_scale_k_major(weight_t_scale),
+                F.ScalingType.BlockWise128x128,
+                out_dtype,
+            )
         out = out.reshape(*x_orig_shape[:-1], out.shape[-1])
         ctx.save_for_backward(x, weight)
         ctx.block_size = block_size
@@ -86,16 +146,24 @@ class fp8_blockwise_mm(torch.autograd.Function):
         )
 
         # grad_x = grad_output @ weight
-        fp8_gemm_1x128_128x128 = (
-            triton_fp8_gemm_1x128_128x128 if use_triton else torch._scaled_mm
-        )
-        grad_x = fp8_gemm_1x128_128x128(
-            grad_output_fp8,
-            weight_fp8,
-            grad_output_scale,
-            weight_scale,
-            out_dtype=out_dtype,
-        )
+        if use_triton:
+            grad_x = triton_fp8_gemm_1x128_128x128(
+                grad_output_fp8,
+                weight_fp8,
+                grad_output_scale,
+                weight_scale,
+                out_dtype=out_dtype,
+            )
+        else:
+            grad_x = _scaled_mm(
+                grad_output_fp8,
+                weight_fp8,
+                grad_output_scale,
+                F.ScalingType.BlockWise1x128,
+                _pad_blockwise_128x128_scale_k_major(weight_scale),
+                F.ScalingType.BlockWise128x128,
+                out_dtype,
+            )
 
         # Cast grad_output_t to fp8 blockwise with (1 x block_size) scaling groups, since it is
         # the grad of the output activation.
@@ -113,16 +181,24 @@ class fp8_blockwise_mm(torch.autograd.Function):
         x_fp8, x_scale = triton_fp8_blockwise_act_quant_rhs(x, block_size)
 
         # grad_weight = grad_output.T @ x
-        fp8_gemm_1x128_128x1 = (
-            triton_fp8_gemm_1x128_128x1 if use_triton else torch._scaled_mm
-        )
-        grad_weight = fp8_gemm_1x128_128x1(
-            grad_output_t_fp8,
-            x_fp8,
-            grad_output_t_scale,
-            x_scale,
-            out_dtype=out_dtype,
-        )
+        if use_triton:
+            grad_weight = triton_fp8_gemm_1x128_128x1(
+                grad_output_t_fp8,
+                x_fp8,
+                grad_output_t_scale,
+                x_scale,
+                out_dtype=out_dtype,
+            )
+        else:
+            grad_weight = _scaled_mm(
+                grad_output_t_fp8,
+                x_fp8,
+                grad_output_t_scale,
+                F.ScalingType.BlockWise1x128,
+                x_scale.transpose(-1, -2),
+                F.ScalingType.BlockWise1x128,
+                out_dtype,
+            )
 
         # Reshape grad_x to expected potentially 3D+ shape
         grad_x = grad_x.reshape(*grad_output_orig_shape[:-1], grad_x.shape[-1])


### PR DESCRIPTION
### Summary

- replace the non-Triton blockwise FP8 matmul path with functional scaled_mm semantics for forward, grad_x, and grad_weight
- fix the BlockWise128x128 RHS scale layout by padding the K-block dimension to a multiple of 4, as required by cuBLASLt
- fix the BlockWise1x128 RHS scale orientation in grad_weight by transposing the activation scales before the matmul
- use aten._scaled_mm_v2 only under torch.compile(fullgraph=True) so the compiler can trace the op without graph-breaking on the Python F.scaled_mm wrapper

#### What was going wrong?

The issue was not just that we were calling torch._scaled_mm, but that this path in our blockwise FP8 linear code was not matching the cuBLASLt scale-layout contract for blockwise scaling.
In particular:
- grad_x = grad_output @ weight uses RHS BlockWise128x128 scales
- cuBLASLt requires those scales to be K-major, with the K-block dimension padded to a multiple of 4
- our code was passing the unpadded layout, which caused incorrect behavior in the scaled-mm backend

There was a second layout bug in grad_weight = grad_output^T @ x:
- the RHS uses BlockWise1x128 scaling
- the quantized activation scales had the right values but the wrong orientation for the RHS scaled-mm call
- transposing those scales fixes the contract mismatch

Also to note:
- eager mode uses torch.nn.functional.scaled_mm
- compile mode calls aten._scaled_mm_v2 directly because, in this torch build, Dynamo fullgraph cannot trace through the Python F.scaled_mm wrapper even though it lowers to the same underlying op

### Testing

```
 pytest -q test/prototype/blockwise_fp8_training/test_blockwise_linear.py
```

cc @slayton58 @drisspg as part of #4209 