### PR TITLE
Add `RopeSDPAFusionPass(CustomGraphPass)` with `uuid()`

### DIFF
--- a/test/prototype/attention/test_rope_fusion_detection.py
+++ b/test/prototype/attention/test_rope_fusion_detection.py
@@ -13,7 +13,6 @@ RoPE pattern in the FX graph, independent of any GPU kernel or hardware.
 import contextlib
 import io
 import unittest
-from functools import partial
 
 import torch
 import torch._inductor.config as inductor_config
@@ -22,7 +21,7 @@ import torch.nn as nn
 from torchao.prototype.attention.shared_utils.custom_ops import (
     register_fp8_attention_ops,
 )
-from torchao.prototype.attention.shared_utils.fusion_utils import rope_sdpa_fusion_pass
+from torchao.prototype.attention.shared_utils.fusion_utils import RopeSDPAFusionPass
 
 
 # Register test-only custom ops with dummy implementations.
@@ -119,8 +118,7 @@ class TestRoPEFusionDetection(unittest.TestCase):
 
     def _run_fusion_pass(self, model, *args):
         """Compile model with fusion pass, return captured stdout."""
-        inductor_config.pre_grad_custom_pass = partial(
-            rope_sdpa_fusion_pass,
+        inductor_config.pre_grad_custom_pass = RopeSDPAFusionPass(
             rope_sdpa_op=_ops.rope_sdpa_op,
             fp8_sdpa_op=_ops.fp8_sdpa_op,
             backend_name="TEST",

--- a/torchao/prototype/attention/shared_utils/fusion_utils.py
+++ b/torchao/prototype/attention/shared_utils/fusion_utils.py
@@ -16,6 +16,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch._inductor.custom_graph_pass import CustomGraphPass, get_hash_for_files
 from torch.fx import Graph, Node
 
 logger = logging.getLogger(__name__)
@@ -1110,3 +1111,21 @@ def rope_sdpa_fusion_pass(
 
     if fused_count > 0:
         graph.eliminate_dead_code()
+
+
+class RopeSDPAFusionPass(CustomGraphPass):
+    def __init__(self, rope_sdpa_op, fp8_sdpa_op, backend_name: str = "FP8"):
+        self.rope_sdpa_op = rope_sdpa_op
+        self.fp8_sdpa_op = fp8_sdpa_op
+        self.backend_name = backend_name
+
+    def __call__(self, graph: Graph) -> None:
+        rope_sdpa_fusion_pass(
+            graph,
+            rope_sdpa_op=self.rope_sdpa_op,
+            fp8_sdpa_op=self.fp8_sdpa_op,
+            backend_name=self.backend_name,
+        )
+
+    def uuid(self) -> bytes:
+        return get_hash_for_files((__file__,))

--- a/torchao/prototype/attention/shared_utils/setup.py
+++ b/torchao/prototype/attention/shared_utils/setup.py
@@ -4,14 +4,12 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from functools import partial
-
 import torch._inductor.config as inductor_config
 import torch.nn as nn
 
 from torchao.prototype.attention.shared_utils.fusion_utils import (
+    RopeSDPAFusionPass,
     detect_causal_mask,
-    rope_sdpa_fusion_pass,
 )
 from torchao.prototype.attention.shared_utils.wrapper import (
     _FP8FlashAttentionMonkeyPatchWrapper,
@@ -31,8 +29,7 @@ def setup_fp8_backend(
 
     strip_causal_mask = detect_causal_mask(model, flash_impl_name=flash_impl_name)
 
-    inductor_config.pre_grad_custom_pass = partial(
-        rope_sdpa_fusion_pass,
+    inductor_config.pre_grad_custom_pass = RopeSDPAFusionPass(
         rope_sdpa_op=_ops.rope_sdpa_op,
         fp8_sdpa_op=_ops.fp8_sdpa_op,
         backend_name=flash_impl_name,


### PR DESCRIPTION
Add a `RopeSDPAFusionPass(CustomGraphPass)` wrapper in `fusion_utils.py` that replaces the `functools.partial(rope_sdpa_fusion_pass, ...)` usage. The new class implements `uuid()`, enabling the AOTAutograd cache when `pre_grad_pass_timing` is "late".

Update `setup.py` and `test_rope_fusion_detection.py` to use `RopeSDPAFusionPass` instead of `partial(rope_sdpa_fusion_pass, ...)`.