### PR TITLE
gptq + nvfp4 smoke test on LLaMa 3.2 1B + wikitext perplexity

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -20,7 +20,10 @@ from torchao.prototype.mx_formats.inference_workflow import (
 )
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
-from torchao.utils import _is_mslk_available
+from torchao.utils import (
+    _is_mslk_available,
+    is_sm_at_least_100,
+)
 
 
 def _calculate_hessian(inputs, device=None):
@@ -449,6 +452,13 @@ class TestGPTQFlow:
     )
     def test_gptq_quantize_better_than_naive(self, base_config):
         """Test that GPTQ produces lower error than naive quantization."""
+
+        if (
+            isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig)
+            and not is_sm_at_least_100()
+        ):
+            pytest.skip("CUDA capability >= 10.0 required for nvfp4")
+
         torch.manual_seed(43)
 
         # Create weight and realistic Hessian from actual activations
@@ -526,6 +536,12 @@ class TestGPTQFlow:
         ],
     )
     def test_gptq_sqnr(self, base_config):
+        if (
+            isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig)
+            and not is_sm_at_least_100()
+        ):
+            pytest.skip("CUDA capability >= 10.0 required for nvfp4")
+
         torch.manual_seed(43)
 
         model = ToyLinearModel(m=512, n=2048, k=1024).cuda().to(torch.bfloat16)

--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -15,6 +15,9 @@ from torchao.prototype.gptq import (
     gptq_quantize,
 )
 from torchao.prototype.gptq.observer import GPTQObserverTensor
+from torchao.prototype.mx_formats.inference_workflow import (
+    NVFP4DynamicActivationNVFP4WeightConfig,
+)
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
 from torchao.utils import _is_mslk_available
@@ -435,6 +438,13 @@ class TestGPTQFlow:
             pytest.param(
                 Int8WeightOnlyConfig(granularity=PerRow(), version=2), id="int8"
             ),
+            pytest.param(
+                NVFP4DynamicActivationNVFP4WeightConfig(
+                    use_dynamic_per_tensor_scale=True,
+                    use_triton_kernel=True,
+                ),
+                id="nvfp4",
+            ),
         ],
     )
     def test_gptq_quantize_better_than_naive(self, base_config):
@@ -506,6 +516,13 @@ class TestGPTQFlow:
             pytest.param(
                 Int8WeightOnlyConfig(granularity=PerRow(), version=2), id="int8"
             ),
+            pytest.param(
+                NVFP4DynamicActivationNVFP4WeightConfig(
+                    use_dynamic_per_tensor_scale=True,
+                    use_triton_kernel=True,
+                ),
+                id="nvfp4",
+            ),
         ],
     )
     def test_gptq_sqnr(self, base_config):
@@ -556,6 +573,10 @@ class TestGPTQFlow:
             assert sqnr_gptq > 25, f"GPTQ SQNR: {sqnr_gptq} is too low"
         elif isinstance(base_config, Int8WeightOnlyConfig):
             assert sqnr_gptq > 30, f"GPTQ SQNR: {sqnr_gptq} is too low"
+        elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+            assert sqnr_gptq > 15, f"GPTQ SQNR: {sqnr_gptq} is too low"
+        else:
+            raise AssertionError("unsupported")
         assert sqnr_gptq > sqnr_rtn, (
             f"GPTQ SQNR: {sqnr_gptq} is not better than RTN SQNR: {sqnr_rtn}"
         )

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -319,6 +319,7 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
         block_size = list(block_size)
         group_size = block_size[-1]
     elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+        assert base_config.use_dynamic_per_tensor_scale, "unsupported"
         group_size = 16
         block_size = [1, group_size]
         # for per-tensor nvfp4, we need to calculate the global scale over the

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -19,6 +19,25 @@ except:
     pack_int4 = None
 
 from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats.constants import F4_E2M1_MAX
+from torchao.prototype.mx_formats.inference_workflow import (
+    NVFP4DynamicActivationNVFP4WeightConfig,
+)
+from torchao.prototype.mx_formats.kernels import (
+    f4_unpacked_to_f32,
+    f32_to_f4_unpacked,
+    pack_uint4,
+)
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    QuantizeTensorToNVFP4Kwargs,
+    nvfp4_quantize,
+    per_tensor_amax_to_scale,
+)
+from torchao.prototype.mx_formats.utils import (
+    hp_data_dims_to_swizzled_scale_dims_nvfp4,
+    to_blocked,
+)
 from torchao.quantization import Int4Tensor, Int8Tensor
 from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_api import (
@@ -33,6 +52,7 @@ from .observer import GPTQObserverTensor
 CONFIG_TO_TORCHAO_BASE_TENSOR = {
     Int4WeightOnlyConfig: Int4Tensor,
     Int8WeightOnlyConfig: Int8Tensor,
+    NVFP4DynamicActivationNVFP4WeightConfig: NVFP4Tensor,
 }
 
 
@@ -61,7 +81,11 @@ class GPTQConfig(AOBaseConfig):
     """
 
     step: str = "observe"  # "observe" or "convert"
-    base_config: Union[Int4WeightOnlyConfig, Int8WeightOnlyConfig] = None
+    base_config: Union[
+        Int4WeightOnlyConfig,
+        Int8WeightOnlyConfig,
+        NVFP4DynamicActivationNVFP4WeightConfig,
+    ] = None
     percdamp: float = 0.01
     gptq_quantize_block_size: int = 256
 
@@ -179,6 +203,59 @@ def _int4_row_dequantize_zp(
     return torch.cat(dequant_chunks, dim=-1)
 
 
+def _nvfp4_with_precalculated_scales_qdq(
+    data_hp: torch.Tensor,
+    per_tensor_scale: torch.Tensor,
+    block_scale: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Same as torchao.prototype.mx_formats.nvfp4_tensor.nvfp4_quantize, but with
+    per_tensor_scale and block_scale precalculated and the end result dequantized.
+    """
+    assert per_tensor_scale.dtype is torch.float32
+    assert block_scale.dtype is torch.float8_e4m3fn
+    # this function only works for data_hp.shape == (N, k_slice)
+    # and block_scale.shape == (N,)
+    assert len(block_scale.shape) == 1
+
+    scaled_block_scales_fp32 = block_scale.to(torch.float32)
+    reciprocal_scale = (1.0 / per_tensor_scale) / scaled_block_scales_fp32
+    data_scaled = data_hp * reciprocal_scale.unsqueeze(-1)
+    data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp_hp = f4_unpacked_to_f32(data_lp)
+    data_lp_hp_unscaled = data_lp_hp / reciprocal_scale.unsqueeze(-1)
+    return data_lp_hp_unscaled
+
+
+def _nvfp4_with_precalculated_scales_q(
+    data_hp: torch.Tensor,
+    per_tensor_scale: torch.Tensor,
+    block_scale: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Same as torchao.prototype.mx_formats.nvfp4_tensor.nvfp4_quantize, but with
+    per_tensor_scale and block_scale precalculated.
+    """
+    assert per_tensor_scale.dtype is torch.float32
+    assert block_scale.dtype is torch.float8_e4m3fn
+
+    # TODO(future): figure out what to reuse vs leave copy-pasted vs
+    # nvfp4_tensor.py
+    scaled_block_scales_fp32 = block_scale.to(torch.float32)
+    reciprocal_scale = (1.0 / per_tensor_scale) / scaled_block_scales_fp32
+    N, K = data_hp.shape
+    # reshape to 3d to properly broadcast for scaling
+    data_hp = data_hp.view(N, K // 16, 16)
+    data_scaled = data_hp * reciprocal_scale.unsqueeze(-1)
+    data_scaled = torch.clamp(data_scaled, -F4_E2M1_MAX, F4_E2M1_MAX)
+    data_lp = f32_to_f4_unpacked(data_scaled)
+    data_lp_packed = pack_uint4(data_lp)
+    # reshape back to 2d
+    data_lp_packed = data_lp_packed.view(N, K // 2)
+    return data_lp_packed
+
+
 def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
     """
     This function implements the GPTQ algorithm described in this paper: https://arxiv.org/abs/2210.17323 (Algorithm 1)
@@ -241,6 +318,15 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
         block_size = get_block_size(W_t.shape, base_config.granularity)
         block_size = list(block_size)
         group_size = block_size[-1]
+    elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+        group_size = 16
+        block_size = [1, group_size]
+        # for per-tensor nvfp4, we need to calculate the global scale over the
+        # entire tensor before we enter the GPTQ loop
+        tensor_amax = torch.max(torch.abs(W_t))
+        nvfp4_global_scale = per_tensor_amax_to_scale(tensor_amax)
+    else:
+        raise AssertionError("unsupported")
 
     assert group_size > 0
 
@@ -337,6 +423,27 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
                         ],
                         base_config.granularity,
                     )
+                elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+                    tensor_slice = B_cur[
+                        :,
+                        G_k_start - B_cur_k_start : G_k_end - B_cur_k_start,
+                    ].contiguous()
+                    # quantize this slice using pre-calculated global scale, to
+                    # get the blockwise dynamic scales, they will be frozen
+                    # after this point
+                    scale, _data_lp = nvfp4_quantize(
+                        tensor_slice,
+                        per_tensor_scale=nvfp4_global_scale,
+                    )
+                    group_qparams.append(scale)
+                    # TODO(future PR): simpler version of `nvfp4_quantize` which
+                    # just calculates the scale, since we are throwing away the
+                    # quantized packed data here. For now, just call the full
+                    # one.
+                    del _data_lp
+
+                else:
+                    raise AssertionError("unsupported")
 
             # Quantize each column and propagate errors to subsequent columns
             for k in range(G_k_start - B_cur_k_start, G_k_end - B_cur_k_start):
@@ -354,6 +461,12 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
                         scale=quantized_tensor.scale,
                     )
                     dq = q.dequantize(output_dtype=torch.float)
+                elif isinstance(base_config, NVFP4DynamicActivationNVFP4WeightConfig):
+                    dq = _nvfp4_with_precalculated_scales_qdq(
+                        w_t,
+                        nvfp4_global_scale,
+                        scale.squeeze(-1),
+                    )
 
                 err1 = (w_t - dq) / Hinv_cur[k, k]
                 B_cur[:, k:] -= err1.matmul(Hinv_cur[k, k:].unsqueeze(0))
@@ -384,6 +497,48 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
     elif isinstance(base_config, Int8WeightOnlyConfig):
         result = Int8Tensor.from_hp(
             W_t, granularity=base_config.granularity, scale=quantized_tensor.scale
+        )
+    else:
+        N, K = W_t.shape
+        # TODO(future PR): clean up the line below. Context: the current nvfp4
+        # code follows the int4 code - we save the blockwise scales to an array
+        # and concat it. This leads to the necessity of t().contiguous().t() to
+        # get the scales back into the right layout for W_t. This is not
+        # intuitive, likely better to initialize the scales holder ahead of time
+        # and write the scales directly to their final place.
+        combined_scale = (
+            torch.cat(group_qparams, dim=0).reshape(K // group_size, N).t().contiguous()
+        )
+        qdata = _nvfp4_with_precalculated_scales_q(
+            W_t,
+            nvfp4_global_scale,
+            combined_scale,
+        )
+
+        act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
+            use_dynamic_per_tensor_scale=base_config.use_dynamic_per_tensor_scale,
+            use_triton_kernel=base_config.use_triton_kernel,
+            is_swizzled_scales=True,
+        )
+
+        # swizzle the block scales
+        combined_scale_swizzled = to_blocked(combined_scale).flatten()
+        scale_N, scale_K = hp_data_dims_to_swizzled_scale_dims_nvfp4(N, K)
+        combined_scale_swizzled = combined_scale_swizzled.view(scale_N, scale_K)
+
+        result = NVFP4Tensor(
+            qdata,
+            combined_scale_swizzled,
+            block_size=group_size,
+            orig_dtype=W_t.dtype,
+            per_tensor_scale=nvfp4_global_scale,
+            # TODO(future): get act_per_tensor_scale from calibration data?
+            # for now, set it to None here to calculate it dynamically at
+            # runtime
+            act_per_tensor_scale=None,
+            is_swizzled_scales=True,
+            use_triton_kernel=base_config.use_triton_kernel,
+            act_quant_kwargs=act_quant_kwargs,
         )
 
     return result

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -99,6 +99,11 @@ class GPTQConfig(AOBaseConfig):
                 )
 
 
+# simple progress counter for GPTQ convert
+# TODO(future): make this cleaner, will require a refactor
+gptq_convert_layer_counter = 0
+
+
 @register_quantize_module_handler(GPTQConfig)
 def _gptq_config_transform(
     module: torch.nn.Module, config: GPTQConfig, *, parameter_name="weight"
@@ -120,7 +125,10 @@ def _gptq_config_transform(
         )
         return module
     elif config.step == "convert":
-        print("gptq convert")
+        global gptq_convert_layer_counter
+        print(f"gptq convert {gptq_convert_layer_counter}")
+        gptq_convert_layer_counter += 1
+
         # Quantization phase: tensor should be an GPTQObserverTensor
         if not isinstance(tensor, GPTQObserverTensor):
             raise ValueError(

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -120,6 +120,7 @@ def _gptq_config_transform(
         )
         return module
     elif config.step == "convert":
+        print('gptq convert')
         # Quantization phase: tensor should be an GPTQObserverTensor
         if not isinstance(tensor, GPTQObserverTensor):
             raise ValueError(

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -230,7 +230,8 @@ def main():
 
     # Generate output directory name from args
     model_name = args.model_id.split("/")[-1]  # Get last part of model ID
-    output_dir = f"{model_name}_{args.quantization}"
+    # TODO(before land): make output dir configurable
+    output_dir = f"/home/dev/tmp/20260420_{model_name}_{args.quantization}"
 
     if args.quantization != "none":
         output_dir += f"_gs{args.group_size}"
@@ -358,11 +359,16 @@ def main():
         "--model_args",
         f"pretrained={output_dir}",
         "--tasks",
-        "leaderboard_bbh",
-        "--num_fewshot",
-        "3",
+        # "leaderboard_bbh",
+        # "gsm8k",
+        "wikitext",
+        # "--num_fewshot",
+        # "3",
         "--batch_size",
-        "auto",
+        # "auto",
+        "1",
+        # "--limit",
+        # "20",
     ]
 
     print(f"Running command: {' '.join(lm_eval_cmd)}")

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -12,14 +12,12 @@ import time
 from typing import Any, List, Optional
 
 import torch
+import transformers
 from datasets import load_dataset
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from packaging.version import Version
-
-import transformers
-
 from torchao.prototype.gptq import GPTQConfig
 from torchao.prototype.gptq.observer import GPTQObserverTensor
 from torchao.prototype.mx_formats.inference_workflow import (

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -154,8 +154,7 @@ def parse_args():
     parser.add_argument(
         "--num-calibration-samples",
         type=int,
-        # default=128,
-        default=2,
+        default=128,
         help="Number of calibration samples to use",
     )
     parser.add_argument(
@@ -265,9 +264,8 @@ def main():
     def skip_lm_head(module, fqn):
         # TODO(before land): remove o_proj from below, it's just for debugging
         return (
-            isinstance(module, torch.nn.Linear)
-            and "lm_head" not in fqn
-            and "o_proj" in fqn
+            isinstance(module, torch.nn.Linear) and "lm_head" not in fqn
+            # and "o_proj" in fqn
         )
 
     if args.quantization == "int4-rtn":
@@ -352,6 +350,13 @@ def main():
             # Run calibration
             for seq in tqdm(dataset, desc="Calibrating"):
                 model(seq.to(input_device))
+            # Print total # of GPTQ modules
+            num_gptq_weights = 0
+            for name, param in model.named_parameters():
+                # TODO(before land): better check
+                if "GPTQ" in str(type(param)):
+                    num_gptq_weights += 1
+            print(f"Total GPTQ weights to convert: {num_gptq_weights}")
             # Apply quantization
             quantize_(model, convert_config, filter_fn=skip_lm_head)
         else:  # sequential
@@ -372,22 +377,12 @@ def main():
     print(f"Saving model to {output_dir}...")
     tokenizer.save_pretrained(output_dir)
     print(model)
-    if model.config.tie_word_embeddings:
-        model.config.tie_word_embeddings = False
-        model._tied_weights_keys = {}
-        model.lm_head.weight = torch.nn.Parameter(
-            model.lm_head.weight.clone(), requires_grad=False
-        )
 
-        # monkey patch huggingface to skip weight tie checks
-        # TODO(before land): debug why i'm hitting this error here,
-        # as nvfp4 works in other hf models just fine
-        # import transformers.modeling_utils
-        # transformers.modeling_utils.remove_tied_weights_from_state_dict = lambda state_dict, model: state_dict
+    # transformers 5.0.0 have a lot of errors with nvfp4 subclasses
+    # TODO(before land): debug this further
+    import transformers
 
-        import transformers
-
-        assert transformers.__version__ == "4.57.6", "unsupported"
+    assert transformers.__version__ == "4.57.6", "unsupported"
 
     model.save_pretrained(output_dir, safe_serialization=False)
 

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -17,6 +17,9 @@ from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from torchao.prototype.gptq import GPTQConfig
+from torchao.prototype.mx_formats.inference_workflow import (
+    NVFP4DynamicActivationNVFP4WeightConfig,
+)
 from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
 from torchao.quantization.granularity import PerRow
 
@@ -98,6 +101,8 @@ def prepare_dataset(
     hf_dataset_id = dataset_map.get(dataset_id, dataset_id)
 
     # Load dataset and preprocess
+    # TODO(before land): clean up below
+    dataset_split = "train"
     train_dataset_raw = load_dataset(hf_dataset_id, split=dataset_split, streaming=True)
     train_dataset_raw = train_dataset_raw.shuffle(seed=seed, buffer_size=1_000)
 
@@ -149,7 +154,8 @@ def parse_args():
     parser.add_argument(
         "--num-calibration-samples",
         type=int,
-        default=128,
+        # default=128,
+        default=2,
         help="Number of calibration samples to use",
     )
     parser.add_argument(
@@ -177,6 +183,9 @@ def parse_args():
             "int8-rtn",
             "int8-gptq-sequential",
             "int8-gptq-nonsequential",
+            "nvfp4-rtn",
+            "nvfp4-gptq-sequential",
+            "nvfp4-gptq-nonsequential",
         ],
         help="Quantization method to use",
     )
@@ -241,6 +250,8 @@ def main():
         "int4-gptq-nonsequential",
         "int8-gptq-sequential",
         "int8-gptq-nonsequential",
+        "nvfp4-gptq-sequential",
+        "nvfp4-gptq-nonsequential",
     ]:
         output_dir += f"_{args.dataset_id}_n{args.num_calibration_samples}"
         output_dir += f"_damp{args.percdamp}_bs{args.gptq_block_size}"
@@ -250,29 +261,51 @@ def main():
     # Handle different quantization methods
     quantization_start_time = time.time()
 
+    def skip_lm_head(module, fqn):
+        # TODO(before land): remove o_proj from below, it's just for debugging
+        return isinstance(module, torch.nn.Linear) and "lm_head" not in fqn and "o_proj" in fqn
+
+
     if args.quantization == "int4-rtn":
         print("Applying Int4 RTN (Round-To-Nearest) quantization...")
         config = Int4WeightOnlyConfig(group_size=args.group_size)
-        quantize_(model, config, filter_fn=None)
+        quantize_(model, config, filter_fn=skip_lm_head)
 
     elif args.quantization == "int8-rtn":
         print("Applying Int8 RTN (Round-To-Nearest) quantization...")
         config = Int8WeightOnlyConfig(version=2, granularity=PerRow())
-        quantize_(model, config, filter_fn=None)
+        quantize_(model, config, filter_fn=skip_lm_head)
+
+    elif args.quantization == "nvfp4-rtn":
+        print("Applying NVFP4 RTN (Round-To-Nearest) quantization...")
+
+        config = NVFP4DynamicActivationNVFP4WeightConfig(
+            use_dynamic_per_tensor_scale=True,
+            use_triton_kernel=True,
+        )
+        quantize_(model, config, filter_fn=skip_lm_head)
 
     elif args.quantization in [
         "int4-gptq-sequential",
         "int4-gptq-nonsequential",
         "int8-gptq-sequential",
         "int8-gptq-nonsequential",
+        "nvfp4-gptq-sequential",
+        "nvfp4-gptq-nonsequential",
     ]:
         # Determine base config based on quantization type
         if "int4" in args.quantization:
             base_config = Int4WeightOnlyConfig(group_size=args.group_size)
             quant_type = "Int4"
-        else:  # int8
+        elif "int8" in args.quantization:
             base_config = Int8WeightOnlyConfig(granularity=PerRow(), version=2)
             quant_type = "Int8"
+        else:  # nvfp4
+            base_config = NVFP4DynamicActivationNVFP4WeightConfig(
+                use_dynamic_per_tensor_scale=True,
+                use_triton_kernel=True,
+            )
+            quant_type = "NVFP4"
 
         # First application: wrap weights with GPTQObserverTensor (observe step)
         print(
@@ -284,7 +317,7 @@ def main():
             percdamp=args.percdamp,
             gptq_quantize_block_size=args.gptq_block_size,
         )
-        quantize_(model, observe_config, filter_fn=None)
+        quantize_(model, observe_config, filter_fn=skip_lm_head)
 
         # Prepare calibration dataset
         print(
@@ -316,7 +349,7 @@ def main():
             for seq in tqdm(dataset, desc="Calibrating"):
                 model(seq.to(input_device))
             # Apply quantization
-            quantize_(model, convert_config, filter_fn=None)
+            quantize_(model, convert_config, filter_fn=skip_lm_head)
         else:  # sequential
             print(f"Applying {quant_type} GPTQ quantization (sequential)...")
             sequential_quantize(model, dataset, convert_config)
@@ -334,6 +367,23 @@ def main():
     # Save model to generated output directory
     print(f"Saving model to {output_dir}...")
     tokenizer.save_pretrained(output_dir)
+    print(model)
+    if model.config.tie_word_embeddings:
+        model.config.tie_word_embeddings = False
+        model._tied_weights_keys = {}
+        model.lm_head.weight = torch.nn.Parameter(
+            model.lm_head.weight.clone(), requires_grad=False
+        )
+
+        # monkey patch huggingface to skip weight tie checks
+        # TODO(before land): debug why i'm hitting this error here,
+        # as nvfp4 works in other hf models just fine
+        # import transformers.modeling_utils
+        # transformers.modeling_utils.remove_tied_weights_from_state_dict = lambda state_dict, model: state_dict
+
+        import transformers
+        assert transformers.__version__ == '4.57.6', "unsupported"
+
     model.save_pretrained(output_dir, safe_serialization=False)
 
     print("DONE!")

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -16,7 +16,12 @@ from datasets import load_dataset
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from packaging.version import Version
+
+import transformers
+
 from torchao.prototype.gptq import GPTQConfig
+from torchao.prototype.gptq.observer import GPTQObserverTensor
 from torchao.prototype.mx_formats.inference_workflow import (
     NVFP4DynamicActivationNVFP4WeightConfig,
 )
@@ -96,14 +101,19 @@ def prepare_dataset(
     dataset_map = {
         "hellaswag": "Rowan/hellaswag",
         "ultrachat200k": "HuggingFaceH4/ultrachat_200k",
+        "c4": ("allenai/c4", "en"),
     }
 
-    hf_dataset_id = dataset_map.get(dataset_id, dataset_id)
+    dataset_entry = dataset_map.get(dataset_id, dataset_id)
+    if isinstance(dataset_entry, tuple):
+        hf_dataset_id, hf_config_name = dataset_entry
+    else:
+        hf_dataset_id, hf_config_name = dataset_entry, None
 
     # Load dataset and preprocess
-    # TODO(before land): clean up below
-    dataset_split = "train"
-    train_dataset_raw = load_dataset(hf_dataset_id, split=dataset_split, streaming=True)
+    train_dataset_raw = load_dataset(
+        hf_dataset_id, hf_config_name, split=dataset_split, streaming=True
+    )
     train_dataset_raw = train_dataset_raw.shuffle(seed=seed, buffer_size=1_000)
 
     def preprocess_hellaswag(example):
@@ -167,8 +177,14 @@ def parse_args():
         "--dataset-id",
         type=str,
         default="ultrachat200k",
-        choices=["hellaswag", "ultrachat200k"],
+        choices=["hellaswag", "ultrachat200k", "c4"],
         help="Dataset for calibration (hellaswag or ultrachat200k)",
+    )
+    parser.add_argument(
+        "--dataset-split",
+        type=str,
+        default="train_sft",
+        help="Dataset split to use for calibration",
     )
     parser.add_argument(
         "--quantization",
@@ -206,11 +222,61 @@ def parse_args():
         default=1024,
         help="Block size for GPTQ quantization",
     )
+    parser.add_argument(
+        "--lm-eval-tasks",
+        type=str,
+        default="leaderboard_bbh",
+        help="Comma-separated tasks for lm_eval",
+    )
+    parser.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=3,
+        help="Number of few-shot examples for lm_eval (0 to disable)",
+    )
+    parser.add_argument(
+        "--lm-eval-batch-size",
+        type=str,
+        default="auto",
+        help="Batch size for lm_eval (default: auto)",
+    )
+    parser.add_argument(
+        "--lm-eval-limit",
+        type=int,
+        default=None,
+        help="Limit number of examples per task for lm_eval (default: no limit)",
+    )
+    parser.add_argument(
+        "--output-dir-prefix",
+        type=str,
+        required=True,
+        help="Prefix for the output directory (e.g. /home/user/tmp/20260420)",
+    )
+    parser.add_argument(
+        "--skip-lm-eval",
+        action="store_true",
+        default=False,
+        help="Skip running lm_eval after quantization, useful for quickly iterating on lm_eval arguments",
+    )
+    parser.add_argument(
+        "--o-proj-only",
+        action="store_true",
+        default=False,
+        help="Only quantize `o_proj` layers, useful for faster GPTQ runs for debugging",
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
+
+    # lm_eval batch_size="auto" with nvfp4 gptq causes the error in
+    # MSLK nvfp4 triton kernel, likely an unsupported shape:
+    # https://gist.github.com/vkuzo/b71ca46365dee017d1602e9638d91603
+    # TODO(future): debug and fix this. For now, the workaround is
+    # for the user to manually specify lm_eval batch_size.
+    if "nvfp4" in args.quantization:
+        assert args.lm_eval_batch_size != "auto", "unsupported"
 
     # Map dtype string to torch dtype
     dtype_map = {
@@ -238,9 +304,7 @@ def main():
 
     # Generate output directory name from args
     model_name = args.model_id.split("/")[-1]  # Get last part of model ID
-    output_dir = f"{model_name}_{args.quantization}"
-    # TODO(before land): make output dir configurable
-    output_dir = f"/home/dev/tmp/20260420_{model_name}_{args.quantization}"
+    output_dir = f"{args.output_dir_prefix}_{model_name}_{args.quantization}"
 
     if args.quantization != "none":
         output_dir += f"_gs{args.group_size}"
@@ -262,21 +326,28 @@ def main():
     quantization_start_time = time.time()
 
     def skip_lm_head(module, fqn):
-        # TODO(before land): remove o_proj from below, it's just for debugging
+        return isinstance(module, torch.nn.Linear) and "lm_head" not in fqn
+
+    def skip_lm_head_o_proj(module, fqn):
         return (
-            isinstance(module, torch.nn.Linear) and "lm_head" not in fqn
-            # and "o_proj" in fqn
+            isinstance(module, torch.nn.Linear)
+            and "lm_head" not in fqn
+            and "o_proj" in fqn
         )
+
+    filter_fn_to_use = skip_lm_head
+    if args.o_proj_only:
+        filter_fn_to_use = skip_lm_head_o_proj
 
     if args.quantization == "int4-rtn":
         print("Applying Int4 RTN (Round-To-Nearest) quantization...")
         config = Int4WeightOnlyConfig(group_size=args.group_size)
-        quantize_(model, config, filter_fn=skip_lm_head)
+        quantize_(model, config, filter_fn=filter_fn_to_use)
 
     elif args.quantization == "int8-rtn":
         print("Applying Int8 RTN (Round-To-Nearest) quantization...")
         config = Int8WeightOnlyConfig(version=2, granularity=PerRow())
-        quantize_(model, config, filter_fn=skip_lm_head)
+        quantize_(model, config, filter_fn=filter_fn_to_use)
 
     elif args.quantization == "nvfp4-rtn":
         print("Applying NVFP4 RTN (Round-To-Nearest) quantization...")
@@ -285,7 +356,7 @@ def main():
             use_dynamic_per_tensor_scale=True,
             use_triton_kernel=True,
         )
-        quantize_(model, config, filter_fn=skip_lm_head)
+        quantize_(model, config, filter_fn=filter_fn_to_use)
 
     elif args.quantization in [
         "int4-gptq-sequential",
@@ -319,7 +390,7 @@ def main():
             percdamp=args.percdamp,
             gptq_quantize_block_size=args.gptq_block_size,
         )
-        quantize_(model, observe_config, filter_fn=skip_lm_head)
+        quantize_(model, observe_config, filter_fn=filter_fn_to_use)
 
         # Prepare calibration dataset
         print(
@@ -330,7 +401,7 @@ def main():
             max_seq_length,
             args.num_calibration_samples,
             dataset_id=args.dataset_id,
-            dataset_split="train_sft",
+            dataset_split=args.dataset_split,
             seed=42,
         )
 
@@ -353,14 +424,14 @@ def main():
             # Print total # of GPTQ modules
             num_gptq_weights = 0
             for name, param in model.named_parameters():
-                # TODO(before land): better check
-                if "GPTQ" in str(type(param)):
+                if isinstance(param, GPTQObserverTensor):
                     num_gptq_weights += 1
             print(f"Total GPTQ weights to convert: {num_gptq_weights}")
             # Apply quantization
-            quantize_(model, convert_config, filter_fn=skip_lm_head)
+            quantize_(model, convert_config, filter_fn=filter_fn_to_use)
         else:  # sequential
             print(f"Applying {quant_type} GPTQ quantization (sequential)...")
+            assert filter_fn_to_use == skip_lm_head, "unsupported"
             sequential_quantize(model, dataset, convert_config)
 
     quantization_end_time = time.time()
@@ -380,9 +451,9 @@ def main():
 
     # transformers 5.0.0 have a lot of errors with nvfp4 subclasses
     # TODO(before land): debug this further
-    import transformers
-
-    assert transformers.__version__ == "4.57.6", "unsupported"
+    assert Version(transformers.__version__) < Version("5.0.0"), (
+        f"transformers {transformers.__version__} is not supported, need < 5.0.0"
+    )
 
     model.save_pretrained(output_dir, safe_serialization=False)
 
@@ -409,18 +480,20 @@ def main():
         "--model_args",
         f"pretrained={output_dir}",
         "--tasks",
-        # "leaderboard_bbh",
-        "wikitext",
-        # "--num_fewshot",
-        # "3",
+        args.lm_eval_tasks,
         "--batch_size",
-        # "auto",
-        "1",
-        # "--limit",
-        # "20",
+        args.lm_eval_batch_size,
     ]
 
+    if args.num_fewshot > 0:
+        lm_eval_cmd += ["--num_fewshot", str(args.num_fewshot)]
+    if args.lm_eval_limit is not None:
+        lm_eval_cmd += ["--limit", str(args.lm_eval_limit)]
+
     print(f"Running command: {' '.join(lm_eval_cmd)}")
+    if args.skip_lm_eval:
+        print("Terminating early due to skip_lm_eval=True")
+        return
     try:
         subprocess.run(lm_eval_cmd, check=True)
     except subprocess.CalledProcessError as e:

--- a/torchao/prototype/gptq/gptq_example.py
+++ b/torchao/prototype/gptq/gptq_example.py
@@ -230,8 +230,7 @@ def main():
 
     # Generate output directory name from args
     model_name = args.model_id.split("/")[-1]  # Get last part of model ID
-    # TODO(before land): make output dir configurable
-    output_dir = f"/home/dev/tmp/20260420_{model_name}_{args.quantization}"
+    output_dir = f"{model_name}_{args.quantization}"
 
     if args.quantization != "none":
         output_dir += f"_gs{args.group_size}"
@@ -359,16 +358,11 @@ def main():
         "--model_args",
         f"pretrained={output_dir}",
         "--tasks",
-        # "leaderboard_bbh",
-        # "gsm8k",
-        "wikitext",
-        # "--num_fewshot",
-        # "3",
+        "leaderboard_bbh",
+        "--num_fewshot",
+        "3",
         "--batch_size",
-        # "auto",
-        "1",
-        # "--limit",
-        # "20",
+        "auto",
     ]
 
     print(f"Running command: {' '.join(lm_eval_cmd)}")

--- a/torchao/prototype/gptq/gptq_nvfp4_llama3_2_1b_nonsequential_wikitext.sh
+++ b/torchao/prototype/gptq/gptq_nvfp4_llama3_2_1b_nonsequential_wikitext.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# A quick smoke test for non-sequential GPTQ on `unsloth/Llama-3.2-1B`
+#
+
+COMMON_ARGS="--output-dir-prefix /home/dev/tmp/20260421 --model-id unsloth/Llama-3.2-1B --lm-eval-tasks wikitext --num-fewshot 0 --lm-eval-batch-size 16"
+
+# baseline (bf16)
+echo -e "\n\nbaseline (bf16)\n\n"
+python -u torchao/prototype/gptq/gptq_example.py $COMMON_ARGS --quantization none 
+echo -e "done"
+
+# nvfp4-rtn
+echo -e "\n\nnvfp4-rtn\n\n"
+python -u torchao/prototype/gptq/gptq_example.py $COMMON_ARGS --quantization nvfp4-rtn
+echo -e "done"
+
+# nvfp4-gptq-nonsequential
+echo -e "\n\nnvfp4-gptq-nonsequential\n\n"
+python -u torchao/prototype/gptq/gptq_example.py $COMMON_ARGS --quantization nvfp4-gptq-nonsequential --dataset-id c4 --dataset-split train
+echo -e "done"


### PR DESCRIPTION
Summary:

Adds a very short e2e test for nonsequential (no modeling changes for dense) GPTQ on LLaMa 3.2 1B + wikitext perplexity. This shows that nonsequential GPTQ is directionally working. Optimizing for speed of iteration here.

GPTQ currently takes around 3 minutes to complete for this model, on a B200.  This is before any performance optimizations.

Test Plan:

```bash
time torchao/prototype/gptq/gptq_nvfp4_llama3_2_1b_nonsequential_wikitext.sh 2>&1 | tee ~/tmp/20260421_gptq_run.txt

// full logs: https://gist.github.com/vkuzo/ca83b024b8268259e21f80522971f240

// baseline

| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|------:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.6699|±  |   N/A|
|        |       |none  |     0|byte_perplexity|↓  | 1.5910|±  |   N/A|
|        |       |none  |     0|word_perplexity|↓  |11.9782|±  |   N/A|

// nvfp4-rtn

| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|------:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.7169|±  |   N/A|
|        |       |none  |     0|byte_perplexity|↓  | 1.6436|±  |   N/A|
|        |       |none  |     0|word_perplexity|↓  |14.2549|±  |   N/A|

// nvfp4-gptq-nonsequential

| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|------:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.7078|±  |   N/A|
|        |       |none  |     0|byte_perplexity|↓  | 1.6333|±  |   N/A|
|        |       |none  |     0|word_perplexity|↓  |13.7856|±  |   N/A|
```
