### PR TITLE
fix(benchmarks): raise-with-string, fd leak, unused arg, and typo (refs #4335)

### DIFF
--- a/benchmarks/benchmark_aq.py
+++ b/benchmarks/benchmark_aq.py
@@ -44,7 +44,7 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
+def _get_ref_change_linear_weights_to_woqtensors(deprecated_tensor_subclass):
     def _ref_change_linear_weights_to_woqtensors(model, filter_fn=None, **kwargs):
         """
         The deprecated implementation for weight only quant API, used as a reference for
@@ -57,7 +57,7 @@ def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
         _replace_with_custom_fn_if_matches_filter(
             model,
             _get_subclass_inserter(
-                deprecated_tenosr_subclass, enable_parametrization=True, **kwargs
+                deprecated_tensor_subclass, enable_parametrization=True, **kwargs
             ),
             filter_fn,
         )

--- a/benchmarks/benchmark_gpu_sparsity.py
+++ b/benchmarks/benchmark_gpu_sparsity.py
@@ -28,7 +28,7 @@ torch.set_printoptions(
 )
 
 
-def benchmark_model_with_warmup(func, x, N_WARMUP=3):
+def benchmark_model_with_warmup(func, N_WARMUP=3):
     benchmark_model(func, N_WARMUP, device_type="cuda")
     return benchmark_model(func, 10, device_type="cuda")
 
@@ -106,18 +106,14 @@ def run_gpu_sparse_benchmark(m, k, n, args):
         else:
             raise ValueError(f"Unknown eval_fn: {args.eval_fn}")
 
-        dense_time = benchmark_model_with_warmup(dense_func, "dense.json.gz")
-        sparse_time = benchmark_model_with_warmup(sparse_func, "sparse.json.gz")
+        dense_time = benchmark_model_with_warmup(dense_func)
+        sparse_time = benchmark_model_with_warmup(sparse_func)
 
         dense_func_c = torch.compile(dense_func, mode="max-autotune")
-        dense_time_c = benchmark_model_with_warmup(
-            dense_func_c, "dense_compile.json.gz"
-        )
+        dense_time_c = benchmark_model_with_warmup(dense_func_c)
 
         sparse_func_c = torch.compile(sparse_func, mode="max-autotune")
-        sparse_time_c = benchmark_model_with_warmup(
-            sparse_func_c, "sparse_compile.json.gz"
-        )
+        sparse_time_c = benchmark_model_with_warmup(sparse_func_c)
 
         torch._dynamo.reset()
 

--- a/benchmarks/benchmark_hqq.py
+++ b/benchmarks/benchmark_hqq.py
@@ -8,9 +8,9 @@ try:
     import triton
 
     if int(triton.__version__.split(".")[0]) < 3:
-        raise "triton >= 3.0.0 is required to run this test"
-except ImportError:
-    raise "triton and hqq required to run this benchmark"
+        raise RuntimeError("triton >= 3.0.0 is required to run this test")
+except ImportError as e:
+    raise RuntimeError("triton and hqq required to run this benchmark") from e
 
 from io import StringIO
 

--- a/benchmarks/intmm.py
+++ b/benchmarks/intmm.py
@@ -99,7 +99,8 @@ if __name__ == "__main__":
     assert file_path.is_file()
 
     # Format is (m, k, n)
-    shapes = list(csv.reader(open(file_path, "r")))[1:]
+    with open(file_path, "r") as f:
+        shapes = list(csv.reader(f))[1:]
     # Turn into list of int tuples
     shapes = list(map(lambda x: tuple(map(int, x)), shapes))
 


### PR DESCRIPTION
Fixes part of #4335 — broken imports and bugs in `benchmarks/` directory.

This PR addresses the bugs that can be fixed without touching benchmarks whose underlying APIs were removed (`benchmark_uintx.py`, `benchmark_rowwise_scaled_linear_sparse_cutlass.py`, `benchmark_sparse_conversion_cutlass.py`); those need a maintainer call on whether to delete the files or rewrite against the post-AQT API, so I left them out.

## Fixes

### 1. `benchmark_hqq.py` — `raise` with string argument (Python 3 invalid)

```py
# before
if int(triton.__version__.split(".")[0]) < 3:
    raise "triton >= 3.0.0 is required to run this test"
except ImportError:
    raise "triton and hqq required to run this benchmark"
```

In Python 3, `raise <str>` raises `TypeError: exceptions must derive from BaseException`, which masks the intended message. Replaced with `raise RuntimeError(...)` (and `from e` chained on the `ImportError` path).

### 2. `intmm.py:102` — leaked file descriptor

```py
shapes = list(csv.reader(open(file_path, "r")))[1:]
```

Wrapped in a `with` block.

### 3. `benchmark_gpu_sparsity.py:31` — unused `x` parameter, callers passing strings

```py
def benchmark_model_with_warmup(func, x, N_WARMUP=3):
    benchmark_model(func, N_WARMUP, device_type="cuda")
    return benchmark_model(func, 10, device_type="cuda")
```

`x` is never used inside the body. Callers were passing strings like `"dense.json.gz"` as the second positional argument — likely a remnant of an earlier signature that took a profile-output filename. The strings were never written anywhere. Dropped the parameter and updated all four call sites.

### 4. `benchmark_aq.py:47` — typo `deprecated_tenosr_subclass`

Renamed to `deprecated_tensor_subclass` (consistent within the function, so behavior unchanged — readability only).

## Not touched

- `benchmark_uintx.py`: `torchao.prototype.uintx` and `uintx_affine_weight_only` have been removed; no drop-in replacement exists per the issue. Needs a maintainer decision on whether to delete or rewrite.
- `benchmark_rowwise_scaled_linear_sparse_cutlass.py` / `benchmark_sparse_conversion_cutlass.py`: import `_float8_cutlass_quant`/`_float8_cutlass_quant_sparse` which were removed when AQT was deleted. The current API is in `torchao/quantization/quantize_/workflows/float8/sparse_2x4_cutlass_float8_tensor.py`, but porting the benchmarks to it is non-trivial — happy to do it in a follow-up if there's interest.
- The output-collision item (both sparse-cutlass benchmarks writing to the same CSV name) is moot until those files are rewritten.

## Verification

```sh
python -m py_compile benchmarks/benchmark_aq.py
python -m py_compile benchmarks/benchmark_hqq.py
python -m py_compile benchmarks/intmm.py
python -m py_compile benchmarks/benchmark_gpu_sparsity.py
```
All four pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
