### PR TITLE
[mxfp8 training] don't use offs as key in cutedsl compile cache

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -616,36 +616,3 @@ def test_mxfp8_grouped_gemm_bias_backward(kernel_preference, M, K, N, num_expert
     assert w_t.grad is not None, "w_t.grad should be computed"
     sqnr_weight = compute_error(w_t_ref.grad, w_t.grad)
     assert sqnr_weight >= 24.0, f"Weight grad sqnr {sqnr_weight} is too low"
-
-
-@skip_if_rocm("ROCm not supported")
-def test_mxfp8_grouped_gemm_bias_none_unchanged():
-    """Test that passing bias=None produces the same result as not passing bias."""
-    M, K, N, num_experts = 4096, 1024, 2048, 8
-    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
-    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
-    w_t = w.transpose(-2, -1)
-    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
-
-    out_default = _to_mxfp8_then_scaled_grouped_mm(
-        x,
-        w_t,
-        offs=offs,
-        out_dtype=torch.bfloat16,
-        kernel_preference=KernelPreference.EMULATED,
-        wgrad_with_hp=True,
-        scale_calculation_mode=ScaleCalculationMode.RCEIL,
-    )
-
-    out_none = _to_mxfp8_then_scaled_grouped_mm(
-        x,
-        w_t,
-        offs=offs,
-        bias=None,
-        out_dtype=torch.bfloat16,
-        kernel_preference=KernelPreference.EMULATED,
-        wgrad_with_hp=True,
-        scale_calculation_mode=ScaleCalculationMode.RCEIL,
-    )
-
-    torch.testing.assert_close(out_default, out_none, rtol=0, atol=0)

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -616,3 +616,36 @@ def test_mxfp8_grouped_gemm_bias_backward(kernel_preference, M, K, N, num_expert
     assert w_t.grad is not None, "w_t.grad should be computed"
     sqnr_weight = compute_error(w_t_ref.grad, w_t.grad)
     assert sqnr_weight >= 24.0, f"Weight grad sqnr {sqnr_weight} is too low"
+
+
+@skip_if_rocm("ROCm not supported")
+def test_mxfp8_grouped_gemm_bias_none_unchanged():
+    """Test that passing bias=None produces the same result as not passing bias."""
+    M, K, N, num_experts = 4096, 1024, 2048, 8
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(num_experts, N, K, dtype=torch.bfloat16, device="cuda")
+    w_t = w.transpose(-2, -1)
+    offs = generate_jagged_offs(num_experts, M, multiple_of=128)
+
+    out_default = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        out_dtype=torch.bfloat16,
+        kernel_preference=KernelPreference.EMULATED,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+    )
+
+    out_none = _to_mxfp8_then_scaled_grouped_mm(
+        x,
+        w_t,
+        offs=offs,
+        bias=None,
+        out_dtype=torch.bfloat16,
+        kernel_preference=KernelPreference.EMULATED,
+        wgrad_with_hp=True,
+        scale_calculation_mode=ScaleCalculationMode.RCEIL,
+    )
+
+    torch.testing.assert_close(out_default, out_none, rtol=0, atol=0)

--- a/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py
@@ -85,7 +85,7 @@ def _compile_mxfp8_quantize_2d_cutedsl(
     k_tiles_per_cta: int,
     is_full_k_tiles: bool,
     blocked_scale_output: bool,
-    offs: Optional[torch.Tensor] = None,
+    has_offs: bool = False,
 ):
     """Compile the 2D MXFP8 quantization kernel using CuTeDSL.
 
@@ -932,7 +932,7 @@ def _compile_mxfp8_quantize_2d_cutedsl(
         )
     fake_stream = make_fake_stream()
 
-    if offs is not None:
+    if has_offs:
         offs_stride = cute.sym_int()
         fake_offs = make_fake_tensor(
             cutlass.Int32,
@@ -1052,7 +1052,7 @@ def mxfp8_quantize_cutedsl_2d_1x32(
         k_tiles_per_cta,
         is_full_k_tiles,
         blocked_scale_output,
-        offs,
+        offs is not None,
     )
 
     import cuda.bindings.driver as cuda

--- a/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_32x1.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_32x1.py
@@ -88,7 +88,7 @@ def _compile_mxfp8_quantize_2d_32x1_cutedsl(
     m_tiles_per_cta: int,
     is_full_m_tiles: bool,
     blocked_scale_output: bool,
-    offs: Optional[torch.Tensor] = None,
+    has_offs: bool = False,
 ):
     """Compile the 2D MXFP8 quantization kernel using CuTeDSL for 32x1 scaling.
 
@@ -944,7 +944,7 @@ def _compile_mxfp8_quantize_2d_32x1_cutedsl(
         )
     fake_stream = make_fake_stream()
 
-    if offs is not None:
+    if has_offs:
         offs_stride = cute.sym_int()
         fake_offs = make_fake_tensor(
             cutlass.Int32,
@@ -1071,7 +1071,7 @@ def mxfp8_quantize_cutedsl_2d_32x1(
         m_tiles_per_cta,
         is_full_m_tiles,
         blocked_scale_output,
-        offs,
+        offs is not None,
     )
 
     import cuda.bindings.driver as cuda

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -452,7 +452,7 @@ def _compute_wgrad(
             wgrad_with_hp,
         )
     else:
-        return __compute_wgrad_sm100(
+        return _compute_wgrad_sm100(
             grad_output,
             input_act,
             group_end_offsets,
@@ -709,7 +709,7 @@ def _compute_dgrad_emulated(
     return grad_input
 
 
-def __compute_wgrad_sm100(
+def _compute_wgrad_sm100(
     grad_output: torch.Tensor,
     input_act: torch.Tensor,
     group_end_offsets: torch.Tensor,

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 import torch
+from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
@@ -538,13 +539,17 @@ def _compute_fwd_sm100(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute output using SM100 kernel
-    output = torch._scaled_grouped_mm(
+    output = scaled_grouped_mm(
         input_act_e4m3,
         weight_e4m3.transpose(-2, -1),  # Transpose back to (E, K, N)
         input_act_scales_blocked,
+        ScalingType.BlockWise1x32,
         weight_scales_blocked,
+        ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
-        out_dtype=out_dtype,
+        output_dtype=out_dtype,
     )
     return output
 

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -8,7 +8,6 @@ import logging
 from typing import Optional
 
 import torch
-from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
@@ -539,17 +538,13 @@ def _compute_fwd_sm100(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute output using SM100 kernel
-    output = scaled_grouped_mm(
+    output = torch._scaled_grouped_mm(
         input_act_e4m3,
         weight_e4m3.transpose(-2, -1),  # Transpose back to (E, K, N)
         input_act_scales_blocked,
-        ScalingType.BlockWise1x32,
         weight_scales_blocked,
-        ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
-        output_dtype=out_dtype,
+        out_dtype=out_dtype,
     )
     return output
 

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -549,7 +549,7 @@ def _compute_fwd_sm100(
         swizzle_a=SwizzleType.SWIZZLE_32_4_4,
         swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
-        out_dtype=out_dtype,
+        output_dtype=out_dtype,
     )
     return output
 

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 import torch
+from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
 from torchao.prototype.moe_training.kernels.mxfp8 import (
     _mxfp8_cuda_kernels_available as _mxfp8_cuda_kernels_available_quant,
@@ -538,11 +539,15 @@ def _compute_fwd_sm100(
     weight_scales_blocked = triton_mx_block_rearrange_per_group_3d(weight_scales)
 
     # Compute output using SM100 kernel
-    output = torch._scaled_grouped_mm(
+    output = scaled_grouped_mm(
         input_act_e4m3,
         weight_e4m3.transpose(-2, -1),  # Transpose back to (E, K, N)
         input_act_scales_blocked,
+        ScalingType.BlockWise1x32,
         weight_scales_blocked,
+        ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
         offs=padded_group_end_offsets,
         out_dtype=out_dtype,
     )

--- a/torchao/prototype/moe_training/utils.py
+++ b/torchao/prototype/moe_training/utils.py
@@ -390,16 +390,20 @@ def _quantize_then_scaled_grouped_mm(
             pad_token_groups_for_grouped_mm=config.pad_token_groups_for_grouped_mm,
         )
     elif isinstance(config, MXFP8TrainingOpConfig):
+        kwargs = {
+            "out_dtype": config.out_dtype,
+            "kernel_preference": config.kernel_preference,
+            "wgrad_with_hp": config.wgrad_with_hp,
+            "scale_calculation_mode": config.scale_calculation_mode,
+            "pad_token_groups_for_grouped_mm": config.pad_token_groups_for_grouped_mm,
+        }
+        if bias is not None:
+            kwargs["bias"] = bias
         return _to_mxfp8_then_scaled_grouped_mm(
             A,
             B_t,
             offs,
-            bias=bias,
-            out_dtype=config.out_dtype,
-            kernel_preference=config.kernel_preference,
-            wgrad_with_hp=config.wgrad_with_hp,
-            scale_calculation_mode=config.scale_calculation_mode,
-            pad_token_groups_for_grouped_mm=config.pad_token_groups_for_grouped_mm,
+            **kwargs,
         )
     else:
         raise ValueError(f"Unsupported config type: {type(config)}")


### PR DESCRIPTION
Fixes #4441 

## Summary
- The `offs` tensor should not have been included as a kernel compilation cache key. This caused recompilation on every MoE layer and every training step, due to the fact that the offsets are determined dynamically per MOE layer every step. The fix is to simply use the presence of offsets, a boolean value, as the kernel compilation key

#### Misc changes
- Only pass bias as a kwarg to `_to_mxfp8_then_scaled_grouped_mm` if it is not None, since otherwise this causes issues with nonstrict trace mode.

## Tests 
- `pytest test/prototype/moe_training/test_training.py -v -s`
- `pytest test/prototype/moe_training/test_mxfp8_grouped_mm.py -v -s `
