### PR TITLE
fix: parametrized dtype ignored in test_autotuner; wrong variable in test_integration error message

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -637,7 +637,7 @@ class TestSaveLoadMeta(unittest.TestCase):
         test = model_qc(x).detach()
 
         assert SQNR(ref_f, test) > min_sqnr, (
-            f"got sqnr: {SQNR(ref_f, ref_q)}, expected: {min_sqnr}"
+            f"got sqnr: {SQNR(ref_f, test)}, expected: {min_sqnr}"
         )
         self.assertTrue(torch.equal(ref_q, test))
 

--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -37,7 +37,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -59,7 +58,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm_float8(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -85,7 +83,6 @@ class TestQuantFlow(unittest.TestCase):
 
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         scales = x.sum(-1, keepdim=True)
@@ -93,7 +90,7 @@ class TestQuantFlow(unittest.TestCase):
         x_int = x.to(dtype=torch.int8)
         w_int = w.to(dtype=torch.int8)
         out32_1 = intmm.safe_int_mm(x_int, w_int) * scales
-        assert out32_1.dtype == torch.bfloat16
+        assert out32_1.dtype == dtype
         out32_2 = intmm.int_scaled_matmul(x_int, w_int, scales)
         assert out32_2.dtype == out32_1.dtype
         torch.testing.assert_allclose(out32_1, out32_2)


### PR DESCRIPTION
Fixes #4339

- Removed hardcoded `dtype = torch.bfloat16` overrides in test_autotuner.py 
  that caused float16 test variants to silently run as bfloat16 instead
- Fixed assertion in test_int_scaled_mm to use `dtype` instead of hardcoded `torch.bfloat16`  
- Fixed wrong variable in error message in test_integration.py (`ref_q` → `test`)