### PR TITLE
Simplify granularity: accept list not tuple

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -2808,10 +2808,10 @@ class TestPatternMatcher(TestPatternMatcherBase):
     @parametrize(
         "base_config",
         [
-            Int8StaticActivationInt8WeightConfig(granularity=(PerTensor(), PerRow())),
+            Int8StaticActivationInt8WeightConfig(granularity=[PerTensor(), PerRow()]),
             Int8StaticActivationInt8WeightConfig(),
             Int8DynamicActivationInt8WeightConfig(
-                version=2, granularity=(PerTensor(), PerRow())
+                version=2, granularity=[PerTensor(), PerRow()]
             ),
             Int8DynamicActivationInt8WeightConfig(version=2),
         ],

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -47,12 +47,12 @@ INT8_TEST_CONFIGS = [
     ),
     Int8DynamicActivationInt8WeightConfig(
         version=2,
-        granularity=(PerTensor(), PerRow()),
+        granularity=[PerTensor(), PerRow()],
         act_mapping_type=MappingType.SYMMETRIC,
     ),
     Int8DynamicActivationInt8WeightConfig(
         version=2,
-        granularity=(PerRow(), PerTensor()),
+        granularity=[PerRow(), PerTensor()],
         act_mapping_type=MappingType.SYMMETRIC,
     ),
     Int8DynamicActivationInt8WeightConfig(

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor_cpu.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor_cpu.py
@@ -39,7 +39,7 @@ class TestInt8TensorCPU(TorchAOIntegrationTestCase):
     @common_utils.parametrize("config_mode", ["dynamic", "static"])
     @common_utils.parametrize(
         "granularity",
-        [PerRow(), PerTensor(), (PerRow(), PerTensor()), (PerTensor(), PerRow())],
+        [PerRow(), PerTensor(), [PerRow(), PerTensor()], [PerTensor(), PerRow()]],
     )
     @common_utils.parametrize(
         "act_mapping_type", [MappingType.SYMMETRIC, MappingType.ASYMMETRIC]

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -835,9 +835,9 @@ class Int8DynamicActivationInt8WeightConfig(AOBaseConfig):
     quantization to linear layers.
 
     Args:
-        granularity: Optional[Union[Granularity, Tuple[Granularity, Granularity], List[Granularity]]] = PerRow()
+        granularity: Optional[Union[Granularity, List[Granularity]]] = PerRow()
             The granularity for quantization. Can be either a single granularity (applied to both
-            activations and weights) or a tuple / list of two granularities (first for activations, second for weights).
+            activations and weights) or a list of two granularities (first for activations, second for weights).
             If None, defaults to PerRow for both. Only PerTensor and PerRow are supported.
         act_mapping_type: Optional[MappingType] = MappingType.SYMMETRIC - Mapping type for activation quantization.
             SYMMETRIC and ASYMMETRIC are supported.
@@ -852,9 +852,7 @@ class Int8DynamicActivationInt8WeightConfig(AOBaseConfig):
 
     act_mapping_type: Optional[MappingType] = MappingType.SYMMETRIC
     weight_only_decode: bool = False
-    granularity: Optional[
-        Union[Granularity, Tuple[Granularity, Granularity], list[Granularity]]
-    ] = PerRow()
+    granularity: Optional[Union[Granularity, list[Granularity]]] = PerRow()
     set_inductor_config: bool = True
     version: int = 2
 
@@ -942,9 +940,9 @@ class Int8StaticActivationInt8WeightConfig(AOBaseConfig):
     Args:
         act_quant_scale (torch.Tensor): The scale tensor for activation quantization.
         act_quant_zero_point (torch.Tensor): The zero_point tensor for activation quantization (asymmetric only).
-        granularity (Optional[Union[Granularity, Tuple[Granularity, Granularity], List[Granularity]]] = PerRow()):
+        granularity (Optional[Union[Granularity, List[Granularity]]] = PerRow()):
             The granularity for quantization. Can be either a single granularity (applied to both
-            activations and weights) or a tuple / list of two granularities (first for activations, second for weights).
+            activations and weights) or a list of two granularities (first for activations, second for weights).
             If None, defaults to PerRow for both. Only PerTensor and PerRow are supported.
         act_mapping_type (MappingType): The mapping type for activation quantization. SYMMETRIC and ASYMMETRIC are supported.
         set_inductor_config (bool): if True, adjusts `torchinductor` settings to recommended values.
@@ -953,9 +951,7 @@ class Int8StaticActivationInt8WeightConfig(AOBaseConfig):
 
     act_quant_scale: Optional[torch.Tensor] = None
     act_quant_zero_point: Optional[torch.Tensor] = None
-    granularity: Optional[
-        Union[Granularity, Tuple[Granularity, Granularity], list[Granularity]]
-    ] = PerRow()
+    granularity: Optional[Union[Granularity, list[Granularity]]] = PerRow()
     act_mapping_type: Optional[MappingType] = MappingType.SYMMETRIC
     set_inductor_config: bool = True
     version: int = 1

--- a/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
@@ -139,7 +139,6 @@ class Int8Tensor(TorchAOBaseTensor):
         granularity: Optional[
             Union[
                 Granularity,
-                Tuple[Granularity, Granularity],
                 list[Granularity],
             ]
         ],
@@ -148,17 +147,17 @@ class Int8Tensor(TorchAOBaseTensor):
             return (PerRow(), PerRow())
         elif isinstance(granularity, Granularity):
             return (granularity, granularity)
-        elif isinstance(granularity, (tuple, list)):
+        elif isinstance(granularity, list):
             if len(granularity) == 2:
                 return tuple(granularity)
             else:
                 raise ValueError(
-                    f"Granularity tuple/list must have exactly 2 elements, got {len(granularity)}: {granularity}"
+                    f"Granularity list must have exactly 2 elements, got {len(granularity)}: {granularity}"
                 )
         else:
             raise ValueError(
                 f"Invalid granularity type: {granularity}. "
-                f"Expected None, Granularity, or tuple/list of 2 Granularities."
+                f"Expected None, Granularity, or list of 2 Granularities."
             )
 
     @classmethod


### PR DESCRIPTION
Simplify int8 tensor granularity by removing tuple support and accepting only list