### PR TITLE
[xpu][test] Enable float8 dtensor tests for Intel XPU

### DIFF
--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -45,14 +45,20 @@ from torchao.utils import torch_version_at_least
 
 torch.set_float32_matmul_precision("high")
 
+_GPU_DEVICE = (
+    str(torch.accelerator.current_accelerator())
+    if torch.accelerator.is_available()
+    else "no_gpu"
+)
+
 
 def setup_distributed():
     world_size = int(os.environ.get("WORLD_SIZE", -1))
-    device_mesh = init_device_mesh("cuda", (world_size,))
+    device_mesh = init_device_mesh(_GPU_DEVICE, (world_size,))
     # seed must be the same in all processes
     torch.manual_seed(1)
     local_rank = torch.distributed.get_rank()
-    torch.cuda.set_device(local_rank)
+    torch.get_device_module(_GPU_DEVICE).set_device(local_rank)
     return device_mesh
 
 
@@ -213,7 +219,7 @@ def _test_fp8_mlp_tensor_parallelism_compile(mesh: DeviceMesh, size=32):
 
 def _test_distribute_fsdp_tensor_subclass(tp_mesh: DeviceMesh):
     torch.manual_seed(42)
-    model = Transformer(ModelArgs(dropout_p=0.0, weight_tying=False)).cuda()
+    model = Transformer(ModelArgs(dropout_p=0.0, weight_tying=False)).to(_GPU_DEVICE)
     convert_to_float8_training(
         model,
         config=Float8LinearConfig(

--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -45,20 +45,14 @@ from torchao.utils import torch_version_at_least
 
 torch.set_float32_matmul_precision("high")
 
-_GPU_DEVICE = (
-    str(torch.accelerator.current_accelerator())
-    if torch.accelerator.is_available()
-    else "no_gpu"
-)
-
-
 def setup_distributed():
     world_size = int(os.environ.get("WORLD_SIZE", -1))
-    device_mesh = init_device_mesh(_GPU_DEVICE, (world_size,))
+    device = str(torch.accelerator.current_accelerator())
+    device_mesh = init_device_mesh(device, (world_size,))
     # seed must be the same in all processes
     torch.manual_seed(1)
     local_rank = torch.distributed.get_rank()
-    torch.get_device_module(_GPU_DEVICE).set_device(local_rank)
+    torch.get_device_module(device).set_device(local_rank)
     return device_mesh
 
 
@@ -219,7 +213,8 @@ def _test_fp8_mlp_tensor_parallelism_compile(mesh: DeviceMesh, size=32):
 
 def _test_distribute_fsdp_tensor_subclass(tp_mesh: DeviceMesh):
     torch.manual_seed(42)
-    model = Transformer(ModelArgs(dropout_p=0.0, weight_tying=False)).to(_GPU_DEVICE)
+    device = tp_mesh.device_type
+    model = Transformer(ModelArgs(dropout_p=0.0, weight_tying=False)).to(device)
     convert_to_float8_training(
         model,
         config=Float8LinearConfig(

--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -45,6 +45,7 @@ from torchao.utils import torch_version_at_least
 
 torch.set_float32_matmul_precision("high")
 
+
 def setup_distributed():
     world_size = int(os.environ.get("WORLD_SIZE", -1))
     device = str(torch.accelerator.current_accelerator())

--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -41,14 +41,15 @@ from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 from torchao.testing.training.dtensor_utils import (
     _test_lowp_mlp_tensor_parallelism_base,
 )
-from torchao.utils import torch_version_at_least
+from torchao.utils import get_current_accelerator_device, torch_version_at_least
+
+device = str(get_current_accelerator_device())
 
 torch.set_float32_matmul_precision("high")
 
 
 def setup_distributed():
     world_size = int(os.environ.get("WORLD_SIZE", -1))
-    device = str(torch.accelerator.current_accelerator())
     device_mesh = init_device_mesh(device, (world_size,))
     # seed must be the same in all processes
     torch.manual_seed(1)
@@ -244,7 +245,7 @@ def _test_distribute_fsdp_tensor_subclass(tp_mesh: DeviceMesh):
 
 
 if __name__ == "__main__":
-    # float8 only works on CUDA H100 so we only test cuda and we follow
+    # float8 only works on CUDA H100 and XPU so we only test cuda/XPU we follow
     # other test files to not use TestCase but instead just add the test
     # cases in the main func.
     device_mesh = setup_distributed()

--- a/test/float8/test_dtensor.py
+++ b/test/float8/test_dtensor.py
@@ -41,15 +41,14 @@ from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 from torchao.testing.training.dtensor_utils import (
     _test_lowp_mlp_tensor_parallelism_base,
 )
-from torchao.utils import get_current_accelerator_device, torch_version_at_least
-
-device = str(get_current_accelerator_device())
+from torchao.utils import torch_version_at_least
 
 torch.set_float32_matmul_precision("high")
 
 
 def setup_distributed():
     world_size = int(os.environ.get("WORLD_SIZE", -1))
+    device = str(torch.accelerator.current_accelerator())
     device_mesh = init_device_mesh(device, (world_size,))
     # seed must be the same in all processes
     torch.manual_seed(1)

--- a/test/float8/test_dtensor.sh
+++ b/test/float8/test_dtensor.sh
@@ -8,8 +8,15 @@
 # terminate script on first error
 set -e
 
-if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
-    echo "Skipping test_dtensor.sh because no CUDA devices are available."
+if ! python - <<'PY'
+import sys
+import torch
+has_xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
+has_cuda = torch.cuda.is_available()
+sys.exit(0 if (has_xpu or has_cuda) else 1)
+PY
+then
+    echo "Skipping test_dtensor.sh because no XPU/CUDA devices are available."
     exit
 fi
 


### PR DESCRIPTION
This PR enables a subset of float8 dtensor tests for Intel XPU as part of the [XPU Enabling Plan for TorchAO](https://github.com/pytorch/ao/issues/3576).

Details:
- The PR does not add any new test logic.
- It introduces a device parameter to allow running the tests on XPU.
- Source code modifications fix failing tests.