### PR TITLE
[pat] (1/5) DTensor proxmap fix + low-rank speedups

### DIFF
--- a/test/prototype/pat/test_pat_proxmap.py
+++ b/test/prototype/pat/test_pat_proxmap.py
@@ -26,27 +26,26 @@ from torchao.prototype.pat.utils import get_index_linspace
 
 
 class TestApplyProx(common_utils.TestCase):
-    """Tests that _apply_prox correctly vmaps the prox map across groups."""
+    """_apply_prox correctly vmaps the prox map across groups."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0)
 
     @common_utils.parametrize("GrouperCls", [Dim0Grouper, Dim1Grouper])
     def test_vmap_matches_manual_per_group(self, GrouperCls):
-        """Verify vmap-based _apply_prox produces correct tensor values."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 2.0
         prox_map = ProxLasso(reg_lambda)
-        # Threshold = reg_lambda * tau * gamma = 0.5 * 1.0 * 2.0 = 1.0
-        # Elements with |x| <= 1.0 should be zeroed via soft thresholding.
 
         p = torch.randn(4, 6)
         p_ref = p.clone()
 
-        # Manual element-wise soft thresholding (reference)
-        threshold = reg_lambda * gamma  # tau=1 for ProxLasso
+        # reference: soft thresholding (tau=1 for ProxLasso)
+        threshold = reg_lambda * gamma
         mult_ref = (1 - threshold / p_ref.abs()).clamp(min=0)
         p_ref.mul_(mult_ref)
 
-        # _apply_prox with vmap
         grouper = GrouperCls(p)
         prox_kwargs = make_prox_kwargs(gamma)
         zero_elts, group_norm, zeros_are_summed = PruneOptimizer._apply_prox(
@@ -61,27 +60,18 @@ class TestApplyProx(common_utils.TestCase):
         self.assertGreater(zero_elts, 0)
 
     def test_per_group_independence(self):
-        """Verify each group is processed independently via vmap.
-
-        With group lasso, vmap should compute the norm per-group (per-row for
-        Dim0Grouper). Without vmap, the norm would be computed over the entire
-        tensor, producing different results.
-        """
+        """Group lasso must compute the norm per-row, not over the whole tensor."""
         reg_lambda = 0.1
         gamma = 1.0
         prox_map = ProxGroupLasso(reg_lambda)
 
-        # Row 0: small values (norm < threshold) -> should be fully zeroed
-        # Row 1: large values (norm >> threshold) -> should survive
+        # Row 0 norm < threshold -> zeroed; Row 1 norm >> threshold -> survives.
         p = torch.tensor(
             [
                 [0.01, 0.02, -0.01, 0.005],
                 [5.0, 6.0, 7.0, 8.0],
             ]
         )
-        # Per-group (per-row) norms:
-        # Row 0 norm ~ 0.025, threshold = 0.1 * sqrt(4) * 1.0 = 0.2 -> zeroed
-        # Row 1 norm ~ 13.19, threshold = 0.2 -> survives
 
         grouper = Dim0Grouper(p)
         prox_kwargs = make_prox_kwargs(gamma)
@@ -89,17 +79,14 @@ class TestApplyProx(common_utils.TestCase):
             grouper, prox_map, p, **prox_kwargs
         )
 
-        # Row 0 should be fully zeroed
         self.assertTrue(p[0].eq(0).all())
-        # Row 1 should be non-zero (slightly shrunk)
         self.assertTrue(p[1].ne(0).all())
 
     def test_gamma_index_slope(self):
-        """_apply_prox with gamma_index_slope applies per-group gamma scaling."""
-        torch.manual_seed(0)
+        """gamma_index_slope applies per-group gamma scaling."""
         reg_lambda = 1.0
         gamma = 4.0
-        slope = 1.0  # linspace from 0 to 1 (after div 2, clamp)
+        slope = 1.0
 
         n_groups = 4
         p = torch.randn(n_groups, 5)
@@ -114,13 +101,11 @@ class TestApplyProx(common_utils.TestCase):
             **prox_kwargs,
         )
 
-        # First group gets smallest gamma multiplier (~0), last gets largest (~1)
-        # so first group should be least pruned and last group most pruned
+        # gamma multiplier increases with group index, so prune count should too.
         first_zeros = p[0].eq(0).sum().item()
         last_zeros = p[-1].eq(0).sum().item()
         self.assertGreaterEqual(last_zeros, first_zeros)
 
-        # Verify tensor values match manual computation
         gamma_multiplier = (
             torch.linspace(1 - slope, 1 + slope, n_groups).div_(2.0).clamp_(min=0.0)
         )
@@ -134,12 +119,14 @@ class TestApplyProx(common_utils.TestCase):
 
 
 class TestProxGroupLassoVectorized(common_utils.TestCase):
-    """Tests that ProxGroupLassoVectorized matches ProxGroupLasso + vmap."""
+    """ProxGroupLassoVectorized matches ProxGroupLasso + vmap."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(42)
 
     @common_utils.parametrize("reduce_dim", [0, 1])
     def test_vectorized_matches_vmap(self, reduce_dim):
-        """Vectorized apply_ produces same results as vmap over ProxGroupLasso."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 2.0
 
@@ -147,13 +134,11 @@ class TestProxGroupLassoVectorized(common_utils.TestCase):
         p_vec = p.clone()
         p_vmap = p.clone()
 
-        # Vectorized path
         prox_vec = ProxGroupLassoVectorized(reg_lambda, reduce_dim=reduce_dim)
         zero_vec, group_norm_vec = prox_vec.apply_(p_vec, gamma, 1.0)
 
-        # vmap path
         prox_map = ProxGroupLasso(reg_lambda)
-        in_dims = int(not reduce_dim)  # vmap iterates over groups dimension
+        in_dims = int(not reduce_dim)
         zero_vmap, group_norm_vmap = torch.vmap(
             prox_map.apply_, in_dims=(in_dims, None, None), out_dims=(0, 0)
         )(p_vmap, gamma, 1.0)
@@ -164,20 +149,31 @@ class TestProxGroupLassoVectorized(common_utils.TestCase):
 
 @unittest.skipUnless(dist.is_available(), "torch.distributed not available")
 class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
-    """Tests that _apply_prox handles DTensor inputs via local_map."""
+    """_apply_prox handles DTensor inputs via local_map."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(42)
 
     @common_utils.parametrize(
         "GrouperCls,placements,prox_cls",
         [
-            (Dim0Grouper, (Shard(0), Replicate()), ProxLasso),
-            (Dim1Grouper, (Shard(1), Replicate()), ProxLasso),
-            (Dim0Grouper, (Shard(0), Replicate()), ProxGroupLasso),
-            (Dim1Grouper, (Shard(1), Replicate()), ProxGroupLasso),
+            # Placement-mismatch cases: DTensor sharded on a dim that does not
+            # match grouper.in_dims, exercising the redistribute + write-back
+            # path in _apply_prox_dtensor (e.g. FSDP2 Shard(0) + Dim1Grouper).
+            (Dim1Grouper, (Shard(0), Replicate()), ProxLasso),
+            (Dim1Grouper, (Shard(0), Replicate()), ProxGroupLasso),
+            (Dim0Grouper, (Shard(1), Replicate()), ProxLasso),
+            (Dim0Grouper, (Shard(1), Replicate()), ProxGroupLasso),
         ],
     )
-    def test_dtensor_matches_regular(self, GrouperCls, placements, prox_cls):
-        """DTensor _apply_prox produces same results as regular tensor path."""
-        torch.manual_seed(42)
+    def test_dtensor_placement_mismatch_writes_back(
+        self, GrouperCls, placements, prox_cls
+    ):
+        """DTensor _apply_prox propagates in-place sparsity updates when
+        parameter placements differ from grouper's required p_in_placements.
+        Regression test for silent sparsity drop on local_map redistribute.
+        """
         reg_lambda = 0.5
         gamma = 2.0
         prox_map = prox_cls(reg_lambda)
@@ -194,7 +190,44 @@ class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
             grouper_reg, prox_map, p_regular, **prox_kwargs
         )
 
-        # Run DTensor path
+        # Run DTensor path with mismatched placements. Without write-back,
+        # p_dtensor.full_tensor() would still hold the pre-prox values.
+        grouper_dt = GrouperCls(p_dtensor)
+        zero_dt, group_norm_dt, summed_dt = PruneOptimizer._apply_prox(
+            grouper_dt, prox_map, p_dtensor, **prox_kwargs
+        )
+
+        self.assertTrue(summed_reg)
+        self.assertTrue(summed_dt)
+        self.assertEqual(zero_reg, zero_dt)
+        # Mutation must be visible on the original DTensor.
+        self.assertEqual(p_regular, p_dtensor.full_tensor())
+
+    @common_utils.parametrize(
+        "GrouperCls,placements,prox_cls",
+        [
+            (Dim0Grouper, (Shard(0), Replicate()), ProxLasso),
+            (Dim1Grouper, (Shard(1), Replicate()), ProxLasso),
+            (Dim0Grouper, (Shard(0), Replicate()), ProxGroupLasso),
+            (Dim1Grouper, (Shard(1), Replicate()), ProxGroupLasso),
+        ],
+    )
+    def test_dtensor_matches_regular(self, GrouperCls, placements, prox_cls):
+        reg_lambda = 0.5
+        gamma = 2.0
+        prox_map = prox_cls(reg_lambda)
+
+        p_regular = torch.randn(4, 6)
+        p_dtensor = distribute_tensor(
+            p_regular.clone(), device_mesh=self.mesh, placements=placements
+        )
+
+        grouper_reg = GrouperCls(p_regular)
+        prox_kwargs = make_prox_kwargs(gamma)
+        zero_reg, group_norm_reg, summed_reg = PruneOptimizer._apply_prox(
+            grouper_reg, prox_map, p_regular, **prox_kwargs
+        )
+
         grouper_dt = GrouperCls(p_dtensor)
         zero_dt, group_norm_dt, summed_dt = PruneOptimizer._apply_prox(
             grouper_dt, prox_map, p_dtensor, **prox_kwargs
@@ -208,17 +241,14 @@ class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
     @common_utils.parametrize(
         "GrouperCls,placements,prox_cls,slope",
         [
-            # Dim0Grouper combinations
             (Dim0Grouper, (Shard(0), Replicate()), ProxLasso, 1.0),
             (Dim0Grouper, (Shard(0), Replicate()), ProxGroupLasso, 1.0),
-            # Dim1Grouper combinations
             (Dim1Grouper, (Shard(1), Replicate()), ProxLasso, 1.0),
             (Dim1Grouper, (Shard(1), Replicate()), ProxGroupLasso, 1.0),
         ],
     )
     def test_dtensor_gamma_index_slope(self, GrouperCls, placements, prox_cls, slope):
-        """DTensor path with gamma_index_slope distributes gamma correctly."""
-        torch.manual_seed(0)
+        """DTensor path distributes gamma_index_slope correctly."""
         reg_lambda = 1.0
         gamma = 4.0
 
@@ -241,12 +271,10 @@ class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
 
         result_dt = p_dtensor.full_tensor()
 
-        # Verify ordering: last group more pruned than first
         first_zeros = result_dt[0].eq(0).sum().item()
         last_zeros = result_dt[-1].eq(0).sum().item()
         self.assertGreaterEqual(last_zeros, first_zeros)
 
-        # Verify values match regular tensor path
         self.assertEqual(p_regular, result_dt)
 
     @common_utils.parametrize(
@@ -258,16 +286,13 @@ class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
     )
     def test_vectorized_tensor_gamma(self, reduce_dim, placements):
         """Vectorized apply_ handles 1D tensor gamma with DTensor inputs."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
 
         p = torch.randn(4, 6)
         n_groups = p.size(1 - reduce_dim)
         gamma = 4.0 * get_index_linspace(1.0, n_groups, device=p.device)
 
-        # --- DTensor path (vectorized) ---
-        # Use placements matching p_in_placements = Shard(int(not reduce_dim))
-        # so local_map doesn't need to redistribute p.
+        # placements match p_in_placements so local_map skips redistribution.
         p_dt = distribute_tensor(
             p.clone(), device_mesh=self.mesh, placements=placements
         )
@@ -294,7 +319,6 @@ class TestApplyProxVmap(DistributedTestMixin, common_utils.TestCase):
             redistribute_inputs=True,
         )(p_dt, gamma_dt, 1.0)
 
-        # --- Reference path (vmap on regular tensor) ---
         p_ref = p.clone()
         prox_ref = ProxGroupLasso(reg_lambda)
         in_dims = int(not reduce_dim)

--- a/torchao/prototype/pat/distributed_utils.py
+++ b/torchao/prototype/pat/distributed_utils.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List
-
 from torch import Tensor
 from torch import distributed as dist
 from torch.distributed.tensor import DTensor
@@ -26,7 +24,7 @@ class _NoopHandle:
 
 
 def _maybe_async_aggregate(
-    handle_buf: List[tuple[Tensor, dist.Work | _NoopHandle]], input_tensor: Tensor
+    handle_buf: list[tuple[Tensor, dist.Work | _NoopHandle]], input_tensor: Tensor
 ) -> None:
     if dist.is_initialized() and not _is_dtensor(input_tensor):
         handle = dist.reduce(input_tensor, dst=0, async_op=True)
@@ -38,7 +36,7 @@ def _maybe_async_aggregate(
             handle_buf.append((input_tensor, _NoopHandle()))
 
 
-def _sum_async_streams(handle_buf: List[tuple[Tensor, dist.Work | _NoopHandle]]) -> int:
+def _sum_async_streams(handle_buf: list[tuple[Tensor, dist.Work | _NoopHandle]]) -> int:
     assert isinstance(handle_buf, list), (
         f"Expected a list of async handles but got {type(handle_buf)}"
     )

--- a/torchao/prototype/pat/group/low_rank.py
+++ b/torchao/prototype/pat/group/low_rank.py
@@ -9,6 +9,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 
+from ..distributed_utils import _is_dtensor
 from ..utils import use_deterministic_algorithms
 from .grouper import Grouper
 from .packed import PackedGrouperMixin
@@ -17,7 +18,19 @@ from .packed import PackedGrouperMixin
 class SVDGrouper(Grouper):
     """Apply SVD to regularize the singular values of a parameter tensor."""
 
+    # Set False to allow non-deterministic SVD (e.g. cuSOLVER's gesvdj) for
+    # speed; safe when only the reconstructed weight is consumed downstream.
+    deterministic: bool = True
+
     def __init__(self, p: Tensor, pack_dim: Optional[int] = None):
+        # SVD on a sharded DTensor would silently decompose only the local
+        # shard; require the caller to materialize the full tensor first.
+        if _is_dtensor(p):
+            raise TypeError(
+                f"{type(self).__name__} does not support DTensor inputs; "
+                "materialize the full tensor before constructing the grouper."
+            )
+
         self._p = p
         self.orig_shape = p.shape
 
@@ -30,18 +43,18 @@ class SVDGrouper(Grouper):
         if self._p.dtype in (torch.bfloat16, torch.float16):
             p = p.to(torch.float32)
 
-        with use_deterministic_algorithms():
+        with use_deterministic_algorithms(self.deterministic):
             (self.U, self.p, self.Vh) = torch.linalg.svd(p, full_matrices=False)
 
         self.in_dims = 0
 
     @torch.no_grad()
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._p.copy_(
-            torch.linalg.multi_dot([self.U, torch.diag(self.p), self.Vh])
-            .view(self.orig_shape)
-            .to(self._p.dtype)
-        )
+        # Reconstruct as (U * S) @ Vh, broadcasting S along U's column axis.
+        # This avoids materializing a [k, k] diagonal matrix and collapses the
+        # U @ diag(S) gemm into a cheap elementwise scale. copy_ also handles
+        # any dtype conversion, so the .to(...) cast can be skipped.
+        self._p.copy_(((self.U * self.p) @ self.Vh).view(self.orig_shape))
 
 
 class PackedSVDGrouper(PackedGrouperMixin, SVDGrouper):
@@ -59,4 +72,6 @@ class PackedSVDGrouper(PackedGrouperMixin, SVDGrouper):
 
     @torch.no_grad()
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._p.copy_(self.U @ torch.diag_embed(self.p) @ self.Vh)
+        # Broadcast S along U's column axis to avoid building a [npack, k, k]
+        # diagonal matrix.
+        self._p.copy_((self.U * self.p.unsqueeze(-2)) @ self.Vh)

--- a/torchao/prototype/pat/optim/group_lasso.py
+++ b/torchao/prototype/pat/optim/group_lasso.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import Tuple, Union
+from typing import Union
 
 import torch
 from torch import Tensor
@@ -26,7 +26,7 @@ class ProxGroupLasso(ProxMap):
         p: Tensor,
         gamma: Union[Tensor, float],
         tau_reweight: Union[Tensor, float] = 1.0,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         p_norm = self._get_norm(p)
         mult = torch.maximum(
             1 - self.threshold(p, gamma, tau_reweight) / p_norm,
@@ -56,7 +56,7 @@ class ProxGroupLassoVectorized(ProxGroupLasso):
         p: Tensor,
         gamma: Union[Tensor, float],
         tau_reweight: Union[Tensor, float] = 1.0,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         p_norm_vec = self._get_norm(p)
         mult = torch.maximum(
             1 - self.threshold(p, gamma, tau_reweight) / p_norm_vec,

--- a/torchao/prototype/pat/optim/lasso.py
+++ b/torchao/prototype/pat/optim/lasso.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple, Union
+from typing import Union
 
 from torch import Tensor
 
@@ -23,7 +23,7 @@ class ProxLasso(ProxMap):
         p: Tensor,
         gamma: Union[Tensor, float],
         tau_reweight: Union[Tensor, float] = 1.0,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         mult = (1 - self.threshold(p, gamma, tau_reweight) / self._get_norm(p)).clamp(
             min=0
         )

--- a/torchao/prototype/pat/optim/nuclear_norm.py
+++ b/torchao/prototype/pat/optim/nuclear_norm.py
@@ -6,7 +6,6 @@
 
 from typing import Union
 
-import torch
 from torch import Tensor
 
 from .proxmap import ProxMap
@@ -26,6 +25,9 @@ class ProxNuclearNorm(ProxMap):
         tau_reweight: Union[Tensor, float] = 1.0,
     ) -> tuple[Tensor, Tensor]:
         thresh = self.threshold(p, gamma, tau_reweight)
-        zero_mask = p.le(thresh)
-        p.sub_(torch.where(zero_mask, p, thresh))
-        return zero_mask.sum(), self._get_norm(p)
+        # Soft-threshold non-negative singular values to zero: equivalent to
+        # relu(p - thresh) for p >= 0. Avoids a torch.where intermediate and
+        # composes under torch.vmap (relu_ has a batching rule; clamp_ does
+        # not at the time of writing).
+        p.sub_(thresh).relu_()
+        return p.eq(0).sum(), self._get_norm(p)

--- a/torchao/prototype/pat/optim/nuclear_norm.py
+++ b/torchao/prototype/pat/optim/nuclear_norm.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple, Union
+from typing import Union
 
 import torch
 from torch import Tensor
@@ -24,7 +24,7 @@ class ProxNuclearNorm(ProxMap):
         p: Tensor,
         gamma: Union[Tensor, float],
         tau_reweight: Union[Tensor, float] = 1.0,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         thresh = self.threshold(p, gamma, tau_reweight)
         zero_mask = p.le(thresh)
         p.sub_(torch.where(zero_mask, p, thresh))

--- a/torchao/prototype/pat/optim/proxmap.py
+++ b/torchao/prototype/pat/optim/proxmap.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Union
+from typing import Union
 
 from torch import Tensor
 
@@ -39,7 +39,7 @@ class ProxMap(ABC):
         p: Tensor,
         gamma: Union[Tensor, float],
         tau_reweight: Union[Tensor, float] = 1.0,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         """Apply proximal mapping to p in-place and return number of zero
         elements and group-level norm of p.
 

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -29,9 +29,8 @@ from .iterative_reweight import IterativeReweight
 
 
 class PruneOptimizer(Optimizer):
-    """PruneOptimizer is a wrapper around a base optimizer that applies proximal
-    updates to induce sparsity or low-rank structure in the parameters during
-    training.
+    """Wraps a base optimizer to apply proximal updates that induce sparsity
+    or low-rank structure during training.
 
     Arguments:
         base_optimizer: The underlying optimizer (e.g., SGD or AdamW) that
@@ -200,8 +199,8 @@ class PruneOptimizer(Optimizer):
         else:
             gamma = distribute_tensor(gamma, device_mesh=p.device_mesh)
 
+        # Use ProxGroupLassoVectorized for group lasso
         if isinstance(prox_map, ProxGroupLasso):
-            # Use ProxGroupLassoVectorized for group lasso
             prox_map_vec = ProxGroupLassoVectorized(
                 prox_map.reg_lambda,
                 reduce_dim=int(not grouper.in_dims),
@@ -221,6 +220,15 @@ class PruneOptimizer(Optimizer):
                 out_dims=(0, 0),
             )
 
+        # Redistribute explicitly so the in-place prox mutation lands on a
+        # tensor we can copy back; local_map's own redistribute would discard it.
+        needs_redistribute = tuple(grouper.p.placements) != p_in_placements
+        p_for_prox = (
+            grouper.p.redistribute(placements=p_in_placements)
+            if needs_redistribute
+            else grouper.p
+        )
+
         zero_elts_per_group, group_norm = local_map(
             local_fn,
             out_placements=(
@@ -232,10 +240,13 @@ class PruneOptimizer(Optimizer):
                 gamma.placements if _is_dtensor(gamma) else None,
                 tau_reweight.placements if _is_dtensor(tau_reweight) else None,
             ),
-            redistribute_inputs=True,
-        )(grouper.p, gamma, tau_reweight)
+            redistribute_inputs=False,
+        )(p_for_prox, gamma, tau_reweight)
 
-        # Gather counts across shards
+        if needs_redistribute:
+            # Write mutated values back to the original parameter.
+            grouper.p.copy_(p_for_prox.redistribute(placements=grouper.p.placements))
+
         return zero_elts_per_group.full_tensor().sum().item(), group_norm
 
     @staticmethod
@@ -250,8 +261,7 @@ class PruneOptimizer(Optimizer):
 
         Returns:
             zero_elts: number of zero elements after applying prox map
-            group_norm: group-level norm of parameters after applying prox map,
-                divided by the prox map's tau term
+            group_norm: per-group norm divided by the prox map's tau
             zeros_are_summed: whether zero_elts is already globally summed
         """
         gamma = prox_kwargs["gamma"]
@@ -334,9 +344,8 @@ class PruneOptimizer(Optimizer):
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """
-        # during healing, freeze pruned params by zeroing out their gradients
-        # and saving masks to re-zero after optimizer step (momentum may push
-        # pruned params away from zero)
+        # during healing, zero grads of pruned params and save masks to re-zero
+        # them after the step (momentum may push them non-zero)
         healing_masks = {}
         if self.num_steps >= self.healing_start_step:
             for group in self.regularized_param_groups():
@@ -356,7 +365,7 @@ class PruneOptimizer(Optimizer):
         ):
             # run base optimizer only during warmup and healing periods
             loss = self.base_optimizer.step(closure=closure)  # pyre-ignore[6]
-            # re-zero pruned params (optimizer momentum may push them non-zero)
+            # re-zero pruned params after step
             for group in self.regularized_param_groups():
                 for p in group["params"]:
                     mask = healing_masks.get(id(p))
@@ -371,10 +380,10 @@ class PruneOptimizer(Optimizer):
             return loss
 
         if self.num_steps == self.warmup_steps:
-            # first step of PAT: save latent params for future proximal updates
+            # first PAT step: save latent params
             self.save_latent_params()
         else:
-            # restore latent params for update by the base optimizer
+            # restore latent params for base optimizer update
             self.restore_latent_params()
 
         # call base optimizer step() method to update latent parameters

--- a/torchao/prototype/pat/utils.py
+++ b/torchao/prototype/pat/utils.py
@@ -8,7 +8,7 @@ import re
 from contextlib import contextmanager
 from functools import partial
 from importlib import import_module
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Optional
 
 import torch
 from torch import nn
@@ -59,10 +59,10 @@ def instantiate_module(module_name: str):
 
 def get_param_groups(
     model: nn.Module,
-    prune_config: Dict[Tuple[nn.Module, str], Any],
-    skip_wd_names: Optional[Set[str]] = None,
+    prune_config: dict[tuple[nn.Module, str], Any],
+    skip_wd_names: Optional[set[str]] = None,
     verbose: bool = True,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     # Create list of regex patterns for matching parameter names
     re_pats = [
         re.compile(k[len(RE_PREFIX) :])

--- a/torchao/prototype/pat/utils.py
+++ b/torchao/prototype/pat/utils.py
@@ -33,10 +33,13 @@ def get_index_linspace(
 
 
 @contextmanager
-def use_deterministic_algorithms():
-    """Context manager to enable deterministic algorithms in PyTorch"""
+def use_deterministic_algorithms(mode: bool = True):
+    """Context manager that toggles PyTorch's deterministic-algorithms mode."""
     deterministic_restore = torch.are_deterministic_algorithms_enabled()
-    torch.use_deterministic_algorithms(True)
+    if deterministic_restore == mode:
+        yield
+        return
+    torch.use_deterministic_algorithms(mode)
     try:
         yield
     finally:
@@ -127,7 +130,7 @@ def latent_svd(self, name=""):
     S = getattr(self, f"{name}_S")
     Vh = getattr(self, f"{name}_Vh")
     orig_shape = torch.Size(getattr(self, f"{name}_orig_shape"))
-    return torch.linalg.multi_dot([U, torch.diag(S), Vh]).view(orig_shape)
+    return ((U * S) @ Vh).view(orig_shape)
 
 
 def insert_svd_modules_(model: nn.Module, optimizer: torch.optim.Optimizer):


### PR DESCRIPTION
### Summary
- `local_map` was discarding the in-place mutation written by the prox step because its implicit redistribute returned a fresh tensor.
- Wrap each prox application in an explicit `redistribute(...)` → in-place prox → `copy_(...)` round-trip, and pass `redistribute_inputs=False` so `local_map` stops re-shuffling the input under us.
- Modernize typing across pat/optim and pat/distributed_utils (typing.{List,Tuple,Dict,Set} -> builtins) and rewrite test_pat_proxmap.py to be DTensor-aware and exercise the redistribute path.
- Speed up the low-rank prox + reconstruction along the same DTensor / `vmap` path.

### Changes
- `torchao/prototype/pat/optim/pruneopt.py`: redistribute/copy-back wrapper around the prox call; flip `redistribute_inputs=False`.
- `torchao/prototype/pat/optim/{proxmap,group_lasso,lasso,nuclear_norm}.py`, `torchao/prototype/pat/{utils,distributed_utils}.py`: modernize typing
  (`typing.{List,Tuple,Dict,Set}` → builtins) — no behavior change.
- `group/low_rank.py`: reject DTensor inputs to `SVDGrouper`; add `deterministic` class flag; reconstruct as `(U * S) @ Vh` to skip `diag` / `diag_embed` materialization.
- `utils.py`: parameterize `use_deterministic_algorithms(mode=True)` and short-circuit when the requested mode already matches.
- `test/prototype/pat/test_pat_proxmap.py`: rewritten to be DTensor-aware and exercise the redistribute path.

### Test plan
- `python -m unittest discover -s test/prototype/pat -p 'test_pat_*.py'`