### PR TITLE
[float8] read `dim` from kwargs in `Float8Tensor` aten.split handler

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -1436,6 +1436,21 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
         x_fp8 = Float8Tensor.from_hp(x)
         self._test_chunk_similar_to_vllm_llama4(x_fp8, dim)
 
+    @common_utils.parametrize("dim", [-2, -1])
+    def test_chunk_via_torch_chunk_with_dim_kwarg(self, dim):
+        # Complements `test_chunk`: that test uses `Tensor.chunk`, which
+        # lands in `aten.split.Tensor` with `dim` in `args`; this one uses
+        # the free function `torch.chunk(t, n, dim=dim)`, which leaves
+        # `dim` in `kwargs` (the path FSDP2's `_chunk_with_empty` takes).
+        device = get_current_accelerator_device()
+        x = torch.randn(16, 5120, 16384, device=device, dtype=torch.bfloat16)
+        x_fp8 = Float8Tensor.from_hp(x)
+        chunks = torch.chunk(x_fp8, 2, dim=dim)
+        recombined = torch.cat(chunks, dim=dim)
+        torch.testing.assert_close(
+            x_fp8.dequantize(), recombined.dequantize(), atol=0, rtol=0
+        )
+
     @common_utils.parametrize(
         "config",
         [

--- a/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_tensor.py
@@ -1024,7 +1024,10 @@ def _(func, types, args, kwargs):
 
 @implements(aten.split.Tensor)
 def _(func, types, args, kwargs):
-    tensor, split_size_or_sections, dim = args
+    # `dim` may arrive positionally or as a kwarg depending on the caller
+    # (e.g. `torch.chunk(t, n, dim=d)` keeps it in kwargs).
+    tensor, split_size_or_sections = args[0], args[1]
+    dim = args[2] if len(args) > 2 else kwargs.get("dim", 0)
     assert isinstance(split_size_or_sections, int), "unimplemented"
 
     # 2D case


### PR DESCRIPTION
Fixes #4430.

## Summary

The `aten.split.Tensor` handler on `Float8Tensor` (added in #3334) unpacks three positionals from `args`:

```python
tensor, split_size_or_sections, dim = args
```

That works for `Tensor.chunk(n, dim=d)` and other call sites where the dispatcher hands `dim` over in `args`. It does **not** work for the free-function form `torch.chunk(t, n, dim=d)`, which reaches the handler with `args = (tensor, split_size_or_sections)` and `dim` in `kwargs`:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

This breaks every `fully_shard(module)` call where the module's weights have been quantized via `quantize_(model, Float8DynamicActivationFloat8WeightConfig(...))`, because FSDP2's `_chunk_with_empty` is implemented as:

```python
chunks = list(torch.chunk(tensor, num_chunks, dim=dim))
```

### Minimal reproducer

```python
import torch
import torchao  # noqa: F401
from torch.distributed._composable.fsdp import fully_shard
from torchao.quantization import (
    Float8DynamicActivationFloat8WeightConfig,
    quantize_,
)
from torchao.quantization.granularity import PerRow
from transformers import AutoModelForCausalLM

model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen2.5-0.5B-Instruct", torch_dtype=torch.bfloat16
).to("cuda")
quantize_(
    model,
    Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
    device="cuda",
)
for block in model.model.layers:
    fully_shard(block)
fully_shard(model)
# -> ValueError: not enough values to unpack (expected 3, got 2)
```

Originally hit under FSDP2 + 4-card NPU (`torchao_npu`); same code path triggers on CUDA + FSDP2 too.

## Fix

Read `dim` from either positional or keyword form, matching the `aten.split.Tensor` schema `(Tensor self, SymInt split_size, int dim=0)`:

```python
tensor, split_size_or_sections = args[0], args[1]
dim = args[2] if len(args) > 2 else kwargs.get("dim", 0)
```

## Test Plan

Adds `test_chunk_via_torch_chunk_with_dim_kwarg` next to the existing `test_chunk`. The existing test only exercises `Tensor.chunk(...)` (the vLLM Llama 4 path from #3334), which is why this regression was not caught. The new test calls `torch.chunk(t, n, dim=dim)` explicitly:

```bash
pytest test/quantization/quantize_/workflows/float8/test_float8_tensor.py -s -x -k 'chunk'
```

The new test fails before the handler fix with `ValueError: not enough values to unpack (expected 3, got 2)`, and passes after.

## Related

- Issue: #4430
- Handler was introduced in #3334 (LLaMA 4 MoE weight loading via vLLM).
- This PR only changes the argument extraction; the body of the handler is untouched.