### PR TITLE
gptq: weight samples by tokens instead of batches

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -37,22 +37,22 @@ from torchao.utils import (
 def _calculate_hessian(inputs, device=None):
     """Calculate Hessian matrix from input activations for GPTQ."""
     H = 0
-    total_batches = 0
+    total_tokens = 0
 
     for inp in inputs:
         # Setup x (activation tensor)
         x = inp.float()
         if device:
             x = x.to(device)
-        shape = x.shape
-        n = 1 if len(shape) == 2 else shape[0]
-        x = x.reshape(-1, shape[-1])
+        x = x.reshape(-1, x.shape[-1])
+        # Token-weighted running mean: each row contributes equally.
+        n = x.shape[0]
 
         # Update Hessian with running average
-        H *= total_batches / (total_batches + n)
-        total_batches += n
+        H *= total_tokens / (total_tokens + n)
+        total_tokens += n
 
-        x = ((2 / total_batches) ** (1 / 2)) * x.t()
+        x = ((2 / total_tokens) ** (1 / 2)) * x.t()
         H += x.matmul(x.t())
 
     return H
@@ -108,8 +108,8 @@ class TestGPTQObserverTensor:
             observer.hessian, torch.zeros(64, 64, dtype=torch.float32, device="cuda")
         )
 
-        # Check total_batches is initialized as 0
-        assert (observer.total_batches == 0).all()
+        # Check total_tokens is initialized as 0
+        assert (observer.total_tokens == 0).all()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_linear_operation_with_observer(self):
@@ -138,7 +138,7 @@ class TestGPTQObserverTensor:
         # Check that Hessian was initialized and updated
         assert observer_weight.hessian is not None
         assert observer_weight.hessian.shape == (in_features, in_features)
-        assert (observer_weight.total_batches == 1).all()
+        assert (observer_weight.total_tokens == batch_size).all()
 
         # Verify output is correct
         expected_output = F.linear(input_tensor, weight)
@@ -164,15 +164,15 @@ class TestGPTQObserverTensor:
             input_tensor = torch.randn(
                 batch_size, in_features, dtype=torch.float32, device="cuda"
             )
-            total_samples += 1
+            total_samples += batch_size
             _ = F.linear(input_tensor, observer_weight)
 
         # Check that Hessian was created and updated
         assert observer_weight.hessian is not None
         assert observer_weight.hessian.shape == (in_features, in_features)
 
-        # Check total_batches matches total samples
-        assert (observer_weight.total_batches == total_samples).all()
+        # Check total_tokens matches total tokens observed
+        assert (observer_weight.total_tokens == total_samples).all()
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_bmm_operation_with_observer(self):
@@ -211,8 +211,8 @@ class TestGPTQObserverTensor:
                 f"Expert {e} hessian mismatch"
             )
             assert torch.equal(
-                observer_3d.total_batches[e : e + 1], observers_2d[e].total_batches
-            ), f"Expert {e} total_batches mismatch"
+                observer_3d.total_tokens[e : e + 1], observers_2d[e].total_tokens
+            ), f"Expert {e} total_tokens mismatch"
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
     @pytest.mark.skipif(
@@ -269,29 +269,31 @@ class TestGPTQObserverTensor:
                 prev_end = end
 
         # Verify per-expert hessians match bitwise to calculating each expert's
-        # hessian individually
+        # hessian individually. All three update paths are token-weighted, so
+        # the multi-row grouped_mm slice and the multi-row F.linear call use
+        # the same `n=slice_rows` and the running-mean math is byte-identical.
         for e in range(num_experts):
             assert torch.equal(observer_3d.hessian[e], observers_2d[e].hessian), (
                 f"Expert {e} hessian mismatch"
             )
             assert torch.equal(
-                observer_3d.total_batches[e : e + 1], observers_2d[e].total_batches
-            ), f"Expert {e} total_batches mismatch"
+                observer_3d.total_tokens[e : e + 1], observers_2d[e].total_tokens
+            ), f"Expert {e} total_tokens mismatch"
 
-        # Verify total_batches matches an independent count derived directly
-        # from the offsets: each non-empty forward pass contributes 1 per
-        # active expert (each expert's 2D slice has len(shape) == 2, so n=1).
-        expected_total_batches = torch.tensor(
+        # Verify total_tokens matches an independent count derived directly
+        # from the token distribution: each token contributes n=1 to its
+        # assigned expert's running-mean weight.
+        expected_total_tokens = torch.tensor(
             [
-                sum(1 for m_per_group in m_per_group_list if m_per_group[e] > 0)
+                sum(m_per_group[e] for m_per_group in m_per_group_list)
                 for e in range(num_experts)
             ],
             dtype=torch.int64,
             device="cuda",
         )
-        assert torch.equal(observer_3d.total_batches, expected_total_batches), (
-            f"total_batches {observer_3d.total_batches.tolist()} "
-            f"does not match expected {expected_total_batches.tolist()}"
+        assert torch.equal(observer_3d.total_tokens, expected_total_tokens), (
+            f"total_tokens {observer_3d.total_tokens.tolist()} "
+            f"does not match expected {expected_total_tokens.tolist()}"
         )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
@@ -328,18 +330,19 @@ class TestGPTQObserverTensor:
             linear.weight.hessian,
             torch.zeros(64, 64, dtype=torch.float32, device="cuda"),
         )
-        assert (linear.weight.total_batches == 0).all()
+        assert (linear.weight.total_tokens == 0).all()
 
         # Perform a forward pass
-        input_tensor = torch.randn(4, 64, dtype=torch.float32, device="cuda")
+        batch_size = 4
+        input_tensor = torch.randn(batch_size, 64, dtype=torch.float32, device="cuda")
         output = linear(input_tensor)
 
-        # Check Hessian was initialized after forward pass
+        # Check Hessian was initialized after forward pass.
         assert linear.weight.hessian is not None
-        assert (linear.weight.total_batches == 1).all()
+        assert (linear.weight.total_tokens == batch_size).all()
 
         # Check output shape
-        assert output.shape == (4, 32)
+        assert output.shape == (batch_size, 32)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA available")
     def test_hessian_incremental_update(self):
@@ -415,7 +418,7 @@ class TestGPTQFlow:
 
         # Verify Hessian was computed
         assert linear.weight.hessian is not None
-        assert linear.weight.total_batches > 0
+        assert linear.weight.total_tokens > 0
 
         # Phase 2: Convert step - apply GPTQ quantization
         convert_config = GPTQConfig(

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -141,10 +141,10 @@ def _gptq_config_transform(
             )
 
         # Validate that observations were recorded
-        if (tensor.total_batches == 0).any():
+        if (tensor.total_tokens == 0).any():
             raise ValueError(
                 f"No observations recorded for {parameter_name}. "
-                f"total_batches is 0. Did you run forward passes during the observe step?"
+                f"total_tokens is 0. Did you run forward passes during the observe step?"
             )
 
         # Use pre-computed Hessian directly

--- a/torchao/prototype/gptq/observer.py
+++ b/torchao/prototype/gptq/observer.py
@@ -11,11 +11,11 @@ from torchao.utils import TorchAOBaseTensor
 
 
 class GPTQObserverTensor(TorchAOBaseTensor):
-    tensor_data_names = ["hp_data", "total_batches"]
+    tensor_data_names = ["hp_data", "total_tokens"]
     optional_tensor_data_names = ["hessian"]
     tensor_attribute_names = []
 
-    def __new__(cls, hp_data: torch.Tensor, total_batches, hessian=None):
+    def __new__(cls, hp_data: torch.Tensor, total_tokens, hessian=None):
         shape = hp_data.shape
         kwargs = {}
         kwargs["device"] = hp_data.device
@@ -23,21 +23,18 @@ class GPTQObserverTensor(TorchAOBaseTensor):
         kwargs["requires_grad"] = False
         return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
 
-    def __init__(self, hp_data: torch.Tensor, total_batches, hessian=None):
+    def __init__(self, hp_data: torch.Tensor, total_tokens, hessian=None):
         super().__init__()
         self.hp_data = hp_data
         self.hessian = hessian
-        if isinstance(total_batches, torch.Tensor):
-            self.total_batches = total_batches
+        if isinstance(total_tokens, torch.Tensor):
+            self.total_tokens = total_tokens
         elif len(self.hp_data.shape) == 3:
-            # TODO(future PR): audit whether we need to change this
-            # from `total_batches` (current) to something like `total_tokens`,
-            # to ensure that each token is weighted equally in the 3d case.
-            self.total_batches = torch.zeros(
+            self.total_tokens = torch.zeros(
                 self.hp_data.shape[0], dtype=torch.int64, device=self.hp_data.device
             )
         else:
-            self.total_batches = torch.zeros(
+            self.total_tokens = torch.zeros(
                 1, dtype=torch.int64, device=self.hp_data.device
             )
 
@@ -65,32 +62,43 @@ class GPTQObserverTensor(TorchAOBaseTensor):
 
     @staticmethod
     def _update_single_hessian(
-        x: torch.Tensor, hessian: torch.Tensor, total_batches: torch.Tensor
+        x: torch.Tensor,
+        hessian: torch.Tensor,
+        total_tokens: torch.Tensor,
+        n: int,
     ):
-        """Update a single 2D Hessian and total_batches in-place."""
-        shape = x.shape
-        n = 1 if len(shape) == 2 else shape[0]
-        x = x.reshape(-1, shape[-1])
+        """Update a single 2D Hessian and total_tokens in-place.
+
+        `n` is the number of tokens this update contributes to the running
+        mean (e.g. `num_tokens` for a 2D call, or the per-expert slice size
+        for grouped_mm).
+        """
+        if n == 0:
+            return
+        x = x.reshape(-1, x.shape[-1])
 
         # cast to Python int64 for optimal type promotion semantics
         # Note: there is definitely a better way to get ^, saving for
         # a follow-up PR. For now, this preserves numerics.
-        tb = total_batches.item()
-        if tb > 0:
-            hessian *= tb / (tb + n)
+        tt = total_tokens.item()
+        if tt > 0:
+            hessian *= tt / (tt + n)
 
-        total_batches += n
+        total_tokens += n
         # cast to Python int64 for optimal type promotion semantics
         # Note: there is definitely a better way to get ^, saving for
         # a follow-up PR. For now, this preserves numerics.
-        tb = total_batches.item()
+        tt = total_tokens.item()
 
-        x = ((2 / tb) ** (1 / 2)) * x.t()
+        x = ((2 / tt) ** (1 / 2)) * x.t()
         hessian += x.matmul(x.t())
 
     def update_2d(self, input: torch.Tensor):
         x = input.float().to(self.hp_data.device)
-        self._update_single_hessian(x, self.hessian, self.total_batches[0:1])
+        x = x.reshape(-1, x.shape[-1])
+        self._update_single_hessian(
+            x, self.hessian, self.total_tokens[0:1], n=x.shape[0]
+        )
 
     def update_3d(self, input: torch.Tensor):
         x = input.float().to(self.hp_data.device)
@@ -98,8 +106,8 @@ class GPTQObserverTensor(TorchAOBaseTensor):
         for e_idx in range(self.hessian.shape[0]):
             x_cur = x[e_idx]
             h_cur = self.hessian[e_idx]
-            total_batches = self.total_batches[e_idx : e_idx + 1]
-            self._update_single_hessian(x_cur, h_cur, total_batches)
+            total_tokens = self.total_tokens[e_idx : e_idx + 1]
+            self._update_single_hessian(x_cur, h_cur, total_tokens, n=x_cur.shape[0])
 
     def update_3d_with_offs(self, input: torch.Tensor, offs: torch.Tensor):
         x = input.float().to(self.hp_data.device)
@@ -114,8 +122,11 @@ class GPTQObserverTensor(TorchAOBaseTensor):
                 continue
             x_cur = x[prev_end:end]
             h_cur = self.hessian[e_idx]
-            total_batches = self.total_batches[e_idx : e_idx + 1]
-            self._update_single_hessian(x_cur, h_cur, total_batches)
+            total_tokens = self.total_tokens[e_idx : e_idx + 1]
+            # Token-weighted: each of the `end - prev_end` rows contributes
+            # equally to the running-mean Hessian, regardless of how this
+            # slice's row count compares to other calls.
+            self._update_single_hessian(x_cur, h_cur, total_tokens, n=end - prev_end)
             prev_end = end
 
     @classmethod
@@ -154,7 +165,7 @@ def _(func, types, args, kwargs):
     }, f"only transpose of last two dims is supported, got dims {dim0}, {dim1}"
     new_data = func(self.hp_data, dim0, dim1)
     new_hessian = func(self.hessian, dim0, dim1)
-    return GPTQObserverTensor(new_data, self.total_batches, new_hessian)
+    return GPTQObserverTensor(new_data, self.total_tokens, new_hessian)
 
 
 @implements(aten.bmm.default)


### PR DESCRIPTION
Summary:

Instead of weighing each batch equally, switch to weighing each token
equally.

This is a no-op (up to small fp differences) for linear/bmm, but is more
correct for grouped_mm.

Test Plan:

A small regression on LLama-3.2-1B wikitext, but I'm going to attribute
that to just dividing by M instead of 1 which should be fine.

```
> torchao/prototype/gptq/gptq_nvfp4_llama3_2_1b_nonsequential_wikitext.sh
...
hf ({'pretrained': '/home/dev/tmp/20260421_Llama-3.2-1B_nvfp4-gptq-nonsequential_gs128_c4_n128_damp0.5_bs1024'}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|------:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.7079|±  |   N/A|
|        |       |none  |     0|byte_perplexity|↓  | 1.6334|±  |   N/A|
|        |       |none  |     0|word_perplexity|↓  |13.7882|±  |   N/A|
```