### PR TITLE
Remove .contiguous() from fp8_sparse_mm (#4388)

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
@@ -211,7 +211,7 @@ def fp8_sparse_mm(
     result = result.t()
     if to_pad:
         result = result.narrow(0, 0, batch)
-    return result.contiguous()
+    return result
 
 
 @fp8_sparse_mm.register_fake


### PR DESCRIPTION
Summary:

What: Removing .contiguous() from fp8_sparse_mm

Why: The `.contiguous()` call at the end of `fp8_sparse_mm` forces a full tensor copy after the transpose + narrow operations. Benchmarking for FP8 sparse on MI350X showed significant regressions from `.contiguous()`, especially for large output dimensions (n >= 16384).

Differential Revision: D104909688


