### PR TITLE
Add _grouped_mm dispatch handler to MXTensor

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -17,14 +17,17 @@ from torchao.prototype.mx_formats.inference_workflow import (
     NVFP4DynamicActivationNVFP4WeightConfig,
     NVFP4WeightOnlyConfig,
 )
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode
 from torchao.prototype.mx_formats.nvfp4_tensor import NVFP4Tensor
 from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_rocm
 from torchao.utils import (
+    get_current_accelerator_device,
     is_sm_at_least_89,
     is_sm_at_least_100,
+    torch_version_at_least,
 )
 
 torch.manual_seed(2)
@@ -445,8 +448,9 @@ def test_grouped_mm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, GroupedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, GroupedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"
@@ -462,6 +466,83 @@ def test_grouped_mm_nvfp4():
     y = model(x, offs)
     y_sqnr = compute_error(y_ref, y)
     assert y_sqnr > 15.0
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+@unittest.skipIf(not is_sm_at_least_100(), "Need sm100+")
+@pytest.mark.parametrize(
+    "E,K,N,m_per_group",
+    [
+        (4, 128, 256, [32, 64, 16, 48]),
+        (8, 256, 512, [16, 16, 16, 16, 16, 16, 16, 16]),
+    ],
+)
+@pytest.mark.parametrize(
+    "kernel_preference",
+    [KernelPreference.EMULATED, KernelPreference.AUTO],
+)
+@pytest.mark.parametrize(
+    "scaling_mode",
+    [ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL],
+)
+@pytest.mark.parametrize(
+    "elem_dtype",
+    [
+        torch.float8_e4m3fn,
+        torch.float4_e2m1fn_x2,
+    ],
+)
+@torch.no_grad()
+def test_grouped_mm_mx_dynamic_activation(
+    E, K, N, m_per_group, kernel_preference, scaling_mode, elem_dtype
+):
+    """Test MXDynamicActivationMXWeightConfig with grouped_mm dispatch."""
+    device = get_current_accelerator_device()
+    dtype = torch.bfloat16
+    total_m = sum(m_per_group)
+
+    model_ref = GroupedMMModel(E, K, N, device=device, dtype=dtype)
+    model = copy.deepcopy(model_ref)
+
+    x = torch.randn(total_m, K, device=device, dtype=dtype)
+    offs = torch.tensor(
+        [sum(m_per_group[: i + 1]) for i in range(E)],
+        device=device,
+        dtype=torch.int32,
+    )
+
+    y_ref = model_ref(x, offs)
+
+    config = MXDynamicActivationMXWeightConfig(
+        activation_dtype=elem_dtype,
+        weight_dtype=elem_dtype,
+        kernel_preference=kernel_preference,
+        scaling_mode=scaling_mode,
+    )
+    quantize_(
+        model,
+        config,
+        filter_fn=lambda mod, fqn: (
+            isinstance(mod, GroupedMMModel) and hasattr(mod, "weight")
+        ),
+    )
+
+    assert isinstance(model.weight, MXTensor)
+
+    # FP4 has lower precision than FP8: use dtype-appropriate thresholds
+    # Aligned with test_mx_tensor (w) and test_mx_inference (y) thresholds
+    is_fp4 = elem_dtype == torch.float4_e2m1fn_x2
+    w_sqnr_threshold = 13.0 if is_fp4 else 18.0
+    y_sqnr_threshold = 12.0 if is_fp4 else 15.0
+
+    w_sqnr = compute_error(
+        model_ref.weight, model.weight.dequantize(model.weight.orig_dtype)
+    )
+    assert w_sqnr > w_sqnr_threshold, f"Weight SQNR too low: {w_sqnr:.2f}"
+
+    y = model(x, offs)
+    y_sqnr = compute_error(y_ref, y)
+    assert y_sqnr > y_sqnr_threshold, f"Output SQNR too low: {y_sqnr:.2f}"
 
 
 class BatchedMMModel(nn.Module):
@@ -505,8 +586,9 @@ def test_bmm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, BatchedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, BatchedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -24,7 +24,6 @@ from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_rocm
 from torchao.utils import (
-    get_current_accelerator_device,
     is_sm_at_least_89,
     is_sm_at_least_100,
 )
@@ -496,7 +495,7 @@ def test_grouped_mm_mx_dynamic_activation(
     E, K, N, m_per_group, kernel_preference, scaling_mode, elem_dtype
 ):
     """Test MXDynamicActivationMXWeightConfig with grouped_mm dispatch."""
-    device = get_current_accelerator_device()
+    device = torch.accelerator.current_accelerator()
     dtype = torch.bfloat16
     total_m = sum(m_per_group)
 

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -529,7 +529,6 @@ def test_grouped_mm_mx_dynamic_activation(
     assert isinstance(model.weight, MXTensor)
 
     # FP4 has lower precision than FP8: use dtype-appropriate thresholds
-    # Aligned with test_mx_tensor (w) and test_mx_inference (y) thresholds
     is_fp4 = elem_dtype == torch.float4_e2m1fn_x2
     w_sqnr_threshold = 13.0 if is_fp4 else 18.0
     y_sqnr_threshold = 12.0 if is_fp4 else 15.0

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -496,6 +496,7 @@ def test_grouped_mm_mx_dynamic_activation(
 ):
     """Test MXDynamicActivationMXWeightConfig with grouped_mm dispatch."""
     device = torch.accelerator.current_accelerator()
+    use_swizzled = device.type == "cuda"
     dtype = torch.bfloat16
     total_m = sum(m_per_group)
 
@@ -516,6 +517,7 @@ def test_grouped_mm_mx_dynamic_activation(
         weight_dtype=elem_dtype,
         kernel_preference=kernel_preference,
         scaling_mode=scaling_mode,
+        is_swizzled_scales=use_swizzled,
     )
     quantize_(
         model,

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -27,7 +27,6 @@ from torchao.utils import (
     get_current_accelerator_device,
     is_sm_at_least_89,
     is_sm_at_least_100,
-    torch_version_at_least,
 )
 
 torch.manual_seed(2)

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-import unittest
 from contextlib import contextmanager
 
 import pytest
@@ -468,8 +467,8 @@ def test_grouped_mm_nvfp4():
     assert y_sqnr > 15.0
 
 
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-@unittest.skipIf(not is_sm_at_least_100(), "Need sm100+")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not is_sm_at_least_100(), reason="Need sm100+")
 @pytest.mark.parametrize(
     "E,K,N,m_per_group",
     [

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import unittest
 from contextlib import contextmanager
 
 import pytest

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -786,7 +786,6 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
-
     block_size = 32
 
     x_hp = torch.randn(*shape, device="cuda")

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -549,6 +549,33 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
+@pytest.mark.skipif(not torch.accelerator.is_available(), reason="Need accelerator")
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.parametrize("dims", ((1, 2), (2, 1), (-1, -2), (-2, -1)))
+def test_3d_transpose(elem_dtype, dims):
+    """
+    Verify that transposing a 3D MX tensor works and dequantize roundtrips.
+    """
+    E, M, K = 4, 128, 256
+    block_size = 32
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(E, M, K, device=device, dtype=torch.bfloat16)
+    tensor_mx = MXTensor.to_mx(
+        tensor_hp,
+        elem_dtype,
+        block_size,
+    )
+    # dequantize then transpose
+    tensor_mx_dq_t = tensor_mx.dequantize(tensor_hp.dtype).transpose(dims[0], dims[1])
+
+    # transpose then dequantize
+    tensor_mx_t = tensor_mx.transpose(dims[0], dims[1])
+    tensor_mx_t_dq = tensor_mx_t.dequantize(tensor_hp.dtype)
+
+    assert tensor_mx_dq_t.shape == tensor_mx_t_dq.shape
+    torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
@@ -749,7 +776,7 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+# @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -759,12 +786,10 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
-    if len(shape) == 3 and transpose:
-        pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device="xpu")
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -813,8 +838,6 @@ def test_scale_shape_matches_qdata(transpose, shape):
     ),
 )
 def test_swizzle(elem_dtype, transpose, shape):
-    if len(shape) == 3 and transpose:
-        pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -558,7 +558,7 @@ def test_3d_transpose(elem_dtype, dims):
     """
     E, M, K = 4, 128, 256
     block_size = 32
-    device = torch.accelerator.current_accelerator().type
+    device = torch.accelerator.current_accelerator()
     tensor_hp = torch.randn(E, M, K, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -776,7 +776,7 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-# @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -789,7 +789,7 @@ def test_scale_shape_matches_qdata(transpose, shape):
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="xpu")
+    x_hp = torch.randn(*shape, device="cuda")
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -838,6 +838,8 @@ def test_scale_shape_matches_qdata(transpose, shape):
     ),
 )
 def test_swizzle(elem_dtype, transpose, shape):
+    if len(shape) == 3 and transpose:
+        pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -135,11 +135,14 @@ def _mx_inference_linear_transform(
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"
     )
+    # Swizzled scales are a CUDA SM100+ optimization; disable on XPU
+    use_swizzled = not weight.is_xpu
+
     act_quant_kwargs = QuantizeTensorToMXKwargs(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        is_swizzled_scales=use_swizzled,
         scaling_mode=config.scaling_mode,
     )
 
@@ -150,7 +153,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        is_swizzled_scales=use_swizzled,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -111,6 +111,9 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
+    # Set to False for non-CUDA backends (e.g., XPU).
+    is_swizzled_scales: bool = True
+
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
             "For now - we only support matching input/weight dtypes."
@@ -135,14 +138,12 @@ def _mx_inference_linear_transform(
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"
     )
-    # Swizzled scales are a CUDA SM100+ optimization; disable on XPU
-    use_swizzled = not weight.is_xpu
 
     act_quant_kwargs = QuantizeTensorToMXKwargs(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=use_swizzled,
+        is_swizzled_scales=config.is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 
@@ -153,7 +154,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=use_swizzled,
+        is_swizzled_scales=config.is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -1095,20 +1095,10 @@ def mx_wait_tensor(func, types, args, kwargs):
     )
 
 
-def _per_group_to_blocked(raw_scale, offs):
-    """Apply to_blocked per-group for CUDA's blocked scale layout.
+def _per_group_to_blocked_fallback(raw_scale, offs):
+    """Fallback: Apply to_blocked per-group using a Python loop.
 
-    CUDA's mslk kernel expects per-group blocked scales where each group's
-    scale region is independently padded to 128-row tiles and swizzled.
-    The kernel internally computes per-group scale offsets from the data offs.
-
-    Args:
-        raw_scale: Unswizzled 2D scale tensor (M, K/bs) from to_mx().
-        offs: Group end offsets (int32), shape (E,).
-
-    Returns:
-        Blocked 2D scale tensor (sum(round_up(group_Mi, 128)), round_up(K/bs, 4))
-        with per-group to_blocked applied.
+    Used when the fused Triton kernel is not available.
     """
     zero = torch.zeros(1, dtype=offs.dtype, device=offs.device)
     group_sizes = torch.diff(offs, prepend=zero)
@@ -1123,26 +1113,40 @@ def _per_group_to_blocked(raw_scale, offs):
         group_M = chunk.shape[0]
         n_row_blocks = math.ceil(group_M / 128)
         blocked_flat = to_blocked(chunk)
-        # to_blocked output is (32*n_row_blocks * 16*n_col_blocks) elements.
-        # CUDA expects shape (128*n_row_blocks, 4*n_col_blocks): same byte count
-        # per tile (32*16 = 128*4 = 512), just different 2D interpretation.
-        # The kernel reads using swizzle pattern from flat memory, so reshape is safe.
         blocked_2d = blocked_flat.view(128 * n_row_blocks, 4 * n_col_blocks)
         blocked_groups.append(blocked_2d)
 
     return torch.cat(blocked_groups, dim=0)
 
 
+def _per_group_to_blocked(raw_scale, offs):
+    """Apply to_blocked per-group for CUDA's blocked scale layout.
+    Args:
+        raw_scale: Unswizzled 2D scale tensor (M, K/bs) from to_mx().
+        offs: Group end offsets (int32), shape (E,).
+
+    Returns:
+        Blocked 2D scale tensor with per-group to_blocked applied.
+        Shape: (padded_rows, round_up(K/bs, 4)) where padded_rows >= M.
+    """
+    try:
+        from torchao.prototype.moe_training.kernels.mxfp8 import (
+            triton_mx_block_rearrange_2d_M_groups,
+        )
+
+        if not raw_scale.is_cuda:
+            return _per_group_to_blocked_fallback(raw_scale, offs)
+
+        return triton_mx_block_rearrange_2d_M_groups(
+            raw_scale.view(torch.uint8), offs
+        ).view(raw_scale.dtype)
+    except (ImportError, NotImplementedError):
+        return _per_group_to_blocked_fallback(raw_scale, offs)
+
+
 @implements([aten._grouped_mm.default])
 def mx_grouped_mm(func, types, args, kwargs):
-    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor.
-
-    Supports both CUDA (swizzled/blocked scales) and XPU (raw scales):
-    - CUDA path (is_swizzled_scales=True): quantizes activation without swizzle,
-      then applies per-group to_blocked so each group has its own 128-row tiles.
-      This matches the pattern in moe_training/mxfp8_grouped_mm.py.
-    - XPU path (is_swizzled_scales=False): whole-tensor to_mx with raw scales.
-    """
+    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor."""
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert isinstance(mat_b, MXTensor)
@@ -1164,31 +1168,23 @@ def mx_grouped_mm(func, types, args, kwargs):
 
     is_fp4 = mat_b.elem_dtype == torch.float4_e2m1fn_x2
 
+    # 1. Quantize activation WITHOUT swizzle to get raw (M, K/bs) scales
+    mat_a_mx = MXTensor.to_mx(
+        mat_a,
+        k.elem_dtype,
+        k.block_size,
+        k.scaling_mode,
+        k.kernel_preference,
+        is_swizzled_scales=False,
+    )
+    a_qdata = mat_a_mx.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_a_mx.qdata
     if k.is_swizzled_scales:
-        # CUDA path: per-group activation blocking
-        # 1. Quantize activation WITHOUT swizzle to get raw (M, K/bs) scales
-        mat_a_mx = MXTensor.to_mx(
-            mat_a,
-            k.elem_dtype,
-            k.block_size,
-            k.scaling_mode,
-            k.kernel_preference,
-            is_swizzled_scales=False,
-        )
-        a_qdata = (
-            mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
-            if is_fp4
-            else mat_a_mx.qdata
-        )
-
         # 2. Per-group blocking of activation scales
         a_scale = _per_group_to_blocked(mat_a_mx.scale, offs)
 
         # 3. Weight scale: transpose back and flatten for CUDA 2D format
         b_scale = mat_b.scale.transpose(-2, -1).flatten(1)
-        b_qdata = (
-            mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
-        )
+        b_qdata = mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
 
         return scaled_grouped_mm(
             a_qdata,
@@ -1203,23 +1199,7 @@ def mx_grouped_mm(func, types, args, kwargs):
             output_dtype=mat_a.dtype,
         )
     else:
-        # XPU path: whole-tensor quantization with raw scales (unchanged)
-        mat_a_mx = MXTensor.to_mx(
-            mat_a,
-            k.elem_dtype,
-            k.block_size,
-            k.scaling_mode,
-            k.kernel_preference,
-            is_swizzled_scales=False,
-        )
-        a_qdata = (
-            mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
-            if is_fp4
-            else mat_a_mx.qdata
-        )
-        b_qdata = (
-            mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
-        )
+        b_qdata = mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
         b_scale = mat_b.scale.contiguous()
 
         return scaled_grouped_mm(

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -1102,7 +1102,7 @@ def mx_grouped_mm(func, types, args, kwargs):
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert isinstance(mat_b, MXTensor)
-    assert offs is not None, "offs is required for _grouped_mm"
+    assert offs is not None, "offs is required for MXTensor grouped_mm"
 
     act_quant_kwargs = mat_b.act_quant_kwargs
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,7 +36,7 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
-from torch.nn.functional import ScalingType, SwizzleType
+from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
@@ -436,10 +436,10 @@ def to_dtype(
     # if the underlying data is transposed, convert to row major before
     # unpacking and unscaling
     if is_transposed:
-        data_lp = data_lp.t()
-        scale_e8m0 = scale_e8m0.t()
+        data_lp = data_lp.transpose(-2, -1)
+        scale_e8m0 = scale_e8m0.transpose(-2, -1)
         assert data_lp.is_contiguous()
-        orig_shape = (orig_shape[1], orig_shape[0])
+        orig_shape = (*orig_shape[:-2], orig_shape[-1], orig_shape[-2])
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_hp = data_lp.to(target_dtype)
@@ -470,7 +470,7 @@ def to_dtype(
 
     # if we converted to row-major before unscaling convert back
     if is_transposed:
-        data_hp = data_hp.t()
+        data_hp = data_hp.transpose(-2, -1)
 
     return data_hp
 
@@ -897,6 +897,25 @@ def mx_t(func, types, args, kwargs):
     return new
 
 
+@implements([aten.transpose.int])
+def mx_transpose(func, types, args, kwargs):
+    old, dim0, dim1 = args
+    assert len(old.shape) == 3, f"unsupported rank {len(old.shape)}"
+    valid_3d_dims = ((1, 2), (2, 1), (-1, -2), (-2, -1))
+    assert (dim0, dim1) in valid_3d_dims, f"transpose unsupported for {dim0=} {dim1=}"
+    new = MXTensor(
+        func(old.qdata, dim0, dim1, **kwargs),
+        func(old.scale, dim0, dim1, **kwargs),
+        old.elem_dtype,
+        old.block_size,
+        old.orig_dtype,
+        old.kernel_preference,
+        old.act_quant_kwargs,
+        old.is_swizzled_scales,
+    )
+    return new
+
+
 @implements([aten.sum.dim_IntList])
 def mx_cast_up_op(func, types, args, kwargs):
     """Be careful with this function, this is a "fallback" op that
@@ -1073,4 +1092,65 @@ def mx_wait_tensor(func, types, args, kwargs):
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
         mx_tensor.is_swizzled_scales,
+    )
+
+
+@implements([aten._grouped_mm.default])
+def mx_grouped_mm(func, types, args, kwargs):
+    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor.
+    """
+    mat_a, mat_b = args[0], args[1]
+    offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
+    assert isinstance(mat_b, MXTensor)
+    assert offs is not None, "offs is required for _grouped_mm"
+
+    act_quant_kwargs = mat_b.act_quant_kwargs
+
+    if act_quant_kwargs is None:
+        return torch._grouped_mm(mat_a, mat_b.dequantize(mat_b.orig_dtype), offs=offs)
+
+    # EMULATED: dequantize weight, run bf16 grouped_mm (no activation quantization)
+    k = act_quant_kwargs
+    if k.kernel_preference == KernelPreference.EMULATED:
+        return torch._grouped_mm(mat_a, mat_b.dequantize(mat_b.orig_dtype), offs=offs)
+
+    mat_a_mx = MXTensor.to_mx(
+        mat_a,
+        k.elem_dtype,
+        k.block_size,
+        k.scaling_mode,
+        k.kernel_preference,
+        is_swizzled_scales=k.is_swizzled_scales,
+    )
+
+    assert mat_b.qdata.stride(-2) < mat_b.qdata.stride(-1), (
+        "_grouped_mm requires weight.transpose(-2, -1)"
+    )
+
+    is_fp4 = mat_b.elem_dtype == torch.float4_e2m1fn_x2
+
+    if is_fp4:
+        a_qdata = mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
+        b_qdata = mat_b.qdata.view(torch.float4_e2m1fn_x2)
+    else:
+        a_qdata = mat_a_mx.qdata
+        b_qdata = mat_b.qdata
+
+    use_swizzled = mat_a_mx.is_swizzled_scales or mat_b.is_swizzled_scales
+
+    a_scale = mat_a_mx.scale
+    b_scale = mat_b.scale.contiguous()
+    swizzle = SwizzleType.SWIZZLE_32_4_4 if use_swizzled else None
+
+    return scaled_grouped_mm(
+        a_qdata,
+        b_qdata,
+        scale_a=a_scale.view(torch.float8_e8m0fnu),
+        scale_recipe_a=ScalingType.BlockWise1x32,
+        scale_b=b_scale.view(torch.float8_e8m0fnu),
+        scale_recipe_b=ScalingType.BlockWise1x32,
+        swizzle_a=swizzle,
+        swizzle_b=swizzle,
+        offs=offs,
+        output_dtype=mat_a.dtype,
     )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -1097,8 +1097,7 @@ def mx_wait_tensor(func, types, args, kwargs):
 
 @implements([aten._grouped_mm.default])
 def mx_grouped_mm(func, types, args, kwargs):
-    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor.
-    """
+    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor."""
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert isinstance(mat_b, MXTensor)

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -913,7 +913,7 @@ def mx_transpose(func, types, args, kwargs):
         old.act_quant_kwargs,
         old.is_swizzled_scales,
     )
-    return new
+    return return_and_correct_aliasing(func, args, kwargs, new)
 
 
 @implements([aten.sum.dim_IntList])
@@ -1095,9 +1095,54 @@ def mx_wait_tensor(func, types, args, kwargs):
     )
 
 
+def _per_group_to_blocked(raw_scale, offs):
+    """Apply to_blocked per-group for CUDA's blocked scale layout.
+
+    CUDA's mslk kernel expects per-group blocked scales where each group's
+    scale region is independently padded to 128-row tiles and swizzled.
+    The kernel internally computes per-group scale offsets from the data offs.
+
+    Args:
+        raw_scale: Unswizzled 2D scale tensor (M, K/bs) from to_mx().
+        offs: Group end offsets (int32), shape (E,).
+
+    Returns:
+        Blocked 2D scale tensor (sum(round_up(group_Mi, 128)), round_up(K/bs, 4))
+        with per-group to_blocked applied.
+    """
+    zero = torch.zeros(1, dtype=offs.dtype, device=offs.device)
+    group_sizes = torch.diff(offs, prepend=zero)
+    K_bs = raw_scale.shape[1]
+    n_col_blocks = math.ceil(K_bs / 4)
+
+    blocked_groups = []
+    group_sizes_list = group_sizes.tolist()
+    scale_chunks = raw_scale.split(group_sizes_list, dim=0)
+
+    for chunk in scale_chunks:
+        group_M = chunk.shape[0]
+        n_row_blocks = math.ceil(group_M / 128)
+        blocked_flat = to_blocked(chunk)
+        # to_blocked output is (32*n_row_blocks * 16*n_col_blocks) elements.
+        # CUDA expects shape (128*n_row_blocks, 4*n_col_blocks): same byte count
+        # per tile (32*16 = 128*4 = 512), just different 2D interpretation.
+        # The kernel reads using swizzle pattern from flat memory, so reshape is safe.
+        blocked_2d = blocked_flat.view(128 * n_row_blocks, 4 * n_col_blocks)
+        blocked_groups.append(blocked_2d)
+
+    return torch.cat(blocked_groups, dim=0)
+
+
 @implements([aten._grouped_mm.default])
 def mx_grouped_mm(func, types, args, kwargs):
-    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor."""
+    """Handles torch._grouped_mm when weight (mat_b) is an MXTensor.
+
+    Supports both CUDA (swizzled/blocked scales) and XPU (raw scales):
+    - CUDA path (is_swizzled_scales=True): quantizes activation without swizzle,
+      then applies per-group to_blocked so each group has its own 128-row tiles.
+      This matches the pattern in moe_training/mxfp8_grouped_mm.py.
+    - XPU path (is_swizzled_scales=False): whole-tensor to_mx with raw scales.
+    """
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert isinstance(mat_b, MXTensor)
@@ -1113,43 +1158,77 @@ def mx_grouped_mm(func, types, args, kwargs):
     if k.kernel_preference == KernelPreference.EMULATED:
         return torch._grouped_mm(mat_a, mat_b.dequantize(mat_b.orig_dtype), offs=offs)
 
-    mat_a_mx = MXTensor.to_mx(
-        mat_a,
-        k.elem_dtype,
-        k.block_size,
-        k.scaling_mode,
-        k.kernel_preference,
-        is_swizzled_scales=k.is_swizzled_scales,
-    )
-
     assert mat_b.qdata.stride(-2) < mat_b.qdata.stride(-1), (
         "_grouped_mm requires weight.transpose(-2, -1)"
     )
 
     is_fp4 = mat_b.elem_dtype == torch.float4_e2m1fn_x2
 
-    if is_fp4:
-        a_qdata = mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
-        b_qdata = mat_b.qdata.view(torch.float4_e2m1fn_x2)
+    if k.is_swizzled_scales:
+        # CUDA path: per-group activation blocking
+        # 1. Quantize activation WITHOUT swizzle to get raw (M, K/bs) scales
+        mat_a_mx = MXTensor.to_mx(
+            mat_a,
+            k.elem_dtype,
+            k.block_size,
+            k.scaling_mode,
+            k.kernel_preference,
+            is_swizzled_scales=False,
+        )
+        a_qdata = (
+            mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
+            if is_fp4
+            else mat_a_mx.qdata
+        )
+
+        # 2. Per-group blocking of activation scales
+        a_scale = _per_group_to_blocked(mat_a_mx.scale, offs)
+
+        # 3. Weight scale: transpose back and flatten for CUDA 2D format
+        b_scale = mat_b.scale.transpose(-2, -1).flatten(1)
+        b_qdata = (
+            mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
+        )
+
+        return scaled_grouped_mm(
+            a_qdata,
+            b_qdata,
+            scale_a=a_scale.view(torch.float8_e8m0fnu),
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_b=b_scale.view(torch.float8_e8m0fnu),
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+            swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            offs=offs,
+            output_dtype=mat_a.dtype,
+        )
     else:
-        a_qdata = mat_a_mx.qdata
-        b_qdata = mat_b.qdata
+        # XPU path: whole-tensor quantization with raw scales (unchanged)
+        mat_a_mx = MXTensor.to_mx(
+            mat_a,
+            k.elem_dtype,
+            k.block_size,
+            k.scaling_mode,
+            k.kernel_preference,
+            is_swizzled_scales=False,
+        )
+        a_qdata = (
+            mat_a_mx.qdata.view(torch.float4_e2m1fn_x2)
+            if is_fp4
+            else mat_a_mx.qdata
+        )
+        b_qdata = (
+            mat_b.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_b.qdata
+        )
+        b_scale = mat_b.scale.contiguous()
 
-    use_swizzled = mat_a_mx.is_swizzled_scales or mat_b.is_swizzled_scales
-
-    a_scale = mat_a_mx.scale
-    b_scale = mat_b.scale.contiguous()
-    swizzle = SwizzleType.SWIZZLE_32_4_4 if use_swizzled else None
-
-    return scaled_grouped_mm(
-        a_qdata,
-        b_qdata,
-        scale_a=a_scale.view(torch.float8_e8m0fnu),
-        scale_recipe_a=ScalingType.BlockWise1x32,
-        scale_b=b_scale.view(torch.float8_e8m0fnu),
-        scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=swizzle,
-        swizzle_b=swizzle,
-        offs=offs,
-        output_dtype=mat_a.dtype,
-    )
+        return scaled_grouped_mm(
+            a_qdata,
+            b_qdata,
+            scale_a=mat_a_mx.scale.view(torch.float8_e8m0fnu),
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_b=b_scale.view(torch.float8_e8m0fnu),
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            offs=offs,
+            output_dtype=mat_a.dtype,
+        )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -38,6 +38,10 @@ if torch_version_at_least("2.12.0.dev0"):
 
 from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
+from torchao.prototype.moe_training.kernels.mxfp8 import (
+    torch_to_blocked_2d_M_groups,
+    triton_mx_block_rearrange_2d_M_groups,
+)
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
     ScaleCalculationMode,
@@ -1095,31 +1099,7 @@ def mx_wait_tensor(func, types, args, kwargs):
     )
 
 
-def _per_group_to_blocked_fallback(raw_scale, offs):
-    """Fallback: Apply to_blocked per-group using a Python loop.
-
-    Used when the fused Triton kernel is not available.
-    """
-    zero = torch.zeros(1, dtype=offs.dtype, device=offs.device)
-    group_sizes = torch.diff(offs, prepend=zero)
-    K_bs = raw_scale.shape[1]
-    n_col_blocks = math.ceil(K_bs / 4)
-
-    blocked_groups = []
-    group_sizes_list = group_sizes.tolist()
-    scale_chunks = raw_scale.split(group_sizes_list, dim=0)
-
-    for chunk in scale_chunks:
-        group_M = chunk.shape[0]
-        n_row_blocks = math.ceil(group_M / 128)
-        blocked_flat = to_blocked(chunk)
-        blocked_2d = blocked_flat.view(128 * n_row_blocks, 4 * n_col_blocks)
-        blocked_groups.append(blocked_2d)
-
-    return torch.cat(blocked_groups, dim=0)
-
-
-def _per_group_to_blocked(raw_scale, offs):
+def _per_group_to_blocked(raw_scale, offs, block_size):
     """Apply to_blocked per-group for CUDA's blocked scale layout.
     Args:
         raw_scale: Unswizzled 2D scale tensor (M, K/bs) from to_mx().
@@ -1130,18 +1110,16 @@ def _per_group_to_blocked(raw_scale, offs):
         Shape: (padded_rows, round_up(K/bs, 4)) where padded_rows >= M.
     """
     try:
-        from torchao.prototype.moe_training.kernels.mxfp8 import (
-            triton_mx_block_rearrange_2d_M_groups,
-        )
-
         if not raw_scale.is_cuda:
-            return _per_group_to_blocked_fallback(raw_scale, offs)
+            blocked_scale, _ = torch_to_blocked_2d_M_groups(raw_scale, offs, block_size)
+            return blocked_scale
 
         return triton_mx_block_rearrange_2d_M_groups(
             raw_scale.view(torch.uint8), offs
         ).view(raw_scale.dtype)
     except (ImportError, NotImplementedError):
-        return _per_group_to_blocked_fallback(raw_scale, offs)
+        blocked_scale, _ = torch_to_blocked_2d_M_groups(raw_scale, offs, block_size)
+        return blocked_scale
 
 
 @implements([aten._grouped_mm.default])
@@ -1180,7 +1158,7 @@ def mx_grouped_mm(func, types, args, kwargs):
     a_qdata = mat_a_mx.qdata.view(torch.float4_e2m1fn_x2) if is_fp4 else mat_a_mx.qdata
     if k.is_swizzled_scales:
         # 2. Per-group blocking of activation scales
-        a_scale = _per_group_to_blocked(mat_a_mx.scale, offs)
+        a_scale = _per_group_to_blocked(mat_a_mx.scale, offs, k.block_size)
 
         # 3. Weight scale: transpose back and flatten for CUDA 2D format
         b_scale = mat_b.scale.transpose(-2, -1).flatten(1)


### PR DESCRIPTION
### Summary

This PR adds `aten._grouped_mm.default` and `aten.transpose.int` dispatch handlers to `MXTensor`, enabling MX-format (FP8/FP4) inference for MoE (Mixture of Experts) models that use `torch._grouped_mm` for expert computation. This follows the same pattern established by NVFP4 in #4316 and Float8 in #4390.

### Motivation

MoE architectures (e.g., DeepSeek, Qwen3-MoE) store expert weights as 3D tensors `(E, N, K)` and use `torch._grouped_mm` in the forward pass. With this PR, users can quantize expert weights to MX format (FP8 or FP4) via `quantize_()` using `MXDynamicActivationMXWeightConfig` and get automatic dispatch through the `_grouped_mm` handler — no model code changes needed.

**Related:** RFC #4355, NVFP4 reference #4316, Float8 reference #4390

### Design

The handler supports three modes based on `act_quant_kwargs` and `kernel_preference`:

**Weight-only** (`act_quant_kwargs is None`):
- Dequantize weight → `_grouped_mm` with bf16

**EMULATED** (`kernel_preference == EMULATED`):
- Dequantize weight → `_grouped_mm` with bf16 (no activation quantization)

**AUTO** (preferred path):
1. Quantize activation to MX format via `MXTensor.to_mx()`
2. For FP4: reinterpret packed `uint8` qdata as `float4_e2m1fn_x2`
3. Call `F.scaled_grouped_mm` with BlockWise1x32 scaling and optional swizzle

```
act_quant_kwargs is None?
├── YES → dequant weight → _grouped_mm (weight-only)
└── NO
    ├── EMULATED → dequant weight → _grouped_mm
    └── AUTO → quantize activation via MXTensor.to_mx
              → scaled_grouped_mm(a_qdata, b_qdata, scales, offs)
```
