### PR TITLE
[ROCm] Switch CI to allowlist of validated tests

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -52,7 +52,6 @@ jobs:
           test/test_utils.py \
           test/test_low_bit_optim.py \
           test/dtypes/test_nf4.py \
-          test/dtypes/test_affine_quantized.py \
           test/float8/test_base.py \
           test/float8/test_float8_utils.py \
           test/float8/test_numerics_integration.py \

--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -48,4 +48,27 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        pytest test --verbose -s
+        pytest \
+          test/test_utils.py \
+          test/test_low_bit_optim.py \
+          test/dtypes/test_nf4.py \
+          test/dtypes/test_affine_quantized.py \
+          test/float8/test_base.py \
+          test/float8/test_float8_utils.py \
+          test/float8/test_numerics_integration.py \
+          test/integration/test_integration.py \
+          test/prototype/test_smoothquant.py \
+          test/prototype/blockwise_fp8_training/ \
+          test/prototype/moe_training/test_kernels.py \
+          test/prototype/moe_training/test_mxfp8_grouped_mm.py \
+          test/prototype/mx_formats/test_mx_tensor.py \
+          test/prototype/mx_formats/test_mx_mm.py \
+          test/prototype/mx_formats/test_inference_workflow.py \
+          test/prototype/mx_formats/test_nvfp4_tensor.py \
+          test/quantization/test_observer.py \
+          test/quantization/test_qat.py \
+          test/quantization/test_quant_api.py \
+          test/quantization/test_quant_primitives.py \
+          test/quantization/quantize_/workflows/float8/test_float8_tensor.py \
+          test/quantization/quantize_/workflows/int4/test_int4_tile_packed_to_4d_tensor.py \
+          --verbose -s


### PR DESCRIPTION
Currently the ROCm CI workflow runs `pytest test` which executes the entire test suite. Most of those tests are irrelevant on ROCm (x86/ARM quantizers, CUTLASS sparse kernels, CoreML codebook tests, etc.) and just add CI time and noise.

This switches to an explicit list of test files that have been validated on MI300X across the ROCm enablement PRs. Individual tests within these files that aren't yet supported still skip themselves via `@skip_if_rocm`. The list can be extended as we enable more functionality.

Addresses #4219.

cc @jerryzh168