### PR TITLE
[pat] (3/5) Add KElementGrouper

### DIFF
--- a/test/prototype/pat/test_pat_k_element_grouper.py
+++ b/test/prototype/pat/test_pat_k_element_grouper.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import unittest
+
+import torch
+from torch.testing._internal import common_utils
+
+from torchao.prototype.pat.group import KElementGrouper
+from torchao.prototype.pat.optim import ProxGroupLasso
+
+
+class TestKElementGrouper(common_utils.TestCase):
+    def __init__(self, methodName):
+        super().__init__(methodName)
+        self.reg_lambda = 1.0
+        self.prox_map = ProxGroupLasso(self.reg_lambda)
+
+    @common_utils.parametrize("k", (2, 4))
+    def test_even_divisible(self, k):
+        """Tensor (2, 8) with k dividing 8 evenly."""
+        M, N = 2, 8
+        p = torch.nn.Parameter(torch.randn(M, N))
+        orig_shape = p.shape
+        with KElementGrouper(p, k=k) as grouper:
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * N // k)
+            self.assertEqual(grouper.p.data.shape, (M * N // k, k))
+        # Shape restored after exit
+        self.assertEqual(p.shape, orig_shape)
+
+    @common_utils.parametrize("k", (4,))
+    def test_remainder(self, k):
+        """Tensor (2, 6) with k=4: 6 is not divisible by 4."""
+        M, N = 2, 6
+        p = torch.nn.Parameter(torch.randn(M, N))
+        orig_data = p.data.clone()
+        orig_shape = p.shape
+        n_groups_per_row = math.ceil(N / k)
+        with KElementGrouper(p, k=k) as grouper:
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * n_groups_per_row)
+            self.assertEqual(grouper.p.data.shape, (M * n_groups_per_row, k))
+        # Shape and data restored after exit
+        self.assertEqual(p.shape, orig_shape)
+        torch.testing.assert_close(p.data, orig_data)
+
+    def test_data_preserved_after_context(self):
+        """Verify data values survive the enter/exit round-trip."""
+        p = torch.nn.Parameter(torch.arange(12, dtype=torch.float).reshape(3, 4))
+        orig_data = p.data.clone()
+        with KElementGrouper(p, k=2):
+            pass
+        torch.testing.assert_close(p.data, orig_data)
+
+    def test_data_preserved_remainder(self):
+        """Verify data round-trips correctly with padding."""
+        p = torch.nn.Parameter(torch.arange(15, dtype=torch.float).reshape(3, 5))
+        orig_data = p.data.clone()
+        with KElementGrouper(p, k=4):
+            pass
+        torch.testing.assert_close(p.data, orig_data)
+
+    @common_utils.parametrize(
+        "shape,k",
+        [
+            ((2, 5, 7), 5),  # 3D: (out, ...) -> 35 cols
+            ((4, 3, 3, 3), 9),  # 4D conv-like: (out, in, H, W) -> 27 cols
+            ((3, 2, 2, 2, 2), 4),  # 5D: (out, ...) -> 16 cols
+        ],
+    )
+    def test_nd_tensor(self, shape, k):
+        """Higher-dim tensors are flattened via DimGrouperMixin before chunking."""
+        p = torch.nn.Parameter(torch.randn(*shape))
+        orig_shape = p.shape
+        with KElementGrouper(p, k=k) as grouper:
+            M = shape[0]  # dim 0 preserved
+            N = math.prod(shape[1:])  # remaining dims flattened
+            n_groups_per_row = math.ceil(N / k)
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * n_groups_per_row)
+        self.assertEqual(p.shape, orig_shape)
+
+    @common_utils.parametrize(
+        "M,N,k",
+        [(2, 8, 4), (3, 6, 2), (1, 12, 3)],
+    )
+    @torch.no_grad()
+    def test_vmap_prox(self, M, N, k):
+        """ProxGroupLasso via vmap zeroes out small-norm groups."""
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=k) as grouper:
+            # Compute the minimum gamma that prunes all groups, plus a small margin
+            max_group_norm = grouper.p.data.norm(dim=-1).max()
+            gamma = torch.tensor(
+                max_group_norm.item() / (self.reg_lambda * math.sqrt(k)) * 1.01
+            )
+            torch.vmap(
+                self.prox_map.apply_,
+                in_dims=(grouper.in_dims, None),
+                out_dims=0,
+            )(grouper.p, gamma)
+        # With a large enough gamma, all groups should be pruned to zero
+        self.assertTrue(torch.all(p.data == 0))
+
+    def test_k_equals_one(self):
+        """k=1 should behave like element-wise grouping."""
+        M, N = 3, 5
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=1) as grouper:
+            self.assertEqual(grouper.group_size(), 1)
+            self.assertEqual(grouper.n_groups(), M * N)
+
+    def test_k_equals_n(self):
+        """k=N means each row is one group."""
+        M, N = 3, 6
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=N) as grouper:
+            self.assertEqual(grouper.group_size(), N)
+            self.assertEqual(grouper.n_groups(), M)
+
+    def test_k_must_be_positive(self):
+        p = torch.nn.Parameter(torch.randn(2, 4))
+        with self.assertRaises(AssertionError):
+            KElementGrouper(p, k=0)
+
+
+common_utils.instantiate_parametrized_tests(TestKElementGrouper)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()

--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -16,4 +16,5 @@ from .grouper import (  # noqa: F401
     Grouper,
     LayerGrouper,
 )
+from .k_element import KElementGrouper  # noqa: F401
 from .low_rank import PackedSVDGrouper, SVDGrouper  # noqa: F401

--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -7,6 +7,7 @@
 from .attention import (  # noqa: F401
     AttentionHeadGrouperDim0,
     AttentionHeadGrouperDim1,
+    QKGrouper,
 )
 from .conv import ConvFilterGrouper  # noqa: F401
 from .dim import Dim0Grouper, Dim1Grouper  # noqa: F401

--- a/torchao/prototype/pat/group/attention.py
+++ b/torchao/prototype/pat/group/attention.py
@@ -8,6 +8,35 @@
 from torch import Tensor
 
 from .dim import Dim0Grouper, Dim1Grouper
+from .packed import PackedGrouperMixin
+
+
+class QKGrouper(PackedGrouperMixin, Dim1Grouper):
+    """Grouper applied only to query and key weights. Assumes that query, key,
+    value weights are packed along `qk_pack_dim` dimension.
+
+    Args:
+        p (Tensor): The packed query, key, value weights.
+        qk_pack_dim (int): Dimension along which query and key are packed.
+        qk_reg_index (int, optional): 0 for query, 1 for key. Default: 0.
+    """
+
+    def __init__(
+        self,
+        p: Tensor,
+        qk_pack_dim: int = 0,
+        qk_reg_index: int = 0,
+    ):
+        super().__init__(p, 3, qk_pack_dim)
+
+        if qk_reg_index == 0:  # query
+            start, end = 0, self.embed_dim
+        else:  # key
+            start, end = self.embed_dim, self.embed_dim * 2
+
+        super(PackedGrouperMixin, self).__init__(
+            p[start:end] if qk_pack_dim == 0 else p[:, start:end]
+        )
 
 
 class AttentionHeadGrouperDim0(Dim0Grouper):
@@ -25,12 +54,8 @@ class AttentionHeadGrouperDim0(Dim0Grouper):
         self.head_dim = p.size(0) // num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(self.num_heads, -1)
+        self.p = self.p.view(self.num_heads, -1)
         return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(self.num_heads * self.head_dim, -1)
-        super().__exit__(exc_type, exc_val, exc_tb)
 
 
 class AttentionHeadGrouperDim1(Dim1Grouper):
@@ -43,11 +68,11 @@ class AttentionHeadGrouperDim1(Dim1Grouper):
         self.num_heads = num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(-1, self.num_heads)
+        self.p = self.p.view(-1, self.num_heads)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(-1, self.head_dim, self.num_heads)
-        self.p = self.p.data.transpose(1, 2).contiguous().view(self._orig_p.shape)
-        self._orig_p.data.copy_(self.p.data)
+        data = self.p.view(-1, self.head_dim, self.num_heads)
+        data = data.transpose(1, 2).contiguous().view(self._orig_p.shape)
+        self._orig_p.data.copy_(data)
         super().__exit__(exc_type, exc_val, exc_tb)

--- a/torchao/prototype/pat/group/k_element.py
+++ b/torchao/prototype/pat/group/k_element.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn.functional as F
+from torch import Tensor
+
+from .dim import DimGrouperMixin
+from .grouper import Grouper
+
+
+class KElementGrouper(DimGrouperMixin, Grouper):
+    """Groups each row of a parameter tensor into chunks of k elements.
+
+    For a 2D tensor (M, N), produces ceil(N/k) groups per row,
+    each of size k (last group may be smaller if N % k != 0).
+    """
+
+    def __init__(self, p: Tensor, k: int, start_dim: int = 1, end_dim: int = -1):
+        assert k > 0, "k must be positive"
+        super().__init__(start_dim, end_dim)
+        super(DimGrouperMixin, self).__init__(p, in_dims=0)
+        self.k = k
+
+    def __enter__(self):
+        super().__enter__()
+        M, N = self.p.shape
+        remainder = N % self.k
+        if remainder == 0:
+            self.p = self.p.view(-1, self.k)
+        else:
+            pad_size = self.k - remainder
+            self._pad_size = pad_size
+            self._unpadded_shape = self.p.shape
+            self.p = F.pad(self.p, (0, pad_size)).view(-1, self.k)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if hasattr(self, "_pad_size"):
+            M = self._unpadded_shape[0]
+            N_padded = self._unpadded_shape[1] + self._pad_size
+            unpadded = self.p.reshape(M, N_padded)[:, : self._unpadded_shape[1]]
+            self._param.data.copy_(unpadded.contiguous().view(self.orig_shape))
+            del self._pad_size, self._unpadded_shape
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def group_size(self):
+        return self.k


### PR DESCRIPTION
### Summary
- New `KElementGrouper` that splits each row of a parameter tensor into fixed-size chunks of `k` elements.
- Non-divisible row sizes are zero-padded inside the context and the padding is stripped on exit, so the original tensor shape is preserved for downstream consumers.

### Changes
- `torchao/prototype/pat/group/k_element.py`
- `torchao/prototype/pat/group/__init__.py`: re-export `KElementGrouper`.
- `test/prototype/pat/test_pat_k_element_grouper.py`

Depends on #4378 