### PR TITLE
[CI][Warning] URL should use meta-pytorch instead of pytorch

### DIFF
--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -1213,7 +1213,7 @@ def _mslk_quantize_nvfp4_custom_op(
     """
     assert _mslk_available, (
         "mslk is required for NVFP4 triton quantization. "
-        "Install from https://github.com/pytorch/MSLK"
+        "Install from https://github.com/meta-pytorch/MSLK"
     )
     from mslk.quantize.triton.fp4_quantize import (
         triton_quantize_nvfp4 as _mslk_triton_quantize_nvfp4,


### PR DESCRIPTION
https://github.com/meta-pytorch/MSLK

FAILED test_inference_workflow.py::test_inference_workflow_nvfp4[2-False-200x192x256-False-True-inpt_dtype1-dynamic-False-True] - AssertionError: mslk is required for NVFP4 triton quantizat
ion. Install from https://github.com/pytorch/MSLK                                                                                                                                            

"Install from https://github.com/pytorch/MSLK" should be 
"Install from https://github.com/meta-pytorch/MSLK"