### PR TITLE
hook up gptq prototype to nvfp4

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -20,7 +20,10 @@ from torchao.prototype.mx_formats.inference_workflow import (
 )
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
-from torchao.utils import _is_mslk_available
+from torchao.utils import (
+    _is_mslk_available,
+    is_sm_at_least_100,
+)
 
 
 def _calculate_hessian(inputs, device=None):
@@ -449,6 +452,13 @@ class TestGPTQFlow:
     )
     def test_gptq_quantize_better_than_naive(self, base_config):
         """Test that GPTQ produces lower error than naive quantization."""
+
+        if (
+            isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig)
+            and not is_sm_at_least_100()
+        ):
+            pytest.skip("CUDA capability >= 10.0 required for nvfp4")
+
         torch.manual_seed(43)
 
         # Create weight and realistic Hessian from actual activations
@@ -526,6 +536,12 @@ class TestGPTQFlow:
         ],
     )
     def test_gptq_sqnr(self, base_config):
+        if (
+            isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig)
+            and not is_sm_at_least_100()
+        ):
+            pytest.skip("CUDA capability >= 10.0 required for nvfp4")
+
         torch.manual_seed(43)
 
         model = ToyLinearModel(m=512, n=2048, k=1024).cuda().to(torch.bfloat16)

--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -15,6 +15,9 @@ from torchao.prototype.gptq import (
     gptq_quantize,
 )
 from torchao.prototype.gptq.observer import GPTQObserverTensor
+from torchao.prototype.mx_formats.inference_workflow import (
+    NVFP4DynamicActivationNVFP4WeightConfig,
+)
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
 from torchao.utils import _is_mslk_available
@@ -435,6 +438,13 @@ class TestGPTQFlow:
             pytest.param(
                 Int8WeightOnlyConfig(granularity=PerRow(), version=2), id="int8"
             ),
+            pytest.param(
+                NVFP4DynamicActivationNVFP4WeightConfig(
+                    use_dynamic_per_tensor_scale=True,
+                    use_triton_kernel=True,
+                ),
+                id="nvfp4",
+            ),
         ],
     )
     def test_gptq_quantize_better_than_naive(self, base_config):
@@ -506,6 +516,13 @@ class TestGPTQFlow:
             pytest.param(
                 Int8WeightOnlyConfig(granularity=PerRow(), version=2), id="int8"
             ),
+            pytest.param(
+                NVFP4DynamicActivationNVFP4WeightConfig(
+                    use_dynamic_per_tensor_scale=True,
+                    use_triton_kernel=True,
+                ),
+                id="nvfp4",
+            ),
         ],
     )
     def test_gptq_sqnr(self, base_config):
@@ -556,6 +573,10 @@ class TestGPTQFlow:
             assert sqnr_gptq > 25, f"GPTQ SQNR: {sqnr_gptq} is too low"
         elif isinstance(base_config, Int8WeightOnlyConfig):
             assert sqnr_gptq > 30, f"GPTQ SQNR: {sqnr_gptq} is too low"
+        elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+            assert sqnr_gptq > 15, f"GPTQ SQNR: {sqnr_gptq} is too low"
+        else:
+            raise AssertionError("unsupported")
         assert sqnr_gptq > sqnr_rtn, (
             f"GPTQ SQNR: {sqnr_gptq} is not better than RTN SQNR: {sqnr_rtn}"
         )

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -319,6 +319,7 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
         block_size = list(block_size)
         group_size = block_size[-1]
     elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+        assert base_config.use_dynamic_per_tensor_scale, "unsupported"
         group_size = 16
         block_size = [1, group_size]
         # for per-tensor nvfp4, we need to calculate the global scale over the

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -19,6 +19,25 @@ except:
     pack_int4 = None
 
 from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats.constants import F4_E2M1_MAX
+from torchao.prototype.mx_formats.inference_workflow import (
+    NVFP4DynamicActivationNVFP4WeightConfig,
+)
+from torchao.prototype.mx_formats.kernels import (
+    f4_unpacked_to_f32,
+    f32_to_f4_unpacked,
+    pack_uint4,
+)
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    QuantizeTensorToNVFP4Kwargs,
+    nvfp4_quantize,
+    per_tensor_amax_to_scale,
+)
+from torchao.prototype.mx_formats.utils import (
+    hp_data_dims_to_swizzled_scale_dims_nvfp4,
+    to_blocked,
+)
 from torchao.quantization import Int4Tensor, Int8Tensor
 from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_api import (
@@ -33,6 +52,7 @@ from .observer import GPTQObserverTensor
 CONFIG_TO_TORCHAO_BASE_TENSOR = {
     Int4WeightOnlyConfig: Int4Tensor,
     Int8WeightOnlyConfig: Int8Tensor,
+    NVFP4DynamicActivationNVFP4WeightConfig: NVFP4Tensor,
 }
 
 
@@ -61,7 +81,11 @@ class GPTQConfig(AOBaseConfig):
     """
 
     step: str = "observe"  # "observe" or "convert"
-    base_config: Union[Int4WeightOnlyConfig, Int8WeightOnlyConfig] = None
+    base_config: Union[
+        Int4WeightOnlyConfig,
+        Int8WeightOnlyConfig,
+        NVFP4DynamicActivationNVFP4WeightConfig,
+    ] = None
     percdamp: float = 0.01
     gptq_quantize_block_size: int = 256
 
@@ -179,6 +203,59 @@ def _int4_row_dequantize_zp(
     return torch.cat(dequant_chunks, dim=-1)
 
 
+def _nvfp4_with_precalculated_scales_qdq(
+    data_hp: torch.Tensor,
+    per_tensor_scale: torch.Tensor,
+    block_scale: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Same as torchao.prototype.mx_formats.nvfp4_tensor.nvfp4_quantize, but with
+    per_tensor_scale and block_scale precalculated and the end result dequantized.
+    """
+    assert per_tensor_scale.dtype is torch.float32
+    assert block_scale.dtype is torch.float8_e4m3fn
+    # this function only works for data_hp.shape == (N, k_slice)
+    # and block_scale.shape == (N,)
+    assert len(block_scale.shape) == 1
+
+    scaled_block_scales_fp32 = block_scale.to(torch.float32)
+    reciprocal_scale = (1.0 / per_tensor_scale) / scaled_block_scales_fp32
+    data_scaled = data_hp * reciprocal_scale.unsqueeze(-1)
+    data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp_hp = f4_unpacked_to_f32(data_lp)
+    data_lp_hp_unscaled = data_lp_hp / reciprocal_scale.unsqueeze(-1)
+    return data_lp_hp_unscaled
+
+
+def _nvfp4_with_precalculated_scales_q(
+    data_hp: torch.Tensor,
+    per_tensor_scale: torch.Tensor,
+    block_scale: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Same as torchao.prototype.mx_formats.nvfp4_tensor.nvfp4_quantize, but with
+    per_tensor_scale and block_scale precalculated.
+    """
+    assert per_tensor_scale.dtype is torch.float32
+    assert block_scale.dtype is torch.float8_e4m3fn
+
+    # TODO(future): figure out what to reuse vs leave copy-pasted vs
+    # nvfp4_tensor.py
+    scaled_block_scales_fp32 = block_scale.to(torch.float32)
+    reciprocal_scale = (1.0 / per_tensor_scale) / scaled_block_scales_fp32
+    N, K = data_hp.shape
+    # reshape to 3d to properly broadcast for scaling
+    data_hp = data_hp.view(N, K // 16, 16)
+    data_scaled = data_hp * reciprocal_scale.unsqueeze(-1)
+    data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp_packed = pack_uint4(data_lp)
+    # reshape back to 2d
+    data_lp_packed = data_lp_packed.view(N, K // 2)
+    return data_lp_packed
+
+
 def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
     """
     This function implements the GPTQ algorithm described in this paper: https://arxiv.org/abs/2210.17323 (Algorithm 1)
@@ -241,6 +318,15 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
         block_size = get_block_size(W_t.shape, base_config.granularity)
         block_size = list(block_size)
         group_size = block_size[-1]
+    elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+        group_size = 16
+        block_size = [1, group_size]
+        # for per-tensor nvfp4, we need to calculate the global scale over the
+        # entire tensor before we enter the GPTQ loop
+        tensor_amax = torch.max(torch.abs(W_t))
+        nvfp4_global_scale = per_tensor_amax_to_scale(tensor_amax)
+    else:
+        raise AssertionError("unsupported")
 
     assert group_size > 0
 
@@ -337,6 +423,27 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
                         ],
                         base_config.granularity,
                     )
+                elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+                    tensor_slice = B_cur[
+                        :,
+                        G_k_start - B_cur_k_start : G_k_end - B_cur_k_start,
+                    ].contiguous()
+                    # quantize this slice using pre-calculated global scale, to
+                    # get the blockwise dynamic scales, they will be frozen
+                    # after this point
+                    scale, _data_lp = nvfp4_quantize(
+                        tensor_slice,
+                        per_tensor_scale=nvfp4_global_scale,
+                    )
+                    group_qparams.append(scale)
+                    # TODO(future PR): simpler version of `nvfp4_quantize` which
+                    # just calculates the scale, since we are throwing away the
+                    # quantized packed data here. For now, just call the full
+                    # one.
+                    del _data_lp
+
+                else:
+                    raise AssertionError("unsupported")
 
             # Quantize each column and propagate errors to subsequent columns
             for k in range(G_k_start - B_cur_k_start, G_k_end - B_cur_k_start):
@@ -354,6 +461,12 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
                         scale=quantized_tensor.scale,
                     )
                     dq = q.dequantize(output_dtype=torch.float)
+                elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+                    dq = _nvfp4_with_precalculated_scales_qdq(
+                        w_t,
+                        nvfp4_global_scale,
+                        scale.squeeze(-1),
+                    )
 
                 err1 = (w_t - dq) / Hinv_cur[k, k]
                 B_cur[:, k:] -= err1.matmul(Hinv_cur[k, k:].unsqueeze(0))
@@ -384,6 +497,48 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
     elif isinstance(base_config, Int8WeightOnlyConfig):
         result = Int8Tensor.from_hp(
             W_t, granularity=base_config.granularity, scale=quantized_tensor.scale
+        )
+    else:
+        N, K = W_t.shape
+        # TODO(future PR): clean up the line below. Context: the current nvfp4
+        # code follows the int4 code - we save the blockwise scales to an array
+        # and concat it. This leads to the necessity of t().contiguous().t() to
+        # get the scales back into the right layout for W_t. This is not
+        # intuitive, likely better to initialize the scales holder ahead of time
+        # and write the scales directly to their final place.
+        combined_scale = (
+            torch.cat(group_qparams, dim=0).reshape(K // group_size, N).t().contiguous()
+        )
+        qdata = _nvfp4_with_precalculated_scales_q(
+            W_t,
+            nvfp4_global_scale,
+            combined_scale,
+        )
+
+        act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
+            use_dynamic_per_tensor_scale=base_config.use_dynamic_per_tensor_scale,
+            use_triton_kernel=base_config.use_triton_kernel,
+            is_swizzled_scales=True,
+        )
+
+        # swizzle the block scales
+        combined_scale_swizzled = to_blocked(combined_scale).flatten()
+        scale_N, scale_K = hp_data_dims_to_swizzled_scale_dims_nvfp4(N, K)
+        combined_scale_swizzled = combined_scale_swizzled.view(scale_N, scale_K)
+
+        result = NVFP4Tensor(
+            qdata,
+            combined_scale_swizzled,
+            block_size=group_size,
+            orig_dtype=W_t.dtype,
+            per_tensor_scale=nvfp4_global_scale,
+            # TODO(future): get act_per_tensor_scale from calibration data?
+            # for now, set it to None here to calculate it dynamically at
+            # runtime
+            act_per_tensor_scale=None,
+            is_swizzled_scales=True,
+            use_triton_kernel=base_config.use_triton_kernel,
+            act_quant_kwargs=act_quant_kwargs,
         )
 
     return result

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -230,7 +230,8 @@ def main():
 
     # Generate output directory name from args
     model_name = args.model_id.split("/")[-1]  # Get last part of model ID
-    output_dir = f"{model_name}_{args.quantization}"
+    # TODO(before land): make output dir configurable
+    output_dir = f"/home/dev/tmp/20260420_{model_name}_{args.quantization}"
 
     if args.quantization != "none":
         output_dir += f"_gs{args.group_size}"
@@ -358,11 +359,16 @@ def main():
         "--model_args",
         f"pretrained={output_dir}",
         "--tasks",
-        "leaderboard_bbh",
-        "--num_fewshot",
-        "3",
+        # "leaderboard_bbh",
+        # "gsm8k",
+        "wikitext",
+        # "--num_fewshot",
+        # "3",
         "--batch_size",
-        "auto",
+        # "auto",
+        "1",
+        # "--limit",
+        # "20",
     ]
 
     print(f"Running command: {' '.join(lm_eval_cmd)}")

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -230,8 +230,7 @@ def main():
 
     # Generate output directory name from args
     model_name = args.model_id.split("/")[-1]  # Get last part of model ID
-    # TODO(before land): make output dir configurable
-    output_dir = f"/home/dev/tmp/20260420_{model_name}_{args.quantization}"
+    output_dir = f"{model_name}_{args.quantization}"
 
     if args.quantization != "none":
         output_dir += f"_gs{args.group_size}"
@@ -359,16 +358,11 @@ def main():
         "--model_args",
         f"pretrained={output_dir}",
         "--tasks",
-        # "leaderboard_bbh",
-        # "gsm8k",
-        "wikitext",
-        # "--num_fewshot",
-        # "3",
+        "leaderboard_bbh",
+        "--num_fewshot",
+        "3",
         "--batch_size",
-        # "auto",
-        "1",
-        # "--limit",
-        # "20",
+        "auto",
     ]
 
     print(f"Running command: {' '.join(lm_eval_cmd)}")


### PR DESCRIPTION
Summary:

For now, this is a numerical reference which hooks up nvfp4 and verifies
that a minimal unit test (random data + toy model) works as expected,
NVFP4 + GPTQ loss is significanly lower than baseline loss.

Future TODOs:
1. validate on e2e model
2. optimize dense performance
3. add moe support (will require custom fwd to ensure every expert sees
   calibration data)

Test Plan:

```
> pytest test/prototype/gptq/ -s -k nvfp4
...
test/prototype/gptq/test_gptqv2.py GPTQ loss: 0.1582, Naive loss: 0.9259
```