### PR TITLE
[xpu][test] Ignore test_x86inductor_fusion.py on XPU CI as it is not target

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -14,7 +14,8 @@ python3 -c "import torch; import torchao; print(f'Torch version: {torch.__versio
 
 pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire
 
-pytest -v -s torchao/test/quantization/pt2e/ \
+pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py \
+        torchao/test/quantization/pt2e/ \
         torchao/test/quantization/*.py \
         torchao/test/dtypes/ \
         torchao/test/float8/ \


### PR DESCRIPTION
This PR is used to align the behavior in the  test_x86inductor_fusion.py between CUDA and XPU. For these UTs , they are all validated on the CPU instead of GPU device. 