### PR TITLE
fix(tests): honor parametrized dtype in test_autotuner; correct SQNR var in test_integration error msg

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -639,7 +639,7 @@ class TestSaveLoadMeta(unittest.TestCase):
         test = model_qc(x).detach()
 
         assert SQNR(ref_f, test) > min_sqnr, (
-            f"got sqnr: {SQNR(ref_f, ref_q)}, expected: {min_sqnr}"
+            f"got sqnr: {SQNR(ref_f, test)}, expected: {min_sqnr}"
         )
         self.assertTrue(torch.equal(ref_q, test))
 

--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -37,7 +37,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -59,7 +58,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm_float8(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -85,7 +83,6 @@ class TestQuantFlow(unittest.TestCase):
 
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         scales = x.sum(-1, keepdim=True)
@@ -93,7 +90,7 @@ class TestQuantFlow(unittest.TestCase):
         x_int = x.to(dtype=torch.int8)
         w_int = w.to(dtype=torch.int8)
         out32_1 = intmm.safe_int_mm(x_int, w_int) * scales
-        assert out32_1.dtype == torch.bfloat16
+        assert out32_1.dtype == dtype
         out32_2 = intmm.int_scaled_matmul(x_int, w_int, scales)
         assert out32_2.dtype == out32_1.dtype
         torch.testing.assert_allclose(out32_1, out32_2)


### PR DESCRIPTION
Fixes two unrelated test bugs reported in #4339.

## Bug 1: `dtype` parametrize silently ignored in `test/kernel/test_autotuner.py`

`TestQuantFlow.test_int_mm`, `test_int_mm_float8`, and `test_int_scaled_mm` are each `@parameterized.expand(...)`'d over both `torch.bfloat16` and `torch.float16`, but each method's body opens with `dtype = torch.bfloat16`, overwriting the parameter. The float16 variants run with bfloat16 inputs, giving false coverage.

Removing the three `dtype = torch.bfloat16` overrides also exposes a hardcoded assertion at the bottom of `test_int_scaled_mm`:

```python
out32_1 = intmm.safe_int_mm(x_int, w_int) * scales
assert out32_1.dtype == torch.bfloat16   # <-- always bfloat16 even when dtype=float16
```

`out32_1.dtype` follows `scales.dtype`, which follows the parametrized `dtype`. Fixed to assert against the parameter:

```python
assert out32_1.dtype == dtype
```

## Bug 2: Wrong variable in error message in `test/integration/test_integration.py`

In `test_save_load_qtensors` (around line 641):

```python
assert SQNR(ref_f, test) > min_sqnr, (
    f"got sqnr: {SQNR(ref_f, ref_q)}, expected: {min_sqnr}"   # <-- prints SQNR vs ref_q, not test
)
```

The assertion compares `ref_f` against `test`, but the failure message reports `SQNR(ref_f, ref_q)` — i.e. SQNR between the float reference and the *compiled* quantized reference computed earlier in the test, not between the float reference and the actual loaded model output. When the assertion fails, the printed value is meaningless for debugging.

Fixed to print `SQNR(ref_f, test)`. (The earlier `assert SQNR(ref_f, ref_q) > min_sqnr` block at ~line 619 is already self-consistent and is left untouched.)

## Test plan

- Both fixes are pure test-suite hygiene; they do not change library behavior.
- Removing the `dtype` overrides means the `float16` parametrize branches now actually execute as float16. If any of those branches were previously hiding a real failure, this PR will surface it — please re-run the relevant CI.
- `test_int_scaled_mm`'s output dtype follows `scales.dtype`, which is now correctly the parametrized `dtype`; the new assertion `out32_1.dtype == dtype` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
