### PR TITLE
fix(setup.py): exclude top-level test/ from find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -888,7 +888,7 @@ if use_cpp != "0":
 setup(
     name="torchao",
     version=version + version_suffix,
-    packages=find_packages(exclude=["benchmarks", "benchmarks.*"]),
+    packages=find_packages(exclude=["benchmarks", "benchmarks.*", "test", "test.*"]),
     include_package_data=True,
     package_data={
         "torchao.kernel.configs": ["*.pkl"],


### PR DESCRIPTION
## Summary

Adds `"test"` and `"test.*"` to the `find_packages(exclude=...)` list in `setup.py`.

## Why

The top-level `test/` directory contains an `__init__.py`, so `find_packages` picks it up and `pip install torchao` ships a `test` package under `site-packages/test/...`. That:

- pollutes the user's import namespace with a name as common as `test`
- causes hard-to-diagnose conflicts with any other distribution that also ships a top-level `test` package (or with the user's own `test` module)

## Repro (per #4360)

```bash
pip install torchao
python -c "import test, os; print(os.path.dirname(test.__file__))"
# → site-packages/test  (instead of failing or finding stdlib test)
```

After this fix the `test` package is no longer installed; the test code stays in the source tree where it belongs.

## Scope

One-line change to `setup.py`. No runtime behavior change. No effect on `torchao` package contents.

Fixes #4360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
