### PR TITLE
add inplace method for low precision attention

### DIFF
--- a/test/prototype/attention/test_fp8_attention.py
+++ b/test/prototype/attention/test_fp8_attention.py
@@ -178,7 +178,8 @@ class TestFP8FA3Attention(TestCase):
     )
     @common_utils.parametrize("dtype", [torch.bfloat16, torch.float16])
     @common_utils.parametrize("hadamard", ["NONE", "QKV", "V_ONLY"])
-    def test_monkey_patch_model(self, dtype, hadamard):
+    @common_utils.parametrize("inplace", [False, True])
+    def test_monkey_patch_model(self, dtype, hadamard, inplace):
         embed_dim, num_heads = 512, 8
         model = (
             SimpleAttentionModel(embed_dim, num_heads)
@@ -200,7 +201,12 @@ class TestFP8FA3Attention(TestCase):
             fp8_model,
             backend=AttentionBackend.FP8_FA3,
             hadamard=HadamardMode(hadamard),
+            inplace=inplace,
         )
+
+        if inplace:
+            self.assertIsInstance(fp8_model, SimpleAttentionModel)
+            self.assertTrue(fp8_model._low_precision_attention_applied)
 
         with torch.no_grad():
             out_fp8 = fp8_model(x)
@@ -209,7 +215,7 @@ class TestFP8FA3Attention(TestCase):
         self.assertGreater(
             sqnr.item(),
             20.0,
-            f"SQNR {sqnr.item():.2f} dB below 20 dB for dtype={dtype}, hadamard={hadamard}",
+            f"SQNR {sqnr.item():.2f} dB below 20 dB for dtype={dtype}, hadamard={hadamard}, inplace={inplace}",
         )
 
     @unittest.skipUnless(
@@ -218,7 +224,8 @@ class TestFP8FA3Attention(TestCase):
     )
     @common_utils.parametrize("dtype", [torch.bfloat16, torch.float16])
     @common_utils.parametrize("hadamard", ["NONE", "QKV", "V_ONLY"])
-    def test_rope_fusion_model(self, dtype, hadamard):
+    @common_utils.parametrize("inplace", [False, True])
+    def test_rope_fusion_model(self, dtype, hadamard, inplace):
         embed_dim, num_heads = 512, 8
         model = (
             SimpleRoPEAttentionModel(embed_dim, num_heads)
@@ -242,6 +249,7 @@ class TestFP8FA3Attention(TestCase):
             fp8_model,
             backend=AttentionBackend.FP8_FA3,
             hadamard=HadamardMode(hadamard),
+            inplace=inplace,
         )
         fp8_model = torch.compile(fp8_model)
 
@@ -252,7 +260,7 @@ class TestFP8FA3Attention(TestCase):
         self.assertGreater(
             sqnr.item(),
             20.0,
-            f"SQNR {sqnr.item():.2f} dB below 20 dB for dtype={dtype}, hadamard={hadamard}",
+            f"SQNR {sqnr.item():.2f} dB below 20 dB for dtype={dtype}, hadamard={hadamard}, inplace={inplace}",
         )
 
 

--- a/torchao/prototype/attention/api.py
+++ b/torchao/prototype/attention/api.py
@@ -69,6 +69,7 @@ def apply_low_precision_attention(
     model: nn.Module,
     backend: Optional[AttentionBackend] = None,
     hadamard: HadamardMode = HadamardMode.NONE,
+    inplace: bool = False,
 ) -> nn.Module:
     """Apply low-precision attention to a model.
 
@@ -90,6 +91,9 @@ def apply_low_precision_attention(
             the transform to V only, improving V quantization quality
             without the cost of transforming Q and K. Requires D to be
             a power of 2 and <= 256.
+        inplace: If True, monkey-patch ``model.forward`` in place and
+            return the same model object instead of wrapping it. Useful
+            for frameworks that require the model type to be preserved.
 
     Example:
 
@@ -99,6 +103,10 @@ def apply_low_precision_attention(
     if not _TORCH_VERSION_AT_LEAST_2_11:
         raise RuntimeError("Low-precision attention requires PyTorch 2.11+.")
     if isinstance(model, _LowPrecisionAttentionWrapper):
+        raise RuntimeError(
+            "apply_low_precision_attention has already been applied to this module."
+        )
+    if getattr(model, "_low_precision_attention_applied", False):
         raise RuntimeError(
             "apply_low_precision_attention has already been applied to this module."
         )
@@ -113,6 +121,6 @@ def apply_low_precision_attention(
         _check_backend_available(backend)
 
     if backend == AttentionBackend.FP8_FA3:
-        return setup_fp8_backend(model, "FA3", hadamard=hadamard.value)
+        return setup_fp8_backend(model, "FA3", hadamard=hadamard.value, inplace=inplace)
 
     raise ValueError(f"Unknown backend: {backend}")

--- a/torchao/prototype/attention/shared_utils/setup.py
+++ b/torchao/prototype/attention/shared_utils/setup.py
@@ -8,6 +8,11 @@ from functools import partial
 
 import torch._inductor.config as inductor_config
 import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.attention import (
+    activate_flash_attention_impl,
+    restore_flash_attention_impl,
+)
 
 from torchao.prototype.attention.shared_utils.fusion_utils import (
     detect_causal_mask,
@@ -23,6 +28,7 @@ def setup_fp8_backend(
     model: nn.Module,
     flash_impl_name: str,
     hadamard: str = "NONE",
+    inplace: bool = False,
 ) -> nn.Module:
     if flash_impl_name == "FA3":
         from torchao.prototype.attention.fp8_fa3.attention import _ops
@@ -38,10 +44,31 @@ def setup_fp8_backend(
         backend_name=flash_impl_name,
     )
 
+    sdpa_patch_fn = _make_causal_aware_sdpa(
+        _ops.fp8_sdpa_op, strip_causal_mask, hadamard=hadamard
+    )
+
+    if inplace:
+        original_forward = model.forward
+
+        def _patched_forward(*args, **kwargs):
+            activate_flash_attention_impl(flash_impl_name)
+            try:
+                orig_sdpa = F.scaled_dot_product_attention
+                F.scaled_dot_product_attention = sdpa_patch_fn
+                try:
+                    return original_forward(*args, **kwargs)
+                finally:
+                    F.scaled_dot_product_attention = orig_sdpa
+            finally:
+                restore_flash_attention_impl()
+
+        model.forward = _patched_forward
+        model._low_precision_attention_applied = True
+        return model
+
     return _FP8FlashAttentionMonkeyPatchWrapper(
         model,
         flash_impl_name=flash_impl_name,
-        sdpa_patch_fn=_make_causal_aware_sdpa(
-            _ops.fp8_sdpa_op, strip_causal_mask, hadamard=hadamard
-        ),
+        sdpa_patch_fn=sdpa_patch_fn,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #4366

- added an inplace option for `apply_low_precision_attention` API
- useful for modules where the name is used in the script (e.g. diffusers integration: https://github.com/huggingface/diffusers/pull/13285)
