### PR TITLE
Add blockwise FP8 in roofline_utils and seperate benchmark script

### DIFF
--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -51,6 +51,10 @@ import torch.nn as nn
 import tqdm
 from torch.profiler import ProfilerActivity, profile
 from utils import (
+    DSV3_16B_671B_DIM,
+    DSV3_16B_671B_INTER_DIM,
+    DSV3_16B_671B_SEQ_LEN,
+    DSV3_16B_671B_SHAPE_GEN_NAME,
     get_gpu_kernel_gemm_time_s,
     get_name_to_shapes_iter,
     profiler_output_to_filtered_time_by_kernel_name,
@@ -67,33 +71,15 @@ from torchao.prototype.moe_training.config import (
 )
 from torchao.quantization import quantize_
 from torchao.testing.training.roofline_utils import (
-    BYTES_PER_EL_BF16,
-    BYTES_PER_EL_FLOAT8,
-    BYTES_PER_EL_FLOAT32,
-    KERNEL_LAUNCH_OVERHEAD_SEC,
+    get_blockwise_float8_mem_sympy,
+    get_blockwise_gemm_time_sympy,
     get_float8_mem_sympy,
     get_gemm_time_sympy,
-    get_specs,
-    gpu_name_to_specs,
+    get_roofline_gpu_name,
 )
-from torchao.utils import is_MI300, is_sm_at_least_90, round_up
+from torchao.utils import is_MI300, round_up
 
 BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
-BLOCKWISE_FP8_BLOCK_SIZE = 128
-DSV3_SEQ_LEN = 4096
-DSV3_DIM = 7168
-DSV3_INTER_DIM = 18432
-
-
-def get_roofline_gpu_name(gpu_name: Optional[str] = None):
-    if gpu_name is None:
-        gpu_name = torch.cuda.get_device_name(0)
-    if gpu_name in gpu_name_to_specs:
-        return gpu_name
-    for known_gpu_name in gpu_name_to_specs:
-        if gpu_name.startswith(known_gpu_name):
-            return known_gpu_name
-    return gpu_name
 
 
 class LNLinearSigmoid(torch.nn.Module):
@@ -243,194 +229,6 @@ def get_gemm_times(
     return bf16_time_s, f8_time_s
 
 
-def get_dsv3_16b_671b_shapes_iter(
-    seq_len: int = DSV3_SEQ_LEN,
-    dim: int = DSV3_DIM,
-    inter_dim: int = DSV3_INTER_DIM,
-):
-    """
-    DeepSeek-V3 dense FFN linear shapes for one microbatch with sequence length
-    `seq_len`, so the GEMM M dimension is `seq_len`.
-    """
-    name_to_shapes = {
-        "dsv3.ffn.w1": (seq_len, dim, inter_dim),
-        "dsv3.ffn.w2": (seq_len, inter_dim, dim),
-        "dsv3.ffn.w3": (seq_len, dim, inter_dim),
-    }
-    return name_to_shapes.items()
-
-
-def get_roofline_name_to_shapes_iter(
-    shape_gen_name: str,
-    dsv3_seq_len: int,
-    dsv3_dim: int,
-    dsv3_inter_dim: int,
-):
-    if shape_gen_name in ("dsv3-16b-671b", "dsv3-16b/671b", "dsv3_16b_671b"):
-        return get_dsv3_16b_671b_shapes_iter(
-            seq_len=dsv3_seq_len,
-            dim=dsv3_dim,
-            inter_dim=dsv3_inter_dim,
-        )
-    return get_name_to_shapes_iter(shape_gen_name, None, None, None)
-
-
-def get_blockwise_mem_time_sympy(bytes_rw, gpu_name: Optional[str] = None):
-    """
-    Estimate memory-bound runtime using roofline_utils GPU specs.
-
-    The memory model is:
-        bytes read/written / peak memory bandwidth / achievable bandwidth pct
-
-    Each modeled kernel is also lower-bounded by KERNEL_LAUNCH_OVERHEAD_SEC.
-    """
-    specs = get_specs(gpu_name)
-    mem_time_s = (
-        bytes_rw / specs["peak_mem_bw_bytes_sec"] / specs["pct_achievable_mem_bw"]
-    )
-    return sympy.Max(mem_time_s, KERNEL_LAUNCH_OVERHEAD_SEC)
-
-
-def get_blockwise_individual_gemm_time_sympy(
-    M,
-    K,
-    N,
-    scale_a_numel,
-    scale_b_numel,
-    gpu_name: Optional[str] = None,
-):
-    """
-    Estimate one blockwise FP8 GEMM runtime using roofline_utils GPU specs.
-
-    The compute model is:
-        2 * M * K * N / fp8_peak_tops / achievable_gemm_tops_pct
-
-    The memory model counts FP8 matrix reads, BF16 output writes, and FP32
-    scale reads. The GEMM estimate is max(compute time, memory time).
-    """
-    specs = get_specs(gpu_name)
-    gemm_ops = 2 * M * K * N
-    compute_gemm_time_s = (
-        gemm_ops / specs["fp8_peak_tops"] / specs["pct_achievable_gemm_tops"]
-    )
-    bytes_rw = (
-        (M * K + K * N) * BYTES_PER_EL_FLOAT8
-        + (M * N) * BYTES_PER_EL_BF16
-        + (scale_a_numel + scale_b_numel) * BYTES_PER_EL_FLOAT32
-    )
-    mem_gemm_time_s = get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
-    return sympy.Max(compute_gemm_time_s, mem_gemm_time_s)
-
-
-def get_blockwise_gemm_time_sympy(
-    M,
-    K,
-    N,
-    gpu_name: Optional[str] = None,
-    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
-):
-    block_size = sympy.Integer(block_size)
-
-    # input @ weight.T = output, with 1x128 activation and 128x128 weight scales
-    gemm_output_time_s = get_blockwise_individual_gemm_time_sympy(
-        M,
-        K,
-        N,
-        M * K / block_size,
-        K * N / (block_size * block_size),
-        gpu_name,
-    )
-    # grad_output @ weight = grad_input
-    gemm_grad_input_time_s = get_blockwise_individual_gemm_time_sympy(
-        M,
-        N,
-        K,
-        M * N / block_size,
-        N * K / (block_size * block_size),
-        gpu_name,
-    )
-    # grad_output.T @ input = grad_weight, with 1x128 and 128x1 scales
-    gemm_grad_weight_time_s = get_blockwise_individual_gemm_time_sympy(
-        N,
-        M,
-        K,
-        N * M / block_size,
-        M * K / block_size,
-        gpu_name,
-    )
-    return gemm_output_time_s + gemm_grad_input_time_s + gemm_grad_weight_time_s
-
-
-def get_blockwise_quant_ovhd_s(
-    numel,
-    scale_numel,
-    gpu_name: Optional[str] = None,
-    fuse_read: bool = False,
-):
-    read_bytes = 0 if fuse_read else BYTES_PER_EL_BF16 * numel
-    bytes_rw = (
-        read_bytes + BYTES_PER_EL_FLOAT8 * numel + BYTES_PER_EL_FLOAT32 * scale_numel
-    )
-    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
-
-
-def get_blockwise_float8_mem_sympy(
-    M,
-    K,
-    N,
-    enable_fusion_modeling: bool,
-    gpu_name: Optional[str] = None,
-    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
-):
-    block_size = sympy.Integer(block_size)
-
-    quant_input_lhs = get_blockwise_quant_ovhd_s(
-        M * K,
-        M * K / block_size,
-        gpu_name,
-        fuse_read=enable_fusion_modeling,
-    )
-    # Current Float8BlockwiseLinear quantizes the weight in two separate
-    # layouts: transposed RHS for forward and regular RHS for grad_input.
-    quant_weight_transposed_rhs = get_blockwise_quant_ovhd_s(
-        N * K,
-        N * K / (block_size * block_size),
-        gpu_name,
-    )
-    quant_weight_rhs = get_blockwise_quant_ovhd_s(
-        N * K,
-        N * K / (block_size * block_size),
-        gpu_name,
-    )
-    quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
-        M * N,
-        M * N / block_size,
-        gpu_name,
-        fuse_read=enable_fusion_modeling,
-    )
-    quant_grad_output_transposed_lhs = get_blockwise_quant_ovhd_s(
-        M * N,
-        M * N / block_size,
-        gpu_name,
-    )
-    quant_input_rhs = get_blockwise_quant_ovhd_s(
-        M * K,
-        M * K / block_size,
-        gpu_name,
-    )
-
-    return sum(
-        [
-            quant_input_lhs,
-            quant_weight_transposed_rhs,
-            quant_weight_rhs,
-            quant_grad_output_lhs,
-            quant_grad_output_transposed_lhs,
-            quant_input_rhs,
-        ]
-    )
-
-
 def run(
     outfile: str,
     do_benchmarks: bool = True,
@@ -440,25 +238,22 @@ def run(
     float8_recipe_name: Optional[str] = None,
     mx_recipe_name: Optional[str] = None,
     enable_fusion_modeling: bool = False,
-    blockwise_use_triton: bool = False,
-    blockwise_compile_benchmarks: bool = False,
-    dsv3_seq_len: int = DSV3_SEQ_LEN,
-    dsv3_dim: int = DSV3_DIM,
-    dsv3_inter_dim: int = DSV3_INTER_DIM,
+    dsv3_seq_len: int = DSV3_16B_671B_SEQ_LEN,
+    dsv3_dim: int = DSV3_16B_671B_DIM,
+    dsv3_inter_dim: int = DSV3_16B_671B_INTER_DIM,
 ):
     """
     Args:
     * `do_benchmarks`: if True, gemm and e2e fwd+bwd of LNLinearSigmoid are benchmarked
-    * `shape_gen_name`: `llama`, `pow2`, `pow2_extended`, or `sweep`
+    * `shape_gen_name`: `llama`, `pow2`, `pow2_extended`, `sweep`, or
+      `dsv3-16b-671b`
     * `gemm_cache_filename (optional)`: file to cache gemm benchmark results
     * `n_limit (optional)`: if specified, only runs `n_limit` iterations
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
-    * `mx_recipe_name=blockwise_fp8_training`: benchmark the prototype
-      Float8BlockwiseLinear layer against a bf16 Linear and use blockwise FP8
-      roofline estimates
-    * `blockwise_use_triton`: if False, use the scaled_mm backend for blockwise
-      FP8 GEMMs; if True, use the custom Triton GEMM backend
+    * `mx_recipe_name=blockwise_fp8_training`: use prototype
+      Float8BlockwiseLinear roofline estimates. Benchmarks are not supported
+      for this recipe in this shared script.
     * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
       `dsv3_seq_len`
     """
@@ -477,8 +272,6 @@ def run(
     print(f"float8_recipe_name: {float8_recipe_name}")
     print(f"mx_recipe_name: {mx_recipe_name}")
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
-    print(f"blockwise_use_triton: {blockwise_use_triton}")
-    print(f"blockwise_compile_benchmarks: {blockwise_compile_benchmarks}")
     print(f"dsv3_seq_len: {dsv3_seq_len}")
     print(f"dsv3_dim: {dsv3_dim}")
     print(f"dsv3_inter_dim: {dsv3_inter_dim}")
@@ -498,10 +291,11 @@ def run(
         BLOCKWISE_FP8_TRAINING_RECIPE_NAME,
     ), f"unsupported {mx_recipe_name=}"
     is_blockwise_fp8_training = mx_recipe_name == BLOCKWISE_FP8_TRAINING_RECIPE_NAME
-    fp8_backend = "n/a"
-    if is_blockwise_fp8_training:
-        fp8_backend = (
-            "blockwise_triton_gemm" if blockwise_use_triton else "blockwise_scaled_mm"
+    if do_benchmarks:
+        assert not is_blockwise_fp8_training, (
+            "do_benchmarks unsupported with "
+            f"mx_recipe_name={BLOCKWISE_FP8_TRAINING_RECIPE_NAME}; run roofline "
+            "estimates with do_benchmarks=False"
         )
 
     M, K, N = sympy.symbols("M K N")
@@ -553,8 +347,6 @@ def run(
 
     headers = [
         "name",
-        "fp8_backend",
-        "compiled",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -586,12 +378,15 @@ def run(
     ]
     results = []
 
-    name_to_shapes = get_roofline_name_to_shapes_iter(
-        shape_gen_name,
-        dsv3_seq_len,
-        dsv3_dim,
-        dsv3_inter_dim,
-    )
+    if shape_gen_name == DSV3_16B_671B_SHAPE_GEN_NAME:
+        name_to_shapes = get_name_to_shapes_iter(
+            shape_gen_name,
+            dsv3_seq_len,
+            dsv3_dim,
+            dsv3_inter_dim,
+        )
+    else:
+        name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
 
     for idx, (name, (M_val, K_val, N_val)) in enumerate(tqdm.tqdm(name_to_shapes)):
         if n_limit is not None and idx >= n_limit:
@@ -611,7 +406,7 @@ def run(
         rb_bf16_gemm_ratio = -1
         rb_fp8_gemm_ratio = -1
 
-        if do_benchmarks and not is_blockwise_fp8_training:
+        if do_benchmarks:
             assert mx_recipe_name not in (
                 "mxfp4_cutlass",
                 "mxfp8_32x32_flexible_gemm_layout",
@@ -688,40 +483,13 @@ def run(
 
             # get the bf16 gpu kernel time
             torch._dynamo.reset()
-            m_bf16 = copy.deepcopy(m_orig)
-            if (not is_blockwise_fp8_training) or blockwise_compile_benchmarks:
-                m_bf16 = torch.compile(m_bf16)
+            m_bf16 = torch.compile(copy.deepcopy(m_orig))
             b_bf16_e2e_time_s = get_gpu_kernel_time(m_bf16, x, grad_output)
 
             # get the float8 dynamic scaling gpu kernel time
 
             torch._dynamo.reset()
-            if is_blockwise_fp8_training:
-                assert is_sm_at_least_90(), (
-                    "Float8BlockwiseLinear benchmarks require CUDA SM90+"
-                )
-                assert K_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
-                    f"K={K_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
-                )
-                assert N_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
-                    f"N={N_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
-                )
-                from torchao.prototype.blockwise_fp8_training.linear import (
-                    Float8BlockwiseLinear,
-                    Float8BlockwiseLinearConfig,
-                )
-
-                m_fp8_dyn = copy.deepcopy(m_orig)
-                quantize_(m_fp8_dyn, config=Float8BlockwiseLinearConfig())
-                found_blockwise_linear = False
-                for module in m_fp8_dyn.modules():
-                    if isinstance(module, Float8BlockwiseLinear):
-                        module.use_triton = blockwise_use_triton
-                        found_blockwise_linear = True
-                assert found_blockwise_linear, "expected a Float8BlockwiseLinear"
-                if blockwise_compile_benchmarks:
-                    m_fp8_dyn = torch.compile(m_fp8_dyn)
-            elif float8_recipe_name is not None:
+            if float8_recipe_name is not None:
                 config = Float8LinearConfig.from_recipe_name(float8_recipe_name)
                 m_fp8_dyn = convert_to_float8_training(
                     copy.deepcopy(m_orig), config=config
@@ -739,8 +507,7 @@ def run(
                     )
                 m_fp8_dyn = copy.deepcopy(m_orig)
                 quantize_(m_fp8_dyn, config=config)
-            if not is_blockwise_fp8_training:
-                m_fp8_dyn = torch.compile(m_fp8_dyn)
+            m_fp8_dyn = torch.compile(m_fp8_dyn)
             b_fp8_e2e_time_s = get_gpu_kernel_time(m_fp8_dyn, x, grad_output)
 
         # Calculate e2e speedup if benchmarks were run, otherwise -1
@@ -756,8 +523,6 @@ def run(
         results.append(
             [
                 name,
-                fp8_backend,
-                blockwise_compile_benchmarks if is_blockwise_fp8_training else True,
                 M_val,
                 K_val,
                 N_val,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -585,8 +585,6 @@ def run(
         "b_fp8_e2e_spdp",
         # measured speedup as a percentage of roofline speedup
         "b_fp8_e2e_spdp_pct_of_r",
-        # roofline FP8 gemm + overhead time as a percentage of measured FP8 time
-        "b_fp8_e2e_time_eff_pct_of_r",
         # how well benchmarked gemms match roofline predicted gemms
         "rb_bf16_gemm_ratio",
         "rb_fp8_gemm_ratio",
@@ -758,13 +756,9 @@ def run(
             b_fp8_e2e_speedup_pct_of_r = (
                 b_fp8_e2e_speedup / r_fp8_gemm_and_ovhd_speedup * 100
             )
-            b_fp8_e2e_time_eff_pct_of_r = (
-                r_fp8_gemm_and_ovhd_time_s / b_fp8_e2e_time_s * 100
-            )
         else:
             b_fp8_e2e_speedup = -1
             b_fp8_e2e_speedup_pct_of_r = -1
-            b_fp8_e2e_time_eff_pct_of_r = -1
 
         results.append(
             [
@@ -790,7 +784,6 @@ def run(
                 b_fp8_e2e_time_s,
                 b_fp8_e2e_speedup,
                 b_fp8_e2e_speedup_pct_of_r,
-                b_fp8_e2e_time_eff_pct_of_r,
                 # gemm ratios
                 rb_bf16_gemm_ratio,
                 rb_fp8_gemm_ratio,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -80,8 +80,6 @@ from torchao.utils import is_MI300, is_sm_at_least_90, round_up
 
 BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
 BLOCKWISE_FP8_BLOCK_SIZE = 128
-BLOCKWISE_WEIGHT_QUANT_SEPARATE = "separate"
-BLOCKWISE_WEIGHT_QUANT_DUAL = "dual"
 DSV3_SEQ_LEN = 4096
 DSV3_DIM = 7168
 DSV3_INTER_DIM = 18432
@@ -376,25 +374,6 @@ def get_blockwise_quant_ovhd_s(
     return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
 
 
-def get_blockwise_dual_weight_quant_ovhd_s(
-    numel,
-    scale_numel,
-    gpu_name: Optional[str] = None,
-):
-    """
-    Estimate the optimized dual-layout weight quantization kernel.
-
-    The optimized kernel reads the BF16 weight once, writes both FP8 RHS
-    layouts, and writes both FP32 scale layouts.
-    """
-    bytes_rw = (
-        BYTES_PER_EL_BF16 * numel
-        + 2 * BYTES_PER_EL_FLOAT8 * numel
-        + 2 * BYTES_PER_EL_FLOAT32 * scale_numel
-    )
-    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
-
-
 def get_blockwise_float8_mem_sympy(
     M,
     K,
@@ -402,13 +381,8 @@ def get_blockwise_float8_mem_sympy(
     enable_fusion_modeling: bool,
     gpu_name: Optional[str] = None,
     block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
-    blockwise_weight_quant_mode: str = BLOCKWISE_WEIGHT_QUANT_SEPARATE,
 ):
     block_size = sympy.Integer(block_size)
-    assert blockwise_weight_quant_mode in (
-        BLOCKWISE_WEIGHT_QUANT_SEPARATE,
-        BLOCKWISE_WEIGHT_QUANT_DUAL,
-    ), f"unsupported {blockwise_weight_quant_mode=}"
 
     quant_input_lhs = get_blockwise_quant_ovhd_s(
         M * K,
@@ -416,28 +390,18 @@ def get_blockwise_float8_mem_sympy(
         gpu_name,
         fuse_read=enable_fusion_modeling,
     )
-    if blockwise_weight_quant_mode == BLOCKWISE_WEIGHT_QUANT_SEPARATE:
-        # Current Float8BlockwiseLinear on main quantizes the weight in two
-        # separate layouts: transposed RHS for forward and regular RHS for
-        # grad_input.
-        quant_weight = get_blockwise_quant_ovhd_s(
-            N * K,
-            N * K / (block_size * block_size),
-            gpu_name,
-        ) + get_blockwise_quant_ovhd_s(
-            N * K,
-            N * K / (block_size * block_size),
-            gpu_name,
-        )
-    else:
-        # Optimized Float8BlockwiseLinear emits both RHS layouts from one
-        # blockwise scale reduction and saves the regular RHS layout for
-        # backward.
-        quant_weight = get_blockwise_dual_weight_quant_ovhd_s(
-            N * K,
-            N * K / (block_size * block_size),
-            gpu_name,
-        )
+    # Current Float8BlockwiseLinear quantizes the weight in two separate
+    # layouts: transposed RHS for forward and regular RHS for grad_input.
+    quant_weight_transposed_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_weight_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
     quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
         M * N,
         M * N / block_size,
@@ -458,7 +422,8 @@ def get_blockwise_float8_mem_sympy(
     return sum(
         [
             quant_input_lhs,
-            quant_weight,
+            quant_weight_transposed_rhs,
+            quant_weight_rhs,
             quant_grad_output_lhs,
             quant_grad_output_transposed_lhs,
             quant_input_rhs,
@@ -477,7 +442,6 @@ def run(
     enable_fusion_modeling: bool = False,
     blockwise_use_triton: bool = False,
     blockwise_compile_benchmarks: bool = False,
-    blockwise_weight_quant_mode: str = BLOCKWISE_WEIGHT_QUANT_SEPARATE,
     dsv3_seq_len: int = DSV3_SEQ_LEN,
     dsv3_dim: int = DSV3_DIM,
     dsv3_inter_dim: int = DSV3_INTER_DIM,
@@ -495,9 +459,6 @@ def run(
       roofline estimates
     * `blockwise_use_triton`: if False, use the scaled_mm backend for blockwise
       FP8 GEMMs; if True, use the custom Triton GEMM backend
-    * `blockwise_weight_quant_mode`: `separate` models the current main branch
-      implementation; `dual` models the optimized kernel which emits both
-      weight RHS layouts from one quantization kernel
     * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
       `dsv3_seq_len`
     """
@@ -518,7 +479,6 @@ def run(
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
     print(f"blockwise_use_triton: {blockwise_use_triton}")
     print(f"blockwise_compile_benchmarks: {blockwise_compile_benchmarks}")
-    print(f"blockwise_weight_quant_mode: {blockwise_weight_quant_mode}")
     print(f"dsv3_seq_len: {dsv3_seq_len}")
     print(f"dsv3_dim: {dsv3_dim}")
     print(f"dsv3_inter_dim: {dsv3_inter_dim}")
@@ -556,7 +516,6 @@ def run(
             N,
             enable_fusion_modeling,
             roofline_gpu_name,
-            blockwise_weight_quant_mode=blockwise_weight_quant_mode,
         )
         fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(
             M,
@@ -596,7 +555,6 @@ def run(
         "name",
         "fp8_backend",
         "compiled",
-        "blockwise_weight_quant_mode",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -800,7 +758,6 @@ def run(
                 name,
                 fp8_backend,
                 blockwise_compile_benchmarks if is_blockwise_fp8_training else True,
-                (blockwise_weight_quant_mode if is_blockwise_fp8_training else "n/a"),
                 M_val,
                 K_val,
                 N_val,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -67,10 +67,34 @@ from torchao.prototype.moe_training.config import (
 )
 from torchao.quantization import quantize_
 from torchao.testing.training.roofline_utils import (
+    BYTES_PER_EL_BF16,
+    BYTES_PER_EL_FLOAT8,
+    BYTES_PER_EL_FLOAT32,
+    KERNEL_LAUNCH_OVERHEAD_SEC,
     get_float8_mem_sympy,
     get_gemm_time_sympy,
+    get_specs,
+    gpu_name_to_specs,
 )
-from torchao.utils import is_MI300, round_up
+from torchao.utils import is_MI300, is_sm_at_least_90, round_up
+
+
+BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
+BLOCKWISE_FP8_BLOCK_SIZE = 128
+DSV3_SEQ_LEN = 4096
+DSV3_DIM = 7168
+DSV3_INTER_DIM = 18432
+
+
+def get_roofline_gpu_name(gpu_name: Optional[str] = None):
+    if gpu_name is None:
+        gpu_name = torch.cuda.get_device_name(0)
+    if gpu_name in gpu_name_to_specs:
+        return gpu_name
+    for known_gpu_name in gpu_name_to_specs:
+        if gpu_name.startswith(known_gpu_name):
+            return known_gpu_name
+    return gpu_name
 
 
 class LNLinearSigmoid(torch.nn.Module):
@@ -220,6 +244,198 @@ def get_gemm_times(
     return bf16_time_s, f8_time_s
 
 
+def get_dsv3_16b_671b_shapes_iter(
+    seq_len: int = DSV3_SEQ_LEN,
+    dim: int = DSV3_DIM,
+    inter_dim: int = DSV3_INTER_DIM,
+):
+    """
+    DeepSeek-V3 dense FFN linear shapes for one microbatch with sequence length
+    `seq_len`, so the GEMM M dimension is `seq_len`.
+    """
+    name_to_shapes = {
+        "dsv3.ffn.w1": (seq_len, dim, inter_dim),
+        "dsv3.ffn.w2": (seq_len, inter_dim, dim),
+        "dsv3.ffn.w3": (seq_len, dim, inter_dim),
+    }
+    return name_to_shapes.items()
+
+
+def get_roofline_name_to_shapes_iter(
+    shape_gen_name: str,
+    dsv3_seq_len: int,
+    dsv3_dim: int,
+    dsv3_inter_dim: int,
+):
+    if shape_gen_name in ("dsv3-16b-671b", "dsv3-16b/671b", "dsv3_16b_671b"):
+        return get_dsv3_16b_671b_shapes_iter(
+            seq_len=dsv3_seq_len,
+            dim=dsv3_dim,
+            inter_dim=dsv3_inter_dim,
+        )
+    return get_name_to_shapes_iter(shape_gen_name, None, None, None)
+
+
+def get_blockwise_mem_time_sympy(bytes_rw, gpu_name: Optional[str] = None):
+    """
+    Estimate memory-bound runtime using roofline_utils GPU specs.
+
+    The memory model is:
+        bytes read/written / peak memory bandwidth / achievable bandwidth pct
+
+    Each modeled kernel is also lower-bounded by KERNEL_LAUNCH_OVERHEAD_SEC.
+    """
+    specs = get_specs(gpu_name)
+    mem_time_s = (
+        bytes_rw
+        / specs["peak_mem_bw_bytes_sec"]
+        / specs["pct_achievable_mem_bw"]
+    )
+    return sympy.Max(mem_time_s, KERNEL_LAUNCH_OVERHEAD_SEC)
+
+
+def get_blockwise_individual_gemm_time_sympy(
+    M,
+    K,
+    N,
+    scale_a_numel,
+    scale_b_numel,
+    gpu_name: Optional[str] = None,
+):
+    """
+    Estimate one blockwise FP8 GEMM runtime using roofline_utils GPU specs.
+
+    The compute model is:
+        2 * M * K * N / fp8_peak_tops / achievable_gemm_tops_pct
+
+    The memory model counts FP8 matrix reads, BF16 output writes, and FP32
+    scale reads. The GEMM estimate is max(compute time, memory time).
+    """
+    specs = get_specs(gpu_name)
+    gemm_ops = 2 * M * K * N
+    compute_gemm_time_s = (
+        gemm_ops / specs["fp8_peak_tops"] / specs["pct_achievable_gemm_tops"]
+    )
+    bytes_rw = (
+        (M * K + K * N) * BYTES_PER_EL_FLOAT8
+        + (M * N) * BYTES_PER_EL_BF16
+        + (scale_a_numel + scale_b_numel) * BYTES_PER_EL_FLOAT32
+    )
+    mem_gemm_time_s = get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+    return sympy.Max(compute_gemm_time_s, mem_gemm_time_s)
+
+
+def get_blockwise_gemm_time_sympy(
+    M,
+    K,
+    N,
+    gpu_name: Optional[str] = None,
+    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+):
+    block_size = sympy.Integer(block_size)
+
+    # input @ weight.T = output, with 1x128 activation and 128x128 weight scales
+    gemm_output_time_s = get_blockwise_individual_gemm_time_sympy(
+        M,
+        K,
+        N,
+        M * K / block_size,
+        K * N / (block_size * block_size),
+        gpu_name,
+    )
+    # grad_output @ weight = grad_input
+    gemm_grad_input_time_s = get_blockwise_individual_gemm_time_sympy(
+        M,
+        N,
+        K,
+        M * N / block_size,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    # grad_output.T @ input = grad_weight, with 1x128 and 128x1 scales
+    gemm_grad_weight_time_s = get_blockwise_individual_gemm_time_sympy(
+        N,
+        M,
+        K,
+        N * M / block_size,
+        M * K / block_size,
+        gpu_name,
+    )
+    return gemm_output_time_s + gemm_grad_input_time_s + gemm_grad_weight_time_s
+
+
+def get_blockwise_quant_ovhd_s(
+    numel,
+    scale_numel,
+    gpu_name: Optional[str] = None,
+    fuse_read: bool = False,
+):
+    read_bytes = 0 if fuse_read else BYTES_PER_EL_BF16 * numel
+    bytes_rw = (
+        read_bytes
+        + BYTES_PER_EL_FLOAT8 * numel
+        + BYTES_PER_EL_FLOAT32 * scale_numel
+    )
+    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+
+
+def get_blockwise_float8_mem_sympy(
+    M,
+    K,
+    N,
+    enable_fusion_modeling: bool,
+    gpu_name: Optional[str] = None,
+    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+):
+    block_size = sympy.Integer(block_size)
+
+    quant_input_lhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    # Current Float8BlockwiseLinear quantizes the weight in two separate
+    # layouts: transposed RHS for forward and regular RHS for grad_input.
+    quant_weight_transposed_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_weight_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    quant_grad_output_transposed_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+    )
+    quant_input_rhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+    )
+
+    return sum(
+        [
+            quant_input_lhs,
+            quant_weight_transposed_rhs,
+            quant_weight_rhs,
+            quant_grad_output_lhs,
+            quant_grad_output_transposed_lhs,
+            quant_input_rhs,
+        ]
+    )
+
+
 def run(
     outfile: str,
     do_benchmarks: bool = True,
@@ -229,6 +445,11 @@ def run(
     float8_recipe_name: Optional[str] = None,
     mx_recipe_name: Optional[str] = None,
     enable_fusion_modeling: bool = False,
+    blockwise_use_triton: bool = False,
+    blockwise_compile_benchmarks: bool = False,
+    dsv3_seq_len: int = DSV3_SEQ_LEN,
+    dsv3_dim: int = DSV3_DIM,
+    dsv3_inter_dim: int = DSV3_INTER_DIM,
 ):
     """
     Args:
@@ -238,6 +459,13 @@ def run(
     * `n_limit (optional)`: if specified, only runs `n_limit` iterations
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
+    * `mx_recipe_name=blockwise_fp8_training`: benchmark the prototype
+      Float8BlockwiseLinear layer against a bf16 Linear and use blockwise FP8
+      roofline estimates
+    * `blockwise_use_triton`: if False, use the scaled_mm backend for blockwise
+      FP8 GEMMs; if True, use the custom Triton GEMM backend
+    * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
+      `dsv3_seq_len`
     """
 
     assert not ((float8_recipe_name is not None) and (mx_recipe_name is not None)), (
@@ -254,6 +482,13 @@ def run(
     print(f"float8_recipe_name: {float8_recipe_name}")
     print(f"mx_recipe_name: {mx_recipe_name}")
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
+    print(f"blockwise_use_triton: {blockwise_use_triton}")
+    print(f"blockwise_compile_benchmarks: {blockwise_compile_benchmarks}")
+    print(f"dsv3_seq_len: {dsv3_seq_len}")
+    print(f"dsv3_dim: {dsv3_dim}")
+    print(f"dsv3_inter_dim: {dsv3_inter_dim}")
+    roofline_gpu_name = get_roofline_gpu_name()
+    print(f"roofline_gpu_name: {roofline_gpu_name}")
 
     assert mx_recipe_name in (
         None,
@@ -264,34 +499,67 @@ def run(
         "mxfp8_32x32_weight",
         # real mxfp4_cutlass recipe
         "mxfp4_cutlass",
+        # prototype DeepSeek-style blockwise FP8 training linear
+        BLOCKWISE_FP8_TRAINING_RECIPE_NAME,
     ), f"unsupported {mx_recipe_name=}"
+    is_blockwise_fp8_training = mx_recipe_name == BLOCKWISE_FP8_TRAINING_RECIPE_NAME
+    fp8_backend = "n/a"
+    if is_blockwise_fp8_training:
+        fp8_backend = (
+            "blockwise_triton_gemm" if blockwise_use_triton else "blockwise_scaled_mm"
+        )
 
     M, K, N = sympy.symbols("M K N")
 
-    fp8_ovhd_time_sympy = get_float8_mem_sympy(
-        M,
-        K,
-        N,
-        float8_recipe_name,
-        mx_recipe_name,
-        enable_fusion_modeling,
-    )
     bf16_gemm_time_sympy = get_gemm_time_sympy(
-        M, K, N, torch.bfloat16, None, None, None
+        M, K, N, torch.bfloat16, None, None, roofline_gpu_name
     )
-    lowp_input_dtype = torch.float8_e4m3fn
-    if mx_recipe_name == "mxfp4_cutlass":
-        lowp_input_dtype = torch.float4_e2m1fn_x2
+    if is_blockwise_fp8_training:
+        fp8_ovhd_time_sympy = get_blockwise_float8_mem_sympy(
+            M,
+            K,
+            N,
+            enable_fusion_modeling,
+            roofline_gpu_name,
+        )
+        fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(
+            M,
+            K,
+            N,
+            roofline_gpu_name,
+        )
+    else:
+        fp8_ovhd_time_sympy = get_float8_mem_sympy(
+            M,
+            K,
+            N,
+            float8_recipe_name,
+            mx_recipe_name,
+            enable_fusion_modeling,
+            roofline_gpu_name,
+        )
+        lowp_input_dtype = torch.float8_e4m3fn
+        if mx_recipe_name == "mxfp4_cutlass":
+            lowp_input_dtype = torch.float4_e2m1fn_x2
 
-    fp8_gemm_time_sympy = get_gemm_time_sympy(
-        M, K, N, lowp_input_dtype, float8_recipe_name, mx_recipe_name, None
-    )
+        fp8_gemm_time_sympy = get_gemm_time_sympy(
+            M,
+            K,
+            N,
+            lowp_input_dtype,
+            float8_recipe_name,
+            mx_recipe_name,
+            roofline_gpu_name,
+        )
     print("bf16_gemm_time_sympy", bf16_gemm_time_sympy)
     print("fp8_gemm_time_sympy", fp8_gemm_time_sympy)
     print("fp8_ovhd_time_sympy", fp8_ovhd_time_sympy)
     print()
 
     headers = [
+        "name",
+        "fp8_backend",
+        "compiled",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -315,13 +583,22 @@ def run(
         # the difference is the fwd+bwd ln and sigmoid terms, for now to keep things simple
         # we don't break them out and don't have a roofline for them.
         "b_fp8_e2e_spdp",
+        # measured speedup as a percentage of roofline speedup
+        "b_fp8_e2e_spdp_pct_of_r",
+        # roofline FP8 gemm + overhead time as a percentage of measured FP8 time
+        "b_fp8_e2e_time_eff_pct_of_r",
         # how well benchmarked gemms match roofline predicted gemms
         "rb_bf16_gemm_ratio",
         "rb_fp8_gemm_ratio",
     ]
     results = []
 
-    name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
+    name_to_shapes = get_roofline_name_to_shapes_iter(
+        shape_gen_name,
+        dsv3_seq_len,
+        dsv3_dim,
+        dsv3_inter_dim,
+    )
 
     for idx, (name, (M_val, K_val, N_val)) in enumerate(tqdm.tqdm(name_to_shapes)):
         if n_limit is not None and idx >= n_limit:
@@ -341,7 +618,7 @@ def run(
         rb_bf16_gemm_ratio = -1
         rb_fp8_gemm_ratio = -1
 
-        if do_benchmarks:
+        if do_benchmarks and not is_blockwise_fp8_training:
             assert mx_recipe_name not in (
                 "mxfp4_cutlass",
                 "mxfp8_32x32_flexible_gemm_layout",
@@ -397,6 +674,10 @@ def run(
         r_fp8_ovhd_time_s = float(
             fp8_ovhd_time_sympy.subs(M, M_val).subs(K, K_val).subs(N, N_val)
         )
+        r_fp8_gemm_and_ovhd_time_s = r_fp8_gemm_time_s + r_fp8_ovhd_time_s
+        r_fp8_gemm_and_ovhd_speedup = (
+            r_bf16_gemm_time_s / r_fp8_gemm_and_ovhd_time_s
+        )
 
         b_bf16_e2e_time_s, b_fp8_e2e_time_s = 0, 0
         if do_benchmarks:
@@ -416,13 +697,40 @@ def run(
 
             # get the bf16 gpu kernel time
             torch._dynamo.reset()
-            m_bf16 = torch.compile(copy.deepcopy(m_orig))
+            m_bf16 = copy.deepcopy(m_orig)
+            if (not is_blockwise_fp8_training) or blockwise_compile_benchmarks:
+                m_bf16 = torch.compile(m_bf16)
             b_bf16_e2e_time_s = get_gpu_kernel_time(m_bf16, x, grad_output)
 
             # get the float8 dynamic scaling gpu kernel time
 
             torch._dynamo.reset()
-            if float8_recipe_name is not None:
+            if is_blockwise_fp8_training:
+                assert is_sm_at_least_90(), (
+                    "Float8BlockwiseLinear benchmarks require CUDA SM90+"
+                )
+                assert K_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
+                    f"K={K_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
+                )
+                assert N_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
+                    f"N={N_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
+                )
+                from torchao.prototype.blockwise_fp8_training.linear import (
+                    Float8BlockwiseLinear,
+                    Float8BlockwiseLinearConfig,
+                )
+
+                m_fp8_dyn = copy.deepcopy(m_orig)
+                quantize_(m_fp8_dyn, config=Float8BlockwiseLinearConfig())
+                found_blockwise_linear = False
+                for module in m_fp8_dyn.modules():
+                    if isinstance(module, Float8BlockwiseLinear):
+                        module.use_triton = blockwise_use_triton
+                        found_blockwise_linear = True
+                assert found_blockwise_linear, "expected a Float8BlockwiseLinear"
+                if blockwise_compile_benchmarks:
+                    m_fp8_dyn = torch.compile(m_fp8_dyn)
+            elif float8_recipe_name is not None:
                 config = Float8LinearConfig.from_recipe_name(float8_recipe_name)
                 m_fp8_dyn = convert_to_float8_training(
                     copy.deepcopy(m_orig), config=config
@@ -440,17 +748,29 @@ def run(
                     )
                 m_fp8_dyn = copy.deepcopy(m_orig)
                 quantize_(m_fp8_dyn, config=config)
-            m_fp8_dyn = torch.compile(m_fp8_dyn)
+            if not is_blockwise_fp8_training:
+                m_fp8_dyn = torch.compile(m_fp8_dyn)
             b_fp8_e2e_time_s = get_gpu_kernel_time(m_fp8_dyn, x, grad_output)
 
         # Calculate e2e speedup if benchmarks were run, otherwise -1
         if b_bf16_e2e_time_s > 0 and b_fp8_e2e_time_s > 0:
             b_fp8_e2e_speedup = b_bf16_e2e_time_s / b_fp8_e2e_time_s
+            b_fp8_e2e_speedup_pct_of_r = (
+                b_fp8_e2e_speedup / r_fp8_gemm_and_ovhd_speedup * 100
+            )
+            b_fp8_e2e_time_eff_pct_of_r = (
+                r_fp8_gemm_and_ovhd_time_s / b_fp8_e2e_time_s * 100
+            )
         else:
             b_fp8_e2e_speedup = -1
+            b_fp8_e2e_speedup_pct_of_r = -1
+            b_fp8_e2e_time_eff_pct_of_r = -1
 
         results.append(
             [
+                name,
+                fp8_backend,
+                blockwise_compile_benchmarks if is_blockwise_fp8_training else True,
                 M_val,
                 K_val,
                 N_val,
@@ -460,8 +780,8 @@ def run(
                 # roofline - fp8 overhead
                 r_fp8_ovhd_time_s,
                 # roofline - gemm + overhead, and speedup
-                r_fp8_gemm_time_s + r_fp8_ovhd_time_s,
-                r_bf16_gemm_time_s / (r_fp8_gemm_time_s + r_fp8_ovhd_time_s),
+                r_fp8_gemm_and_ovhd_time_s,
+                r_fp8_gemm_and_ovhd_speedup,
                 # benchmarks - gemm
                 b_bf16_gemm_time_s,
                 b_fp8_gemm_time_s,
@@ -469,6 +789,8 @@ def run(
                 b_bf16_e2e_time_s,
                 b_fp8_e2e_time_s,
                 b_fp8_e2e_speedup,
+                b_fp8_e2e_speedup_pct_of_r,
+                b_fp8_e2e_time_eff_pct_of_r,
                 # gemm ratios
                 rb_bf16_gemm_ratio,
                 rb_fp8_gemm_ratio,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -78,9 +78,10 @@ from torchao.testing.training.roofline_utils import (
 )
 from torchao.utils import is_MI300, is_sm_at_least_90, round_up
 
-
 BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
 BLOCKWISE_FP8_BLOCK_SIZE = 128
+BLOCKWISE_WEIGHT_QUANT_SEPARATE = "separate"
+BLOCKWISE_WEIGHT_QUANT_DUAL = "dual"
 DSV3_SEQ_LEN = 4096
 DSV3_DIM = 7168
 DSV3_INTER_DIM = 18432
@@ -287,9 +288,7 @@ def get_blockwise_mem_time_sympy(bytes_rw, gpu_name: Optional[str] = None):
     """
     specs = get_specs(gpu_name)
     mem_time_s = (
-        bytes_rw
-        / specs["peak_mem_bw_bytes_sec"]
-        / specs["pct_achievable_mem_bw"]
+        bytes_rw / specs["peak_mem_bw_bytes_sec"] / specs["pct_achievable_mem_bw"]
     )
     return sympy.Max(mem_time_s, KERNEL_LAUNCH_OVERHEAD_SEC)
 
@@ -372,9 +371,26 @@ def get_blockwise_quant_ovhd_s(
 ):
     read_bytes = 0 if fuse_read else BYTES_PER_EL_BF16 * numel
     bytes_rw = (
-        read_bytes
-        + BYTES_PER_EL_FLOAT8 * numel
-        + BYTES_PER_EL_FLOAT32 * scale_numel
+        read_bytes + BYTES_PER_EL_FLOAT8 * numel + BYTES_PER_EL_FLOAT32 * scale_numel
+    )
+    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+
+
+def get_blockwise_dual_weight_quant_ovhd_s(
+    numel,
+    scale_numel,
+    gpu_name: Optional[str] = None,
+):
+    """
+    Estimate the optimized dual-layout weight quantization kernel.
+
+    The optimized kernel reads the BF16 weight once, writes both FP8 RHS
+    layouts, and writes both FP32 scale layouts.
+    """
+    bytes_rw = (
+        BYTES_PER_EL_BF16 * numel
+        + 2 * BYTES_PER_EL_FLOAT8 * numel
+        + 2 * BYTES_PER_EL_FLOAT32 * scale_numel
     )
     return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
 
@@ -386,8 +402,13 @@ def get_blockwise_float8_mem_sympy(
     enable_fusion_modeling: bool,
     gpu_name: Optional[str] = None,
     block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+    blockwise_weight_quant_mode: str = BLOCKWISE_WEIGHT_QUANT_SEPARATE,
 ):
     block_size = sympy.Integer(block_size)
+    assert blockwise_weight_quant_mode in (
+        BLOCKWISE_WEIGHT_QUANT_SEPARATE,
+        BLOCKWISE_WEIGHT_QUANT_DUAL,
+    ), f"unsupported {blockwise_weight_quant_mode=}"
 
     quant_input_lhs = get_blockwise_quant_ovhd_s(
         M * K,
@@ -395,18 +416,28 @@ def get_blockwise_float8_mem_sympy(
         gpu_name,
         fuse_read=enable_fusion_modeling,
     )
-    # Current Float8BlockwiseLinear quantizes the weight in two separate
-    # layouts: transposed RHS for forward and regular RHS for grad_input.
-    quant_weight_transposed_rhs = get_blockwise_quant_ovhd_s(
-        N * K,
-        N * K / (block_size * block_size),
-        gpu_name,
-    )
-    quant_weight_rhs = get_blockwise_quant_ovhd_s(
-        N * K,
-        N * K / (block_size * block_size),
-        gpu_name,
-    )
+    if blockwise_weight_quant_mode == BLOCKWISE_WEIGHT_QUANT_SEPARATE:
+        # Current Float8BlockwiseLinear on main quantizes the weight in two
+        # separate layouts: transposed RHS for forward and regular RHS for
+        # grad_input.
+        quant_weight = get_blockwise_quant_ovhd_s(
+            N * K,
+            N * K / (block_size * block_size),
+            gpu_name,
+        ) + get_blockwise_quant_ovhd_s(
+            N * K,
+            N * K / (block_size * block_size),
+            gpu_name,
+        )
+    else:
+        # Optimized Float8BlockwiseLinear emits both RHS layouts from one
+        # blockwise scale reduction and saves the regular RHS layout for
+        # backward.
+        quant_weight = get_blockwise_dual_weight_quant_ovhd_s(
+            N * K,
+            N * K / (block_size * block_size),
+            gpu_name,
+        )
     quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
         M * N,
         M * N / block_size,
@@ -427,8 +458,7 @@ def get_blockwise_float8_mem_sympy(
     return sum(
         [
             quant_input_lhs,
-            quant_weight_transposed_rhs,
-            quant_weight_rhs,
+            quant_weight,
             quant_grad_output_lhs,
             quant_grad_output_transposed_lhs,
             quant_input_rhs,
@@ -447,6 +477,7 @@ def run(
     enable_fusion_modeling: bool = False,
     blockwise_use_triton: bool = False,
     blockwise_compile_benchmarks: bool = False,
+    blockwise_weight_quant_mode: str = BLOCKWISE_WEIGHT_QUANT_SEPARATE,
     dsv3_seq_len: int = DSV3_SEQ_LEN,
     dsv3_dim: int = DSV3_DIM,
     dsv3_inter_dim: int = DSV3_INTER_DIM,
@@ -464,6 +495,9 @@ def run(
       roofline estimates
     * `blockwise_use_triton`: if False, use the scaled_mm backend for blockwise
       FP8 GEMMs; if True, use the custom Triton GEMM backend
+    * `blockwise_weight_quant_mode`: `separate` models the current main branch
+      implementation; `dual` models the optimized kernel which emits both
+      weight RHS layouts from one quantization kernel
     * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
       `dsv3_seq_len`
     """
@@ -484,6 +518,7 @@ def run(
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
     print(f"blockwise_use_triton: {blockwise_use_triton}")
     print(f"blockwise_compile_benchmarks: {blockwise_compile_benchmarks}")
+    print(f"blockwise_weight_quant_mode: {blockwise_weight_quant_mode}")
     print(f"dsv3_seq_len: {dsv3_seq_len}")
     print(f"dsv3_dim: {dsv3_dim}")
     print(f"dsv3_inter_dim: {dsv3_inter_dim}")
@@ -521,6 +556,7 @@ def run(
             N,
             enable_fusion_modeling,
             roofline_gpu_name,
+            blockwise_weight_quant_mode=blockwise_weight_quant_mode,
         )
         fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(
             M,
@@ -560,6 +596,7 @@ def run(
         "name",
         "fp8_backend",
         "compiled",
+        "blockwise_weight_quant_mode",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -673,9 +710,7 @@ def run(
             fp8_ovhd_time_sympy.subs(M, M_val).subs(K, K_val).subs(N, N_val)
         )
         r_fp8_gemm_and_ovhd_time_s = r_fp8_gemm_time_s + r_fp8_ovhd_time_s
-        r_fp8_gemm_and_ovhd_speedup = (
-            r_bf16_gemm_time_s / r_fp8_gemm_and_ovhd_time_s
-        )
+        r_fp8_gemm_and_ovhd_speedup = r_bf16_gemm_time_s / r_fp8_gemm_and_ovhd_time_s
 
         b_bf16_e2e_time_s, b_fp8_e2e_time_s = 0, 0
         if do_benchmarks:
@@ -765,6 +800,7 @@ def run(
                 name,
                 fp8_backend,
                 blockwise_compile_benchmarks if is_blockwise_fp8_training else True,
+                (blockwise_weight_quant_mode if is_blockwise_fp8_training else "n/a"),
                 M_val,
                 K_val,
                 N_val,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -7,7 +7,7 @@
 """
 This is a script to estimate the benefit from converting a `torch.nn.Linear`
 layer to float8 given a single saturated GPU, by estimating the difference
-in e2e GPU kernel time between:
+in e2e GPU elapsed time between:
 1. bf16 gemms in fwd and bwd, and
 2. float8 gemms in fwd and bwd, and float8 overhead
 
@@ -67,10 +67,34 @@ from torchao.prototype.moe_training.config import (
 )
 from torchao.quantization import quantize_
 from torchao.testing.training.roofline_utils import (
+    BYTES_PER_EL_BF16,
+    BYTES_PER_EL_FLOAT8,
+    BYTES_PER_EL_FLOAT32,
+    KERNEL_LAUNCH_OVERHEAD_SEC,
     get_float8_mem_sympy,
     get_gemm_time_sympy,
+    get_specs,
+    gpu_name_to_specs,
 )
-from torchao.utils import is_MI300, round_up
+from torchao.utils import is_MI300, is_sm_at_least_90, round_up
+
+
+BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
+BLOCKWISE_FP8_BLOCK_SIZE = 128
+DSV3_SEQ_LEN = 4096
+DSV3_DIM = 7168
+DSV3_INTER_DIM = 18432
+
+
+def get_roofline_gpu_name(gpu_name: Optional[str] = None):
+    if gpu_name is None:
+        gpu_name = torch.cuda.get_device_name(0)
+    if gpu_name in gpu_name_to_specs:
+        return gpu_name
+    for known_gpu_name in gpu_name_to_specs:
+        if gpu_name.startswith(known_gpu_name):
+            return known_gpu_name
+    return gpu_name
 
 
 class LNLinearSigmoid(torch.nn.Module):
@@ -220,6 +244,186 @@ def get_gemm_times(
     return bf16_time_s, f8_time_s
 
 
+def get_dsv3_16b_671b_shapes_iter(
+    seq_len: int = DSV3_SEQ_LEN,
+    dim: int = DSV3_DIM,
+    inter_dim: int = DSV3_INTER_DIM,
+):
+    """
+    DeepSeek-V3 dense FFN linear shapes for one microbatch with sequence length
+    `seq_len`, so the GEMM M dimension is `seq_len`.
+    """
+    name_to_shapes = {
+        "dsv3.ffn.w1": (seq_len, dim, inter_dim),
+        "dsv3.ffn.w2": (seq_len, inter_dim, dim),
+        "dsv3.ffn.w3": (seq_len, dim, inter_dim),
+    }
+    return name_to_shapes.items()
+
+
+def get_roofline_name_to_shapes_iter(
+    shape_gen_name: str,
+    dsv3_seq_len: int,
+    dsv3_dim: int,
+    dsv3_inter_dim: int,
+):
+    if shape_gen_name in ("dsv3-16b-671b", "dsv3-16b/671b", "dsv3_16b_671b"):
+        return get_dsv3_16b_671b_shapes_iter(
+            seq_len=dsv3_seq_len,
+            dim=dsv3_dim,
+            inter_dim=dsv3_inter_dim,
+        )
+    return get_name_to_shapes_iter(shape_gen_name, None, None, None)
+
+
+def get_blockwise_mem_time_sympy(bytes_rw, gpu_name: Optional[str] = None):
+    specs = get_specs(gpu_name)
+    mem_time_s = (
+        bytes_rw
+        / specs["peak_mem_bw_bytes_sec"]
+        / specs["pct_achievable_mem_bw"]
+    )
+    return sympy.Max(mem_time_s, KERNEL_LAUNCH_OVERHEAD_SEC)
+
+
+def get_blockwise_individual_gemm_time_sympy(
+    M,
+    K,
+    N,
+    scale_a_numel,
+    scale_b_numel,
+    gpu_name: Optional[str] = None,
+):
+    specs = get_specs(gpu_name)
+    gemm_ops = 2 * M * K * N
+    compute_gemm_time_s = (
+        gemm_ops / specs["fp8_peak_tops"] / specs["pct_achievable_gemm_tops"]
+    )
+    bytes_rw = (
+        (M * K + K * N) * BYTES_PER_EL_FLOAT8
+        + (M * N) * BYTES_PER_EL_BF16
+        + (scale_a_numel + scale_b_numel) * BYTES_PER_EL_FLOAT32
+    )
+    mem_gemm_time_s = get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+    return sympy.Max(compute_gemm_time_s, mem_gemm_time_s)
+
+
+def get_blockwise_gemm_time_sympy(
+    M,
+    K,
+    N,
+    gpu_name: Optional[str] = None,
+    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+):
+    block_size = sympy.Integer(block_size)
+
+    # input @ weight.T = output, with 1x128 activation and 128x128 weight scales
+    gemm_output_time_s = get_blockwise_individual_gemm_time_sympy(
+        M,
+        K,
+        N,
+        M * K / block_size,
+        K * N / (block_size * block_size),
+        gpu_name,
+    )
+    # grad_output @ weight = grad_input
+    gemm_grad_input_time_s = get_blockwise_individual_gemm_time_sympy(
+        M,
+        N,
+        K,
+        M * N / block_size,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    # grad_output.T @ input = grad_weight, with 1x128 and 128x1 scales
+    gemm_grad_weight_time_s = get_blockwise_individual_gemm_time_sympy(
+        N,
+        M,
+        K,
+        N * M / block_size,
+        M * K / block_size,
+        gpu_name,
+    )
+    return gemm_output_time_s + gemm_grad_input_time_s + gemm_grad_weight_time_s
+
+
+def get_blockwise_quant_ovhd_s(
+    numel,
+    scale_numel,
+    gpu_name: Optional[str] = None,
+    fuse_read: bool = False,
+):
+    read_bytes = 0 if fuse_read else BYTES_PER_EL_BF16 * numel
+    bytes_rw = (
+        read_bytes
+        + BYTES_PER_EL_FLOAT8 * numel
+        + BYTES_PER_EL_FLOAT32 * scale_numel
+    )
+    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+
+
+def get_blockwise_dual_quant_ovhd_s(
+    numel,
+    scale_numel,
+    gpu_name: Optional[str] = None,
+):
+    bytes_rw = (
+        BYTES_PER_EL_BF16 * numel
+        + 2 * BYTES_PER_EL_FLOAT8 * numel
+        + 2 * BYTES_PER_EL_FLOAT32 * scale_numel
+    )
+    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+
+
+def get_blockwise_float8_mem_sympy(
+    M,
+    K,
+    N,
+    enable_fusion_modeling: bool,
+    gpu_name: Optional[str] = None,
+    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+):
+    block_size = sympy.Integer(block_size)
+
+    quant_input_lhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    quant_weight_dual_rhs = get_blockwise_dual_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    quant_grad_output_transposed_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+    )
+    quant_input_rhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+    )
+
+    return sum(
+        [
+            quant_input_lhs,
+            quant_weight_dual_rhs,
+            quant_grad_output_lhs,
+            quant_grad_output_transposed_lhs,
+            quant_input_rhs,
+        ]
+    )
+
+
 def run(
     outfile: str,
     do_benchmarks: bool = True,
@@ -229,6 +433,11 @@ def run(
     float8_recipe_name: Optional[str] = None,
     mx_recipe_name: Optional[str] = None,
     enable_fusion_modeling: bool = False,
+    blockwise_use_triton: bool = False,
+    blockwise_compile_benchmarks: bool = False,
+    dsv3_seq_len: int = DSV3_SEQ_LEN,
+    dsv3_dim: int = DSV3_DIM,
+    dsv3_inter_dim: int = DSV3_INTER_DIM,
 ):
     """
     Args:
@@ -238,6 +447,13 @@ def run(
     * `n_limit (optional)`: if specified, only runs `n_limit` iterations
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
+    * `mx_recipe_name=blockwise_fp8_training`: benchmark the prototype
+      Float8BlockwiseLinear layer against a bf16 Linear and use blockwise FP8
+      roofline estimates
+    * `blockwise_use_triton`: if False, use the scaled_mm backend for blockwise
+      FP8 GEMMs; if True, use the custom Triton GEMM backend
+    * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
+      `dsv3_seq_len`
     """
 
     assert not ((float8_recipe_name is not None) and (mx_recipe_name is not None)), (
@@ -254,6 +470,13 @@ def run(
     print(f"float8_recipe_name: {float8_recipe_name}")
     print(f"mx_recipe_name: {mx_recipe_name}")
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
+    print(f"blockwise_use_triton: {blockwise_use_triton}")
+    print(f"blockwise_compile_benchmarks: {blockwise_compile_benchmarks}")
+    print(f"dsv3_seq_len: {dsv3_seq_len}")
+    print(f"dsv3_dim: {dsv3_dim}")
+    print(f"dsv3_inter_dim: {dsv3_inter_dim}")
+    roofline_gpu_name = get_roofline_gpu_name()
+    print(f"roofline_gpu_name: {roofline_gpu_name}")
 
     assert mx_recipe_name in (
         None,
@@ -264,34 +487,67 @@ def run(
         "mxfp8_32x32_weight",
         # real mxfp4_cutlass recipe
         "mxfp4_cutlass",
+        # prototype DeepSeek-style blockwise FP8 training linear
+        BLOCKWISE_FP8_TRAINING_RECIPE_NAME,
     ), f"unsupported {mx_recipe_name=}"
+    is_blockwise_fp8_training = mx_recipe_name == BLOCKWISE_FP8_TRAINING_RECIPE_NAME
+    fp8_backend = "n/a"
+    if is_blockwise_fp8_training:
+        fp8_backend = (
+            "blockwise_triton_gemm" if blockwise_use_triton else "blockwise_scaled_mm"
+        )
 
     M, K, N = sympy.symbols("M K N")
 
-    fp8_ovhd_time_sympy = get_float8_mem_sympy(
-        M,
-        K,
-        N,
-        float8_recipe_name,
-        mx_recipe_name,
-        enable_fusion_modeling,
-    )
     bf16_gemm_time_sympy = get_gemm_time_sympy(
-        M, K, N, torch.bfloat16, None, None, None
+        M, K, N, torch.bfloat16, None, None, roofline_gpu_name
     )
-    lowp_input_dtype = torch.float8_e4m3fn
-    if mx_recipe_name == "mxfp4_cutlass":
-        lowp_input_dtype = torch.float4_e2m1fn_x2
+    if is_blockwise_fp8_training:
+        fp8_ovhd_time_sympy = get_blockwise_float8_mem_sympy(
+            M,
+            K,
+            N,
+            enable_fusion_modeling,
+            roofline_gpu_name,
+        )
+        fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(
+            M,
+            K,
+            N,
+            roofline_gpu_name,
+        )
+    else:
+        fp8_ovhd_time_sympy = get_float8_mem_sympy(
+            M,
+            K,
+            N,
+            float8_recipe_name,
+            mx_recipe_name,
+            enable_fusion_modeling,
+            roofline_gpu_name,
+        )
+        lowp_input_dtype = torch.float8_e4m3fn
+        if mx_recipe_name == "mxfp4_cutlass":
+            lowp_input_dtype = torch.float4_e2m1fn_x2
 
-    fp8_gemm_time_sympy = get_gemm_time_sympy(
-        M, K, N, lowp_input_dtype, float8_recipe_name, mx_recipe_name, None
-    )
+        fp8_gemm_time_sympy = get_gemm_time_sympy(
+            M,
+            K,
+            N,
+            lowp_input_dtype,
+            float8_recipe_name,
+            mx_recipe_name,
+            roofline_gpu_name,
+        )
     print("bf16_gemm_time_sympy", bf16_gemm_time_sympy)
     print("fp8_gemm_time_sympy", fp8_gemm_time_sympy)
     print("fp8_ovhd_time_sympy", fp8_ovhd_time_sympy)
     print()
 
     headers = [
+        "name",
+        "fp8_backend",
+        "compiled",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -321,7 +577,12 @@ def run(
     ]
     results = []
 
-    name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
+    name_to_shapes = get_roofline_name_to_shapes_iter(
+        shape_gen_name,
+        dsv3_seq_len,
+        dsv3_dim,
+        dsv3_inter_dim,
+    )
 
     for idx, (name, (M_val, K_val, N_val)) in enumerate(tqdm.tqdm(name_to_shapes)):
         if n_limit is not None and idx >= n_limit:
@@ -341,7 +602,7 @@ def run(
         rb_bf16_gemm_ratio = -1
         rb_fp8_gemm_ratio = -1
 
-        if do_benchmarks:
+        if do_benchmarks and not is_blockwise_fp8_training:
             assert mx_recipe_name not in (
                 "mxfp4_cutlass",
                 "mxfp8_32x32_flexible_gemm_layout",
@@ -416,13 +677,40 @@ def run(
 
             # get the bf16 gpu kernel time
             torch._dynamo.reset()
-            m_bf16 = torch.compile(copy.deepcopy(m_orig))
+            m_bf16 = copy.deepcopy(m_orig)
+            if (not is_blockwise_fp8_training) or blockwise_compile_benchmarks:
+                m_bf16 = torch.compile(m_bf16)
             b_bf16_e2e_time_s = get_gpu_kernel_time(m_bf16, x, grad_output)
 
             # get the float8 dynamic scaling gpu kernel time
 
             torch._dynamo.reset()
-            if float8_recipe_name is not None:
+            if is_blockwise_fp8_training:
+                assert is_sm_at_least_90(), (
+                    "Float8BlockwiseLinear benchmarks require CUDA SM90+"
+                )
+                assert K_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
+                    f"K={K_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
+                )
+                assert N_val % BLOCKWISE_FP8_BLOCK_SIZE == 0, (
+                    f"N={N_val} must be divisible by {BLOCKWISE_FP8_BLOCK_SIZE}"
+                )
+                from torchao.prototype.blockwise_fp8_training.linear import (
+                    Float8BlockwiseLinear,
+                    Float8BlockwiseLinearConfig,
+                )
+
+                m_fp8_dyn = copy.deepcopy(m_orig)
+                quantize_(m_fp8_dyn, config=Float8BlockwiseLinearConfig())
+                found_blockwise_linear = False
+                for module in m_fp8_dyn.modules():
+                    if isinstance(module, Float8BlockwiseLinear):
+                        module.use_triton = blockwise_use_triton
+                        found_blockwise_linear = True
+                assert found_blockwise_linear, "expected a Float8BlockwiseLinear"
+                if blockwise_compile_benchmarks:
+                    m_fp8_dyn = torch.compile(m_fp8_dyn)
+            elif float8_recipe_name is not None:
                 config = Float8LinearConfig.from_recipe_name(float8_recipe_name)
                 m_fp8_dyn = convert_to_float8_training(
                     copy.deepcopy(m_orig), config=config
@@ -440,7 +728,8 @@ def run(
                     )
                 m_fp8_dyn = copy.deepcopy(m_orig)
                 quantize_(m_fp8_dyn, config=config)
-            m_fp8_dyn = torch.compile(m_fp8_dyn)
+            if not is_blockwise_fp8_training:
+                m_fp8_dyn = torch.compile(m_fp8_dyn)
             b_fp8_e2e_time_s = get_gpu_kernel_time(m_fp8_dyn, x, grad_output)
 
         # Calculate e2e speedup if benchmarks were run, otherwise -1
@@ -451,6 +740,9 @@ def run(
 
         results.append(
             [
+                name,
+                fp8_backend,
+                blockwise_compile_benchmarks if is_blockwise_fp8_training else True,
                 M_val,
                 K_val,
                 N_val,

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -51,10 +51,6 @@ import torch.nn as nn
 import tqdm
 from torch.profiler import ProfilerActivity, profile
 from utils import (
-    DSV3_16B_671B_DIM,
-    DSV3_16B_671B_INTER_DIM,
-    DSV3_16B_671B_SEQ_LEN,
-    DSV3_16B_671B_SHAPE_GEN_NAME,
     get_gpu_kernel_gemm_time_s,
     get_name_to_shapes_iter,
     profiler_output_to_filtered_time_by_kernel_name,
@@ -71,15 +67,10 @@ from torchao.prototype.moe_training.config import (
 )
 from torchao.quantization import quantize_
 from torchao.testing.training.roofline_utils import (
-    get_blockwise_float8_mem_sympy,
-    get_blockwise_gemm_time_sympy,
     get_float8_mem_sympy,
     get_gemm_time_sympy,
-    get_roofline_gpu_name,
 )
 from torchao.utils import is_MI300, round_up
-
-BLOCKWISE_FP8_TRAINING_RECIPE_NAME = "blockwise_fp8_training"
 
 
 class LNLinearSigmoid(torch.nn.Module):
@@ -238,24 +229,15 @@ def run(
     float8_recipe_name: Optional[str] = None,
     mx_recipe_name: Optional[str] = None,
     enable_fusion_modeling: bool = False,
-    dsv3_seq_len: int = DSV3_16B_671B_SEQ_LEN,
-    dsv3_dim: int = DSV3_16B_671B_DIM,
-    dsv3_inter_dim: int = DSV3_16B_671B_INTER_DIM,
 ):
     """
     Args:
     * `do_benchmarks`: if True, gemm and e2e fwd+bwd of LNLinearSigmoid are benchmarked
-    * `shape_gen_name`: `llama`, `pow2`, `pow2_extended`, `sweep`, or
-      `dsv3-16b-671b`
+    * `shape_gen_name`: `llama`, `pow2`, `pow2_extended`, or `sweep`
     * `gemm_cache_filename (optional)`: file to cache gemm benchmark results
     * `n_limit (optional)`: if specified, only runs `n_limit` iterations
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
-    * `mx_recipe_name=blockwise_fp8_training`: use prototype
-      Float8BlockwiseLinear roofline estimates. Benchmarks are not supported
-      for this recipe in this shared script.
-    * `shape_gen_name=dsv3-16b-671b`: use DSV3 FFN shapes with M fixed to
-      `dsv3_seq_len`
     """
 
     assert not ((float8_recipe_name is not None) and (mx_recipe_name is not None)), (
@@ -272,11 +254,6 @@ def run(
     print(f"float8_recipe_name: {float8_recipe_name}")
     print(f"mx_recipe_name: {mx_recipe_name}")
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
-    print(f"dsv3_seq_len: {dsv3_seq_len}")
-    print(f"dsv3_dim: {dsv3_dim}")
-    print(f"dsv3_inter_dim: {dsv3_inter_dim}")
-    roofline_gpu_name = get_roofline_gpu_name()
-    print(f"roofline_gpu_name: {roofline_gpu_name}")
 
     assert mx_recipe_name in (
         None,
@@ -287,66 +264,34 @@ def run(
         "mxfp8_32x32_weight",
         # real mxfp4_cutlass recipe
         "mxfp4_cutlass",
-        # prototype DeepSeek-style blockwise FP8 training linear
-        BLOCKWISE_FP8_TRAINING_RECIPE_NAME,
     ), f"unsupported {mx_recipe_name=}"
-    is_blockwise_fp8_training = mx_recipe_name == BLOCKWISE_FP8_TRAINING_RECIPE_NAME
-    if do_benchmarks:
-        assert not is_blockwise_fp8_training, (
-            "do_benchmarks unsupported with "
-            f"mx_recipe_name={BLOCKWISE_FP8_TRAINING_RECIPE_NAME}; run roofline "
-            "estimates with do_benchmarks=False"
-        )
 
     M, K, N = sympy.symbols("M K N")
 
-    bf16_gemm_time_sympy = get_gemm_time_sympy(
-        M, K, N, torch.bfloat16, None, None, roofline_gpu_name
+    fp8_ovhd_time_sympy = get_float8_mem_sympy(
+        M,
+        K,
+        N,
+        float8_recipe_name,
+        mx_recipe_name,
+        enable_fusion_modeling,
     )
-    if is_blockwise_fp8_training:
-        fp8_ovhd_time_sympy = get_blockwise_float8_mem_sympy(
-            M,
-            K,
-            N,
-            enable_fusion_modeling,
-            roofline_gpu_name,
-        )
-        fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(
-            M,
-            K,
-            N,
-            roofline_gpu_name,
-        )
-    else:
-        fp8_ovhd_time_sympy = get_float8_mem_sympy(
-            M,
-            K,
-            N,
-            float8_recipe_name,
-            mx_recipe_name,
-            enable_fusion_modeling,
-            roofline_gpu_name,
-        )
-        lowp_input_dtype = torch.float8_e4m3fn
-        if mx_recipe_name == "mxfp4_cutlass":
-            lowp_input_dtype = torch.float4_e2m1fn_x2
+    bf16_gemm_time_sympy = get_gemm_time_sympy(
+        M, K, N, torch.bfloat16, None, None, None
+    )
+    lowp_input_dtype = torch.float8_e4m3fn
+    if mx_recipe_name == "mxfp4_cutlass":
+        lowp_input_dtype = torch.float4_e2m1fn_x2
 
-        fp8_gemm_time_sympy = get_gemm_time_sympy(
-            M,
-            K,
-            N,
-            lowp_input_dtype,
-            float8_recipe_name,
-            mx_recipe_name,
-            roofline_gpu_name,
-        )
+    fp8_gemm_time_sympy = get_gemm_time_sympy(
+        M, K, N, lowp_input_dtype, float8_recipe_name, mx_recipe_name, None
+    )
     print("bf16_gemm_time_sympy", bf16_gemm_time_sympy)
     print("fp8_gemm_time_sympy", fp8_gemm_time_sympy)
     print("fp8_ovhd_time_sympy", fp8_ovhd_time_sympy)
     print()
 
     headers = [
-        "name",
         "fwd_M",
         "fwd_K",
         "fwd_N",
@@ -370,23 +315,13 @@ def run(
         # the difference is the fwd+bwd ln and sigmoid terms, for now to keep things simple
         # we don't break them out and don't have a roofline for them.
         "b_fp8_e2e_spdp",
-        # measured speedup as a percentage of roofline speedup
-        "b_fp8_e2e_spdp_pct_of_r",
         # how well benchmarked gemms match roofline predicted gemms
         "rb_bf16_gemm_ratio",
         "rb_fp8_gemm_ratio",
     ]
     results = []
 
-    if shape_gen_name == DSV3_16B_671B_SHAPE_GEN_NAME:
-        name_to_shapes = get_name_to_shapes_iter(
-            shape_gen_name,
-            dsv3_seq_len,
-            dsv3_dim,
-            dsv3_inter_dim,
-        )
-    else:
-        name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
+    name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
 
     for idx, (name, (M_val, K_val, N_val)) in enumerate(tqdm.tqdm(name_to_shapes)):
         if n_limit is not None and idx >= n_limit:
@@ -462,8 +397,6 @@ def run(
         r_fp8_ovhd_time_s = float(
             fp8_ovhd_time_sympy.subs(M, M_val).subs(K, K_val).subs(N, N_val)
         )
-        r_fp8_gemm_and_ovhd_time_s = r_fp8_gemm_time_s + r_fp8_ovhd_time_s
-        r_fp8_gemm_and_ovhd_speedup = r_bf16_gemm_time_s / r_fp8_gemm_and_ovhd_time_s
 
         b_bf16_e2e_time_s, b_fp8_e2e_time_s = 0, 0
         if do_benchmarks:
@@ -513,16 +446,11 @@ def run(
         # Calculate e2e speedup if benchmarks were run, otherwise -1
         if b_bf16_e2e_time_s > 0 and b_fp8_e2e_time_s > 0:
             b_fp8_e2e_speedup = b_bf16_e2e_time_s / b_fp8_e2e_time_s
-            b_fp8_e2e_speedup_pct_of_r = (
-                b_fp8_e2e_speedup / r_fp8_gemm_and_ovhd_speedup * 100
-            )
         else:
             b_fp8_e2e_speedup = -1
-            b_fp8_e2e_speedup_pct_of_r = -1
 
         results.append(
             [
-                name,
                 M_val,
                 K_val,
                 N_val,
@@ -532,8 +460,8 @@ def run(
                 # roofline - fp8 overhead
                 r_fp8_ovhd_time_s,
                 # roofline - gemm + overhead, and speedup
-                r_fp8_gemm_and_ovhd_time_s,
-                r_fp8_gemm_and_ovhd_speedup,
+                r_fp8_gemm_time_s + r_fp8_ovhd_time_s,
+                r_bf16_gemm_time_s / (r_fp8_gemm_time_s + r_fp8_ovhd_time_s),
                 # benchmarks - gemm
                 b_bf16_gemm_time_s,
                 b_fp8_gemm_time_s,
@@ -541,7 +469,6 @@ def run(
                 b_bf16_e2e_time_s,
                 b_fp8_e2e_time_s,
                 b_fp8_e2e_speedup,
-                b_fp8_e2e_speedup_pct_of_r,
                 # gemm ratios
                 rb_bf16_gemm_ratio,
                 rb_fp8_gemm_ratio,

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -12,6 +12,11 @@ from typing import Optional
 import torch.utils.benchmark as benchmark
 from torch.profiler import ProfilerActivity, profile
 
+DSV3_16B_671B_SHAPE_GEN_NAME = "dsv3-16b-671b"
+DSV3_16B_671B_SEQ_LEN = 4096
+DSV3_16B_671B_DIM = 7168
+DSV3_16B_671B_INTER_DIM = 18432
+
 
 def profiler_output_to_filtered_time_by_kernel_name(
     prof,
@@ -231,6 +236,18 @@ def get_name_to_shapes_iter(
             "moe.shared_experts.w1": (M, 7168, 2048),
             "moe.shared_experts.w2": (M, 2048, 7168),
             "moe.shared_experts.w3": (M, 7168, 2048),
+        }
+        return name_to_shapes.items()
+
+    elif shape_gen_name == DSV3_16B_671B_SHAPE_GEN_NAME:
+        seq_len = M if M is not None else DSV3_16B_671B_SEQ_LEN
+        dim = K if K is not None else DSV3_16B_671B_DIM
+        inter_dim = N if N is not None else DSV3_16B_671B_INTER_DIM
+
+        name_to_shapes = {
+            "dsv3.ffn.w1": (seq_len, dim, inter_dim),
+            "dsv3.ffn.w2": (seq_len, inter_dim, dim),
+            "dsv3.ffn.w3": (seq_len, dim, inter_dim),
         }
         return name_to_shapes.items()
 

--- a/benchmarks/prototype/blockwise_fp8_training/README.md
+++ b/benchmarks/prototype/blockwise_fp8_training/README.md
@@ -3,6 +3,27 @@
 This directory contains benchmarking scripts for the blockwise FP8 quantization
 and GEMM paths under `torchao.prototype.blockwise_fp8_training.kernels`.
 
+## Linear Roofline Benchmark
+
+The linear benchmark compares measured `Float8BlockwiseLinear` fwd/bwd speedup
+against the shared blockwise FP8 roofline target:
+
+```bash
+python benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py
+```
+
+What it reports:
+
+- `b_bf16_e2e_s`: measured BF16 linear fwd/bwd time.
+- `b_fp8_e2e_s`: measured `Float8BlockwiseLinear` fwd/bwd time.
+- `b_fp8_e2e_spdp`: measured BF16 / FP8 speedup.
+- `r_fp8_gemm_and_ovhd_spdp`: modeled blockwise FP8 roofline speedup.
+- `b_fp8_e2e_spdp_pct_of_r`: measured speedup as a percentage of modeled
+  roofline speedup.
+
+By default, it runs the DSV3 16B/671B FFN shapes with the scaled-mm backend.
+Pass `--use_triton` to time the prototype Triton GEMM backend.
+
 ## Quantized Kernel Bandwidth Benchmark
 
 The kernel-path bandwidth utility is:

--- a/benchmarks/prototype/blockwise_fp8_training/README.md
+++ b/benchmarks/prototype/blockwise_fp8_training/README.md
@@ -18,7 +18,7 @@ What it reports:
 - `b_fp8_e2e_s`: measured `Float8BlockwiseLinear` fwd/bwd time.
 - `b_fp8_e2e_spdp`: measured BF16 / FP8 speedup.
 - `r_fp8_gemm_and_ovhd_spdp`: modeled blockwise FP8 roofline speedup.
-- `b_fp8_e2e_spdp_pct_of_r`: measured speedup as a percentage of modeled
+- `b_fp8_e2e_spdp_ratio_of_r`: measured speedup as a ratio of modeled
   roofline speedup.
 
 By default, it runs the DSV3 16B/671B FFN shapes with the scaled-mm backend.

--- a/benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py
+++ b/benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py
@@ -1,0 +1,273 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import copy
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import pandas as pd
+import sympy
+import torch
+import torch.nn as nn
+import tqdm
+
+from benchmarks.float8.utils import (
+    DSV3_16B_671B_DIM,
+    DSV3_16B_671B_INTER_DIM,
+    DSV3_16B_671B_SEQ_LEN,
+    DSV3_16B_671B_SHAPE_GEN_NAME,
+    get_name_to_shapes_iter,
+)
+from torchao.testing.training.roofline_utils import (
+    get_blockwise_float8_mem_sympy,
+    get_blockwise_gemm_time_sympy,
+    get_gemm_time_sympy,
+    get_roofline_gpu_name,
+)
+from torchao.utils import is_sm_at_least_90
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    name: str
+    M: int
+    K: int
+    N: int
+
+
+def _get_shape_configs(
+    shape_gen_name: str,
+    dsv3_seq_len: int,
+    dsv3_dim: int,
+    dsv3_inter_dim: int,
+    n_limit: Optional[int],
+):
+    if shape_gen_name == DSV3_16B_671B_SHAPE_GEN_NAME:
+        name_to_shapes = get_name_to_shapes_iter(
+            shape_gen_name,
+            dsv3_seq_len,
+            dsv3_dim,
+            dsv3_inter_dim,
+        )
+    else:
+        name_to_shapes = get_name_to_shapes_iter(shape_gen_name, None, None, None)
+
+    configs = []
+    for idx, (name, (M, K, N)) in enumerate(name_to_shapes):
+        if n_limit is not None and idx >= n_limit:
+            break
+        configs.append(ExperimentConfig(name=str(name), M=M, K=K, N=N))
+    return configs
+
+
+def _set_blockwise_backend(model: nn.Module, use_triton: bool):
+    from torchao.prototype.blockwise_fp8_training.linear import Float8BlockwiseLinear
+
+    found_blockwise_linear = False
+    for module in model.modules():
+        if isinstance(module, Float8BlockwiseLinear):
+            module.use_triton = use_triton
+            found_blockwise_linear = True
+    if not found_blockwise_linear:
+        raise AssertionError("expected a Float8BlockwiseLinear")
+
+
+def _make_models(K: int, N: int, use_triton: bool, compile: bool):
+    from torchao.prototype.blockwise_fp8_training.linear import (
+        Float8BlockwiseLinearConfig,
+    )
+    from torchao.quantization import quantize_
+
+    bf16_model = nn.Sequential(nn.Linear(K, N, bias=False)).cuda().bfloat16()
+    fp8_model = copy.deepcopy(bf16_model)
+    quantize_(fp8_model, config=Float8BlockwiseLinearConfig())
+    _set_blockwise_backend(fp8_model, use_triton)
+
+    if compile:
+        bf16_model = torch.compile(bf16_model)
+        fp8_model = torch.compile(fp8_model)
+
+    return bf16_model, fp8_model
+
+
+def _benchmark_fwd_bwd_s(
+    model: nn.Module,
+    x: torch.Tensor,
+    grad_output: torch.Tensor,
+    warmup: int,
+    iterations: int,
+):
+    def step():
+        model.zero_grad(set_to_none=True)
+        x.grad = None
+        y = model(x)
+        y.backward(grad_output)
+
+    for _ in range(warmup):
+        step()
+    torch.cuda.synchronize()
+
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(iterations):
+        step()
+    end_event.record()
+    torch.cuda.synchronize()
+    return start_event.elapsed_time(end_event) / 1000 / iterations
+
+
+def _get_roofline_expressions(gpu_name: str, enable_fusion_modeling: bool):
+    M, K, N = sympy.symbols("M K N")
+    bf16_gemm_time_sympy = get_gemm_time_sympy(
+        M, K, N, torch.bfloat16, None, None, gpu_name
+    )
+    fp8_gemm_time_sympy = get_blockwise_gemm_time_sympy(M, K, N, gpu_name)
+    fp8_ovhd_time_sympy = get_blockwise_float8_mem_sympy(
+        M, K, N, enable_fusion_modeling, gpu_name
+    )
+    return M, K, N, bf16_gemm_time_sympy, fp8_gemm_time_sympy, fp8_ovhd_time_sympy
+
+
+def _eval_roofline_s(expr, M_sym, K_sym, N_sym, M_val: int, K_val: int, N_val: int):
+    return float(expr.subs(M_sym, M_val).subs(K_sym, K_val).subs(N_sym, N_val))
+
+
+def run(args: argparse.Namespace):
+    torch.cuda.get_device_name(0)
+    if not is_sm_at_least_90():
+        raise RuntimeError("Float8BlockwiseLinear benchmarks require CUDA SM90+")
+
+    torch.random.manual_seed(args.seed)
+    roofline_gpu_name = get_roofline_gpu_name(args.roofline_gpu_name)
+    backend = "blockwise_triton_gemm" if args.use_triton else "blockwise_scaled_mm"
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"torch version: {torch.__version__}")
+    print(f"shape_gen_name: {args.shape_gen_name}")
+    print(f"roofline_gpu_name: {roofline_gpu_name}")
+    print(f"backend: {backend}")
+    print(f"compile: {args.compile}")
+
+    configs = _get_shape_configs(
+        args.shape_gen_name,
+        args.dsv3_seq_len,
+        args.dsv3_dim,
+        args.dsv3_inter_dim,
+        args.n_limit,
+    )
+    M_sym, K_sym, N_sym, r_bf16_expr, r_fp8_gemm_expr, r_fp8_ovhd_expr = (
+        _get_roofline_expressions(roofline_gpu_name, args.enable_fusion_modeling)
+    )
+
+    rows = []
+    for config in tqdm.tqdm(configs):
+        if config.K % 128 != 0 or config.N % 128 != 0:
+            raise AssertionError(
+                f"{config.name}: K={config.K} and N={config.N} must be divisible by 128"
+            )
+
+        bf16_model, fp8_model = _make_models(
+            config.K,
+            config.N,
+            args.use_triton,
+            args.compile,
+        )
+        x = torch.randn(
+            config.M,
+            config.K,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        grad_output = torch.randn(
+            config.M,
+            config.N,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+
+        b_bf16_e2e_s = _benchmark_fwd_bwd_s(
+            bf16_model, x, grad_output, args.warmup, args.iterations
+        )
+        b_fp8_e2e_s = _benchmark_fwd_bwd_s(
+            fp8_model, x, grad_output, args.warmup, args.iterations
+        )
+
+        r_bf16_gemm_s = _eval_roofline_s(
+            r_bf16_expr, M_sym, K_sym, N_sym, config.M, config.K, config.N
+        )
+        r_fp8_gemm_s = _eval_roofline_s(
+            r_fp8_gemm_expr, M_sym, K_sym, N_sym, config.M, config.K, config.N
+        )
+        r_fp8_ovhd_s = _eval_roofline_s(
+            r_fp8_ovhd_expr, M_sym, K_sym, N_sym, config.M, config.K, config.N
+        )
+        r_fp8_gemm_and_ovhd_s = r_fp8_gemm_s + r_fp8_ovhd_s
+        r_fp8_gemm_and_ovhd_spdp = r_bf16_gemm_s / r_fp8_gemm_and_ovhd_s
+        b_fp8_e2e_spdp = b_bf16_e2e_s / b_fp8_e2e_s
+        b_fp8_e2e_spdp_pct_of_r = b_fp8_e2e_spdp / r_fp8_gemm_and_ovhd_spdp * 100
+
+        rows.append(
+            {
+                "name": config.name,
+                "fp8_backend": backend,
+                "compiled": args.compile,
+                "fwd_M": config.M,
+                "fwd_K": config.K,
+                "fwd_N": config.N,
+                "r_bf16_gemm_s": r_bf16_gemm_s,
+                "r_fp8_gemm_s": r_fp8_gemm_s,
+                "r_fp8_ovhd_s": r_fp8_ovhd_s,
+                "r_fp8_gemm_and_ovhd_s": r_fp8_gemm_and_ovhd_s,
+                "r_fp8_gemm_and_ovhd_spdp": r_fp8_gemm_and_ovhd_spdp,
+                "b_bf16_e2e_s": b_bf16_e2e_s,
+                "b_fp8_e2e_s": b_fp8_e2e_s,
+                "b_fp8_e2e_spdp": b_fp8_e2e_spdp,
+                "b_fp8_e2e_spdp_pct_of_r": b_fp8_e2e_spdp_pct_of_r,
+            }
+        )
+
+    df = pd.DataFrame(rows)
+    pd.set_option("display.precision", 3)
+    print(df)
+    if args.outfile:
+        df.to_csv(args.outfile, index=False)
+        print(f"wrote {args.outfile}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark Float8BlockwiseLinear fwd/bwd and compare measured "
+            "speedup against the shared blockwise FP8 roofline target."
+        )
+    )
+    parser.add_argument("--outfile", default=None)
+    parser.add_argument("--shape_gen_name", default=DSV3_16B_671B_SHAPE_GEN_NAME)
+    parser.add_argument("--n_limit", type=int, default=None)
+    parser.add_argument("--dsv3_seq_len", type=int, default=DSV3_16B_671B_SEQ_LEN)
+    parser.add_argument("--dsv3_dim", type=int, default=DSV3_16B_671B_DIM)
+    parser.add_argument("--dsv3_inter_dim", type=int, default=DSV3_16B_671B_INTER_DIM)
+    parser.add_argument("--roofline_gpu_name", default=None)
+    parser.add_argument("--enable_fusion_modeling", action="store_true")
+    parser.add_argument("--use_triton", action="store_true")
+    parser.add_argument("--compile", action="store_true")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=123)
+    run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py
+++ b/benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py
@@ -216,7 +216,7 @@ def run(args: argparse.Namespace):
         r_fp8_gemm_and_ovhd_s = r_fp8_gemm_s + r_fp8_ovhd_s
         r_fp8_gemm_and_ovhd_spdp = r_bf16_gemm_s / r_fp8_gemm_and_ovhd_s
         b_fp8_e2e_spdp = b_bf16_e2e_s / b_fp8_e2e_s
-        b_fp8_e2e_spdp_pct_of_r = b_fp8_e2e_spdp / r_fp8_gemm_and_ovhd_spdp * 100
+        b_fp8_e2e_spdp_ratio_of_r = b_fp8_e2e_spdp / r_fp8_gemm_and_ovhd_spdp
 
         rows.append(
             {
@@ -234,7 +234,7 @@ def run(args: argparse.Namespace):
                 "b_bf16_e2e_s": b_bf16_e2e_s,
                 "b_fp8_e2e_s": b_fp8_e2e_s,
                 "b_fp8_e2e_spdp": b_fp8_e2e_spdp,
-                "b_fp8_e2e_spdp_pct_of_r": b_fp8_e2e_spdp_pct_of_r,
+                "b_fp8_e2e_spdp_ratio_of_r": b_fp8_e2e_spdp_ratio_of_r,
             }
         )
 

--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -13,6 +13,7 @@ BYTES_PER_EL_FLOAT4 = 0.5
 BYTES_PER_EL_FLOAT8 = 1
 BYTES_PER_EL_BF16 = 2
 BYTES_PER_EL_FLOAT32 = 4
+BLOCKWISE_FP8_BLOCK_SIZE = 128
 
 gpu_name_to_specs = {
     "NVIDIA H100": {
@@ -98,9 +99,21 @@ gpu_name_to_specs = {
 }
 
 
-def get_specs(gpu_name: Optional[str] = None):
+def get_roofline_gpu_name(gpu_name: Optional[str] = None):
     if gpu_name is None:
         gpu_name = torch.cuda.get_device_name(0)
+    if gpu_name in gpu_name_to_specs:
+        return gpu_name
+    for known_gpu_name in gpu_name_to_specs:
+        if gpu_name.startswith(known_gpu_name):
+            return known_gpu_name
+    raise ValueError(
+        f"Unrecognized GPU '{gpu_name}'. Known GPUs: {list(gpu_name_to_specs.keys())}"
+    )
+
+
+def get_specs(gpu_name: Optional[str] = None):
+    gpu_name = get_roofline_gpu_name(gpu_name)
     return gpu_name_to_specs[gpu_name]
 
 
@@ -383,6 +396,117 @@ def get_gemm_time_sympy(
     )
     total = gemm_output_time_s + gemm_grad_input_time_s + gemm_grad_weight_time_s
     return total
+
+
+def get_blockwise_mem_time_sympy(bytes_rw, gpu_name: Optional[str] = None):
+    specs = get_specs(gpu_name)
+    mem_time_s = (
+        bytes_rw / specs["peak_mem_bw_bytes_sec"] / specs["pct_achievable_mem_bw"]
+    )
+    return sympy.Max(mem_time_s, KERNEL_LAUNCH_OVERHEAD_SEC)
+
+
+def get_blockwise_gemm_time_sympy(
+    M,
+    K,
+    N,
+    gpu_name: Optional[str] = None,
+):
+    # Float8BlockwiseLinear executes the same three linear fwd/bwd GEMMs:
+    # input @ weight.T, grad_output @ weight, and grad_output.T @ input.
+    # The scale tensors are intentionally ignored in this GEMM memory model.
+    # For the DSV3 shapes they are much smaller than the FP8 operand reads and
+    # BF16 output writes, so this follows the existing FP8 GEMM roofline model.
+    gemm_output_time_s = get_individual_gemm_time_sympy(
+        M, K, N, torch.float8_e4m3fn, None, gpu_name
+    )
+    gemm_grad_input_time_s = get_individual_gemm_time_sympy(
+        M, N, K, torch.float8_e4m3fn, None, gpu_name
+    )
+    gemm_grad_weight_time_s = get_individual_gemm_time_sympy(
+        N, M, K, torch.float8_e4m3fn, None, gpu_name
+    )
+    return gemm_output_time_s + gemm_grad_input_time_s + gemm_grad_weight_time_s
+
+
+def get_blockwise_quant_ovhd_s(
+    numel,
+    scale_numel,
+    gpu_name: Optional[str] = None,
+    fuse_read: bool = False,
+):
+    # Model one blockwise quantization kernel. It reads the BF16 tensor unless
+    # that read can be fused into the producer, writes FP8 data, and writes FP32
+    # scales. Reduction temporaries and scale reads inside the following GEMMs
+    # are intentionally not modeled.
+    read_bytes = 0 if fuse_read else BYTES_PER_EL_BF16 * numel
+    bytes_rw = (
+        read_bytes + BYTES_PER_EL_FLOAT8 * numel + BYTES_PER_EL_FLOAT32 * scale_numel
+    )
+    return get_blockwise_mem_time_sympy(bytes_rw, gpu_name)
+
+
+def get_blockwise_float8_mem_sympy(
+    M,
+    K,
+    N,
+    enable_fusion_modeling: bool,
+    gpu_name: Optional[str] = None,
+    block_size: int = BLOCKWISE_FP8_BLOCK_SIZE,
+):
+    block_size = sympy.Integer(block_size)
+
+    # Current Float8BlockwiseLinear materializes FP8 operands for each GEMM
+    # layout it needs. Activations and grad_outputs use 1 x block_size scales,
+    # so only the reduction dimension must be divisible by block_size; M does
+    # not need a divisibility constraint.
+    quant_input_lhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    # Weight is quantized twice because forward reads weight.T as RHS and
+    # grad_input reads weight as RHS. Both use block_size x block_size scales.
+    quant_weight_transposed_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_weight_rhs = get_blockwise_quant_ovhd_s(
+        N * K,
+        N * K / (block_size * block_size),
+        gpu_name,
+    )
+    quant_grad_output_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+        fuse_read=enable_fusion_modeling,
+    )
+    # grad_weight uses grad_output.T @ input, so grad_output and input each need
+    # one additional transposed/alternate RHS layout.
+    quant_grad_output_transposed_lhs = get_blockwise_quant_ovhd_s(
+        M * N,
+        M * N / block_size,
+        gpu_name,
+    )
+    quant_input_rhs = get_blockwise_quant_ovhd_s(
+        M * K,
+        M * K / block_size,
+        gpu_name,
+    )
+
+    return sum(
+        [
+            quant_input_lhs,
+            quant_weight_transposed_rhs,
+            quant_weight_rhs,
+            quant_grad_output_lhs,
+            quant_grad_output_transposed_lhs,
+            quant_input_rhs,
+        ]
+    )
 
 
 def get_float8_mem_sympy(


### PR DESCRIPTION
### Summary

Added FP8 blockwise linear benchmarking script. This will let us compare performance of our FP8 blockwise linear layer against FP16 linear layer across the DeepSeek V3 shapes.

Added
- A canonical DSV3 16B/671B FFN shape generator selected via
  `--shape_gen_name=dsv3-16b-671b`.
- Default DSV3 training-shape parameters: `M=seq_len=4096`, `dim=7168`,
  `inter_dim=18432`.
- Blockwise FP8 roofline estimates in `roofline_utils`, including FP8 GEMM time
  and modeled quantization overhead.
- GPU-name normalization in `roofline_utils` so device names with suffixes such
  as `NVIDIA H100 80GB HBM3` resolve to the existing roofline spec key.
- A focused `Float8BlockwiseLinear` benchmark script at
  `benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py` which
  measures BF16 and blockwise FP8 fwd/bwd time, then reports measured speedup as
  a ratio of the shared roofline speedup target.
- README coverage for the focused benchmark output columns.

`blockwise_fp8_training` is intentionally roofline-only in this shared roofline script.
If `--do_benchmarks=True` is used with this recipe, the script raises an
unsupported assertion and asks the user to run roofline estimates with
`--do_benchmarks=False`.

### Results

```bash
python benchmarks/prototype/blockwise_fp8_training/bench_linear_roofline.py \
  --outfile=/tmp/blockwise_linear_roofline_dsv3_scaled_mm_rerun.csv \
  --iterations=20
```

Environment:

- GPU: NVIDIA H100 80GB HBM3
- PyTorch: `2.13.0a0+gitd129991`
- torchao: `0.17.0+gitcf0b50ae1`
- Shape set: `dsv3-16b-671b`
- Backend: `blockwise_scaled_mm`
- Compile: `False`

Roofline target:

- Roofline BF16 time: `4.209 ms`
- Roofline FP8 GEMM time: `2.103 ms`
- Roofline FP8 quantization overhead: `0.647 ms`
- Roofline FP8 total time: `2.750 ms`
- Roofline speedup estimate: `1.530x`

| layer | shape `(M,K,N)` | BF16 roofline ms | FP8 GEMM roofline ms | FP8 overhead ms | FP8 total ms | roofline speedup |
|---|---:|---:|---:|---:|---:|---:|
| `dsv3.ffn.w1` | `(4096,7168,18432)` | 4.209 | 2.103 | 0.647 | 2.750 | 1.530x |
| `dsv3.ffn.w2` | `(4096,18432,7168)` | 4.209 | 2.103 | 0.647 | 2.750 | 1.530x |
| `dsv3.ffn.w3` | `(4096,7168,18432)` | 4.209 | 2.103 | 0.647 | 2.750 | 1.530x |

Measured benchmark:

| layer | shape `(M,K,N)` | BF16 measured ms | FP8 measured ms | measured speedup | roofline speedup | speedup ratio of roofline |
|---|---:|---:|---:|---:|---:|---:|
| `dsv3.ffn.w1` | `(4096,7168,18432)` | 4.419 | 3.393 | 1.302x | 1.530x | 0.851 |
| `dsv3.ffn.w2` | `(4096,18432,7168)` | 4.233 | 3.271 | 1.294x | 1.530x | 0.845 |
| `dsv3.ffn.w3` | `(4096,7168,18432)` | 4.340 | 3.648 | 1.190x | 1.530x | 0.777 |
| average | | 4.330 | 3.437 | 1.262x | 1.530x | 0.825 |

The blockwise overhead model matches the current `Float8BlockwiseLinear`
implementation: input, weight, grad_output, transposed grad_output, and input
RHS layouts are modeled as separate quantization kernels, with weight
quantization modeled as two kernels for the transposed RHS layout used in
forward and the regular RHS layout used in `grad_input`.

The FP8 GEMM roofline intentionally ignores scale reads inside the GEMMs. For
these DSV3 shapes, scale reads are small relative to FP8 operand reads and BF16
output writes. Scale writes remain part of the quantization-overhead model.
