### PR TITLE
Fix INT8 quantization precision loss for bf16 inputs in IntxUnpackedToInt8Tensor

### DIFF
--- a/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py
@@ -408,5 +408,34 @@ class TestIntxUnpackedToInt8Tensor(TestCase):
             )
 
 
+    def test_int8_small_bf16_weights_precision(self):
+        """INT8 quantization of small bf16 weights must use full int8 range.
+
+        Regression: choose_qparams_affine in bf16 collapses per-group
+        scales for weights with small magnitudes (abs_mean ~0.01), wasting
+        most of the int8 dynamic range. The fix casts to float32 internally.
+        """
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        device = "cpu"
+        config = IntxWeightOnlyConfig(
+            weight_dtype=torch.int8,
+            granularity=PerGroup(32),
+            version=2,
+        )
+        linear = torch.nn.Linear(256, 128, bias=False, dtype=dtype, device=device)
+        linear.weight.data.normal_(0, 0.01)
+        input = torch.randn(1, 256, dtype=dtype, device=device)
+        original = linear(input)
+        quantize_(linear, config)
+        quantized = linear(input)
+        error = compute_error(original, quantized)
+        self.assertTrue(
+            error > 30,
+            f"INT8 on small bf16 weights got SQNR {error:.1f} dB, expected > 30 dB. "
+            f"Likely quantizing in bf16 instead of float32.",
+        )
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torchao/quantization/quantize_/workflows/intx/intx_unpacked_to_int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/intx/intx_unpacked_to_int8_tensor.py
@@ -216,13 +216,18 @@ class IntxUnpackedToInt8Tensor(TorchAOBaseTensor):
             )
         elif intx_choose_qparams_algorithm == IntxChooseQParamsAlgorithm.HQQ_SCALE_ONLY:
             qdata, scale = _choose_qparams_and_quantize_scale_only_hqq(
-                hp_tensor, block_size, qmin, qmax
+                hp_tensor.float(), block_size, qmin, qmax
             )
             qdata = qdata.to(torch.int8)
             zero_point = torch.zeros_like(scale, dtype=torch.int8)
         elif intx_choose_qparams_algorithm == IntxChooseQParamsAlgorithm.AFFINE:
+            # Cast to float32 for numerical precision: bf16 inputs with
+            # small magnitudes (e.g., abs_mean ~0.01) lose per-group scale
+            # granularity in bf16, collapsing all scales to a single value
+            # and wasting most of the int8 range.
+            hp_float = hp_tensor.float()
             scale, zero_point = choose_qparams_affine(
-                hp_tensor,
+                hp_float,
                 mapping_type,
                 block_size,
                 target_dtype=torch.int8,
@@ -232,7 +237,7 @@ class IntxUnpackedToInt8Tensor(TorchAOBaseTensor):
                 keepdim=True,  # Use keepdim=True to get reshaped output matching block structure
             )
             qdata = quantize_affine(
-                hp_tensor,
+                hp_float,
                 block_size,
                 scale,
                 zero_point,


### PR DESCRIPTION
Cast to float32 before choose_qparams_affine and quantize_affine in
from_hp. Without this, bf16 inputs with small magnitudes (abs_mean ~0.01)
collapse all per-group scales to a single value, using only ~3% of the
int8 dynamic range.

Example: a (128, 256) bf16 weight scaled by 0.01 with group_size=32:
  Before: all scales identical, qdata in [-4, 4], SQNR ~13 dB
  After:  per-group scales preserved, qdata in [-128, 127], SQNR ~43 dB

This affects models with normalized attention projections (e.g., weights
after QK-norm) where weight magnitudes are significantly smaller than 1.0.

Affects both AFFINE and HQQ_SCALE_ONLY paths.
