### PR TITLE
[test][xpu] Fix RuntimeError for nf4 cases after the running of test_float8_tensor.py

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -21,4 +21,8 @@ pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py 
         torchao/test/float8/ \
         torchao/test/integration/test_integration.py \
         torchao/test/prototype/ \
-        torchao/test/quantization/quantize_/workflows/
+        torchao/test/quantization/quantize_/workflows/int4/ \
+        torchao/test/quantization/quantize_/workflows/int8/ \
+        torchao/test/quantization/quantize_/workflows/intx/\
+        torchao/test/quantization/quantize_/workflows/nf4/ \
+        torchao/test/quantization/quantize_/workflows/float8/

--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -23,8 +23,4 @@ pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py 
         torchao/test/float8/ \
         torchao/test/integration/test_integration.py \
         torchao/test/prototype/ \
-        torchao/test/quantization/quantize_/workflows/int4/ \
-        torchao/test/quantization/quantize_/workflows/int8/ \
-        torchao/test/quantization/quantize_/workflows/intx/\
-        torchao/test/quantization/quantize_/workflows/nf4/ \
-        torchao/test/quantization/quantize_/workflows/float8/
+        torchao/test/quantization/quantize_/workflows/

--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -23,4 +23,8 @@ pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py 
         torchao/test/float8/ \
         torchao/test/integration/test_integration.py \
         torchao/test/prototype/ \
-        torchao/test/quantization/quantize_/workflows/
+        torchao/test/quantization/quantize_/workflows/int4/ \
+        torchao/test/quantization/quantize_/workflows/int8/ \
+        torchao/test/quantization/quantize_/workflows/intx/\
+        torchao/test/quantization/quantize_/workflows/nf4/ \
+        torchao/test/quantization/quantize_/workflows/float8/

--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -186,6 +186,7 @@ class ToyLoRAModel(torch.nn.Module):
 @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need sm89+")
 class TestFloat8Tensor(TorchAOIntegrationTestCase):
     def setUp(self):
+        super().setUp()
         _DEVICE = get_current_accelerator_device()
         self.GPU_DEVICES = [_DEVICE] if torch.accelerator.is_available() else []
         torch.set_grad_enabled(False)


### PR DESCRIPTION
Same as https://github.com/pytorch/ao/pull/3589, https://github.com/pytorch/ao/actions/runs/24608583955/job/71958890270 nf4 cases encounter ```RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn``` after the running of test/quantization/quantize_/workflows/float8/test_float8_tensor.py. This PR intends to put test/quantization/quantize_/workflows/float8/ at last in CI test to work around this issue.