### PR TITLE
[ROCm] test(moe): skip jagged rowwise scales test.

### DIFF
--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -69,6 +69,7 @@ from .testing_utils import generate_split_sizes
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
+@skip_if_rocm("jagged rowwise scales kernel vs torch reference mismatch on ROCm")
 def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
     # Tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).


### PR DESCRIPTION
Test failing post merge https://github.com/pytorch/ao/pull/4113 pytest test_kernels.py -k test_row_major_with_jagged_rowwise_scales -vv
test_kernels.py::test_row_major_with_jagged_rowwise_scales[True] FAILED                         [ 25%]
test_kernels.py::test_row_major_with_jagged_rowwise_scales[False] FAILED                        [ 50%]
test_kernels.py::test_row_major_with_jagged_rowwise_scales_transpose_method[True] PASSED        [ 75%]
test_kernels.py::test_row_major_with_jagged_rowwise_scales_transpose_method[False] PASSED       [100%]