### PR TITLE
update executorch's torch version pin in CI

### DIFF
--- a/.github/workflows/regression_test_aarch64.yml
+++ b/.github/workflows/regression_test_aarch64.yml
@@ -37,7 +37,7 @@ jobs:
           # Install executorch first because it installs its own version
           # of torch and torchao, which we do not want to use
           pip install executorch
-          pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall
+          pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -r dev-requirements.txt
           USE_CPP=1 TORCHAO_BUILD_KLEIDIAI=1 pip install . --no-build-isolation
       - name: Install requirements linux
@@ -45,7 +45,7 @@ jobs:
         run: |
           conda activate venv
           pip install coremltools
-          pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cpu --force-reinstall
+          pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -r dev-requirements.txt
           BUILD_TORCHAO_EXPERIMENTAL=1 TORCHAO_BUILD_CPU_AARCH64=1 TORCHAO_BUILD_KLEIDIAI=1 TORCHAO_ENABLE_ARM_NEON_DOT=1 TORCHAO_PARALLEL_BACKEND=OPENMP pip install . --no-build-isolation
       - name: Run python tests


### PR DESCRIPTION
Summary:

This was previously pinned to 2.9.0, updating to 2.11.0 in preparation
for deleting old PT version support from ao.

Test Plan: CI