### PR TITLE
[AARCH64] Enable MKLDNN Backend for Int8DynamicActivationInt8WeightConfig() on ARM

### DIFF
--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -162,10 +162,10 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
-        if platform.machine() == "aarch64":
-            c = torch._int_mm_acc_f32(a, b)
-        else:
+    else:
+        if platform.machine() == "aarch64": # s8s8 ARM (aarch64) optimized path
+            c = torch._int_mm_acc(a, b, out_dtype=torch.float32)
+        else:  #s8s8: Computation done with AMX or as the fallback.
             c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import logging
 import os
+import platform
 
 import torch
 from torch._dynamo import is_compiling as dynamo_is_compiling
@@ -161,8 +162,11 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX or as the fallback.
-        c = torch._int_mm(a, b)
+    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
+        if platform.machine() == "aarch64":
+            c = torch._int_mm_acc_f32(a, b)
+        else:
+            c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 
 

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import logging
 import os
+import platform
 
 import torch
 from torch._dynamo import is_compiling as dynamo_is_compiling
@@ -140,8 +141,11 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX or as the fallback.
-        c = torch._int_mm(a, b)
+    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
+        if platform.machine() == "aarch64":
+            c = torch._int_mm_acc_f32(a, b)
+        else:
+            c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 
 

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -141,10 +141,10 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
-        if platform.machine() == "aarch64":
-            c = torch._int_mm_acc_f32(a, b)
-        else:
+    else:
+        if platform.machine() == "aarch64": # s8s8 ARM (aarch64) optimized path
+            c = torch._int_mm(a, b, out_dtype=torch.float32)
+        else:  #s8s8: Computation done with AMX or as the fallback.
             c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 

--- a/torchao/quantization/quantize_/workflows/int8/kernels.py
+++ b/torchao/quantization/quantize_/workflows/int8/kernels.py
@@ -107,10 +107,10 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
-        if platform.machine() == "aarch64":
-            c = torch._int_mm_acc_f32(a, b)
-        else:
+    else:
+        if platform.machine() == "aarch64": # s8s8 ARM (aarch64) optimized path
+            c = torch._int_mm(a, b, out_dtype=torch.float32)
+        else:  #s8s8: Computation done with AMX or as the fallback.
             c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 

--- a/torchao/quantization/quantize_/workflows/int8/kernels.py
+++ b/torchao/quantization/quantize_/workflows/int8/kernels.py
@@ -14,6 +14,7 @@ from torchao.utils import (
     torch_version_at_least,
 )
 
+import platform
 
 def safe_int_mm(input: torch.Tensor, mat2: torch.Tensor) -> torch.Tensor:
     """
@@ -106,8 +107,11 @@ def _int_scaled_matmul_cpu(
         comp = b.sum(dim=0, keepdim=True, dtype=torch.int32) * 128
         c.sub_(comp)
         return c.to(scales1.dtype) * scales1
-    else:  # s8s8: Computation done with AMX or as the fallback.
-        c = torch._int_mm(a, b)
+    else:  # s8s8: Computation done with AMX, ARM (aarch64) optimized path, or fallback.
+        if platform.machine() == "aarch64":
+            c = torch._int_mm_acc_f32(a, b)
+        else:
+            c = torch._int_mm(a, b)
         return c.to(scales1.dtype) * scales1
 
 


### PR DESCRIPTION
Enabled MKLDNN backend for Int8DynamicActivationInt8Weight(layout=plain) for AARCH64 using torch op introduced in the PR : https://github.com/pytorch/pytorch/pull/180455

Both PR needs to be used in conjugation to trigger acl::lowp int8 kernels via the TorchAO quantization workflow.

Performance Numbers :
Quantized Linear Layer Inference Benchmarks

**Configuration:**  
- Quantization: `TorchAO Int8DynamicActivationInt8WeightConfig()`  
- Machine: Graviton 3E (AARCH64)  
- Cores: 32  
- torch: `2.12.0a0+gitfe372f9`  
- torchao: `0.18.0+giteca5d97f2`  

---

**N = 4096, K = 4096**

| M   | MKLDNN Patched (`_int_mm_acc_f32`) | Current (`_int_mm`) |
|-----|-----------------------------------|---------------------|
| 1   | 1.27 ms                          | 1.23 ms            |
| 4   | 1.27 ms                          | 1.94 ms            |
| 8   | 1.53 ms                          | 3.02 ms            |
| 16  | 1.50 ms                          | 4.67 ms            |
| 32  | 1.59 ms                          | 8.35 ms            |
| 64  | 1.72 ms                          | 15.35 ms           |
| 128 | 1.91 ms                          | 29.60 ms           |

---

**N = 4096, K = 11008**

| M   | MKLDNN Patched (`_int_mm_acc_f32`) | Current (`_int_mm`) |
|-----|-----------------------------------|---------------------|
| 1   | 1.79 ms                          | 1.59 ms            |
| 4   | 1.89 ms                          | 3.44 ms            |
| 8   | 1.92 ms                          | 5.98 ms            |
| 16  | 2.18 ms                          | 10.75 ms           |
| 32  | 2.19 ms                          | 20.28 ms           |
| 64  | 2.50 ms                          | 39.43 ms           |
| 128 | 3.03 ms                          | 77.58 ms           |

**Test Script :**

```
import time
import torch
import torch.profiler
from torch.profiler import profile
import copy

torch.manual_seed(0)
itr = 100

m = 128
n = 4096
k = 4096

x = torch.rand(m, n).float()
print("Input shape:")
print(x.shape)

class LinearModel(torch.nn.Module):
    def __init__(self, n, k):
        super().__init__()
        self.fc = torch.nn.Linear(n, k, bias=True)

    def forward(self, x):
        return self.fc(x)

model = LinearModel(n, k).eval()

print("Weight Matrix shape:")
print(model.fc.weight.shape)

from torchao import quantize_
from torchao.quantization.quant_api import Int8DynamicActivationInt8WeightConfig

quantize_(model, Int8DynamicActivationInt8WeightConfig(version=2))
print("Initiating Torch ao plain layout Inference int8.....")
with torch.inference_mode():
        # Warm‑up
    for _ in range(10):
        _ = model(x)

    start = time.time()
    for _ in range(itr):
            _ = model(x)
    end = time.time()

    with profile(with_stack=True,
    profile_memory=True, record_shapes=True) as prof_torchao_plain:
        for _ in range(itr):
            output = model(x)
    print(prof_torchao_plain.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total",row_limit=-1))
    print(f"INT8 Torch AO plain avg time: {(end - start)*1e3 / itr:.3f} milliseconds")
    print(output)
```

cc : @jerryzh168, @fadara01, @Xia-Weiwen