### PR TITLE
[test][xpu] Remove get_current_accelerator_device() in test_nf4_tensor.py and device agnostic test_pin_memory in test_int8_tensor.py

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -14,7 +14,7 @@ cd torchao && python -m pip install . --no-build-isolation && cd ..
 
 python -c "import torch; import torchao; print(f'Torch version: {torch.__version__}')"
 
-python -m pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire
+python -m pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire bitsandbytes
 
 pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py \
         torchao/test/quantization/pt2e/ \

--- a/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
+++ b/test/quantization/quantize_/workflows/int4/test_int4_plain_int32_tensor.py
@@ -87,9 +87,6 @@ class Int4PlainInt32Tensor(TestCase):
     @parametrize("dtype", [torch.float16, torch.bfloat16])
     @parametrize("thresholds", [{"xpu": 20, "npu": 10}])
     def test_activation_prescaling(self, device, dtype, thresholds):
-        if "xpu" in device and dtype == torch.float16:
-            pytest.skip(f"{device} test_activation_prescaling don't test {dtype}")
-
         threshold = thresholds.get(device.split(":")[0])
         K, N, group_size = 128, 256, 128
         if "npu" in device:

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -28,7 +28,7 @@ from torchao.quantization.quantize_.workflows.int8.int8_tensor import (
 )
 from torchao.quantization.utils import compute_error, get_block_size
 from torchao.testing.model_architectures import ToyTwoLinearModel
-from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_xpu
+from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
     get_available_devices,
     is_ROCM,
@@ -277,11 +277,11 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
             "extern_kernels._int_mm", 1
         ).check_count("triton_poi_fused", 1).run(code[0])
 
-    @skip_if_xpu("pin memory is not supported on XPU")
+    @common_utils.parametrize("device", get_available_devices())
     @common_utils.parametrize("config", INT8_TEST_CONFIGS)
-    def test_pin_memory(self, config):
+    def test_pin_memory(self, config, device):
         linear = torch.nn.Linear(
-            256, 512, bias=False, dtype=torch.bfloat16, device="cuda"
+            256, 512, bias=False, dtype=torch.bfloat16, device=device
         )
         quantize_(linear, config)
         weight_cpu = linear.weight.cpu()

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -280,6 +280,8 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
     @common_utils.parametrize("device", get_available_devices())
     @common_utils.parametrize("config", INT8_TEST_CONFIGS)
     def test_pin_memory(self, config, device):
+        if device == "cpu":
+            self.skipTest("pin_memory requires an accelerator")
         linear = torch.nn.Linear(
             256, 512, bias=False, dtype=torch.bfloat16, device=device
         )

--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -47,7 +47,7 @@ from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import (
     linear_nf4,
 )
 from torchao.testing.utils import skip_if_rocm
-from torchao.utils import get_available_devices
+from torchao.utils import torch_version_at_least
 
 bnb_available = False
 
@@ -126,14 +126,15 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not bnb_available, "Need bnb availble")
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @unittest.skipIf(
+        torch_version_at_least("2.7.0"), reason="Failing in CI"
+    )  # TODO: fix this
     @skip_if_rocm("ROCm enablement in progress")
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_reconstruction_qlora_vs_bnb(self, device, dtype: torch.dtype):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_reconstruction_qlora_vs_bnb(self, dtype: torch.dtype):
         # From https://github.com/drisspg/transformer_nuggets/blob/f05afad68ad9086d342268f46a7f344617a02314/test/test_qlora.py#L65C1-L81C47
         torch.manual_seed(0)
+        device = torch.acceraltor.get_current_accelerator()
         embed_dim = 512
         input_weight = _build_input_weight(embed_dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
@@ -152,17 +153,18 @@ class TestNF4Linear(TestCase):
     @unittest.skipIf(not bnb_available, "Need bnb availble")
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @skip_if_rocm("ROCm enablement in progress")
-    @parametrize("device", get_available_devices())
+    @unittest.skipIf(
+        torch_version_at_least("2.7.0"), reason="Failing in CI"
+    )  # TODO: fix this
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_nf4_bnb_linear(self, device, dtype: torch.dtype):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_nf4_bnb_linear(self, dtype: torch.dtype):
         """
         This test ensures that nf4_linear is "no worse" than BNB by ensuring the
         error compared to a bf16 linear is not more than BNB's implementation.
         """
         torch.manual_seed(0)
         dim = 512
+        device = torch.accelerator.current_accelerator()
         input_weight = _build_input_weight(dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
         bnb_linear = _build_bnb_linear(input_weight, device)
@@ -179,12 +181,10 @@ class TestNF4Linear(TestCase):
         assert err_bnb < 0.5 * dim
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU for test")
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_load_from_state_dicts(self, device, dtype: torch.dtype):
-        if device == "cpu":
-            self.skipTest("Need GPU for test")
+    def test_load_from_state_dicts(self, dtype: torch.dtype):
         """Tests loading to and from different module state dicts"""
+        device = torch.accelerator.current_accelerator()
         input_tensor = torch.rand(64, device=device, dtype=dtype)
         base_mod = self.TestMod(input_tensor, 32, 2)
 
@@ -220,38 +220,36 @@ class TestNF4Linear(TestCase):
         assert other_mod.param.block_size == 64
         assert other_mod.param.scaler_block_size == 1
 
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_to_copy(self, device, dtype: torch.dtype):
+    def test_to_copy(self, dtype: torch.dtype):
         input_tensor = torch.rand(128, device="cpu")
         input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
         nf4_to_dtype = input_tensor_nf4.to(dtype)
         torch.testing.assert_allclose(input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
 
-        if device == "cpu":
-            return
-
-        input_tensor = torch.rand(128, device=device)
-        input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
-        nf4_to_dtype = input_tensor_nf4.to(dtype)
-        torch.testing.assert_allclose(input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
+        if torch.accelerator.is_available():
+            device = torch.accelerator.current_accelerator()
+            input_tensor = torch.rand(128, device=device)
+            input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
+            nf4_to_dtype = input_tensor_nf4.to(dtype)
+            torch.testing.assert_allclose(
+                input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13
+            )
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need gpu for test")
-    @parametrize("device", get_available_devices())
-    def test_to_copy_device(self, device):
-        if device == "cpu":
-            self.skipTest("Need gpu for test")
+    def test_to_copy_device(self):
+        device = torch.accelerator.current_accelerator()
         input_tensor = torch.rand(128, device="cpu")
         t = to_nf4(input_tensor, 32, 2)
         assert t.device == torch.device("cpu")
         z = t.to(device)
-        assert z.device.type == device  # Because the device could be cuda:0
+        assert z.device.type == device.type  # Because the device could be cuda:0
         x = z.cpu()
         assert x.device == torch.device("cpu")
 
         input_tensor = torch.rand(128, device=device)
         t = to_nf4(input_tensor, 32, 2)
-        assert t.device.type == device
+        assert t.device.type == device.type
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_to_dtype(self, dtype: torch.dtype):
@@ -262,11 +260,9 @@ class TestNF4Linear(TestCase):
         assert input_tensor_nf4.to(dtype).dtype is dtype
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear(self, device, dtype: torch.dtype):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_smoketest_linear(self, dtype: torch.dtype):
+        device = torch.accelerator.current_accelerator()
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
@@ -274,11 +270,8 @@ class TestNF4Linear(TestCase):
         _ = torch.nn.functional.linear(inp, a_nf4)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear_compile(self, device, dtype: torch.dtype):
-        if device == "cpu":
-            self.skipTest("Need CUDA available")
+    def test_smoketest_linear_compile(self, dtype: torch.dtype):
         if (
             torch.cuda.is_available()
             and torch.cuda.get_device_capability() < (8, 0)
@@ -287,21 +280,18 @@ class TestNF4Linear(TestCase):
             self.skipTest("test requires SM capability of at least (8, 0).")
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest("test requires 2.3.0 and above for tracing NF4Tensor")
+        device = torch.accelerator.current_accelerator()
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
         _ = torch.compile(torch.nn.functional.linear, mode="max-autotune")(inp, a_nf4)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("shape", [(16, 16), (32, 16)])
     @parametrize("chunk_size", [8, 16, 32])
-    def test_chunk_size_equivalence(
-        self, device, dtype: torch.dtype, shape, chunk_size
-    ):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_chunk_size_equivalence(self, dtype: torch.dtype, shape, chunk_size):
+        device = torch.accelerator.current_accelerator()
         a = torch.randn(shape, device=device, dtype=dtype)
         with unittest.mock.patch.object(_nf4_tensor_mod, "CHUNK_SIZE", chunk_size):
             nf4_patched = to_nf4(a, 16, 2)
@@ -311,11 +301,9 @@ class TestNF4Linear(TestCase):
         torch.testing.assert_close(nf4_patched.quantized_data, nf4_base.quantized_data)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
     @parametrize("input_size", [(512 * 512,), (512, 512)])
-    def test_empty_like(self, device, input_size: Union[Tuple[int], int]):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_empty_like(self, input_size: Union[Tuple[int], int]):
+        device = torch.accelerator.current_accelerator()
         nf4_tensor = to_nf4(torch.rand(input_size, device=device))
         new_tensor = torch.empty_like(nf4_tensor, device="cpu")
         self.assertTrue(isinstance(new_tensor, NF4Tensor))
@@ -323,11 +311,9 @@ class TestNF4Linear(TestCase):
         self.assertEqual(new_tensor.size(), nf4_tensor.size())
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
     @parametrize("compile", [False, True])
-    def test_quantize_api(self, device, compile):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_quantize_api(self, compile):
+        device = torch.accelerator.current_accelerator()
         nf4_linear = nn.Linear(512, 512, device=device)
         torchao.quantize_(nf4_linear, nf4_weight_only())
         assert isinstance(nf4_linear.weight, NF4Tensor)
@@ -538,50 +524,44 @@ class TestFSDPOps(TestCase):
                 )
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPu available")
-    @parametrize("device", get_available_devices())
-    def test_pin_memory(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPu available")
+    def test_pin_memory(self):
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertFalse(nf4_tensor.is_pinned())
 
         nf4_tensor = nf4_tensor.pin_memory()
         self.assertTrue(nf4_tensor.is_pinned())
 
+        device = torch.accelerator.current_accelerator()
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         self.assertFalse(nf4_tensor.is_pinned())
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
-    def test_to_cuda(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_to_cuda(self):
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
+        device = torch.accelerator.current_accelerator()
         nf4_tensor = nf4_tensor.to(device, non_blocking=True)
-        self.assertEqual(nf4_tensor.device.type, device)
+        self.assertEqual(nf4_tensor.device.type, device.type)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device)
-        self.assertEqual(nf4_tensor.device.type, device)
+        self.assertEqual(nf4_tensor.device.type, device.type)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device, torch.bfloat16)
-        self.assertEqual(nf4_tensor.device.type, device)
+        self.assertEqual(nf4_tensor.device.type, device.type)
         self.assertEqual(nf4_tensor.dtype, torch.bfloat16)
         self.assertEqual(type(nf4_tensor), torch.Tensor)  # dequantized
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
-    def test_to_cpu(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_to_cpu(self):
+        device = torch.accelerator.current_accelerator()
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         nf4_tensor = nf4_tensor.cpu()
         self.assertEqual(nf4_tensor.device.type, "cpu")
@@ -591,18 +571,16 @@ class TestFSDPOps(TestCase):
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
-    def test_to_module(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_to_module(self):
         linear = nn.Linear(512, 512, bias=False)
         linear.weight = nn.Parameter(
             to_nf4(linear.weight.detach()), requires_grad=False
         )
+        device = torch.accelerator.current_accelerator()
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device)
+        self.assertEqual(linear.weight.device.type, device.type)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device)
+        self.assertEqual(weight.device.type, device.type)
 
         linear.cpu()
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -614,9 +592,9 @@ class TestFSDPOps(TestCase):
             to_nf4(linear.weight.detach()), requires_grad=False
         )
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device)
+        self.assertEqual(linear.weight.device.type, device.type)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device)
+        self.assertEqual(weight.device.type, device.type)
 
         linear.to("cpu")
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -624,11 +602,9 @@ class TestFSDPOps(TestCase):
         self.assertEqual(weight.device.type, "cpu")
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @parametrize("device", get_available_devices())
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
-    def test_tensor_deepcopy(self, device, input_size: Union[Tuple[int], int]):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_tensor_deepcopy(self, input_size: Union[Tuple[int], int]):
+        device = torch.accelerator.current_accelerator()
         nf4_orig = to_nf4(torch.randn(input_size, device=device))
         nf4_clone = copy.deepcopy(nf4_orig)
         self.assertEqual(

--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -47,7 +47,7 @@ from torchao.quantization.quantize_.workflows.nf4.nf4_tensor import (
     linear_nf4,
 )
 from torchao.testing.utils import skip_if_rocm
-from torchao.utils import get_current_accelerator_device, torch_version_at_least
+from torchao.utils import get_available_devices
 
 bnb_available = False
 
@@ -126,15 +126,14 @@ class TestNF4Linear(TestCase):
 
     @unittest.skipIf(not bnb_available, "Need bnb availble")
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(
-        torch_version_at_least("2.7.0"), reason="Failing in CI"
-    )  # TODO: fix this
     @skip_if_rocm("ROCm enablement in progress")
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_reconstruction_qlora_vs_bnb(self, dtype: torch.dtype):
+    def test_reconstruction_qlora_vs_bnb(self, device, dtype: torch.dtype):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         # From https://github.com/drisspg/transformer_nuggets/blob/f05afad68ad9086d342268f46a7f344617a02314/test/test_qlora.py#L65C1-L81C47
         torch.manual_seed(0)
-        device = get_current_accelerator_device()
         embed_dim = 512
         input_weight = _build_input_weight(embed_dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
@@ -153,18 +152,17 @@ class TestNF4Linear(TestCase):
     @unittest.skipIf(not bnb_available, "Need bnb availble")
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @skip_if_rocm("ROCm enablement in progress")
-    @unittest.skipIf(
-        torch_version_at_least("2.7.0"), reason="Failing in CI"
-    )  # TODO: fix this
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_nf4_bnb_linear(self, dtype: torch.dtype):
+    def test_nf4_bnb_linear(self, device, dtype: torch.dtype):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         """
         This test ensures that nf4_linear is "no worse" than BNB by ensuring the
         error compared to a bf16 linear is not more than BNB's implementation.
         """
         torch.manual_seed(0)
         dim = 512
-        device = get_current_accelerator_device()
         input_weight = _build_input_weight(dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
         bnb_linear = _build_bnb_linear(input_weight, device)
@@ -181,10 +179,12 @@ class TestNF4Linear(TestCase):
         assert err_bnb < 0.5 * dim
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU for test")
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_load_from_state_dicts(self, dtype: torch.dtype):
+    def test_load_from_state_dicts(self, device, dtype: torch.dtype):
+        if device == "cpu":
+            self.skipTest("Need GPU for test")
         """Tests loading to and from different module state dicts"""
-        device = get_current_accelerator_device()
         input_tensor = torch.rand(64, device=device, dtype=dtype)
         base_mod = self.TestMod(input_tensor, 32, 2)
 
@@ -220,36 +220,38 @@ class TestNF4Linear(TestCase):
         assert other_mod.param.block_size == 64
         assert other_mod.param.scaler_block_size == 1
 
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_to_copy(self, dtype: torch.dtype):
+    def test_to_copy(self, device, dtype: torch.dtype):
         input_tensor = torch.rand(128, device="cpu")
         input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
         nf4_to_dtype = input_tensor_nf4.to(dtype)
         torch.testing.assert_allclose(input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
 
-        if torch.accelerator.is_available():
-            device = get_current_accelerator_device()
-            input_tensor = torch.rand(128, device=device)
-            input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
-            nf4_to_dtype = input_tensor_nf4.to(dtype)
-            torch.testing.assert_allclose(
-                input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13
-            )
+        if device == "cpu":
+            return
+
+        input_tensor = torch.rand(128, device=device)
+        input_tensor_nf4 = to_nf4(input_tensor, 32, 2)
+        nf4_to_dtype = input_tensor_nf4.to(dtype)
+        torch.testing.assert_allclose(input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need gpu for test")
-    def test_to_copy_device(self):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_to_copy_device(self, device):
+        if device == "cpu":
+            self.skipTest("Need gpu for test")
         input_tensor = torch.rand(128, device="cpu")
         t = to_nf4(input_tensor, 32, 2)
         assert t.device == torch.device("cpu")
         z = t.to(device)
-        assert z.device.type == device.type  # Because the device could be cuda:0
+        assert z.device.type == device  # Because the device could be cuda:0
         x = z.cpu()
         assert x.device == torch.device("cpu")
 
         input_tensor = torch.rand(128, device=device)
         t = to_nf4(input_tensor, 32, 2)
-        assert t.device.type == device.type
+        assert t.device.type == device
 
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_to_dtype(self, dtype: torch.dtype):
@@ -260,18 +262,23 @@ class TestNF4Linear(TestCase):
         assert input_tensor_nf4.to(dtype).dtype is dtype
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear(self, dtype: torch.dtype):
-        device = get_current_accelerator_device()
+    def test_smoketest_linear(self, device, dtype: torch.dtype):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
         _ = torch.nn.functional.linear(inp, a)
         _ = torch.nn.functional.linear(inp, a_nf4)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
-    def test_smoketest_linear_compile(self, dtype: torch.dtype):
+    def test_smoketest_linear_compile(self, device, dtype: torch.dtype):
+        if device == "cpu":
+            self.skipTest("Need CUDA available")
         if (
             torch.cuda.is_available()
             and torch.cuda.get_device_capability() < (8, 0)
@@ -280,18 +287,19 @@ class TestNF4Linear(TestCase):
             self.skipTest("test requires SM capability of at least (8, 0).")
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest("test requires 2.3.0 and above for tracing NF4Tensor")
-        device = get_current_accelerator_device()
         a = torch.randn(32, 32, dtype=dtype, device=device)
         a_nf4 = to_nf4(a, 16, 2)
         inp = torch.randn(2, 32, 32, dtype=a.dtype, device=a.device)
         _ = torch.compile(torch.nn.functional.linear, mode="max-autotune")(inp, a_nf4)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @parametrize("device", get_available_devices())
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("shape", [(16, 16), (32, 16)])
     @parametrize("chunk_size", [8, 16, 32])
-    def test_chunk_size_equivalence(self, dtype: torch.dtype, shape, chunk_size):
-        device = get_current_accelerator_device()
+    def test_chunk_size_equivalence(self, device, dtype: torch.dtype, shape, chunk_size):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         a = torch.randn(shape, device=device, dtype=dtype)
         with unittest.mock.patch.object(_nf4_tensor_mod, "CHUNK_SIZE", chunk_size):
             nf4_patched = to_nf4(a, 16, 2)
@@ -301,9 +309,11 @@ class TestNF4Linear(TestCase):
         torch.testing.assert_close(nf4_patched.quantized_data, nf4_base.quantized_data)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @parametrize("device", get_available_devices())
     @parametrize("input_size", [(512 * 512,), (512, 512)])
-    def test_empty_like(self, input_size: Union[Tuple[int], int]):
-        device = get_current_accelerator_device()
+    def test_empty_like(self, device, input_size: Union[Tuple[int], int]):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         nf4_tensor = to_nf4(torch.rand(input_size, device=device))
         new_tensor = torch.empty_like(nf4_tensor, device="cpu")
         self.assertTrue(isinstance(new_tensor, NF4Tensor))
@@ -311,9 +321,11 @@ class TestNF4Linear(TestCase):
         self.assertEqual(new_tensor.size(), nf4_tensor.size())
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @parametrize("device", get_available_devices())
     @parametrize("compile", [False, True])
-    def test_quantize_api(self, compile):
-        device = get_current_accelerator_device()
+    def test_quantize_api(self, device, compile):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         nf4_linear = nn.Linear(512, 512, device=device)
         torchao.quantize_(nf4_linear, nf4_weight_only())
         assert isinstance(nf4_linear.weight, NF4Tensor)
@@ -524,44 +536,50 @@ class TestFSDPOps(TestCase):
                 )
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPu available")
-    def test_pin_memory(self):
+    @parametrize("device", get_available_devices())
+    def test_pin_memory(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPu available")
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertFalse(nf4_tensor.is_pinned())
 
         nf4_tensor = nf4_tensor.pin_memory()
         self.assertTrue(nf4_tensor.is_pinned())
 
-        device = get_current_accelerator_device()
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         self.assertFalse(nf4_tensor.is_pinned())
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_cuda(self):
+    @parametrize("device", get_available_devices())
+    def test_to_cuda(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
-        device = get_current_accelerator_device()
         nf4_tensor = nf4_tensor.to(device, non_blocking=True)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(type(nf4_tensor), NF4Tensor)
         nf4_tensor.get_original_weight()
 
         nf4_tensor = to_nf4(torch.randn(512 * 512))
         self.assertEqual(nf4_tensor.device.type, "cpu")
         nf4_tensor = nf4_tensor.to(device, torch.bfloat16)
-        self.assertEqual(nf4_tensor.device.type, device.type)
+        self.assertEqual(nf4_tensor.device.type, device)
         self.assertEqual(nf4_tensor.dtype, torch.bfloat16)
         self.assertEqual(type(nf4_tensor), torch.Tensor)  # dequantized
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_cpu(self):
-        device = get_current_accelerator_device()
+    @parametrize("device", get_available_devices())
+    def test_to_cpu(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         nf4_tensor = to_nf4(torch.randn(512 * 512, device=device))
         nf4_tensor = nf4_tensor.cpu()
         self.assertEqual(nf4_tensor.device.type, "cpu")
@@ -571,16 +589,18 @@ class TestFSDPOps(TestCase):
         nf4_tensor.get_original_weight()  # make sure we can dequantize
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_to_module(self):
+    @parametrize("device", get_available_devices())
+    def test_to_module(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         linear = nn.Linear(512, 512, bias=False)
         linear.weight = nn.Parameter(
             to_nf4(linear.weight.detach()), requires_grad=False
         )
-        device = get_current_accelerator_device()
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device.type)
+        self.assertEqual(linear.weight.device.type, device)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device.type)
+        self.assertEqual(weight.device.type, device)
 
         linear.cpu()
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -592,9 +612,9 @@ class TestFSDPOps(TestCase):
             to_nf4(linear.weight.detach()), requires_grad=False
         )
         linear.to(device)
-        self.assertEqual(linear.weight.device.type, device.type)
+        self.assertEqual(linear.weight.device.type, device)
         weight = linear.weight.get_original_weight()
-        self.assertEqual(weight.device.type, device.type)
+        self.assertEqual(weight.device.type, device)
 
         linear.to("cpu")
         self.assertEqual(linear.weight.device.type, "cpu")
@@ -602,9 +622,11 @@ class TestFSDPOps(TestCase):
         self.assertEqual(weight.device.type, "cpu")
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @parametrize("device", get_available_devices())
     @parametrize("input_size", [512 * 512, (512 * 512,), (512, 512)])
-    def test_tensor_deepcopy(self, input_size: Union[Tuple[int], int]):
-        device = get_current_accelerator_device()
+    def test_tensor_deepcopy(self, device, input_size: Union[Tuple[int], int]):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         nf4_orig = to_nf4(torch.randn(input_size, device=device))
         nf4_clone = copy.deepcopy(nf4_orig)
         self.assertEqual(
@@ -695,7 +717,7 @@ class TestQLoRA(FSDPTest):
             dropout_p=0,
         )
         torch.manual_seed(42)
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
         with torch.device(device):
             base_model = Transformer(model_args)
             for layer in base_model.layers:
@@ -786,7 +808,7 @@ class TestComm(FSDPTest):
         from torch.distributed._composable.fsdp import fully_shard
         from torch.distributed._tensor import distribute_tensor
 
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
         model = nn.Linear(input_size, input_size, device=device)
         origin_tensor = model.weight
         origin_nf4_tensor = to_nf4(origin_tensor)

--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -297,7 +297,9 @@ class TestNF4Linear(TestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     @parametrize("shape", [(16, 16), (32, 16)])
     @parametrize("chunk_size", [8, 16, 32])
-    def test_chunk_size_equivalence(self, device, dtype: torch.dtype, shape, chunk_size):
+    def test_chunk_size_equivalence(
+        self, device, dtype: torch.dtype, shape, chunk_size
+    ):
         if device == "cpu":
             self.skipTest("Need GPU available")
         a = torch.randn(shape, device=device, dtype=dtype)

--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -134,7 +134,7 @@ class TestNF4Linear(TestCase):
     def test_reconstruction_qlora_vs_bnb(self, dtype: torch.dtype):
         # From https://github.com/drisspg/transformer_nuggets/blob/f05afad68ad9086d342268f46a7f344617a02314/test/test_qlora.py#L65C1-L81C47
         torch.manual_seed(0)
-        device = torch.acceraltor.get_current_accelerator()
+        device = torch.accelerator.current_accelerator()
         embed_dim = 512
         input_weight = _build_input_weight(embed_dim, device, dtype)
         nf4_weight = to_nf4(input_weight)
@@ -236,7 +236,7 @@ class TestNF4Linear(TestCase):
                 input_tensor, nf4_to_dtype, atol=0.13, rtol=0.13
             )
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need gpu for test")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU for test")
     def test_to_copy_device(self):
         device = torch.accelerator.current_accelerator()
         input_tensor = torch.rand(128, device="cpu")
@@ -269,7 +269,7 @@ class TestNF4Linear(TestCase):
         _ = torch.nn.functional.linear(inp, a)
         _ = torch.nn.functional.linear(inp, a_nf4)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
     def test_smoketest_linear_compile(self, dtype: torch.dtype):
         if (

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -23,6 +23,7 @@ from torchao.prototype.mx_formats.inference_workflow import (
 )
 from torchao.quantization import (
     Float8Tensor,
+    Int4PlainInt32Tensor,
     Int4TilePackedTo4dTensor,
     Int8Tensor,
     IntxUnpackedToInt8Tensor,
@@ -57,6 +58,7 @@ from torchao.testing.pt2e._xnnpack_quantizer import (
 )
 from torchao.testing.utils import skip_if_rocm, skip_if_xpu
 from torchao.utils import (
+    get_available_devices,
     get_current_accelerator_device,
     is_ROCM,
     is_sm_at_least_89,
@@ -64,7 +66,6 @@ from torchao.utils import (
     is_sm_at_least_100,
     unwrap_tensor_subclass,
 )
-
 
 def dynamic_quant(model, example_inputs):
     m = torch.export.export(model, example_inputs, strict=True).module()
@@ -401,7 +402,6 @@ class TestQuantFlow(TestCase):
             Int8WeightOnlyConfig(),
         ],
     )
-    @skip_if_xpu("XPU enablement in progress")
     @skip_if_rocm("ROCm enablement in progress")
     def test_workflow_e2e_numerics(self, config):
         """
@@ -438,12 +438,14 @@ class TestQuantFlow(TestCase):
         assert sqnr >= 16.5, f"SQNR {sqnr} is too low"
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
-    def test_module_fqn_to_config_default(self):
+    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_default(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"_default": config1, "linear2": config2})
-        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -452,12 +454,14 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
-    def test_module_fqn_to_config_module_name(self):
+    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_module_name(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"linear1": config1, "linear2": config2})
-        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -465,60 +469,84 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_module_fqn_to_config_regex_basic(self):
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_regex_basic(self, device):
+        if device == "cpu":
+            self.skipTest("Need accelerator available")
+        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
+        int4_tensor_type = (
+            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
+        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format="tile_packed_to_4d"
+            group_size=32, int4_packing_format=packing_format
         )
         config = ModuleFqnToConfig({"re:linear.": config1})
-        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
+        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
-        assert isinstance(model.linear2.weight, Int4TilePackedTo4dTensor)
+        assert isinstance(model.linear1.weight, int4_tensor_type)
+        assert isinstance(model.linear2.weight, int4_tensor_type)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_module_fqn_to_config_regex_precedence(self):
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_regex_precedence(self, device):
         """Testing that full path config takes precedence over
         regex config in ModuleFqnToConfig
         """
+        if device == "cpu":
+            self.skipTest("Need accelerator available")
+        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
+        int4_tensor_type = (
+            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
+        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format="tile_packed_to_4d"
+            group_size=32, int4_packing_format=packing_format
         )
         config2 = IntxWeightOnlyConfig()
         config = ModuleFqnToConfig({"linear1": config1, "re:linear.": config2})
-        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
+        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
+        assert isinstance(model.linear1.weight, int4_tensor_type)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_module_fqn_to_config_regex_precedence2(self):
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_regex_precedence2(self, device):
         """Testing that full path config takes precedence over
         regex config in ModuleFqnToConfig, swapping
         the order of `re:linear.*` and `linear1` to make sure that
         `linear1` config has precedence even it comes after `linear*`
         """
+        if device == "cpu":
+            self.skipTest("Need accelerator available")
+        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
+        int4_tensor_type = (
+            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
+        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format="tile_packed_to_4d"
+            group_size=32, int4_packing_format=packing_format
         )
         config2 = IntxWeightOnlyConfig()
         config = ModuleFqnToConfig({"re:linear.": config2, "linear1": config1})
-        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
+        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
+        assert isinstance(model.linear1.weight, int4_tensor_type)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
-    def test_module_fqn_to_config_regex_fullmatch(self):
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_regex_fullmatch(self, device):
         """Testing that we will only match the fqns that fully
         matches the regex
         """
+        if device == "cpu":
+            self.skipTest("Need accelerator available")
 
         class M(torch.nn.Module):
             def __init__(self, dtype, device):
@@ -542,8 +570,12 @@ class TestQuantFlow(TestCase):
             def example_inputs(self):
                 return (torch.randn(1, 32, dtype=self.dtype, device=self.device),)
 
+        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
+        int4_tensor_type = (
+            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
+        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format="tile_packed_to_4d"
+            group_size=32, int4_packing_format=packing_format
         )
         config2 = Float8WeightOnlyConfig()
         config = ModuleFqnToConfig(
@@ -553,11 +585,11 @@ class TestQuantFlow(TestCase):
                 "linear3_full_match.bias": None,
             }
         )
-        model = M(dtype=torch.bfloat16, device="cuda")
+        model = M(dtype=torch.bfloat16, device=device)
         example_inputs = model.example_inputs()
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
+        assert isinstance(model.linear1.weight, int4_tensor_type)
         # since fqn does not fully match `linear*`, it should not be quantized
         assert not isinstance(model.not_full_match_linear2.weight, Float8Tensor)
         # linear3_full_match matches `linear*`, so should be quantized
@@ -591,11 +623,13 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear.weight, IntxUnpackedToInt8Tensor)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
-    def test_module_fqn_to_config_skip(self):
+    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
+    @common_utils.parametrize("device", get_available_devices())
+    def test_module_fqn_to_config_skip(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config = ModuleFqnToConfig({"_default": config1, "linear2": None})
-        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -607,10 +641,14 @@ class TestQuantFlow(TestCase):
 common_utils.instantiate_parametrized_tests(TestQuantFlow)
 
 
-@unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
-@unittest.skipIf(not is_sm_at_least_90(), "Checkpoints are produced in SM90+")
+@unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+@unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
+@common_utils.instantiate_parametrized_tests
 class TestFqnToConfig(TestCase):
-    def test_fqn_to_config_repr_custom(self):
+    @common_utils.parametrize("device", get_available_devices())
+    def test_fqn_to_config_repr_custom(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         class TestModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -621,7 +659,7 @@ class TestFqnToConfig(TestCase):
                     "y", torch.nn.Parameter(torch.randn(128, 128, dtype=torch.bfloat16))
                 )
 
-        custom_module = TestModule().cuda().eval()
+        custom_module = TestModule().to(device).eval()
         custom_module_config = FqnToConfig(
             {
                 "x": Float8DynamicActivationFloat8WeightConfig(
@@ -639,8 +677,11 @@ class TestFqnToConfig(TestCase):
         assert "Float8Tensor(" in str(custom_module)
         assert "PerTensor()" in str(custom_module)
 
-    def test_fqn_to_config_repr_linear(self):
-        linear_model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_fqn_to_config_repr_linear(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        linear_model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
         linear_quant_config = FqnToConfig(
             {
                 "linear1.weight": Float8DynamicActivationFloat8WeightConfig(
@@ -732,7 +773,8 @@ class TestFqnToConfig(TestCase):
         config = AutoConfig.from_pretrained(
             "unsloth/Llama-4-Scout-17B-16E-Instruct"
         ).text_config
-        model = Llama4TextMoe(config).to(torch.bfloat16).cuda()
+        device = get_current_accelerator_device()
+        model = Llama4TextMoe(config).to(torch.bfloat16).to(device)
 
         quant_config = FqnToConfig(
             {
@@ -750,8 +792,11 @@ class TestFqnToConfig(TestCase):
 
         assert isinstance(model.experts.gate_up_proj, Float8Tensor)
 
-    def test_quantize_fqn_precedence_param_over_module(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_param_over_module(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -765,8 +810,11 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    def test_quantize_fqn_precedence_param_over_module_regex(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_param_over_module_regex(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -780,8 +828,11 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    def test_quantize_fqn_precedence_param_regex_over_module_regex(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_param_regex_over_module_regex(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -795,8 +846,11 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    def test_quantize_fqn_precedence_module_over_param_regex(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_module_over_param_regex(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -811,8 +865,11 @@ class TestFqnToConfig(TestCase):
         assert model.linear1.weight.scale.numel() == 1
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
-    def test_quantize_fqn_precedence_param_over_default(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_param_over_default(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -827,8 +884,11 @@ class TestFqnToConfig(TestCase):
         assert model.linear1.weight.scale.numel() == 1
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
-    def test_quantize_fqn_precedence_param_regex_over_default(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_fqn_precedence_param_regex_over_default(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
 
         quant_config = FqnToConfig(
             {
@@ -842,8 +902,11 @@ class TestFqnToConfig(TestCase):
         assert not isinstance(model.linear2.weight, Float8Tensor)
         assert not isinstance(model.linear1.weight, Float8Tensor)
 
-    def test_quantize_model_same_module_different_param(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_model_same_module_different_param(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
         model.linear1.register_parameter(
             "weight2", torch.nn.Parameter(model.linear1.weight.clone())
         )
@@ -868,8 +931,11 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight2, Float8Tensor)
         assert model.linear1.weight2.scale.numel() == 32
 
-    def test_quantize_model_same_module_different_param_regex(self):
-        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantize_model_same_module_different_param_regex(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
         quant_config = FqnToConfig(
             {
                 "re:.*weight": Float8DynamicActivationFloat8WeightConfig(
@@ -891,13 +957,16 @@ class TestFqnToConfig(TestCase):
         assert model.linear2.weight.scale.numel() == 1
         assert not isinstance(model.linear2.bias, Float8Tensor)
 
-    def test_unsupported_param_config_raises_not_implemented_error(self):
+    @common_utils.parametrize("device", get_available_devices())
+    def test_unsupported_param_config_raises_not_implemented_error(self, device):
         """Test that using an unsupported parameter config raises NotImplementedError.
 
         This test creates a custom config whose handler does not have a 'parameter_name'
         kwarg in its signature. This verifies that _handler_supports_fqn_quantization()
         correctly identifies handlers that don't support parameter-level quantization.
         """
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         from dataclasses import dataclass
 
         from torchao.core.config import AOBaseConfig
@@ -920,7 +989,7 @@ class TestFqnToConfig(TestCase):
             return module
 
         # Create a simple model
-        model = torch.nn.Sequential(torch.nn.Linear(10, 5).cuda().bfloat16())
+        model = torch.nn.Sequential(torch.nn.Linear(10, 5)).to(device).bfloat16()
 
         # Create config targeting a parameter (not a module)
         quant_config = FqnToConfig(
@@ -936,11 +1005,14 @@ class TestFqnToConfig(TestCase):
 
         self.assertIn("does not yet support parameter quantization", str(cm.exception))
 
-    def test_filter_fn_and_fqn_to_config_error(self):
+    @common_utils.parametrize("device", get_available_devices())
+    def test_filter_fn_and_fqn_to_config_error(self, device):
         """Test that specifying non-default filter_fn and FqnToConfig raises ValueError."""
+        if device == "cpu":
+            self.skipTest("Need GPU available")
 
         # Create a simple model
-        model = torch.nn.Sequential(torch.nn.Linear(10, 5).cuda().bfloat16())
+        model = torch.nn.Sequential(torch.nn.Linear(10, 5)).to(device).bfloat16()
 
         # Create config with unsupported parameter handler
         quant_config = FqnToConfig(
@@ -955,8 +1027,11 @@ class TestFqnToConfig(TestCase):
         with self.assertRaises(ValueError):
             quantize_(model, quant_config, filter_fn=lambda mod, fqn: True)
 
-    def test_top_level_param(self):
-        model = torch.nn.Linear(16, 16).cuda().bfloat16()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_top_level_param(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = torch.nn.Linear(16, 16).to(device).bfloat16()
 
         quant_config = FqnToConfig(
             {
@@ -971,8 +1046,11 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.weight, Float8Tensor)
         assert model.weight.scale.numel() == 1
 
-    def test_non_fqn_config_filter_fn_none(self):
-        model = torch.nn.Linear(16, 16).cuda().bfloat16()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_non_fqn_config_filter_fn_none(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
+        model = torch.nn.Linear(16, 16).to(device).bfloat16()
         quant_config = Float8DynamicActivationFloat8WeightConfig(
             granularity=PerTensor()
         )
@@ -982,8 +1060,10 @@ class TestFqnToConfig(TestCase):
         assert model.weight.scale.numel() == 1
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    def test_quantized_model_streaming_fqn_config(self):
-        device = get_current_accelerator_device()
+    @common_utils.parametrize("device", get_available_devices())
+    def test_quantized_model_streaming_fqn_config(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         device_module = torch.get_device_module(device)
 
         def reset_memory():
@@ -1004,7 +1084,7 @@ class TestFqnToConfig(TestCase):
         memory_streaming = device_module.max_memory_allocated()
 
         for param in m.parameters():
-            assert param.device.type == device.type
+            assert param.device.type == device
         self.assertLess(memory_streaming, memory_baseline)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
@@ -1083,10 +1163,17 @@ class TestFqnToConfig(TestCase):
         assert isinstance(m.nested.linear.weight, Int8Tensor)
         assert isinstance(m.linear1.weight, Int8Tensor)
 
-    def test_fqn_to_config_non_weight_param(self):
+    @common_utils.parametrize("device", get_available_devices())
+    def test_fqn_to_config_non_weight_param(self, device):
+        if device == "cpu":
+            self.skipTest("Need GPU available")
         configs = [
-            Int4WeightOnlyConfig(group_size=128),
-            Float8DynamicActivationInt4WeightConfig(),
+            Int4WeightOnlyConfig(
+                group_size=128,
+                int4_packing_format="plain_int32"
+                if device == "xpu"
+                else "tile_packed_to_4d",
+            ),
             Int8WeightOnlyConfig(),
             Int8DynamicActivationInt8WeightConfig(),
             Int8DynamicActivationIntxWeightConfig(),
@@ -1095,6 +1182,9 @@ class TestFqnToConfig(TestCase):
             Float8WeightOnlyConfig(),
             Float8DynamicActivationFloat8WeightConfig(granularity=PerTensor()),
         ]
+        if device != "xpu":
+            # Float8DynamicActivationInt4WeightConfig requires mslk (CUDA-only library)
+            configs.append(Float8DynamicActivationInt4WeightConfig())
         if is_sm_at_least_100():
             configs.append(MXDynamicActivationMXWeightConfig())
         if is_sm_at_least_100():
@@ -1102,12 +1192,12 @@ class TestFqnToConfig(TestCase):
         for config in configs:
             with self.subTest(config=type(config).__name__):
                 model = torch.nn.Sequential(
-                    torch.nn.Linear(128, 128).to(torch.bfloat16).cuda()
+                    torch.nn.Linear(128, 128).to(device).to(torch.bfloat16)
                 )
                 model[0].register_parameter(
                     "custom_param",
                     torch.nn.Parameter(
-                        torch.randn(128, 128, dtype=torch.bfloat16, device="cuda")
+                        torch.randn(128, 128, dtype=torch.bfloat16, device=device)
                     ),
                 )
                 original_custom_param = model[0].custom_param

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -23,7 +23,6 @@ from torchao.prototype.mx_formats.inference_workflow import (
 )
 from torchao.quantization import (
     Float8Tensor,
-    Int4PlainInt32Tensor,
     Int4TilePackedTo4dTensor,
     Int8Tensor,
     IntxUnpackedToInt8Tensor,
@@ -58,7 +57,6 @@ from torchao.testing.pt2e._xnnpack_quantizer import (
 )
 from torchao.testing.utils import skip_if_rocm, skip_if_xpu
 from torchao.utils import (
-    get_available_devices,
     get_current_accelerator_device,
     is_ROCM,
     is_sm_at_least_89,
@@ -66,6 +64,7 @@ from torchao.utils import (
     is_sm_at_least_100,
     unwrap_tensor_subclass,
 )
+
 
 def dynamic_quant(model, example_inputs):
     m = torch.export.export(model, example_inputs, strict=True).module()
@@ -402,6 +401,7 @@ class TestQuantFlow(TestCase):
             Int8WeightOnlyConfig(),
         ],
     )
+    @skip_if_xpu("XPU enablement in progress")
     @skip_if_rocm("ROCm enablement in progress")
     def test_workflow_e2e_numerics(self, config):
         """
@@ -438,14 +438,12 @@ class TestQuantFlow(TestCase):
         assert sqnr >= 16.5, f"SQNR {sqnr} is too low"
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_default(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
+    def test_module_fqn_to_config_default(self):
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"_default": config1, "linear2": config2})
+        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -454,14 +452,12 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_module_name(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
+    def test_module_fqn_to_config_module_name(self):
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config2 = Int8WeightOnlyConfig()
         config = ModuleFqnToConfig({"linear1": config1, "linear2": config2})
+        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -469,84 +465,60 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_regex_basic(self, device):
-        if device == "cpu":
-            self.skipTest("Need accelerator available")
-        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
-        int4_tensor_type = (
-            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
-        )
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_module_fqn_to_config_regex_basic(self):
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format=packing_format
+            group_size=32, int4_packing_format="tile_packed_to_4d"
         )
         config = ModuleFqnToConfig({"re:linear.": config1})
-        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
+        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, int4_tensor_type)
-        assert isinstance(model.linear2.weight, int4_tensor_type)
+        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
+        assert isinstance(model.linear2.weight, Int4TilePackedTo4dTensor)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_regex_precedence(self, device):
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_module_fqn_to_config_regex_precedence(self):
         """Testing that full path config takes precedence over
         regex config in ModuleFqnToConfig
         """
-        if device == "cpu":
-            self.skipTest("Need accelerator available")
-        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
-        int4_tensor_type = (
-            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
-        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format=packing_format
+            group_size=32, int4_packing_format="tile_packed_to_4d"
         )
         config2 = IntxWeightOnlyConfig()
         config = ModuleFqnToConfig({"linear1": config1, "re:linear.": config2})
-        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
+        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, int4_tensor_type)
+        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_regex_precedence2(self, device):
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_module_fqn_to_config_regex_precedence2(self):
         """Testing that full path config takes precedence over
         regex config in ModuleFqnToConfig, swapping
         the order of `re:linear.*` and `linear1` to make sure that
         `linear1` config has precedence even it comes after `linear*`
         """
-        if device == "cpu":
-            self.skipTest("Need accelerator available")
-        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
-        int4_tensor_type = (
-            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
-        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format=packing_format
+            group_size=32, int4_packing_format="tile_packed_to_4d"
         )
         config2 = IntxWeightOnlyConfig()
         config = ModuleFqnToConfig({"re:linear.": config2, "linear1": config1})
-        model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
-        example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
+        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
+        example_inputs = model.example_inputs(device="cuda", dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, int4_tensor_type)
+        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
         assert isinstance(model.linear2.weight, IntxUnpackedToInt8Tensor)
 
-    @unittest.skipIf(not torch.accelerator.is_available(), "Need accelerator available")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_regex_fullmatch(self, device):
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_module_fqn_to_config_regex_fullmatch(self):
         """Testing that we will only match the fqns that fully
         matches the regex
         """
-        if device == "cpu":
-            self.skipTest("Need accelerator available")
 
         class M(torch.nn.Module):
             def __init__(self, dtype, device):
@@ -570,12 +542,8 @@ class TestQuantFlow(TestCase):
             def example_inputs(self):
                 return (torch.randn(1, 32, dtype=self.dtype, device=self.device),)
 
-        packing_format = "plain_int32" if device == "xpu" else "tile_packed_to_4d"
-        int4_tensor_type = (
-            Int4PlainInt32Tensor if device == "xpu" else Int4TilePackedTo4dTensor
-        )
         config1 = Int4WeightOnlyConfig(
-            group_size=32, int4_packing_format=packing_format
+            group_size=32, int4_packing_format="tile_packed_to_4d"
         )
         config2 = Float8WeightOnlyConfig()
         config = ModuleFqnToConfig(
@@ -585,11 +553,11 @@ class TestQuantFlow(TestCase):
                 "linear3_full_match.bias": None,
             }
         )
-        model = M(dtype=torch.bfloat16, device=device)
+        model = M(dtype=torch.bfloat16, device="cuda")
         example_inputs = model.example_inputs()
         quantize_(model, config, filter_fn=None)
         model(*example_inputs)
-        assert isinstance(model.linear1.weight, int4_tensor_type)
+        assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
         # since fqn does not fully match `linear*`, it should not be quantized
         assert not isinstance(model.not_full_match_linear2.weight, Float8Tensor)
         # linear3_full_match matches `linear*`, so should be quantized
@@ -623,13 +591,11 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear.weight, IntxUnpackedToInt8Tensor)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_module_fqn_to_config_skip(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    @unittest.skipIf(not is_sm_at_least_89(), "Need SM 8.9+")
+    def test_module_fqn_to_config_skip(self):
         config1 = Float8DynamicActivationFloat8WeightConfig()
         config = ModuleFqnToConfig({"_default": config1, "linear2": None})
+        device = get_current_accelerator_device()
         model = ToyLinearModel().to(device).to(dtype=torch.bfloat16)
         example_inputs = model.example_inputs(device=device, dtype=torch.bfloat16)
         quantize_(model, config, filter_fn=None)
@@ -641,14 +607,10 @@ class TestQuantFlow(TestCase):
 common_utils.instantiate_parametrized_tests(TestQuantFlow)
 
 
-@unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-@unittest.skipIf(torch.cuda.is_available() and not is_sm_at_least_89(), "Need SM 8.9+")
-@common_utils.instantiate_parametrized_tests
+@unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
+@unittest.skipIf(not is_sm_at_least_90(), "Checkpoints are produced in SM90+")
 class TestFqnToConfig(TestCase):
-    @common_utils.parametrize("device", get_available_devices())
-    def test_fqn_to_config_repr_custom(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_fqn_to_config_repr_custom(self):
         class TestModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -659,7 +621,7 @@ class TestFqnToConfig(TestCase):
                     "y", torch.nn.Parameter(torch.randn(128, 128, dtype=torch.bfloat16))
                 )
 
-        custom_module = TestModule().to(device).eval()
+        custom_module = TestModule().cuda().eval()
         custom_module_config = FqnToConfig(
             {
                 "x": Float8DynamicActivationFloat8WeightConfig(
@@ -677,11 +639,8 @@ class TestFqnToConfig(TestCase):
         assert "Float8Tensor(" in str(custom_module)
         assert "PerTensor()" in str(custom_module)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_fqn_to_config_repr_linear(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        linear_model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_fqn_to_config_repr_linear(self):
+        linear_model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
         linear_quant_config = FqnToConfig(
             {
                 "linear1.weight": Float8DynamicActivationFloat8WeightConfig(
@@ -773,8 +732,7 @@ class TestFqnToConfig(TestCase):
         config = AutoConfig.from_pretrained(
             "unsloth/Llama-4-Scout-17B-16E-Instruct"
         ).text_config
-        device = get_current_accelerator_device()
-        model = Llama4TextMoe(config).to(torch.bfloat16).to(device)
+        model = Llama4TextMoe(config).to(torch.bfloat16).cuda()
 
         quant_config = FqnToConfig(
             {
@@ -792,11 +750,8 @@ class TestFqnToConfig(TestCase):
 
         assert isinstance(model.experts.gate_up_proj, Float8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_param_over_module(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_param_over_module(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -810,11 +765,8 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_param_over_module_regex(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_param_over_module_regex(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -828,11 +780,8 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_param_regex_over_module_regex(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_param_regex_over_module_regex(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -846,11 +795,8 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert model.linear1.weight.scale.numel() == 1
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_module_over_param_regex(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_module_over_param_regex(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -865,11 +811,8 @@ class TestFqnToConfig(TestCase):
         assert model.linear1.weight.scale.numel() == 1
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_param_over_default(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_param_over_default(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -884,11 +827,8 @@ class TestFqnToConfig(TestCase):
         assert model.linear1.weight.scale.numel() == 1
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_fqn_precedence_param_regex_over_default(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_fqn_precedence_param_regex_over_default(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
 
         quant_config = FqnToConfig(
             {
@@ -902,11 +842,8 @@ class TestFqnToConfig(TestCase):
         assert not isinstance(model.linear2.weight, Float8Tensor)
         assert not isinstance(model.linear1.weight, Float8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_model_same_module_different_param(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_model_same_module_different_param(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
         model.linear1.register_parameter(
             "weight2", torch.nn.Parameter(model.linear1.weight.clone())
         )
@@ -931,11 +868,8 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.linear1.weight2, Float8Tensor)
         assert model.linear1.weight2.scale.numel() == 32
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantize_model_same_module_different_param_regex(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = ToyLinearModel().to(device).to(torch.bfloat16).eval()
+    def test_quantize_model_same_module_different_param_regex(self):
+        model = ToyLinearModel().to(torch.bfloat16).cuda().eval()
         quant_config = FqnToConfig(
             {
                 "re:.*weight": Float8DynamicActivationFloat8WeightConfig(
@@ -957,16 +891,13 @@ class TestFqnToConfig(TestCase):
         assert model.linear2.weight.scale.numel() == 1
         assert not isinstance(model.linear2.bias, Float8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_unsupported_param_config_raises_not_implemented_error(self, device):
+    def test_unsupported_param_config_raises_not_implemented_error(self):
         """Test that using an unsupported parameter config raises NotImplementedError.
 
         This test creates a custom config whose handler does not have a 'parameter_name'
         kwarg in its signature. This verifies that _handler_supports_fqn_quantization()
         correctly identifies handlers that don't support parameter-level quantization.
         """
-        if device == "cpu":
-            self.skipTest("Need GPU available")
         from dataclasses import dataclass
 
         from torchao.core.config import AOBaseConfig
@@ -989,7 +920,7 @@ class TestFqnToConfig(TestCase):
             return module
 
         # Create a simple model
-        model = torch.nn.Sequential(torch.nn.Linear(10, 5)).to(device).bfloat16()
+        model = torch.nn.Sequential(torch.nn.Linear(10, 5).cuda().bfloat16())
 
         # Create config targeting a parameter (not a module)
         quant_config = FqnToConfig(
@@ -1005,14 +936,11 @@ class TestFqnToConfig(TestCase):
 
         self.assertIn("does not yet support parameter quantization", str(cm.exception))
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_filter_fn_and_fqn_to_config_error(self, device):
+    def test_filter_fn_and_fqn_to_config_error(self):
         """Test that specifying non-default filter_fn and FqnToConfig raises ValueError."""
-        if device == "cpu":
-            self.skipTest("Need GPU available")
 
         # Create a simple model
-        model = torch.nn.Sequential(torch.nn.Linear(10, 5)).to(device).bfloat16()
+        model = torch.nn.Sequential(torch.nn.Linear(10, 5).cuda().bfloat16())
 
         # Create config with unsupported parameter handler
         quant_config = FqnToConfig(
@@ -1027,11 +955,8 @@ class TestFqnToConfig(TestCase):
         with self.assertRaises(ValueError):
             quantize_(model, quant_config, filter_fn=lambda mod, fqn: True)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_top_level_param(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = torch.nn.Linear(16, 16).to(device).bfloat16()
+    def test_top_level_param(self):
+        model = torch.nn.Linear(16, 16).cuda().bfloat16()
 
         quant_config = FqnToConfig(
             {
@@ -1046,11 +971,8 @@ class TestFqnToConfig(TestCase):
         assert isinstance(model.weight, Float8Tensor)
         assert model.weight.scale.numel() == 1
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_non_fqn_config_filter_fn_none(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
-        model = torch.nn.Linear(16, 16).to(device).bfloat16()
+    def test_non_fqn_config_filter_fn_none(self):
+        model = torch.nn.Linear(16, 16).cuda().bfloat16()
         quant_config = Float8DynamicActivationFloat8WeightConfig(
             granularity=PerTensor()
         )
@@ -1060,10 +982,8 @@ class TestFqnToConfig(TestCase):
         assert model.weight.scale.numel() == 1
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
-    @common_utils.parametrize("device", get_available_devices())
-    def test_quantized_model_streaming_fqn_config(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_quantized_model_streaming_fqn_config(self):
+        device = get_current_accelerator_device()
         device_module = torch.get_device_module(device)
 
         def reset_memory():
@@ -1084,7 +1004,7 @@ class TestFqnToConfig(TestCase):
         memory_streaming = device_module.max_memory_allocated()
 
         for param in m.parameters():
-            assert param.device.type == device
+            assert param.device.type == device.type
         self.assertLess(memory_streaming, memory_baseline)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
@@ -1163,17 +1083,10 @@ class TestFqnToConfig(TestCase):
         assert isinstance(m.nested.linear.weight, Int8Tensor)
         assert isinstance(m.linear1.weight, Int8Tensor)
 
-    @common_utils.parametrize("device", get_available_devices())
-    def test_fqn_to_config_non_weight_param(self, device):
-        if device == "cpu":
-            self.skipTest("Need GPU available")
+    def test_fqn_to_config_non_weight_param(self):
         configs = [
-            Int4WeightOnlyConfig(
-                group_size=128,
-                int4_packing_format="plain_int32"
-                if device == "xpu"
-                else "tile_packed_to_4d",
-            ),
+            Int4WeightOnlyConfig(group_size=128),
+            Float8DynamicActivationInt4WeightConfig(),
             Int8WeightOnlyConfig(),
             Int8DynamicActivationInt8WeightConfig(),
             Int8DynamicActivationIntxWeightConfig(),
@@ -1182,9 +1095,6 @@ class TestFqnToConfig(TestCase):
             Float8WeightOnlyConfig(),
             Float8DynamicActivationFloat8WeightConfig(granularity=PerTensor()),
         ]
-        if device != "xpu":
-            # Float8DynamicActivationInt4WeightConfig requires mslk (CUDA-only library)
-            configs.append(Float8DynamicActivationInt4WeightConfig())
         if is_sm_at_least_100():
             configs.append(MXDynamicActivationMXWeightConfig())
         if is_sm_at_least_100():
@@ -1192,12 +1102,12 @@ class TestFqnToConfig(TestCase):
         for config in configs:
             with self.subTest(config=type(config).__name__):
                 model = torch.nn.Sequential(
-                    torch.nn.Linear(128, 128).to(device).to(torch.bfloat16)
+                    torch.nn.Linear(128, 128).to(torch.bfloat16).cuda()
                 )
                 model[0].register_parameter(
                     "custom_param",
                     torch.nn.Parameter(
-                        torch.randn(128, 128, dtype=torch.bfloat16, device=device)
+                        torch.randn(128, 128, dtype=torch.bfloat16, device="cuda")
                     ),
                 )
                 original_custom_param = model[0].custom_param


### PR DESCRIPTION
For https://github.com/pytorch/ao/issues/2917, this PR is target to:

- Refactor the device generalization and remove get_current_accelerator_device() in test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
- Device agnostic more cases in test/quantization/quantize_/workflows/{int4/test_int4_plain_int32_tensor.py, int8/test_int8_tensor.py, nf4/test_nf4_tensor.py}.