### PR TITLE
Exclude test/ directory from package distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -888,7 +888,9 @@ if use_cpp != "0":
 setup(
     name="torchao",
     version=version + version_suffix,
-    packages=find_packages(exclude=["benchmarks", "benchmarks.*"]),
+    packages=find_packages(
+        exclude=["benchmarks", "benchmarks.*", "test", "test.*"]
+    ),
     include_package_data=True,
     package_data={
         "torchao.kernel.configs": ["*.pkl"],


### PR DESCRIPTION
## Summary

- `find_packages()` in `setup.py` was discovering `test/` and its subpackages because some subdirectories contain `__init__.py` files
- This caused `pip install torchao` to install a top-level `test` package that conflicts with other packages' test directories
- Added `"test"` and `"test.*"` to the `find_packages(exclude=...)` list, matching the existing exclusion pattern for `"benchmarks"`

Packages that were incorrectly included:
```
test
test.prototype
test.prototype.attention
test.prototype.blockwise_fp8_training
test.prototype.moe_training
test.prototype.moe_training.ep
test.prototype.moe_training.mxfp8
```

Fixes #4360

## Test plan

- [x] Verified `find_packages(exclude=[..., "test", "test.*"])` returns 0 test packages
- [x] Verified all 99 `torchao.*` packages are still discovered