### PR TITLE
Enable building under a free-threaded Python interpreter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -793,7 +793,9 @@ def get_extensions():
 
     maybe_cpython_limited_api = []
     if not is_freethreaded():
-        maybe_cpython_limited_api += [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
+        maybe_cpython_limited_api += [
+            f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"
+        ]
 
     extra_link_args = []
     extra_compile_args = {
@@ -1035,7 +1037,8 @@ def get_extensions():
                             "-DUSE_CUDA",
                             # define TORCH_TARGET_VERSION with min version 2.11 for ABI stable Float8_e8m0fnu
                             "-DTORCH_TARGET_VERSION=0x020b000000000000",
-                        ] + maybe_cpython_limited_api,
+                        ]
+                        + maybe_cpython_limited_api,
                         "nvcc": nvcc_args
                         + [
                             "-gencode=arch=compute_100,code=sm_100",
@@ -1157,5 +1160,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch/ao",
     cmdclass={"build_ext": TorchAOBuildExt, "build_py": TorchAOBuildPy},
-    options={"bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}},
+    options={
+        "bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1027,6 +1027,7 @@ def get_extensions():
                     include_dirs=[
                         mxfp8_extension_dir,  # For mxfp8_quantize.cuh, mxfp8_extension.cpp, and mxfp8_cuda.cu
                     ],
+                    py_limited_api=not is_freethreaded(),
                     extra_compile_args={
                         "cxx": [
                             "-std=c++20",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+import sysconfig
 import time
 from datetime import datetime
 from pathlib import Path
@@ -748,6 +749,10 @@ class CMakeExtension(Extension):
         self.cmake_args = cmake_args
 
 
+def is_freethreaded():
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
 def get_extensions():
     # Skip building C++ extensions if USE_CPP is set to "0"
     if use_cpp == "0":
@@ -786,10 +791,13 @@ def get_extensions():
     if use_rocm and detect_hipify_v2():
         maybe_hipify_v2_flag = ["-DHIPIFY_V2"]
 
+    maybe_cpython_limited_api = []
+    if not is_freethreaded():
+        maybe_cpython_limited_api += [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
+
     extra_link_args = []
     extra_compile_args = {
-        "cxx": [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
-        + maybe_hipify_v2_flag,
+        "cxx": maybe_cpython_limited_api + maybe_hipify_v2_flag,
         "nvcc": nvcc_args if use_cuda else rocm_args + maybe_hipify_v2_flag,
     }
 
@@ -989,7 +997,7 @@ def get_extensions():
             extension(
                 "torchao._C",
                 sources,
-                py_limited_api=True,
+                py_limited_api=not is_freethreaded(),
                 extra_compile_args=extra_compile_args,
                 extra_link_args=extra_link_args,
             )
@@ -1021,13 +1029,12 @@ def get_extensions():
                     ],
                     extra_compile_args={
                         "cxx": [
-                            f"-DPy_LIMITED_API={min_supported_cpython_hexcode}",
                             "-std=c++20",
                             "-O3",
                             "-DUSE_CUDA",
                             # define TORCH_TARGET_VERSION with min version 2.11 for ABI stable Float8_e8m0fnu
                             "-DTORCH_TARGET_VERSION=0x020b000000000000",
-                        ],
+                        ] + maybe_cpython_limited_api,
                         "nvcc": nvcc_args
                         + [
                             "-gencode=arch=compute_100,code=sm_100",
@@ -1068,7 +1075,7 @@ def get_extensions():
             extension(
                 "torchao._C_cutlass_90a",
                 cutlass_90a_sources,
-                py_limited_api=True,
+                py_limited_api=not is_freethreaded(),
                 extra_compile_args=cutlass_90a_extra_compile_args,
                 extra_link_args=extra_link_args,
             )
@@ -1149,5 +1156,5 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch/ao",
     cmdclass={"build_ext": TorchAOBuildExt, "build_py": TorchAOBuildPy},
-    options={"bdist_wheel": {"py_limited_api": "cp310"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}},
 )


### PR DESCRIPTION
Free-threaded interpreters do not support the CPython Limited C API, and hence use of the limited API has to be disabled. With this one change, `torchao` builds fine.

The `is_freethreaded` function is in widespread use, and documented as the canonical way of doing this check here:
https://py-free-threading.github.io/running-gil-disabled/#check-if-using-a-free-threaded-build

The changes to `setup.py` mirror how this was done in other projects, e.g., [vllm#29241](https://github.com/vllm-project/vllm/pull/29241).

This implements the first step of https://github.com/pytorch/ao/issues/3243#issuecomment-4428954678. I have tested this locally, and (after fixing a couple of unrelated issues, namely gh-4426, gh-4427) with this change `torchao` can be installed under a free-threading Python 3.14t interpreter, and almost all tests pass (the ones that don't look 3.14 rather than free-threading related). 

***

The second commit also fixes a problem under a default interpreter: the `_C_mxfp8` extension module was not being compiled against the CPython Limited API, and hence wheels were not `abi3`-compatible.