### PR TITLE
[ROCm] Add HIP device synchronize event to profiler overhead filter

### DIFF
--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -85,7 +85,7 @@ def profiler_output_to_filtered_time_by_kernel_name(
                 f"unexpected number of iter for {e.key}"
             )
             continue
-        elif e.key == "cudaDeviceSynchronize":
+        elif e.key in ("cudaDeviceSynchronize", "hipDeviceSynchronize"):
             continue
         elif e.key == "Activity Buffer Request":
             continue


### PR DESCRIPTION
Extend the profiler overhead filtering in benchmarks/float8/utils.py to ignore hipDeviceSynchronize in addition to cudaDeviceSynchronize. This keeps benchmark timing cleanup backend-agnostic for ROCm/HIP runs and avoids counting device synchronization overhead as kernel time.