### PR TITLE
docs(Float8DynamicActivationFloat8WeightConfig): mark as inference-only (#4376)

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1157,6 +1157,16 @@ class Float8DynamicActivationFloat8WeightConfig(AOBaseConfig):
         set_inductor_config (bool): if True, adjusts `torchinductor` settings to recommended values.
         version (int): the version of the config, version 1 is deprecated, version 2 is using Float8Tensor (default)
 
+    Note:
+        This is an **inference-only** configuration. Calling ``backward()`` through a
+        linear quantized with this config raises
+        ``RuntimeError: derivative for aten::_scaled_mm is not implemented`` because
+        the underlying ``torch._scaled_mm`` op has no autograd kernel. Use a LoRA-style
+        ``filter_fn`` to skip trainable adapter modules during ``quantize_``, and keep
+        anything that needs gradients (e.g. LoRA ``A``/``B``) outside the quantized base.
+        For float8 *training*, use ``torchao.float8.convert_to_float8_training`` instead.
+        See: https://github.com/pytorch/ao/issues/4376.
+
     Example:
 
     .. literalinclude:: ../../examples/inference/float8_dynamic_activation_float8_weight.py


### PR DESCRIPTION
## Summary

Closes #4376.

Adds an explicit `Note: inference-only` block to `Float8DynamicActivationFloat8WeightConfig`'s docstring so users picking up this config for LoRA-on-quantized-base (or any other training workflow) discover up-front that the backward pass will raise `RuntimeError: derivative for aten::_scaled_mm is not implemented`, and don't have to debug it from a crash.

This is option (1) from the issue — the lowest-risk path. The training-aware variant in option (2) is a separate, larger change.

## What changes

- **`torchao/quantization/quant_api.py`** — one docstring-only block added to `Float8DynamicActivationFloat8WeightConfig`. Mirrors the existing `Note:` block style on `Float8WeightOnlyConfig` a few lines above.

The note:
- Names the actual exception users see (`derivative for aten::_scaled_mm is not implemented`).
- Explains the root cause in one line (`torch._scaled_mm` has no autograd kernel).
- Points users at the LoRA-skip `filter_fn` pattern they almost certainly want next.
- Points users at `torchao.float8.convert_to_float8_training` for the actual float8 *training* path.
- Links back to #4376 so future readers can find the original discussion.

No code changes — purely a docstring addition that flows through to the generated API docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
