### PR TITLE
fix(quantizer): guard mkldnn._is_mkldnn_acl_supported for macOS ARM import

### DIFF
--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -3270,8 +3270,14 @@ def _register_quantization_weight_pack_pass():
     _register_smooth_quant_int_mm_pattern()
 
     # Step 5: QLinear post op Fusion
-    if not torch.ops.mkldnn._is_mkldnn_acl_supported():
-        # skip fusion on ARM
+    # torch.ops.mkldnn._is_mkldnn_acl_supported is only registered when PyTorch
+    # is built with AT_MKLDNN_ENABLED (e.g. not on macOS ARM wheels). Treat its
+    # absence as "MKLDNN unavailable" and skip x86 MKLDNN fusion passes there.
+    _mkldnn_acl_check = getattr(
+        torch.ops.mkldnn, "_is_mkldnn_acl_supported", None
+    )
+    if _mkldnn_acl_check is not None and not _mkldnn_acl_check():
+        # skip fusion on ARM with MKLDNN-ACL, or when MKLDNN is not built in
         _register_qconv_unary_fusion()
         _register_qconv_binary_fusion()
         _register_qlinear_unary_fusion()


### PR DESCRIPTION
## Summary

Fixes #4403 — import-time crash of `torchao.quantization.pt2e.quantizer.x86_inductor_quantizer` on macOS ARM (Apple Silicon).

`torch.ops.mkldnn._is_mkldnn_acl_supported` is only registered when PyTorch is built with `AT_MKLDNN_ENABLED`, which is false for macOS ARM wheels. The unconditional call in `_register_quantization_weight_pack_pass` raises `AttributeError` at module-import time:

```
AttributeError: '_OpNamespace' 'mkldnn' object has no attribute '_is_mkldnn_acl_supported'
```

This is a regression from the migration out of `torch.ao`, where the equivalent module did not have this registration at import time and could be imported on any platform without error.

## Fix

Use `getattr` to detect the op's absence and treat that case as "MKLDNN unavailable", which correctly skips the x86 MKLDNN fusion passes on macOS ARM while preserving existing behavior elsewhere.

Behavior matrix after this change:

| Platform | `_is_mkldnn_acl_supported` | Old behavior | New behavior |
|---|---|---|---|
| x86 Linux + MKLDNN (no ACL) | returns `False` | register fusion | register fusion (unchanged) |
| Linux ARM + MKLDNN-ACL | returns `True` | skip fusion | skip fusion (unchanged) |
| macOS ARM, no MKLDNN | **AttributeError** | **import crash** | skip fusion |

## Test plan

- [x] On macOS ARM (no MKLDNN): `import torchao.quantization.pt2e.quantizer.x86_inductor_quantizer` succeeds.
- [ ] On x86 Linux with MKLDNN: existing fusion passes still register (no behavior change — `_is_mkldnn_acl_supported` is still called and returns `False`).
- [ ] On Linux ARM with MKLDNN-ACL: fusion passes are still skipped.

## Notes

The branch is based on a commit several behind `main`, but the diff against `main` is a clean single-file change (+8 / −2). The targeted block has not been modified upstream since this branch was cut.

---

AI-assisted, human reviewed.
