### PR TITLE
Handle saturated eager float8 casts

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -694,11 +694,18 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
         device="cuda",
     )
 
-    # verify that in eager mode PyTorch casting to float8 is unsaturated
+    # Eager mode used to produce NaNs for out-of-range e4m3fn casts, but newer
+    # PyTorch versions saturate to the finite max like the compiled path.
     data_in_range_f8 = data_in_range_bf16.to(torch.float8_e4m3fn)
     data_out_of_range_f8 = data_out_of_range_bf16.to(torch.float8_e4m3fn)
     assert not torch.any(torch.isnan(data_in_range_f8))
-    assert torch.all(torch.isnan(data_out_of_range_f8))
+    eager_cast_saturates = not torch.any(torch.isnan(data_out_of_range_f8))
+    if eager_cast_saturates:
+        torch.testing.assert_close(
+            data_in_range_f8, data_out_of_range_f8, atol=0, rtol=0
+        )
+    else:
+        assert torch.all(torch.isnan(data_out_of_range_f8))
 
     # verify that in triton, casting to float8 is saturated
     # for simplicity, use torch.compile to generate triton code

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -669,9 +669,11 @@ def test_index_select():
     not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
+@pytest.mark.skipif(
+    not torch_version_at_least("2.12.0.dev0"),
+    reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
+)
 def test_cast_to_float8_e4m3fn_saturation_behavior():
-    # TODO(#1912): make the saturated cast work in eager mode and remove this
-    # test
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -694,18 +696,13 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
         device="cuda",
     )
 
-    # Eager mode used to produce NaNs for out-of-range e4m3fn casts, but newer
-    # PyTorch versions saturate to the finite max like the compiled path.
+    # PyTorch core saturates finite-overflow e4m3fn casts as of
+    # https://github.com/pytorch/pytorch/pull/178817.
     data_in_range_f8 = data_in_range_bf16.to(torch.float8_e4m3fn)
     data_out_of_range_f8 = data_out_of_range_bf16.to(torch.float8_e4m3fn)
     assert not torch.any(torch.isnan(data_in_range_f8))
-    eager_cast_saturates = not torch.any(torch.isnan(data_out_of_range_f8))
-    if eager_cast_saturates:
-        torch.testing.assert_close(
-            data_in_range_f8, data_out_of_range_f8, atol=0, rtol=0
-        )
-    else:
-        assert torch.all(torch.isnan(data_out_of_range_f8))
+    assert not torch.any(torch.isnan(data_out_of_range_f8))
+    torch.testing.assert_close(data_in_range_f8, data_out_of_range_f8, atol=0, rtol=0)
 
     # verify that in triton, casting to float8 is saturated
     # for simplicity, use torch.compile to generate triton code

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -119,11 +119,17 @@ def to_fp8_saturated(x: torch.Tensor, float8_dtype: torch.dtype):
     """Converts a tensor to a saturated fp8 tensor.
 
     Note:
-        This helper clamps explicitly before casting so torchao has stable
-        saturation semantics across PyTorch versions and FP8 dtypes. A common
-        case where we want to saturate is delayed scaling, where the history of
-        a tensor has a maximum value of `amax1`, and the current amax value is
-        `amax2`, where `amax1 < amax2`.
+        In PyTorch 2.11 and older, eager casts to FP8 did not saturate finite
+        overflow values. So we saturate in this function. In compile, it was
+        satured and so this extra clamp is a no-op in accuracy and regresses
+        performance.
+        
+        In PyTorch 2.12 and newer, eager mode now saturates and this clamp
+        is no longer needed. 
+        
+        TODO:
+        this explicit clamp can be removed after torchao stops supporting
+        PyTorch 2.11.
     """
     if float8_dtype in FP8_TYPES:
         max_value = torch.finfo(float8_dtype).max

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -123,10 +123,10 @@ def to_fp8_saturated(x: torch.Tensor, float8_dtype: torch.dtype):
         overflow values. So we saturate in this function. In compile, it was
         satured and so this extra clamp is a no-op in accuracy and regresses
         performance.
-        
+
         In PyTorch 2.12 and newer, eager mode now saturates and this clamp
-        is no longer needed. 
-        
+        is no longer needed.
+
         TODO:
         this explicit clamp can be removed after torchao stops supporting
         PyTorch 2.11.

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -119,12 +119,11 @@ def to_fp8_saturated(x: torch.Tensor, float8_dtype: torch.dtype):
     """Converts a tensor to a saturated fp8 tensor.
 
     Note:
-        The default behavior in PyTorch for casting to `float8_e4m3fn`
-        and `e5m2` is to not saturate. In this context, we should saturate.
-        A common case where we want to saturate is when the history of a
-        tensor has a maximum value of `amax1`, and the current amax value
-        is `amax2`, where `amax1 < amax2`. This is common when using delayed
-        scaling.
+        This helper clamps explicitly before casting so torchao has stable
+        saturation semantics across PyTorch versions and FP8 dtypes. A common
+        case where we want to saturate is delayed scaling, where the history of
+        a tensor has a maximum value of `amax1`, and the current amax value is
+        `amax2`, where `amax1 < amax2`.
     """
     if float8_dtype in FP8_TYPES:
         max_value = torch.finfo(float8_dtype).max

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -363,9 +363,13 @@ def to_mx(
             elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
             and not torch._dynamo.is_compiling()
         ):
-            # Keep eager conversion saturated across PyTorch versions and FP8
-            # dtypes. Inductor/Triton casts already saturate, so compiled mode
-            # skips this redundant clamp for better fusion/codegen.
+            # PyTorch 2.11 and older eager casts did not saturate finite
+            # overflow values, so torchao clamps before casting. Triton
+            # casts saturate, if we are compute bound we see a speedup if we remove
+            # this redundant clamp (in the case of compiling to Triton)
+            # TODO(#1912): PyTorch core fixed eager saturation in
+            # https://github.com/pytorch/pytorch/pull/178817. Remove this
+            # workaround after torchao stops supporting PyTorch 2.11.
             data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
 
     # cast to target dtype

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -363,12 +363,9 @@ def to_mx(
             elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
             and not torch._dynamo.is_compiling()
         ):
-            # As of 20250317, the Pytorch eager mode cast to `torch.float8_e4m3fn`
-            # is unsaturated. This cast is saturated in triton. If we are compute bound,
-            # we see a speedup if we remove this redundant clamp if we are compiling
-            # to triton.
-            # TODO(#1912): make the saturated cast work in eager mode and remove this
-            # workaround.
+            # Keep eager conversion saturated across PyTorch versions and FP8
+            # dtypes. Inductor/Triton casts already saturate, so compiled mode
+            # skips this redundant clamp for better fusion/codegen.
             data_lp = torch.clamp(data_lp, min=-1 * max_pos, max=max_pos)
 
     # cast to target dtype

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -239,6 +239,9 @@ class _Round(torch.autograd.Function):
 class _RoundToFloat8(torch.autograd.Function):
     """
     Implementation of `tensor.to(float8_dtype)` with backward STE.
+
+    Callers that require saturated FP8 semantics should clamp before invoking
+    this function; `_quantize_affine_float8` does that before casting.
     """
 
     @staticmethod

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -240,8 +240,10 @@ class _RoundToFloat8(torch.autograd.Function):
     """
     Implementation of `tensor.to(float8_dtype)` with backward STE.
 
-    Callers that require saturated FP8 semantics should clamp before invoking
-    this function; `_quantize_affine_float8` does that before casting.
+    In PyTorch 2.11 and older, eager casts to FP8 do not saturate finite
+    overflow values. Callers that require saturated FP8 semantics should
+    clamp before invoking this function, `_quantize_affine_float8` does
+    that before casting.
     """
 
     @staticmethod


### PR DESCRIPTION
## Summary

Update the MX tensor float8 saturation test to run only on PyTorch versions where core eager casts for finite-overflow `float8_e4m3fn` values saturate instead of returning `NaN`.

- gate the test to PyTorch `2.12.0.dev0+`
- link the upstream core fix: https://github.com/pytorch/pytorch/pull/178817
- require eager and compiled/Triton casts to saturate to `448` / `-448`
- document the existing torchao saturation guards in shared float8, affine float8 quantization, and MX conversion helpers

This keeps the coverage for saturated float8 casts while avoiding compatibility code for the older broken eager behavior.

## Test Plan

- `ruff check test/prototype/mx_formats/test_mx_tensor.py`
- `ruff format --check test/prototype/mx_formats/test_mx_tensor.py`
- `pytest -q test/prototype/mx_formats/test_mx_tensor.py::test_cast_to_float8_e4m3fn_saturation_behavior`
