### PR TITLE
fix fb-built pytorch cannot use fp16 2:4 sparsity (#4280)

### DIFF
--- a/torchao/sparsity/sparse_api.py
+++ b/torchao/sparsity/sparse_api.py
@@ -92,7 +92,11 @@ def _semi_sparse_weight_transform(
     module: torch.nn.Module,
     config: SemiSparseWeightConfig,
 ) -> torch.nn.Module:
-    is_nightly_or_source = "dev" in torch.__version__ or "git" in torch.__version__
+    is_nightly_or_source = (
+        "dev" in torch.__version__
+        or "git" in torch.__version__
+        or "fb" in torch.__version__
+    )
     if is_nightly_or_source:
         new_weight = to_sparse_semi_structured(module.weight, alg_id=config.alg_id)
     else:


### PR DESCRIPTION
Summary:

as title

We cannot use alg_id in fp16 2:4 path as restricted by sparse_api.py line 95. We will need to allow it internally. All fbsouce-built pytorch version has a "fb" suffix implemented here: https://www.internalfb.com/code/fbsource/[7165ee013b34]/fbcode/caffe2/fb/version.py?lines=62

Reviewed By: jerryzh168

Differential Revision: D100873142


