### PR TITLE
Add Sparse2x4HIPSPARSELTFloat8Tensor (#4277)

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_sparse_2x4_1d_data_1d_metadata_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_sparse_2x4_1d_data_1d_metadata_tensor.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import copy
+import logging
+import unittest
+
+import torch
+from torch import nn
+from torch.testing._internal import common_utils
+
+try:
+    from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8_SPARSE
+except ImportError:
+    PLATFORM_SUPPORTS_FP8_SPARSE = False
+from torchao.quantization import (
+    Float8DynamicActivationFloat8WeightConfig,
+)
+from torchao.quantization.granularity import PerTensor
+from torchao.quantization.quant_api import (
+    quantize_,
+)
+from torchao.quantization.quantize_.workflows import (
+    Float8PackingFormat,
+)
+from torchao.quantization.utils import compute_error
+from torchao.sparsity import apply_fake_sparsity
+from torchao.utils import (
+    is_ROCM,
+    torch_version_at_least,
+)
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
+)
+
+
+@unittest.skipIf(
+    not torch_version_at_least("2.10.0"),
+    "Need torch >= 2.10.0",
+)
+class TestFloat8Sparse2x4_1DData1DMetadataTensor(common_utils.TestCase):
+    def setUp(self):
+        if not is_ROCM():
+            self.skipTest("hipSPARSELt path requires ROCm")
+        if not PLATFORM_SUPPORTS_FP8_SPARSE:
+            self.skipTest("Need platform with FP8 sparse support (hipSPARSELt)")
+
+    @common_utils.parametrize("compile", [True, False])
+    def test_fp8_hipsparselt_sparse(self, compile):
+        with torch.inference_mode():
+            input = torch.rand((256, 256), dtype=torch.bfloat16, device="cuda")
+            model = (
+                nn.Sequential(
+                    nn.Linear(256, 1024),
+                    nn.Linear(1024, 256),
+                )
+                .bfloat16()
+                .cuda()
+                .eval()
+            )
+
+            apply_fake_sparsity(model)
+            baseline_result = model(input)
+            model_copy = copy.deepcopy(model)
+
+            # Quantized (dense)
+            quantize_(
+                model_copy,
+                Float8DynamicActivationFloat8WeightConfig(
+                    granularity=PerTensor(),
+                ),
+            )
+            dense_result = model_copy(input)
+            dense_sqnr = compute_error(baseline_result, dense_result)
+
+            # Sparse + quantized
+            quantize_(
+                model,
+                Float8DynamicActivationFloat8WeightConfig(
+                    version=2,
+                    packing_format=Float8PackingFormat.SPARSE_1D_DATA_1D_METADATA,
+                    granularity=PerTensor(),
+                ),
+            )
+            if compile:
+                model = torch.compile(model)
+            sparse_result = model(input)
+            sparse_sqnr = compute_error(baseline_result, sparse_result)
+
+            self.assertEqual(dense_sqnr, sparse_sqnr)
+
+    def test_fp8_hipsparselt_sparse_lowering_op_clone(self):
+        """Validates clone dispatch correctly copies both sparse data and scale metadata."""
+        with torch.inference_mode():
+            model = nn.Linear(256, 1024).half().cuda().eval()
+            apply_fake_sparsity(model)
+            quantize_(
+                model,
+                Float8DynamicActivationFloat8WeightConfig(
+                    version=2,
+                    packing_format=Float8PackingFormat.SPARSE_1D_DATA_1D_METADATA,
+                    granularity=PerTensor(),
+                ),
+            )
+
+            original = model.weight.dequantize()
+            cloned = model.weight.clone().dequantize()
+
+            for o, c in zip(original, cloned):
+                self.assertEqual(o, c)
+
+    def test_fp8_hipsparselt_sparse_lowering_op_to(self):
+        """Validates both to.dtype_layout and to.dtype dispatch paths correctly dequantize the sparse tensor."""
+        with torch.inference_mode():
+            model = nn.Linear(256, 1024).half().cuda().eval()
+            apply_fake_sparsity(model)
+            model_copy = copy.deepcopy(model)
+            expected = model_copy.weight.to(dtype=torch.float)
+
+            quantize_(
+                model,
+                Float8DynamicActivationFloat8WeightConfig(
+                    version=2,
+                    packing_format=Float8PackingFormat.SPARSE_1D_DATA_1D_METADATA,
+                    granularity=PerTensor(),
+                ),
+            )
+
+            original_by_to_dtype_layout = torch.ops.aten.to.dtype_layout(
+                model.weight,
+                dtype=torch.float,
+                layout=torch.strided,
+            )
+            torch.testing.assert_close(
+                expected, original_by_to_dtype_layout, atol=1e-1, rtol=1e-1
+            )
+
+            original_by_to_dtype = torch.ops.aten.to.dtype(
+                model.weight,
+                torch.float,
+            )
+            torch.testing.assert_close(
+                expected, original_by_to_dtype, atol=1e-1, rtol=1e-1
+            )
+
+
+common_utils.instantiate_parametrized_tests(TestFloat8Sparse2x4_1DData1DMetadataTensor)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -52,6 +52,7 @@ from torchao.quantization.quantize_.common import (
 )
 from torchao.quantization.quantize_.workflows import (
     Float8PackingFormat,
+    Float8Sparse2x4_1DData1DMetadataTensor,
     Float8Tensor,
     Int4ChooseQParamsAlgorithm,
     Int4PackingFormat,
@@ -1262,6 +1263,17 @@ def _float8_dynamic_activation_float8_weight_quantize_tensor(weight, config):
             "Sparse packing format only supports per-row quantization"
         )
         quantized_weight = Sparse2x4CUTLASSFloat8Tensor.from_hp(
+            weight,
+            float8_dtype=weight_dtype,
+            granularity=weight_granularity,
+            act_quant_kwargs=act_quant_kwargs,
+        )
+        return quantized_weight
+    elif packing_format == Float8PackingFormat.SPARSE_1D_DATA_1D_METADATA:
+        assert isinstance(weight_granularity, PerTensor), (
+            "Sparse 1D data 1D metadata packing format only supports per-tensor quantization"
+        )
+        quantized_weight = Float8Sparse2x4_1DData1DMetadataTensor.from_hp(
             weight,
             float8_dtype=weight_dtype,
             granularity=weight_granularity,

--- a/torchao/quantization/quantize_/workflows/__init__.py
+++ b/torchao/quantization/quantize_/workflows/__init__.py
@@ -1,6 +1,9 @@
 from .float8.float8_packing_format import (
     Float8PackingFormat,
 )
+from .float8.float8_sparse_2x4_1d_data_1d_metadata_tensor import (
+    Float8Sparse2x4_1DData1DMetadataTensor,
+)
 from .float8.float8_tensor import (
     Float8Tensor,
     QuantizeTensorToFloat8Kwargs,
@@ -45,6 +48,7 @@ __all__ = [
     "QuantizeTensorToInt8Kwargs",
     "Float8Tensor",
     "Sparse2x4CUTLASSFloat8Tensor",
+    "Float8Sparse2x4_1DData1DMetadataTensor",
     "Float8PackingFormat",
     "QuantizeTensorToFloat8Kwargs",
     "Int8Tensor",

--- a/torchao/quantization/quantize_/workflows/float8/float8_packing_format.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_packing_format.py
@@ -33,6 +33,23 @@ class Float8PackingFormat(str, Enum):
     This packing format will dispatch to `rowwise_scaled_linear_sparse_cutlass_f8f8`, which will fuse the per-row scaling into the sparse matmul.
     """
     SPARSE_CUTLASS = "sparse_cutlass"
+    """
+    Sparse packing format for 2:4 sparsity + FP8 quantization using hipSPARSELt (ROCm/AMD only).
+
+    SPARSE_1D_DATA_1D_METADATA will pack the quantized_data into a single tensor containing both the quantized data and metadata
+    as a 1D tensor of r*c/2 + r*c/8 bytes with the following layout: [compressed_data | metadata]
+
+    - compressed_data: r*c/2 bytes
+        The 2 non-zero FP8 values per group of 4 elements, stored row-major:
+        row0_group0_val0, row0_group0_val1, row0_group1_val0, row0_group1_val1, ..., row1_group0_val0, ...
+    - metadata: r*c/8 bytes
+        4 bits per group of 4 elements encoding the positions of the 2 kept values
+        (2 bits per kept element index), groups packed contiguously row-major:
+        row0_group0_meta, row0_group1_meta, ..., row1_group0_meta, ...
+
+    This packing format will dispatch to torch._cslt_sparse_mm for matmul, with per-tensor scaling passed as alpha.
+    """
+    SPARSE_1D_DATA_1D_METADATA = "sparse_1d_data_1d_metadata"
 
 
 torch.serialization.add_safe_globals([Float8PackingFormat])

--- a/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import List, Optional, Tuple
+
+import torch
+
+from torchao.float8.inference import (
+    FP8Granularity,
+)
+from torchao.quantization.granularity import PerTensor
+from torchao.quantization.quant_primitives import (
+    _choose_scale_float8,
+    _quantize_affine_float8,
+)
+from torchao.quantization.quantize_.common import (
+    _choose_quant_func_and_quantize_tensor,
+)
+from torchao.quantization.utils import get_block_size
+from torchao.utils import (
+    TorchAOBaseTensor,
+    is_MI350,
+    is_ROCM,
+)
+
+__all__ = [
+    "Float8Sparse2x4_1DData1DMetadataTensor",
+]
+
+aten = torch.ops.aten
+
+
+from .float8_tensor import QuantizeTensorToFloat8Kwargs
+
+
+class Float8Sparse2x4_1DData1DMetadataTensor(TorchAOBaseTensor):
+    """
+    Float8 Quantized + 2:4 sparse (weight) Tensor using hipSPARSELt kernels (ROCm/AMD only),
+    with float8 dynamic quantization for activation.
+
+    Unlike the CUTLASS variant which stores specified values and metadata as two
+    separate tensors, this variant packs them into a single tensor via torch._cslt_compress
+    (which dispatches to hipSPARSELt on ROCm), and dispatches matmul via torch._cslt_sparse_mm.
+
+    Only per-tensor scaling is supported — hipSPARSELt lacks per-operand scaling,
+    so A_scale * B_scale is passed as the alpha parameter to _cslt_sparse_mm.
+
+    Tensor Attributes:
+        qdata_and_metadata: compressed sparse tensor (specified values + metadata in one tensor)
+        scale: per-tensor scale for float8 quantization
+
+    Non-Tensor Attributes:
+        block_size (List[int]): the block size for float8 quantization
+        original_shape (Tuple[int, int]): the shape of the original dense weight
+        act_quant_kwargs (QuantizeTensorToFloat8Kwargs): the kwargs for activation quantization
+        dtype: Original Tensor dtype
+    """
+
+    tensor_data_names = ["qdata_and_metadata", "scale"]
+    tensor_attribute_names = []
+    optional_tensor_attribute_names = [
+        "block_size",
+        "original_shape",
+        "act_quant_kwargs",
+        "dtype",
+    ]
+
+    def __new__(
+        cls,
+        qdata_and_metadata: torch.Tensor,
+        scale: torch.Tensor,
+        block_size: Optional[List[int]] = None,
+        original_shape: Optional[Tuple[int, int]] = None,
+        act_quant_kwargs: Optional[QuantizeTensorToFloat8Kwargs] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        assert original_shape is not None, "original_shape must be specified"
+        kwargs = {}
+        kwargs["device"] = qdata_and_metadata.device
+        kwargs["dtype"] = dtype
+        kwargs["requires_grad"] = False
+        return torch.Tensor._make_wrapper_subclass(cls, original_shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        qdata_and_metadata: torch.Tensor,
+        scale: torch.Tensor,
+        block_size: Optional[List[int]] = None,
+        original_shape: Optional[Tuple[int, int]] = None,
+        act_quant_kwargs: Optional[QuantizeTensorToFloat8Kwargs] = None,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.qdata_and_metadata = qdata_and_metadata
+        self.scale = scale
+        self.block_size = block_size
+        self.original_shape = original_shape
+        self.act_quant_kwargs = act_quant_kwargs
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}({self.act_quant_kwargs=}, {self.qdata_and_metadata.shape=}, {self.scale=}, "
+            f"{self.block_size=}, "
+            f"{self.shape=}, {self.device=}, {self.dtype=})"
+        )
+
+    def _quantization_type(self):
+        return f"{self.act_quant_kwargs=}, {self.block_size=}, {self.scale.shape=}"
+
+    def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+        in_features = self.shape[1]
+        mm_out_dtype = torch.float32
+        identity = torch.eye(in_features, device=self.qdata_and_metadata.device).to(
+            self.qdata_and_metadata.dtype
+        )
+        dense = torch._cslt_sparse_mm(
+            self.qdata_and_metadata,
+            identity,
+            alpha=self.scale,
+            out_dtype=mm_out_dtype,
+        )
+
+        if output_dtype is not None:
+            dense = dense.to(output_dtype)
+        return dense
+
+    @classmethod
+    def from_hp(
+        cls,
+        hp_tensor: torch.Tensor,
+        float8_dtype: torch.dtype = torch.float8_e4m3fn,
+        granularity: FP8Granularity = PerTensor(),
+        hp_value_lb: Optional[float] = None,
+        hp_value_ub: Optional[float] = None,
+        act_quant_kwargs: Optional[QuantizeTensorToFloat8Kwargs] = None,
+    ):
+        assert is_ROCM(), (
+            "SPARSE_1D_DATA_1D_METADATA packing format is only supported on ROCm (hipSPARSELt)"
+        )
+        assert is_MI350(), "hipSPARSELt FP8 sparse requires MI350 (gfx950) GPU"
+        assert isinstance(granularity, PerTensor), (
+            "hipSPARSELt sparse kernel only supports per-tensor quantization"
+        )
+        assert float8_dtype == torch.float8_e4m3fn, (
+            "hipSPARSELt sparse kernel only supports float8_e4m3fn dtype"
+        )
+
+        block_size = get_block_size(hp_tensor.shape, granularity)
+        block_size = list(block_size)
+        scale = _choose_scale_float8(
+            hp_tensor,
+            float8_dtype=float8_dtype,
+            block_size=block_size,
+            hp_value_lb=hp_value_lb,
+            hp_value_ub=hp_value_ub,
+        )
+        data = _quantize_affine_float8(hp_tensor, scale, float8_dtype)
+        hp_dtype = hp_tensor.dtype
+        original_shape = tuple(hp_tensor.shape)
+
+        # Compress using hipSPARSELt — packs specified values + metadata into one tensor
+        qdata_and_metadata = torch._cslt_compress(data)
+
+        return Float8Sparse2x4_1DData1DMetadataTensor(
+            qdata_and_metadata,
+            scale,
+            block_size=block_size,
+            original_shape=original_shape,
+            act_quant_kwargs=act_quant_kwargs,
+            dtype=hp_dtype,
+        )
+
+
+implements = Float8Sparse2x4_1DData1DMetadataTensor.implements
+implements_torch_function = (
+    Float8Sparse2x4_1DData1DMetadataTensor.implements_torch_function
+)
+
+
+@implements(aten.linear.default)
+@implements_torch_function(torch.nn.functional.linear)
+def _(func, types, args, kwargs):
+    input_tensor = kwargs.get("input", args[0] if len(args) > 0 else None)
+    weight_tensor = kwargs.get("weight", args[1] if len(args) > 1 else None)
+    bias = kwargs.get("bias", args[2] if len(args) > 2 else None)
+
+    assert input_tensor is not None, "input tensor must not be None"
+    assert weight_tensor is not None, "weight tensor must not be None"
+
+    act_quant_kwargs = weight_tensor.act_quant_kwargs
+    # quantize activation, if `act_quant_kwargs` is specified
+    if act_quant_kwargs is not None:
+        assert not isinstance(input_tensor, TorchAOBaseTensor), (
+            "input tensor was already quantized"
+        )
+        input_tensor = _choose_quant_func_and_quantize_tensor(
+            input_tensor, act_quant_kwargs
+        )
+
+    input_fp8 = input_tensor.qdata
+    input_scale = input_tensor.scale
+    weight_packed = weight_tensor.qdata_and_metadata
+    weight_scale = weight_tensor.scale
+
+    mm_out_dtype = torch.float32
+
+    # linear: y = x @ W^T
+    # _cslt_sparse_mm(compressed_A [m,k], dense_B [k,n]) -> [m,n]
+    # A = weight (out_features, in_features), B = input^T (in_features, batch)
+    orig_shape = input_fp8.shape
+    input_2d = input_fp8.reshape(-1, orig_shape[-1])
+
+    # Per-tensor scaling: pass combined scale as alpha
+    alpha = input_scale * weight_scale
+
+    # hipSPARSELt requires bias dtype to match out_dtype
+    bias_mm = bias.to(mm_out_dtype) if bias is not None else None
+
+    result = torch._cslt_sparse_mm(
+        weight_packed,
+        input_2d.t(),
+        bias=bias_mm,
+        alpha=alpha,
+        out_dtype=mm_out_dtype,
+    )
+    # result: (out_features, batch) -> (batch, out_features)
+    result = result.t()
+
+    out_dtype = input_tensor.dtype
+    result = result.to(out_dtype)
+
+    result = result.reshape(*orig_shape[:-1], result.shape[-1])
+
+    return result
+
+
+@implements(aten.to.dtype_layout)
+def _(func, types, args, kwargs):
+    return (
+        args[0]
+        .dequantize()
+        .to(
+            *args[1:],
+            dtype=kwargs.get("dtype", args[0].dtype),
+            device=kwargs.get("device", args[0].device),
+        )
+    )
+
+
+@implements(aten.to.dtype)
+def _(func, types, args, kwargs):
+    dtype = kwargs.get("dtype", args[1] if len(args) > 1 else None)
+    assert dtype is not None, "dtype must not be None"
+
+    return (
+        args[0]
+        .dequantize()
+        .to(
+            dtype=dtype,
+        )
+    )
+
+
+# Allow a model with Float8Sparse2x4_1DData1DMetadataTensor weights to be loaded with `weights_only=True`
+torch.serialization.add_safe_globals([Float8Sparse2x4_1DData1DMetadataTensor])


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/180312


What: Adding a new tensor subclass for FP8 2:4 sparsity via hipSPARSELt (ROCm only). Packs compressed values + metadata into a single tensor with `_cslt_compress` and dispatches through `_cslt_sparse_mm` with `A_scale * B_scale` as `alpha`.

Why: This hipSPARSELt path differs enough in packing and kernel routing from CUTLASS to warrant a dedicated path.

Reference: https://rocm.blogs.amd.com/artificial-intelligence/introduce_hipsparselt/README.html

Reviewed By: RandySheriff

Differential Revision: D100640267


