### PR TITLE
Add torch.uint16, torch.uint32

### DIFF
--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -136,7 +136,9 @@ with warnings.catch_warnings():
     _DTYPE_TO_QVALUE_BOUNDS: Dict[Union[torch.dtype, TorchAODType], Tuple[int, int]] = {
         torch.uint8: (0, 255),
         torch.int8: (-128, 127),
+        torch.uint16: (0, 2**16 - 1),
         torch.int16: (-(2**15), 2**15 - 1),
+        torch.uint32: (0, 2**32 - 1),
         torch.int32: (-(2**31), 2**31 - 1),
     }
 
@@ -150,7 +152,9 @@ with warnings.catch_warnings():
         TorchAODType.INT7: 7,
         torch.uint8: 8,
         torch.int8: 8,
+        torch.uint16: 16,
         torch.int16: 16,
+        torch.uint32: 32,
         torch.int32: 32,
     }
 


### PR DESCRIPTION
- **[TP] reorder MXFP8 wrapper over DTensor (#4010)**
- **Patch nightly Linux AArch64-specific wheel build (#3954)**
- **[ROCm] Fix ROCm CI failures (#4061)**
- **Add CuTeDSL kernel for 3D tensor quantization to MXFP8 (#4090)**
- **[mxfp8] fix exp2f_rcp to handle special case of unbiased exponent of 127 (#4117)**
- **add bandwidth benchmarking script for fp8 quant blockwise (#4128)**
- **Delete autoquant_v2 and subgraph_utils (#4121)**
- **Delete deprecated autoquant v1 and all references (#4122)**
- **Delete deprecated CutlassSemiSparseLayout and related code (#4126)**
- **Upgrade torchao build configs to C++20 (#4025)**
- **[mxfp8 moe training] remove unnecessary memory fences in cutedsl kernel; unify redundant conditionals (#4129)**
- **Delete deprecated Float8Layout and Float8AQTTensorImpl (#4127)**
- **[moe training] Optimize FP8 MoE backward pass: fused colwise kernel + AMD tuning (#4069)**
- **[claude] Make MXFP8 cuda kernels ABI stable (#3610)**
- **Add cross attention support for low precision attention API (#4142)**
- **[mxfp8 training] require torch nightly and cuda 12.8+ (#4141)**
- **Delete deprecated BlockSparseLayout and related code (#4143)**
- **Delete deprecated GemlitePackedLayout and GemliteUIntXWeightOnlyConfig (#4144)**
- **[X86] Re-enable DA8W4 path on X86 CPU (#4033)**
- **Remove version compatibility table (#4154)**
- **Suppress deprecation warnings from #4074 and #4100 (#4155)**
- **Delete deprecated UintxLayout and related code (#4145)**
- **Delete deprecated QDQLayout and related code (#4146)**
- **Delete deprecated Int4XPULayout and related code (#4147)**
- **Delete deprecated SemiSparseLayout and related code (#4148)**
- **Delete deprecated Int4CPULayout and related code (#4149)**
- **Delete deprecated PackedLinearInt8DynamicActivationIntxWeightLayout and related code (#4150)**
- **Fix test_sparse_api failures for builds without hipSPARSELt (#4125) (#4125)**
- **[reland][xpu] INT8 quantization on Intel XPU (#3782)**
- **Skip test_fsdp2 if PyTorch version is 2.11.0 or higher (#4168)**
- **Move bitpacking.py to prototype and add uintx_utils.py (#4152)**
- **Fix rocm CI (#4167)**
- **[xpu][test] Skip WIP config for Intel GPU in test_safetensors_support.py and test_x86inductor_fusion.py (#4049)**
- **Remove tensor parallel test for v1 of Int8DynamicActivationInt8WeightConfig (#4169)**
- **clean up unused rocm references in test_training.py (#4170)**
- **[mxfp8 training] add cutedsl kernel for mxfp8 quantation along dim0 (#4156)**
- **Add PerGroup granularity for Float8WeightOnly config (#4174)**
- **Add embedding op support for Float8Tensor with PerGroup quantization (#4175)**
- **remove per kernel fp8 triton quantized benchmarks (#4166)**
- **Add WAN style rope detection pattern for low precision attention API (#4173)**
- **[mxfp8 moe training] refactor autograd func (#4176)**
- **[mxfp8 moe training] remove unused block_size arg (#4177)**
- **Add better debug print for failed prepare (#3950)**
- **fix undefined values for tail elements in act quant kernels (#4186)**
- **[mxfp8 moe training] register sharding rules for cutedsl 2d quant kernel (#4178)**
- **[CPU] Add software prefetch to overlap bandwidth for scaled_embedding_bag (#4171)**
- **[X86] intmm: Use u8s8 when only support avx512-vnni (#4103)**
- **Add CodeML'25 BibTeX (#3978)**
- **add rope fusion detection tests (#4183)**
- **Bump version from 0.17.0 to 0.18.0 (#4202)**
- **[xpu][test] Add weekly test for Intel GPU (#4190)**
- **add torch.compile test for Float8BlockwiseLinear (#4187)**
- **install torchvision to resolve ci issue (#4203)**
- **Create recipe for flux2pro running on AMD (#4200)**
- **fix ruff on main branch (#4207)**
- **Add CLAUDE.md with AI agent instructions and quick reference (#4195)**
- **Add llms.txt to docs site for LLM crawler discoverability (#4196)**
- **Skip test_comm for nvfp4 (#4210)**
- **[CPU] Update qsdpa lowering to return only the output node (#4162)**
- **Bump version from 0.17.0 to 0.18.0 (#4172)**
- **Fix NF4Tensor narrow() crash with recent PyTorch nightly (#4208)**
- **Delete deprecated TensorCoreTiledLayout and related code (#4153)**
- **[CPU] Re-enable the previously failing test_fp8_q_attention_block UT (#4212)**
- **[CPU] Rename Int4WeightOnlyOpaqueTensorConfig to PrototypeInt4WeightOnlyConfig (#4205)**
- **add hadamard option to low precision attention api (#4194)**
- **[ROCm] Enable FP8 QAT test on MI300/MI350 (#4132)**
- **Delete benchmark_e2e_fp8_sparse_linear.py (#4217)**
- **Add RunningAbsMaxSmoothQuantObserver for memory-efficient calibration (#3946)**
- **Add zero_point and act_mapping_type checks in int8 quantization (#4160)**
- **Fix ROCM CI: skipped some tests, added checks, install torchvision (#4218)**
- **support pinning for mx and nvfp4 tensors (#4192)**
- **Expand CODEOWNERS and add GitHub issue templates (#4197)**
- **Delete deprecated PlainLayout, PlainAQTTensorImpl and related v1 code paths (#4151)**
- **[nvfp4] Make per_tensor_scale optional for triton kernel path (#4188)**
- **unbreak gptq int4 test and add to CI (#4223)**
- **add sharding rules for fp8 blockwise kernels (#4220)**
- **Replace mock-based MI350 tests with functional PerRow FP8 test (#4228)**
- **gptq: rename `W` to `W_t` (#4224)**
- **gptq: more obvious block var names (#4225)**
- **gptq: more obvious group var names (#4226)**
- **gptq: more obvious inner loop var names (#4227)**
- **fix ruff (#4235)**
- **[moe training] fix fp8 grouped mm compile issue (#4233)**
- **[mxfp8 training] make alignment size configurable in benchmark script (#4246)**
- **[mxfp8 training] add cutedsl kernel for 32x1 mxfp8 quantization on 2d tensors (#4239)**
- **[pt2e] Skip linear+bn fusion when input is higher than 2-D (#4242)**
- **Add alg_id argument to SemiSparseWeightConfig (#4238) (#4238)**
- **Update clean_release_notes.py to use per-module highlights (#4250)**
- **[nvfp4 training] emulated nvfp4 grouped gemm (#4240)**
- **[mxfp8 training] update triton_to_mxfp8_dim0 nan handling; fix offset int32 overflow issue (#4201)**
- **Delete AffineQuantizedTensor, AQTTensorImpl, and Layout (#4245)**
- **Adding V-only Hadamard support to low precision attention API (#4249)**
- **Remove tutorials/calibration_flow/ and update stale references (#4257)**
- **Remove LinearActivationQuantizedTensor and all related code (#4258)**
- **Prevent folding of mutable input to copy_ and put_ operators (#4181)**
- **[xpu][test] Ignore test_x86inductor_fusion.py on XPU CI as it is not target (#4265)**
- **Remove LinearActivationWeightObservedTensor and insert_observers_ (#4261)**
- **Remove WeightTensorWithLinearActivationScaleMetadata and related code (#4262)**
- **Remove WeightTensorWithLinearActivationQuantizationMetadata (#4263)**
- **Use fixed scale for Float8 softmax quantization instead of observer (#4260)**
- **Add torch.uint16, torch.uint32**
