### PR TITLE
basic enablement for mxfp8 and mxfp4 inference on AMD MI350x

### DIFF
--- a/benchmarks/float8/bench_matmul.py
+++ b/benchmarks/float8/bench_matmul.py
@@ -19,7 +19,7 @@ from utils import (
 from torchao.prototype.mx_formats.mx_tensor import to_mx
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.testing.training.roofline_utils import get_specs
-from torchao.utils import is_MI300, torch_version_at_least
+from torchao.utils import is_MI300, is_ROCM, torch_version_at_least
 
 # ScalingType and SwizzleType are only available in PyTorch 2.10+
 if torch_version_at_least("2.10.0"):
@@ -42,6 +42,7 @@ def run(
     assert recipe in (
         "tensorwise",
         "rowwise",
+        "mxfp8_cublas",
         "mxfp4_cutlass",
         "nvfp4",
     ), "unsupported"
@@ -132,13 +133,18 @@ def run(
         elif recipe == "mxfp8_cublas":
             scale_a = torch.ones(M, K // 32, device=device, dtype=torch.float8_e8m0fnu)
             scale_b = torch.ones(N, K // 32, device=device, dtype=torch.float8_e8m0fnu)
-            # pad if needed
-            scale_a = to_blocked(scale_a)
-            scale_b = to_blocked(scale_b)
+            if not is_ROCM():
+                # pad if needed
+                scale_a = to_blocked(scale_a)
+                scale_b = to_blocked(scale_b)
         elif recipe == "mxfp4_cutlass":
             # Use the blockwise scales from to_mx
-            scale_a = to_blocked(A_scales)
-            scale_b = to_blocked(B_scales)
+            if is_ROCM():
+                scale_a = A_scales
+                scale_b = B_scales
+            else:
+                scale_a = to_blocked(A_scales)
+                scale_b = to_blocked(B_scales)
         elif recipe == "nvfp4":
             # Use the blockwise scales from nvfp4_quantize
             scale_a = A_scales.view(torch.float8_e4m3fn)
@@ -163,6 +169,9 @@ def run(
                 raise RuntimeError(
                     "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
                 )
+            swizzle = (
+                SwizzleType.NO_SWIZZLE if is_ROCM() else SwizzleType.SWIZZLE_32_4_4
+            )
             return F.scaled_mm(
                 A,
                 B,
@@ -170,8 +179,32 @@ def run(
                 scale_recipe_a=ScalingType.BlockWise1x32,
                 scale_b=scale_b,
                 scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
+                output_dtype=dtype,
+            )
+
+        def do_matmul_mxfp8_rocm(A, B):
+            nonlocal scale_a
+            nonlocal scale_b
+            if not torch_version_at_least("2.10.0"):
+                raise RuntimeError(
+                    "MXFP8 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+                )
+            if not is_ROCM():
+                # TODO(future): add CUDA support for mxfp8_cublas via F.scaled_mm
+                raise NotImplementedError(
+                    "mxfp8_cublas bench_matmul only supports AMD/ROCm for now"
+                )
+            return F.scaled_mm(
+                A,
+                B,
+                scale_a=scale_a,
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=scale_b,
+                scale_recipe_b=ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.NO_SWIZZLE,
+                swizzle_b=SwizzleType.NO_SWIZZLE,
                 output_dtype=dtype,
             )
 
@@ -190,7 +223,9 @@ def run(
                 A, B, scale_a, scale_b, use_fast_accum=fast_accum
             )
 
-        if recipe == "mxfp4_cutlass":
+        if recipe == "mxfp8_cublas":
+            do_matmul = do_matmul_mxfp8_rocm
+        elif recipe == "mxfp4_cutlass":
             do_matmul = do_matmul_mxfp4
         elif recipe == "nvfp4":
             do_matmul = do_matmul_nvfp4

--- a/benchmarks/float8/float8_inference_roofline.py
+++ b/benchmarks/float8/float8_inference_roofline.py
@@ -62,7 +62,7 @@ from torchao.testing.training.roofline_utils import (
     get_inference_float8_mem_sympy,
     get_inference_gemm_time_sympy,
 )
-from torchao.utils import _is_mslk_available, is_MI300, is_sm_at_least_100
+from torchao.utils import _is_mslk_available, is_MI300, is_MI350, is_sm_at_least_100
 
 # Import mslk.conv to register the fp8 conv operator
 if _is_mslk_available():
@@ -791,6 +791,7 @@ def run(
                         activation_dtype=torch.float8_e4m3fn,
                         weight_dtype=torch.float8_e4m3fn,
                         kernel_preference=KernelPreference.AUTO,
+                        swizzle_scales=(not is_MI350()),
                     )
                 elif recipe_name == "mxfp4_cutlass":
                     config = MXDynamicActivationMXWeightConfig(

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -22,6 +22,7 @@ from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_rocm
 from torchao.utils import (
+    is_MI350,
     is_sm_at_least_89,
     is_sm_at_least_100,
     torch_version_at_least,
@@ -71,9 +72,6 @@ def cuda_kernel_profiler(kernel_pattern):
 @pytest.mark.parametrize("use_inference_mode", [True, False])
 @pytest.mark.parametrize("x_rank", [2, 3])
 @torch.no_grad()
-@skip_if_rocm(
-    "ROCm float4 gemm require gfx950"
-)  # TODO(future): deploy gfx950 in ROCM CI
 def test_inference_workflow_mx(
     elem_dtype,
     bias: bool,
@@ -88,18 +86,22 @@ def test_inference_workflow_mx(
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if not (is_sm_at_least_89() or is_MI350()):
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
-        elif not is_sm_at_least_100() and not emulate:
+        elif not (is_sm_at_least_100() or is_MI350()) and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp8 gemm")
     elif elem_dtype == torch.float4_e2m1fn_x2:
-        if not is_sm_at_least_100() and not emulate:
+        if not (is_sm_at_least_100() or is_MI350()) and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
 
-    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
+    # K must be >= 64 for MI350x (smallest rocm mxfp8 kernel tile is 64 on K dim)
+    # if K < 64, MI350x just hangs forever since it cannot find a gemm kernel
+    # TODO(future): we should fix ^ in PyTorch Core
+    K = 64
+    m = nn.Linear(K, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
     m_mx = copy.deepcopy(m)
 
     if emulate:
@@ -110,12 +112,13 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
+        swizzle_scales=(not is_MI350()),
     )
     quantize_(m_mx, config=config)
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True)
 
-    x = torch.randn(128, 32, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(128, K, device="cuda", dtype=torch.bfloat16)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -13,6 +13,7 @@ from torchao.float8.float8_utils import compute_error
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import (
+    is_MI350,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -26,7 +27,7 @@ if torch_version_at_least("2.10.0"):
 
 
 def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
-    """Wrapper for F.scaled_mm with MXFP4 configuration."""
+    """Wrapper for F.scaled_mm with MXFP4 configuration on CUDA."""
     if not torch_version_at_least("2.10.0"):
         raise RuntimeError(
             "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
@@ -44,19 +45,65 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     )
 
 
+def _mxfp4_scaled_mm_rocm(a_data, b_data, a_scale_block, b_scale_block):
+    """Wrapper for F.scaled_mm with MXFP4 configuration on ROCm."""
+    if not torch_version_at_least("2.10.0"):
+        raise RuntimeError(
+            "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+        )
+    return F.scaled_mm(
+        a_data.view(torch.float4_e2m1fn_x2),
+        b_data.view(torch.float4_e2m1fn_x2),
+        scale_a=a_scale_block,
+        scale_recipe_a=ScalingType.BlockWise1x32,
+        scale_b=b_scale_block,
+        scale_recipe_b=ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.NO_SWIZZLE,
+        swizzle_b=SwizzleType.NO_SWIZZLE,
+        output_dtype=torch.bfloat16,
+    )
+
+
+def _mxfp8_scaled_mm_rocm(a_data, b_data, a_scale_block, b_scale_block):
+    """Wrapper for F.scaled_mm with MXFP8 configuration on ROCm."""
+    if not torch_version_at_least("2.10.0"):
+        raise RuntimeError(
+            "MXFP8 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+        )
+    return F.scaled_mm(
+        a_data,
+        b_data,
+        scale_a=a_scale_block,
+        scale_recipe_a=ScalingType.BlockWise1x32,
+        scale_b=b_scale_block,
+        scale_recipe_b=ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.NO_SWIZZLE,
+        swizzle_b=SwizzleType.NO_SWIZZLE,
+        output_dtype=torch.bfloat16,
+    )
+
+
 def run_matrix_test(M: int, K: int, N: int, format) -> float:
     dtype = torch.bfloat16
     device = torch.device("cuda")
 
-    a = torch.rand((M, K), dtype=dtype, device=device)
-    b = torch.rand((N, K), dtype=dtype, device=device)
+    # hand craft input values to ensure we get scales where
+    # not all scale values are equal to each other
+    a = torch.arange(0, M * K, dtype=dtype, device=device).view(M, K) / (M * K)
+    b = torch.arange(N * K, 0, -1, dtype=dtype, device=device).view(N, K) / (M * K)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-    mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-        if format == "fp8"
-        else _mxfp4_scaled_mm
-    )
+    if format == "fp8":
+        if is_MI350():
+            mx_func = _mxfp8_scaled_mm_rocm
+        else:
+            mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+    else:
+        assert format == "fp4"
+        if is_MI350():
+            mx_func = _mxfp4_scaled_mm_rocm
+        else:
+            mx_func = _mxfp4_scaled_mm
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -69,8 +116,13 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if is_MI350():
+        # no swizzling on ROCm
+        a_scale_block = a_scale
+        b_scale_block = b_scale
+    else:
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
@@ -82,7 +134,8 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="CUDA capability >= 10.0 or MI350x required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -106,8 +159,10 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 )
 def test_matrix_multiplication(size, format):
     M, K, N = size
+    if is_MI350() and (M % 128 != 0):
+        pytest.skip("TODO add support for unaligned M on AMD MI350x")
     sqnr = run_matrix_test(M, K, N, format)
-    threshold = 80.0
+    threshold = 45.0 if is_MI350() else 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"
     )

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import types
+import warnings
 from dataclasses import dataclass
 from functools import partial
 from typing import Optional
@@ -32,6 +33,7 @@ from torchao.quantization.transform_module import (
 )
 from torchao.quantization.utils import _module_extra_repr, _quantization_type
 from torchao.utils import (
+    is_MI350,
     is_sm_at_least_100,
     torch_version_at_least,
 )
@@ -114,12 +116,20 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
+    # whether to swizzle the scales (should be True on CUDA and False on ROCm)
+    swizzle_scales: bool = True
+
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
             "For now - we only support matching input/weight dtypes."
         )
         _validate_elem_dtype(self.activation_dtype)
         _validate_elem_dtype(self.weight_dtype)
+        if is_MI350() and self.swizzle_scales:
+            warnings.warn(
+                "swizzle_scales=True is not supported on AMD MI350x. "
+                "Pass swizzle_scales=False to fix this."
+            )
 
 
 def _linear_extra_repr(self):
@@ -142,7 +152,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        is_swizzled_scales=config.swizzle_scales,
         scaling_mode=config.scaling_mode,
     )
 
@@ -153,7 +163,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        is_swizzled_scales=config.swizzle_scales,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -31,7 +31,7 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._pytree import tree_map
 
-from torchao.utils import is_sm_at_least_100, torch_version_at_least
+from torchao.utils import is_MI350, is_sm_at_least_100, torch_version_at_least
 
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
@@ -785,48 +785,99 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.is_swizzled_scales:
-            a_scale_block = a.scale
-        else:
-            a_scale = a.scale.view(M, K // a.block_size)
-            a_scale_block = maybe_dtensor_to_blocked(a_scale)
+        if not is_MI350():
+            # CUDA path - swizzle
 
-        if b.is_swizzled_scales:
-            b_scale_block = b.scale.t()
-        else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            b_scale_block = maybe_dtensor_to_blocked(b_scale)
+            if a.is_swizzled_scales:
+                a_scale_block = a.scale
+            else:
+                a_scale = a.scale.view(M, K // a.block_size)
+                a_scale_block = maybe_dtensor_to_blocked(a_scale)
 
-        if a.elem_dtype == torch.float8_e4m3fn:
-            assert b.elem_dtype == torch.float8_e4m3fn
-            res = torch._scaled_mm(
-                a.qdata,
-                b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
-                bias=bias,
-                out_dtype=torch.bfloat16,
-            )
-        else:
-            assert a.elem_dtype == torch.float4_e2m1fn_x2
-            assert b.elem_dtype == torch.float4_e2m1fn_x2
-            if not torch_version_at_least("2.10.0"):
-                raise RuntimeError(
-                    "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+            if b.is_swizzled_scales:
+                b_scale_block = b.scale.t()
+            else:
+                b_scale = b.scale.t().view(N, K // b.block_size)
+                b_scale_block = maybe_dtensor_to_blocked(b_scale)
+
+            if a.elem_dtype == torch.float8_e4m3fn:
+                assert b.elem_dtype == torch.float8_e4m3fn
+                # TODO(future PR): convert this to F.scaled_mm
+                res = torch._scaled_mm(
+                    a.qdata,
+                    b.qdata,
+                    a_scale_block.view(torch.float8_e8m0fnu),
+                    b_scale_block.view(torch.float8_e8m0fnu),
+                    bias=bias,
+                    out_dtype=torch.bfloat16,
                 )
-            # FP4 operations using F.scaled_mm
-            res = F.scaled_mm(
-                a.qdata.view(torch.float4_e2m1fn_x2),
-                b.qdata.view(torch.float4_e2m1fn_x2),
-                scale_a=a_scale_block,
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block,
-                scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-                bias=bias,
-                output_dtype=torch.bfloat16,
-            )
+            else:
+                assert a.elem_dtype == torch.float4_e2m1fn_x2
+                assert b.elem_dtype == torch.float4_e2m1fn_x2
+                if not torch_version_at_least("2.10.0"):
+                    raise RuntimeError(
+                        "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+                    )
+                # FP4 operations using F.scaled_mm
+                res = F.scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    scale_a=a_scale_block,
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b_scale_block,
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                    swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                    bias=bias,
+                    output_dtype=torch.bfloat16,
+                )
+        else:
+            # MI350 path - do not swizzle, and add bias separately
+            assert not a.is_swizzled_scales
+            assert not b.is_swizzled_scales
+
+            if a.elem_dtype == torch.float8_e4m3fn:
+                assert b.elem_dtype == torch.float8_e4m3fn
+                res = F.scaled_mm(
+                    a.qdata,
+                    b.qdata,
+                    scale_a=a.scale,
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b.scale.t(),
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=SwizzleType.NO_SWIZZLE,
+                    swizzle_b=SwizzleType.NO_SWIZZLE,
+                    bias=None,
+                    output_dtype=torch.bfloat16,
+                )
+                if bias is not None:
+                    # bias addition not currently supported for
+                    # ROCm + mxfp8 + scaled_mm, so we do it separately
+                    res = res + bias
+            else:
+                assert a.elem_dtype == torch.float4_e2m1fn_x2
+                assert b.elem_dtype == torch.float4_e2m1fn_x2
+                if not torch_version_at_least("2.10.0"):
+                    raise RuntimeError(
+                        "MXFP4 matmul requires PyTorch 2.10.0 or later for F.scaled_mm support"
+                    )
+                # FP4 operations using F.scaled_mm
+                res = F.scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    scale_a=a.scale,
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b.scale.t(),
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=SwizzleType.NO_SWIZZLE,
+                    swizzle_b=SwizzleType.NO_SWIZZLE,
+                    bias=None,
+                    output_dtype=torch.bfloat16,
+                )
+                if bias is not None:
+                    # bias addition not currently supported for
+                    # ROCm + mxfp8 + scaled_mm, so we do it separately
+                    res = res + bias
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -87,6 +87,20 @@ gpu_name_to_specs = {
         # TODO(future): run measurement on hardware
         "pct_achievable_mem_bw": 0.92,
     },
+    "AMD Instinct MI350X": {
+        # https://www.amd.com/en/products/accelerators/instinct/mi350/mi350x.html
+        "bf16_peak_tops": 2300e12,
+        "fp8_peak_tops": 4600e12,
+        "fp4_peak_tops": 9200e12,
+        # 8.0 TB per second
+        "peak_mem_bw_bytes_sec": 8.0e12,
+        # for now, copy over from H100
+        # TODO(future): run measurement on hardware
+        "pct_achievable_gemm_tops": 0.78,
+        # for now, copy over from H100
+        # TODO(future): run measurement on hardware
+        "pct_achievable_mem_bw": 0.92,
+    },
     "NVIDIA GeForce RTX 5090": {
         # https://images.nvidia.com/aem-dam/Solutions/geforce/blackwell/nvidia-rtx-blackwell-gpu-architecture.pdf
         "bf16_peak_tops": 209.5e12,


### PR DESCRIPTION
Summary:

Makes basic things work on AMD MI350x for mxfp8|mxfp4 and inference:
* numerical tests pass
* basic performance benchmarks run

GEMM performance is very poor right now, because we don't have a fast gemm in core:
* for mxfp8, `F.scaled_mm` is consistently slower than bf16 across various shapes
* for mxfp4, `F.scaled_mm` achieves at most a 2x (not 4x) over bf16 across various shapes (logs: https://gist.github.com/vkuzo/bd620805ee0d3d9a230655a822ecc0bc)

bf16_to_mx kernel performance is not as bad: 4.5 TB/s for rceil, 4.4 TB/s for floor. This is about 55% of peak mem bw (8 TB/s) on AMD 350x.

(logs: https://gist.github.com/vkuzo/11e577c011976127379af9c061bd2e5a)

Next steps to make this useful would be to get a fast gemm, either by improving the one in core or checking a kernel into ao.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: