### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/metal_test.yml
+++ b/.github/workflows/metal_test.yml
@@ -9,6 +9,9 @@ on:
       - main
       - 'gh/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-mps-ops:
     name: test-mps-ops

--- a/.github/workflows/regression_test_aarch64.yml
+++ b/.github/workflows/regression_test_aarch64.yml
@@ -10,6 +10,9 @@ on:
       - main
       - 'gh/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-cpu-ops:
     strategy:

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -6,6 +6,9 @@ on:
       - ciflow/tutorials/*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run_tutorials:
     runs-on: linux.aws.a100


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `dashboard_perf_test.yml`, `run_microbenchmarks.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.