### PR TITLE
docs: clarify Float8DynamicActivationFloat8WeightConfig is inference-only

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1138,6 +1138,12 @@ class Float8DynamicActivationFloat8WeightConfig(AOBaseConfig):
     """
     Configuration for applying float8 dynamic symmetric quantization to both activations and weights of linear layers.
 
+    .. note::
+        This config is for **inference only**. Calling ``loss.backward()``
+        will raise ``RuntimeError: derivative for aten::_scaled_mm is not
+        implemented``. For fp8 training, use
+        ``torchao.float8.convert_to_float8_training`` instead.
+
     Args:
         activation_dtype (torch.dtype): The target data type for activation quantization. Default is torch.float8_e4m3fn.
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m3fn.


### PR DESCRIPTION
Fixes #4376 (partial — option 1)

Adds a docstring note to Float8DynamicActivationFloat8WeightConfig
clarifying that this config is inference-only and backward() will fail.
Points users to torchao.float8.convert_to_float8_training for the
training path, as suggested in the issue.