### PR TITLE
Guard _is_mkldnn_acl_supported call for non-MKLDNN builds (macOS ARM)

### DIFF
--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -3470,7 +3470,12 @@ def _register_quantization_weight_pack_pass():
     _register_smooth_quant_int_mm_pattern()
 
     # Step 5: QLinear post op Fusion
-    if not torch.ops.mkldnn._is_mkldnn_acl_supported():
+    _acl_supported = (
+        hasattr(torch.ops, "mkldnn")
+        and hasattr(torch.ops.mkldnn, "_is_mkldnn_acl_supported")
+        and torch.ops.mkldnn._is_mkldnn_acl_supported()
+    )
+    if not _acl_supported:
         # skip fusion on ARM
         _register_qconv_unary_fusion()
         _register_qconv_binary_fusion()


### PR DESCRIPTION
## Summary

- Fixes import crash on macOS ARM (Apple Silicon) when importing `x86_inductor_quantizer`
- The module-level call to `_register_quantization_weight_pack_pass()` unconditionally calls `torch.ops.mkldnn._is_mkldnn_acl_supported()`, which does not exist on platforms where PyTorch is built without `AT_MKLDNN_ENABLED` (macOS ARM wheels)
- Added `hasattr` guards so the import succeeds on all platforms. On non-MKLDNN platforms, the x86 fusion passes are still registered (they simply won't match any graphs on non-x86 hardware)

This is a regression from the migration out of `torch.ao` — the original `torch.ao.quantization.quantizer.x86_inductor_quantizer` in PyTorch 2.10 did not have this module-level registration.

Fixes #4403

## Test plan

- [x] `from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import X86InductorQuantizer` succeeds on Linux (no MKLDNN ACL)
- [ ] Verify on macOS ARM (Apple Silicon) — the reporter's platform

To verify on macOS ARM:
```python
from torchao.quantization.pt2e.quantizer.x86_inductor_quantizer import X86InductorQuantizer
print("Import OK")
```