### PR TITLE
[mxfp8 moe training] integrate 1x32 cutedsl quantization kernel

### DIFF
--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -61,11 +61,10 @@ from torchao.prototype.moe_training.utils import (
     torch_to_float8_per_group_colwise,
     torch_to_float8_per_group_rowwise,
 )
+from torchao.prototype.mx_formats.kernels import triton_mx_block_rearrange
 from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
 from torchao.prototype.mx_formats.utils import from_blocked
 from torchao.testing.utils import skip_if_rocm
-
-from .testing_utils import generate_split_sizes
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
@@ -448,8 +447,8 @@ def test_cuda_mx_dim1_3d_numerics(E, N, K, input_dtype, scaling_mode):
     not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
-@pytest.mark.parametrize("M", (32, 160, 8192))
-@pytest.mark.parametrize("K", (32, 96, 1536, 5120, 7168, 8192))
+@pytest.mark.parametrize("M", (128, 8192))
+@pytest.mark.parametrize("K", (1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("input_dtype", (torch.bfloat16,))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
@@ -472,6 +471,7 @@ def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
         block_size=block_size,
         scaling_mode=scaling_mode,
     )
+    s_d0_ref = triton_mx_block_rearrange(s_d0_ref)
 
     # CuTeDSL kernel implementation
     y_d0, s_d0 = mxfp8_quantize_2d_1x32_cutedsl(
@@ -479,9 +479,6 @@ def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
         block_size=block_size,
         scaling_mode=scaling_mode_str,
     )
-
-    # Convert blocked scales back to reference format
-    s_d0 = from_blocked(s_d0, M, K // block_size).to(s_d0_ref.dtype)
 
     # Check scales
     torch.testing.assert_close(s_d0, s_d0_ref, rtol=0, atol=0)
@@ -502,7 +499,7 @@ def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
     not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
-@pytest.mark.parametrize("M", (32, 128, 160, 1024))
+@pytest.mark.parametrize("M", (128, 1024))
 @pytest.mark.parametrize("K", (128, 256, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("input_dtype", (torch.bfloat16,))
 @pytest.mark.parametrize(
@@ -719,29 +716,27 @@ def test_triton_fp8_rowwise_2d_scale_and_cast(
 @skip_if_rocm("ROCm enablement in progress")
 def test_cutedsl_1x32_group_validation_error():
     """Test that 1x32 CuTeDSL kernel raises error for non-128-multiple group sizes."""
-    device = "cuda"
-    M, K = 512, 1024
-    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
-    num_groups = 4
+    import subprocess
+    import sys
 
-    # Generate group sizes and force at least one to be invalid
-    group_sizes = generate_split_sizes(num_groups, M, device)
-    if group_sizes[0] % 128 == 0:
-        group_sizes[0] = group_sizes[0] - 1  # Make it not a multiple of 128
-        group_sizes[1] = group_sizes[1] + 1  # Compensate to maintain total sum
+    script = """\
+import torch
+from torchao.prototype.moe_training.kernels.mxfp8.quant import mxfp8_quantize_2d_1x32_cutedsl
 
-    invalid_offsets = torch.cumsum(group_sizes, dim=0, dtype=torch.int32)
-
-    # Test should raise RuntimeError due to device assertion failure with specific message
-    with pytest.raises(
-        RuntimeError,
-        match=r"unspecified launch failure",
-    ):
-        _ = mxfp8_quantize_2d_1x32_cutedsl(
-            x, block_size=32, scaling_mode="rceil", offs=invalid_offsets
-        )
-        # Force synchronization to ensure device error propagates
-        torch.cuda.synchronize()
+M, K = 512, 1024
+x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+invalid_offsets = torch.tensor([127, 256, 384, 512], dtype=torch.int32, device="cuda")
+mxfp8_quantize_2d_1x32_cutedsl(x, block_size=32, scaling_mode="rceil", offs=invalid_offsets)
+torch.cuda.synchronize()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        timeout=120,
+    )
+    assert result.returncode != 0, (
+        "Expected subprocess to fail for non-128-multiple group sizes"
+    )
 
 
 @pytest.mark.skipif(
@@ -755,26 +750,27 @@ def test_cutedsl_1x32_group_validation_error():
 @skip_if_rocm("ROCm enablement in progress")
 def test_cutedsl_32x1_group_validation_error():
     """Test that 32x1 CuTeDSL kernel raises error for non-128-multiple group sizes."""
-    device = "cuda"
-    M, K = 512, 1024
-    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
-    num_groups = 4
+    import subprocess
+    import sys
 
-    # Generate group sizes and force at least one to be invalid
-    group_sizes = generate_split_sizes(num_groups, M, device)
-    if group_sizes[0] % 128 == 0:
-        group_sizes[0] = group_sizes[0] - 1  # Make it not a multiple of 128
-        group_sizes[1] = group_sizes[1] + 1  # Compensate to maintain total sum
+    script = """\
+import torch
+from torchao.prototype.moe_training.kernels.mxfp8.quant import mxfp8_quantize_2d_32x1_cutedsl
 
-    invalid_offsets = torch.cumsum(group_sizes, dim=0, dtype=torch.int32)
-
-    # Test should raise RuntimeError due to device assertion failure with specific message
-    with pytest.raises(RuntimeError, match=r"unspecified launch failure"):
-        _ = mxfp8_quantize_2d_32x1_cutedsl(
-            x, block_size=32, scaling_mode="rceil", offs=invalid_offsets
-        )
-        # Force synchronization to ensure device error propagates
-        torch.cuda.synchronize()
+M, K = 512, 1024
+x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+invalid_offsets = torch.tensor([127, 256, 384, 512], dtype=torch.int32, device="cuda")
+mxfp8_quantize_2d_32x1_cutedsl(x, block_size=32, scaling_mode="rceil", offs=invalid_offsets)
+torch.cuda.synchronize()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        timeout=120,
+    )
+    assert result.returncode != 0, (
+        "Expected subprocess to fail for non-128-multiple group sizes"
+    )
 
 
 @pytest.mark.skipif(
@@ -794,9 +790,9 @@ def test_cutedsl_kernels_work_with_valid_128_multiple_groups():
 
     # Create valid group offsets (all group sizes are multiples of 128)
     valid_group_sizes = [128, 256, 128]  # All multiples of 128
-    valid_offsets = torch.cumsum(
-        torch.tensor(valid_group_sizes, dtype=torch.int32), dim=0
-    ).to(device)
+    valid_offsets = (
+        torch.cumsum(torch.tensor(valid_group_sizes), dim=0).to(device).to(torch.int32)
+    )
 
     # Verify all group sizes are multiples of 128
     group_sizes = torch.diff(

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -133,7 +133,6 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 @pytest.mark.parametrize("num_experts", (1, 8))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
 @pytest.mark.parametrize("use_compile", (False, True))
-@pytest.mark.parametrize("pad_token_groups_for_grouped_mm", (False, True))
 @pytest.mark.parametrize(
     "kernel_preference", (KernelPreference.AUTO, KernelPreference.EMULATED)
 )
@@ -149,18 +148,13 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     use_compile,
     kernel_preference,
     scale_mode,
-    pad_token_groups_for_grouped_mm,
 ):
     # MXFP8 hardware path requires SM100
     if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
         pytest.skip(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
-    if (
-        kernel_preference == KernelPreference.EMULATED
-        and use_compile
-        and pad_token_groups_for_grouped_mm
-    ):
+    if kernel_preference == KernelPreference.EMULATED and use_compile:
         pytest.skip(
             "torch native dynamic per group pad/unpad functions do not work with torch.compile yet: https://github.com/pytorch/pytorch/issues/176770"
         )
@@ -175,8 +169,7 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
 
-    multiple_of = 1 if pad_token_groups_for_grouped_mm else 32
-    offs = generate_jagged_offs(num_experts, M, multiple_of=multiple_of)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
     x_ref, w_t_ref, offs_ref = (
         x.clone().detach().requires_grad_(True),
         w_t.clone().detach().requires_grad_(True),
@@ -196,7 +189,7 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
         kernel_preference=kernel_preference,
         wgrad_with_hp=wgrad_with_hp,
         scale_calculation_mode=scale_mode,
-        pad_token_groups_for_grouped_mm=pad_token_groups_for_grouped_mm,
+        pad_token_groups_for_grouped_mm=False,
     )
     ref_out = torch._grouped_mm(x_ref, w_t_ref, offs=offs_ref, out_dtype=torch.bfloat16)
     sqnr = compute_error(ref_out, out)
@@ -238,7 +231,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         device="cuda",
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
 
     x_ref = x.detach().clone().requires_grad_(True)
     w_t_ref = w_t.detach().clone().requires_grad_(True)
@@ -311,7 +304,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         device="cuda",
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
 
     x_scale, x_qdata = to_mx(
         x.detach(),
@@ -365,7 +358,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         device="cuda",
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
 
     x_scale, x_qdata = to_mx(
         x,

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -133,9 +133,7 @@ def test_moe_training(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
 
-    alignment_size = 32 if isinstance(recipe, MXFP8TrainingRecipe) else 16
-    if not token_groups_aligned:
-        alignment_size = 1
+    alignment_size = 128 if isinstance(recipe, MXFP8TrainingRecipe) else 16
     set_token_group_alignment_size_m(alignment_size)
 
     model_args = MoEArgs(

--- a/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py
@@ -998,7 +998,8 @@ def mxfp8_quantize_cutedsl_2d_1x32(
     assert x.is_cuda, "Input tensor must be CUDA"
     assert block_size == 32, "Only block_size=32 is supported"
     M, K = x.shape
-    assert K % block_size == 0, "K must be divisible by block_size"
+    assert K % 128 == 0, "K must be divisible by 128"
+    assert M % 128 == 0, "M must be divisible by 128"
 
     if offs is not None:
         assert offs.is_cuda, "offs tensor must be CUDA"
@@ -1029,9 +1030,9 @@ def mxfp8_quantize_cutedsl_2d_1x32(
         dtype=torch.float8_e4m3fn,
     )
     k_blocks = K // block_size
+    padded_scale_rows = ceil_div(M, 128) * 128
+    padded_scale_cols = ceil_div(k_blocks, 4) * 4
     if blocked_scale_output:
-        padded_scale_rows = ceil_div(M, 128) * 128
-        padded_scale_cols = ceil_div(k_blocks, 4) * 4
         scales_u8 = torch.empty(
             (padded_scale_rows * padded_scale_cols,),
             device=x.device,
@@ -1075,5 +1076,10 @@ def mxfp8_quantize_cutedsl_2d_1x32(
         stream,
         offs,
     )
-
-    return q_data, scales_u8.view(torch.float8_e8m0fnu)
+    scales = scales_u8.view(torch.float8_e8m0fnu)
+    scales = (
+        scales.view(padded_scale_rows, padded_scale_cols)
+        if blocked_scale_output
+        else scales_u8.view(M, k_blocks)
+    )
+    return q_data, scales

--- a/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_32x1.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_32x1.py
@@ -1011,7 +1011,8 @@ def mxfp8_quantize_cutedsl_2d_32x1(
     assert x.is_cuda, "Input tensor must be CUDA"
     assert block_size == 32, "Only block_size=32 is supported"
     M, K = x.shape
-    assert M % block_size == 0, "M must be divisible by block_size for 32x1 scaling"
+    assert M % 128 == 0, "M must be divisible by 128"
+    assert K % 128 == 0, "K must be divisible by 128"
 
     if offs is not None:
         assert offs.is_cuda, "offs tensor must be CUDA"
@@ -1050,7 +1051,7 @@ def mxfp8_quantize_cutedsl_2d_32x1(
             ceil_div(m_blocks, 4) * 4
         )  # M//32 rounded to multiple of 4 (second dim)
         scales_u8 = (
-            torch.zeros(  # Initialize with zeros to match to_blocked() padding behavior
+            torch.empty(  # Initialize with zeros to match to_blocked() padding behavior
                 (padded_scale_rows * padded_scale_cols,),
                 device=x.device,
                 dtype=torch.uint8,

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -943,7 +943,7 @@ def _mxfp8_quantize_2d_1x32_cutedsl_custom_op(
         mxfp8_quantize_cutedsl_2d_1x32,
     )
 
-    return mxfp8_quantize_cutedsl_2d_1x32(
+    qdata, scales = mxfp8_quantize_cutedsl_2d_1x32(
         x,
         block_size=block_size,
         scaling_mode=scaling_mode,
@@ -951,6 +951,7 @@ def _mxfp8_quantize_2d_1x32_cutedsl_custom_op(
         blocked_scale_output=True,
         offs=offs,
     )
+    return qdata, scales
 
 
 @torch.library.custom_op("torchao::mxfp8_quantize_2d_32x1_cutedsl", mutates_args=())
@@ -997,7 +998,10 @@ def _fake_mxfp8_quantize_2d_1x32_cutedsl_custom_op(
     padded_scale_rows = ceil_div(m, 128) * 128
     padded_scale_cols = ceil_div(k_blocks, 4) * 4
     scales = x.new_empty(
-        (padded_scale_rows * padded_scale_cols,),
+        (
+            padded_scale_rows,
+            padded_scale_cols,
+        ),
         dtype=torch.float8_e8m0fnu,
     )
     return q_data, scales
@@ -1350,13 +1354,14 @@ def mxfp8_quantize_2d_1x32_cutedsl(
         raise NotImplementedError(
             "mxfp8_quantize_2d requires CUDA, SM 10.x, and CUDA 12.8+."
         )
-    return _mxfp8_quantize_2d_1x32_cutedsl_custom_op(
+    qdata, scales = _mxfp8_quantize_2d_1x32_cutedsl_custom_op(
         x,
         block_size=block_size,
         scaling_mode=scaling_mode,
         stage_count=stage_count,
         offs=offs,
     )
+    return qdata, scales
 
 
 def mxfp8_quantize_2d_32x1_cutedsl(

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -550,10 +550,6 @@ def _compute_fwd_sm100(
             scaling_mode=scale_calculation_mode.value.lower(),
             offs=padded_group_end_offsets,
         )
-        # TODO: cutedsl shouldn't flatten scales
-        input_act_scales_blocked = input_act_scales_blocked.view(
-            input_act_e4m3.shape[0], -1
-        )
 
     # Quantize weights along dim0 (after transposing from (E, K, N) to (E, N, K))
     weight_e4m3, weight_scales = triton_to_mxfp8_dim0(
@@ -653,10 +649,6 @@ def _compute_dgrad_sm100(
             grad_output,
             scaling_mode=scale_calculation_mode.value.lower(),
             offs=group_end_offsets,
-        )
-        # TODO: cutedsl shouldn't flatten scales
-        grad_output_scales_blocked = grad_output_scales_blocked.view(
-            grad_out_e4m3.shape[0], -1
         )
 
     # Quantize weights directly to blocked tcgen05 scales.

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -14,6 +14,7 @@ from torchao.prototype.moe_training.kernels.mxfp8 import (
 )
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     mx_block_rearrange_2d_M_groups_cuda,
+    mxfp8_quantize_2d_1x32_cutedsl,
     mxfp8_quantize_cuda_3d,
     triton_mx_block_rearrange_2d_K_groups,
     triton_mx_block_rearrange_per_group_3d,
@@ -423,7 +424,7 @@ def _compute_dgrad(
             scale_calculation_mode,
         )
     else:
-        return __compute_dgrad_sm100(
+        return _compute_dgrad_sm100(
             grad_output,
             weight_t,
             group_end_offsets,
@@ -481,34 +482,7 @@ def _compute_wgrad(
         )
 
 
-def _extract_or_quantize_dim0_auto(
-    tensor: torch.Tensor,
-    block_size: int,
-    scale_calculation_mode: ScaleCalculationMode,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Extract qdata and scales from MXTensor or quantize using Triton kernels (AUTO path).
-
-    Args:
-        tensor: Input tensor (MXTensor or high-precision)
-        block_size: Block size for quantization
-        scale_calculation_mode: Mode for scale calculation
-
-    Returns:
-        tuple: (quantized_data, scales)
-    """
-    if isinstance(tensor, MXTensor):
-        return tensor.qdata, tensor.scale
-
-    qdata, scale = triton_to_mxfp8_dim0(
-        tensor,
-        inner_block_size=block_size,
-        scaling_mode=str(scale_calculation_mode.value).lower(),
-    )
-    return qdata, scale
-
-
-def _extract_or_quantize_dim0_emulated(
+def _extract_or_quantize_1x32_emulated(
     tensor: torch.Tensor,
     block_size: int,
     scale_calculation_mode: ScaleCalculationMode,
@@ -558,19 +532,32 @@ def _compute_fwd_sm100(
     Returns:
         Output tensor, shape (M, N)
     """
-    # Quantize input activations along dim0
-    input_act_e4m3, input_act_scales = _extract_or_quantize_dim0_auto(
-        padded_input_act, block_size, scale_calculation_mode
-    )
+    # Quantize input activations along dim0.
+    # May be prequantized, if so extract qdata and scales.
+    if isinstance(padded_input_act, MXTensor):
+        input_act_e4m3, input_act_scales_blocked = (
+            padded_input_act.qdata,
+            padded_input_act.scale,
+        )
+        if not padded_input_act.is_swizzled_scales:
+            # Convert scales to blocked layout for SM100 kernels
+            input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
+                padded_input_act.scales, padded_group_end_offsets
+            )
+    else:
+        input_act_e4m3, input_act_scales_blocked = mxfp8_quantize_2d_1x32_cutedsl(
+            padded_input_act,
+            scaling_mode=scale_calculation_mode.value.lower(),
+            offs=padded_group_end_offsets,
+        )
+        # TODO: cutedsl shouldn't flatten scales
+        input_act_scales_blocked = input_act_scales_blocked.view(
+            input_act_e4m3.shape[0], -1
+        )
 
     # Quantize weights along dim0 (after transposing from (E, K, N) to (E, N, K))
-    weight_e4m3, weight_scales = _extract_or_quantize_dim0_auto(
-        weight_t.transpose(-2, -1), block_size, scale_calculation_mode
-    )
-
-    # Convert scales to blocked layout for SM100 kernels
-    input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
-        input_act_scales, padded_group_end_offsets
+    weight_e4m3, weight_scales = triton_to_mxfp8_dim0(
+        weight_t.transpose(-2, -1), block_size, scale_calculation_mode.value.lower()
     )
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
@@ -609,12 +596,12 @@ def _compute_fwd_emulated(
         Output tensor, shape (M, N)
     """
     # Quantize input activations along dim0
-    input_act_e4m3, input_act_scales = _extract_or_quantize_dim0_emulated(
+    input_act_e4m3, input_act_scales = _extract_or_quantize_1x32_emulated(
         padded_input_act, block_size, scale_calculation_mode
     )
 
     # Quantize weights along dim0 (after transposing from (E, K, N) to (E, N, K))
-    weight_e4m3, weight_scales = _extract_or_quantize_dim0_emulated(
+    weight_e4m3, weight_scales = _extract_or_quantize_1x32_emulated(
         weight_t.transpose(-2, -1), block_size, scale_calculation_mode
     )
 
@@ -631,7 +618,7 @@ def _compute_fwd_emulated(
     return output
 
 
-def __compute_dgrad_sm100(
+def _compute_dgrad_sm100(
     grad_output: torch.Tensor,
     weight_t: torch.Tensor,
     group_end_offsets: torch.Tensor,
@@ -654,11 +641,26 @@ def __compute_dgrad_sm100(
         grad_input, shape (M, K)
     """
     # Quantize grad_output along dim0
-    grad_output_data, grad_output_scales = _extract_or_quantize_dim0_auto(
-        grad_output, block_size, scale_calculation_mode
-    )
+    if isinstance(grad_output, MXTensor):
+        grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
+        if not grad_output.is_swizzled_scales:
+            # Convert scales to blocked layout for SM100 kernels
+            grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
+                grad_output.scales, group_end_offsets
+            )
+    else:
+        grad_out_e4m3, grad_output_scales_blocked = mxfp8_quantize_2d_1x32_cutedsl(
+            grad_output,
+            scaling_mode=scale_calculation_mode.value.lower(),
+            offs=group_end_offsets,
+        )
+        # TODO: cutedsl shouldn't flatten scales
+        grad_output_scales_blocked = grad_output_scales_blocked.view(
+            grad_out_e4m3.shape[0], -1
+        )
 
-    # Quantize weights directly to blocked tcgen05 scales
+    # Quantize weights directly to blocked tcgen05 scales.
+    # (E,N,K) with 1x32 scaling, per-expert column major layout.
     weight = weight_t.transpose(-2, -1)
     weight_e4m3, weight_scales_blocked = mxfp8_quantize_cuda_3d(
         weight._data if hasattr(weight, "_data") else weight,
@@ -666,13 +668,9 @@ def __compute_dgrad_sm100(
         scaling_mode=scale_calculation_mode.value.lower(),
     )
 
-    grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
-        grad_output_scales, group_end_offsets
-    )
-
     # Compute grad_input = grad_output @ weight
     grad_input = torch._scaled_grouped_mm(
-        grad_output_data,
+        grad_out_e4m3,
         weight_e4m3,
         grad_output_scales_blocked,
         weight_scales_blocked,
@@ -705,7 +703,7 @@ def _compute_dgrad_emulated(
         grad_input, shape (M, K)
     """
     # Quantize grad_output along dim0
-    grad_output_data, grad_output_scales = _extract_or_quantize_dim0_emulated(
+    grad_output_data, grad_output_scales = _extract_or_quantize_1x32_emulated(
         grad_output, block_size, scale_calculation_mode
     )
 


### PR DESCRIPTION
## Summary
- Use cutedsl mxfp8 quantization kernel for 1x32 scaling of 2d tensors in `_compute_fwd` and `_compute_dgrad`

## Other changes
- Remove pad_token_groups_for_grouped_mm test case - to be deprecated since we are now validating token group sizes are a multiple of 128 (no padding needed)
- Update tests to use `multiple_of=128`, per above (quantization kernels validate group sizes)
- Remove extraneous extra "__" that should be single "_" in some method names
- Remove `_extract_or_quantize_dim0_auto` and just inline the logic, it was obfuscating things:

## Tests
- `pytest test/prototype/moe_training/ -v -s`

## Benchmarks
Planning to do after integrating the 32x1 kernel next