### PR TITLE
Fix Python 3.14 compatibility of quantization/pt2e

### DIFF
--- a/torchao/quantization/pt2e/__init__.py
+++ b/torchao/quantization/pt2e/__init__.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import sys
 from typing import Callable, Optional, Union
 
 import torch
@@ -91,12 +92,14 @@ for _f in [
 
 # ensure __module__ is set correctly for public APIs
 ObserverOrFakeQuantize = Union[ObserverBase, FakeQuantizeBase]
-ObserverOrFakeQuantize.__module__ = "torchao.quantization.pt2e"
+if sys.version_info < (3, 14):
+    ObserverOrFakeQuantize.__module__ = "torchao.quantization.pt2e"
 
 ObserverOrFakeQuantizeConstructor = Union[
     PartialWrapper, type[ObserverBase], type[FakeQuantizeBase]
 ]
-ObserverOrFakeQuantizeConstructor.__module__ = "torchao.quantization.pt2e"
+if sys.version_info < (3, 14):
+    ObserverOrFakeQuantizeConstructor.__module__ = "torchao.quantization.pt2e"
 
 
 __all__ = [

--- a/torchao/quantization/pt2e/quantizer/utils.py
+++ b/torchao/quantization/pt2e/quantizer/utils.py
@@ -6,6 +6,7 @@
 
 # mypy: allow-untyped-defs
 
+import sys
 import typing
 from dataclasses import dataclass
 from typing import Callable, NamedTuple, Optional
@@ -31,7 +32,8 @@ class QuantizationConfig:
 
 # Use Annotated because list[Callable].__module__ is read-only.
 OperatorPatternType = typing.Annotated[list[Callable], None]
-OperatorPatternType.__module__ = "torchao.quantization.pt2e.quantizer.utils"
+if sys.version_info < (3, 14):
+    OperatorPatternType.__module__ = "torchao.quantization.pt2e.quantizer.utils"
 
 
 class OperatorConfig(NamedTuple):

--- a/torchao/testing/pt2e/_xnnpack_quantizer_utils.py
+++ b/torchao/testing/pt2e/_xnnpack_quantizer_utils.py
@@ -6,6 +6,7 @@
 
 # mypy: allow-untyped-defs
 import itertools
+import sys
 import typing
 from dataclasses import dataclass
 from typing import Callable, NamedTuple, Optional
@@ -62,9 +63,10 @@ class QuantizationConfig:
 
 # Use Annotated because list[Callable].__module__ is read-only.
 OperatorPatternType = typing.Annotated[list[Callable], None]
-OperatorPatternType.__module__ = (
-    "torchao.quantization.pt2e.quantizer.xnnpack_quantizer_utils"
-)
+if sys.version_info < (3, 14):
+    OperatorPatternType.__module__ = (
+        "torchao.quantization.pt2e.quantizer.xnnpack_quantizer_utils"
+    )
 
 AnnotatorType = Callable[
     [


### PR DESCRIPTION
Avoids the error:
```
AttributeError: 'typing.Union' object has no attribute '__module__'
```

This is a known issue, in Python 3.14 it's no longer supported to do this.

Closes gh-3619
Supersedes and closes gh-3657

The same kind of fix was already merged in gh-3832, this is just more of the same.