### PR TITLE
docs: fix broken quantize_ link in first_quantization_example

### DIFF
--- a/docs/source/eager_tutorials/first_quantization_example.rst
+++ b/docs/source/eager_tutorials/first_quantization_example.rst
@@ -1,7 +1,7 @@
 First Quantization Example
 ==========================
 
-The main entry point for quantization in torchao is the `quantize_ <https://pytorch.org/ao/stable/generated/torchao.quantization.quantize_.html#torchao.quantization.quantize_>`__ API.
+The main entry point for quantization in torchao is the `quantize_ <../api_reference/generated/torchao.quantization.quantize_.html#torchao.quantization.quantize_>`__ API.
 This function mutates your model inplace based on the quantization config you provide.
 All code in this guide can be found in this `example script <https://github.com/pytorch/ao/blob/main/scripts/quick_start.py>`__.
 


### PR DESCRIPTION
## Summary

Fixes the remaining broken `quantize_` hyperlink in the first sentence of `docs/source/eager_tutorials/first_quantization_example.rst`, as noted by @andrewor14 in [#4286](https://github.com/pytorch/ao/issues/4286#issuecomment-2817088819) after PR #4291 was merged.

**Problem:** The link pointed to `https://pytorch.org/ao/stable/generated/torchao.quantization.quantize_.html`, which is missing the `api_reference/` path segment (the `autosummary` directive in `api_ref_quantization.rst` outputs to `api_reference/generated/`).

**Fix:** Replace the absolute URL with a relative path `../api_reference/generated/torchao.quantization.quantize_.html#torchao.quantization.quantize_`, consistent with the relative-link style used in the other fixes from #4291.

Closes #4286