### PR TITLE
[xpu][mx] Enable mx matmul tests on xpu

### DIFF
--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -13,37 +13,20 @@ from torch.nn.functional import ScalingType, SwizzleType
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
-from torchao.utils import is_sm_at_least_100
-
-
-def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
-    """Wrapper for F.scaled_mm with MXFP4 configuration."""
-    return F.scaled_mm(
-        a_data.view(torch.float4_e2m1fn_x2),
-        b_data.view(torch.float4_e2m1fn_x2),
-        scale_a=a_scale_block,
-        scale_recipe_a=ScalingType.BlockWise1x32,
-        scale_b=b_scale_block,
-        scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-        output_dtype=torch.bfloat16,
-    )
+from torchao.utils import (
+    is_sm_at_least_100,
+    torch_version_at_least,
+)
 
 
 def run_matrix_test(M: int, K: int, N: int, format) -> float:
     dtype = torch.bfloat16
-    device = torch.device("cuda")
+    device = torch.accelerator.current_accelerator()
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-    mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-        if format == "fp8"
-        else _mxfp4_scaled_mm
-    )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -56,20 +39,47 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if device == torch.device("cuda"):
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
+    else:
+        a_scale_block = a_scale
+        b_scale_block = b_scale
+
+    swizzle_type = (
+        SwizzleType.SWIZZLE_32_4_4
+        if device == torch.device("cuda")
+        else SwizzleType.NO_SWIZZLE
+    )
+    mx_func = partial(
+        F.scaled_mm,
+        scale_a=a_scale_block,
+        scale_recipe_a=ScalingType.BlockWise1x32,
+        scale_b=b_scale_block,
+        scale_recipe_b=ScalingType.BlockWise1x32,
+        swizzle_a=swizzle_type,
+        swizzle_b=swizzle_type,
+        output_dtype=torch.bfloat16,
+    )
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+    out = mx_func(a_data.view(fmt), b_data.view(fmt))
 
     return compute_error(out_hp, out).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not torch.accelerator.is_available(), reason="No accelerator available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
+)
+@pytest.mark.skipif(
+    torch.xpu.is_available() and not torch_version_at_least("2.13.0"),
+    reason="XPU blockwise scaled_mm requires PyTorch 2.13+ (pytorch/pytorch#173630, #176043, #176064)",
 )
 @pytest.mark.parametrize(
     "size",

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -784,28 +784,49 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.is_swizzled_scales:
+        data_is_cuda = a.qdata.is_cuda
+
+        if a.is_swizzled_scales or not data_is_cuda:
             a_scale_block = a.scale
         else:
             a_scale = a.scale.view(M, K // a.block_size)
             a_scale_block = maybe_dtensor_to_blocked(a_scale)
 
-        if b.is_swizzled_scales:
+        if b.is_swizzled_scales or not data_is_cuda:
             b_scale_block = b.scale.t()
         else:
             b_scale = b.scale.t().view(N, K // b.block_size)
             b_scale_block = maybe_dtensor_to_blocked(b_scale)
 
+        if data_is_cuda:
+            swizzle_type = SwizzleType.SWIZZLE_32_4_4
+        else:
+            swizzle_type = SwizzleType.NO_SWIZZLE
+
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            res = torch._scaled_mm(
-                a.qdata,
-                b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
-                bias=bias,
-                out_dtype=torch.bfloat16,
-            )
+            if torch_version_at_least("2.10.0"):
+                res = F.scaled_mm(
+                    a.qdata,
+                    b.qdata,
+                    scale_a=a_scale_block.view(torch.float8_e8m0fnu),
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b_scale_block.view(torch.float8_e8m0fnu),
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=swizzle_type,
+                    swizzle_b=swizzle_type,
+                    bias=bias,
+                    output_dtype=torch.bfloat16,
+                )
+            else:
+                res = torch._scaled_mm(
+                    a.qdata,
+                    b.qdata,
+                    a_scale_block.view(torch.float8_e8m0fnu),
+                    b_scale_block.view(torch.float8_e8m0fnu),
+                    bias=bias,
+                    out_dtype=torch.bfloat16,
+                )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
@@ -817,8 +838,8 @@ def _addmm_mx_dispatch(
                 scale_recipe_a=ScalingType.BlockWise1x32,
                 scale_b=b_scale_block,
                 scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_a=swizzle_type,
+                swizzle_b=swizzle_type,
                 bias=bias,
                 output_dtype=torch.bfloat16,
             )


### PR DESCRIPTION
In the context of https://github.com/pytorch/ao/issues/3576.

To enable matmul tests on xpu, the "new" PyTorch matmul API needs to be used with torch 2.10+.

The older `torch._scaled_mm` infers scaling type and memory layout from tensor shapes alone. This only works on CUDA with the specific swizzled scale layout the hardware expects. 

PyTorch 2.10 introduced `torch.functional.scaled_mm` as the public API. It takes explicit `ScalingType` and `SwizzleType` arguments, making it possible to specify non-swizzled layouts needed by backends like XPU.
