### PR TITLE
[xpu][test] Enable MoE fp8/mxfp8/nvfp4 tests for Intel XPU

### DIFF
--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -12,16 +12,18 @@ from torchao.utils import (
     is_MI350,
     is_sm_at_least_90,
     is_sm_version,
+    is_XPU,
     torch_version_at_least,
 )
 
-if not (
-    torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
-    and (is_sm_at_least_90() or is_MI300() or is_MI350())
-):
+_is_xpu_available = is_XPU()
+_is_compatible_cuda = torch.cuda.is_available() and (
+    is_sm_at_least_90() or is_MI300() or is_MI350()
+)
+
+if not ((_is_xpu_available or _is_compatible_cuda) and torch_version_at_least("2.7.0")):
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350 or XPU)",
         allow_module_level=True,
     )
 
@@ -41,10 +43,17 @@ from torchao.prototype.moe_training.config import (
 from torchao.prototype.moe_training.fp8_grouped_mm import (
     _to_fp8_rowwise_then_scaled_grouped_mm,
 )
-from torchao.utils import is_MI300, is_MI350, is_ROCM
+from torchao.utils import get_available_devices, is_MI300, is_MI350, is_ROCM
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
+
+_DEVICES = get_available_devices()[1:]
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.skipif(
@@ -55,7 +64,7 @@ torch._dynamo.config.cache_size_limit = 1000
 @pytest.mark.parametrize("n", [8192])
 @pytest.mark.parametrize("k", [5120])
 @pytest.mark.parametrize("n_groups", [1, 2, 4, 8])
-def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
+def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups, device):
     if is_ROCM():
         if not (is_MI300() or is_MI350()):
             pytest.skip("FP8 rowwise test requires MI300 or MI350 on ROCm")
@@ -64,7 +73,6 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
             pytest.skip("FP8 rowwise test requires SM 9.0 on CUDA")
 
     out_dtype = torch.bfloat16
-    device = "cuda"
     a = torch.randn(
         m * n_groups,
         k,
@@ -79,7 +87,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
         device=device,
         dtype=torch.bfloat16,
     )
-    offs = torch.arange(m, n_groups * m + 1, m, device="cuda", dtype=torch.int32)
+    offs = torch.arange(m, n_groups * m + 1, m, device=device, dtype=torch.int32)
 
     # b must be transposed and in column major format.
     b_t = b.contiguous().transpose(-2, -1).requires_grad_(True)
@@ -91,7 +99,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
         b_t,
         offs=offs,
         out_dtype=config.out_dtype,
-        float8_dtyep=config.float8_dtype,
+        float8_dtype=config.float8_dtype,
     )
 
     # Validate result.
@@ -111,7 +119,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
     ref_out.sum().backward()
 
     # Validate gradients.
-    if is_ROCM():
+    if is_ROCM() or _is_xpu_available:
         # ROCm: reference vs tested path use different backends:
         # - `torch._scaled_mm` uses hipBLASLt
         # - `_to_fp8_rowwise_then_scaled_grouped_mm` uses CK
@@ -130,7 +138,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
 @pytest.mark.parametrize("m", [16, 17])
 @pytest.mark.parametrize("k", [16, 18])
 @pytest.mark.parametrize("n", [32, 33])
-def test_K_or_N_dim_not_multiple_of_16(m, n, k):
+def test_K_or_N_dim_not_multiple_of_16(m, n, k, device):
     # - Leading dim of A doesn't have to be divisible by 16, since it will be
     # divided up into groups based on offset anyway.
     # - Trailing dim of A must be divisible by 16.
@@ -138,7 +146,6 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     # - Last 2 dims of B must be divisible by 16.
     if n % 16 == 0 and k % 16 == 0:
         return
-    device = "cuda"
     n_groups = 4
     a = torch.randn(
         m * n_groups,
@@ -161,7 +168,7 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k):
     b_t = b_t.transpose(-2, -1).contiguous().transpose(-2, -1)
 
     config = Float8TrainingOpConfig.from_recipe(Float8TrainingRecipe.FP8_ROWWISE)
-    offs = torch.arange(m, n_groups * m + 1, m, device="cuda", dtype=torch.int32)
+    offs = torch.arange(m, n_groups * m + 1, m, device=device, dtype=torch.int32)
 
     # Compute output.
     with pytest.raises(AssertionError):

--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -178,6 +178,7 @@ def test_K_or_N_dim_not_multiple_of_16(m, n, k, device):
             offs=offs,
             out_dtype=config.out_dtype,
             float8_dtype=config.float8_dtype,
+            pad_token_groups_for_grouped_mm=config.pad_token_groups_for_grouped_mm,
         )
 
 

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -14,16 +14,17 @@ from torchao.utils import (
     is_MI350,
     is_sm_at_least_90,
     is_sm_version,
+    is_XPU,
     torch_version_at_least,
 )
 
-if not (
-    torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
-    and (is_sm_at_least_90() or is_MI300() or is_MI350())
-):
+_is_xpu = is_XPU()
+_is_compatible_cuda = torch.cuda.is_available() and (
+    is_sm_at_least_90() or is_MI300() or is_MI350()
+)
+if not ((_is_xpu or _is_compatible_cuda) and torch_version_at_least("2.7.0")):
     pytest.skip(
-        "Requires FP8-capable GPU (CUDA SM90+, MI300, or MI350)",
+        "Requires FP8-capable GPU (CUDA SM90+, MI300, MI350, or XPU) and PyTorch 2.7+",
         allow_module_level=True,
     )
 
@@ -47,7 +48,16 @@ from torchao.prototype.moe_training.utils import (
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.testing.utils import skip_if_rocm
+from torchao.testing.utils import skip_if_rocm, skip_if_xpu
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
+
 
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
@@ -55,7 +65,7 @@ torch._dynamo.config.cache_size_limit = 1000
 
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.skipif(
-    not is_sm_version(10, 0),
+    torch.cuda.is_available() and not is_sm_version(10, 0),
     reason="3D MXFP8 quantization requires SM100",
 )
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
@@ -65,11 +75,11 @@ torch._dynamo.config.cache_size_limit = 1000
     "scale_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 def test_emulate_mxfp8_grouped_gemm_2d_3d(
-    M, K, N, num_experts, scale_block_k, scale_mode
+    M, K, N, num_experts, scale_block_k, scale_mode, device
 ):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, device=device)
     offs_ref = offs.clone()
 
     # Quantize inputs to mxpf8 for emulated mxfp8 scaled grouped mm
@@ -120,8 +130,9 @@ def test_emulate_mxfp8_grouped_gemm_2d_3d(
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.skipif(
-    not is_sm_version(10, 0),
+    torch.cuda.is_available() and not is_sm_version(10, 0),
     reason="3D MXFP8 quantization and MXFP8 grouped GEMM require SM100",
 )
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
@@ -130,10 +141,12 @@ def test_emulate_mxfp8_grouped_gemm_2d_3d(
 @pytest.mark.parametrize(
     "scale_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
-def test_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts, scale_block_k, scale_mode):
-    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M)
+def test_mxfp8_grouped_gemm_2d_3d(
+    M, K, N, num_experts, scale_block_k, scale_mode, device
+):
+    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, device=device)
     offs_ref = offs.clone()
 
     # Real SM100 grouped MM: 1x32-scaled A @ 3D-quantized B -> grad_input.
@@ -193,13 +206,13 @@ def test_mxfp8_grouped_gemm_2d_3d(M, K, N, num_experts, scale_block_k, scale_mod
 @pytest.mark.parametrize("M", (1024, 4096))
 @pytest.mark.parametrize("N", (1024, 4096))
 @pytest.mark.parametrize("num_experts", (8, 16))
-def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
+def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts, device):
     # Simluate 2d-2d grouped gemm grad_weight = grad_output_t @ x
     block_size = 32
-    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+    grad_out = torch.randn(M, N, dtype=torch.bfloat16, device=device)
     grad_out_t = grad_out.t().contiguous()
-    x = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size)
+    x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=block_size, device=device)
     x_ref, grad_out_t_ref, offs_ref = x.clone(), grad_out_t.clone(), offs.clone()
 
     # bf16 reference grouped gemm
@@ -238,6 +251,7 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 
 
 @skip_if_rocm("ROCm not supported")
+@skip_if_xpu("XPU support not yet available")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (1, 8))
 @pytest.mark.parametrize("wgrad_with_hp", (True, False))
@@ -257,9 +271,14 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
     use_compile,
     kernel_preference,
     scale_mode,
+    device,
 ):
     # MXFP8 hardware path requires SM100
-    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+    if (
+        torch.cuda.is_available()
+        and kernel_preference != KernelPreference.EMULATED
+        and not is_sm_version(10, 0)
+    ):
         pytest.skip(
             f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
         )
@@ -268,17 +287,17 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
             "torch native dynamic per group pad/unpad functions do not work with torch.compile yet: https://github.com/pytorch/pytorch/issues/176770"
         )
 
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
 
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
     x_ref, w_t_ref, offs_ref = (
         x.clone().detach().requires_grad_(True),
         w_t.clone().detach().requires_grad_(True),
@@ -328,19 +347,19 @@ def test_mxfp8_grouped_gemm_with_dq_fwd_bwd(
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
+def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic(device):
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device, requires_grad=True)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1).requires_grad_(True)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
 
     x_ref = x.detach().clone().requires_grad_(True)
     w_t_ref = w_t.detach().clone().requires_grad_(True)
@@ -401,19 +420,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
+def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward(device):
     block_size = 32
     M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
 
     x_scale, x_qdata = to_mx(
         x.detach(),
@@ -455,19 +474,19 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
 
 
 @skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
+def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp(device):
     block_size = 32
     M, K, N, num_experts = 1024, 1024, 2048, 4
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
     w = torch.randn(
         num_experts,
         N,
         K,
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
     w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128, device=device)
 
     x_scale, x_qdata = to_mx(
         x,

--- a/test/prototype/moe_training/test_nvfp4_grouped_mm.py
+++ b/test/prototype/moe_training/test_nvfp4_grouped_mm.py
@@ -7,15 +7,22 @@
 import pytest
 import torch
 
-from torchao.utils import is_MI300, is_MI350, is_sm_at_least_90, torch_version_at_least
+from torchao.utils import (
+    is_MI300,
+    is_MI350,
+    is_sm_at_least_90,
+    is_XPU,
+    torch_version_at_least,
+)
 
-if not (
-    torch_version_at_least("2.7.0")
-    and torch.cuda.is_available()
-    and (is_sm_at_least_90() or is_MI300() or is_MI350())
-):
+_is_xpu = is_XPU()
+_is_cuda_compatible = torch.cuda.is_available() and (
+    is_sm_at_least_90() or is_MI300() or is_MI350()
+)
+
+if not ((_is_xpu or _is_cuda_compatible) and torch_version_at_least("2.7.0")):
     pytest.skip(
-        "Requires SM90+ GPU (torch._grouped_mm), MI300, or MI350",
+        "Requires XPU or SM90+ GPU (torch._grouped_mm), MI300, or MI350",
         allow_module_level=True,
     )
 
@@ -27,8 +34,16 @@ from torchao.prototype.moe_training.nvfp4_grouped_mm import (
 from torchao.prototype.moe_training.utils import generate_jagged_offs
 from torchao.prototype.mx_formats.nvfp4_tensor import nvfp4_quantize
 from torchao.testing.utils import skip_if_rocm
+from torchao.utils import get_available_devices
+
+_DEVICES = get_available_devices()[1:]
 
 BLOCK_SIZE = 16
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 def _quantize_for_test(x: torch.Tensor):
@@ -55,10 +70,10 @@ def _quantize_3d_for_test(w: torch.Tensor):
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 1024), (1024, 2048, 4096)])
 @pytest.mark.parametrize("num_experts", (1, 8, 16))
-def test_emulated_nvfp4_grouped_gemm_2d_3d(M, K, N, num_experts):
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w_t = torch.randn(num_experts, K, N, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M)
+def test_emulated_nvfp4_grouped_gemm_2d_3d(M, K, N, num_experts, device):
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w_t = torch.randn(num_experts, K, N, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, device=device)
     x_ref, w_t_ref, offs_ref = x.clone(), w_t.clone(), offs.clone()
 
     # Quantize activations (M, K) -> packed (M, K//2), scales (M, K//16)
@@ -87,12 +102,12 @@ def test_emulated_nvfp4_grouped_gemm_2d_3d(M, K, N, num_experts):
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(1024, 1024, 2048), (1024, 2048, 4096)])
 @pytest.mark.parametrize("num_experts", (1, 8, 16))
-def test_emulated_nvfp4_grouped_gemm_2d_2d(M, K, N, num_experts):
+def test_emulated_nvfp4_grouped_gemm_2d_2d(M, K, N, num_experts, device):
     # Simulate 2d-2d grouped gemm: grad_weight = grad_output_t @ input
     # grad_output_t: (N, M), input: (M, K) -> result: (E, N, K)
-    grad_out_t = torch.randn(N, M, dtype=torch.bfloat16, device="cuda")
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    offs = generate_jagged_offs(num_experts, M, multiple_of=BLOCK_SIZE)
+    grad_out_t = torch.randn(N, M, dtype=torch.bfloat16, device=device)
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=BLOCK_SIZE, device=device)
     grad_out_t_ref, x_ref, offs_ref = (
         grad_out_t.clone(),
         x.clone(),
@@ -126,14 +141,14 @@ def test_emulated_nvfp4_grouped_gemm_2d_2d(M, K, N, num_experts):
     assert sqnr >= min_sqnr, f"sqnr {sqnr} is too low, must be >= {min_sqnr}"
 
 
-def test_nvfp4_dequant_roundtrip():
+def test_nvfp4_dequant_roundtrip(device):
     """Test that quantize -> dequantize preserves values approximately."""
     from torchao.prototype.moe_training.nvfp4_grouped_mm import (
         _nvfp4_dequantize,
     )
 
     torch.manual_seed(42)
-    x = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(32, 64, device=device, dtype=torch.bfloat16)
     scales, packed = nvfp4_quantize(x, block_size=BLOCK_SIZE)
     x_recon = _nvfp4_dequantize(packed, scales, output_dtype=torch.bfloat16)
 
@@ -145,7 +160,7 @@ def test_nvfp4_dequant_roundtrip():
     assert sqnr >= min_sqnr, f"Roundtrip sqnr {sqnr} is too low, must be >= {min_sqnr}"
 
 
-def test_nvfp4_dequant_roundtrip_with_per_tensor_scale():
+def test_nvfp4_dequant_roundtrip_with_per_tensor_scale(device):
     """Test that two-level scaling (block + per-tensor) dequantizes correctly."""
     from torchao.prototype.moe_training.nvfp4_grouped_mm import (
         _nvfp4_dequantize,
@@ -153,7 +168,7 @@ def test_nvfp4_dequant_roundtrip_with_per_tensor_scale():
     from torchao.prototype.mx_formats.nvfp4_tensor import per_tensor_amax_to_scale
 
     torch.manual_seed(42)
-    x = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(32, 64, device=device, dtype=torch.bfloat16)
     amax = x.abs().max()
     per_tensor_scale = per_tensor_amax_to_scale(amax)
     scales, packed = nvfp4_quantize(

--- a/test/prototype/moe_training/test_training.py
+++ b/test/prototype/moe_training/test_training.py
@@ -11,10 +11,18 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-# this feature requires CUDA and SM89+
-if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
+from torchao.utils import is_XPU
+
+_is_xpu = is_XPU()
+_is_compatible_cuda = (
+    torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)
+)
+
+# this feature requires XPU or CUDA with SM89+
+if not (_is_xpu or _is_compatible_cuda):
     pytest.skip(
-        "CUDA not available or compute capability < 8.9", allow_module_level=True
+        "Requires XPU or CUDA with compute capability >= 8.9",
+        allow_module_level=True,
     )
 
 from torchao.utils import is_ROCM
@@ -31,13 +39,21 @@ from torchao.prototype.moe_training.config import (
 )
 from torchao.quantization.quant_api import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import get_available_devices
 
 # Reference MoE implementation (copied from torchtitan to avoid external dependency)
 from .reference_moe import MoE, MoEArgs, set_token_group_alignment_size_m
 from .testing_utils import _validate_model_conversion
 
+_DEVICES = get_available_devices()[1:]
+
 # Needed since changing args to function causes recompiles
 torch._dynamo.config.cache_size_limit = 1000
+
+
+@pytest.fixture(scope="module", params=_DEVICES)
+def device(request):
+    return request.param
 
 
 @pytest.mark.parametrize(
@@ -87,6 +103,7 @@ def test_moe_training(
     kernel_preference: KernelPreference,
     token_groups_aligned: bool,
     recipe_config: dict,
+    device: str,
 ):
     (
         recipe,
@@ -99,7 +116,6 @@ def test_moe_training(
         recipe_config["min_input_grad_sqnr"],
         recipe_config["min_param_grad_sqnr"],
     )
-    assert torch.cuda.is_available()
 
     # Emulated mode with compile is not supported
     if recipe == MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL and compile:
@@ -114,10 +130,11 @@ def test_moe_training(
                 "https://github.com/pytorch/ao/issues/4048: 'FakeTensor' object has no attribute '__tensor_flatten__'"
             )
 
-        if torch.cuda.get_device_capability() != (9, 0):
+        if device == "cuda" and torch.cuda.get_device_capability() != (9, 0):
             pytest.skip(
                 f"Skipping FP8 rowwise tests, only supported on compute capability 9.0 and found {torch.cuda.get_device_capability()}"
             )
+
         if not token_groups_aligned:
             pytest.skip("FP8 rowwise doesn't support per group token padding yet")
 
@@ -125,13 +142,13 @@ def test_moe_training(
     if recipe in (
         MXFP8TrainingRecipe.MXFP8_RCEIL,
         MXFP8TrainingRecipe.MXFP8_RCEIL_WGRAD_WITH_HP,
-    ) and torch.cuda.get_device_capability() != (
-        10,
-        0,
     ):
-        pytest.skip(
-            f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
-        )
+        if device == "xpu":
+            pytest.skip("MXFP8 hardware mode is not yet supported on XPU")
+        if device == "cuda" and torch.cuda.get_device_capability() != (10, 0):
+            pytest.skip(
+                f"Skipping MXFP8 hardware mode tests, only supported on compute capability 10.0 and found {torch.cuda.get_device_capability()}"
+            )
 
     alignment_size = 128 if isinstance(recipe, MXFP8TrainingRecipe) else 16
     set_token_group_alignment_size_m(alignment_size)
@@ -142,11 +159,11 @@ def test_moe_training(
         use_grouped_mm=True,
     )
     init_std = 0.02
-    device = torch.device("cuda")
+    device = torch.device(device)
 
     # reference bf16 MoE
     dim, hidden_dim = 5120, 8192
-    ref_model = MoE(model_args, dim, hidden_dim).to(torch.bfloat16).cuda()
+    ref_model = MoE(model_args, dim, hidden_dim).to(torch.bfloat16).to(device)
     torch.manual_seed(42)
     ref_model.init_weights(init_std, device)
 

--- a/torchao/prototype/moe_training/kernels/mxfp8/quant.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/quant.py
@@ -22,6 +22,7 @@ from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import (
     ceil_div,
     is_cuda_version_at_least,
+    is_XPU,
     torch_version_at_least,
 )
 
@@ -90,6 +91,10 @@ def _mxfp8_quantize_reference_3d(
             block_size=scale_block_n * block_size,
             scaling_mode=scale_mode,
         )
+        # to_mx may return a trailing singleton dim when block_size equals the
+        # last dimension; squeeze it so scales are always (E, N//sbn, K//bs).
+        if scales.ndim == 4 and scales.shape[-1] == 1:
+            scales = scales.squeeze(-1)
         q_data = (
             q_tiles.view(
                 E,
@@ -964,6 +969,8 @@ def _has_cuda_dispatch_kernel(opname: str) -> bool:
         return False
 
 
+_xpu_available = is_XPU()
+
 _mxfp8_cuda_kernels_available = (
     _is_sm_10x()
     and is_cuda_version_at_least(12, 8)
@@ -1144,7 +1151,7 @@ def _fake_mxfp8_quantize_2d_32x1_cutedsl_custom_op(
     return q_data, scales
 
 
-if _mxfp8_cutedsl_kernels_available:
+if _mxfp8_cutedsl_kernels_available or _xpu_available:
 
     @register_sharding(torch.ops.torchao.mxfp8_quantize_2d_1x32_cutedsl.default)
     def custom_sharding_for_cutedsl_mxfp8_2d_1x32_kernel(
@@ -1162,7 +1169,7 @@ if _mxfp8_cutedsl_kernels_available:
         return acceptable_shardings
 
 
-if _mxfp8_cuda_kernels_available:
+if _mxfp8_cuda_kernels_available or _xpu_available:
     # CUDA kernel for per group blocked layout transform with groups along M
     def mx_block_rearrange_2d_M_groups_cuda(
         scales_tensor: torch.Tensor,
@@ -1441,7 +1448,7 @@ def mxfp8_quantize_cuda_3d(
             blocked_scale_output=blocked_scale_output,
         )
 
-    if not _mxfp8_cutedsl_kernels_available:
+    if not (_mxfp8_cutedsl_kernels_available or _xpu_available):
         missing_packages = _missing_cutedsl_runtime_packages()
         if missing_packages:
             missing = ", ".join(missing_packages)
@@ -1485,7 +1492,7 @@ def mxfp8_quantize_2d_1x32_cutedsl(
         Quantized data in row-major layout with shape (M, K) and scales in
         blocked tcgen05 layout with shape (M, K//32).
     """
-    if not _mxfp8_cutedsl_kernels_available:
+    if not (_mxfp8_cutedsl_kernels_available or _xpu_available):
         missing_packages = _missing_cutedsl_runtime_packages()
         if missing_packages:
             missing = ", ".join(missing_packages)
@@ -1531,7 +1538,7 @@ def mxfp8_quantize_2d_32x1_cutedsl(
         - Scales tensor in blocked tcgen05 layout suitable for 4x128 scale factor tiles
           where only the scales dimensions are padded, not the data tensor
     """
-    if not _mxfp8_cutedsl_kernels_available:
+    if not (_mxfp8_cutedsl_kernels_available or _xpu_available):
         missing_packages = _missing_cutedsl_runtime_packages()
         if missing_packages:
             missing = ", ".join(missing_packages)

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -39,6 +39,7 @@ from torchao.prototype.mx_formats.kernels import (
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import is_XPU
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ _SM100_KERNELS_AVAILABLE = (
     and _mxfp8_cuda_kernels_available_mx
     and _triton_kernels_available
 )
+
+_XPU_AVAILABLE = is_XPU()
 
 
 def _validate_grouped_mm_input_act(
@@ -173,11 +176,11 @@ class _MXFP8GroupedMM(torch.autograd.Function):
         ), "kernel_preference must be AUTO or EMULATED"
 
         # Validate SM100 kernels are available if not using emulated mode
-        if kernel_preference != KernelPreference.EMULATED:
-            assert _SM100_KERNELS_AVAILABLE, (
-                "SM100 kernels not available. Please use torchao CUDA 12.8+ build on SM100/100a device(s). "
-                "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
-            )
+        emulated = kernel_preference == KernelPreference.EMULATED
+        assert emulated or _SM100_KERNELS_AVAILABLE or _XPU_AVAILABLE, (
+            "XPU or SM100 kernels not available. Please use use torchao XPU or CUDA 12.8+ build on SM100/100a device(s). "
+            "Otherwise, set kernel_preference=KernelPreference.EMULATED (emulated mode implements basic functionality without efficient kernels)."
+        )
 
         # Input validation
         assert input_act.ndim == 2, "input_act must be 2D"

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -25,8 +25,11 @@ from torchao.utils import (
     is_mslk_version_at_least,
     is_ROCM,
     is_sm_at_least_100,
+    is_XPU,
     torch_version_at_least,
 )
+
+_is_xpu = is_XPU()
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +172,9 @@ if torch_version_at_least("2.7.0") and has_triton():
     import triton
     import triton.language as tl
     from torch.library import triton_op, wrap_triton
+    from triton.language.extra import libdevice
+
+    IS_XPU = tl.constexpr(_is_xpu)
 
     def triton_to_mxfp8_dim1_reference(
         x_hp: torch.Tensor,
@@ -314,7 +320,10 @@ if torch_version_at_least("2.7.0") and has_triton():
         e8m0_nan_val = 255
         e8m0_exponent_bias = 127
         s_offset = scale_e8m0.to(tl.int16) - e8m0_exponent_bias
-        s_fp = tl.exp2(s_offset.to(tl.float32))
+        if IS_XPU:
+            s_fp = libdevice.exp2(s_offset.to(tl.float32))
+        else:
+            s_fp = tl.exp2(s_offset.to(tl.float32))
         s_fp = tl.where(scale_e8m0 != e8m0_nan_val, s_fp, float("nan"))
         return s_fp.to(tl.float32)
 
@@ -456,19 +465,20 @@ else:
         raise AssertionError("needs torch version 2.8+ and triton")
 
 
+_is_nvidia_sm100 = (
+    torch.cuda.is_available()
+    and is_sm_at_least_100()
+    and is_cuda_version_at_least(12, 8)
+)
+_is_rocm_mi350 = is_ROCM() and is_MI350()
+
 _triton_kernels_available = (
     torch_version_at_least("2.7.0")
     and has_triton()
-    and torch.cuda.is_available()
-    and (is_sm_at_least_100() and is_cuda_version_at_least(12, 8))
-    or (is_ROCM() and is_MI350())
+    and (_is_nvidia_sm100 or _is_rocm_mi350 or _is_xpu)
 )
 
 if _triton_kernels_available:
-    import triton
-    import triton.language as tl
-    from torch.library import triton_op, wrap_triton
-
     IS_ROCM = tl.constexpr(is_ROCM())
 
     @triton.jit
@@ -691,7 +701,7 @@ if _triton_kernels_available:
             col_rcp_scale_fp32, col_scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_t_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=not (IS_ROCM or IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")
@@ -802,7 +812,7 @@ if _triton_kernels_available:
             descale_fp32_r, scale_e8m0_r = _triton_calculate_scale_rceil(
                 x_block_abs_r,
                 axis=1,
-                USE_PTX=not IS_ROCM,
+                USE_PTX=not (IS_ROCM or IS_XPU),
             )
         else:
             tl.static_assert(SCALING_MODE == "floor")
@@ -1017,7 +1027,7 @@ _mxfp8_cuda_kernels_available = (
     and is_cuda_version_at_least(12, 8)
 )
 
-if _mxfp8_cuda_kernels_available:
+if _mxfp8_cuda_kernels_available or _is_xpu:
     lib = torch.library.Library("torchao", "FRAGMENT")
     lib.define(
         "mxfp8_quantize(Tensor input, bool rowwise, bool colwise, int scale_dim_x, int scale_dim_y, str fp8_format, str scaling_mode) -> (Tensor, Tensor, Tensor, Tensor)",

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -1161,6 +1161,10 @@ def is_sm_at_least_100():
     )
 
 
+def is_XPU():
+    return torch.xpu.is_available() if hasattr(torch, "xpu") else False
+
+
 def is_cuda_version_at_least(major: int, minor: int) -> bool:
     if not torch.cuda.is_available():
         return False


### PR DESCRIPTION
The PR enables a subset of MoE tests for Intel XPU and is part of the https://github.com/pytorch/ao/issues/3576.

Details:
- Enables MoE fp8/mxfp8/nvfp4 unit tests.
- Adds a device parameter to be able to run the tests on the XPU.
- Skips not yet supported scenarios.
- Source code modifications fix failing tests.