### PR TITLE
Fix Int4WeightFakeQuantizer and Float8FakeQuantizer missing enabled attribute

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -56,6 +56,7 @@ from torchao.quantization.qat.fake_quantize_config import (
 )
 from torchao.quantization.qat.fake_quantizer import (
     Float8FakeQuantizer,
+    Int4WeightFakeQuantizer,
     IntxFakeQuantizer,
 )
 from torchao.quantization.qat.linear import (
@@ -1780,6 +1781,41 @@ class TestQAT(TestCase):
         out_expected = Float8Tensor.from_hp(x, dtype, granularity).dequantize()
         sqnr = compute_error(out, out_expected)
         self.assertGreater(sqnr, 16)
+
+    def test_fake_quantizer_enabled_attribute(self):
+        """
+        Test that `Int4WeightFakeQuantizer` and `Float8FakeQuantizer` initialize
+        `enabled = True` and gate fake quantization in forward, matching the
+        behavior of `IntxFakeQuantizer`.
+        """
+        # Int4WeightFakeQuantizer: enabled gate exercised on CPU via the
+        # bf16 activation path, which only uses ATen ops.
+        int4_config = Int4WeightFakeQuantizeConfig(
+            group_size=32,
+            activation_dtype=torch.bfloat16,
+        )
+        int4_fake_quantizer = Int4WeightFakeQuantizer(int4_config)
+        self.assertTrue(int4_fake_quantizer.enabled)
+
+        torch.manual_seed(self.SEED)
+        w = torch.randn(64, 64, dtype=torch.bfloat16)
+
+        int4_fake_quantizer.enabled = False
+        torch.testing.assert_close(int4_fake_quantizer(w), w, atol=0, rtol=0)
+
+        int4_fake_quantizer.enabled = True
+        self.assertFalse(torch.equal(int4_fake_quantizer(w), w))
+
+        # Float8FakeQuantizer: only the disabled path is exercised here,
+        # since the enabled path requires fp8-capable hardware (covered by
+        # `test_float8_fake_quantize`).
+        float8_config = Float8FakeQuantizeConfig(torch.float8_e4m3fn, PerRow())
+        float8_fake_quantizer = Float8FakeQuantizer(float8_config)
+        self.assertTrue(float8_fake_quantizer.enabled)
+
+        x = torch.randn(32, 64)
+        float8_fake_quantizer.enabled = False
+        torch.testing.assert_close(float8_fake_quantizer(x), x, atol=0, rtol=0)
 
     def _test_quantize_api_against_ptq(
         self,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -78,9 +78,12 @@ class Float8FakeQuantizer(FakeQuantizerBase):
     def __init__(self, config: Float8FakeQuantizeConfig):
         super().__init__()
         self.config = config
+        self.enabled = True
         torch._C._log_api_usage_once("torchao.quantization.qat.Float8FakeQuantizer")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.enabled:
+            return x
         original_dtype = x.dtype
         block_size = get_block_size(x.shape, self.config.granularity)
         scale = _choose_scale_float8(
@@ -107,9 +110,12 @@ class Int4WeightFakeQuantizer(FakeQuantizerBase):
     def __init__(self, config: Int4WeightFakeQuantizeConfig):
         super().__init__()
         self.config = config
+        self.enabled = True
         torch._C._log_api_usage_once("torchao.quantization.qat.Int4WeightFakeQuantizer")
 
     def forward(self, w: torch.Tensor) -> torch.Tensor:
+        if not self.enabled:
+            return w
         if self.config.activation_dtype == torch.float8_e4m3fn:
             return self._fp8_activations_forward(w)
         elif self.config.activation_dtype == torch.bfloat16:


### PR DESCRIPTION
**Summary**

Fixes #3573.

`Int4WeightFakeQuantizer` and `Float8FakeQuantizer` did not initialize `self.enabled`, so toggling it via `enable_linear_fake_quant` (`torchao/quantization/qat/linear.py:169`) was silently ignored: the attribute was set on the module via `nn.Module.__setattr__` but the forward path never consulted it, and reading the attribute before any write raised `AttributeError` — exactly the breakage described by the reporter.

The fix mirrors the existing `IntxFakeQuantizer` pattern in the same file (`fake_quantizer.py:193,207`): initialize `self.enabled = True` in `__init__` and short-circuit `forward` to return the input tensor unchanged when disabled.

**Test plan**

Added `test_fake_quantizer_enabled_attribute` in `test/quantization/test_qat.py`:
- For `Int4WeightFakeQuantizer` (bf16 activation path, CPU-friendly): asserts `enabled` defaults to `True`, that disabling makes `forward` return the input tensor unchanged, and that re-enabling produces a fake-quantized output.
- For `Float8FakeQuantizer`: asserts `enabled` defaults to `True` and that disabling makes `forward` return the input unchanged. The enabled path requires fp8-capable hardware and is already covered by `test_float8_fake_quantize`.

Verified locally:
- `ruff check torchao/quantization/qat/fake_quantizer.py test/quantization/test_qat.py` → clean
- `ruff format --check ...` → clean