### PR TITLE
Fix broken links in first quantization example docs (Issue #4286)

### DIFF
--- a/docs/source/eager_tutorials/first_quantization_example.rst
+++ b/docs/source/eager_tutorials/first_quantization_example.rst
@@ -160,8 +160,8 @@ In this tutorial, we learned how to quantize a simple model with
 torchao. To learn more about the different workflows supported in torchao,
 see our main `README <https://github.com/pytorch/ao/blob/main/README.md>`__.
 For a more detailed overview of quantization in torchao, visit
-`this page <../developer_notes/quantization_overview.html>`__.
+`this page <../contributing/quantization_overview.html>`__.
 
 Finally, if you would like to contribute to torchao, don't forget to check
-out our `contributor guide <../developer_notes/contributor_guide.html>`__ and our list of
+out our `contributor guide <../contributing/contributor_guide.html>`__ and our list of
 `good first issues <https://github.com/pytorch/ao/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22>`__ on Github!


### PR DESCRIPTION
Fixes broken internal documentation links in first_quantization_example.rst.
- Replaces outdated ../developer_notes/ paths with correct ../contributing/ paths.
- Verified both target documentation files exist in current repo structure.
- Closes #4286