### PR TITLE
[pat] (2/5) Add QKGrouper and refactor AttentionHeadGrouper for vmap

### DIFF
--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -7,6 +7,7 @@
 from .attention import (  # noqa: F401
     AttentionHeadGrouperDim0,
     AttentionHeadGrouperDim1,
+    QKGrouper,
 )
 from .conv import ConvFilterGrouper  # noqa: F401
 from .dim import Dim0Grouper, Dim1Grouper  # noqa: F401

--- a/torchao/prototype/pat/group/attention.py
+++ b/torchao/prototype/pat/group/attention.py
@@ -8,6 +8,35 @@
 from torch import Tensor
 
 from .dim import Dim0Grouper, Dim1Grouper
+from .packed import PackedGrouperMixin
+
+
+class QKGrouper(PackedGrouperMixin, Dim1Grouper):
+    """Grouper applied only to query and key weights. Assumes that query, key,
+    value weights are packed along `qk_pack_dim` dimension.
+
+    Args:
+        p (Tensor): The packed query, key, value weights.
+        qk_pack_dim (int): Dimension along which query and key are packed.
+        qk_reg_index (int, optional): 0 for query, 1 for key. Default: 0.
+    """
+
+    def __init__(
+        self,
+        p: Tensor,
+        qk_pack_dim: int = 0,
+        qk_reg_index: int = 0,
+    ):
+        super().__init__(p, 3, qk_pack_dim)
+
+        if qk_reg_index == 0:  # query
+            start, end = 0, self.embed_dim
+        else:  # key
+            start, end = self.embed_dim, self.embed_dim * 2
+
+        super(PackedGrouperMixin, self).__init__(
+            p[start:end] if qk_pack_dim == 0 else p[:, start:end]
+        )
 
 
 class AttentionHeadGrouperDim0(Dim0Grouper):
@@ -25,12 +54,8 @@ class AttentionHeadGrouperDim0(Dim0Grouper):
         self.head_dim = p.size(0) // num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(self.num_heads, -1)
+        self.p = self.p.view(self.num_heads, -1)
         return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(self.num_heads * self.head_dim, -1)
-        super().__exit__(exc_type, exc_val, exc_tb)
 
 
 class AttentionHeadGrouperDim1(Dim1Grouper):
@@ -43,11 +68,11 @@ class AttentionHeadGrouperDim1(Dim1Grouper):
         self.num_heads = num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(-1, self.num_heads)
+        self.p = self.p.view(-1, self.num_heads)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(-1, self.head_dim, self.num_heads)
-        self.p = self.p.data.transpose(1, 2).contiguous().view(self._orig_p.shape)
-        self._orig_p.data.copy_(self.p.data)
+        data = self.p.view(-1, self.head_dim, self.num_heads)
+        data = data.transpose(1, 2).contiguous().view(self._orig_p.shape)
+        self._orig_p.data.copy_(data)
         super().__exit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
### Summary
- `QKGrouper`: new grouper that prunes only the Q and K slabs of a packed QKV tensor, leaving V untouched.
- `AttentionHeadGrouperDim0`/`Dim1`: stop in-place-mutating `self.p.data` and reassign `self.p` instead, so `torch.vmap` (used by `PruneOptimizer`'s `local_map` path from PR1) can iterate over the grouped view without tripping the in-place check.

### Changes
- `torchao/prototype/pat/group/attention.py`
- `torchao/prototype/pat/group/__init__.py`: re-export `QKGrouper`.

Depends on #4377 
