### PR TITLE
docs: fix Int8Tensor row in Tensor Subclasses list-table

### DIFF
--- a/docs/source/contributing/quantization_overview.rst
+++ b/docs/source/contributing/quantization_overview.rst
@@ -89,7 +89,9 @@ So in general we structure Tensor subclasses by dervied dtpype and packing forma
      - preshuffled (special format to optimize for loading)
      - float8 act + int4 weight dynamic quantization and int4 weight only quantization
    * - Int8Tensor
+     - scaled int8
      - plain (no packing needed)
+     - int8 act + int8 weight dynamic quantization and int8 weight only quantization
 
 .. note::
    We don't have granularity specific tensor subclasses, i.e. no Float8RowwiseTensor or Float8BlockwiseTensor, all granularities are implemented in the same Tensor, we typically use a general `block_size` attribute to distinguish between different granularities, and each Tensor is allowed to support only a subset of all possible granularity options.


### PR DESCRIPTION
## Summary

One item from the tracker at #3863.

`docs/source/contributing/quantization_overview.rst` declares a four-column list-table (`:widths: 20 10 30 40`, header `Tensor / Derived Dtype / Packing Format / Support`) but the `Int8Tensor` row only supplies two cells, so `make html` errors:

```
docs/source/contributing/quantization_overview.rst:71:
ERROR: Error parsing content block for the "list-table" directive:
uniform two-level bullet list expected, but row 5 does not contain
the same number of items as row 1 (2 vs 4).
```

Add the two missing cells. Values chosen to match the repo's source of truth:

- **Derived Dtype:** `scaled int8` — tracks `class Int8Tensor`'s docstring ("int8 quantized tensor with plain layout") in `torchao/quantization/quantize_/workflows/int8/int8_tensor.py` and the naming pattern used for `Float8Tensor` / `Int4Tensor` rows in the same table.
- **Support:** `int8 act + int8 weight dynamic quantization and int8 weight only quantization` — the two public configs that build an `Int8Tensor` via `Int8Tensor.from_hp()` today (`Int8DynamicActivationInt8WeightConfig` and `Int8WeightOnlyConfig` in `torchao/quantization/quant_api.py`).

## Testing

- Parsed the file through `docutils.parsers.rst.Parser` — no `system_message` nodes related to the list-table (previously "uniform two-level bullet list expected"); `rst2html docs/source/contributing/quantization_overview.rst > /dev/null` completes with empty stderr.
- Verified the new row still has four cells, matching `:widths: 20 10 30 40` and the header row count.