### PR TITLE
Use fixed scale for Float8 softmax quantization instead of observer

### DIFF
--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -531,7 +531,6 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
         # Verify observers were inserted
         self.assertIsInstance(model.linear, Float8ObservedLinear)
         self.assertIsInstance(model.softmax, Float8ObservedSoftmax)
-        self.assertIsNotNone(model.softmax.output_act_obs)
 
         # Step 2: Calibrate with representative data
         for _ in range(10):

--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -517,6 +517,8 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
         self.assertIsInstance(model.linear, Float8ObservedLinear)
         self.assertIsInstance(model.softmax, Float8ObservedSoftmax)
 
+        # Calibration loop: needed for linear observers to collect min/max stats.
+        # For softmax, this only records the input device (scale is fixed).
         for _ in range(10):
             model(*example_inputs)
 

--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -494,92 +494,110 @@ class TestFloat8StaticActivation(TorchAOIntegrationTestCase):
             self.assertEqual(output.dtype, dtype)
 
     def test_static_quant_softmax(self):
-        """
-        Test static quantization of Softmax output.
-
-        This tests the flow:
-        1. Prepare model by inserting observers on Softmax (step="prepare")
-        2. Calibrate with representative data
-        3. Convert observed model to quantized model (step="convert")
-        4. Verify the Softmax output is quantized and dequantized
-        """
+        """Test end-to-end static quantization of Softmax with SQNR and compile."""
         torch.compiler.reset()
         torch.manual_seed(42)
 
         dtype = self.dtype
 
-        # Create model with Linear + Softmax
         model = ToyLinearSoftmaxModel(
             input_dim=64, output_dim=32, dtype=dtype, device="cuda"
         ).eval()
         example_inputs = model.example_inputs(batch_size=4)
-
-        # Get reference output before quantization
         before_quant = model(*example_inputs)
 
-        # Filter function that matches both Linear and Softmax
         def linear_or_softmax_filter(module, fqn):
             return isinstance(module, (torch.nn.Linear, torch.nn.Softmax))
 
-        # Step 1: Prepare model by inserting observers
         quantize_(
             model,
             Float8StaticActivationFloat8WeightConfig(step="prepare"),
             filter_fn=linear_or_softmax_filter,
         )
-
-        # Verify observers were inserted
         self.assertIsInstance(model.linear, Float8ObservedLinear)
         self.assertIsInstance(model.softmax, Float8ObservedSoftmax)
 
-        # Step 2: Calibrate with representative data
         for _ in range(10):
             model(*example_inputs)
 
-        # Filter function for convert step (matches observed modules)
         def observed_filter(module, fqn):
             return isinstance(module, (Float8ObservedLinear, Float8ObservedSoftmax))
 
-        # Step 3: Convert observed model to quantized model
         quantize_(
             model,
             Float8StaticActivationFloat8WeightConfig(step="convert"),
             filter_fn=observed_filter,
         )
-
-        # Verify quantization was applied
         self.assertIsInstance(model.linear.weight, PrototypeFloat8Tensor)
         self.assertIsInstance(model.softmax, Float8QuantizedSoftmax)
         self.assertIsNotNone(model.softmax.output_act_quant_scale)
         self.assertIsNotNone(model.softmax.output_act_quant_kwargs)
 
-        # Test inference - output should be a regular tensor (dequantized)
         after_quant = model(*example_inputs)
-
-        # The output should be a regular tensor since we dequantize after quantizing
         self.assertNotIsInstance(after_quant, PrototypeFloat8Tensor)
         self.assertEqual(after_quant.dtype, dtype)
 
-        # Verify quantization quality
         error = compute_error(before_quant, after_quant)
-        self.assertGreater(
-            error,
-            15,
-            f"SQNR of quantized vs original should be > 15 dB, got {error}",
-        )
+        self.assertGreater(error, 15, f"SQNR should be > 15 dB, got {error}")
 
-        # Test with torch.compile
+        # torch.compile
         model_compiled = torch.compile(model, fullgraph=True)
         after_quant_compiled = model_compiled(*example_inputs)
-
         self.assertNotIsInstance(after_quant_compiled, PrototypeFloat8Tensor)
         self.assertEqual(after_quant_compiled.dtype, dtype)
         error_compiled = compute_error(before_quant, after_quant_compiled)
         self.assertGreater(
-            error_compiled,
-            15,
-            f"SQNR of compiled quantized vs original should be > 15 dB, got {error_compiled}",
+            error_compiled, 15, f"Compiled SQNR should be > 15 dB, got {error_compiled}"
         )
+
+    def test_static_quant_softmax_device_and_dims(self):
+        """Test Float8QuantizedSoftmax with different devices and input dimensions."""
+        torch.compiler.reset()
+        torch.manual_seed(42)
+
+        dtype = self.dtype
+
+        input_shapes = [
+            (4, 32),  # 2D
+            (2, 4, 32),  # 3D
+            (2, 2, 4, 32),  # 4D
+        ]
+        for device in ["cpu", "cuda"]:
+            for shape in input_shapes:
+                container = torch.nn.ModuleDict({"softmax": torch.nn.Softmax(dim=-1)})
+
+                def softmax_filter(module, fqn):
+                    return isinstance(module, torch.nn.Softmax)
+
+                quantize_(
+                    container,
+                    Float8StaticActivationFloat8WeightConfig(step="prepare"),
+                    filter_fn=softmax_filter,
+                )
+
+                x = torch.randn(shape, dtype=dtype, device=device)
+                container.softmax(x)
+
+                def obs_filter(module, fqn):
+                    return isinstance(module, Float8ObservedSoftmax)
+
+                quantize_(
+                    container,
+                    Float8StaticActivationFloat8WeightConfig(step="convert"),
+                    filter_fn=obs_filter,
+                )
+
+                self.assertIsInstance(container.softmax, Float8QuantizedSoftmax)
+                self.assertEqual(
+                    container.softmax.output_act_quant_scale.device.type,
+                    device,
+                    f"Scale device mismatch for {device}, shape {shape}",
+                )
+
+                output = container.softmax(x)
+                self.assertEqual(output.device.type, device)
+                self.assertEqual(output.shape, shape)
+                self.assertEqual(output.dtype, dtype)
 
 
 if __name__ == "__main__":

--- a/torchao/prototype/quantization/quant_api.py
+++ b/torchao/prototype/quantization/quant_api.py
@@ -436,10 +436,14 @@ class Float8QuantizedSoftmax(torch.nn.Module):
 
         # Apply quantize-and-dequantize if configured
         if self.output_act_quant_kwargs is not None:
+            # Reshape scale to match output ndim (e.g. [448.] -> [[448.]] for 2D)
+            scale = self.output_act_quant_scale
+            while scale.ndim < output.ndim:
+                scale = scale.unsqueeze(0)
             quantized_output = _choose_quant_func_and_quantize_tensor(
                 output,
                 self.output_act_quant_kwargs,
-                act_quant_scale=self.output_act_quant_scale,
+                act_quant_scale=scale,
             )
             output = quantized_output.dequantize()
 

--- a/torchao/prototype/quantization/quant_api.py
+++ b/torchao/prototype/quantization/quant_api.py
@@ -384,8 +384,10 @@ class Float8ObservedSoftmax(torch.nn.Softmax):
         dim: Optional[int] = None,
     ):
         super().__init__(dim=dim)
+        self._device: Optional[torch.device] = None
 
     def forward(self, input: Tensor) -> Tensor:
+        self._device = input.device
         return F.softmax(input, self.dim, _stacklevel=5)
 
     @classmethod
@@ -518,7 +520,9 @@ def _float8_static_activation_float8_weight_transform(
             # Softmax output is in [0, 1], so use a fixed scale:
             # scale = float8_max / 1.0 = float8_max
             float8_max = torch.finfo(config.activation_dtype).max
-            output_act_quant_scale = torch.tensor([float8_max], dtype=torch.float32)
+            output_act_quant_scale = torch.tensor(
+                [float8_max], dtype=torch.float32, device=module._device
+            )
 
             output_act_quant_kwargs = QuantizeTensorToFloat8Kwargs(
                 float8_dtype=config.activation_dtype,

--- a/torchao/prototype/quantization/quant_api.py
+++ b/torchao/prototype/quantization/quant_api.py
@@ -377,6 +377,9 @@ class Float8ObservedSoftmax(torch.nn.Softmax):
     Softmax output is always in [0, 1], so we use a fixed scale of
     ``finfo(float8_dtype).max`` instead of observing. This module simply
     marks the softmax for later conversion by the convert step.
+
+    Unlike linear observers, the calibration loop does not collect statistics
+    here — it only records the input device for scale tensor placement.
     """
 
     def __init__(
@@ -422,10 +425,25 @@ class Float8QuantizedSoftmax(torch.nn.Module):
         else:
             self.output_act_quant_scale = None
         self.output_act_quant_kwargs = output_act_quant_kwargs
+        # Cached version of scale reshaped to match input ndim, populated on first forward
+        self._reshaped_scale: Optional[torch.Tensor] = None
 
     @property
     def dim(self) -> Optional[int]:
         return self._dim
+
+    def _get_reshaped_scale(self, target_ndim: int) -> torch.Tensor:
+        """Return the scale reshaped to match target_ndim, caching the result."""
+        if (
+            self._reshaped_scale is not None
+            and self._reshaped_scale.ndim == target_ndim
+        ):
+            return self._reshaped_scale
+        scale = self.output_act_quant_scale
+        while scale.ndim < target_ndim:
+            scale = scale.unsqueeze(0)
+        self._reshaped_scale = scale
+        return scale
 
     def forward(self, input: Tensor) -> Tensor:
         from torchao.prototype.quantization.float8_static_quant.prototype_float8_tensor import (
@@ -436,10 +454,7 @@ class Float8QuantizedSoftmax(torch.nn.Module):
 
         # Apply quantize-and-dequantize if configured
         if self.output_act_quant_kwargs is not None:
-            # Reshape scale to match output ndim (e.g. [448.] -> [[448.]] for 2D)
-            scale = self.output_act_quant_scale
-            while scale.ndim < output.ndim:
-                scale = scale.unsqueeze(0)
+            scale = self._get_reshaped_scale(output.ndim)
             quantized_output = _choose_quant_func_and_quantize_tensor(
                 output,
                 self.output_act_quant_kwargs,
@@ -521,11 +536,18 @@ def _float8_static_activation_float8_weight_transform(
     elif step == QuantizationStep.CONVERT or step == "convert":
         # Handle observed Softmax modules
         if isinstance(module, Float8ObservedSoftmax):
+            device = module._device
+            if device is None:
+                logger.warning(
+                    "Float8ObservedSoftmax._device is None (forward() was never called). "
+                    "Defaulting scale device to CPU."
+                )
+                device = torch.device("cpu")
             # Softmax output is in [0, 1], so use a fixed scale:
             # scale = float8_max / 1.0 = float8_max
             float8_max = torch.finfo(config.activation_dtype).max
             output_act_quant_scale = torch.tensor(
-                [float8_max], dtype=torch.float32, device=module._device
+                [float8_max], dtype=torch.float32, device=device
             )
 
             output_act_quant_kwargs = QuantizeTensorToFloat8Kwargs(

--- a/torchao/prototype/quantization/quant_api.py
+++ b/torchao/prototype/quantization/quant_api.py
@@ -372,41 +372,29 @@ class Float8ObservedLinear(torch.nn.Linear):
 
 class Float8ObservedSoftmax(torch.nn.Softmax):
     """
-    A softmax module with an observer for float8 static quantization.
+    A softmax module placeholder for float8 static quantization.
 
-    This module wraps a softmax layer and adds an AffineQuantizedMinMaxObserver
-    that collects statistics on the output during calibration. After calibration,
-    use `quantize_` with `Float8StaticActivationFloat8WeightConfig(step="convert")`
-    to convert to a quantized softmax module that applies quantize-and-dequantize
-    to simulate quantization error.
+    Softmax output is always in [0, 1], so we use a fixed scale of
+    ``finfo(float8_dtype).max`` instead of observing. This module simply
+    marks the softmax for later conversion by the convert step.
     """
 
     def __init__(
         self,
         dim: Optional[int] = None,
-        output_act_obs: Optional["AffineQuantizedMinMaxObserver"] = None,  # noqa: F821
     ):
         super().__init__(dim=dim)
-        self.output_act_obs = output_act_obs
 
     def forward(self, input: Tensor) -> Tensor:
-        output = F.softmax(input, self.dim, _stacklevel=5)
-        if self.output_act_obs is not None:
-            self.output_act_obs(output)
-        return output
+        return F.softmax(input, self.dim, _stacklevel=5)
 
     @classmethod
     def from_float(
         cls,
         float_softmax: torch.nn.Softmax,
-        output_act_obs: "AffineQuantizedMinMaxObserver",  # noqa: F821
     ) -> "Float8ObservedSoftmax":
         """Create an observed softmax from a float softmax module."""
-        observed_softmax = cls(
-            dim=float_softmax.dim,
-            output_act_obs=output_act_obs,
-        )
-        return observed_softmax
+        return cls(dim=float_softmax.dim)
 
 
 class Float8QuantizedSoftmax(torch.nn.Module):
@@ -497,16 +485,7 @@ def _float8_static_activation_float8_weight_transform(
     if step == QuantizationStep.PREPARE or step == "prepare":
         # Handle Softmax modules
         if isinstance(module, torch.nn.Softmax):
-            output_observer = AffineQuantizedMinMaxObserver(
-                mapping_type=MappingType.SYMMETRIC,
-                target_dtype=config.activation_dtype,
-                granularity=granularity,
-                eps=torch.finfo(torch.float32).eps,
-                scale_dtype=torch.float32,
-                zero_point_dtype=torch.float32,
-                keepdim=True,
-            )
-            return Float8ObservedSoftmax.from_float(module, output_observer)
+            return Float8ObservedSoftmax.from_float(module)
 
         # Handle Linear modules
         # Create input observer and wrap linear
@@ -536,14 +515,10 @@ def _float8_static_activation_float8_weight_transform(
     elif step == QuantizationStep.CONVERT or step == "convert":
         # Handle observed Softmax modules
         if isinstance(module, Float8ObservedSoftmax):
-            if module.output_act_obs is None:
-                logger.warning(
-                    "Float8ObservedSoftmax has no output observer, returning as-is"
-                )
-                return module
-
-            # Extract output scale from observer
-            output_act_quant_scale, _ = module.output_act_obs.calculate_qparams()
+            # Softmax output is in [0, 1], so use a fixed scale:
+            # scale = float8_max / 1.0 = float8_max
+            float8_max = torch.finfo(config.activation_dtype).max
+            output_act_quant_scale = torch.tensor([float8_max], dtype=torch.float32)
 
             output_act_quant_kwargs = QuantizeTensorToFloat8Kwargs(
                 float8_dtype=config.activation_dtype,
@@ -554,7 +529,7 @@ def _float8_static_activation_float8_weight_transform(
 
             return Float8QuantizedSoftmax.from_observed(
                 module,
-                output_act_quant_scale=output_act_quant_scale.detach(),
+                output_act_quant_scale=output_act_quant_scale,
                 output_act_quant_kwargs=output_act_quant_kwargs,
             )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4260

Summary:
Softmax output is always in [0, 1], so observing during calibration is
unnecessary. Replace the observer-based flow with a fixed output scale
of `finfo(float8_dtype).max / 1.0` (448.0 for float8_e4m3fn). This
simplifies `Float8ObservedSoftmax` to a plain marker module and removes
the observer allocation + calibration overhead for softmax layers.

Test Plan:
pytest test/prototype/test_prototype_float8_tensor.py -k test_static_quant_softmax -x