### PR TITLE
enable inline asm for mxfp8+rceil+compile+cuda+sm100

### DIFF
--- a/docs/source/workflows/inference.md
+++ b/docs/source/workflows/inference.md
@@ -138,15 +138,15 @@ to increase as MKN increases.
 > python benchmarks/float8/float8_inference_roofline.py --recipe_name mxfp8_cublas --enable_fusion_modeling True --skip_printing_detailed_metrics True
 ...
 GPU                     NVIDIA B200
-torch version           2.12.0.dev20260218+cu130
-torchao version         0.17.0+git3075bb624
+torch version           2.12.0.dev20260414+cu130
+torchao version         0.17.0+gitbd7717d20
 ...
    fwd_M  fwd_K  fwd_N  r_fp8_gemm_and_ovhd_spdp  b_fp8_e2e_spdp
-0   1024   1024   1024                      1.00            0.93
-1   2048   2048   2048                      1.75            1.20
-2   4096   4096   4096                      1.90            1.46
+0   1024   1024   1024                      1.00            0.96
+1   2048   2048   2048                      1.76            1.22
+2   4096   4096   4096                      1.89            1.50
 3   8192   8192   8192                      1.94            1.76
-4  16384  16384  16384                      1.97            1.77
+4  16384  16384  16384                      1.97            1.81
 
 #
 # nvfp4 with dynamic global scaling

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -139,9 +139,9 @@ def _to_mx_rceil(
         # not work properly in eager mode due to mismatch between input and
         # output tensor dtype (limitation of JITerator).
         # Note: we use both `torch.compiler.is_compiling()` as well as `is_fake`
-        # because `torch.compiler.is_compiling()` properly covers 
+        # because `torch.compiler.is_compiling()` properly covers
         # microbenchmarks, and `is_fake` properly covers e2e runs where this code
-        # path is hit through `__torch_dispatch__` and 
+        # path is hit through `__torch_dispatch__` and
         # `torch.compiler.is_compiling()` returns False.
         # Note that we need both checks, as neither of them work in both benchmark
         # and e2e use cases by themselves.

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -23,6 +23,7 @@ from typing import Optional, Union
 
 import torch
 import torch.nn.functional as F
+from torch._subclasses.fake_tensor import is_fake
 from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.distributed.tensor.experimental import local_map
 from torch.utils._python_dispatch import (
@@ -30,7 +31,10 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._pytree import tree_map
 
-from torchao.utils import torch_version_at_least
+from torchao.utils import is_sm_at_least_100, torch_version_at_least
+
+if torch_version_at_least("2.12.0.dev0"):
+    from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
 # ScalingType and SwizzleType are only available in PyTorch 2.10+
 if torch_version_at_least("2.10.0"):
@@ -114,9 +118,9 @@ def _to_mx_rceil(
     https://docs.nvidia.com/cuda/cublas/#d-block-quantization
 
     For Nvidia GPU with Blackwell+ architecture, the scale factor derivation method
-    could be accelerated by the `cvt.rp.satfinite.ue8m0x2.f32` instruction.
-
-    Fixed to match CUDA float_to_e8m0 and exp2f_rcp behavior with per-element handling.
+    is accelerated by the `cvt.rp.satfinite.ue8m0x2.f32` instruction via
+    `inline_asm_elementwise`, if torch.compile is on. Falls back to pure PyTorch ops
+    on other hardware and in eager mode.
 
     Args:
         data_hp: High precision data.
@@ -130,24 +134,55 @@ def _to_mx_rceil(
     """
     descale = max_abs / max_pos
 
-    # Handle special values in scale calculation
-    exponent = torch.where(
-        torch.isnan(descale),
-        255,  # 0xFF for NaN in amax
-        torch.where(
-            torch.isinf(descale),
-            254,  # 0xFE for inf in amax
-            # Normal case
-            (
-                torch.clamp(
-                    torch.ceil(torch.log2(descale)),
-                    min=-E8M0_EXPONENT_BIAS,
-                    max=E8M0_EXPONENT_BIAS,
-                )
-                + E8M0_EXPONENT_BIAS
-            ).to(torch.uint8),
-        ),
-    )
+    if (
+        # gate the inline PTX to compile only because the functionality does
+        # not work properly in eager mode due to mismatch between input and
+        # output tensor dtype (limitation of JITerator).
+        # Note: we use both `torch.compiler.is_compiling()` as well as `is_fake`
+        # because `torch.compiler.is_compiling()` properly covers 
+        # microbenchmarks, and `is_fake` properly covers e2e runs where this code
+        # path is hit through `__torch_dispatch__` and 
+        # `torch.compiler.is_compiling()` returns False.
+        # Note that we need both checks, as neither of them work in both benchmark
+        # and e2e use cases by themselves.
+        (torch.compiler.is_compiling() or is_fake(descale))
+        and is_sm_at_least_100()
+        # the PyTorch Core support for inline_asm_elementwise is available in
+        # 2.12.0 nightly and above
+        and torch_version_at_least("2.12.0.dev0")
+        and descale.is_cuda
+    ):
+        # Use cvt.rp.satfinite.ue8m0x2.f32 to convert fp32 descale to e8m0.
+        # The instruction takes two fp32 inputs, packs two e8m0 results into uint16.
+        # We pass 0.0 as the first input (high byte) and descale as the second (low byte).
+        # Handles NaN->255, Inf->254, subnormals->0 in hardware.
+        scale_e8m0_u16 = inline_asm_elementwise(
+            descale.to(torch.float32),
+            asm_str="cvt.rp.satfinite.ue8m0x2.f32 $0, 0.0, $1;",
+            constraints="=h,r",
+            dtype=torch.uint16,
+        )
+        # Low byte contains e8m0 of our input; truncate uint16 -> uint8
+        exponent = scale_e8m0_u16.to(torch.uint8)
+    else:
+        # Fallback
+        exponent = torch.where(
+            torch.isnan(descale),
+            255,  # 0xFF for NaN in amax
+            torch.where(
+                torch.isinf(descale),
+                254,  # 0xFE for inf in amax
+                # Normal case
+                (
+                    torch.clamp(
+                        torch.ceil(torch.log2(descale)),
+                        min=-E8M0_EXPONENT_BIAS,
+                        max=E8M0_EXPONENT_BIAS,
+                    )
+                    + E8M0_EXPONENT_BIAS
+                ).to(torch.uint8),
+            ),
+        )
 
     # Ref: https://github.com/NVIDIA/TransformerEngine/blob/b7598aa887eb7d619d64c90692980009669379bf/transformer_engine/common/util/ptx.cuh#L332-L341
     rcp_fp32 = torch.where(


### PR DESCRIPTION
Summary:

PyTorch Core support for compile fusing `inline_asm_elementwise` into
surrounding ops landed in https://github.com/pytorch/pytorch/pull/177922

This PR modifies the mxfp8 RCEIL cast to use the
`cvt.rp.satfinite.ue8m0x2.f32` instruction when the hardware supports
it.

Cast mem bw 3.7 TB/s -> 4.1 TB/s

Test Plan:

```
// correctness
pytest test/prototype/mx_formats -s

// cast perf
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python benchmarks/mx_formats/cast_bench.py --mode dim0_mxfp8_rceil
...
// before
mem_bw_gbps 3676.9529733517074
// after
mem_bw_gbps 4116.556410292409

// microbenchmark perf - see PR doc update, we see small speedups across
// the board on relu->linear benchmark
```