### PR TITLE
[xpu][mx] Fix NaN scale propagation in RCEIL triton kernel

### DIFF
--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -512,12 +512,9 @@ if _triton_kernels_available:
         max_abs = tl.max(x, axis=axis)
 
         # Check for NaN presence: if ANY element in each row is NaN,
-        # set that row's max_abs to NaN (per-axis NaN detection)
+        # flag that row for post-chain correction (see below).
         nan_mask = x != x
         has_nan_per_axis = tl.max(nan_mask, axis=axis)
-
-        # If any element in a row was NaN, set that row's max_abs to NaN
-        max_abs = tl.where(has_nan_per_axis > 0, float("nan"), max_abs)
 
         F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
 
@@ -544,6 +541,17 @@ if _triton_kernels_available:
             scale_e8m0_biased = (scale_e8m0_unbiased + 127).to(tl.uint8)
 
         descale_fp = _calculate_reciprocal_scale(scale_e8m0_biased)
+
+        # Overwrite scale and descale for NaN rows. This is done after the
+        # chain rather than by injecting NaN into max_abs, because tl.clamp
+        # and .to(uint8) silently destroy NaN on SPIR-V backends (XPU):
+        # - tl.clamp uses NaN-ignoring fmin/fmax, so tl.clamp(NaN) → -127.0
+        #   (intel/intel-xpu-backend-for-triton#5003)
+        # - fptoui(NaN) is undefined behavior per LLVM spec, returning 0 on
+        #   XPU instead of the expected 255
+        # 255 is the E8M0 NaN encoding; NaN descale ensures NaN propagation.
+        scale_e8m0_biased = tl.where(has_nan_per_axis > 0, 255, scale_e8m0_biased)
+        descale_fp = tl.where(has_nan_per_axis > 0, float("nan"), descale_fp)
 
         return descale_fp, scale_e8m0_biased
 

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -510,12 +510,9 @@ if _triton_kernels_available:
         max_abs = tl.max(x, axis=axis)
 
         # Check for NaN presence: if ANY element in each row is NaN,
-        # set that row's max_abs to NaN (per-axis NaN detection)
+        # flag that row for post-chain correction (see below).
         nan_mask = x != x
         has_nan_per_axis = tl.max(nan_mask, axis=axis)
-
-        # If any element in a row was NaN, set that row's max_abs to NaN
-        max_abs = tl.where(has_nan_per_axis > 0, float("nan"), max_abs)
 
         F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
 
@@ -542,6 +539,17 @@ if _triton_kernels_available:
             scale_e8m0_biased = (scale_e8m0_unbiased + 127).to(tl.uint8)
 
         descale_fp = _calculate_reciprocal_scale(scale_e8m0_biased)
+
+        # Overwrite scale and descale for NaN rows. This is done after the
+        # chain rather than by injecting NaN into max_abs, because tl.clamp
+        # and .to(uint8) silently destroy NaN on SPIR-V backends (XPU):
+        # - tl.clamp uses NaN-ignoring fmin/fmax, so tl.clamp(NaN) → -127.0
+        #   (intel/intel-xpu-backend-for-triton#5003)
+        # - fptoui(NaN) is undefined behavior per LLVM spec, returning 0 on
+        #   XPU instead of the expected 255
+        # 255 is the E8M0 NaN encoding; NaN descale ensures NaN propagation.
+        scale_e8m0_biased = tl.where(has_nan_per_axis > 0, 255, scale_e8m0_biased)
+        descale_fp = tl.where(has_nan_per_axis > 0, float("nan"), descale_fp)
 
         return descale_fp, scale_e8m0_biased
 


### PR DESCRIPTION
In the context of https://github.com/pytorch/ao/issues/3576.

Fix NaN scale propagation in RCEIL triton kernel for SPIR-V backends

On XPU's SPIR-V backend, `tl.clamp` and `.to(uint8)` silently destroy NaN values:
- `tl.clamp` uses NaN-ignoring `fmin/fmax` (returning -127.0 instead of NaN) - see [intel/intel-xpu-backend-for-triton#5003](https://github.com/intel/intel-xpu-backend-for-triton/issues/5003) and [KhronosGroup/SPIRV-LLVM-Translator#3282](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3282)
- `fptoui(NaN)`, used by `.to(uint8)` is undefined behavior per the LLVM spec (returning 0 instead of 255) - see [The LLVM LangRef `fptoui` semantics section](https://llvm.org/docs/LangRef.html#fptoui-to-instruction)

The existing NaN workaround in `_triton_calculate_scale_rceil` correctly detected NaN blocks via `x != x` + `tl.max(nan_mask)`, but then injected NaN into `max_abs`, which was subsequently killed by `tl.clamp` further down the chain.

The proposed solution is to move the NaN correction after the `log2 -> ceil -> clamp -> +127 -> to(uint8)` chain.
