### PR TITLE
Fix build failure with GCC 14 in `rowwise_scaled_linear_sparse_cutlass_f8f8.cu`

### DIFF
--- a/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_f8f8.cu
+++ b/torchao/csrc/cuda/rowwise_scaled_linear_sparse_cutlass/rowwise_scaled_linear_sparse_cutlass_f8f8.cu
@@ -21,8 +21,8 @@ Tensor
 rowwise_scaled_linear_sparse_cutlass_f8f8(
     const Tensor& Xq, const Tensor& X_scale, const Tensor& Wq,
     const Tensor& W_meta, const Tensor& W_scale,
-    const std::optional<Tensor>& bias_opt = std::nullopt,
-    const std::optional<torch::headeronly::ScalarType> out_dtype_opt = std::nullopt) {
+    const std::optional<Tensor>& bias_opt,
+    const std::optional<torch::headeronly::ScalarType> out_dtype_opt) {
   // Validate input datatypes.
   STD_TORCH_CHECK(
       (Xq.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn &&


### PR DESCRIPTION
With recent toolchains (Python 3.14, PyTorch 2.11 and 2.12, GCC 14.3.0, nvcc 13.0), building the `torchao._C_cutlass_90a` extension fails:

```
  rowwise_scaled_linear_sparse_cutlass_f8f8.cu: In function
  'void torchao::STABLE_TORCH_LIBRARY_IMPL_init_torchao_CUDA_0(...)':
  rowwise_scaled_linear_sparse_cutlass_f8f8.cu:68:394: error:
    default arguments are only permitted for function parameters [-fpermissive]
     68 |   m.impl("torchao::rowwise_scaled_linear_sparse_cutlass_f8f8",
  rowwise_scaled_linear_sparse_cutlass_f8f8.cu:68:463: error:
    default arguments are only permitted for function parameters [-fpermissive]
```

`rowwise_scaled_linear_sparse_cutlass_f8f8` was defined with default arguments (`= std::nullopt`) on its `bias_opt` and `out_dtype_opt` parameters, and then registered with the stable-ABI dispatcher via `TORCH_BOX(&rowwise_scaled_linear_sparse_cutlass_f8f8)`. `TORCH_BOX` (torch/csrc/stable/library.h) expands into a
`torch::stable::detail::boxer<...>` template instantiation that reflects on the function's type via `decltype(func)`; GCC then rejects the default arguments inside that non-type-template-parameter context.

The defaults on the C++ signature are redundant: the operator schema already declares them (`Tensor? bias=None, ScalarType? out_dtype=None`) in `m.def(...)` a few lines above, and the function has no direct C++ callers - every caller goes through
`torch.ops.torchao.rowwise_scaled_linear_sparse_cutlass_f8f8`. The sibling header `rowwise_scaled_linear_sparse_cutlass_e4m3e4m3.h` already declares the per-dtype variants without defaults, so this also brings the file in line with the surrounding pattern.

Note that:

- All other call sites for `TORCH_BOX` (there are 5 more) don't use `= std::nullopt`, so this change makes the code in this file consistent with the other usages
- This isn't visible in CI because jobs seem to all be using GCC 11.