### PR TITLE
[mxfp8 moe training] add support for bias parm in _to_mxfp8_then_scaled_grouped_mm

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -493,3 +493,144 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
             wgrad_with_hp=False,
             scale_calculation_mode=ScaleCalculationMode.RCEIL,
         )
+
+
+@skip_if_rocm("ROCm not supported")
+@pytest.mark.parametrize(
+    "kernel_preference", (KernelPreference.AUTO, KernelPreference.EMULATED)
+)
+@pytest.mark.parametrize("M,K,N", [(4096, 1024, 2048)])
+@pytest.mark.parametrize("num_experts", (1, 8))
+def test_mxfp8_grouped_gemm_bias_forward(kernel_preference, M, K, N, num_experts):
+    """Test that bias is correctly added to the forward output."""
+    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+        pytest.skip("MXFP8 hardware mode tests require SM100")
+
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
+    w_t = w.transpose(-2, -1)
+    bias = torch.randn(N, dtype=torch.bfloat16, device="cuda")
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+
+    # Output without bias
+    out_no_bias = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        bias=None,
+        out_dtype=torch.bfloat16,
+        kernel_preference=kernel_preference,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+        pad_token_groups_for_grouped_mm=False,
+    )
+
+    # Output with bias
+    out_with_bias = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        bias=bias,
+        out_dtype=torch.bfloat16,
+        kernel_preference=kernel_preference,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+        pad_token_groups_for_grouped_mm=False,
+    )
+
+    # The difference should be exactly the bias (broadcast along dim0)
+    diff = out_with_bias - out_no_bias
+    expected_bias = bias.unsqueeze(0).expand_as(diff)
+    torch.testing.assert_close(diff, expected_bias, rtol=0, atol=0)
+
+
+@skip_if_rocm("ROCm not supported")
+@pytest.mark.parametrize(
+    "kernel_preference", (KernelPreference.AUTO, KernelPreference.EMULATED)
+)
+@pytest.mark.parametrize("M,K,N", [(4096, 1024, 2048)])
+@pytest.mark.parametrize("num_experts", (1, 8))
+def test_mxfp8_grouped_gemm_bias_backward(kernel_preference, M, K, N, num_experts):
+    """Test that bias gradient is correctly computed via autograd."""
+    if kernel_preference != KernelPreference.EMULATED and not is_sm_version(10, 0):
+        pytest.skip("MXFP8 hardware mode tests require SM100")
+
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
+    w_t = w.transpose(-2, -1).requires_grad_(True)
+    bias = torch.randn(N, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+
+    # Reference: bf16 grouped mm + bias
+    x_ref = x.clone().detach().requires_grad_(True)
+    w_t_ref = w_t.clone().detach().requires_grad_(True)
+    bias_ref = bias.clone().detach().requires_grad_(True)
+    ref_out = torch._grouped_mm(x_ref, w_t_ref, offs=offs, out_dtype=torch.bfloat16)
+    ref_out = ref_out + bias_ref
+
+    # MXFP8 with bias
+    out = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        bias=bias,
+        out_dtype=torch.bfloat16,
+        kernel_preference=kernel_preference,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+        pad_token_groups_for_grouped_mm=False,
+    )
+
+    # Backward
+    labels = torch.ones_like(ref_out)
+    F.mse_loss(ref_out, labels).backward()
+    F.mse_loss(out, labels).backward()
+
+    # Bias gradient should exist and be close to reference
+    assert bias.grad is not None, "bias.grad should be computed"
+    assert bias_ref.grad is not None, "bias_ref.grad should be computed"
+    sqnr = compute_error(bias_ref.grad, bias.grad)
+    min_sqnr = 25.0
+    assert sqnr >= min_sqnr, f"Bias grad sqnr {sqnr} is too low, must be >= {min_sqnr}"
+
+    # Input and weight grads should still be correct
+    assert x.grad is not None, "x.grad should be computed"
+    sqnr_input = compute_error(x_ref.grad, x.grad)
+    assert sqnr_input >= 25.0, f"Input grad sqnr {sqnr_input} is too low"
+
+    assert w_t.grad is not None, "w_t.grad should be computed"
+    sqnr_weight = compute_error(w_t_ref.grad, w_t.grad)
+    assert sqnr_weight >= 24.0, f"Weight grad sqnr {sqnr_weight} is too low"
+
+
+@skip_if_rocm("ROCm not supported")
+def test_mxfp8_grouped_gemm_bias_none_unchanged():
+    """Test that passing bias=None produces the same result as not passing bias."""
+    M, K, N, num_experts = 4096, 1024, 2048, 8
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
+    w_t = w.transpose(-2, -1)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+
+    out_default = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        out_dtype=torch.bfloat16,
+        kernel_preference=KernelPreference.EMULATED,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+    )
+
+    out_none = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        bias=None,
+        out_dtype=torch.bfloat16,
+        kernel_preference=KernelPreference.EMULATED,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+    )
+
+    torch.testing.assert_close(out_default, out_none, rtol=0, atol=0)

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -240,8 +240,10 @@ def test_emulate_mxfp8_grouped_gemm_2d_2d(M, N, num_experts):
 @skip_if_rocm("ROCm not supported")
 @pytest.mark.parametrize("M,K,N", [(32768, 5120, 8192), (16640, 7168, 2048)])
 @pytest.mark.parametrize("num_experts", (1, 8))
-@pytest.mark.parametrize("wgrad_with_hp", (True, False))
-@pytest.mark.parametrize("use_compile", (False, True))
+@pytest.mark.parametrize(
+    "wgrad_with_hp", (True, False), ids=("wgrad_with_hp=True", "wgrad_with_hp=False")
+)
+@pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compile"))
 @pytest.mark.parametrize(
     "kernel_preference", (KernelPreference.AUTO, KernelPreference.EMULATED)
 )
@@ -538,10 +540,11 @@ def test_mxfp8_grouped_gemm_bias_forward(kernel_preference, M, K, N, num_experts
         pad_token_groups_for_grouped_mm=False,
     )
 
-    # The difference should be exactly the bias (broadcast along dim0)
-    diff = out_with_bias - out_no_bias
-    expected_bias = bias.unsqueeze(0).expand_as(diff)
-    torch.testing.assert_close(diff, expected_bias, rtol=0, atol=0)
+    # The biased output should match applying the same bf16 bias add to the
+    # unbiased output. Checking (out_with_bias - out_no_bias) exactly is not
+    # stable in bf16 because the subtraction rounds again.
+    expected_out = out_no_bias + bias.to(out_no_bias.dtype)
+    torch.testing.assert_close(out_with_bias, expected_out, rtol=0, atol=0)
 
 
 @skip_if_rocm("ROCm not supported")

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -601,36 +601,3 @@ def test_mxfp8_grouped_gemm_bias_backward(kernel_preference, M, K, N, num_expert
     assert w_t.grad is not None, "w_t.grad should be computed"
     sqnr_weight = compute_error(w_t_ref.grad, w_t.grad)
     assert sqnr_weight >= 24.0, f"Weight grad sqnr {sqnr_weight} is too low"
-
-
-@skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_bias_none_unchanged():
-    """Test that passing bias=None produces the same result as not passing bias."""
-    M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
-
-    out_default = _to_mxfp8_then_scaled_grouped_mm(
-        x,
-        w_t,
-        offs=offs,
-        out_dtype=torch.bfloat16,
-        kernel_preference=KernelPreference.EMULATED,
-        wgrad_with_hp=True,
-        scale_calculation_mode=ScaleCalculationMode.RCEIL,
-    )
-
-    out_none = _to_mxfp8_then_scaled_grouped_mm(
-        x,
-        w_t,
-        offs=offs,
-        bias=None,
-        out_dtype=torch.bfloat16,
-        kernel_preference=KernelPreference.EMULATED,
-        wgrad_with_hp=True,
-        scale_calculation_mode=ScaleCalculationMode.RCEIL,
-    )
-
-    torch.testing.assert_close(out_default, out_none, rtol=0, atol=0)

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -288,3 +288,71 @@ def test_float8_training_tensor_ops_fwd_bwd(op_name, batch_size, float8_linear_r
     assert sqnr_weight_grad >= min_sqnr_weight_grad, (
         f"Weight grad SQNR {sqnr_weight_grad} is too low, must be >= {min_sqnr_weight_grad}"
     )
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL, MXFP8TrainingRecipe.MXFP8_RCEIL],
+)
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_mxfp8_grouped_mm_with_bias(recipe, use_bias):
+    """Test that bias is correctly forwarded through MXFP8TrainingWeightWrapperTensor.__torch_function__
+    for the grouped_mm dispatch path."""
+    if recipe != MXFP8TrainingRecipe.MXFP8_EMULATED_RCEIL:
+        if not is_sm_at_least_100() or not _triton_kernels_available:
+            pytest.skip("SM 100+ required for real MXFP8 support")
+
+    from torchao.prototype.moe_training.utils import generate_jagged_offs
+
+    config = MXFP8TrainingOpConfig.from_recipe(recipe)
+
+    M, K, N, num_experts = 4096, 1024, 2048, 8
+    A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    B = torch.randn(
+        num_experts, K, N, dtype=torch.bfloat16, device="cuda", requires_grad=True
+    )
+    bias = (
+        torch.randn(N, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        if use_bias
+        else None
+    )
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+
+    # Reference: bf16 grouped mm (+ bias if applicable)
+    A_ref = A.clone().detach().requires_grad_(True)
+    B_ref = B.clone().detach().requires_grad_(True)
+    bias_ref = bias.clone().detach().requires_grad_(True) if bias is not None else None
+    ref_out = torch._grouped_mm(A_ref, B_ref, offs=offs, out_dtype=torch.bfloat16)
+    if bias_ref is not None:
+        ref_out = ref_out + bias_ref
+
+    # MXFP8 grouped mm via tensor dispatch
+    B_mxfp8 = MXFP8TrainingWeightWrapperTensor(B, config)
+    kwargs = {"offs": offs}
+    if bias is not None:
+        kwargs["bias"] = bias
+    out = torch._grouped_mm(A, B_mxfp8, **kwargs)
+
+    # Forward SQNR
+    sqnr_fwd = compute_error(ref_out, out)
+    min_sqnr_fwd = 25.0
+    assert sqnr_fwd >= min_sqnr_fwd, (
+        f"Forward SQNR {sqnr_fwd} is too low, must be >= {min_sqnr_fwd}"
+    )
+
+    # Backward
+    labels = torch.ones_like(ref_out)
+    F.mse_loss(ref_out, labels).backward()
+    F.mse_loss(out, labels).backward()
+
+    # Check input grads
+    assert A.grad is not None, "A.grad should be computed"
+    sqnr_input = compute_error(A_ref.grad, A.grad)
+    assert sqnr_input >= 24.0, f"Input grad SQNR {sqnr_input} is too low"
+
+    # Check bias gradient if bias is used
+    if use_bias:
+        assert bias.grad is not None, "bias.grad should be computed"
+        assert bias_ref.grad is not None, "bias_ref.grad should be computed"
+        sqnr_bias = compute_error(bias_ref.grad, bias.grad)
+        assert sqnr_bias >= 25.0, f"Bias grad SQNR {sqnr_bias} is too low"

--- a/test/prototype/moe_training/test_tensor.py
+++ b/test/prototype/moe_training/test_tensor.py
@@ -309,7 +309,7 @@ def test_mxfp8_grouped_mm_with_bias(recipe, use_bias):
     M, K, N, num_experts = 4096, 1024, 2048, 8
     A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
     B = torch.randn(
-        num_experts, K, N, dtype=torch.bfloat16, device="cuda", requires_grad=True
+        num_experts, N, K, dtype=torch.bfloat16, device="cuda", requires_grad=True
     )
     bias = (
         torch.randn(N, dtype=torch.bfloat16, device="cuda", requires_grad=True)
@@ -322,7 +322,9 @@ def test_mxfp8_grouped_mm_with_bias(recipe, use_bias):
     A_ref = A.clone().detach().requires_grad_(True)
     B_ref = B.clone().detach().requires_grad_(True)
     bias_ref = bias.clone().detach().requires_grad_(True) if bias is not None else None
-    ref_out = torch._grouped_mm(A_ref, B_ref, offs=offs, out_dtype=torch.bfloat16)
+    ref_out = torch._grouped_mm(
+        A_ref, B_ref.transpose(-2, -1), offs=offs, out_dtype=torch.bfloat16
+    )
     if bias_ref is not None:
         ref_out = ref_out + bias_ref
 
@@ -331,7 +333,7 @@ def test_mxfp8_grouped_mm_with_bias(recipe, use_bias):
     kwargs = {"offs": offs}
     if bias is not None:
         kwargs["bias"] = bias
-    out = torch._grouped_mm(A, B_mxfp8, **kwargs)
+    out = torch._grouped_mm(A, B_mxfp8.transpose(-2, -1), **kwargs)
 
     # Forward SQNR
     sqnr_fwd = compute_error(ref_out, out)

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 import torch
+from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
@@ -51,39 +52,13 @@ _SM100_KERNELS_AVAILABLE = (
 )
 
 
-def _validate_grouped_mm_input_act(
-    input_act: torch.Tensor,
-    block_size: int,
-) -> None:
-    if not isinstance(input_act, MXTensor):
-        return
-
-    assert input_act.elem_dtype == torch.float8_e4m3fn, (
-        f"Expected MXTensor with elem_dtype float8_e4m3fn, but got {input_act.elem_dtype}"
-    )
-    assert input_act.block_size == block_size, (
-        f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
-    )
-    assert not input_act.is_swizzled_scales, (
-        "MXTensor input scales must be unswizzled for grouped GEMM"
-    )
-    assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"
-    assert input_act.scale.ndim == 2, "MXTensor input_act scale must be 2D"
-    assert input_act.scale.shape == (
-        input_act.shape[0],
-        input_act.shape[1] // block_size,
-    ), (
-        "MXTensor input scales must be rowwise with shape "
-        f"({input_act.shape[0]}, {input_act.shape[1] // block_size})"
-    )
-
-
 # Aliases for convenience/clarity
 @conditional_nostrict_trace
 def _to_mxfp8_then_scaled_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,
     offs: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = torch.bfloat16,
     kernel_preference: KernelPreference = KernelPreference.AUTO,
     wgrad_with_hp: bool = False,
@@ -115,7 +90,7 @@ def _to_mxfp8_then_scaled_grouped_mm(
     # block_size is always 32 for MXFP8
     block_size = 32
     _validate_grouped_mm_input_act(A, block_size)
-    return _MXFP8GroupedMM.apply(
+    output = _MXFP8GroupedMM.apply(
         A,
         B_t,
         offs,
@@ -125,6 +100,13 @@ def _to_mxfp8_then_scaled_grouped_mm(
         scale_calculation_mode,
         pad_token_groups_for_grouped_mm,
     )
+
+    # add bias outside the autograd function so that autograd
+    # handles the bias gradient automatically.
+    if bias is not None:
+        output = output + bias.to(output.dtype)
+
+    return output
 
 
 class _MXFP8GroupedMM(torch.autograd.Function):
@@ -558,11 +540,15 @@ def _compute_fwd_sm100(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute output using SM100 kernel
-    output = torch._scaled_grouped_mm(
+    output = scaled_grouped_mm(
         input_act_e4m3,
         weight_e4m3.transpose(-2, -1),  # Transpose back to (E, K, N)
         input_act_scales_blocked,
+        ScalingType.BlockWise1x32,
         weight_scales_blocked,
+        ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
         out_dtype=out_dtype,
     )
@@ -1074,3 +1060,30 @@ def _emulated_mxfp8_scaled_grouped_mm_2d_2d(
 
 def round_up(x, y):
     return ((x + y - 1) // y) * y
+
+
+def _validate_grouped_mm_input_act(
+    input_act: torch.Tensor,
+    block_size: int,
+) -> None:
+    if not isinstance(input_act, MXTensor):
+        return
+
+    assert input_act.elem_dtype == torch.float8_e4m3fn, (
+        f"Expected MXTensor with elem_dtype float8_e4m3fn, but got {input_act.elem_dtype}"
+    )
+    assert input_act.block_size == block_size, (
+        f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
+    )
+    assert not input_act.is_swizzled_scales, (
+        "MXTensor input scales must be unswizzled for grouped GEMM"
+    )
+    assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"
+    assert input_act.scale.ndim == 2, "MXTensor input_act scale must be 2D"
+    assert input_act.scale.shape == (
+        input_act.shape[0],
+        input_act.shape[1] // block_size,
+    ), (
+        "MXTensor input scales must be rowwise with shape "
+        f"({input_act.shape[0]}, {input_act.shape[1] // block_size})"
+    )

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -550,7 +550,7 @@ def _compute_fwd_sm100(
         swizzle_a=SwizzleType.SWIZZLE_32_4_4,
         swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
-        out_dtype=out_dtype,
+        output_dtype=out_dtype,
     )
     return output
 

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -8,7 +8,6 @@ import logging
 from typing import Optional
 
 import torch
-from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
@@ -540,17 +539,13 @@ def _compute_fwd_sm100(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute output using SM100 kernel
-    output = scaled_grouped_mm(
+    output = torch._scaled_grouped_mm(
         input_act_e4m3,
         weight_e4m3.transpose(-2, -1),  # Transpose back to (E, K, N)
         input_act_scales_blocked,
-        ScalingType.BlockWise1x32,
         weight_scales_blocked,
-        ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
-        output_dtype=out_dtype,
+        out_dtype=out_dtype,
     )
     return output
 

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -295,15 +295,17 @@ class MXFP8TrainingWeightWrapperTensor(TrainingWeightWrapperBaseTensor):
 
             assert isinstance(B, cls), f"B should be a {cls.__name__}"
 
-            config = B.config
+            config: TrainingOpBaseConfig = B.config
             A_is_2d = A.ndim == 2
-            B_is_2d_or_3d = B.ndim == 2 or B.ndim == 3
-            offs = kwargs.get("offs", None)
+            B_is_2d_or_3d: bool = B.ndim == 2 or B.ndim == 3
+            offs: torch.Tensor | None = kwargs.get("offs", None)
+            bias: torch.Tensor | None = kwargs.get("bias", None)
 
             if A_is_2d and B_is_2d_or_3d and offs is not None:
                 return _quantize_then_scaled_grouped_mm(
                     A,
                     unwrap_weight(B),
+                    bias=bias,
                     offs=offs,
                     config=config,
                 )

--- a/torchao/prototype/moe_training/utils.py
+++ b/torchao/prototype/moe_training/utils.py
@@ -371,6 +371,7 @@ def _quantize_then_scaled_grouped_mm(
     B_t: torch.Tensor,
     config: TrainingOpBaseConfig,
     offs: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     This function performs dynamic quantization with the given config
@@ -404,6 +405,7 @@ def _quantize_then_scaled_grouped_mm(
             A,
             B_t,
             offs,
+            bias=bias,
             out_dtype=config.out_dtype,
             kernel_preference=config.kernel_preference,
             wgrad_with_hp=config.wgrad_with_hp,


### PR DESCRIPTION
Fixes #4341 

## Summary
- The public `torch.nn.functional.scaled_grouped_mm` api supports a `bias` parameter, that the private `torch._scaled_grouped_mm` api does not support. 
- We built torchao's `_to_mxfp8_then_scaled_grouped_mm` before the public scaled_grouped_mm api existed, so it doesn't support bias. 
- Users using the public `scaled_grouped_mm` api are now reporting issues due to the param mismatch: #4341 
- This PR adds support for bias.

## Tests
- Added unit tests exercising bias path