### PR TITLE
create a new CI job with clang

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -28,11 +28,19 @@ jobs:
             torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
+            compiler: ""
           - name: CPU Nightly
             runs-on: linux.4xlarge
             torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
+            compiler: ""
+          - name: CPU Nightly (Clang)
+            runs-on: linux.4xlarge
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu'
+            gpu-arch-type: "cpu"
+            gpu-arch-version: ""
+            compiler: "clang"
 
     permissions:
       id-token: write
@@ -45,8 +53,27 @@ jobs:
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       submodules: recursive
       script: |
-        conda create -n venv python=3.10 libgcc-ng=11.2.0 libstdcxx-ng=11.2.0 -y
-        conda activate venv
+        if [ "${{ matrix.compiler }}" = "clang" ]; then
+          # Install clang from the system package manager. The docker image's
+          # bundled conda has a broken menuinst plugin that rejects -c conda-forge,
+          # so we cannot install clangxx via conda here.
+          dnf install -y clang
+          clang --version
+          conda create -n venv python=3.10 libgcc-ng=11.2.0 libstdcxx-ng=11.2.0 -y
+          conda activate venv
+          export CC=clang
+          export CXX=clang++
+          # distutils (used by setup.py via cpp_extension.BuildExtension) reads
+          # CFLAGS from the env and applies it to both C and C++ compiles.
+          # It does NOT honor CXXFLAGS — that is a Make convention, not distutils.
+          export CFLAGS="-Werror -Wno-vla-cxx-extension"
+          # Compile the x86 CPU aten_kernels — they are off by default
+          # in setup.py and not otherwise exercised by any OSS CI job.
+          export USE_CPU_KERNELS=1
+        else
+          conda create -n venv python=3.10 libgcc-ng=11.2.0 libstdcxx-ng=11.2.0 -y
+          conda activate venv
+        fi
         python -m pip install --upgrade pip
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt

--- a/torchao/csrc/cpu/aten_kernels/float8_linear_krnl.cpp
+++ b/torchao/csrc/cpu/aten_kernels/float8_linear_krnl.cpp
@@ -22,7 +22,11 @@ namespace CPU_CAPABILITY {
 static std::once_flag cpublas_flag;
 static bool cpublas_can_pack = false;
 
-#define USING_FP8_BRGEMM (defined(CPUBLAS_BRGEMM_F8F8F32) && defined(CPU_CAPABILITY_AVX10_2))
+#if defined(CPUBLAS_BRGEMM_F8F8F32) && defined(CPU_CAPABILITY_AVX10_2)
+#define USING_FP8_BRGEMM 1
+#else
+#define USING_FP8_BRGEMM 0
+#endif
 
 static inline bool cpublas_could_pack() {
   std::call_once(cpublas_flag, []() {

--- a/torchao/csrc/cpu/aten_kernels/quantized_sdpa_krnl.cpp
+++ b/torchao/csrc/cpu/aten_kernels/quantized_sdpa_krnl.cpp
@@ -35,7 +35,11 @@ static std::once_flag cpublas_once;
 static bool cpublas_can_pack_int8 = false;
 static bool cpublas_can_pack_fp8 = false;
 
-#define USING_FP8_BRGEMM (defined(CPUBLAS_BRGEMM_F8F8F32) && defined(CPU_CAPABILITY_AVX10_2))
+#if defined(CPUBLAS_BRGEMM_F8F8F32) && defined(CPU_CAPABILITY_AVX10_2)
+#define USING_FP8_BRGEMM 1
+#else
+#define USING_FP8_BRGEMM 0
+#endif
 
 static inline bool cpublas_could_pack(at::ScalarType dtype) {
   // the could_pack check requires AMX support implicitly


### PR DESCRIPTION
Summary:

This is useful to catch errors which might break Meta's internal builds in OSS CI

Also, fix torchao/csrc/cpu/aten_kernels/float8_linear_krnl.cpp and torchao/csrc/cpu/aten_kernels/quantized_sdpa_krnl.cpp to not break this build.

99% clauded

Test Plan: CI

Reviewers:

Subscribers:

Tasks:

Tags: