### PR TITLE
fix: float8_transpose uses == instead of = when remapping _axiswise_dim

### DIFF
--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -174,9 +174,9 @@ def float8_transpose(aten_op, args, kwargs=None):
     new_axiswise_dim = old_axiswise_dim
     if old_axiswise_dim is not None:
         if old_axiswise_dim == 0:
-            new_axiswise_dim == -1
+            new_axiswise_dim = -1
         else:
-            new_axiswise_dim == 0
+            new_axiswise_dim = 0
 
     return Float8TrainingTensor(
         new_data,


### PR DESCRIPTION
Fixes #4444

In `torchao/float8/float8_ops.py` inside `float8_transpose`, two lines
used `==` (comparison, result discarded) instead of `=` (assignment),
so `new_axiswise_dim` was never updated after a transpose.

Changed both `new_axiswise_dim == -1` and `new_axiswise_dim == 0`
to use `=` so the attribute is correctly remapped.