### PR TITLE
Fix regex escape characters in documentation

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1512,9 +1512,9 @@ class FqnToConfig(AOBaseConfig):
          Config key ordered by precedence:
            * fully qualified parameter name, e.g. `language.layers.0.q_proj.weight`
            * fully qualified module name, e.g. `language.layers.0.q_proj`
-           * regex for parameter names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj.weight`.
+           * regex for parameter names, must start with `re:`, e.g. `re:language\\.layers\\..+\\.q_proj.weight`.
              The first regex that matches will be applied.
-           * regex for module names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj`,
+           * regex for module names, must start with `re:`, e.g. `re:language\\.layers\\..+\\.q_proj`,
              whichever regex fully matches the module fqn first will be applied
              (order of keys for dictionary are kept consistent since we are using OrderedDict)
            * "_default", fallback if no match for all previous keys


### PR DESCRIPTION
Fix for vllm

error:

vllm
/home/tore/.venvs/comfy/lib/python3.12/site-packages/torchao/quantization/quant_api.py:1501: SyntaxWarning: invalid escape sequence '\.'
  """Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
  
  