### PR TITLE
[CPU] skip registration of PT2E inductor passes if mkldnn not available

### DIFF
--- a/torchao/quantization/pt2e/inductor_passes/x86.py
+++ b/torchao/quantization/pt2e/inductor_passes/x86.py
@@ -3456,6 +3456,8 @@ def _register_concat_dq_q_pattern():
 
 @functools.lru_cache(None)
 def _register_quantization_weight_pack_pass():
+    if not torch.backends.mkldnn.is_available():
+        return
     # Step 1: Dequant promotion for int8-mixed-fp32/bf16
     _register_dequant_promotion()
 


### PR DESCRIPTION
fixes https://github.com/pytorch/ao/issues/4403

Add a check and skip the registration if mkldnn not available.