### PR TITLE
Refactor tests to reuse model architectures from torchao.testing

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -24,6 +24,7 @@ from torchao.quantization.quant_primitives import (
     _dequantize_affine_float8,
     _quantize_affine_float8,
 )
+from torchao.testing.model_architectures import ToyTwoLinearModel
 from torchao.utils import (
     get_current_accelerator_device,
     is_sm_at_least_89,
@@ -31,18 +32,6 @@ from torchao.utils import (
 
 random.seed(0)
 torch.manual_seed(0)
-
-
-class ToyLinearModel(torch.nn.Module):
-    def __init__(self, in_features, out_features):
-        super().__init__()
-        self.linear1 = torch.nn.Linear(in_features, out_features, bias=False)
-        self.linear2 = torch.nn.Linear(out_features, in_features, bias=False)
-
-    def forward(self, x):
-        x = self.linear1(x)
-        x = self.linear2(x)
-        return x
 
 
 class TestAffineQuantizedFloat8Compile(InductorTestCase):
@@ -89,7 +78,7 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
             AssertionError,
             match="PerRow quantization only works for bfloat16 precision",
         ):
-            model = ToyLinearModel(64, 64).eval().to(torch.float32).to("cuda")
+            model = ToyTwoLinearModel(64, 64, 64, torch.float32, "cuda").eval()
             quantize_(
                 model,
                 Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),

--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -16,6 +16,7 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import run_tests
 
 from torchao.core.config import config_from_dict, config_to_dict
+from torchao.testing.model_architectures import ToyTwoLinearModel
 from torchao.quantization import (
     Float8DynamicActivationFloat8WeightConfig,
     Float8Tensor,
@@ -42,18 +43,14 @@ from torchao.utils import (
 torch._dynamo.config.cache_size_limit = 128
 
 
-class ToyLinearModel(torch.nn.Module):
+class ToyLinearModel(ToyTwoLinearModel):
     def __init__(self, in_features, out_features, bias):
-        super().__init__()
+        super().__init__(
+            in_features, out_features, in_features,
+            torch.float32, "cpu", has_bias=bias,
+        )
         self.in_features = in_features
         self.out_features = out_features
-        self.linear1 = torch.nn.Linear(in_features, out_features, bias=bias)
-        self.linear2 = torch.nn.Linear(out_features, in_features, bias=bias)
-
-    def forward(self, x):
-        x = self.linear1(x)
-        x = self.linear2(x)
-        return x
 
     def check_weight_scaling(self, granularity: Granularity):
         qs1 = self.linear1.weight.scale

--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor_mi300.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor_mi300.py
@@ -16,21 +16,18 @@ from torchao.quantization import (
     quantize_,
 )
 from torchao.quantization.utils import compute_error
+from torchao.testing.model_architectures import ToyTwoLinearModel
 from torchao.utils import get_current_accelerator_device, is_fbcode, is_MI300
 
 
-class ToyLinearModel(torch.nn.Module):
+class ToyLinearModel(ToyTwoLinearModel):
     def __init__(self, in_features, out_features, bias):
-        super().__init__()
+        super().__init__(
+            in_features, out_features, in_features,
+            torch.float32, "cpu", has_bias=bias,
+        )
         self.in_features = in_features
         self.out_features = out_features
-        self.linear1 = torch.nn.Linear(in_features, out_features, bias=bias)
-        self.linear2 = torch.nn.Linear(out_features, in_features, bias=bias)
-
-    def forward(self, x):
-        x = self.linear1(x)
-        x = self.linear2(x)
-        return x
 
     def check_weight_scaling(self, granularity: Granularity):
         qs1 = self.linear1.weight.scale

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -93,6 +93,7 @@ from torchao.quantization.utils import (
     get_groupwise_affine_qparams,
     groupwise_affine_quantize_tensor,
 )
+from torchao.testing.model_architectures import ToyTwoLinearModel
 from torchao.testing.utils import skip_if_xpu
 from torchao.utils import (
     _is_mslk_available,
@@ -199,21 +200,6 @@ class M4(torch.nn.Module):
 
     def forward(self, x):
         return self.linear(x)
-
-
-class ModelWithLinearBias(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.linear1 = torch.nn.Linear(512, 256, bias=True)
-        self.linear2 = torch.nn.Linear(256, 512, bias=True)
-
-    def example_inputs(self):
-        return (torch.randn(1, 512),)
-
-    def forward(self, x):
-        x = self.linear1(x)
-        x = self.linear2(x)
-        return x
 
 
 class TestQAT(TestCase):
@@ -1392,7 +1378,7 @@ class TestQAT(TestCase):
         """
         Test that QAT supports linear bias.
         """
-        m = ModelWithLinearBias()
+        m = ToyTwoLinearModel(512, 256, 512, torch.float32, "cpu", has_bias=True)
         act_config = IntxFakeQuantizeConfig(torch.int8, "per_token", is_symmetric=False)
         weight_config = IntxFakeQuantizeConfig(TorchAODType.INT4, group_size=32)
         qat_config = QATConfig(


### PR DESCRIPTION
## Summary

Replaces duplicated inline model class definitions in test files with shared implementations from `torchao.testing.model_architectures`, reducing code duplication and improving consistency across the test suite.

**Changes:**
- `test/dtypes/test_affine_quantized_float.py`: Removed inline `ToyLinearModel` class (exact duplicate of `ToyTwoLinearModel`), replaced with direct import
- `test/quantization/test_qat.py`: Removed `ModelWithLinearBias` class (two-linear model with bias), replaced with `ToyTwoLinearModel`
- `test/quantization/quantize_/workflows/float8/test_float8_tensor.py`: Refactored `ToyLinearModel` to inherit from `ToyTwoLinearModel`, keeping the test-specific `check_weight_scaling` method
- `test/quantization/quantize_/workflows/float8/test_float8_tensor_mi300.py`: Same refactoring as above

**Net result:** 4 files changed, 16 insertions(+), 47 deletions(-) — 31 lines of duplicated code removed.

Part of #2078

## Test plan
- [x] Verified all test files collect successfully via `pytest --collect-only`
- [x] `test_affine_quantized_float.py`: 7 passed, 22 skipped (GPU-only tests)
- [x] `test_qat_linear_bias`: Passed
- [x] Manual verification that `ToyTwoLinearModel` produces identical model structure and forward behavior