### PR TITLE
[nvfp4_training] Add Triton kernel for global amax of columnwise RHT (SM90+)

### DIFF
--- a/benchmarks/prototype/nvfp4_training/README.md
+++ b/benchmarks/prototype/nvfp4_training/README.md
@@ -1,0 +1,55 @@
+# NVFP4 Training Benchmarks
+
+This directory contains benchmarking scripts for the NVFP4 training kernels
+under `torchao.prototype.mx_formats`.
+
+## Hadamard Amax Benchmark
+
+Benchmarks `triton_rht_amax` — the fused Randomized Hadamard Transform + amax
+reduction kernel used in NVFP4 training.
+
+```bash
+python -m benchmarks.prototype.nvfp4_training.bench_hadamard_amax
+```
+
+To run model-derived representative shapes:
+
+```bash
+python -m benchmarks.prototype.nvfp4_training.bench_hadamard_amax --shape-set representative-models
+```
+
+What it reports:
+
+- `time_us`: median kernel runtime in microseconds
+- `gbps`: effective memory bandwidth (input read bytes / time)
+
+### Methodology
+
+- Sweeps M ∈ {128, 256, 1024, 8192} × N ∈ {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768}
+- Uses `benchmark_cuda_function_in_microseconds` from `benchmarks/utils.py`,
+  which wraps `triton.testing.do_bench` and returns the median.
+- Bandwidth is computed from input read bytes only (bfloat16 input, scalar output).
+
+### Representative Model Results
+
+The following shapes are activation-input matrices `(M, N)` for representative
+linear layers. `M` is `batch_size * sequence_length` except for the DeepSeek-V3
+routed expert rows, where `M` is the average per-expert token count:
+`4096 tokens * 8 experts per token / 256 routed experts = 128`.
+
+Run environment: NVIDIA GB200, PyTorch 2.12.0a0, Triton 3.7.0.
+
+| Model | Shape | M | N | time_us | gbps |
+|---|---|---:|---:|---:|---:|
+| DeepSeek-V3 671B | attn.wkv_b input | 4096 | 512 | 43.328 | 96.804 |
+| DeepSeek-V3 671B | attn.wq_b input | 4096 | 1536 | 46.048 | 273.256 |
+| DeepSeek-V3 671B | shared expert w2 input | 4096 | 2048 | 48.128 | 348.596 |
+| DeepSeek-V3 671B | hidden-state input | 4096 | 7168 | 45.088 | 1302.350 |
+| DeepSeek-V3 671B | attn.wo input | 4096 | 16384 | 64.512 | 2080.510 |
+| DeepSeek-V3 671B | dense ffn.w2 input | 4096 | 18432 | 68.672 | 2198.780 |
+| DeepSeek-V3 671B | avg routed expert w2 input | 128 | 2048 | 42.720 | 12.273 |
+| DeepSeek-V3 671B | avg routed expert w1/w3 input | 128 | 7168 | 42.240 | 43.442 |
+| Llama 3 8B | hidden-state input | 2048 | 4096 | 46.496 | 360.831 |
+| Llama 3 8B | mlp.down input | 2048 | 14336 | 46.080 | 1274.310 |
+| Llama 3 70B | hidden-state input | 2048 | 8192 | 44.032 | 762.047 |
+| Llama 3 70B | mlp.down input | 2048 | 28672 | 58.368 | 2012.070 |

--- a/benchmarks/prototype/nvfp4_training/bench_hadamard_amax.py
+++ b/benchmarks/prototype/nvfp4_training/bench_hadamard_amax.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+import torch
+import triton
+from tabulate import tabulate
+from tqdm import tqdm
+
+from benchmarks.utils import benchmark_cuda_function_in_microseconds
+from torchao.prototype.mx_formats.hadamard_amax_triton import _hadamard_amax_kernel
+from torchao.prototype.mx_formats.hadamard_utils import get_rht_matrix
+
+device = torch.device("cuda")
+
+M_SHAPES = [128, 256, 1024, 8192]
+N_SHAPES = [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+BENCH_OUTPUT_BUFFER_COUNT = 1_000_000
+
+LLAMA_BATCH_SIZE = 1
+LLAMA_SEQ_LEN = 2048
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    m: int
+    n: int
+    model: str = ""
+    shape: str = ""
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    time_us: float
+    gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    return [
+        ExperimentConfig(m=m, n=n) for m, n in itertools.product(M_SHAPES, N_SHAPES)
+    ]
+
+
+def get_representative_model_configs() -> List[ExperimentConfig]:
+    llama_m = LLAMA_BATCH_SIZE * LLAMA_SEQ_LEN
+
+    return [
+        ExperimentConfig(llama_m, 4096, "Llama 3 8B", "hidden-state input"),
+        ExperimentConfig(llama_m, 14336, "Llama 3 8B", "mlp.down input"),
+        ExperimentConfig(llama_m, 8192, "Llama 3 70B", "hidden-state input"),
+        ExperimentConfig(llama_m, 28672, "Llama 3 70B", "mlp.down input"),
+    ]
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    x = torch.randn(config.m, config.n, dtype=torch.bfloat16, device=device)
+
+    # tl.make_tensor_descriptor requires a Triton allocator for per-CTA scratch
+    # space. Set it outside the timed region so the benchmark measures the
+    # kernel body instead of wrapper setup.
+    if hasattr(triton, "set_allocator"):
+        triton.set_allocator(
+            lambda size, align, stream: torch.empty(
+                size, dtype=torch.int8, device=x.device
+            )
+        )
+
+    rht_matrix = get_rht_matrix(
+        sign_vector=None, device=x.device, hadamard_dimension=16
+    ).to(torch.bfloat16)
+    global_rht_amaxes = torch.zeros(
+        BENCH_OUTPUT_BUFFER_COUNT, dtype=torch.float32, device=x.device
+    )
+    global_a_amaxes = torch.zeros_like(global_rht_amaxes)
+    num_sms = torch.cuda.get_device_properties(x.device).multi_processor_count
+    next_output_idx = 0
+
+    def run_kernel():
+        nonlocal next_output_idx
+        if next_output_idx >= BENCH_OUTPUT_BUFFER_COUNT:
+            raise RuntimeError(
+                "Exhausted pre-zeroed output buffers; increase "
+                "BENCH_OUTPUT_BUFFER_COUNT."
+            )
+        output_idx = next_output_idx
+        next_output_idx += 1
+        _hadamard_amax_kernel[(num_sms,)](
+            x,
+            rht_matrix,
+            global_rht_amaxes[output_idx],
+            global_a_amaxes[output_idx],
+            config.m,
+            config.n,
+            GROUP_SIZE_N=8,
+            NUM_SMS=num_sms,
+        )
+
+    time_us = benchmark_cuda_function_in_microseconds(run_kernel)
+
+    read_bytes = x.numel() * (torch.finfo(torch.bfloat16).bits // 8)
+    gbps = (read_bytes / 1e9) / (time_us / 1e6)
+
+    return ExperimentResult(time_us=time_us, gbps=gbps)
+
+
+def print_results(experiments: List[Experiment]):
+    has_labels = any(e.config.model or e.config.shape for e in experiments)
+    headers = ["M", "N", "time_us", "gbps"]
+    rows = []
+    for e in experiments:
+        row = [
+            e.config.m,
+            e.config.n,
+            round(e.result.time_us, 3),
+            round(e.result.gbps, 3),
+        ]
+        if has_labels:
+            row = [e.config.model, e.config.shape] + row
+        rows.append(row)
+    if has_labels:
+        headers = ["model", "shape"] + headers
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--shape-set",
+        choices=("sweep", "representative-models"),
+        default="sweep",
+        help="Benchmark the original sweep or selected model-derived shapes.",
+    )
+    args = parser.parse_args()
+
+    torch.random.manual_seed(123)
+    configs = (
+        get_representative_model_configs()
+        if args.shape_set == "representative-models"
+        else get_configs()
+    )
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/prototype/mx_formats/test_hadamard_amax_triton.py
+++ b/test/prototype/mx_formats/test_hadamard_amax_triton.py
@@ -1,0 +1,97 @@
+"""Tests for triton_rht_amax (SM100+ kernel)."""
+
+import pytest
+import torch
+from torch.utils._triton import has_triton
+
+from torchao.prototype.mx_formats.hadamard_utils import (
+    get_hadamard_matrix,
+    get_rht_matrix,
+    get_wgrad_sign_vector,
+)
+from torchao.utils import is_sm_at_least_100
+
+_HARDCODED_SIGN_VECTOR = (
+    1,
+    1,
+    1,
+    -1,
+    1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    1,
+    -1,
+    1,
+    -1,
+    -1,
+)
+
+
+# M=32 excluded: all BLOCK_M configs (64, 128) exceed M=32 → all autotune configs fail.
+_M_VALUES = [64, 96, 128, 160, 256, 512]
+# N=100 excluded: TMA TensorDescriptor requires stride % 16 bytes == 0;
+# for bf16 this means N % 8 == 0. N=100 (100*2=200 bytes, 200%16=8) fails.
+_N_VALUES = [128, 200, 256, 384, 512, 1024]
+
+
+@torch.no_grad()
+def test_get_rht_matrix_with_hardcoded_sign_vector():
+    rht_matrix = get_rht_matrix(sign_vector=_HARDCODED_SIGN_VECTOR, device="cpu")
+
+    expected_signs = torch.tensor(_HARDCODED_SIGN_VECTOR, dtype=torch.bfloat16)
+    expected = torch.diag(expected_signs) @ get_hadamard_matrix(16, device="cpu")
+    torch.testing.assert_close(rht_matrix, expected, atol=0, rtol=0)
+
+
+@torch.no_grad()
+def test_get_rht_matrix_with_generated_sign_matches_sampled_signs():
+    get_rht_matrix.cache_clear()
+    torch.manual_seed(42)
+    expected_signs = get_wgrad_sign_vector(16, device="cpu")
+
+    get_rht_matrix.cache_clear()
+    torch.manual_seed(42)
+    rht_matrix = get_rht_matrix(sign_vector=None, device="cpu")
+
+    expected = torch.diag(expected_signs) @ get_hadamard_matrix(16, device="cpu")
+    torch.testing.assert_close(rht_matrix, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "sign_vector",
+    [None, _HARDCODED_SIGN_VECTOR],
+    ids=["generated_sign_vector", "hardcoded_sign_vector"],
+)
+@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
+@pytest.mark.skipif(not is_sm_at_least_100(), reason="Requires SM100+")
+@pytest.mark.parametrize("N", _N_VALUES, ids=lambda n: f"N{n}")
+@pytest.mark.parametrize("M", _M_VALUES, ids=lambda m: f"M{m}")
+@torch.no_grad()
+def test_triton_rht_amax_vs_reference(M, N, sign_vector):
+    """triton_rht_amax must match the reference RHT matmul amax exactly (bitwise)."""
+    from torchao.prototype.mx_formats.hadamard_amax_triton import triton_rht_amax
+
+    torch.manual_seed(42)
+    A = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+
+    get_rht_matrix.cache_clear()
+    if sign_vector is None:
+        torch.manual_seed(42)
+    B = get_rht_matrix(sign_vector=sign_vector, device="cuda")
+    ref_rht_amax = (
+        (A.t().reshape(N * M // 16, 16) @ B).to(torch.bfloat16).abs().max().float()
+    )
+    ref_amax = A.abs().max().float()
+
+    get_rht_matrix.cache_clear()
+    if sign_vector is None:
+        torch.manual_seed(42)
+
+    # Check RHT amax and regular amax are bitwise identical to reference.
+    triton_rht_amax_val, triton_amax_val = triton_rht_amax(A, sign_vector=sign_vector)
+    torch.testing.assert_close(triton_rht_amax_val, ref_rht_amax, atol=0, rtol=0)
+    torch.testing.assert_close(triton_amax_val, ref_amax, atol=0, rtol=0)

--- a/torchao/prototype/mx_formats/hadamard_amax_triton.py
+++ b/torchao/prototype/mx_formats/hadamard_amax_triton.py
@@ -1,0 +1,199 @@
+"""
+Triton kernel for Randomized Hadamard Transform (RHT) with fused global amax reduction.
+
+Entry point: triton_rht_amax(A) returns a scalar float32 global absolute maximum of
+the post-RHT output without materializing the full (N, M) output tensor. Uses a
+persistent warp-specialized TMA kernel with per-CTA cumulative max and one atomic_max
+per CTA into a caller-provided scalar buffer.
+"""
+
+import itertools
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+from torchao.prototype.mx_formats.hadamard_utils import _compute_pid, get_rht_matrix
+from torchao.utils import is_sm_at_least_100
+
+# SM100+ autotune configs. BLOCK_M must be divisible by 16 (RHT reshape constraint).
+HADAMARD_TILE_SHAPES: list[tuple[int, int]] = [
+    (64, 32),
+    (64, 64),
+    (64, 128),
+    (128, 32),
+    (128, 64),
+]
+
+HADAMARD_CONFIGS: list[triton.Config] = [
+    triton.Config(
+        {"BLOCK_M": bm, "BLOCK_N": bn, "NUM_STAGES": ns},
+        num_warps=nw,
+        num_stages=ns,
+    )
+    for (bm, bn), ns, nw in itertools.product(
+        HADAMARD_TILE_SHAPES,
+        [2, 3, 4],  # NUM_STAGES
+        [4, 8],  # NUM_WARPS
+    )
+]
+
+
+@triton.autotune(configs=HADAMARD_CONFIGS, key=["M", "N"])
+@triton.jit
+def _hadamard_amax_kernel(
+    a_ptr,
+    b_ptr,
+    global_rht_amax_ptr,
+    global_a_amax_ptr,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUP_SIZE_N: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    """Persistent RHT kernel with fused amax reduction; no output tensor written."""
+    # Create TMA descriptors in-kernel from raw pointers and shape/stride
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[M, N],
+        strides=[N, 1],
+        block_shape=[BLOCK_M, BLOCK_N],
+    )
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[16, 16],
+        strides=[16, 1],
+        block_shape=[16, 16],
+    )
+
+    # Persistent grid-stride loop
+    start_pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_pid_in_group = GROUP_SIZE_N * num_pid_m
+    num_tiles = num_pid_m * num_pid_n
+
+    # Load (16, 16) random hadamard matrix once
+    hadamard = b_desc.load([0, 0])
+
+    # Track cumulative max across all tiles for this block
+    cumulative_rht_amax = tl.zeros((BLOCK_N * BLOCK_M // 16, 16), dtype=tl.float32)
+    cumulative_a_amax = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # warp-specialized: producer warps issue TMA loads, consumer warps run wgmma
+    for tile_id in tl.range(
+        start_pid,
+        num_tiles,
+        NUM_SMS,
+        flatten=False,
+        warp_specialize=True,
+        num_stages=NUM_STAGES,
+    ):
+        pid_n, pid_m = _compute_pid(tile_id, num_pid_in_group, num_pid_n, GROUP_SIZE_N)
+
+        # Load A (BLOCK_M, BLOCK_N)
+        a = a_desc.load([pid_m * BLOCK_M, pid_n * BLOCK_N])
+
+        # Transpose A_t (BLOCK_N, BLOCK_M)
+        a_t = tl.trans(a)
+
+        # Reshape to A_r (BLOCK_N * BLOCK_M//16, 16)
+        a_t_r = tl.reshape(a_t, [BLOCK_N * BLOCK_M // 16, 16])
+
+        a_t_rht = tl.dot(a_t_r, hadamard)
+
+        # Cast to bfloat16 like regular matmul output
+        a_t_rht = a_t_rht.to(tl.bfloat16)
+
+        # Update cumulative max at tile level to avoid failing
+        # TritonGPUAutomaticWarpSpecialization MLIR pass
+        abs_a_t_rht = tl.abs(a_t_rht)
+        cumulative_rht_amax = tl.maximum(cumulative_rht_amax, abs_a_t_rht)
+
+        cumulative_a_amax = tl.maximum(cumulative_a_amax, tl.abs(a.to(tl.float32)))
+
+    # Get scalar max for this block and update global max with atomic max operation
+    tile_rht_amax = tl.max(tl.max(cumulative_rht_amax, axis=1), axis=0)
+    tl.atomic_max(global_rht_amax_ptr, tile_rht_amax.to(tl.float32))
+
+    tile_a_amax = tl.max(tl.max(cumulative_a_amax, axis=1), axis=0)
+    tl.atomic_max(global_a_amax_ptr, tile_a_amax.to(tl.float32))
+
+
+def triton_rht_amax(
+    A: torch.Tensor,
+    sign_vector: tuple[int, ...] | None = None,
+    hadamard_dimension: int = 16,
+    scaling_type: F.ScalingType = F.ScalingType.TensorWise,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply RHT to A and return global absolute maxima without materializing output.
+
+    Args:
+        A: (M, N) bfloat16 tensor, row-major. M must be divisible by 16.
+        sign_vector: Optional sign vector for the RHT. If None, a random one is generated.
+        hadamard_dimension: Dimension of the Hadamard matrix (default 16).
+        scaling_type: ScalingType controlling reduction granularity. Only
+            ``ScalingType.TensorWise`` is currently supported.
+
+    Returns:
+        Tuple of (global_rht_amax, global_a_amax):
+          - global_rht_amax: scalar float32 containing max(abs(RHT(A))).
+          - global_a_amax: scalar float32 containing max(abs(A)).
+
+    Raises:
+        NotImplementedError: If hardware is pre-SM100.
+        ValueError: If A is not bfloat16, not 2-D, not contiguous, M % 16 != 0, or
+            scaling_type is not ScalingType.TensorWise.
+    """
+    if torch.cuda.is_available() and not is_sm_at_least_100():
+        raise NotImplementedError(
+            "Kernel requires SM100 (Blackwell); detected pre-SM100 hardware."
+        )
+    if A.dtype != torch.bfloat16:
+        raise ValueError(f"Expected bfloat16, got {A.dtype}")
+    if A.ndim != 2:
+        raise ValueError("Tensor A must be 2-D")
+    if not A.is_contiguous():
+        raise ValueError("A must be row-major (contiguous)")
+    if A.shape[0] % 16 != 0:
+        raise ValueError(f"M must be divisible by 16, got M={A.shape[0]}")
+    if scaling_type != F.ScalingType.TensorWise:
+        raise ValueError(
+            f"scaling_type={scaling_type!r} is not supported; "
+            "only ScalingType.TensorWise is implemented."
+        )
+    M, N = A.shape
+
+    NUM_SMS = torch.cuda.get_device_properties(A.device).multi_processor_count
+    GROUP_SIZE_N: int = 8  # L2 reuse grouping along M
+
+    # tl.make_tensor_descriptor requires a Triton allocator for per-CTA scratch space.
+    # Outside torch.compile, none is set by default; mirror what torch._inductor does.
+    if hasattr(triton, "set_allocator"):
+        triton.set_allocator(
+            lambda size, align, stream: torch.empty(
+                size, dtype=torch.int8, device=A.device
+            )
+        )
+
+    B = get_rht_matrix(
+        sign_vector=sign_vector, device=A.device, hadamard_dimension=hadamard_dimension
+    ).to(torch.bfloat16)
+    global_rht_amax = torch.zeros((), dtype=torch.float32, device=A.device)
+    global_a_amax = torch.zeros((), dtype=torch.float32, device=A.device)
+
+    _hadamard_amax_kernel[(NUM_SMS,)](
+        A,
+        B,
+        global_rht_amax,
+        global_a_amax,
+        M,
+        N,
+        GROUP_SIZE_N=GROUP_SIZE_N,
+        NUM_SMS=NUM_SMS,
+    )
+    return global_rht_amax, global_a_amax

--- a/torchao/prototype/mx_formats/hadamard_utils.py
+++ b/torchao/prototype/mx_formats/hadamard_utils.py
@@ -1,0 +1,99 @@
+"""RHT utility functions: Hadamard matrix construction, sign vector helpers, and Triton PIDs.
+
+Provides get_wgrad_sign_vector, get_hadamard_matrix, get_rht_matrix, cast_to_fp4x2,
+and the Triton JIT helper _compute_pid.
+"""
+
+import functools
+import math
+
+import torch
+from torch.utils._triton import has_triton
+
+
+def get_wgrad_sign_vector(
+    shape, device, dtype: torch.dtype = torch.bfloat16
+) -> torch.Tensor:
+    """Generate a random {-1, 1} sign vector for the Hadamard transform."""
+    return torch.where(
+        torch.rand(shape, device=device) >= 0.5,
+        torch.ones(shape, dtype=dtype, device=device),
+        -torch.ones(shape, dtype=dtype, device=device),
+    )
+
+
+def get_hadamard_matrix(
+    hadamard_dimension: int, device, dtype: torch.dtype = torch.bfloat16
+) -> torch.Tensor:
+    """Construct a 16x16 Hadamard matrix (scaled by 1/sqrt(16))."""
+    if hadamard_dimension != 16:
+        raise ValueError("Only hadamard dimension 16 is supported.")
+    hadamard_scale = 1 / math.sqrt(hadamard_dimension)
+    return (
+        torch.tensor(
+            [
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                [1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1],
+                [1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1],
+                [1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1],
+                [1, 1, 1, 1, -1, -1, -1, -1, 1, 1, 1, 1, -1, -1, -1, -1],
+                [1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1],
+                [1, 1, -1, -1, -1, -1, 1, 1, 1, 1, -1, -1, -1, -1, 1, 1],
+                [1, -1, -1, 1, -1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, -1],
+                [1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1],
+                [1, -1, 1, -1, 1, -1, 1, -1, -1, 1, -1, 1, -1, 1, -1, 1],
+                [1, 1, -1, -1, 1, 1, -1, -1, -1, -1, 1, 1, -1, -1, 1, 1],
+                [1, -1, -1, 1, 1, -1, -1, 1, -1, 1, 1, -1, -1, 1, 1, -1],
+                [1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1, 1, 1, 1, 1],
+                [1, -1, 1, -1, -1, 1, -1, 1, -1, 1, -1, 1, 1, -1, 1, -1],
+                [1, 1, -1, -1, -1, -1, 1, 1, -1, -1, 1, 1, 1, 1, -1, -1],
+                [1, -1, -1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1, -1, -1, 1],
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        * hadamard_scale
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def get_rht_matrix(
+    sign_vector: tuple[int, ...] | None,
+    device,
+    dtype: torch.dtype = torch.bfloat16,
+    hadamard_dimension: int = 16,
+) -> torch.Tensor:
+    """Construct an RHT matrix from an explicit sign vector or a generated sign vector."""
+    if sign_vector is None:
+        signs = get_wgrad_sign_vector(hadamard_dimension, device=device, dtype=dtype)
+    else:
+        if len(sign_vector) != hadamard_dimension:
+            raise ValueError(
+                f"Expected sign_vector length {hadamard_dimension}, "
+                f"got {len(sign_vector)}"
+            )
+        signs = torch.tensor(sign_vector, dtype=dtype, device=device)
+    sign_matrix = signs * torch.eye(hadamard_dimension, dtype=dtype, device=device)
+    return sign_matrix @ get_hadamard_matrix(
+        hadamard_dimension, device=device, dtype=dtype
+    )
+
+
+if has_triton():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _compute_pid(tile_id, num_pid_in_group, num_pid_n, GROUP_SIZE_N: tl.constexpr):
+        r"""Convert flat tile_id to (pid_n, pid_m) with L2-cache-friendly grouping."""
+        group_id = tile_id // num_pid_in_group
+        first_pid_n = group_id * GROUP_SIZE_N
+        group_size_n = tl.minimum(num_pid_n - first_pid_n, GROUP_SIZE_N)
+        pid_n = first_pid_n + (tile_id % group_size_n)
+        pid_m = (tile_id % num_pid_in_group) // group_size_n
+        return pid_n, pid_m
+
+else:
+
+    def _compute_pid(*args, **kwargs):
+        raise RuntimeError("_compute_pid requires Triton")


### PR DESCRIPTION
## Summary                                                                                                                                                              
                                                                                                                                                                          
  - Adds `triton_rht_amax` (`hadamard_amax_triton.py`): a persistent, warp-specialized Triton kernel that applies the Randomized Hadamard Transform (RHT) to the input and reduces to a scalar global absolute maximum, without materializing the full post-RHT tensor                                                                            
  - This is a prerequisite building block for `triton_rht_quantize_row_col`: the global amax determines the per-tensor decode scale (`global_amax / (FP8_E4M3_MAX × FP4_E2M1_MAX)`) used in two-level NVFP4 quantization                                                                                                                    
  - Adds `_compute_pid` and related RHT matrix helpers to `hadamard_utils.py`                                                                             
                                                                                                                                                                          
## Key design choices                                                                                                                                                  
  - **Persistent grid**: kernel launches with `NUM_SMS` CTAs and each CTA iterates over all tiles, amortizing launch overhead
  - **Warp specialization**: producer warps issue TMA loads; consumer warps run `wgmma` for the RHT matrix multiply
  - **No output buffer**: per-CTA cumulative max is reduced with one `atomic_max` per CTA, avoiding a full `(N, M)` intermediate allocation

## Performance
| Model | Shape | M | N | time_us | gbps |
|---|---|---:|---:|---:|---:|
| Llama 3 8B | hidden-state input | 2048 | 4096 | 19.488 | 860.900 |
| Llama 3 8B | mlp.down input | 2048 | 14336 | 31.744 | 1849.810 |
| Llama 3 70B | hidden-state input | 2048 | 8192 | 25.600 | 1310.720 |
| Llama 3 70B | mlp.down input | 2048 | 28672 | 46.048 | 2550.390 |
                                                                                                                                                                          
## Test plan                                                                                                                                                            
  - [ ] `pytest test/prototype/mx_formats/test_hadamard_amax_triton.py -v`                                                                                                
  - [ ] Covered transitively by `test_hadamard_quantize_row_col_triton.py` — incorrect amax would break scale computation and fail SQNR/bitwise tests 