### PR TITLE
Convert 4 test files from pytest to unittest (#1621)

### DIFF
--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -3,8 +3,15 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
+import unittest
+
 import torch
+from torch.testing._internal.common_utils import (
+    TestCase,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
 from torch.utils._triton import has_triton
 
 from torchao.prototype.dtypes.uintx.bitpacking import pack, pack_cpu, unpack, unpack_cpu
@@ -14,77 +21,88 @@ bit_widths = (1, 2, 3, 4, 5, 6, 7)
 dimensions = (0, -1, 1)
 
 
-@pytest.fixture(autouse=True)
-def run_before_and_after_tests():
-    yield
-    torch._dynamo.reset()  # reset cache between tests
+class TestBitpacking(TestCase):
+    def tearDown(self):
+        torch._dynamo.reset()
 
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    def test_CPU(self, bit_width, dim):
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8, device="cpu"
+        )
+        packed = pack_cpu(test_tensor, bit_width, dim=dim)
+        unpacked = unpack_cpu(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_CPU(bit_width, dim):
-    test_tensor = torch.randint(
-        0, 2**bit_width, (32, 32, 32), dtype=torch.uint8, device="cpu"
+    @unittest.skipIf(
+        not torch.accelerator.is_available(), "GPU not available"
     )
-    packed = pack_cpu(test_tensor, bit_width, dim=dim)
-    unpacked = unpack_cpu(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    def test_GPU(self, bit_width, dim):
+        device = get_current_accelerator_device()
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8
+        ).to(device)
+        packed = pack(test_tensor, bit_width, dim=dim)
+        unpacked = unpack(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
-
-@pytest.mark.skipif(not torch.accelerator.is_available(), reason="GPU not available")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_GPU(bit_width, dim):
-    device = get_current_accelerator_device()
-    test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).to(
-        device
+    @unittest.skipIf(
+        not torch.accelerator.is_available(), "GPU not available"
     )
-    packed = pack(test_tensor, bit_width, dim=dim)
-    unpacked = unpack(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    @unittest.skipIf(not has_triton(), "unsupported without triton")
+    @parametrize("bit_width", bit_widths)
+    @parametrize("dim", dimensions)
+    def test_compile(self, bit_width, dim):
+        device = get_current_accelerator_device()
+        torch._dynamo.config.specialize_int = True
+        torch.compile(pack, fullgraph=True)
+        torch.compile(unpack, fullgraph=True)
+        test_tensor = torch.randint(
+            0, 2**bit_width, (32, 32, 32), dtype=torch.uint8
+        ).to(device)
+        packed = pack(test_tensor, bit_width, dim=dim)
+        unpacked = unpack(packed, bit_width, dim=dim)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
-
-@pytest.mark.skipif(not torch.accelerator.is_available(), reason="GPU not available")
-@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
-@pytest.mark.parametrize("bit_width", bit_widths)
-@pytest.mark.parametrize("dim", dimensions)
-def test_compile(bit_width, dim):
-    device = get_current_accelerator_device()
-    torch._dynamo.config.specialize_int = True
-    torch.compile(pack, fullgraph=True)
-    torch.compile(unpack, fullgraph=True)
-    test_tensor = torch.randint(0, 2**bit_width, (32, 32, 32), dtype=torch.uint8).to(
-        device
+    @unittest.skipIf(
+        not torch.accelerator.is_available(), "GPU not available"
     )
-    packed = pack(test_tensor, bit_width, dim=dim)
-    unpacked = unpack(packed, bit_width, dim=dim)
-    assert unpacked.allclose(test_tensor)
+    def test_pack_example(self):
+        device = get_current_accelerator_device()
+        test_tensor = torch.tensor(
+            [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
+        ).to(device)
+        shard_4, shard_2 = pack(test_tensor, 6)
+        self.assertTrue(
+            torch.tensor([0, 105, 151, 37], dtype=torch.uint8)
+            .to(device)
+            .allclose(shard_4)
+        )
+        self.assertTrue(
+            torch.tensor([39, 146], dtype=torch.uint8).to(device).allclose(shard_2)
+        )
+        unpacked = unpack([shard_4, shard_2], 6)
+        self.assertTrue(unpacked.allclose(test_tensor))
+
+    def test_pack_example_CPU(self):
+        test_tensor = torch.tensor(
+            [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
+        )
+        shard_4, shard_2 = pack(test_tensor, 6)
+        self.assertTrue(
+            torch.tensor([0, 105, 151, 37], dtype=torch.uint8).allclose(shard_4)
+        )
+        self.assertTrue(
+            torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
+        )
+        unpacked = unpack([shard_4, shard_2], 6)
+        self.assertTrue(unpacked.allclose(test_tensor))
 
 
-# these test cases are for the example pack walk through in the bitpacking.py file
-@pytest.mark.skipif(not torch.accelerator.is_available(), reason="GPU not available")
-def test_pack_example():
-    device = get_current_accelerator_device()
-    test_tensor = torch.tensor(
-        [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
-    ).to(device)
-    shard_4, shard_2 = pack(test_tensor, 6)
-    print(shard_4, shard_2)
-    assert (
-        torch.tensor([0, 105, 151, 37], dtype=torch.uint8).to(device).allclose(shard_4)
-    )
-    assert torch.tensor([39, 146], dtype=torch.uint8).to(device).allclose(shard_2)
-    unpacked = unpack([shard_4, shard_2], 6)
-    assert unpacked.allclose(test_tensor)
+instantiate_parametrized_tests(TestBitpacking)
 
-
-def test_pack_example_CPU():
-    test_tensor = torch.tensor(
-        [0x30, 0x29, 0x17, 0x5, 0x20, 0x16, 0x9, 0x22], dtype=torch.uint8
-    )
-    shard_4, shard_2 = pack(test_tensor, 6)
-    print(shard_4, shard_2)
-    assert torch.tensor([0, 105, 151, 37], dtype=torch.uint8).allclose(shard_4)
-    assert torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
-    unpacked = unpack([shard_4, shard_2], 6)
-    assert unpacked.allclose(test_tensor)
+if __name__ == "__main__":
+    run_tests()

--- a/test/prototype/test_autoround.py
+++ b/test/prototype/test_autoround.py
@@ -3,12 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
-
-from torchao.prototype.autoround.utils import is_auto_round_available
-
-if not is_auto_round_available():
-    pytest.skip("AutoRound is not available", allow_module_level=True)
+import unittest
 
 import torch
 from torch.testing._internal.common_utils import (
@@ -17,6 +12,8 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
+
+from torchao.prototype.autoround.utils import is_auto_round_available
 
 from torchao import quantize_
 from torchao.prototype.autoround.core import (
@@ -89,8 +86,9 @@ def _check_params_and_buffers_type(module, check_fun):
     ]
 
 
+@unittest.skipUnless(is_auto_round_available(), "AutoRound is not available")
 class TestAutoRound(TestCase):
-    @pytest.mark.skip("these tests are broken on main branch")
+    @unittest.skip("these tests are broken on main branch")
     @parametrize("device", _AVAILABLE_DEVICES)
     @torch.no_grad()
     def test_auto_round(self, device: str):
@@ -108,9 +106,14 @@ class TestAutoRound(TestCase):
             iters=20,
             device=device,
         )
-        assert all(
-            _check_params_and_buffers_type(m, lambda x: isinstance(x, MultiTensor))
-        ), "Expected all parameters and buffers to be `MultiTensor`."
+        self.assertTrue(
+            all(
+                _check_params_and_buffers_type(
+                    m, lambda x: isinstance(x, MultiTensor)
+                )
+            ),
+            "Expected all parameters and buffers to be `MultiTensor`.",
+        )
         input1 = []
         input2 = []
         for _ in range(10):
@@ -120,18 +123,23 @@ class TestAutoRound(TestCase):
         mt_input1 = MultiTensor(input1)
         mt_input2 = MultiTensor(input2)
         out = m(mt_input1, mt_input2)
-        assert isinstance(out, MultiTensor), f"Expected MultiTensor, got {type(out)}"
-        assert all(
-            _check_params_and_buffers_type(m, lambda x: not isinstance(x, MultiTensor))
-        ), "Expected all parameters and buffers have been converted back to tensor."
+        self.assertIsInstance(out, MultiTensor)
+        self.assertTrue(
+            all(
+                _check_params_and_buffers_type(
+                    m, lambda x: not isinstance(x, MultiTensor)
+                )
+            ),
+            "Expected all parameters and buffers have been converted back to tensor.",
+        )
         quantize_(m, apply_auto_round(), _is_two_linear, device=device)
         for l in m.modules():
             if isinstance(l, torch.nn.Linear):
-                assert isinstance(l.weight, TorchAOBaseTensor)
+                self.assertIsInstance(l.weight, TorchAOBaseTensor)
         after_quant = m(*example_inputs)
-        assert after_quant is not None, "Quantized model forward pass failed"
+        self.assertIsNotNone(after_quant, "Quantized model forward pass failed")
 
-    @pytest.mark.skip("these tests are broken on main branch")
+    @unittest.skip("these tests are broken on main branch")
     @parametrize("device", _AVAILABLE_DEVICES)
     @torch.no_grad()
     def test_wrap_model_with_multi_tensor(self, device: str):
@@ -147,9 +155,14 @@ class TestAutoRound(TestCase):
             iters=20,
             device=device,
         )
-        assert all(
-            _check_params_and_buffers_type(m, lambda x: isinstance(x, MultiTensor))
-        ), "Expected all parameters and buffers to be `MultiTensor`."
+        self.assertTrue(
+            all(
+                _check_params_and_buffers_type(
+                    m, lambda x: isinstance(x, MultiTensor)
+                )
+            ),
+            "Expected all parameters and buffers to be `MultiTensor`.",
+        )
         input1 = []
         input2 = []
         for _ in range(2):
@@ -159,16 +172,21 @@ class TestAutoRound(TestCase):
         mt_input1 = MultiTensor(input1)
         mt_input2 = MultiTensor(input2)
         out = m(mt_input1, mt_input2)
-        assert isinstance(out, MultiTensor), f"Expected MultiTensor, got {type(out)}"
-        assert all(
-            _check_params_and_buffers_type(m, lambda x: not isinstance(x, MultiTensor))
-        ), "Expected all parameters and buffers have been converted back to tensor."
+        self.assertIsInstance(out, MultiTensor)
+        self.assertTrue(
+            all(
+                _check_params_and_buffers_type(
+                    m, lambda x: not isinstance(x, MultiTensor)
+                )
+            ),
+            "Expected all parameters and buffers have been converted back to tensor.",
+        )
         quantize_(m, apply_auto_round(), _is_model_with_inplace_op, device=device)
         for l in m.modules():
             if isinstance(l, torch.nn.Linear):
-                assert isinstance(l.weight, TorchAOBaseTensor)
+                self.assertIsInstance(l.weight, TorchAOBaseTensor)
         after_quant = m(input1[0], input2[0])
-        assert after_quant is not None, "Quantized model forward pass failed"
+        self.assertIsNotNone(after_quant, "Quantized model forward pass failed")
 
 
 instantiate_parametrized_tests(TestAutoRound)

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import copy
+import unittest
 
-import pytest
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
@@ -161,7 +161,7 @@ class TestQuantizedTraining(TestCase):
             loss_int8 = F.cross_entropy(model_int8(inputs), labels)
 
             rel_error = abs(loss_int8.item() - loss_fp32.item()) / abs(loss_fp32.item())
-            assert rel_error < 2e-3, rel_error
+            self.assertLess(rel_error, 2e-3, f"rel_error={rel_error}")
 
             loss_fp32.backward()
             optim_fp32.step()
@@ -182,7 +182,7 @@ class TestQuantizedTraining(TestCase):
         ],
     )
     @parametrize("module_swap", [False, True])
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_int8_mixed_precision_training(self, compile, config, module_swap):
         _reset()
         bsize = 64
@@ -215,13 +215,13 @@ class TestQuantizedTraining(TestCase):
                 torch.linalg.vector_norm(ref) / torch.linalg.vector_norm(error)
             )
 
-        assert snr(outputs_ref, outputs_int8mp) > 20
-        assert snr(inputs_ref.grad, inputs_int8mp.grad) > 20
-        assert snr(linear.weight.grad, linear_int8mp.weight.grad) > 20
+        self.assertGreater(snr(outputs_ref, outputs_int8mp), 20)
+        self.assertGreater(snr(inputs_ref.grad, inputs_int8mp.grad), 20)
+        self.assertGreater(snr(linear.weight.grad, linear_int8mp.weight.grad), 20)
 
-    @pytest.mark.skip("Flaky on CI")
+    @unittest.skip("Flaky on CI")
     @parametrize("compile", [False, True])
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_bitnet_training(self, compile):
         # reference implementation
         # https://github.com/microsoft/unilm/blob/master/bitnet/The-Era-of-1-bit-LLMs__Training_Tips_Code_FAQ.pdf
@@ -282,7 +282,7 @@ class TestQuantizedTraining(TestCase):
 
             loss.backward()
             for p in model.parameters():
-                assert p.grad is not None
+                self.assertIsNotNone(p.grad)
             optim.step()
             optim.zero_grad()
 
@@ -296,7 +296,7 @@ class TestFSDP2(FSDPTest):
         return _FSDP_WORLD_SIZE
 
     @skip_if_lt_x_gpu(_FSDP_WORLD_SIZE)
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_fsdp2_correctness(self):
         mp_policy = MixedPrecisionPolicy()
 
@@ -367,27 +367,26 @@ class TestFSDP2(FSDPTest):
             fsdp_loss = fsdp_model(inp).sum()
             fsdp_loss.backward()
             for param in fsdp_model.parameters():
-                assert param.grad is not None
+                self.assertIsNotNone(param.grad)
             fsdp_optim.step()
 
             base_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
             base_loss = base_model(inp).sum()
             base_loss.backward()
             for param in base_model.parameters():
-                assert param.grad is not None
+                self.assertIsNotNone(param.grad)
                 dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
             base_optim.step()
 
             rel_error = (fsdp_loss - base_loss).abs() / base_loss.abs()
-            assert rel_error < tolerance, (
-                quantize_fn.__name__,
-                mp_policy,
-                iter_idx,
+            self.assertLess(
                 rel_error,
+                tolerance,
+                f"{quantize_fn.__name__}, {mp_policy}, iter={iter_idx}, rel_error={rel_error}",
             )
 
     @skip_if_lt_x_gpu(_FSDP_WORLD_SIZE)
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_precompute_bitnet_scale(self):
         from torchao.prototype.quantized_training.bitnet import (
             get_bitnet_scale,

--- a/test/prototype/test_smoothquant.py
+++ b/test/prototype/test_smoothquant.py
@@ -138,16 +138,18 @@ class TestSmoothQuant(unittest.TestCase):
 
         config.step = QuantizationStep.CONVERT
         quantize_(model, config)
-        assert isinstance(model.linear1.weight, SupportsActivationPreScaling)
-        assert isinstance(model.linear2.weight, SupportsActivationPreScaling)
-        assert model.linear1.weight.act_pre_scale is not None
-        assert model.linear2.weight.act_pre_scale is not None
+        self.assertIsInstance(model.linear1.weight, SupportsActivationPreScaling)
+        self.assertIsInstance(model.linear2.weight, SupportsActivationPreScaling)
+        self.assertIsNotNone(model.linear1.weight.act_pre_scale)
+        self.assertIsNotNone(model.linear2.weight.act_pre_scale)
 
         out_smoothquant = model(*x)
         loss_smoothquant = torch.nn.functional.mse_loss(out_smoothquant, out_ref).item()
 
-        assert loss_smoothquant < loss_base, (
-            f"SmoothQuant loss ({loss_smoothquant:.6f}) should not be higher than basic loss ({loss_base:.6f})"
+        self.assertLess(
+            loss_smoothquant,
+            loss_base,
+            f"SmoothQuant loss ({loss_smoothquant:.6f}) should not be higher than basic loss ({loss_base:.6f})",
         )
         # Make sure the result is reasonable
         self.assertGreater(SQNR(out_ref, out_smoothquant), 20.0)


### PR DESCRIPTION
## Summary

Migrate 4 test files from pytest to unittest as tracked by #1621 (source: #1321 — fbcode is deprecating pytest support).

**Files migrated:**

- **`test/dtypes/test_bitpacking.py`** (full conversion): Function-style pytest tests → `TestCase` class, `@pytest.fixture(autouse=True)` → `tearDown()`, `@pytest.mark.parametrize` → PyTorch `@parametrize`, `@pytest.mark.skipif` → `@unittest.skipIf`, bare `assert` → `self.assertTrue`
- **`test/prototype/test_autoround.py`**: Module-level `pytest.skip(allow_module_level=True)` → `@unittest.skipUnless` on class, `@pytest.mark.skip` → `@unittest.skip`, bare `assert` → `self.assertTrue/assertIsInstance/assertIsNotNone`
- **`test/prototype/test_quantized_training.py`**: `@pytest.mark.skipif` → `@unittest.skipIf`, `@pytest.mark.skip` → `@unittest.skip`, bare `assert` → `self.assertLess/assertIsNotNone/assertGreater`
- **`test/prototype/test_smoothquant.py`**: bare `assert isinstance/is not None` → `self.assertIsInstance/assertIsNotNone/assertLess`

## Test plan

- [x] All test files collect correctly with both pytest and unittest
- [x] `test/dtypes/test_bitpacking.py`: 65/65 passed on GPU (H100), including CPU, GPU, and compile tests
- [x] `test/prototype/test_autoround.py`: 2 skipped as expected (marked broken on main)
- [x] `test/prototype/test_quantized_training.py`: 46 passed, 2 skipped (bitnet marked flaky) on GPU; FSDP tests excluded (require multi-GPU)
- [x] `test/prototype/test_smoothquant.py`: observer + insertion + prepare_for_loading tests all pass

cc @jerryzh168