### PR TITLE
Use transpose_result=True for fp8_sparse_mm (#4433)

### DIFF
--- a/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
+++ b/torchao/quantization/quantize_/workflows/float8/float8_sparse_2x4_1d_data_1d_metadata_tensor.py
@@ -215,11 +215,11 @@ def fp8_sparse_mm(
         alpha=alpha,
         out_dtype=torch.float32,
         alg_id=alg_id,
+        transpose_result=True,
     )
-    result = result.t()
     if to_pad:
         result = result.narrow(0, 0, batch)
-    return result.contiguous()
+    return result
 
 
 @fp8_sparse_mm.register_fake


### PR DESCRIPTION
Summary:
What: Replace `result.t() + result.contiguous()` with `transpose_result=True` in `fp8_sparse_mm`.

Why: Use native transpose through hipSPARSELt + `torch._cslt_sparse_mm`.


Reviewed By: ZihaoLiu0927

Differential Revision: D105060886

Pulled By: gyllstromk


