### PR TITLE
[pat] (5/5) Add NMSparseConstraint and MinSparsityConstraint

### DIFF
--- a/test/prototype/pat/test_pat_iterative_reweight.py
+++ b/test/prototype/pat/test_pat_iterative_reweight.py
@@ -62,30 +62,13 @@ class TestIterativeReweight(common_utils.TestCase):
         result = reweight(group_norm.clone(), sigma.clone())
         self.assertAlmostEqual(result.item(), 1.0 / eps, places=1)
 
-    def test_should_update_at_end_step(self):
-        """True when step == end_step and on-frequency; False one step later."""
-        rw = IterativeReweight(reweight_freq=2, reweight_end_step=6)
-        self.assertTrue(rw.should_update(6))
-        self.assertFalse(rw.should_update(7))
-
-    def test_should_update_past_end_step(self):
-        """Updates at steps 0..end_step, stops after."""
-        rw = IterativeReweight(reweight_freq=1, reweight_end_step=3)
-        for step in range(4):
-            self.assertTrue(rw.should_update(step), f"step={step}")
-        for step in range(4, 7):
-            self.assertFalse(rw.should_update(step), f"step={step}")
-
-    def test_should_update_step_zero_with_freq_gt_one(self):
-        """Step 0 is always on-frequency (0 % freq == 0)."""
-        rw = IterativeReweight(reweight_freq=3, reweight_end_step=100)
-        self.assertTrue(rw.should_update(0))
-        self.assertFalse(rw.should_update(1))
-        self.assertTrue(rw.should_update(3))
-
 
 class TestApplyProxReweight(common_utils.TestCase):
     """Tests _apply_prox with tau_reweight != 1.0 across branches."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0)
 
     @common_utils.parametrize(
         "grouper_cls,prox_cls,tau_reweight,disable_vmap",
@@ -99,7 +82,6 @@ class TestApplyProxReweight(common_utils.TestCase):
         self, grouper_cls, prox_cls, tau_reweight, disable_vmap
     ):
         """tau_reweight multiplies into the pruning threshold correctly."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 2.0
 
@@ -129,7 +111,6 @@ class TestApplyProxReweight(common_utils.TestCase):
 
     def test_reweight_monotonicity(self):
         """Higher tau_reweight zeros more elements; lower zeros fewer."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 1.0
 
@@ -148,9 +129,16 @@ class TestApplyProxReweight(common_utils.TestCase):
         self.assertGreaterEqual(zeros[5.0], zeros[1.0])
 
 
+common_utils.instantiate_parametrized_tests(TestApplyProxReweight)
+
+
 @unittest.skipUnless(dist.is_available(), "torch.distributed not available")
 class TestApplyProxReweightDTensor(DistributedTestMixin, common_utils.TestCase):
     """DTensor tests for _apply_prox with tau_reweight."""
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0)
 
     @common_utils.parametrize(
         "GrouperCls,placements,prox_cls",
@@ -165,7 +153,6 @@ class TestApplyProxReweightDTensor(DistributedTestMixin, common_utils.TestCase):
         self, GrouperCls, placements, prox_cls
     ):
         """DTensor vs regular tensor equivalence with tau_reweight."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 2.0
         tau_reweight = 2.5
@@ -211,7 +198,6 @@ class TestApplyProxReweightDTensor(DistributedTestMixin, common_utils.TestCase):
         self, GrouperCls, placements, prox_cls
     ):
         """DTensor with gamma_index_slope > 0 and tensor tau_reweight."""
-        torch.manual_seed(42)
         reg_lambda = 0.5
         gamma = 2.0
 
@@ -247,12 +233,18 @@ class TestApplyProxReweightDTensor(DistributedTestMixin, common_utils.TestCase):
         self.assertEqual(p_regular, p_dtensor.full_tensor())
 
 
+common_utils.instantiate_parametrized_tests(TestApplyProxReweightDTensor)
+
+
 class TestPruneOptimizerReweight(common_utils.TestCase):
     """End-to-end tests using PruneOptimizer with reweight_tau_freq > 0."""
 
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(0)
+
     def test_sigma_initialized_at_warmup_end(self):
         """After warmup, state['sigma'] exists for regularized params."""
-        torch.manual_seed(42)
         model = TwoLayerMLP(input_size=10, output_size=2)
         prune_config = model._linear_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
@@ -279,7 +271,6 @@ class TestPruneOptimizerReweight(common_utils.TestCase):
 
     def test_tau_reweight_updated_at_freq(self):
         """state['tau_reweight'] is updated every reweight_tau_freq steps."""
-        torch.manual_seed(42)
         model = TwoLayerMLP(input_size=10, output_size=2)
         prune_config = model._linear_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
@@ -304,7 +295,6 @@ class TestPruneOptimizerReweight(common_utils.TestCase):
 
     def test_no_reweight_when_freq_zero(self):
         """With reweight_tau_freq=0, no sigma/tau_reweight in state."""
-        torch.manual_seed(42)
         model = TwoLayerMLP(input_size=10, output_size=2)
         prune_config = model._linear_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
@@ -325,45 +315,8 @@ class TestPruneOptimizerReweight(common_utils.TestCase):
                 self.assertNotIn("sigma", optimizer.state[p])
                 self.assertNotIn("tau_reweight", optimizer.state[p])
 
-    def test_tau_reweight_frozen_after_end_step(self):
-        """tau_reweight stops updating after reweight_tau_end_step."""
-        torch.manual_seed(42)
-        model = TwoLayerMLP(input_size=10, output_size=2)
-        prune_config = model._linear_prune_config()
-        param_groups = get_param_groups(model, prune_config, verbose=False)
-        end_step = 5
-        optimizer = PruneOptimizer(
-            torch.optim.SGD(param_groups, lr=0.1),
-            reg_lambda=1.0,
-            warmup_steps=0,
-            reweight_tau_freq=1,
-            reweight_tau_end_step=end_step,
-        )
-
-        dummy_input = torch.randn(20, 10)
-        label = torch.randint(0, 2, (20,))
-        for step in range(10):
-            optim_step(model, optimizer, dummy_input, label, step)
-
-        # Capture tau_reweight after it should have frozen
-        frozen = {
-            id(p): optimizer.state[p]["tau_reweight"].clone()
-            for group in optimizer.regularized_param_groups()
-            for p in group["params"]
-            if "tau_reweight" in optimizer.state[p]
-        }
-        self.assertTrue(len(frozen) > 0, "tau_reweight should exist")
-
-        for step in range(10, 15):
-            optim_step(model, optimizer, dummy_input, label, step)
-
-        for group in optimizer.regularized_param_groups():
-            for p in group["params"]:
-                self.assertEqual(optimizer.state[p]["tau_reweight"], frozen[id(p)])
-
     def test_reweight_with_group_lasso(self):
         """End-to-end with Dim0Grouper + ProxGroupLasso (hits vmap branch)."""
-        torch.manual_seed(42)
         model = TwoLayerMLP(input_size=10, output_size=2)
         prune_config = model._group_lasso_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
@@ -387,9 +340,6 @@ class TestPruneOptimizerReweight(common_utils.TestCase):
                 n_groups = p.size(0)  # Dim0Grouper groups along dim 0
                 self.assertEqual(state["tau_reweight"].numel(), n_groups)
 
-
-common_utils.instantiate_parametrized_tests(TestApplyProxReweight)
-common_utils.instantiate_parametrized_tests(TestApplyProxReweightDTensor)
 
 if __name__ == "__main__":
     random.seed(0)

--- a/test/prototype/pat/test_pat_k_element_grouper.py
+++ b/test/prototype/pat/test_pat_k_element_grouper.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import unittest
+
+import torch
+from torch.testing._internal import common_utils
+
+from torchao.prototype.pat.group import KElementGrouper
+from torchao.prototype.pat.optim import ProxGroupLasso
+
+
+class TestKElementGrouper(common_utils.TestCase):
+    def __init__(self, methodName):
+        super().__init__(methodName)
+        self.reg_lambda = 1.0
+        self.prox_map = ProxGroupLasso(self.reg_lambda)
+
+    @common_utils.parametrize("k", (2, 4))
+    def test_even_divisible(self, k):
+        """Tensor (2, 8) with k dividing 8 evenly."""
+        M, N = 2, 8
+        p = torch.nn.Parameter(torch.randn(M, N))
+        orig_shape = p.shape
+        with KElementGrouper(p, k=k) as grouper:
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * N // k)
+            self.assertEqual(grouper.p.data.shape, (M * N // k, k))
+        # Shape restored after exit
+        self.assertEqual(p.shape, orig_shape)
+
+    @common_utils.parametrize("k", (4,))
+    def test_remainder(self, k):
+        """Tensor (2, 6) with k=4: 6 is not divisible by 4."""
+        M, N = 2, 6
+        p = torch.nn.Parameter(torch.randn(M, N))
+        orig_data = p.data.clone()
+        orig_shape = p.shape
+        n_groups_per_row = math.ceil(N / k)
+        with KElementGrouper(p, k=k) as grouper:
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * n_groups_per_row)
+            self.assertEqual(grouper.p.data.shape, (M * n_groups_per_row, k))
+        # Shape and data restored after exit
+        self.assertEqual(p.shape, orig_shape)
+        torch.testing.assert_close(p.data, orig_data)
+
+    def test_data_preserved_after_context(self):
+        """Verify data values survive the enter/exit round-trip."""
+        p = torch.nn.Parameter(torch.arange(12, dtype=torch.float).reshape(3, 4))
+        orig_data = p.data.clone()
+        with KElementGrouper(p, k=2):
+            pass
+        torch.testing.assert_close(p.data, orig_data)
+
+    def test_data_preserved_remainder(self):
+        """Verify data round-trips correctly with padding."""
+        p = torch.nn.Parameter(torch.arange(15, dtype=torch.float).reshape(3, 5))
+        orig_data = p.data.clone()
+        with KElementGrouper(p, k=4):
+            pass
+        torch.testing.assert_close(p.data, orig_data)
+
+    @common_utils.parametrize(
+        "shape,k",
+        [
+            ((2, 5, 7), 5),  # 3D: (out, ...) -> 35 cols
+            ((4, 3, 3, 3), 9),  # 4D conv-like: (out, in, H, W) -> 27 cols
+            ((3, 2, 2, 2, 2), 4),  # 5D: (out, ...) -> 16 cols
+        ],
+    )
+    def test_nd_tensor(self, shape, k):
+        """Higher-dim tensors are flattened via DimGrouperMixin before chunking."""
+        p = torch.nn.Parameter(torch.randn(*shape))
+        orig_shape = p.shape
+        with KElementGrouper(p, k=k) as grouper:
+            M = shape[0]  # dim 0 preserved
+            N = math.prod(shape[1:])  # remaining dims flattened
+            n_groups_per_row = math.ceil(N / k)
+            self.assertEqual(grouper.group_size(), k)
+            self.assertEqual(grouper.n_groups(), M * n_groups_per_row)
+        self.assertEqual(p.shape, orig_shape)
+
+    @common_utils.parametrize(
+        "M,N,k",
+        [(2, 8, 4), (3, 6, 2), (1, 12, 3)],
+    )
+    @torch.no_grad()
+    def test_vmap_prox(self, M, N, k):
+        """ProxGroupLasso via vmap zeroes out small-norm groups."""
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=k) as grouper:
+            # Compute the minimum gamma that prunes all groups, plus a small margin
+            max_group_norm = grouper.p.data.norm(dim=-1).max()
+            gamma = torch.tensor(
+                max_group_norm.item() / (self.reg_lambda * math.sqrt(k)) * 1.01
+            )
+            torch.vmap(
+                self.prox_map.apply_,
+                in_dims=(grouper.in_dims, None),
+                out_dims=0,
+            )(grouper.p, gamma)
+        # With a large enough gamma, all groups should be pruned to zero
+        self.assertTrue(torch.all(p.data == 0))
+
+    def test_k_equals_one(self):
+        """k=1 should behave like element-wise grouping."""
+        M, N = 3, 5
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=1) as grouper:
+            self.assertEqual(grouper.group_size(), 1)
+            self.assertEqual(grouper.n_groups(), M * N)
+
+    def test_k_equals_n(self):
+        """k=N means each row is one group."""
+        M, N = 3, 6
+        p = torch.nn.Parameter(torch.randn(M, N))
+        with KElementGrouper(p, k=N) as grouper:
+            self.assertEqual(grouper.group_size(), N)
+            self.assertEqual(grouper.n_groups(), M)
+
+    def test_k_must_be_positive(self):
+        p = torch.nn.Parameter(torch.randn(2, 4))
+        with self.assertRaises(AssertionError):
+            KElementGrouper(p, k=0)
+
+
+common_utils.instantiate_parametrized_tests(TestKElementGrouper)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()

--- a/test/prototype/pat/test_pat_min_sparsity.py
+++ b/test/prototype/pat/test_pat_min_sparsity.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import random
+import unittest
+
+import torch
+import torch.nn.functional as F
+from torch.distributed.tensor import distribute_tensor
+from torch.distributed.tensor.placement_types import Shard
+from torch.testing._internal import common_utils
+
+from test.prototype.pat.test_common import (
+    DistributedTestMixin,
+    TwoLayerMLP,
+    make_prox_kwargs,
+    optim_step,
+)
+from torchao.prototype.pat.group import Dim0Grouper, Dim1Grouper, KElementGrouper
+from torchao.prototype.pat.optim import MinSparsityConstraint, PruneOptimizer
+from torchao.prototype.pat.utils import get_param_groups
+
+
+class TestMinSparsityConstraint(common_utils.TestCase):
+    """Direct unit tests for MinSparsityConstraint.apply_ on a 2-D view."""
+
+    @common_utils.parametrize(
+        "M,min_sparsity",
+        [(4, 0.0), (4, 0.5), (5, 0.6), (4, 1.0)],
+    )
+    def test_ranking_by_l2_norm(self, M, min_sparsity):
+        """Rows with strictly increasing per-row L2 norms; the smallest
+        ceil(min_sparsity * M) rows must be zeroed and survivors intact.
+        Covers boundary values (sp=0 leaves p untouched, sp=1 zeros all)."""
+        N = 4
+        p = torch.zeros(M, N)
+        for i in range(M):
+            p[i] = float(i + 1)
+        original = p.clone()
+        prox = MinSparsityConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        zeros_count, group_norm = prox.apply_(p, gamma=1.0)
+
+        n_killed = math.ceil(min_sparsity * M)
+        self.assertEqual(zeros_count.item(), n_killed * N)
+        for i in range(n_killed):
+            self.assertTrue(p[i].eq(0).all(), f"row {i} should be zero")
+        for i in range(n_killed, M):
+            self.assertTrue(torch.equal(p[i], original[i]), f"row {i} should be intact")
+        if min_sparsity == 1.0:
+            self.assertEqual(group_norm.item(), 0.0)
+
+    def test_assert_2d_view(self):
+        """Non-2-D input raises a clear assertion."""
+        p = torch.randn(4, 5, 3)
+        prox = MinSparsityConstraint(reg_lambda=0.0, min_sparsity=0.5)
+        with self.assertRaises(AssertionError):
+            prox.apply_(p, gamma=1.0)
+
+    @common_utils.parametrize("min_sparsity", [-0.1, 1.1])
+    def test_invalid_min_sparsity(self, min_sparsity):
+        """Out-of-range min_sparsity values are rejected at construction."""
+        with self.assertRaises(AssertionError):
+            MinSparsityConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+
+
+class TestMinSparsityWithGrouper(common_utils.TestCase):
+    """Integration: MinSparsityConstraint + grouper via _apply_prox."""
+
+    @common_utils.parametrize("grouper_cls,axis", [(Dim0Grouper, 0), (Dim1Grouper, 1)])
+    def test_dim_grouper(self, grouper_cls, axis):
+        """Dim{0,1}Grouper kills whole rows/columns. Dim1 exercises the
+        whole_tensor transpose branch in PruneOptimizer._apply_prox."""
+        torch.manual_seed(0)
+        M, N, min_sparsity = 8, 4, 0.5
+        n_total = M if axis == 0 else N
+        p = torch.zeros(M, N)
+        for i in range(n_total):
+            if axis == 0:
+                p[i] = float(i + 1)
+            else:
+                p[:, i] = float(i + 1)
+        original = p.clone()
+
+        prox = MinSparsityConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        grouper = grouper_cls(p)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        zero_elts, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p, **prox_kwargs
+        )
+
+        n_killed = math.ceil(min_sparsity * n_total)
+        view = p if axis == 0 else p.transpose(0, 1)
+        orig_view = original if axis == 0 else original.transpose(0, 1)
+        for i in range(n_killed):
+            self.assertTrue(view[i].eq(0).all(), f"slice {i} should be zero")
+        for i in range(n_killed, n_total):
+            self.assertTrue(
+                torch.equal(view[i], orig_view[i]), f"slice {i} should be intact"
+            )
+        self.assertTrue(zeros_are_summed)
+        group_size = N if axis == 0 else M
+        self.assertEqual(zero_elts, n_killed * group_size)
+
+    def test_with_layer_grouper_global_magnitude(self):
+        """KElementGrouper(k=1) reshapes to (numel, 1) so per-row L2 collapses
+        to per-element |x| -- global magnitude pruning over the whole tensor."""
+        torch.manual_seed(0)
+        M, N, min_sparsity = 4, 5, 0.4
+        p = torch.randn(M, N)
+        original = p.clone()
+        prox = MinSparsityConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+
+        grouper = KElementGrouper(p, k=1)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        zero_elts, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p, **prox_kwargs
+        )
+
+        n_zero = math.ceil(min_sparsity * p.numel())
+        self.assertEqual(p.eq(0).sum().item(), n_zero)
+        self.assertEqual(zero_elts, n_zero)
+        # Survivors are exactly the top |x| from the original tensor.
+        sorted_abs = original.abs().flatten().sort().values
+        threshold = sorted_abs[n_zero - 1].item()
+        survivors = p[p.ne(0)].abs()
+        self.assertTrue((survivors > threshold).all())
+        self.assertTrue(zeros_are_summed)
+
+
+class TestMinSparsityDTensor(DistributedTestMixin, common_utils.TestCase):
+    """Whole-tensor DTensor branch in PruneOptimizer._apply_prox: gather,
+    mutate, scatter. Covers both Dim0Grouper (no transpose) and Dim1Grouper
+    (transpose round-trip)."""
+
+    @common_utils.parametrize("grouper_cls,axis", [(Dim0Grouper, 0), (Dim1Grouper, 1)])
+    def test_dim_grouper_dtensor(self, grouper_cls, axis):
+        torch.manual_seed(0)
+        M, N, min_sparsity = 8, 4, 0.5
+        n_total = M if axis == 0 else N
+
+        p = torch.zeros(M, N)
+        for i in range(n_total):
+            if axis == 0:
+                p[i] = float(i + 1)
+            else:
+                p[:, i] = float(i + 1)
+        original = p.clone()
+
+        p_dt = distribute_tensor(
+            p, device_mesh=self.mesh, placements=[Shard(0)] * self.mesh.ndim
+        )
+        prox = MinSparsityConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        grouper = grouper_cls(p_dt)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        _, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p_dt, **prox_kwargs
+        )
+
+        result = p_dt.full_tensor()
+        n_killed = math.ceil(min_sparsity * n_total)
+        view = result if axis == 0 else result.transpose(0, 1)
+        orig_view = original if axis == 0 else original.transpose(0, 1)
+        for i in range(n_killed):
+            self.assertTrue(view[i].eq(0).all(), f"slice {i} should be zero")
+        for i in range(n_killed, n_total):
+            self.assertTrue(
+                torch.equal(view[i], orig_view[i]), f"slice {i} should be intact"
+            )
+        self.assertTrue(zeros_are_summed)
+
+
+class TestMinSparsityOptimizer(common_utils.TestCase):
+    """End-to-end PruneOptimizer tests against the shipped configs."""
+
+    def test_with_dim0_grouper_e2e(self):
+        torch.manual_seed(42)
+        min_sparsity, total_steps = 0.5, 5
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        prune_config = {
+            (torch.nn.Linear, "weight"): {
+                "group_type": "Dim0Grouper",
+                "prox_type": "MinSparsityConstraint",
+                "min_sparsity": min_sparsity,
+            }
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            reg_lambda=0.0,
+        )
+
+        dummy_input = torch.randn(total_steps, 8)
+        label = torch.randint(0, 2, (total_steps,))
+        for step in range(total_steps):
+            optim_step(model, optimizer, dummy_input, label, step)
+
+        for group in optimizer.regularized_param_groups():
+            for p in group["params"]:
+                flat = p.data.view(p.size(0), -1)
+                M = flat.size(0)
+                expected_killed = math.ceil(min_sparsity * M)
+                row_is_zero = sum(flat[i].eq(0).all().item() for i in range(M))
+                self.assertEqual(
+                    row_is_zero,
+                    expected_killed,
+                    f"Expected {expected_killed} rows zeroed, got {row_is_zero}",
+                )
+
+        self.assertGreaterEqual(optimizer.relative_sparsity, min_sparsity)
+
+    def test_with_conv_filter_grouper(self):
+        """ConvFilterGrouper + MinSparsityConstraint zeroes whole filter slices."""
+        torch.manual_seed(42)
+        min_sparsity, total_steps = 0.5, 3
+
+        class TinyConv(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(4, 6, kernel_size=3)
+
+            def forward(self, x):
+                return self.conv(x).flatten(1)
+
+        model = TinyConv()
+        prune_config = {
+            (torch.nn.Conv2d, "weight"): {
+                "group_type": "ConvFilterGrouper",
+                "prox_type": "MinSparsityConstraint",
+                "min_sparsity": min_sparsity,
+            }
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            reg_lambda=0.0,
+        )
+
+        for step in range(total_steps):
+            x = torch.randn(1, 4, 5, 5)
+            output = model(x)
+            label = torch.randint(0, output.size(1), (1,))
+            loss = F.cross_entropy(output, label)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        w = model.conv.weight.data  # (C_out, C_in, kH, kW)
+        c_out, c_in, kH, kW = w.shape
+        flat = w.view(c_out * c_in, kH * kW)
+        n_slices = c_out * c_in
+        expected_killed = math.ceil(min_sparsity * n_slices)
+        slice_is_zero = sum(flat[i].eq(0).all().item() for i in range(n_slices))
+        self.assertEqual(slice_is_zero, expected_killed)
+
+
+common_utils.instantiate_parametrized_tests(TestMinSparsityConstraint)
+common_utils.instantiate_parametrized_tests(TestMinSparsityWithGrouper)
+common_utils.instantiate_parametrized_tests(TestMinSparsityDTensor)
+common_utils.instantiate_parametrized_tests(TestMinSparsityOptimizer)
+
+
+if __name__ == "__main__":
+    random.seed(0)
+    torch.manual_seed(0)
+    unittest.main()

--- a/test/prototype/pat/test_pat_min_sparsity.py
+++ b/test/prototype/pat/test_pat_min_sparsity.py
@@ -317,19 +317,19 @@ class TestMinSparsitySchedule(common_utils.TestCase):
         then load_state_dict() + patch_state_dict() into a fresh opt_b and
         verify the schedule state survives the checkpoint round-trip."""
         warmup, healing, target = 2, 10, 0.6
-        model, opt_a = self._make_optimizer(True, warmup, healing, target)
+        model_a, opt_a = self._make_optimizer(True, warmup, healing, target)
         # 5 real step() calls land us mid-ramp (warmup < n < healing).
         n_steps = 5
-        dummy_input = torch.randn(n_steps, 8)
-        label = torch.randint(0, 2, (n_steps,))
+        dummy_input = torch.randn(n_steps + 3, 8)
+        label = torch.randint(0, 2, (n_steps + 3,))
         for s in range(n_steps):
-            optim_step(model, opt_a, dummy_input, label, s)
+            optim_step(model_a, opt_a, dummy_input, label, s)
         self.assertGreater(opt_a.num_steps, warmup)
         self.assertLess(opt_a.num_steps, healing)
 
         # Snapshot, then load + patch into a fresh optimizer.
         sd = opt_a.state_dict()
-        _, opt_b = self._make_optimizer(True, warmup, healing, target)
+        model_b, opt_b = self._make_optimizer(True, warmup, healing, target)
         opt_b.load_state_dict(sd)
         opt_b.patch_state_dict(sd)
 
@@ -340,6 +340,17 @@ class TestMinSparsitySchedule(common_utils.TestCase):
             opt_a._effective_min_sparsity(g_a),
             opt_b._effective_min_sparsity(g_b),
         )
+
+        # Continue training both. Schedule state must stay in sync, including
+        # across the healing boundary where the ramp clamps to target.
+        for s in range(n_steps, n_steps + 3):
+            optim_step(model_a, opt_a, dummy_input, label, s)
+            optim_step(model_b, opt_b, dummy_input, label, s)
+            self.assertEqual(opt_b.num_steps, opt_a.num_steps)
+            self.assertEqual(
+                opt_a._effective_min_sparsity(g_a),
+                opt_b._effective_min_sparsity(g_b),
+            )
 
 
 common_utils.instantiate_parametrized_tests(TestMinSparsityConstraint)

--- a/test/prototype/pat/test_pat_min_sparsity.py
+++ b/test/prototype/pat/test_pat_min_sparsity.py
@@ -6,6 +6,7 @@
 
 import math
 import random
+import sys
 import unittest
 
 import torch
@@ -257,10 +258,82 @@ class TestMinSparsityOptimizer(common_utils.TestCase):
         self.assertEqual(slice_is_zero, expected_killed)
 
 
+class TestMinSparsitySchedule(common_utils.TestCase):
+    """Cubic min_sparsity ramp from 0 -> target over (warmup, healing_start)."""
+
+    def _make_optimizer(self, schedule, warmup, healing, target=0.8):
+        torch.manual_seed(0)
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        cfg = {
+            (torch.nn.Linear, "weight"): {
+                "group_type": "Dim0Grouper",
+                "prox_type": "MinSparsityConstraint",
+                "min_sparsity": target,
+            }
+        }
+        if schedule:
+            cfg[(torch.nn.Linear, "weight")]["min_sparsity_schedule"] = True
+        param_groups = get_param_groups(model, cfg, verbose=False)
+        return PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            warmup_steps=warmup,
+            healing_start_step=healing,
+            reg_lambda=0.0,
+        )
+
+    def test_disabled_returns_target(self):
+        opt = self._make_optimizer(schedule=False, warmup=2, healing=10, target=0.8)
+        opt.num_steps = 5
+        for g in opt.regularized_param_groups():
+            self.assertEqual(opt._effective_min_sparsity(g), 0.8)
+
+    def test_cubic_endpoints_and_midpoint(self):
+        warmup, healing, target = 4, 12, 0.8
+        opt = self._make_optimizer(True, warmup, healing, target)
+        g = next(opt.regularized_param_groups())
+        # Pre-warmup -> 0
+        opt.num_steps = 0
+        self.assertEqual(opt._effective_min_sparsity(g), 0.0)
+        opt.num_steps = warmup
+        self.assertEqual(opt._effective_min_sparsity(g), 0.0)
+        # Post-healing -> target
+        opt.num_steps = healing
+        self.assertEqual(opt._effective_min_sparsity(g), target)
+        opt.num_steps = healing + 5
+        self.assertEqual(opt._effective_min_sparsity(g), target)
+        # Midpoint t=0.5 -> target * (1 - 0.5^3) = target * 0.875
+        opt.num_steps = warmup + (healing - warmup) // 2
+        self.assertAlmostEqual(
+            opt._effective_min_sparsity(g), target * (1 - 0.5**3), places=6
+        )
+
+    def test_schedule_requires_finite_healing(self):
+        with self.assertRaises(AssertionError):
+            self._make_optimizer(True, warmup=2, healing=sys.maxsize, target=0.5)
+
+    def test_resume_equivalence(self):
+        """Saving + restoring num_steps via patch_state_dict yields the same
+        effective min_sparsity at every step."""
+        warmup, healing, target = 2, 10, 0.6
+        opt_a = self._make_optimizer(True, warmup, healing, target)
+        opt_b = self._make_optimizer(True, warmup, healing, target)
+        g_a = next(opt_a.regularized_param_groups())
+        g_b = next(opt_b.regularized_param_groups())
+        # Drive opt_a forward, snapshot num_steps, restore into opt_b.
+        for n in (0, warmup, warmup + 3, healing, healing + 1):
+            opt_a.num_steps = n
+            opt_b.num_steps = n  # mimic patch_state_dict restoring this scalar
+            self.assertEqual(
+                opt_a._effective_min_sparsity(g_a),
+                opt_b._effective_min_sparsity(g_b),
+            )
+
+
 common_utils.instantiate_parametrized_tests(TestMinSparsityConstraint)
 common_utils.instantiate_parametrized_tests(TestMinSparsityWithGrouper)
 common_utils.instantiate_parametrized_tests(TestMinSparsityDTensor)
 common_utils.instantiate_parametrized_tests(TestMinSparsityOptimizer)
+common_utils.instantiate_parametrized_tests(TestMinSparsitySchedule)
 
 
 if __name__ == "__main__":

--- a/test/prototype/pat/test_pat_min_sparsity.py
+++ b/test/prototype/pat/test_pat_min_sparsity.py
@@ -274,22 +274,23 @@ class TestMinSparsitySchedule(common_utils.TestCase):
         if schedule:
             cfg[(torch.nn.Linear, "weight")]["min_sparsity_schedule"] = True
         param_groups = get_param_groups(model, cfg, verbose=False)
-        return PruneOptimizer(
+        opt = PruneOptimizer(
             torch.optim.SGD(param_groups, lr=0.1),
             warmup_steps=warmup,
             healing_start_step=healing,
             reg_lambda=0.0,
         )
+        return model, opt
 
     def test_disabled_returns_target(self):
-        opt = self._make_optimizer(schedule=False, warmup=2, healing=10, target=0.8)
+        _, opt = self._make_optimizer(schedule=False, warmup=2, healing=10, target=0.8)
         opt.num_steps = 5
         for g in opt.regularized_param_groups():
             self.assertEqual(opt._effective_min_sparsity(g), 0.8)
 
     def test_cubic_endpoints_and_midpoint(self):
         warmup, healing, target = 4, 12, 0.8
-        opt = self._make_optimizer(True, warmup, healing, target)
+        _, opt = self._make_optimizer(True, warmup, healing, target)
         g = next(opt.regularized_param_groups())
         # Pre-warmup -> 0
         opt.num_steps = 0
@@ -311,22 +312,34 @@ class TestMinSparsitySchedule(common_utils.TestCase):
         with self.assertRaises(AssertionError):
             self._make_optimizer(True, warmup=2, healing=sys.maxsize, target=0.5)
 
-    def test_resume_equivalence(self):
-        """Saving + restoring num_steps via patch_state_dict yields the same
-        effective min_sparsity at every step."""
+    def test_resume_via_patch_state_dict(self):
+        """Drive opt_a forward with real step() calls, snapshot via state_dict(),
+        then load_state_dict() + patch_state_dict() into a fresh opt_b and
+        verify the schedule state survives the checkpoint round-trip."""
         warmup, healing, target = 2, 10, 0.6
-        opt_a = self._make_optimizer(True, warmup, healing, target)
-        opt_b = self._make_optimizer(True, warmup, healing, target)
+        model, opt_a = self._make_optimizer(True, warmup, healing, target)
+        # 5 real step() calls land us mid-ramp (warmup < n < healing).
+        n_steps = 5
+        dummy_input = torch.randn(n_steps, 8)
+        label = torch.randint(0, 2, (n_steps,))
+        for s in range(n_steps):
+            optim_step(model, opt_a, dummy_input, label, s)
+        self.assertGreater(opt_a.num_steps, warmup)
+        self.assertLess(opt_a.num_steps, healing)
+
+        # Snapshot, then load + patch into a fresh optimizer.
+        sd = opt_a.state_dict()
+        _, opt_b = self._make_optimizer(True, warmup, healing, target)
+        opt_b.load_state_dict(sd)
+        opt_b.patch_state_dict(sd)
+
+        self.assertEqual(opt_b.num_steps, opt_a.num_steps)
         g_a = next(opt_a.regularized_param_groups())
         g_b = next(opt_b.regularized_param_groups())
-        # Drive opt_a forward, snapshot num_steps, restore into opt_b.
-        for n in (0, warmup, warmup + 3, healing, healing + 1):
-            opt_a.num_steps = n
-            opt_b.num_steps = n  # mimic patch_state_dict restoring this scalar
-            self.assertEqual(
-                opt_a._effective_min_sparsity(g_a),
-                opt_b._effective_min_sparsity(g_b),
-            )
+        self.assertEqual(
+            opt_a._effective_min_sparsity(g_a),
+            opt_b._effective_min_sparsity(g_b),
+        )
 
 
 common_utils.instantiate_parametrized_tests(TestMinSparsityConstraint)

--- a/test/prototype/pat/test_pat_nm_sparse.py
+++ b/test/prototype/pat/test_pat_nm_sparse.py
@@ -1,0 +1,238 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import distribute_tensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.testing._internal import common_utils
+
+from test.prototype.pat.test_common import (
+    DistributedTestMixin,
+    TwoLayerMLP,
+    make_prox_kwargs,
+    optim_step,
+)
+from torchao.prototype.pat.group import KElementGrouper
+from torchao.prototype.pat.optim import NMSparseConstraint, PruneOptimizer
+from torchao.prototype.pat.utils import get_param_groups
+
+
+class TestNMSparseConstraint(common_utils.TestCase):
+    """Direct unit tests for NMSparseConstraint.apply_."""
+
+    def test_keeps_n_nonzero_largest(self):
+        """Exactly n_nonzero largest-magnitude elements survive."""
+        p = torch.tensor([1.0, -3.0, 2.0, -0.5])
+        n_nonzero = 2
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=n_nonzero)
+        zeros_count, group_norm = prox.apply_(p, gamma=1.0)
+
+        self.assertEqual(p.ne(0).sum().item(), n_nonzero)
+        self.assertEqual(zeros_count.item(), p.numel() - n_nonzero)
+        self.assertEqual(p.ne(0).tolist(), [False, True, True, False])
+
+    def test_n_nonzero_equals_zero(self):
+        """Keep nothing: all elements are zeroed."""
+        p = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=0)
+        zeros_count, group_norm = prox.apply_(p, gamma=1.0)
+
+        self.assertEqual(zeros_count.item(), 4)
+        self.assertTrue(p.eq(0).all())
+        self.assertEqual(group_norm.item(), 0.0)
+
+    def test_group_norm_is_scalar(self):
+        """group_norm must be a 0-dim tensor (scalar)."""
+        p = torch.tensor([1.0, -3.0, 2.0, -0.5])
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=2)
+        _, group_norm = prox.apply_(p, gamma=1.0)
+        self.assertEqual(group_norm.dim(), 0)
+
+
+class TestNMSparseWithKElementGrouper(common_utils.TestCase):
+    """Integration tests: NMSparseConstraint + KElementGrouper via _apply_prox."""
+
+    @staticmethod
+    def assert_nm_pattern(p, k, n_nonzero, exact=True):
+        """Each consecutive block of k elements has (== or <=) n_nonzero non-zeros."""
+        M, N = p.shape
+        for i in range(M):
+            for start in range(0, N, k):
+                block = p[i, start : start + k]
+                count = block.ne(0).sum().item()
+                if exact:
+                    assert count == n_nonzero, (
+                        f"Block ({i},{start}:{start + k}) has {count}, want {n_nonzero}"
+                    )
+                else:
+                    assert count <= n_nonzero, (
+                        f"Block ({i},{start}:{start + k}) has {count} > {n_nonzero}"
+                    )
+
+    @common_utils.parametrize(
+        "n_nonzero,k",
+        [(2, 4), (1, 4), (3, 4)],
+    )
+    def test_nm_sparsity(self, n_nonzero, k):
+        """Each block of k elements has exactly n_nonzero non-zeros."""
+        torch.manual_seed(42)
+        M, N = 4, 8
+        p = torch.randn(M, N)
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=n_nonzero)
+
+        grouper = KElementGrouper(p, k=k)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        zero_elts, group_norm, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p, **prox_kwargs
+        )
+
+        self.assert_nm_pattern(p, k, n_nonzero, exact=True)
+        n_groups = M * N // k
+        self.assertEqual(zero_elts, (k - n_nonzero) * n_groups)
+
+    def test_k_equals_one_elementwise(self):
+        """k=1 makes each element its own group; n_nonzero=0 zeroes everything."""
+        torch.manual_seed(42)
+        M, N = 3, 5
+        p = torch.randn(M, N)
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=0)
+
+        grouper = KElementGrouper(p, k=1)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        zero_elts, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p, **prox_kwargs
+        )
+
+        self.assertTrue(p.eq(0).all())
+        self.assertEqual(zero_elts, M * N)
+        self.assertTrue(zeros_are_summed)
+
+    def test_nm_sparsity_with_padding(self):
+        """N:M pattern holds when N is not divisible by k (padding needed)."""
+        torch.manual_seed(42)
+        M, N, k, n_nonzero = 2, 6, 4, 2
+        p = torch.randn(M, N)
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=n_nonzero)
+
+        grouper = KElementGrouper(p, k=k)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        _, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper, prox, p, **prox_kwargs
+        )
+
+        # Padded blocks may have <= n_nonzero (partial last block).
+        self.assert_nm_pattern(p, k, n_nonzero, exact=False)
+        self.assertTrue(zeros_are_summed)
+
+    def test_group_norm_is_scalar_per_group(self):
+        """group_norm shape should be (n_groups,), not (n_groups, k)."""
+        torch.manual_seed(42)
+        M, N, k, n_nonzero = 4, 8, 4, 2
+        p = torch.randn(M, N)
+        prox = NMSparseConstraint(reg_lambda=0.0, n_nonzero=n_nonzero)
+
+        grouper = KElementGrouper(p, k=k)
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+        _, group_norm, _ = PruneOptimizer._apply_prox(grouper, prox, p, **prox_kwargs)
+
+        n_groups = M * N // k
+        self.assertEqual(group_norm.shape, (n_groups,))
+
+
+@unittest.skipUnless(dist.is_available(), "torch.distributed not available")
+class TestNMSparseDTensor(DistributedTestMixin, common_utils.TestCase):
+    """DTensor tests for NMSparseConstraint + KElementGrouper."""
+
+    def test_dtensor_matches_regular(self):
+        """DTensor path produces same results as regular tensor path."""
+        torch.manual_seed(42)
+        M, N, k, n_nonzero = 4, 8, 4, 2
+        reg_lambda = 0.0
+
+        p_regular = torch.randn(M, N)
+        p_dtensor = distribute_tensor(
+            p_regular.clone(),
+            device_mesh=self.mesh,
+            placements=(Shard(0), Replicate()),
+        )
+
+        prox_kwargs = make_prox_kwargs(gamma=1.0, zero_elts_are_counts=True)
+
+        # Regular path
+        grouper_reg = KElementGrouper(p_regular, k=k)
+        z_reg, gn_reg, _ = PruneOptimizer._apply_prox(
+            grouper_reg,
+            NMSparseConstraint(reg_lambda, n_nonzero=n_nonzero),
+            p_regular,
+            **prox_kwargs,
+        )
+
+        # DTensor path
+        grouper_dt = KElementGrouper(p_dtensor, k=k)
+        z_dt, gn_dt, _ = PruneOptimizer._apply_prox(
+            grouper_dt,
+            NMSparseConstraint(reg_lambda, n_nonzero=n_nonzero),
+            p_dtensor,
+            **prox_kwargs,
+        )
+
+        self.assertEqual(z_reg, z_dt)
+        self.assertEqual(p_regular, p_dtensor.full_tensor())
+
+
+class TestNMSparseOptimizer(common_utils.TestCase):
+    """End-to-end test: PruneOptimizer with KElementGrouper + NMSparseConstraint."""
+
+    def test_nm_sparsity_e2e(self):
+        """After pruning steps, weights exhibit N:M sparsity pattern."""
+        torch.manual_seed(42)
+        k, n_nonzero, total_steps = 4, 2, 5
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        prune_config = {
+            (torch.nn.Linear, "weight"): {
+                "group_type": "KElementGrouper",
+                "prox_type": "NMSparseConstraint",
+                "k": k,
+                "n_nonzero": n_nonzero,
+            }
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            reg_lambda=0.0,
+        )
+
+        dummy_input = torch.randn(total_steps, 8)
+        label = torch.randint(0, 2, (total_steps,))
+        for step in range(total_steps):
+            optim_step(model, optimizer, dummy_input, label, step)
+
+        for group in optimizer.regularized_param_groups():
+            for p in group["params"]:
+                flat = p.data.view(p.size(0), -1)
+                # Training may not yet hit the full N:M pattern; allow <=.
+                TestNMSparseWithKElementGrouper.assert_nm_pattern(
+                    flat, k, n_nonzero, exact=False
+                )
+
+        self.assertGreater(optimizer.relative_sparsity, 0)
+        self.assertLessEqual(optimizer.relative_sparsity, 1.0)
+
+
+common_utils.instantiate_parametrized_tests(TestNMSparseConstraint)
+common_utils.instantiate_parametrized_tests(TestNMSparseWithKElementGrouper)
+common_utils.instantiate_parametrized_tests(TestNMSparseDTensor)
+common_utils.instantiate_parametrized_tests(TestNMSparseOptimizer)
+
+
+if __name__ == "__main__":
+    random.seed(0)
+    torch.manual_seed(0)
+    unittest.main()

--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -16,4 +16,5 @@ from .grouper import (  # noqa: F401
     Grouper,
     LayerGrouper,
 )
+from .k_element import KElementGrouper  # noqa: F401
 from .low_rank import PackedSVDGrouper, SVDGrouper  # noqa: F401

--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -7,6 +7,7 @@
 from .attention import (  # noqa: F401
     AttentionHeadGrouperDim0,
     AttentionHeadGrouperDim1,
+    QKGrouper,
 )
 from .conv import ConvFilterGrouper  # noqa: F401
 from .dim import Dim0Grouper, Dim1Grouper  # noqa: F401

--- a/torchao/prototype/pat/group/attention.py
+++ b/torchao/prototype/pat/group/attention.py
@@ -8,6 +8,35 @@
 from torch import Tensor
 
 from .dim import Dim0Grouper, Dim1Grouper
+from .packed import PackedGrouperMixin
+
+
+class QKGrouper(PackedGrouperMixin, Dim1Grouper):
+    """Grouper applied only to query and key weights. Assumes that query, key,
+    value weights are packed along `qk_pack_dim` dimension.
+
+    Args:
+        p (Tensor): The packed query, key, value weights.
+        qk_pack_dim (int): Dimension along which query and key are packed.
+        qk_reg_index (int, optional): 0 for query, 1 for key. Default: 0.
+    """
+
+    def __init__(
+        self,
+        p: Tensor,
+        qk_pack_dim: int = 0,
+        qk_reg_index: int = 0,
+    ):
+        super().__init__(p, 3, qk_pack_dim)
+
+        if qk_reg_index == 0:  # query
+            start, end = 0, self.embed_dim
+        else:  # key
+            start, end = self.embed_dim, self.embed_dim * 2
+
+        super(PackedGrouperMixin, self).__init__(
+            p[start:end] if qk_pack_dim == 0 else p[:, start:end]
+        )
 
 
 class AttentionHeadGrouperDim0(Dim0Grouper):
@@ -25,12 +54,8 @@ class AttentionHeadGrouperDim0(Dim0Grouper):
         self.head_dim = p.size(0) // num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(self.num_heads, -1)
+        self.p = self.p.view(self.num_heads, -1)
         return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(self.num_heads * self.head_dim, -1)
-        super().__exit__(exc_type, exc_val, exc_tb)
 
 
 class AttentionHeadGrouperDim1(Dim1Grouper):
@@ -43,11 +68,11 @@ class AttentionHeadGrouperDim1(Dim1Grouper):
         self.num_heads = num_heads
 
     def __enter__(self):
-        self.p.data = self.p.data.view(-1, self.num_heads)
+        self.p = self.p.view(-1, self.num_heads)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.p.data = self.p.data.view(-1, self.head_dim, self.num_heads)
-        self.p = self.p.data.transpose(1, 2).contiguous().view(self._orig_p.shape)
-        self._orig_p.data.copy_(self.p.data)
+        data = self.p.view(-1, self.head_dim, self.num_heads)
+        data = data.transpose(1, 2).contiguous().view(self._orig_p.shape)
+        self._orig_p.data.copy_(data)
         super().__exit__(exc_type, exc_val, exc_tb)

--- a/torchao/prototype/pat/group/k_element.py
+++ b/torchao/prototype/pat/group/k_element.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn.functional as F
+from torch import Tensor
+
+from .dim import DimGrouperMixin
+from .grouper import Grouper
+
+
+class KElementGrouper(DimGrouperMixin, Grouper):
+    """Groups each row of a parameter tensor into chunks of k elements.
+
+    For a 2D tensor (M, N), produces ceil(N/k) groups per row,
+    each of size k (last group may be smaller if N % k != 0).
+    """
+
+    def __init__(self, p: Tensor, k: int, start_dim: int = 1, end_dim: int = -1):
+        assert k > 0, "k must be positive"
+        super().__init__(start_dim, end_dim)
+        super(DimGrouperMixin, self).__init__(p, in_dims=0)
+        self.k = k
+
+    def __enter__(self):
+        super().__enter__()
+        M, N = self.p.shape
+        remainder = N % self.k
+        if remainder == 0:
+            self.p = self.p.view(-1, self.k)
+        else:
+            pad_size = self.k - remainder
+            self._pad_size = pad_size
+            self._unpadded_shape = self.p.shape
+            self.p = F.pad(self.p, (0, pad_size)).view(-1, self.k)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if hasattr(self, "_pad_size"):
+            M = self._unpadded_shape[0]
+            N_padded = self._unpadded_shape[1] + self._pad_size
+            unpadded = self.p.reshape(M, N_padded)[:, : self._unpadded_shape[1]]
+            self._param.data.copy_(unpadded.contiguous().view(self.orig_shape))
+            del self._pad_size, self._unpadded_shape
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def group_size(self):
+        return self.k

--- a/torchao/prototype/pat/optim/__init__.py
+++ b/torchao/prototype/pat/optim/__init__.py
@@ -10,6 +10,7 @@ from torch.optim import Optimizer
 
 from .group_lasso import ProxGroupLasso, ProxGroupLassoVectorized  # noqa: F401
 from .lasso import ProxLasso  # noqa: F401
+from .min_sparsity import MinSparsityConstraint, NMSparseConstraint  # noqa: F401
 from .nuclear_norm import ProxNuclearNorm  # noqa: F401
 from .proxmap import ProxMap  # noqa: F401
 from .pruneopt import PruneOptimizer

--- a/torchao/prototype/pat/optim/min_sparsity.py
+++ b/torchao/prototype/pat/optim/min_sparsity.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from typing import Union
+
+import torch
+from torch import Tensor
+
+from .proxmap import ProxMap
+
+
+class _TopKZeroMixin:
+    """Zero the ``n_zero`` leading-dim slices of ``p`` with smallest scores."""
+
+    @staticmethod
+    def _topk_zero_(p: Tensor, scores: Tensor, n_zero: int) -> tuple[Tensor, Tensor]:
+        """Returns ``(zeros_count, group_norm)``; ``zeros_count`` is in
+        elements of ``p``, not slices."""
+        total = scores.numel()
+        if n_zero <= 0:
+            zeros = 0
+        elif n_zero >= total:
+            p.zero_()
+            zeros = p.numel()
+        else:
+            _, idx = torch.topk(scores, k=n_zero, largest=False, sorted=False)
+            p[idx] = 0.0
+            zeros = n_zero * (p.numel() // total)
+        zeros_count = torch.tensor(zeros, device=p.device, dtype=torch.long)
+        group_norm = torch.linalg.vector_norm(p)
+        return zeros_count, group_norm
+
+
+class MinSparsityConstraint(ProxMap, _TopKZeroMixin):
+    """Drops the smallest-L2-norm ``ceil(min_sparsity * n_groups)`` whole
+    groups of a 2-D ``(n_groups, group_size)`` view. ``whole_tensor = True``
+    routes the optimizer around ``torch.vmap`` so the prox sees all groups
+    at once. ``reg_lambda``, ``gamma``, and ``tau_reweight`` are ignored.
+
+    Pair with ``Dim0Grouper`` / ``Dim1Grouper`` / ``ConvFilterGrouper`` for
+    row/column/filter pruning, or with ``KElementGrouper(k=1)`` for global
+    magnitude pruning of every element of the tensor (each element becomes
+    its own group, so per-row L2 collapses to per-element ``|x|``).
+    """
+
+    whole_tensor = True
+
+    def __init__(self, reg_lambda: float, min_sparsity: float) -> None:
+        super().__init__(reg_lambda)
+        assert 0.0 <= min_sparsity <= 1.0, (
+            f"min_sparsity must be in [0, 1], but got {min_sparsity}"
+        )
+        self.min_sparsity = min_sparsity
+
+    def _get_norm(self, p: Tensor) -> Tensor:
+        return torch.linalg.vector_norm(p, dim=1)
+
+    def tau(self, p: Tensor) -> float:
+        return 1.0
+
+    def apply_(
+        self,
+        p: Tensor,
+        gamma: Union[Tensor, float],
+        tau_reweight: Union[Tensor, float] = 1.0,
+    ) -> tuple[Tensor, Tensor]:
+        assert p.dim() == 2, (
+            f"MinSparsityConstraint expects a 2-D (n_groups, group_size) view, "
+            f"got shape {tuple(p.shape)}."
+        )
+        n_groups = p.size(0)
+        n_zero = math.ceil(self.min_sparsity * n_groups)
+        scores = self._get_norm(p)
+        return self._topk_zero_(p, scores, n_zero)
+
+
+class NMSparseConstraint(ProxMap, _TopKZeroMixin):
+    """Keeps at most ``n_nonzero`` largest-magnitude elements per group.
+    Vmapped per group, so ``apply_`` receives one 1-D group at a time.
+    ``reg_lambda`` is ignored.
+    """
+
+    def __init__(self, reg_lambda: float, n_nonzero: int) -> None:
+        super().__init__(reg_lambda)
+        assert n_nonzero >= 0, f"n_nonzero must be non-negative, but got {n_nonzero}"
+        self.n_nonzero = n_nonzero
+
+    def _get_norm(self, p: Tensor) -> Tensor:
+        return p.abs()
+
+    def tau(self, p: Tensor) -> float:
+        return 1.0
+
+    def apply_(
+        self,
+        p: Tensor,
+        gamma: Union[Tensor, float],
+        tau_reweight: Union[Tensor, float] = 1.0,
+    ) -> tuple[Tensor, Tensor]:
+        assert self.n_nonzero <= p.numel(), (
+            f"n_nonzero ({self.n_nonzero}) must be at most group_size ({p.numel()})"
+        )
+        n_zero = p.numel() - self.n_nonzero
+        scores = self._get_norm(p)
+        return self._topk_zero_(p, scores, n_zero)

--- a/torchao/prototype/pat/optim/proxmap.py
+++ b/torchao/prototype/pat/optim/proxmap.py
@@ -13,6 +13,8 @@ from torch import Tensor
 class ProxMap(ABC):
     """Abstract base class that defines the proximal mapping interface"""
 
+    whole_tensor: bool = False
+
     def __init__(self, reg_lambda: float) -> None:
         self.reg_lambda = reg_lambda
 

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -182,11 +182,8 @@ class PruneOptimizer(Optimizer):
         n = self.num_steps
         if n <= self.warmup_steps:
             return 0.0
-        # NOTE: During normal training this branch is unreachable: step() takes
-        # the healing early-return at n == healing_start_step before the prox
-        # map runs, so _effective_min_sparsity is only invoked for
-        # warmup_steps < n < healing_start_step. Kept as a correct guard for
-        # direct callers (tests, introspection) reasoning about the boundary.
+        # Unreachable in training (step() short-circuits at healing_start_step);
+        # kept as a boundary guard for direct callers.
         if n >= self.healing_start_step:
             return target
         t = (n - self.warmup_steps) / (self.healing_start_step - self.warmup_steps)

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -182,6 +182,11 @@ class PruneOptimizer(Optimizer):
         n = self.num_steps
         if n <= self.warmup_steps:
             return 0.0
+        # NOTE: During normal training this branch is unreachable: step() takes
+        # the healing early-return at n == healing_start_step before the prox
+        # map runs, so _effective_min_sparsity is only invoked for
+        # warmup_steps < n < healing_start_step. Kept as a correct guard for
+        # direct callers (tests, introspection) reasoning about the boundary.
         if n >= self.healing_start_step:
             return target
         t = (n - self.warmup_steps) / (self.healing_start_step - self.warmup_steps)

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -73,6 +73,11 @@ class PruneOptimizer(Optimizer):
         for group in self.regularized_param_groups():
             group.setdefault("gamma", 0.0)
             group.setdefault("reg_lambda", reg_lambda)
+            if group.get("min_sparsity_schedule", False):
+                assert self.healing_start_step != sys.maxsize, (
+                    "min_sparsity_schedule requires a finite healing_start_step; "
+                    "the ramp ends when the mask freezes."
+                )
 
         self.iterative_reweight = (
             IterativeReweight(reweight_tau_freq, reweight_tau_end_step, reweight_eps)
@@ -150,8 +155,7 @@ class PruneOptimizer(Optimizer):
             if group.get("prox_type"):
                 yield group
 
-    @staticmethod
-    def _get_prox_kwargs(group: dict[str, Any]) -> dict[str, Any]:
+    def _get_prox_kwargs(self, group: dict[str, Any]) -> dict[str, Any]:
         prox_kwargs = {}
         if group["prox_type"] == "NMSparseConstraint":
             assert "n_nonzero" in group, (
@@ -162,8 +166,26 @@ class PruneOptimizer(Optimizer):
             assert "min_sparsity" in group, (
                 "MinSparsityConstraint requires 'min_sparsity' in prune config"
             )
-            prox_kwargs["min_sparsity"] = group["min_sparsity"]
+            prox_kwargs["min_sparsity"] = self._effective_min_sparsity(group)
         return prox_kwargs
+
+    def _effective_min_sparsity(self, group: dict[str, Any]) -> float:
+        """Cubic ramp from 0 -> ``min_sparsity`` over (warmup, healing_start).
+
+        When ``min_sparsity_schedule`` is unset (default), returns the static
+        target. The ramp ends at ``healing_start_step`` because the mask
+        freezes there — pushing the target up after that would be a no-op.
+        """
+        target = group["min_sparsity"]
+        if not group.get("min_sparsity_schedule", False):
+            return target
+        n = self.num_steps
+        if n <= self.warmup_steps:
+            return 0.0
+        if n >= self.healing_start_step:
+            return target
+        t = (n - self.warmup_steps) / (self.healing_start_step - self.warmup_steps)
+        return target * (1 - (1 - t) ** 3)
 
     @staticmethod
     def _get_grouper_kwargs(group: dict[str, Any]) -> dict[str, Any]:

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -151,7 +151,22 @@ class PruneOptimizer(Optimizer):
                 yield group
 
     @staticmethod
-    def _get_grouper_kwargs(group) -> dict[str, Any]:
+    def _get_prox_kwargs(group: dict[str, Any]) -> dict[str, Any]:
+        prox_kwargs = {}
+        if group["prox_type"] == "NMSparseConstraint":
+            assert "n_nonzero" in group, (
+                "NMSparseConstraint requires 'n_nonzero' in prune config"
+            )
+            prox_kwargs["n_nonzero"] = group["n_nonzero"]
+        elif group["prox_type"] == "MinSparsityConstraint":
+            assert "min_sparsity" in group, (
+                "MinSparsityConstraint requires 'min_sparsity' in prune config"
+            )
+            prox_kwargs["min_sparsity"] = group["min_sparsity"]
+        return prox_kwargs
+
+    @staticmethod
+    def _get_grouper_kwargs(group: dict[str, Any]) -> dict[str, Any]:
         grouper_kwargs = {}
         if group["group_type"].startswith("AttentionHeadGrouper"):
             grouper_kwargs["num_heads"] = group["num_heads"]
@@ -280,9 +295,30 @@ class PruneOptimizer(Optimizer):
                 )
                 gamma_in_dims = 0
 
-            if prox_kwargs["disable_vmap"]:
-                # Element- or layer-wise pruning
-                zero_elts, group_norm = prox_map.apply_(grouper.p, gamma, tau_reweight)
+            if prox_kwargs["disable_vmap"] or prox_map.whole_tensor:
+                # Element-, layer-, or whole-tensor pruning: bypass vmap and
+                # call apply_ once on the full grouped view. whole_tensor prox
+                # maps treat p.size(0) as n_groups, so transpose when the
+                # grouper iterates dim 1 (e.g. Dim1Grouper).
+                transpose = getattr(grouper, "in_dims", 0) == 1 and grouper.p.dim() == 2
+                if _is_dtensor(grouper.p):
+                    # Prox maps that mutate via index_put_ (e.g.
+                    # MinSparsityConstraint) have no DTensor sharding rule and
+                    # the whole-tensor variants need a global view to compute
+                    # correct top-k. Gather, mutate, then scatter back.
+                    full = grouper.p.full_tensor()
+                    view = full.transpose(0, 1) if transpose else full
+                    zero_elts, group_norm = prox_map.apply_(view, gamma, tau_reweight)
+                    grouper.p.copy_(
+                        distribute_tensor(
+                            full,
+                            device_mesh=grouper.p.device_mesh,
+                            placements=grouper.p.placements,
+                        )
+                    )
+                else:
+                    view = grouper.p.transpose(0, 1) if transpose else grouper.p
+                    zero_elts, group_norm = prox_map.apply_(view, gamma, tau_reweight)
                 zeros_are_summed = zero_elts.dim() == 0
             else:
                 if not prox_kwargs["is_svd_grouper"] and _is_dtensor(p):
@@ -310,7 +346,9 @@ class PruneOptimizer(Optimizer):
                 zeros_are_summed = True
 
                 # Adjust for group-based pruning
-                if not prox_kwargs["is_svd_grouper"]:
+                if not prox_kwargs["is_svd_grouper"] and not prox_kwargs.get(
+                    "zero_elts_are_counts", False
+                ):
                     zero_elts *= grouper.group_size()
 
             # Record for reconstruction and logging
@@ -419,7 +457,7 @@ class PruneOptimizer(Optimizer):
             # apply shrinkage to latent parameters in place
             prox_map = instantiate_module(
                 f"torchao.prototype.pat.optim.{group['prox_type']}"
-            )(group["reg_lambda"])
+            )(group["reg_lambda"], **self._get_prox_kwargs(group))
 
             # grouper is a context manager that reshapes p if needed
             grouper_cls = instantiate_module(
@@ -433,6 +471,8 @@ class PruneOptimizer(Optimizer):
                     ("ElemGrouper", "LayerGrouper")
                 ),
                 "is_svd_grouper": group["group_type"].endswith("SVDGrouper"),
+                "zero_elts_are_counts": group["prox_type"]
+                in ("NMSparseConstraint", "MinSparsityConstraint"),
             }
             for p in group["params"]:
                 if not p.requires_grad:


### PR DESCRIPTION
### Summary
Two new prox maps for structured pruning:
- NMSparseConstraint: keeps n_nonzero largest-magnitude elements per group; pair with KElementGrouper(k) for N:M sparsity patterns.
- MinSparsityConstraint: drops the smallest-L2-norm ceil(min_sparsity * n_groups) whole groups of a 2-D (n_groups, group_size) view, bypassing torch.vmap via the new ProxMap.whole_tensor flag.

### Changes
- `torchao/prototype/pat/optim/min_sparsity.py`
- `torchao/prototype/pat/optim/proxmap.py`: add `whole_tensor` flag.
- `torchao/prototype/pat/optim/pruneopt.py`: `_get_prox_kwargs` reads `n_nonzero` / `min_sparsity` from prune config; `_apply_prox` routes `whole_tensor` prox maps through a gather → mutate → scatter path for DTensor inputs, respecting `zero_elts_are_counts`.
- `torchao/prototype/pat/optim/__init__.py`: re-exports
- `test/prototype/pat/test_pat_{min_sparsity,nm_sparse}.py`

### 2:4 Sparsity Results
The first row is a baseline 548M Olmo3 model with no pruning (baseline), compared to a 2:4 sparse version trained with NMSparseConstraint. Both models are trained on a Chinchilla-optimal number of DCLM tokens.
<img width="984" height="112" alt="Screenshot 2026-04-28 at 6 02 17 PM" src="https://github.com/user-attachments/assets/d024da9a-76c4-45c2-a3b9-4f80002d3a64" />

Below is the same but for a 1.3B Olmo3 model. Once again, we see minimal accuracy degradation in the 2:4 sparse model.
<img width="946" height="112" alt="Screenshot 2026-04-28 at 6 11 22 PM" src="https://github.com/user-attachments/assets/76e5f99f-a804-417d-b6ba-d2b227a21538" />

### MinSparsityConstraint Results
Here we show the benefits of using MinSparsityConstraint over (group) Lasso regularization. There are 2 baselines: "lasso" (blue) and "2elem-group-lasso" (red).
- "1elem-constraint" (orange) line shows small but significant improvements over "lasso", especially at milder relative sparsity levels <50%.
- "2elem-constraint" (green) shows huge improvements over "2elem-group-lasso", which catastrophically fails at every relative sparsity level.
<img width="770" alt="constraint-loss" src="https://github.com/user-attachments/assets/7870f8e8-89e6-472a-97c1-d8ea55ced9b6" />
<img width="770" alt="constraint-accu" src="https://github.com/user-attachments/assets/75e27a10-b8d6-4894-9d8c-72e406cea3cf" />


Depends on #4380 