### PR TITLE
[xpu][test] Enable MoE MX format kernels and tensor tests for Intel XPU

### DIFF
--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -7,17 +7,29 @@
 import pytest
 import torch
 
-from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100, is_XPU
 
-if not (
+_is_xpu = is_XPU()
+_is_compatible_cuda = (
     torch.cuda.is_available()
     and is_sm_at_least_100()
     and is_cuda_version_at_least(12, 8)
-):
-    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+)
+if not (_is_xpu or _is_compatible_cuda):
+    pytest.skip(
+        "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
+    )
 
 from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
 from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize(
@@ -41,10 +53,8 @@ from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
     ],
 )
 def test_triton_permute_bwd(
-    num_tokens, hidden_dim, num_local_experts, ep_degree, alignment
+    num_tokens, hidden_dim, num_local_experts, ep_degree, alignment, device
 ):
-    device = "cuda"
-
     # Generate realistic permutation indices using generate_permute_indices
     # Simulate token distribution across experts
     tokens_per_expert_group = torch.randint(

--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -1,23 +1,35 @@
 import pytest
 import torch
 
-from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100
+from torchao.utils import is_cuda_version_at_least, is_sm_at_least_100, is_XPU
 
-if not (
+_is_xpu = is_XPU()
+_is_compatible_cuda = (
     torch.cuda.is_available()
     and is_sm_at_least_100()
     and is_cuda_version_at_least(12, 8)
-):
-    pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
+)
+
+if not (_is_xpu or _is_compatible_cuda):
+    pytest.skip(
+        "Test requires XPU or CUDA 12.8+ with SM >= 100", allow_module_level=True
+    )
 
 from torchao.prototype.moe_training.ep import permute_mxfp8_fwd_hp_bwd
 from torchao.prototype.moe_training.ep.permute import permute_and_pad
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.quantization.utils import compute_error
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]
 
 
-def test_mxfp8_permute_forward():
-    device = "cuda"
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
+
+def test_mxfp8_permute_forward(device: str):
     tokens = 64
     dim = 128
     num_experts = 8

--- a/test/prototype/moe_training/test_kernels.py
+++ b/test/prototype/moe_training/test_kernels.py
@@ -8,16 +8,21 @@ import pytest
 import torch
 
 # FP8 MoE kernels require FP8-capable hardware (SM 10.x on CUDA, MI300+ on ROCm)
-from torchao.utils import is_MI300, is_MI350
+from torchao.utils import is_MI300, is_MI350, is_XPU
 
 
 def _is_sm_10x() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
 
 
-if not (torch.cuda.is_available() and (_is_sm_10x() or is_MI300() or is_MI350())):
+_is_xpu = is_XPU()
+_is_cuda_compatible = torch.cuda.is_available() and (
+    _is_sm_10x() or is_MI300() or is_MI350()
+)
+
+if not (_is_xpu or _is_cuda_compatible):
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM 10.x, MI300, MI350, or XPU)",
         allow_module_level=True,
     )
 
@@ -65,15 +70,24 @@ from torchao.prototype.moe_training.utils import (
 from torchao.prototype.mx_formats.kernels import triton_mx_block_rearrange
 from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
 from torchao.prototype.mx_formats.utils import from_blocked
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 @skip_if_rocm("jagged rowwise scales kernel vs torch reference mismatch on ROCm")
-def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
+def test_row_major_with_jagged_rowwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # Tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(k, m * n_groups, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -102,10 +116,10 @@ def test_row_major_with_jagged_rowwise_scales(round_scales_to_power_of_2: bool):
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
 def test_row_major_with_jagged_rowwise_scales_transpose_method(
     round_scales_to_power_of_2: bool,
+    device: str,
 ):
     # tests case where rowwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end column indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     grad_out = torch.randn(m * n_groups, k, device=device)
     colwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -137,10 +151,11 @@ def test_row_major_with_jagged_rowwise_scales_transpose_method(
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: bool):
+def test_column_major_with_jagged_colwise_scales(
+    round_scales_to_power_of_2: bool, device: str
+):
     # tests case where colwise scales are computed for multiple distinct subtensors,
     # with end boundary of each group is determine by their end row indexes (offsets).
-    device = "cuda"
     m, k, n_groups = 256, 256, 4
     x = torch.randn(m * n_groups, k, device=device).t().contiguous().t()
     rowwise_offs = torch.arange(m, m * n_groups + 1, m, device=device)
@@ -164,8 +179,9 @@ def test_column_major_with_jagged_colwise_scales(round_scales_to_power_of_2: boo
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_atomic(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -198,8 +214,9 @@ def test_fp8_rowwise_3d_transpose_rhs_atomic(round_scales_to_power_of_2: bool):
 
 
 @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])
-def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool):
-    device = "cuda"
+def test_fp8_rowwise_3d_transpose_rhs_reduction(
+    round_scales_to_power_of_2: bool, device: str
+):
     experts, n, k = 8, 4 * 5120, 5120
 
     # Example expert weights as it comes into forward transposed
@@ -236,11 +253,8 @@ def test_fp8_rowwise_3d_transpose_rhs_reduction(round_scales_to_power_of_2: bool
     "m,k,n_groups", [(256, 256, 4), (16640, 5120, 16), (16640, 8192, 16)]
 )
 def test_triton_mx_block_rearrange_2d_M_groups(
-    m: int,
-    k: int,
-    n_groups: int,
+    m: int, k: int, n_groups: int, device: str
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, k, device=device)
     e8m0_scales, _ = to_mx(
@@ -266,10 +280,11 @@ def test_triton_mx_block_rearrange_2d_M_groups(
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize(
     "m,k,n_groups,chunks_per_tb",
     [
@@ -291,8 +306,8 @@ def test_cuda_mx_block_rearrange_2d_M_groups(
     k: int,
     n_groups: int,
     chunks_per_tb: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, k, device=device)
     e8m0_scales, _ = to_mx(
@@ -326,8 +341,8 @@ def test_mxfp8_per_group_blocked_scales_3d(
     e: int,
     n: int,
     k: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     weights = torch.randn(e, n, k // block_size, device=device)
     weight_scales, _ = to_mx(
@@ -352,8 +367,8 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     m: int,
     total_k: int,
     n_groups: int,
+    device: str,
 ):
-    device = "cuda"
     block_size = 32
     input_data = torch.randn(m, total_k, device=device)
 
@@ -382,9 +397,10 @@ def test_triton_mx_block_rearrange_2d_K_groups(
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("E", (1, 2, 4, 8))
 @pytest.mark.parametrize("N", (32, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("K", (32, 1536, 5120, 7168, 8192))
@@ -397,8 +413,10 @@ def test_triton_mx_block_rearrange_2d_K_groups(
     (1, 32),
     ids=("32x1", "32x32"),
 )
-def test_cuda_mx_3d_cutedsl_numerics(E, N, K, input_dtype, scaling_mode, scale_block_k):
-    if not _mxfp8_cutedsl_kernels_available:
+def test_cuda_mx_3d_cutedsl_numerics(
+    E, N, K, input_dtype, scaling_mode, scale_block_k, device
+):
+    if not (_is_xpu or _mxfp8_cutedsl_kernels_available):
         pytest.skip("mxfp8_quantize_3d is unavailable")
 
     scaling_mode_str = (
@@ -408,7 +426,7 @@ def test_cuda_mx_3d_cutedsl_numerics(E, N, K, input_dtype, scaling_mode, scale_b
 
     # Use disinct incrementing values from 0 to E*M*K-1 to make debugging easier.
     x = (
-        torch.arange(0, E * N * K, dtype=input_dtype, device="cuda")
+        torch.arange(0, E * N * K, dtype=input_dtype, device=device)
         .reshape(E, N, K)
         .contiguous()
     )
@@ -423,10 +441,8 @@ def test_cuda_mx_3d_cutedsl_numerics(E, N, K, input_dtype, scaling_mode, scale_b
         y_ref = y_ref.transpose(-2, -1)
         s_ref = s_ref.transpose(-2, -1)
         s_rows, s_cols = K, N // block_size
-        undo_scale = (
-            lambda scale: from_blocked(scale, s_rows, s_cols)
-            .transpose(-2, -1)
-            .contiguous()
+        undo_scale = lambda scale: (
+            from_blocked(scale, s_rows, s_cols).transpose(-2, -1).contiguous()
         )
     else:
         x_tiles = (
@@ -507,26 +523,27 @@ def test_cuda_mx_3d_cutedsl_numerics(E, N, K, input_dtype, scaling_mode, scale_b
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @pytest.mark.skipif(
-    not _mxfp8_cutedsl_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("M", (128, 8192))
 @pytest.mark.parametrize("K", (1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("input_dtype", (torch.bfloat16,))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
-def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
+def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode, device):
     scaling_mode_str = scaling_mode.value.lower()
     block_size = 32
 
     # Use distinct incrementing values from 0 to M*K-1 to make debugging easier.
     x = (
-        torch.arange(0, M * K, dtype=input_dtype, device="cuda")
+        torch.arange(0, M * K, dtype=input_dtype, device=device)
         .reshape(M, K)
         .contiguous()
     )
@@ -559,13 +576,14 @@ def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @pytest.mark.skipif(
-    not _mxfp8_cutedsl_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("M", (128, 1024))
 @pytest.mark.parametrize("K", (128, 256, 1536, 5120, 7168, 8192))
 @pytest.mark.parametrize("input_dtype", (torch.bfloat16,))
@@ -574,7 +592,7 @@ def test_cuda_mx_dim0_2d_numerics(M, K, input_dtype, scaling_mode):
 )
 @pytest.mark.parametrize("blocked_scale_output", [False, True])
 def test_cuda_mx_dim1_2d_numerics_32x1(
-    M, K, input_dtype, scaling_mode, blocked_scale_output
+    M, K, input_dtype, scaling_mode, blocked_scale_output, device
 ):
     """Test 32x1 scaling kernel that quantizes along M dimension."""
     scaling_mode_str = scaling_mode.value.lower()
@@ -588,7 +606,7 @@ def test_cuda_mx_dim1_2d_numerics_32x1(
 
     # Use distinct incrementing values from 0 to M*K-1 to make debugging easier.
     x = (
-        torch.arange(0, M * K, dtype=input_dtype, device="cuda")
+        torch.arange(0, M * K, dtype=input_dtype, device=device)
         .reshape(M, K)
         .contiguous()
     )
@@ -631,20 +649,25 @@ def test_cuda_mx_dim1_2d_numerics_32x1(
 
 
 @pytest.mark.skipif(
-    not _mxfp8_cuda_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cuda_kernels_available,
     reason="CUDA kernel requires sm_100 and CUDA 12.8+",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("num_tokens", [128, 157, 4096, 16392])
 @pytest.mark.parametrize("dim", [7168])
 @pytest.mark.parametrize("num_groups", [1, 2, 4, 8])
 @pytest.mark.parametrize("alignment_size", [32])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_cuda_fused_pad_token_groups(
-    num_tokens: int, dim: int, num_groups: int, alignment_size: int, dtype: torch.dtype
+    num_tokens: int,
+    dim: int,
+    num_groups: int,
+    alignment_size: int,
+    dtype: torch.dtype,
+    device: str,
 ):
     """Test fused_pad_token_groups_cuda kernel for padding token groups to alignment."""
-    device = "cuda"
 
     # Create input activations
     inputs = torch.randn(num_tokens, dim, dtype=dtype, device=device)
@@ -678,20 +701,25 @@ def test_cuda_fused_pad_token_groups(
 
 
 @pytest.mark.skipif(
-    not _mxfp8_cuda_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cuda_kernels_available,
     reason="CUDA kernel requires sm_100 and CUDA 12.8+",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("num_tokens", [128, 157, 4096])
 @pytest.mark.parametrize("dim", [7168])
 @pytest.mark.parametrize("num_groups", [1, 2, 4, 8])
 @pytest.mark.parametrize("alignment_size", [32])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_cuda_fused_unpad_token_groups(
-    num_tokens: int, dim: int, num_groups: int, alignment_size: int, dtype: torch.dtype
+    num_tokens: int,
+    dim: int,
+    num_groups: int,
+    alignment_size: int,
+    dtype: torch.dtype,
+    device: str,
 ):
     """Test fused_unpad_token_groups_cuda kernel for removing padding from token groups."""
-    device = "cuda"
 
     # Create input activations
     inputs = torch.randn(num_tokens, dim, dtype=dtype, device=device)
@@ -741,9 +769,8 @@ def test_cuda_fused_unpad_token_groups(
     [(128, 5120), (1024, 8192), (4096, 5120)],
 )
 def test_triton_fp8_rowwise_2d_scale_and_cast(
-    m: int, k: int, round_scales_to_power_of_2: bool
+    m: int, k: int, round_scales_to_power_of_2: bool, device: str
 ):
-    device = "cuda"
     float8_dtype = torch.float8_e4m3fn
 
     torch.manual_seed(0)
@@ -778,9 +805,8 @@ def test_triton_fp8_rowwise_2d_scale_and_cast(
     [(1, 8192, 5120), (2, 5120, 8192), (8, 8192, 5120)],
 )
 def test_triton_fp8_colwise_3d_scale_and_cast(
-    e: int, n: int, k: int, round_scales_to_power_of_2: bool
+    e: int, n: int, k: int, round_scales_to_power_of_2: bool, device: str
 ):
-    device = "cuda"
     float8_dtype = torch.float8_e4m3fn
 
     torch.manual_seed(0)
@@ -812,14 +838,15 @@ def test_triton_fp8_colwise_3d_scale_and_cast(
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @pytest.mark.skipif(
-    not _mxfp8_cutedsl_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 def test_cutedsl_1x32_group_validation_error():
     """Test that 1x32 CuTeDSL kernel raises error for non-128-multiple group sizes."""
     import subprocess
@@ -846,14 +873,15 @@ torch.cuda.synchronize()
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @pytest.mark.skipif(
-    not _mxfp8_cutedsl_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
 @skip_if_rocm("ROCm enablement in progress")
+@skip_if_xpu("XPU support not yet available")
 def test_cutedsl_32x1_group_validation_error():
     """Test that 32x1 CuTeDSL kernel raises error for non-128-multiple group sizes."""
     import subprocess
@@ -880,17 +908,17 @@ torch.cuda.synchronize()
 
 
 @pytest.mark.skipif(
-    not _is_sm_10x(),
+    torch.cuda.is_available() and not _is_sm_10x(),
     reason="MXFP8 requires CUDA SM 10.x",
 )
 @pytest.mark.skipif(
-    not _mxfp8_cutedsl_kernels_available,
+    torch.cuda.is_available() and not _mxfp8_cutedsl_kernels_available,
     reason="MXFP8 cutedsl kernels not available",
 )
 @skip_if_rocm("ROCm enablement in progress")
-def test_cutedsl_kernels_work_with_valid_128_multiple_groups():
+@skip_if_xpu("XPU support not yet available")
+def test_cutedsl_kernels_work_with_valid_128_multiple_groups(device: str):
     """Test that both CuTeDSL kernels work correctly with valid 128-multiple group sizes."""
-    device = "cuda"
     M, K = 512, 1024
     x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
 

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -8,11 +8,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from torchao.utils import torch_version_at_least
+from torchao.utils import is_XPU, torch_version_at_least
 
 # Skip module if basic requirements aren't met
-if not (torch_version_at_least("2.7.0") and torch.cuda.is_available()):
-    pytest.skip("CUDA and PyTorch 2.7.0+ required", allow_module_level=True)
+
+if not ((is_XPU() or torch.cuda.is_available()) and torch_version_at_least("2.7.0")):
+    pytest.skip("CUDA or XPU with PyTorch 2.7.0+ required", allow_module_level=True)
 
 from torchao.prototype.moe_training.config import (
     Float8TrainingOpConfig,
@@ -34,9 +35,18 @@ from torchao.prototype.mx_formats.kernels import (
     _triton_kernels_available,
 )
 from torchao.quantization.utils import compute_error
-from torchao.utils import is_sm_at_least_100
+from torchao.testing.utils import skip_if_xpu
+from torchao.utils import get_available_devices, is_sm_at_least_100
+
+_DEVICES = get_available_devices()[1:]
 
 
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
+
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("op_name", ["mm", "matmul", "linear"])
 @pytest.mark.parametrize("batch_size", [None, 2, 4])
 @pytest.mark.parametrize(
@@ -48,9 +58,9 @@ from torchao.utils import is_sm_at_least_100
     [MXFP8Dim1CastKernelChoice.CUDA, MXFP8Dim1CastKernelChoice.CUTEDSL],
 )
 def test_mxfp8_training_tensor_ops_fwd_bwd(
-    op_name, batch_size, recipe, cast_kernel_choice
+    op_name, batch_size, recipe, cast_kernel_choice, device
 ):
-    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
+    if device == "cuda" and recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
         if not is_sm_at_least_100() or not _triton_kernels_available:
             pytest.skip("SM 100+ required for real MXFP8 support")
         if (
@@ -79,10 +89,10 @@ def test_mxfp8_training_tensor_ops_fwd_bwd(
     else:
         A_shape = (batch_size, M, K)
 
-    A = torch.randn(*A_shape, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-    B = torch.randn(N, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    A = torch.randn(*A_shape, dtype=torch.bfloat16, device=device, requires_grad=True)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     bias = (
-        torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        torch.randn(N, dtype=torch.bfloat16, device=device)
         if op_name == "linear"
         else None
     )
@@ -152,10 +162,10 @@ def test_mxfp8_training_tensor_ops_fwd_bwd(
     )
 
 
-def test_mxfp8_training_tensor_ops_preserve_subclass():
+def test_mxfp8_training_tensor_ops_preserve_subclass(device):
     config = MXFP8TrainingOpConfig.from_recipe(MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL)
 
-    B = torch.randn(64, 32, dtype=torch.bfloat16, device="cuda")
+    B = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
     B_mxfp8 = MXFP8TrainingWeightWrapperTensor(B, config)
 
     # view
@@ -194,21 +204,24 @@ def test_mxfp8_training_tensor_ops_preserve_subclass():
 @pytest.mark.parametrize(
     "float8_linear_recipe", ["tensorwise", "rowwise", "rowwise_with_gw_hp"]
 )
-def test_float8_training_tensor_ops_fwd_bwd(op_name, batch_size, float8_linear_recipe):
+def test_float8_training_tensor_ops_fwd_bwd(
+    op_name, batch_size, float8_linear_recipe, device
+):
     # mm doesn't support batching
     if op_name == "mm" and batch_size is not None:
         pytest.skip("mm doesn't support batching")
 
-    # All FP8 linear recipes require SM89+ (torch._scaled_mm)
-    if torch.cuda.get_device_capability() < (8, 9):
-        pytest.skip("FP8 linear requires SM89+")
+    if device == "cuda":
+        # All FP8 linear recipes require SM89+ (torch._scaled_mm)
+        if torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("FP8 linear requires SM89+")
 
-    # rowwise and rowwise_with_gw_hp require SM90+ (CUTLASS axiswise kernels)
-    if float8_linear_recipe in (
-        "rowwise",
-        "rowwise_with_gw_hp",
-    ) and torch.cuda.get_device_capability() < (9, 0):
-        pytest.skip("Rowwise FP8 requires SM90+")
+        # rowwise and rowwise_with_gw_hp require SM90+ (CUTLASS axiswise kernels)
+        if float8_linear_recipe in (
+            "rowwise",
+            "rowwise_with_gw_hp",
+        ) and torch.cuda.get_device_capability() < (9, 0):
+            pytest.skip("Rowwise FP8 requires SM90+")
 
     config = Float8TrainingOpConfig(float8_linear_recipe=float8_linear_recipe)
 
@@ -218,10 +231,10 @@ def test_float8_training_tensor_ops_fwd_bwd(op_name, batch_size, float8_linear_r
     else:
         A_shape = (batch_size, M, K)
 
-    A = torch.randn(*A_shape, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-    B = torch.randn(N, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    A = torch.randn(*A_shape, dtype=torch.bfloat16, device=device, requires_grad=True)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     bias = (
-        torch.randn(N, dtype=torch.bfloat16, device="cuda")
+        torch.randn(N, dtype=torch.bfloat16, device=device)
         if op_name == "linear"
         else None
     )

--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -530,6 +530,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         BLOCK_SIZE_K: tl.constexpr,
         BLOCK_SIZE_N: tl.constexpr,
         EPS: tl.constexpr,
+        is_xpu: tl.constexpr,
     ):
         """
         Fused two-pass kernel for 3D column-major axiswise FP8 scale+cast.
@@ -566,7 +567,10 @@ if torch_version_at_least("2.7.0") and has_triton():
             col_amax = tl.maximum(col_amax, block_amax)
 
         clamped_amax = tl.clamp(col_amax, min=EPS, max=float("inf"))
-        scales = (fp8_dtype_max / clamped_amax.to(tl.float64)).to(tl.float32)
+        if is_xpu:
+            scales = tl.math.div_rn(fp8_dtype_max, clamped_amax)
+        else:
+            scales = (fp8_dtype_max / clamped_amax.to(tl.float64)).to(tl.float32)
 
         if round_scales_to_power_of_2:
             scales = tl.exp2(tl.floor(tl.log2(scales)))
@@ -671,6 +675,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             tl_output_dtype,
             round_scales_to_power_of_2=round_scales_to_power_of_2,
             EPS=EPS,
+            is_xpu=hp_tensor.device.type == "xpu",
         )
 
         return output_buffer, scales_buffer.unsqueeze(1)
@@ -748,6 +753,7 @@ if torch_version_at_least("2.7.0") and has_triton():
         round_scales_to_power_of_2: tl.constexpr,
         BLOCK_SIZE_K: tl.constexpr,
         EPS: tl.constexpr,
+        is_xpu: tl.constexpr,
     ):
         """
         Fused kernel that computes per-row absmax scale and casts a 2D tensor
@@ -802,8 +808,10 @@ if torch_version_at_least("2.7.0") and has_triton():
         # This maps the row's dynamic range into the FP8 representable range.
         # Use float64 for the division to maintain precision, then convert back.
         row_amax = tl.maximum(row_amax, EPS)
-        scale = fp8_dtype_max / row_amax.to(tl.float64)
-        scale = scale.to(tl.float32)
+        if is_xpu:
+            scale = tl.math.div_rn(fp8_dtype_max, row_amax)
+        else:
+            scale = (fp8_dtype_max / row_amax.to(tl.float64)).to(tl.float32)
 
         # Optionally round to power of 2 for hardware-friendly scaling.
         # Power-of-2 scales can be applied as exponent additions rather than
@@ -891,6 +899,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             tl_output_dtype,
             round_scales_to_power_of_2=round_scales_to_power_of_2,
             EPS=EPS,
+            is_xpu=hp_tensor.device.type == "xpu",
         )
 
         return output_buffer, scales_buffer.unsqueeze(-1)

--- a/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
+++ b/torchao/prototype/moe_training/kernels/jagged_float8_scales.py
@@ -129,7 +129,7 @@ if torch_version_at_least("2.7.0") and has_triton():
             tl_output_dtype,
             round_scales_to_power_of_2,
             EPS=EPS,
-            STRIDE_OUTPUT_ROW=1,
+            STRIDE_OUTPUT_ROW=output_buffer.stride(0),
             STRIDE_INPUT_COL=hp_tensor.stride(1),
         )
         return output_buffer, scales_buffer

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -25,8 +25,11 @@ from torchao.utils import (
     is_mslk_version_at_least,
     is_ROCM,
     is_sm_at_least_100,
+    is_XPU,
     torch_version_at_least,
 )
+
+_is_xpu = is_XPU()
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +172,9 @@ if torch_version_at_least("2.7.0") and has_triton():
     import triton
     import triton.language as tl
     from torch.library import triton_op, wrap_triton
+    from triton.language.extra import libdevice
+
+    IS_XPU = tl.constexpr(_is_xpu)
 
     def triton_to_mxfp8_dim1_reference(
         x_hp: torch.Tensor,
@@ -314,7 +320,10 @@ if torch_version_at_least("2.7.0") and has_triton():
         e8m0_nan_val = 255
         e8m0_exponent_bias = 127
         s_offset = scale_e8m0.to(tl.int16) - e8m0_exponent_bias
-        s_fp = tl.exp2(s_offset.to(tl.float32))
+        if IS_XPU:
+            s_fp = libdevice.exp2(s_offset.to(tl.float32))
+        else:
+            s_fp = tl.exp2(s_offset.to(tl.float32))
         s_fp = tl.where(scale_e8m0 != e8m0_nan_val, s_fp, float("nan"))
         return s_fp.to(tl.float32)
 
@@ -456,19 +465,20 @@ else:
         raise AssertionError("needs torch version 2.8+ and triton")
 
 
+_is_nvidia_sm100 = (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
+)
+_is_rocm_mi350 = is_ROCM() and is_MI350()
+
 _triton_kernels_available = (
     torch_version_at_least("2.7.0")
     and has_triton()
-    and torch.cuda.is_available()
-    and (is_sm_at_least_100() and is_cuda_version_at_least(12, 8))
-    or (is_ROCM() and is_MI350())
+    and (_is_nvidia_sm100 or _is_rocm_mi350 or _is_xpu)
 )
 
 if _triton_kernels_available:
-    import triton
-    import triton.language as tl
-    from torch.library import triton_op, wrap_triton
-
     IS_ROCM = tl.constexpr(is_ROCM())
 
     @triton.jit
@@ -691,7 +701,7 @@ if _triton_kernels_available:
             col_rcp_scale_fp32, col_scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_t_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=not (IS_ROCM or IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")
@@ -802,7 +812,7 @@ if _triton_kernels_available:
             descale_fp32_r, scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=not (IS_ROCM or IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")
@@ -1017,7 +1027,7 @@ _mxfp8_cuda_kernels_available = (
     and is_cuda_version_at_least(12, 8)
 )
 
-if _mxfp8_cuda_kernels_available:
+if _mxfp8_cuda_kernels_available or _is_xpu:
     lib = torch.library.Library("torchao", "FRAGMENT")
     lib.define(
         "mxfp8_quantize(Tensor input, bool rowwise, bool colwise, int scale_dim_x, int scale_dim_y, str fp8_format, str scaling_mode) -> (Tensor, Tensor, Tensor, Tensor)",

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1161,6 +1161,10 @@ def is_sm_at_least_100():
     )
 
 
+def is_XPU():
+    return torch.xpu.is_available() if hasattr(torch, "xpu") else False
+
+
 def is_cuda_version_at_least(major: int, minor: int) -> bool:
     if not torch.cuda.is_available():
         return False


### PR DESCRIPTION
The PR enables a subset of MoE tests for Intel XPU and is part of the [XPU Enabling Plan for TorchAO](https://github.com/pytorch/ao/issues/3576).

Details:
- Enables MoE MX format kernels and tensor tests.
- Adds a device parameter to be able to run the tests on the XPU.
- Skips not yet supported scenarios.
- Source code modifications fix failing tests.