### PR TITLE
Convert `quant_lift_up` to `CustomGraphPass` with `uuid()`

### DIFF
--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import torch
 from torch._dynamo.utils import counters
+from torch._inductor.custom_graph_pass import CustomGraphPass, get_hash_for_files
 from torch._inductor.fx_passes.freezing_patterns import register_freezing_graph_pattern
 from torch._inductor.pattern_matcher import (
     Arg,
@@ -3482,7 +3483,7 @@ def _register_quantization_weight_pack_pass():
     _register_concat_dq_q_pattern()
 
 
-def quant_lift_up(module_graph: torch.fx.graph.Graph):
+class QuantLiftUp(CustomGraphPass):
     """
     Lift up the quant node before view like nodes. It can benefit performance
     of Attention like block. For example, we have the pattern as:
@@ -3517,70 +3518,77 @@ def quant_lift_up(module_graph: torch.fx.graph.Graph):
     It produces a DQ->LINEAR->Q pattern which can be fused by backend.
     """
 
-    def is_view_op(node):
-        return (node.op == "call_function" and node.target in _VIEW_FUNCTION_OPS) or (
-            node.op == "call_method" and node.target in _VIEW_METHOD_OPS
-        )
-
-    def quant_input_check(node):
-        if len(node.all_input_nodes) == 1:
-            return True
-        elif (
-            node.target
-            == torch.ops.torchao.quantize_affine_float8_non_decomposed.default
-        ):
-            # check if scale created by torch.tensor
+    def __call__(self, module_graph: torch.fx.graph.Graph) -> None:
+        def is_view_op(node):
             return (
-                len(node.all_input_nodes) == 2
-                and node.all_input_nodes[1].target == torch.tensor
-            )
-        return False
+                node.op == "call_function" and node.target in _VIEW_FUNCTION_OPS
+            ) or (node.op == "call_method" and node.target in _VIEW_METHOD_OPS)
 
-    for node in module_graph.nodes:
-        # <TODO> Leslie: Here we verify that the quant node has exactly
-        # one input FX node, with constant scalar value for scale and zero point.
-        # For the case input of quant node has more than one input FX nodes,
-        # extend the implementation to lift up all the connected nodes
-        # before the view nodes to keep the topological order.
-        if (
-            node.op == "call_function"
-            and node.target in _PER_TENSOR_QUANTIZE_OPS
-            and quant_input_check(node)
-            and is_view_op(node.all_input_nodes[0])
-        ):
-            quant_node = node
-            input_node_of_quant = quant_node.all_input_nodes[0]
+        def quant_input_check(node):
+            if len(node.all_input_nodes) == 1:
+                return True
+            elif (
+                node.target
+                == torch.ops.torchao.quantize_affine_float8_non_decomposed.default
+            ):
+                # check if scale created by torch.tensor
+                return (
+                    len(node.all_input_nodes) == 2
+                    and node.all_input_nodes[1].target == torch.tensor
+                )
+            return False
 
-            # Check the nodes along lift up path has only 1 user node
-            # Propagate view like node to find where to insert the new quant node
-            could_lift_up = True
-            current_node = quant_node
-            input_node = current_node.all_input_nodes[0]
-            while is_view_op(input_node):
-                if len(input_node.users) != 1:
-                    could_lift_up = False
-                    break
-                current_node = input_node
+        for node in module_graph.nodes:
+            # <TODO> Leslie: Here we verify that the quant node has exactly
+            # one input FX node, with constant scalar value for scale and zero point.
+            # For the case input of quant node has more than one input FX nodes,
+            # extend the implementation to lift up all the connected nodes
+            # before the view nodes to keep the topological order.
+            if (
+                node.op == "call_function"
+                and node.target in _PER_TENSOR_QUANTIZE_OPS
+                and quant_input_check(node)
+                and is_view_op(node.all_input_nodes[0])
+            ):
+                quant_node = node
+                input_node_of_quant = quant_node.all_input_nodes[0]
+
+                # Check the nodes along lift up path has only 1 user node
+                # Propagate view like node to find where to insert the new quant node
+                could_lift_up = True
+                current_node = quant_node
                 input_node = current_node.all_input_nodes[0]
+                while is_view_op(input_node):
+                    if len(input_node.users) != 1:
+                        could_lift_up = False
+                        break
+                    current_node = input_node
+                    input_node = current_node.all_input_nodes[0]
 
-            # Further check the input node of the first view node has only 1 user node
-            if could_lift_up and len(input_node.users) == 1:
-                # Replace dequant's input from quant to quant's input
-                quant_node.replace_all_uses_with(input_node_of_quant)
-                # Insert the new quant node
-                with module_graph.inserting_before(current_node):
-                    new_quant_node = module_graph.node_copy(quant_node)
-                    input_node.replace_all_uses_with(new_quant_node)
+                # Further check the input node of the first view node has only 1 user node
+                if could_lift_up and len(input_node.users) == 1:
+                    # Replace dequant's input from quant to quant's input
+                    quant_node.replace_all_uses_with(input_node_of_quant)
+                    # Insert the new quant node
+                    with module_graph.inserting_before(current_node):
+                        new_quant_node = module_graph.node_copy(quant_node)
+                        input_node.replace_all_uses_with(new_quant_node)
 
-                    # Update inputs of new_quant_node
-                    def maybe_replace_node(n: torch.fx.Node) -> torch.fx.Node:
-                        if n == input_node_of_quant:
-                            return input_node
-                        else:
-                            return n
+                        # Update inputs of new_quant_node
+                        def maybe_replace_node(n: torch.fx.Node) -> torch.fx.Node:
+                            if n == input_node_of_quant:
+                                return input_node
+                            else:
+                                return n
 
-                    new_args = map_arg(new_quant_node.args, maybe_replace_node)
-                    new_kwargs = map_arg(new_quant_node.kwargs, maybe_replace_node)
-                    new_quant_node.args = new_args  # type: ignore[assignment]
-                    new_quant_node.kwargs = new_kwargs  # type: ignore[assignment]
-                    module_graph.erase_node(quant_node)
+                        new_args = map_arg(new_quant_node.args, maybe_replace_node)
+                        new_kwargs = map_arg(new_quant_node.kwargs, maybe_replace_node)
+                        new_quant_node.args = new_args  # type: ignore[assignment]
+                        new_quant_node.kwargs = new_kwargs  # type: ignore[assignment]
+                        module_graph.erase_node(quant_node)
+
+    def uuid(self) -> bytes:
+        return get_hash_for_files((__file__,))
+
+
+quant_lift_up = QuantLiftUp()


### PR DESCRIPTION
Convert the `quant_lift_up` pre-grad custom pass in the x86 inductor passes from a plain function to a `QuantLiftUp(CustomGraphPass)` subclass that implements `uuid()`. This enables the AOTAutograd cache when `pre_grad_pass_timing` is "late".

A module-level `quant_lift_up` instance preserves backward compatibility with `x86_inductor_quantizer` registration.