### PR TITLE
[ROCm] Add MXFP8 training support for gfx950 (MI355X)

### DIFF
--- a/benchmarks/prototype/moe_training/bench_2d_3d_grouped_gemm.py
+++ b/benchmarks/prototype/moe_training/bench_2d_3d_grouped_gemm.py
@@ -23,6 +23,7 @@ from torchao.prototype.moe_training.kernels.mxfp8 import (
 )
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 from torchao.prototype.mx_formats.mx_tensor import to_mx
+from torchao.utils import is_MI350
 
 device = torch.device("cuda")
 
@@ -115,13 +116,17 @@ def run_experiment(
         fp8_rowwise_us = bench_fp8_rowwise_grouped_mm(A, B_t, offs)
 
     # benchmark mxfp8 grouped mm
-    if torch.cuda.get_device_capability() != (10, 0):
+    if torch.cuda.get_device_capability() == (10, 0):
+        mxfp8_us = bench_mxfp8_grouped_mm(A, B_t, offs)
+    elif is_MI350():
+        mxfp8_us = bench_mxfp8_grouped_mm_rocm(A, B_t, offs)
+    else:
         logging.warning(
-            f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
+            f"Skipping MXFP8 benchmarks, only supported on CUDA SM 10.0 or MI350+ "
+            f"(found device_capability={torch.cuda.get_device_capability()}, "
+            f"hip={torch.version.hip})"
         )
         mxfp8_us = float("inf")
-    else:
-        mxfp8_us = bench_mxfp8_grouped_mm(A, B_t, offs)
 
     return ExperimentResult(
         bf16_us=round(bf16_us, 3),
@@ -148,13 +153,12 @@ def print_results(experiments: List[Experiment]):
     rows = []
     for experiment in experiments:
         # calculate tflops
-        e, m, n, k = (
-            experiment.config.e,
+        m, n, k = (
             experiment.config.m,
             experiment.config.n,
             experiment.config.k,
         )
-        flops = 2 * e * m * n * k
+        flops = 2 * m * n * k
         bf16_tflops = (flops / 1e12) / (experiment.result.bf16_us / 1e6)
         fp8_rowwise_tflops = (flops / 1e12) / (experiment.result.fp8_rowwise_us / 1e6)
         mxfp8_tflops = (flops / 1e12) / (experiment.result.mxfp8_us / 1e6)
@@ -243,6 +247,30 @@ def bench_mxfp8_grouped_mm(A, B_t, offs, block_size=32) -> float:
         A_scales_blocked,
         B_scales_blocked,
         offs=offs,
+    )
+    return mxfp8_us
+
+
+def bench_mxfp8_grouped_mm_rocm(A, B_t, offs, block_size=32) -> float:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_grouped_mm,
+    )
+
+    A_scales, A_fp8 = to_mx(A, elem_dtype=torch.float8_e4m3fn, block_size=block_size)
+    B_nkK = B_t.transpose(-2, -1).contiguous()
+    B_scales, B_fp8 = to_mx(B_nkK, elem_dtype=torch.float8_e4m3fn, block_size=block_size)
+
+    E = offs.shape[0]
+    Mg = A.shape[0]
+    offs_mxfp8 = generate_jagged_offs(E, Mg, multiple_of=block_size)
+
+    mxfp8_us = benchmark_cuda_function_in_microseconds(
+        triton_mxfp8_grouped_mm,
+        A_fp8,
+        B_fp8,
+        A_scales,
+        B_scales,
+        offs_mxfp8,
     )
     return mxfp8_us
 

--- a/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
+++ b/benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py
@@ -249,9 +249,13 @@ def main(args: argparse.Namespace):
         elif config.recipe in (
             MXFP8TrainingRecipe.MXFP8_RCEIL,
             MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
-        ) and torch.cuda.get_device_capability() != (10, 0):
+        ) and not (
+            torch.cuda.get_device_capability() == (10, 0) or is_MI350()
+        ):
             logging.warning(
-                f"Skipping MXFP8 benchmarks, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
+                f"Skipping MXFP8 benchmarks, only supported on CUDA SM 10.0 or MI350+ "
+                f"(found device_capability={torch.cuda.get_device_capability()}, "
+                f"hip={torch.version.hip})"
             )
             continue
 

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -42,13 +42,11 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.testing.utils import skip_if_rocm
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
 
 
-@skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
 @pytest.mark.parametrize("num_experts", (1, 8, 16))
 def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
@@ -80,7 +78,6 @@ def test_emulate_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts):
     assert sqnr >= min_sqnr, f"sqnr {sqnr} is too low, must be >= {min_sqnr}"
 
 
-@skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M", (1024, 4096))
 @pytest.mark.parametrize("N", (1024, 4096))
 @pytest.mark.parametrize("num_experts", (8, 16))
@@ -128,7 +125,6 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
     assert sqnr >= min_sqnr, f"sqnr {sqnr} is too low, must be >= {min_sqnr}"
 
 
-@skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (1, 8))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
@@ -152,7 +148,7 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     pad_token_groups_for_grouped_mm,
 ):
     # MXFP8 hardware path requires SM100
-    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+    if kernel_preference != KernelPreference.EMULATED and not (is_sm_version(10, 0) or is_MI350()):
         pytest.skip(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
@@ -225,7 +221,6 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     )
 
 
-@skip_if_rocm("ROCm not supported")
 def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
@@ -298,7 +293,6 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
     )
 
 
-@skip_if_rocm("ROCm not supported")
 def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
@@ -352,7 +346,6 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
     )
 
 
-@skip_if_rocm("ROCm not supported")
 def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
     block_size = 32
     M, K, N, num_experts = 1024, 1024, 2048, 4

--- a/torchao/prototype/moe_training/config.py
+++ b/torchao/prototype/moe_training/config.py
@@ -12,7 +12,10 @@ import torch
 from torch import nn
 
 from torchao.core.config import AOBaseConfig
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import (
+    MXFP8Dim1CastKernelChoice,
+    ScaleCalculationMode,
+)
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.transform_module import register_quantize_module_handler
 from torchao.utils import is_MI300, register_as_pytree_constant
@@ -131,6 +134,13 @@ class MXFP8TrainingOpConfig(TrainingOpBaseConfig):
     # Whether to pad the token group sizes to multiples of 32 (MXFP8 scaling block size).
     pad_token_groups_for_grouped_mm: bool = False
 
+    # Kernel used for the MXFP8 dim1 cast in backward (wgrad path). Default is
+    # CUDA (best on CUDA SM100+). On backends without the CUDA kernel (e.g.
+    # ROCm), set to MXFP8Dim1CastKernelChoice.TRITON.
+    mxfp8_dim1_cast_kernel_choice: MXFP8Dim1CastKernelChoice = (
+        MXFP8Dim1CastKernelChoice.CUDA
+    )
+
     @classmethod
     def from_recipe(
         cls,
@@ -173,6 +183,8 @@ class MXFP8TrainingOpConfig(TrainingOpBaseConfig):
                 and self.scale_calculation_mode == other.scale_calculation_mode
                 and self.pad_token_groups_for_grouped_mm
                 == other.pad_token_groups_for_grouped_mm
+                and self.mxfp8_dim1_cast_kernel_choice
+                == other.mxfp8_dim1_cast_kernel_choice
             )
         return NotImplemented
 
@@ -184,6 +196,7 @@ class MXFP8TrainingOpConfig(TrainingOpBaseConfig):
                 self.wgrad_with_hp,
                 self.scale_calculation_mode,
                 self.pad_token_groups_for_grouped_mm,
+                self.mxfp8_dim1_cast_kernel_choice,
             )
         )
 

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -15,3 +15,7 @@ from torchao.prototype.moe_training.kernels.mxfp8.quant import (
     triton_mx_block_rearrange_2d_M_groups,  # noqa: F401
     triton_mx_block_rearrange_per_group_3d,  # noqa: F401
 )
+from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+    triton_mxfp8_grouped_mm,  # noqa: F401
+    triton_mxfp8_wgrad,  # noqa: F401
+)

--- a/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/__init__.py
@@ -15,3 +15,8 @@ from torchao.prototype.moe_training.kernels.mxfp8.quant import (
     triton_mx_block_rearrange_2d_M_groups,  # noqa: F401
     triton_mx_block_rearrange_per_group_3d,  # noqa: F401
 )
+from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+    triton_mxfp8_grouped_mm,  # noqa: F401
+    triton_mxfp8_mm,  # noqa: F401
+    triton_mxfp8_wgrad,  # noqa: F401
+)

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -260,6 +260,7 @@ def compute_blocked_scale_offsets_for_K_groups(
     return group_sizes, starting_col_after_padding
 
 
+@torch.library.custom_op("torchao::torch_pad_token_groups", mutates_args=())
 def torch_pad_token_groups(
     inputs: torch.Tensor, group_offsets: torch.Tensor, alignment_size: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -323,6 +324,27 @@ def torch_pad_token_groups(
     return padded_tokens, padded_start_offsets, padded_offsets
 
 
+@torch_pad_token_groups.register_fake
+def _torch_pad_token_groups_fake(
+    inputs: torch.Tensor, group_offsets: torch.Tensor, alignment_size: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_tokens, dim = inputs.shape
+    num_groups = group_offsets.shape[0]
+    output_rows = num_tokens + num_groups * alignment_size
+    output_rows = (
+        (output_rows + alignment_size - 1) // alignment_size
+    ) * alignment_size
+    padded_tokens = inputs.new_empty((output_rows, dim))
+    padded_group_start_offsets = torch.empty(
+        (num_groups,), dtype=torch.int32, device=inputs.device
+    )
+    padded_group_end_offsets = torch.empty(
+        (num_groups,), dtype=torch.int32, device=inputs.device
+    )
+    return padded_tokens, padded_group_start_offsets, padded_group_end_offsets
+
+
+@torch.library.custom_op("torchao::torch_unpad_token_groups", mutates_args=())
 def torch_unpad_token_groups(
     padded_inputs: torch.Tensor,
     group_offsets: torch.Tensor,
@@ -371,6 +393,18 @@ def torch_unpad_token_groups(
         )
 
     return unpadded_tokens
+
+
+@torch_unpad_token_groups.register_fake
+def _torch_unpad_token_groups_fake(
+    padded_inputs: torch.Tensor,
+    group_offsets: torch.Tensor,
+    padded_group_start_offsets: torch.Tensor,
+    num_tokens: int,
+    alignment_size: int,
+) -> torch.Tensor:
+    dim = padded_inputs.shape[1]
+    return padded_inputs.new_empty((num_tokens, dim))
 
 
 if torch_version_at_least("2.7.0") and has_triton():

--- a/torchao/prototype/moe_training/kernels/mxfp8/rocm_mxfp8_mm.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/rocm_mxfp8_mm.py
@@ -1,0 +1,469 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Triton MXFP8 grouped-GEMM kernels for ROCm gfx950+.
+
+Use ``tl.dot_scaled`` to consume per-block e8m0 scales directly as a stand-in
+for ``torch._scaled_grouped_mm``'s MXFP8 path until that ships on ROCm.
+
+Contents:
+  - ``triton_mxfp8_grouped_mm``: persistent grouped GEMM for MoE fwd / dgrad.
+  - ``triton_mxfp8_wgrad``: weight-gradient grouped GEMM.
+"""
+
+import torch
+
+from torchao.prototype.mx_formats.kernels import _triton_kernels_available
+from torchao.utils import is_ROCM
+
+_rocm_mxfp8_available = is_ROCM() and _triton_kernels_available
+
+if _rocm_mxfp8_available:
+    import triton
+    import triton.language as tl
+
+    # ==================== Grouped GEMM (fwd / dgrad) ====================
+    #
+    # Persistent kernel: grid = num_CUs * ctas_per_cu. Each CTA walks the
+    # expert list with a global tile counter and picks every num_ctas-th
+    # (group, m_tile, n_tile) triple. This avoids a data-dependent grid and
+    # silent row-dropping when any group exceeds an M-per-expert bound, so
+    # the Python dispatcher needs no sync on offsets and stays
+    # torch.compile-clean.
+
+    @triton.jit
+    def _mxfp8_grouped_mm_kernel(
+        A_ptr, A_stride_m, A_stride_k,
+        B_ptr, B_stride_e, B_stride_n, B_stride_k,
+        A_scales_ptr, A_scales_stride_m, A_scales_stride_kb,
+        B_scales_ptr, B_scales_stride_e, B_scales_stride_n, B_scales_stride_kb,
+        C_ptr, C_stride_m, C_stride_n,
+        group_end_offsets_ptr,
+        M, N, K,
+        E: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        num_ctas = tl.num_programs(0)
+
+        num_n = tl.cdiv(N, BLOCK_N)
+        SUB_PER_BLOCK_K: tl.constexpr = BLOCK_K // SCALE_BLOCK
+        K_SCALES = K // SCALE_BLOCK
+
+        my_next = pid  # this CTA's next global tile index
+        cum = 0        # total tiles across groups [0, g)
+
+        for g in range(E):
+            group_start = tl.load(
+                group_end_offsets_ptr + g - 1, mask=g > 0, other=0
+            )
+            group_end = tl.load(group_end_offsets_ptr + g)
+            group_size = group_end - group_start
+            num_m = tl.cdiv(group_size, BLOCK_M)
+            tiles_in_group = num_m * num_n
+
+            while my_next < cum + tiles_in_group:
+                local = my_next - cum
+                mt = local // num_n
+                nt = local % num_n
+
+                m_base = group_start + mt * BLOCK_M
+                n_base = nt * BLOCK_N
+
+                m_offs = m_base + tl.arange(0, BLOCK_M)
+                n_offs = n_base + tl.arange(0, BLOCK_N)
+                m_mask = (m_offs < group_end) & (m_offs < M)
+                n_mask = n_offs < N
+
+                acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+                for k_outer in range(0, tl.cdiv(K, BLOCK_K)):
+                    k_offs = k_outer * BLOCK_K + tl.arange(0, BLOCK_K)
+                    k_mask = k_offs < K
+                    a = tl.load(
+                        A_ptr + m_offs[:, None] * A_stride_m
+                              + k_offs[None, :] * A_stride_k,
+                        mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+                    )
+                    b = tl.load(
+                        B_ptr + g * B_stride_e
+                              + n_offs[None, :] * B_stride_n
+                              + k_offs[:, None] * B_stride_k,
+                        mask=k_mask[:, None] & n_mask[None, :], other=0.0,
+                    )
+                    kb_offs = k_outer * SUB_PER_BLOCK_K + tl.arange(0, SUB_PER_BLOCK_K)
+                    kb_mask = kb_offs < K_SCALES
+                    # other=127: e8m0 bias 127 = 2^0 = 1.0 (neutral); combined
+                    # with data masked to 0.0 the tail contribution is 0.
+                    a_scale = tl.load(
+                        A_scales_ptr + m_offs[:, None] * A_scales_stride_m
+                                     + kb_offs[None, :] * A_scales_stride_kb,
+                        mask=m_mask[:, None] & kb_mask[None, :], other=127,
+                    )
+                    b_scale = tl.load(
+                        B_scales_ptr + g * B_scales_stride_e
+                                     + n_offs[:, None] * B_scales_stride_n
+                                     + kb_offs[None, :] * B_scales_stride_kb,
+                        mask=n_mask[:, None] & kb_mask[None, :], other=127,
+                    )
+                    acc = tl.dot_scaled(
+                        a, a_scale, "e4m3",
+                        b, b_scale, "e4m3",
+                        acc=acc, out_dtype=tl.float32,
+                    )
+
+                c_mask = m_mask[:, None] & n_mask[None, :]
+                tl.store(
+                    C_ptr + m_offs[:, None] * C_stride_m
+                          + n_offs[None, :] * C_stride_n,
+                    acc.to(tl.bfloat16), mask=c_mask,
+                )
+
+                my_next += num_ctas
+
+            cum += tiles_in_group
+
+    def triton_mxfp8_grouped_mm(
+        input_act: torch.Tensor,
+        weight: torch.Tensor,
+        input_act_scales: torch.Tensor,
+        weight_scales: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype = torch.bfloat16,
+        BLOCK_M: int = 128,
+        BLOCK_N: int = 128,
+        BLOCK_K: int = 128,
+        num_warps: int = 8,
+        num_stages: int = 2,
+        ctas_per_cu: int = 2,
+    ) -> torch.Tensor:
+        """MXFP8 grouped GEMM: ``output[g] = input_act[group_g] @ weight[g]^T``.
+
+        Args:
+            input_act: ``(M, K)`` fp8.
+            weight: ``(E, N, K)`` fp8.
+            ctas_per_cu: number of persistent CTAs per compute unit; grid is
+                ``num_cus * ctas_per_cu``.
+        """
+        M, K = input_act.shape
+        E, N, _ = weight.shape
+        SCALE_BLOCK = 32
+
+        output = torch.empty((M, N), dtype=out_dtype, device=input_act.device)
+        num_cus = torch.cuda.get_device_properties(input_act.device).multi_processor_count
+        grid = (num_cus * ctas_per_cu,)
+
+        _mxfp8_grouped_mm_kernel[grid](
+            input_act, input_act.stride(0), input_act.stride(1),
+            weight, weight.stride(0), weight.stride(1), weight.stride(2),
+            input_act_scales.view(torch.uint8),
+            input_act_scales.stride(0), input_act_scales.stride(1),
+            weight_scales.view(torch.uint8),
+            weight_scales.stride(0), weight_scales.stride(1), weight_scales.stride(2),
+            output, output.stride(0), output.stride(1),
+            group_end_offsets,
+            M, N, K,
+            E=E,
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+            SCALE_BLOCK=SCALE_BLOCK,
+            num_warps=num_warps, num_stages=num_stages,
+            matrix_instr_nonkdim=0, kpack=1,
+        )
+        return output
+
+    # ==================== Weight-gradient grouped GEMM ====================
+
+    @triton.jit
+    def _mxfp8_wgrad_direct_kernel(
+        GO_ptr, GO_stride_n, GO_stride_m,
+        GO_scales_ptr, GO_scales_stride_n, GO_scales_stride_mb,
+        IA_ptr, IA_stride_k, IA_stride_m,
+        IA_scales_ptr, IA_scales_stride_k, IA_scales_stride_mb,
+        C_ptr, C_stride_e, C_stride_n, C_stride_k,
+        group_end_offsets_ptr,
+        M, N, K,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid_n = tl.program_id(0)
+        pid_k = tl.program_id(1)
+        pid_g = tl.program_id(2)
+
+        group_start = tl.load(group_end_offsets_ptr + pid_g - 1, mask=pid_g > 0, other=0)
+        group_end = tl.load(group_end_offsets_ptr + pid_g)
+        M_g = group_end - group_start
+
+        n_base = pid_n * BLOCK_N
+        k_base = pid_k * BLOCK_K
+        if n_base >= N or k_base >= K:
+            return
+
+        n_offs = n_base + tl.arange(0, BLOCK_N)
+        k_offs = k_base + tl.arange(0, BLOCK_K)
+        n_mask = n_offs < N
+        k_mask = k_offs < K
+
+        SUB_PER_BLOCK_M: tl.constexpr = BLOCK_M // SCALE_BLOCK
+        M_SCALES = M // SCALE_BLOCK
+        acc = tl.zeros((BLOCK_N, BLOCK_K), dtype=tl.float32)
+
+        for m_iter in range(0, tl.cdiv(M_g, BLOCK_M)):
+            m_base = group_start + m_iter * BLOCK_M
+            m_offs = m_base + tl.arange(0, BLOCK_M)
+            m_mask = m_offs < group_end
+
+            go_tile = tl.load(
+                GO_ptr + n_offs[:, None] * GO_stride_n + m_offs[None, :] * GO_stride_m,
+                mask=n_mask[:, None] & m_mask[None, :], other=0.0,
+            )
+            ia_tile = tl.load(
+                IA_ptr + k_offs[None, :] * IA_stride_k + m_offs[:, None] * IA_stride_m,
+                mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+            )
+
+            mb_base = m_base // SCALE_BLOCK
+            mb_offs = mb_base + tl.arange(0, SUB_PER_BLOCK_M)
+            mb_mask = mb_offs < M_SCALES
+            # other=127: e8m0 bias 127 = 2^0 = 1.0 (neutral).
+            go_scale = tl.load(
+                GO_scales_ptr + n_offs[:, None] * GO_scales_stride_n + mb_offs[None, :] * GO_scales_stride_mb,
+                mask=n_mask[:, None] & mb_mask[None, :], other=127,
+            )
+            ia_scale = tl.load(
+                IA_scales_ptr + k_offs[:, None] * IA_scales_stride_k + mb_offs[None, :] * IA_scales_stride_mb,
+                mask=k_mask[:, None] & mb_mask[None, :], other=127,
+            )
+
+            acc = tl.dot_scaled(
+                go_tile, go_scale, "e4m3",
+                ia_tile, ia_scale, "e4m3",
+                acc=acc, out_dtype=tl.float32,
+            )
+
+        c_mask = n_mask[:, None] & k_mask[None, :]
+        tl.store(
+            C_ptr + pid_g * C_stride_e + n_offs[:, None] * C_stride_n + k_offs[None, :] * C_stride_k,
+            acc.to(tl.bfloat16), mask=c_mask,
+        )
+
+    # Partial-sum wgrad: partitions the per-group M-loop across SPLIT_M CTAs
+    # and writes fp32 partials to an (E, SPLIT_M, N, K) buffer; a reduce
+    # kernel sums across SPLIT_M into the (E, N, K) bf16 output. Worth it
+    # when a single group leaves too few CTAs to saturate the device.
+
+    @triton.jit
+    def _mxfp8_wgrad_partial_kernel(
+        GO_ptr, GO_stride_n, GO_stride_m,
+        GO_scales_ptr, GO_scales_stride_n, GO_scales_stride_mb,
+        IA_ptr, IA_stride_k, IA_stride_m,
+        IA_scales_ptr, IA_scales_stride_k, IA_scales_stride_mb,
+        P_ptr, P_stride_e, P_stride_s, P_stride_n, P_stride_k,
+        group_end_offsets_ptr,
+        M, N, K,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        SPLIT_M: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid_n = tl.program_id(0)
+        pid_k = tl.program_id(1)
+        pid_eg = tl.program_id(2)
+        pid_split = pid_eg % SPLIT_M
+        pid_g = pid_eg // SPLIT_M
+
+        group_start = tl.load(group_end_offsets_ptr + pid_g - 1, mask=pid_g > 0, other=0)
+        group_end = tl.load(group_end_offsets_ptr + pid_g)
+        M_g = group_end - group_start
+
+        n_base = pid_n * BLOCK_N
+        k_base = pid_k * BLOCK_K
+        if n_base >= N or k_base >= K:
+            return
+
+        n_offs = n_base + tl.arange(0, BLOCK_N)
+        k_offs = k_base + tl.arange(0, BLOCK_K)
+        n_mask = n_offs < N
+        k_mask = k_offs < K
+
+        SUB_PER_BLOCK_M: tl.constexpr = BLOCK_M // SCALE_BLOCK
+        M_SCALES = M // SCALE_BLOCK
+        acc = tl.zeros((BLOCK_N, BLOCK_K), dtype=tl.float32)
+
+        num_m_iters = tl.cdiv(M_g, BLOCK_M)
+        for m_iter in range(pid_split, num_m_iters, SPLIT_M):
+            m_base = group_start + m_iter * BLOCK_M
+            m_offs = m_base + tl.arange(0, BLOCK_M)
+            m_mask = m_offs < group_end
+
+            go_tile = tl.load(
+                GO_ptr + n_offs[:, None] * GO_stride_n + m_offs[None, :] * GO_stride_m,
+                mask=n_mask[:, None] & m_mask[None, :], other=0.0,
+            )
+            ia_tile = tl.load(
+                IA_ptr + k_offs[None, :] * IA_stride_k + m_offs[:, None] * IA_stride_m,
+                mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+            )
+
+            mb_base = m_base // SCALE_BLOCK
+            mb_offs = mb_base + tl.arange(0, SUB_PER_BLOCK_M)
+            mb_mask = mb_offs < M_SCALES
+            go_scale = tl.load(
+                GO_scales_ptr + n_offs[:, None] * GO_scales_stride_n + mb_offs[None, :] * GO_scales_stride_mb,
+                mask=n_mask[:, None] & mb_mask[None, :], other=127,
+            )
+            ia_scale = tl.load(
+                IA_scales_ptr + k_offs[:, None] * IA_scales_stride_k + mb_offs[None, :] * IA_scales_stride_mb,
+                mask=k_mask[:, None] & mb_mask[None, :], other=127,
+            )
+
+            acc = tl.dot_scaled(
+                go_tile, go_scale, "e4m3",
+                ia_tile, ia_scale, "e4m3",
+                acc=acc, out_dtype=tl.float32,
+            )
+
+        p_mask = n_mask[:, None] & k_mask[None, :]
+        tl.store(
+            P_ptr + pid_g * P_stride_e + pid_split * P_stride_s
+                  + n_offs[:, None] * P_stride_n + k_offs[None, :] * P_stride_k,
+            acc, mask=p_mask,
+        )
+
+    @triton.jit
+    def _mxfp8_wgrad_reduce_kernel(
+        P_ptr, P_stride_e, P_stride_s, P_stride_n, P_stride_k,
+        C_ptr, C_stride_e, C_stride_n, C_stride_k,
+        N, K,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        SPLIT_M: tl.constexpr,
+    ):
+        pid_n = tl.program_id(0)
+        pid_k = tl.program_id(1)
+        pid_g = tl.program_id(2)
+
+        n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        k_offs = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+        n_mask = n_offs < N
+        k_mask = k_offs < K
+        c_mask = n_mask[:, None] & k_mask[None, :]
+
+        acc = tl.zeros((BLOCK_N, BLOCK_K), dtype=tl.float32)
+        for s in range(SPLIT_M):
+            acc += tl.load(
+                P_ptr + pid_g * P_stride_e + s * P_stride_s
+                      + n_offs[:, None] * P_stride_n + k_offs[None, :] * P_stride_k,
+                mask=c_mask, other=0.0,
+            )
+
+        tl.store(
+            C_ptr + pid_g * C_stride_e + n_offs[:, None] * C_stride_n + k_offs[None, :] * C_stride_k,
+            acc.to(tl.bfloat16), mask=c_mask,
+        )
+
+    def triton_mxfp8_wgrad(
+        go_t: torch.Tensor,
+        go_scale: torch.Tensor,
+        ia_t: torch.Tensor,
+        ia_scale: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype = torch.bfloat16,
+        BLOCK_N: int = 256,
+        BLOCK_K: int = 256,
+        BLOCK_M: int = 64,
+        num_warps: int = 8,
+        num_stages: int = 2,
+    ) -> torch.Tensor:
+        """MXFP8 weight gradient: ``grad_W[g] = grad_output[group_g]^T @ input_act[group_g]``.
+
+        Both inputs must be dim1-quantized (scales along the M / token dim).
+        For a single group (``E == 1``) the (N/BN, K/BK) grid may not saturate
+        the device, so we partition the per-group M-loop across SPLIT_M CTAs
+        and reduce their fp32 partials in a second pass; for E >= 2 the natural
+        grid is enough and we write bf16 directly.
+
+        Args:
+            go_t: ``(N, M)`` fp8.
+            ia_t: ``(K, M)`` fp8.
+
+        Returns:
+            ``(E, N, K)`` bf16.
+        """
+        N, M = go_t.shape
+        K, _ = ia_t.shape
+        E = group_end_offsets.shape[0]
+        SCALE_BLOCK = 32
+        SPLIT_M = 2 if E == 1 else 1
+
+        output = torch.empty((E, N, K), dtype=out_dtype, device=go_t.device)
+
+        if SPLIT_M == 1:
+            grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(K, BLOCK_K), E)
+            _mxfp8_wgrad_direct_kernel[grid](
+                go_t, go_t.stride(0), go_t.stride(1),
+                go_scale.view(torch.uint8),
+                go_scale.stride(0), go_scale.stride(1),
+                ia_t, ia_t.stride(0), ia_t.stride(1),
+                ia_scale.view(torch.uint8),
+                ia_scale.stride(0), ia_scale.stride(1),
+                output, output.stride(0), output.stride(1), output.stride(2),
+                group_end_offsets,
+                M, N, K,
+                BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, BLOCK_M=BLOCK_M,
+                SCALE_BLOCK=SCALE_BLOCK,
+                num_warps=num_warps, num_stages=num_stages,
+                matrix_instr_nonkdim=0, kpack=1,
+            )
+            return output
+
+        partials = torch.empty(
+            (E, SPLIT_M, N, K), dtype=torch.float32, device=go_t.device
+        )
+        partial_grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(K, BLOCK_K), E * SPLIT_M)
+        _mxfp8_wgrad_partial_kernel[partial_grid](
+            go_t, go_t.stride(0), go_t.stride(1),
+            go_scale.view(torch.uint8),
+            go_scale.stride(0), go_scale.stride(1),
+            ia_t, ia_t.stride(0), ia_t.stride(1),
+            ia_scale.view(torch.uint8),
+            ia_scale.stride(0), ia_scale.stride(1),
+            partials,
+            partials.stride(0), partials.stride(1),
+            partials.stride(2), partials.stride(3),
+            group_end_offsets,
+            M, N, K,
+            BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, BLOCK_M=BLOCK_M,
+            SPLIT_M=SPLIT_M, SCALE_BLOCK=SCALE_BLOCK,
+            num_warps=num_warps, num_stages=num_stages,
+            matrix_instr_nonkdim=0, kpack=1,
+        )
+
+        reduce_grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(K, BLOCK_K), E)
+        _mxfp8_wgrad_reduce_kernel[reduce_grid](
+            partials,
+            partials.stride(0), partials.stride(1),
+            partials.stride(2), partials.stride(3),
+            output,
+            output.stride(0), output.stride(1), output.stride(2),
+            N, K,
+            BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, SPLIT_M=SPLIT_M,
+            num_warps=num_warps, num_stages=num_stages,
+        )
+        return output
+
+else:
+    _UNAVAILABLE_MSG = "ROCm MXFP8 kernels require gfx950 or later"
+
+    def triton_mxfp8_grouped_mm(*args, **kwargs):
+        raise NotImplementedError(_UNAVAILABLE_MSG)
+
+    def triton_mxfp8_wgrad(*args, **kwargs):
+        raise NotImplementedError(_UNAVAILABLE_MSG)

--- a/torchao/prototype/moe_training/kernels/mxfp8/rocm_mxfp8_mm.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/rocm_mxfp8_mm.py
@@ -1,0 +1,393 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Triton MXFP8 matmul kernels for ROCm (gfx950 / MI355X and later).
+
+On ROCm, torch._scaled_mm and torch._scaled_grouped_mm only support FP8
+rowwise (float32 scales), not MXFP8 block scaling (float8_e8m0fnu). These
+kernels use tl.dot_scaled to feed per-block E8M0 scales directly into
+gfx950's native v_mfma_scale_f32_*_f8f6f4 instructions.
+
+This is a workaround until torch._scaled_mm / torch._scaled_grouped_mm
+gain native MXFP8 block-scale support on ROCm.
+
+Contents:
+  - triton_mxfp8_grouped_mm: Grouped GEMM for MoE fwd/dgrad
+  - triton_mxfp8_wgrad: Weight gradient grouped GEMM
+  - triton_mxfp8_mm: Dense matmul for shared-expert linear paths
+"""
+
+import torch
+
+from torchao.prototype.mx_formats.kernels import _triton_kernels_available
+from torchao.utils import is_ROCM
+
+_rocm_mxfp8_available = is_ROCM() and _triton_kernels_available
+
+if _rocm_mxfp8_available:
+    import triton
+    import triton.language as tl
+
+    # ==================== Grouped GEMM (fwd / dgrad) ====================
+
+    @triton.jit
+    def _mxfp8_grouped_mm_kernel(
+        A_ptr, A_stride_m, A_stride_k,
+        B_ptr, B_stride_e, B_stride_n, B_stride_k,
+        A_scales_ptr, A_scales_stride_m, A_scales_stride_kb,
+        B_scales_ptr, B_scales_stride_e, B_scales_stride_n, B_scales_stride_kb,
+        C_ptr, C_stride_m, C_stride_n,
+        group_end_offsets_ptr,
+        M, N, K,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_g = tl.program_id(2)
+
+        group_start = tl.load(group_end_offsets_ptr + pid_g - 1, mask=pid_g > 0, other=0)
+        group_end = tl.load(group_end_offsets_ptr + pid_g)
+
+        m_base = group_start + pid_m * BLOCK_M
+        if m_base >= group_end:
+            return
+        n_base = pid_n * BLOCK_N
+        if n_base >= N:
+            return
+
+        m_offs = m_base + tl.arange(0, BLOCK_M)
+        n_offs = n_base + tl.arange(0, BLOCK_N)
+        m_mask = m_offs < group_end
+        n_mask = n_offs < N
+
+        SUB_PER_BLOCK_K: tl.constexpr = BLOCK_K // SCALE_BLOCK
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        num_outer = K // BLOCK_K
+        for k_outer in range(0, num_outer):
+            k_offs = k_outer * BLOCK_K + tl.arange(0, BLOCK_K)
+            k_mask = k_offs < K
+
+            a = tl.load(
+                A_ptr + m_offs[:, None] * A_stride_m + k_offs[None, :] * A_stride_k,
+                mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+            )
+            b = tl.load(
+                B_ptr + pid_g * B_stride_e + n_offs[None, :] * B_stride_n + k_offs[:, None] * B_stride_k,
+                mask=k_mask[:, None] & n_mask[None, :], other=0.0,
+            )
+
+            kb_offs = k_outer * SUB_PER_BLOCK_K + tl.arange(0, SUB_PER_BLOCK_K)
+            a_scale = tl.load(
+                A_scales_ptr + m_offs[:, None] * A_scales_stride_m + kb_offs[None, :] * A_scales_stride_kb,
+                mask=m_mask[:, None], other=127,
+            )
+            b_scale = tl.load(
+                B_scales_ptr + pid_g * B_scales_stride_e + n_offs[:, None] * B_scales_stride_n + kb_offs[None, :] * B_scales_stride_kb,
+                mask=n_mask[:, None], other=127,
+            )
+
+            acc = tl.dot_scaled(a, a_scale, "e4m3", b, b_scale, "e4m3", acc=acc, out_dtype=tl.float32)
+
+        c_mask = m_mask[:, None] & n_mask[None, :]
+        tl.store(
+            C_ptr + m_offs[:, None] * C_stride_m + n_offs[None, :] * C_stride_n,
+            acc.to(tl.bfloat16), mask=c_mask,
+        )
+
+    def triton_mxfp8_grouped_mm(
+        input_act: torch.Tensor,
+        weight: torch.Tensor,
+        input_act_scales: torch.Tensor,
+        weight_scales: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype = torch.bfloat16,
+        BLOCK_M: int = 128,
+        BLOCK_N: int = 128,
+        BLOCK_K: int = 128,
+        num_warps: int = 8,
+        num_stages: int = 2,
+        max_M_per_expert: int = 0,
+    ) -> torch.Tensor:
+        """
+        MXFP8 grouped GEMM: output[g] = input_act[group_g] @ weight[g]^T
+
+        Args:
+            input_act: (M, K) fp8, weight: (E, N, K) fp8
+            max_M_per_expert: grid optimization hint for uniform group sizes
+        """
+        M, K = input_act.shape
+        E, N, K2 = weight.shape
+        SCALE_BLOCK = 32
+
+        output = torch.empty((M, N), dtype=out_dtype, device=input_act.device)
+
+        grid_m_bound = max_M_per_expert if max_M_per_expert > 0 else M
+        grid = (
+            triton.cdiv(grid_m_bound, BLOCK_M),
+            triton.cdiv(N, BLOCK_N),
+            E,
+        )
+
+        _mxfp8_grouped_mm_kernel[grid](
+            input_act, input_act.stride(0), input_act.stride(1),
+            weight, weight.stride(0), weight.stride(1), weight.stride(2),
+            input_act_scales.view(torch.uint8),
+            input_act_scales.stride(0), input_act_scales.stride(1),
+            weight_scales.view(torch.uint8),
+            weight_scales.stride(0), weight_scales.stride(1), weight_scales.stride(2),
+            output, output.stride(0), output.stride(1),
+            group_end_offsets,
+            M, N, K,
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+            SCALE_BLOCK=SCALE_BLOCK,
+            num_warps=num_warps, num_stages=num_stages,
+        )
+        return output
+
+    # ==================== Weight gradient grouped GEMM ====================
+
+    @triton.jit
+    def _mxfp8_wgrad_kernel(
+        GO_ptr, GO_stride_n, GO_stride_m,
+        GO_scales_ptr, GO_scales_stride_n, GO_scales_stride_mb,
+        IA_ptr, IA_stride_k, IA_stride_m,
+        IA_scales_ptr, IA_scales_stride_k, IA_scales_stride_mb,
+        C_ptr, C_stride_e, C_stride_n, C_stride_k,
+        group_end_offsets_ptr,
+        M, N, K,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid_n = tl.program_id(0)
+        pid_k = tl.program_id(1)
+        pid_g = tl.program_id(2)
+
+        group_start = tl.load(group_end_offsets_ptr + pid_g - 1, mask=pid_g > 0, other=0)
+        group_end = tl.load(group_end_offsets_ptr + pid_g)
+        M_g = group_end - group_start
+
+        n_base = pid_n * BLOCK_N
+        k_base = pid_k * BLOCK_K
+        if n_base >= N or k_base >= K:
+            return
+
+        n_offs = n_base + tl.arange(0, BLOCK_N)
+        k_offs = k_base + tl.arange(0, BLOCK_K)
+        n_mask = n_offs < N
+        k_mask = k_offs < K
+
+        SUB_PER_BLOCK_M: tl.constexpr = BLOCK_M // SCALE_BLOCK
+        acc = tl.zeros((BLOCK_N, BLOCK_K), dtype=tl.float32)
+
+        num_m_iters = (M_g + BLOCK_M - 1) // BLOCK_M
+        for m_iter in range(0, num_m_iters):
+            m_base = group_start + m_iter * BLOCK_M
+            m_offs = m_base + tl.arange(0, BLOCK_M)
+            m_mask = m_offs < group_end
+
+            go_tile = tl.load(
+                GO_ptr + n_offs[:, None] * GO_stride_n + m_offs[None, :] * GO_stride_m,
+                mask=n_mask[:, None] & m_mask[None, :], other=0.0,
+            )
+            ia_tile = tl.load(
+                IA_ptr + k_offs[None, :] * IA_stride_k + m_offs[:, None] * IA_stride_m,
+                mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+            )
+
+            mb_base = m_base // SCALE_BLOCK
+            mb_offs = mb_base + tl.arange(0, SUB_PER_BLOCK_M)
+
+            go_scale = tl.load(
+                GO_scales_ptr + n_offs[:, None] * GO_scales_stride_n + mb_offs[None, :] * GO_scales_stride_mb,
+                mask=n_mask[:, None], other=127,
+            )
+            ia_scale = tl.load(
+                IA_scales_ptr + k_offs[:, None] * IA_scales_stride_k + mb_offs[None, :] * IA_scales_stride_mb,
+                mask=k_mask[:, None], other=127,
+            )
+
+            acc = tl.dot_scaled(go_tile, go_scale, "e4m3", ia_tile, ia_scale, "e4m3", acc=acc, out_dtype=tl.float32)
+
+        c_mask = n_mask[:, None] & k_mask[None, :]
+        tl.store(
+            C_ptr + pid_g * C_stride_e + n_offs[:, None] * C_stride_n + k_offs[None, :] * C_stride_k,
+            acc.to(tl.bfloat16), mask=c_mask,
+        )
+
+    def triton_mxfp8_wgrad(
+        go_t: torch.Tensor,
+        go_scale: torch.Tensor,
+        ia_t: torch.Tensor,
+        ia_scale: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype = torch.bfloat16,
+        BLOCK_N: int = 128,
+        BLOCK_K: int = 128,
+        BLOCK_M: int = 128,
+        num_warps: int = 8,
+        num_stages: int = 2,
+    ) -> torch.Tensor:
+        """
+        MXFP8 weight gradient: grad_W[g] = grad_output[group_g]^T @ input_act[group_g]
+
+        Both inputs must be dim1-quantized (scales along the M/token dimension).
+        go_t: (N, M) fp8, ia_t: (K, M) fp8. Returns (E, N, K) bf16.
+        """
+        N, M = go_t.shape
+        K, M2 = ia_t.shape
+        E = group_end_offsets.shape[0]
+        SCALE_BLOCK = 32
+
+        output = torch.empty((E, N, K), dtype=out_dtype, device=go_t.device)
+
+        grid = (
+            triton.cdiv(N, BLOCK_N),
+            triton.cdiv(K, BLOCK_K),
+            E,
+        )
+
+        _mxfp8_wgrad_kernel[grid](
+            go_t, go_t.stride(0), go_t.stride(1),
+            go_scale.view(torch.uint8),
+            go_scale.stride(0), go_scale.stride(1),
+            ia_t, ia_t.stride(0), ia_t.stride(1),
+            ia_scale.view(torch.uint8),
+            ia_scale.stride(0), ia_scale.stride(1),
+            output, output.stride(0), output.stride(1), output.stride(2),
+            group_end_offsets,
+            M, N, K,
+            BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, BLOCK_M=BLOCK_M,
+            SCALE_BLOCK=SCALE_BLOCK,
+            num_warps=num_warps, num_stages=num_stages,
+        )
+        return output
+
+    # ==================== Dense matmul (shared experts) ====================
+
+    @triton.jit
+    def _mxfp8_mm_kernel(
+        A_ptr, A_stride_m, A_stride_k,
+        B_ptr, B_stride_k, B_stride_n,
+        A_scales_ptr, A_scales_stride_m, A_scales_stride_kb,
+        B_scales_ptr, B_scales_stride_n, B_scales_stride_kb,
+        C_ptr, C_stride_m, C_stride_n,
+        M, N, K,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        SCALE_BLOCK: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        m_base = pid_m * BLOCK_M
+        n_base = pid_n * BLOCK_N
+
+        m_offs = m_base + tl.arange(0, BLOCK_M)
+        n_offs = n_base + tl.arange(0, BLOCK_N)
+        m_mask = m_offs < M
+        n_mask = n_offs < N
+
+        SUB_PER_BLOCK_K: tl.constexpr = BLOCK_K // SCALE_BLOCK
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        num_outer = K // BLOCK_K
+        for k_outer in range(0, num_outer):
+            k_offs = k_outer * BLOCK_K + tl.arange(0, BLOCK_K)
+            k_mask = k_offs < K
+
+            a = tl.load(
+                A_ptr + m_offs[:, None] * A_stride_m + k_offs[None, :] * A_stride_k,
+                mask=m_mask[:, None] & k_mask[None, :], other=0.0,
+            )
+            b = tl.load(
+                B_ptr + k_offs[:, None] * B_stride_k + n_offs[None, :] * B_stride_n,
+                mask=k_mask[:, None] & n_mask[None, :], other=0.0,
+            )
+
+            kb_offs = k_outer * SUB_PER_BLOCK_K + tl.arange(0, SUB_PER_BLOCK_K)
+            a_scale = tl.load(
+                A_scales_ptr + m_offs[:, None] * A_scales_stride_m + kb_offs[None, :] * A_scales_stride_kb,
+                mask=m_mask[:, None], other=127,
+            )
+            b_scale = tl.load(
+                B_scales_ptr + n_offs[:, None] * B_scales_stride_n + kb_offs[None, :] * B_scales_stride_kb,
+                mask=n_mask[:, None], other=127,
+            )
+
+            acc = tl.dot_scaled(a, a_scale, "e4m3", b, b_scale, "e4m3", acc=acc, out_dtype=tl.float32)
+
+        c_mask = m_mask[:, None] & n_mask[None, :]
+        tl.store(
+            C_ptr + m_offs[:, None] * C_stride_m + n_offs[None, :] * C_stride_n,
+            acc.to(tl.bfloat16), mask=c_mask,
+        )
+
+    def triton_mxfp8_mm(
+        a_fp8: torch.Tensor,
+        b_fp8: torch.Tensor,
+        a_scale: torch.Tensor,
+        b_scale: torch.Tensor,
+        out_dtype: torch.dtype = torch.bfloat16,
+        BLOCK_M: int = 128,
+        BLOCK_N: int = 128,
+        BLOCK_K: int = 128,
+        num_warps: int = 8,
+        num_stages: int = 2,
+    ) -> torch.Tensor:
+        """
+        Dense MXFP8 matmul: C = A @ B
+
+        A: (M, K) fp8, B: (K, N) fp8. Returns (M, N) bf16.
+        Workaround for torch._scaled_mm lacking MXFP8 block-scale support on ROCm.
+        """
+        M, K = a_fp8.shape
+        K2, N = b_fp8.shape
+
+        C = torch.empty((M, N), dtype=out_dtype, device=a_fp8.device)
+
+        grid = (
+            triton.cdiv(M, BLOCK_M),
+            triton.cdiv(N, BLOCK_N),
+        )
+
+        _mxfp8_mm_kernel[grid](
+            a_fp8, a_fp8.stride(0), a_fp8.stride(1),
+            b_fp8, b_fp8.stride(0), b_fp8.stride(1),
+            a_scale.view(torch.uint8),
+            a_scale.stride(0), a_scale.stride(1),
+            b_scale.view(torch.uint8),
+            b_scale.stride(0), b_scale.stride(1),
+            C, C.stride(0), C.stride(1),
+            M, N, K,
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+            SCALE_BLOCK=32,
+            num_warps=num_warps, num_stages=num_stages,
+        )
+        return C
+
+else:
+    def triton_mxfp8_grouped_mm(*args, **kwargs):
+        raise NotImplementedError(
+            "ROCm MXFP8 kernels require gfx950 (MI355X) or later"
+        )
+
+    def triton_mxfp8_wgrad(*args, **kwargs):
+        raise NotImplementedError(
+            "ROCm MXFP8 kernels require gfx950 (MI355X) or later"
+        )
+
+    def triton_mxfp8_mm(*args, **kwargs):
+        raise NotImplementedError(
+            "ROCm MXFP8 kernels require gfx950 (MI355X) or later"
+        )

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -38,6 +38,7 @@ from torchao.prototype.mx_formats.kernels import (
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import is_ROCM
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -48,6 +49,9 @@ _SM100_KERNELS_AVAILABLE = (
     and _mxfp8_cuda_kernels_available_mx
     and _triton_kernels_available
 )
+
+# ROCm path: gfx950 (MI355X) and later support MXFP8 via Triton kernels
+_ROCM_MXFP8_KERNELS_AVAILABLE = is_ROCM() and _triton_kernels_available
 
 
 def _validate_grouped_mm_input_act(
@@ -171,11 +175,12 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             KernelPreference.EMULATED,
         ), "kernel_preference must be AUTO or EMULATED"
 
-        # Validate SM100 kernels are available if not using emulated mode
+        # Validate hardware kernels are available if not using emulated mode
         if kernel_preference != KernelPreference.EMULATED:
-            assert _SM100_KERNELS_AVAILABLE, (
-                "SM100 kernels not available. Please use torchao CUDA 12.8+ build on SM100/100a device(s). "
-                "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
+            assert _SM100_KERNELS_AVAILABLE or _ROCM_MXFP8_KERNELS_AVAILABLE, (
+                "MXFP8 kernels not available. On CUDA, use torchao CUDA 12.8+ on SM100/100a. "
+                "On ROCm, gfx950 (MI355X) or later is required. "
+                "Otherwise, set kernel_preference=KernelPreference.EMULATED."
             )
 
         # Input validation
@@ -378,6 +383,15 @@ def _compute_fwd(
             out_dtype,
             scale_calculation_mode,
         )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_fwd_rocm(
+            padded_input_act,
+            weight_t,
+            padded_group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+        )
     else:
         return _compute_fwd_sm100(
             padded_input_act,
@@ -415,6 +429,15 @@ def _compute_dgrad(
     """
     if kernel_preference == KernelPreference.EMULATED:
         return _compute_dgrad_emulated(
+            grad_output,
+            weight_t,
+            group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+        )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_dgrad_rocm(
             grad_output,
             weight_t,
             group_end_offsets,
@@ -461,6 +484,16 @@ def _compute_wgrad(
     """
     if kernel_preference == KernelPreference.EMULATED:
         return _compute_wgrad_emulated(
+            grad_output,
+            input_act,
+            group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+            wgrad_with_hp,
+        )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_wgrad_rocm(
             grad_output,
             input_act,
             group_end_offsets,
@@ -1082,3 +1115,125 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
 
 def round_up(x, y):
     return ((x + y - 1) // y) * y
+
+
+# ==================== ROCm implementations ====================
+
+
+def _rocm_grouped_mm_cfg(E: int, N: int) -> dict:
+    """Tile + ctas_per_cu pick for the ROCm grouped-MM kernel."""
+    if N >= 4096:
+        cpc = 1 if E >= 2 else 2
+        return dict(BLOCK_M=256, BLOCK_N=256, BLOCK_K=128,
+                    num_warps=8, num_stages=2, ctas_per_cu=cpc)
+    return dict(BLOCK_M=128, BLOCK_N=128, BLOCK_K=128,
+                num_warps=8, num_stages=2, ctas_per_cu=2)
+
+
+def _compute_fwd_rocm(
+    padded_input_act: torch.Tensor,
+    weight_t: torch.Tensor,
+    padded_group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_grouped_mm,
+    )
+
+    input_act_e4m3, input_act_scales = _extract_or_quantize_dim0_auto(
+        padded_input_act, block_size, scale_calculation_mode
+    )
+    weight_e4m3, weight_scales = _extract_or_quantize_dim0_auto(
+        weight_t.transpose(-2, -1).contiguous(), block_size, scale_calculation_mode
+    )
+    E, N, _ = weight_e4m3.shape
+    cfg = _rocm_grouped_mm_cfg(E, N)
+
+    return triton_mxfp8_grouped_mm(
+        input_act_e4m3, weight_e4m3, input_act_scales, weight_scales,
+        padded_group_end_offsets, out_dtype=out_dtype, **cfg,
+    )
+
+
+def _compute_dgrad_rocm(
+    grad_output: torch.Tensor,
+    weight_t: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_grouped_mm,
+    )
+
+    grad_output_data, grad_output_scales = _extract_or_quantize_dim0_auto(
+        grad_output.contiguous(), block_size, scale_calculation_mode
+    )
+    weight_e4m3, weight_scales = _extract_or_quantize_dim0_auto(
+        weight_t.contiguous(), block_size, scale_calculation_mode
+    )
+    E, N, _ = weight_e4m3.shape
+    cfg = _rocm_grouped_mm_cfg(E, N)
+
+    return triton_mxfp8_grouped_mm(
+        grad_output_data, weight_e4m3, grad_output_scales, weight_scales,
+        group_end_offsets, out_dtype=out_dtype, **cfg,
+    )
+
+
+def _compute_wgrad_rocm(
+    grad_output: torch.Tensor,
+    input_act: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+    wgrad_with_hp: bool = False,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_wgrad,
+    )
+    from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim1
+
+    grad_output = _dequantize_if_mxtensor(grad_output, block_size)
+    input_act = _dequantize_if_mxtensor(input_act, block_size)
+
+    if wgrad_with_hp:
+        grad_weight = torch._grouped_mm(
+            grad_output.transpose(-2, -1),
+            input_act,
+            offs=group_end_offsets,
+            out_dtype=out_dtype,
+        )
+        return grad_weight.transpose(-2, -1)
+
+    # MXFP8 wgrad: dim1-quantize both inputs, then use wgrad kernel.
+    # triton_to_mxfp8_dim1 requires n_rows % 128 == 0; pad the M dim when
+    # needed (padded rows don't belong to any group so the kernel ignores
+    # them via group_end_offsets).
+    MX_ROW_ALIGN = 128
+    M_orig = grad_output.shape[0]
+    pad_rows = (-M_orig) % MX_ROW_ALIGN
+    if pad_rows > 0:
+        grad_output = torch.nn.functional.pad(
+            grad_output.contiguous(), (0, 0, 0, pad_rows)
+        )
+        input_act = torch.nn.functional.pad(
+            input_act.contiguous(), (0, 0, 0, pad_rows)
+        )
+
+    go_data, go_scale = triton_to_mxfp8_dim1(
+        grad_output.contiguous(), block_size, scale_calculation_mode.value
+    )
+    ia_data, ia_scale = triton_to_mxfp8_dim1(
+        input_act.contiguous(), block_size, scale_calculation_mode.value
+    )
+
+    grad_weight = triton_mxfp8_wgrad(
+        go_data.t(), go_scale, ia_data.t(), ia_scale, group_end_offsets,
+        out_dtype=out_dtype,
+    )
+    return grad_weight.transpose(-2, -1)

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -38,6 +38,7 @@ from torchao.prototype.mx_formats.kernels import (
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import is_ROCM
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -48,6 +49,9 @@ _SM100_KERNELS_AVAILABLE = (
     and _mxfp8_cuda_kernels_available_mx
     and _triton_kernels_available
 )
+
+# ROCm path: gfx950 (MI355X) and later support MXFP8 via Triton kernels
+_ROCM_MXFP8_KERNELS_AVAILABLE = is_ROCM() and _triton_kernels_available
 
 
 def _validate_grouped_mm_input_act(
@@ -171,11 +175,12 @@ class _MXFP8GroupedMM(torch.autograd.Function):
             KernelPreference.EMULATED,
         ), "kernel_preference must be AUTO or EMULATED"
 
-        # Validate SM100 kernels are available if not using emulated mode
+        # Validate hardware kernels are available if not using emulated mode
         if kernel_preference != KernelPreference.EMULATED:
-            assert _SM100_KERNELS_AVAILABLE, (
-                "SM100 kernels not available. Please use torchao CUDA 12.8+ build on SM100/100a device(s). "
-                "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
+            assert _SM100_KERNELS_AVAILABLE or _ROCM_MXFP8_KERNELS_AVAILABLE, (
+                "MXFP8 kernels not available. On CUDA, use torchao CUDA 12.8+ on SM100/100a. "
+                "On ROCm, gfx950 (MI355X) or later is required. "
+                "Otherwise, set kernel_preference=KernelPreference.EMULATED."
             )
 
         # Input validation
@@ -378,6 +383,15 @@ def _compute_fwd(
             out_dtype,
             scale_calculation_mode,
         )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_fwd_rocm(
+            padded_input_act,
+            weight_t,
+            padded_group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+        )
     else:
         return _compute_fwd_sm100(
             padded_input_act,
@@ -415,6 +429,15 @@ def _compute_dgrad(
     """
     if kernel_preference == KernelPreference.EMULATED:
         return _compute_dgrad_emulated(
+            grad_output,
+            weight_t,
+            group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+        )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_dgrad_rocm(
             grad_output,
             weight_t,
             group_end_offsets,
@@ -461,6 +484,16 @@ def _compute_wgrad(
     """
     if kernel_preference == KernelPreference.EMULATED:
         return _compute_wgrad_emulated(
+            grad_output,
+            input_act,
+            group_end_offsets,
+            block_size,
+            out_dtype,
+            scale_calculation_mode,
+            wgrad_with_hp,
+        )
+    elif _ROCM_MXFP8_KERNELS_AVAILABLE:
+        return _compute_wgrad_rocm(
             grad_output,
             input_act,
             group_end_offsets,
@@ -1082,3 +1115,111 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
 
 def round_up(x, y):
     return ((x + y - 1) // y) * y
+
+
+# ==================== ROCm (gfx950 / MI355X) implementations ====================
+
+
+def _compute_fwd_rocm(
+    padded_input_act: torch.Tensor,
+    weight_t: torch.Tensor,
+    padded_group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_grouped_mm,
+    )
+
+    input_act_e4m3, input_act_scales = _extract_or_quantize_dim0_auto(
+        padded_input_act, block_size, scale_calculation_mode
+    )
+    weight_e4m3, weight_scales = _extract_or_quantize_dim0_auto(
+        weight_t.transpose(-2, -1).contiguous(), block_size, scale_calculation_mode
+    )
+
+    M = input_act_e4m3.shape[0]
+    E = weight_e4m3.shape[0]
+    max_M_per_expert = (M + E - 1) // E
+
+    return triton_mxfp8_grouped_mm(
+        input_act_e4m3, weight_e4m3, input_act_scales, weight_scales,
+        padded_group_end_offsets, out_dtype=out_dtype,
+        BLOCK_M=128, BLOCK_N=128, BLOCK_K=128,
+        num_warps=8, num_stages=2, max_M_per_expert=max_M_per_expert,
+    )
+
+
+def _compute_dgrad_rocm(
+    grad_output: torch.Tensor,
+    weight_t: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_grouped_mm,
+    )
+
+    grad_output_data, grad_output_scales = _extract_or_quantize_dim0_auto(
+        grad_output.contiguous(), block_size, scale_calculation_mode
+    )
+    weight_e4m3, weight_scales = _extract_or_quantize_dim0_auto(
+        weight_t.contiguous(), block_size, scale_calculation_mode
+    )
+
+    M = grad_output_data.shape[0]
+    E = weight_e4m3.shape[0]
+    max_M_per_expert = (M + E - 1) // E
+
+    return triton_mxfp8_grouped_mm(
+        grad_output_data, weight_e4m3, grad_output_scales, weight_scales,
+        group_end_offsets, out_dtype=out_dtype,
+        BLOCK_M=128, BLOCK_N=128, BLOCK_K=128,
+        num_warps=8, num_stages=2, max_M_per_expert=max_M_per_expert,
+    )
+
+
+def _compute_wgrad_rocm(
+    grad_output: torch.Tensor,
+    input_act: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int,
+    out_dtype: torch.dtype,
+    scale_calculation_mode: ScaleCalculationMode,
+    wgrad_with_hp: bool = False,
+) -> torch.Tensor:
+    from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+        triton_mxfp8_wgrad,
+    )
+    from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim1
+
+    grad_output = _dequantize_if_mxtensor(grad_output, block_size)
+    input_act = _dequantize_if_mxtensor(input_act, block_size)
+
+    if wgrad_with_hp:
+        grad_weight = torch._grouped_mm(
+            grad_output.transpose(-2, -1),
+            input_act,
+            offs=group_end_offsets,
+            out_dtype=out_dtype,
+        )
+        return grad_weight.transpose(-2, -1)
+
+    # MXFP8 wgrad: dim1-quantize both inputs, then use wgrad kernel
+    go_data, go_scale = triton_to_mxfp8_dim1(
+        grad_output.contiguous(), block_size, scale_calculation_mode.value
+    )
+    ia_data, ia_scale = triton_to_mxfp8_dim1(
+        input_act.contiguous(), block_size, scale_calculation_mode.value
+    )
+
+    grad_weight = triton_mxfp8_wgrad(
+        go_data.t(), go_scale, ia_data.t(), ia_scale, group_end_offsets,
+        out_dtype=out_dtype,
+        BLOCK_N=128, BLOCK_K=128, BLOCK_M=128,
+        num_warps=8, num_stages=2,
+    )
+    return grad_weight.transpose(-2, -1)

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -313,6 +313,7 @@ class MXFP8TrainingWeightWrapperTensor(TrainingWeightWrapperBaseTensor):
                 kernel_preference=config.kernel_preference,
                 scale_calculation_mode=config.scale_calculation_mode,
                 wgrad_with_hp=config.wgrad_with_hp,
+                mxfp8_dim1_cast_kernel_choice=config.mxfp8_dim1_cast_kernel_choice,
             )
 
         else:

--- a/torchao/prototype/moe_training/utils.py
+++ b/torchao/prototype/moe_training/utils.py
@@ -355,7 +355,16 @@ def generate_jagged_offs(E, M, multiple_of=32, dtype=torch.int32, device="cuda")
 def conditional_nostrict_trace(fn):
     """
     Applies @torch._dynamo.nonstrict_trace if exists, otherwise no-op.
+
+    ROCm: newer dynamo rejects the FakeTensor output of a custom_op-based
+    kernel (which is what the ROCm MXFP8 path uses) as "not a basic type"
+    when the wrapped function's output is inspected by nonstrict_trace.
+    The function still runs correctly under torch.compile without the
+    decorator — we just lose the explicit trace hint. Skip the decorator
+    on ROCm until dynamo learns this.
     """
+    if torch.version.hip is not None:
+        return fn
     if torch_version_at_least("2.7.0"):
         return torch._dynamo.nonstrict_trace(fn)
     warnings.warn(

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -231,11 +231,10 @@ if torch_version_at_least("2.7.0") and has_triton():
         return out_buffer.reshape(orig_shape)
 
     def _get_mxfp8_quant_autotune_configs():
-        # Values to sweep over here were determined by a manual
-        # sweep over a small set of shapes, it's likely that this
-        # can be improved in the future.
+        # Tile sweep tuned for both SM100 and MI355X (304 CUs).
+        # ROW_TILE=64 helps small activation shapes on ROCm.
         results = []
-        for ROW_TILE_SIZE in (128, 256, 512):
+        for ROW_TILE_SIZE in (64, 128, 256, 512):
             # TODO: we can't use 512 for COL_TILE_SIZE.
             # This is likely a triton bug, tracked in
             # https://github.com/pytorch/ao/issues/3362
@@ -749,7 +748,9 @@ if _triton_kernels_available:
 
     @triton.autotune(
         configs=_get_mxfp8_quant_autotune_configs(),
-        key=["n_cols", "SCALE_BLOCK_SIZE"],
+        # Include n_rows so small activation tensors get a different tuned
+        # config from large weight tensors that share the same n_cols.
+        key=["n_rows", "n_cols", "SCALE_BLOCK_SIZE"],
     )
     @triton.jit
     def to_mxfp8_dim0_kernel(
@@ -1009,6 +1010,7 @@ else:
         scaling_mode: str = "rceil",
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise AssertionError("needs torch version 2.8+ and triton")
+
 
 
 _mxfp8_cuda_kernels_available = (

--- a/torchao/prototype/mx_formats/mx_linear.py
+++ b/torchao/prototype/mx_formats/mx_linear.py
@@ -29,6 +29,9 @@ def _to_mxfp8_then_scaled_mm(
     kernel_preference: KernelPreference,
     scale_calculation_mode: ScaleCalculationMode,
     wgrad_with_hp: bool = False,
+    mxfp8_dim1_cast_kernel_choice: MXFP8Dim1CastKernelChoice = (
+        MXFP8Dim1CastKernelChoice.CUDA
+    ),
 ) -> torch.Tensor:
     """
     Performs a matrix multiplication with MXFP8 quantization on both forward and backward passes.
@@ -47,6 +50,11 @@ def _to_mxfp8_then_scaled_mm(
         kernel_preference: Whether to use AUTO (best kernel for each operation) or EMULATED mode
         scale_calculation_mode: Scale calculation method (RCEIL or FLOOR) for MXFP8 quantization
         wgrad_with_hp: If True, compute grad_weight in high precision instead of MXFP8. Default: False
+        mxfp8_dim1_cast_kernel_choice: Which kernel to use for the MXFP8 dim1
+            quantization in the backward. Default is
+            ``MXFP8Dim1CastKernelChoice.CUDA`` (best for CUDA SM100+). On
+            backends without the CUDA kernel (e.g. ROCm), set this to
+            ``MXFP8Dim1CastKernelChoice.TRITON``.
 
     Returns:
         Output tensor of shape [..., out_features] in high precision
@@ -55,14 +63,12 @@ def _to_mxfp8_then_scaled_mm(
         Forward and backward grad_input are always computed using MXFP8 with block_size=32
         and element_dtype=float8_e4m3fn. Backward grad_weight uses MXFP8 by default, but can
         optionally use high precision when wgrad_with_hp=True for improved accuracy.
-        The Triton kernel is used for dim0 quantization and CUDA kernel for dim1 quantization.
     """
     in_elem_dtype = torch.float8_e4m3fn
     w_elem_dtype = torch.float8_e4m3fn
     grad_elem_dtype = torch.float8_e4m3fn
     block_size = 32
     mxfp8_dim0_cast_kernel_choice = MXFP8Dim0CastKernelChoice.TRITON
-    mxfp8_dim1_cast_kernel_choice = MXFP8Dim1CastKernelChoice.CUDA
 
     return mx_mm.apply(
         input_hp,

--- a/torchao/prototype/mx_formats/mx_linear.py
+++ b/torchao/prototype/mx_formats/mx_linear.py
@@ -62,7 +62,12 @@ def _to_mxfp8_then_scaled_mm(
     grad_elem_dtype = torch.float8_e4m3fn
     block_size = 32
     mxfp8_dim0_cast_kernel_choice = MXFP8Dim0CastKernelChoice.TRITON
-    mxfp8_dim1_cast_kernel_choice = MXFP8Dim1CastKernelChoice.CUDA
+    # On ROCm, CUDA dim1 kernels are not available; use Triton instead.
+    from torchao.utils import is_ROCM
+    mxfp8_dim1_cast_kernel_choice = (
+        MXFP8Dim1CastKernelChoice.TRITON if is_ROCM()
+        else MXFP8Dim1CastKernelChoice.CUDA
+    )
 
     return mx_mm.apply(
         input_hp,

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -31,7 +31,7 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._pytree import tree_map
 
-from torchao.utils import is_sm_at_least_100, torch_version_at_least
+from torchao.utils import is_ROCM, is_sm_at_least_100, torch_version_at_least
 
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
@@ -784,6 +784,32 @@ def _addmm_mx_dispatch(
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
+
+        # ROCm: dispatch to native F.scaled_mm with BlockWise1x32 scale recipe.
+        if (
+            is_ROCM()
+            and not a.is_swizzled_scales
+            and not b.is_swizzled_scales
+            and a.elem_dtype == torch.float8_e4m3fn
+            and b.elem_dtype == torch.float8_e4m3fn
+            and K % 128 == 0
+        ):
+            a_qdata = a.qdata                                        # (M, K)
+            b_qdata = b.qdata                                        # (K, N)
+            a_scale_2d = a.scale.reshape(M, K // a.block_size).contiguous()
+            b_scale_2d = b.scale.t().reshape(N, K // b.block_size).contiguous()
+            res = F.scaled_mm(
+                a_qdata,
+                b_qdata,
+                scale_a=a_scale_2d,
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_2d,
+                scale_recipe_b=ScalingType.BlockWise1x32,
+                output_dtype=torch.bfloat16,
+            )
+            if bias is not None:
+                res = res + bias
+            return res
 
         if a.is_swizzled_scales:
             a_scale_block = a.scale

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -30,7 +30,7 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._pytree import tree_map
 
-from torchao.utils import torch_version_at_least
+from torchao.utils import is_ROCM, torch_version_at_least
 
 # ScalingType and SwizzleType are only available in PyTorch 2.10+
 if torch_version_at_least("2.10.0"):
@@ -749,6 +749,44 @@ def _addmm_mx_dispatch(
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
+
+        # ROCm fast path: use our Triton dense MXFP8 kernel which is faster
+        # than torch._scaled_mm and doesn't need to_blocked scale conversion.
+        if (
+            is_ROCM()
+            and not a.is_swizzled_scales
+            and not b.is_swizzled_scales
+            and a.elem_dtype == torch.float8_e4m3fn
+            and b.elem_dtype == torch.float8_e4m3fn
+            and K % 128 == 0
+        ):
+            from torchao.prototype.moe_training.kernels.mxfp8.rocm_mxfp8_mm import (
+                triton_mxfp8_mm,
+            )
+            a_qdata = a.qdata                                        # (M, K)
+            b_qdata = b.qdata                                        # (K, N)
+            a_scale_2d = a.scale.reshape(M, K // a.block_size).contiguous()
+            b_scale_2d = b.scale.t().reshape(N, K // b.block_size).contiguous()
+            # Shape-aware tile selection: K=2816 (w2) benefits from BLOCK_K=256.
+            if K % 256 == 0 and K >= 2560:
+                bm, bn, bk = 256, 128, 256
+            else:
+                bm, bn, bk = 256, 256, 128
+            res = triton_mxfp8_mm(
+                a_qdata,
+                b_qdata,
+                a_scale_2d,
+                b_scale_2d,
+                out_dtype=torch.bfloat16,
+                BLOCK_M=bm,
+                BLOCK_N=bn,
+                BLOCK_K=bk,
+                num_warps=8,
+                num_stages=2,
+            )
+            if bias is not None:
+                res = res + bias
+            return res
 
         if a.is_swizzled_scales:
             a_scale_block = a.scale


### PR DESCRIPTION
### Summary

Adds ROCm gfx950 (MI355X) support for MXFP8 MoE training. Provides Triton kernel
replacements using `tl.dot_scaled` which feeds E8M0 block scales directly into
gfx950's native scaled MFMA instructions.

All changes are gated behind `is_ROCM()` — no impact on CUDA/SM100 paths.

### Changes

**New file:**
- `torchao/prototype/moe_training/kernels/mxfp8/rocm_mxfp8_mm.py` — Two Triton
  kernel entry points:
  - `triton_mxfp8_grouped_mm` — Persistent grouped GEMM for MoE fwd and dgrad.
    Grid = `num_CUs * ctas_per_cu`, each CTA walks the expert list with a
    global tile counter. No data-dependent grid, no silent row-dropping.
  - `triton_mxfp8_wgrad` — Weight gradient grouped GEMM. Internally dispatches
    to a split-K variant when `E == 1` (single-group grid too small to saturate
    the device); otherwise the direct path writes bf16 output in-place.

**Modified files:**

*MoE training:*
- `torchao/prototype/moe_training/mxfp8_grouped_mm.py` — ROCm dispatch for
  fwd / dgrad / wgrad, gated by `_ROCM_MXFP8_KERNELS_AVAILABLE`.
- `torchao/prototype/moe_training/config.py` — Add `mxfp8_dim1_cast_kernel_choice`
  field on `MXFP8TrainingOpConfig` so callers can pick `TRITON` on ROCm.
- `torchao/prototype/moe_training/tensor.py` — Thread the new config field
  through to the op.
- `torchao/prototype/moe_training/utils.py` — Skip `@nonstrict_trace` on
  ROCm; newer dynamo rejects the FakeTensor output of our custom-op kernels.
- `torchao/prototype/moe_training/kernels/mxfp8/__init__.py` — Export the
  two new ROCm kernel entry points.
- `torchao/prototype/moe_training/kernels/mxfp8/quant.py` — Register
  `torch_pad_token_groups` as a `torch.library.custom_op` with a
  `register_fake` implementation so it traces cleanly under torch.compile.

*MX formats (used by the shared-expert dense path):*
- `torchao/prototype/mx_formats/mx_tensor.py` — ROCm path uses `F.scaled_mm`
  with `ScalingType.BlockWise1x32` for the dense matmul.
- `torchao/prototype/mx_formats/mx_linear.py` — Select `TRITON` dim1 cast
  kernel on ROCm (CUDA dim1 kernel unavailable there).
- `torchao/prototype/mx_formats/kernels.py` — `ROW_TILE=64` autotune config
  and `n_rows` on the autotune key for better per-shape tuning of dim1 cast.

*Tests + benchmarks:*
- `test/prototype/moe_training/test_mxfp8_grouped_mm.py` — Drop
  `@skip_if_rocm` markers now that the ROCm path is correct.
- `benchmarks/prototype/moe_training/bench_2d_3d_grouped_gemm.py` — Extend
  the MXFP8 gate to MI350+; add the ROCm call path
  (`bench_mxfp8_grouped_mm_rocm`).
- `benchmarks/prototype/moe_training/benchmark_scaled_grouped_mm_dq.py` —
  Extend the MXFP8 gate to MI350+.

### Benchmarks

Env: 1× AMD MI355X (gfx950), ROCm 7.1, torch nightly `2.13.0.dev20260417+rocm7.1`, `triton-rocm==3.7.0`.

Detailed run info (raw logs + env): https://github.com/indianspeedster/ao/actions/runs/24588975436

**Full training step (`benchmark_scaled_grouped_mm_dq.py`, fwd + dgrad + wgrad + dim1 quant, `--alignment-size 32`):**

| M | N | K | G | bf16 fwd+bwd (μs) | mxfp8 fwd+bwd (μs) | fwd+bwd speedup | bf16 fwd (μs) | mxfp8 fwd (μs) | fwd speedup |
|---|---|---|---|-------------------|---------------------|------------------|----------------|------------------|--------------|
| 32768  | 8192 | 5120 | 1 | 6564  | 9227  | 0.71× | 1807 | 1810 | 1.00× |
| 32768  | 8192 | 5120 | 2 | 6927  | 9645  | 0.72× | 1882 | 1907 | 0.99× |
| 128000 | 8192 | 5120 | 1 | 25579 | 33931 | 0.75× | 7001 | 7052 | 0.99× |
| 128000 | 8192 | 5120 | 2 | 25714 | 35146 | 0.73× | 7047 | 7100 | 0.99× |
| 32768  | 2048 | 7168 | 4 | 2976  | 4208  | 0.71× | 807  | 929  | 0.87× |
| 32768  | 2048 | 7168 | 8 | 3411  | 4549  | 0.75× | 972  | 954  | 1.02× |
| 128000 | 2048 | 7168 | 4 | 9882  | 15501 | 0.64× | 2697 | 3625 | 0.74× |
| 128000 | 2048 | 7168 | 8 | 10318 | 15812 | 0.65× | 2737 | 3682 | 0.74× |

**Grouped GEMM fwd-only (`bench_2d_3d_grouped_gemm.py`):**

| E | M | N | K | bf16 (μs) | mxfp8 (μs) | speedup |
|---|---|---|---|-----------|-------------|---------|
| 1 | 16640 | 2048 | 2048 | 159 | 110 | 1.44× |
| 1 | 16640 | 2048 | 5120 | 326 | 285 | 1.14× |
| 1 | 16640 | 2048 | 8192 | 483 | 433 | 1.11× |
| 1 | 16640 | 5120 | 2048 | 317 | 257 | 1.23× |
| 1 | 16640 | 5120 | 5120 | 692 | 648 | 1.07× |
| 1 | 16640 | 5120 | 8192 | 1106 | 1019 | 1.09× |
| 1 | 16640 | 8192 | 2048 | 471 | 404 | 1.16× |
| 1 | 16640 | 8192 | 5120 | 1063 | 1005 | 1.06× |
| 1 | 16640 | 8192 | 8192 | 1646 | 1565 | 1.05× |
| 2 | 16640 | 2048 | 2048 | 159 | 114 | 1.39× |
| 2 | 16640 | 2048 | 5120 | 321 | 284 | 1.13× |
| 2 | 16640 | 2048 | 8192 | 473 | 435 | 1.09× |
| 2 | 16640 | 5120 | 2048 | 316 | 263 | 1.20× |
| 2 | 16640 | 5120 | 5120 | 635 | 663 | 0.96× |
| 2 | 16640 | 5120 | 8192 | 1013 | 1019 | 0.99× |
| 2 | 16640 | 8192 | 2048 | 448 | 421 | 1.06× |
| 2 | 16640 | 8192 | 5120 | 984 | 1026 | 0.96× |
| 2 | 16640 | 8192 | 8192 | 1574 | 1597 | 0.99× |
| 4 | 16640 | 2048 | 2048 | 193 | 114 | 1.69× |
| 4 | 16640 | 2048 | 5120 | 396 | 296 | 1.34× |
| 4 | 16640 | 2048 | 8192 | 548 | 441 | 1.25× |
| 4 | 16640 | 5120 | 2048 | 371 | 267 | 1.39× |
| 4 | 16640 | 5120 | 5120 | 700 | 682 | 1.03× |
| 4 | 16640 | 5120 | 8192 | 1036 | 1032 | 1.00× |
| 4 | 16640 | 8192 | 2048 | 549 | 420 | 1.31× |
| 4 | 16640 | 8192 | 5120 | 1088 | 1048 | 1.04× |
| 4 | 16640 | 8192 | 8192 | 1738 | 1618 | 1.07× |
| 8 | 16640 | 2048 | 2048 | 244 | 120 | 2.04× |
| 8 | 16640 | 2048 | 5120 | 559 | 316 | 1.77× |
| 8 | 16640 | 2048 | 8192 | 737 | 449 | 1.64× |
| 8 | 16640 | 5120 | 2048 | 429 | 271 | 1.59× |
| 8 | 16640 | 5120 | 5120 | 847 | 695 | 1.22× |
| 8 | 16640 | 5120 | 8192 | 1207 | 1060 | 1.14× |
| 8 | 16640 | 8192 | 2048 | 589 | 432 | 1.36× |
| 8 | 16640 | 8192 | 5120 | 1297 | 1098 | 1.18× |
| 8 | 16640 | 8192 | 8192 | 1719 | 1704 | 1.01× |

**Accuracy (`test_mxfp8_grouped_mm.py`):** 129 passed, 16 skipped.

### Note

This is the initial functional baseline; more optimizations are in progress
and will land soon.
