### PR TITLE
fix(fp8_fa3): remove broken import and fix setup_fp8_fa3 signature

### DIFF
--- a/test/prototype/attention/test_fp8_attention.py
+++ b/test/prototype/attention/test_fp8_attention.py
@@ -6,6 +6,7 @@
 
 """Tests for FP8 low-precision attention (FA3 backend on Hopper)."""
 
+import inspect
 import unittest
 
 import torch
@@ -443,6 +444,38 @@ class TestHadamardAccuracy(TestCase):
                 f"had={err_had.item():.6f} vs none={err_none.item():.6f} "
                 f"for shape={shape}, dtype={dtype}",
             )
+
+
+class TestFP8FA3SetupRegression(TestCase):
+    """Regression coverage for the broken import + signature in
+    ``torchao/prototype/attention/fp8_fa3/setup.py`` (issue #4318).
+
+    ``setup_fp8_fa3`` previously imported a non-existent
+    ``torchao.prototype.attention.config`` module, so importing it raised
+    ``ModuleNotFoundError`` before any FA3 hardware path was reached, and its
+    signature did not match ``setup_fp8_backend``. Both checks are
+    hardware-independent and run on CPU.
+    """
+
+    @unittest.skipUnless(
+        torch_version_at_least("2.11.0"),
+        "fp8_fa3 setup imports torch.nn.attention helpers added in torch 2.11",
+    )
+    def test_setup_fp8_fa3_imports_without_error(self):
+        from torchao.prototype.attention.fp8_fa3.setup import setup_fp8_fa3
+
+        self.assertTrue(callable(setup_fp8_fa3))
+
+    @unittest.skipUnless(
+        torch_version_at_least("2.11.0"),
+        "fp8_fa3 setup imports torch.nn.attention helpers added in torch 2.11",
+    )
+    def test_setup_fp8_fa3_signature_matches_backend(self):
+        from torchao.prototype.attention.fp8_fa3.setup import setup_fp8_fa3
+
+        params = inspect.signature(setup_fp8_fa3).parameters
+        self.assertEqual(list(params), ["model", "hadamard"])
+        self.assertEqual(params["hadamard"].default, "NONE")
 
 
 if __name__ == "__main__":

--- a/torchao/prototype/attention/fp8_fa3/setup.py
+++ b/torchao/prototype/attention/fp8_fa3/setup.py
@@ -8,20 +8,16 @@
 
 import torch.nn as nn
 
-from torchao.prototype.attention.config import LowPrecisionAttentionConfig
 from torchao.prototype.attention.shared_utils.setup import setup_fp8_backend
 
 
 def setup_fp8_fa3(
     model: nn.Module,
-    config: LowPrecisionAttentionConfig,
+    hadamard: str = "NONE",
 ) -> nn.Module:
     """Set up FP8 FA3 attention on *model* and wrap it."""
-    from torchao.prototype.attention.fp8_fa3.attention import fp8_fa3_sdpa
-
     return setup_fp8_backend(
         model,
-        config,
         flash_impl_name="FA3",
-        sdpa_fn=fp8_fa3_sdpa,
+        hadamard=hadamard,
     )


### PR DESCRIPTION
## Problem

Closes #4318.

`torchao/prototype/attention/fp8_fa3/setup.py` contains two bugs that make `setup_fp8_fa3` completely unusable:

**1. Import from a non-existent module:**
```python
from torchao.prototype.attention.config import LowPrecisionAttentionConfig
```
There is no `config.py` or `config/` package under `torchao/prototype/attention/`. Importing `setup_fp8_fa3` raises `ModuleNotFoundError` immediately.

**2. Incorrect call to `setup_fp8_backend`:**
```python
# OLD (broken)
return setup_fp8_backend(
    model,
    config,               # should be flash_impl_name: str
    flash_impl_name="FA3",
    sdpa_fn=fp8_fa3_sdpa, # no such parameter
)
```
The actual signature is `setup_fp8_backend(model, flash_impl_name, hadamard="NONE")`.

Note: the public `apply_low_precision_attention` in `api.py` is unaffected — it calls `setup_fp8_backend` correctly with `"FA3"` directly.

## Fix

- Remove the broken `LowPrecisionAttentionConfig` import
- Update `setup_fp8_fa3` to accept `hadamard: str = "NONE"` (matching `setup_fp8_backend`)
- Fix the call to `setup_fp8_backend` to use the correct signature

## Before / After

```python
# BEFORE (broken)
from torchao.prototype.attention.config import LowPrecisionAttentionConfig

def setup_fp8_fa3(model: nn.Module, config: LowPrecisionAttentionConfig) -> nn.Module:
    return setup_fp8_backend(model, config, flash_impl_name="FA3", sdpa_fn=fp8_fa3_sdpa)

# AFTER (fixed)
def setup_fp8_fa3(model: nn.Module, hadamard: str = "NONE") -> nn.Module:
    return setup_fp8_backend(model, flash_impl_name="FA3", hadamard=hadamard)
```