### PR TITLE
fix(pt2e/constant_fold): preserve shared get_attr target when only some uses are dead (#4420)

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1938,6 +1938,14 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         ao_constant_fold(gm)
 
         self.assertTrue(hasattr(gm, "shared"))
+        # The dead get_attr node must still be erased: exactly one get_attr
+        # referencing "shared" (the live one) should remain after folding, so
+        # the test pins down both halves of the behavior -- the attribute is
+        # preserved AND the dead node is removed.
+        remaining_shared_get_attrs = [
+            n for n in gm.graph.find_nodes(op="get_attr") if n.target == "shared"
+        ]
+        self.assertEqual(len(remaining_shared_get_attrs), 1)
         gm(torch.zeros(2))
 
     def test_save_load(self):

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1913,6 +1913,33 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             m_not_fold.code
         )
 
+    def test_constant_fold_preserves_shared_get_attr_target(self):
+        # Regression test for https://github.com/pytorch/ao/issues/4420.
+        # When an FX graph has multiple get_attr nodes referencing the same
+        # buffer and only some of them are dead, constant_fold must not
+        # delete the underlying module attribute, or the surviving get_attr
+        # node will dangle and graph.lint() will fail.
+        from torchao.quantization.pt2e.constant_fold import (
+            constant_fold as ao_constant_fold,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        live = graph.get_attr("shared")
+        # Used in a placeholder-dependent op so the folder can't fold it away.
+        out = graph.call_function(torch.ops.aten.add.Tensor, args=(x, live))
+        graph.get_attr("shared")  # second, dead reference to the same target
+        graph.output(out)
+
+        root = torch.nn.Module()
+        root.register_buffer("shared", torch.ones(2))
+        gm = torch.fx.GraphModule(root, graph)
+
+        ao_constant_fold(gm)
+
+        self.assertTrue(hasattr(gm, "shared"))
+        gm(torch.zeros(2))
+
     def test_save_load(self):
         """Test save/load a quantized model"""
         m = self._get_pt2e_quantized_linear()

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -353,11 +353,24 @@ def constant_fold(
         erased_params = []
         for node in gm.graph.find_nodes(op="get_attr"):
             if len(node.users) == 0:
-                if hasattr(gm, node.target):
-                    delattr(gm, node.target)
                 erased_params.append(node)
 
+        # Only delete the underlying module attribute when no other live
+        # get_attr node still references the same target. Without this guard,
+        # graphs that contain multiple get_attr nodes pointing at the same
+        # buffer/parameter would lose the attribute as soon as any one of
+        # them became dead, leaving the remaining live get_attr dangling and
+        # making the subsequent graph.lint() fail.
+        live_get_attr_targets = {
+            n.target
+            for n in gm.graph.find_nodes(op="get_attr")
+            if len(n.users) > 0
+        }
         for node in erased_params:
+            if node.target not in live_get_attr_targets and hasattr(
+                gm, node.target
+            ):
+                delattr(gm, node.target)
             gm.graph.erase_node(node)
 
         gm.graph.eliminate_dead_code()

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -362,14 +362,10 @@ def constant_fold(
         # them became dead, leaving the remaining live get_attr dangling and
         # making the subsequent graph.lint() fail.
         live_get_attr_targets = {
-            n.target
-            for n in gm.graph.find_nodes(op="get_attr")
-            if len(n.users) > 0
+            n.target for n in gm.graph.find_nodes(op="get_attr") if len(n.users) > 0
         }
         for node in erased_params:
-            if node.target not in live_get_attr_targets and hasattr(
-                gm, node.target
-            ):
+            if node.target not in live_get_attr_targets and hasattr(gm, node.target):
                 delattr(gm, node.target)
             gm.graph.erase_node(node)
 


### PR DESCRIPTION
## Summary

Fixes #4420.

`torchao.quantization.pt2e.constant_fold.constant_fold` previously called `delattr(gm, node.target)` for every dead `get_attr` node without checking whether **other live** `get_attr` nodes still pointed at the same target. When an FX graph contains multiple `get_attr` nodes referencing the same buffer/parameter (e.g. ExecuTorch graphs where a shared buffer is read through several `get_attr` nodes), the attribute would be deleted as soon as any one of them became dead, leaving the remaining live `get_attr` nodes dangling and causing the immediately-following `graph.lint()` to raise:

```
RuntimeError: Node shared_1 target shared references nonexistent attribute shared of <graph module>
```

This PR splits the loop in two: first collect the dead `get_attr` nodes, then build the set of targets that still have at least one live `get_attr`, and only call `delattr` for targets that fall entirely out of that set.

## Reproducer (from #4420)

```python
import torch
from torch.fx import Graph, GraphModule
from torchao.quantization.pt2e.constant_fold import constant_fold

class Root(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("shared", torch.arange(4.0))

root = Root().eval()
g = Graph()
x = g.placeholder("x")
shared0 = g.get_attr("shared")
folded = g.call_function(torch.ops.aten.neg.default, (shared0,))
shared1 = g.get_attr("shared")
live = g.call_function(torch.ops.aten.add.Tensor, (x, shared1))
g.output((folded, live))
gm = GraphModule(root, g)

constant_fold(gm)  # before: RuntimeError on graph.lint(); after: ok
```

## Test plan

- [x] Reproducer from #4420 no longer raises.
- [ ] Existing `test/quantization/pt2e/` tests should continue to pass (no behavioural change when at most one `get_attr` references a given target).

---

AI-assisted, human reviewed.