### PR TITLE
[CI] Switch H100 jobs to linux_job_v3 (OSDC/ARC)

### DIFF
--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -24,14 +24,14 @@ jobs:
       matrix:
         include:
           - name: H100
-            runs-on: linux.aws.h100
+            runs-on: mt-l-x86iamx-22-225-h100
             torch-spec: '--pre torch torchvision torchaudio mslk --index-url https://download.pytorch.org/whl/nightly/cu130'
             gpu-arch-type: "cuda"
             gpu-arch-version: "13.0"
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     with:
       timeout: 90
       runner: ${{ matrix.runs-on }}
@@ -44,7 +44,11 @@ jobs:
         export PATH=/opt/rh/devtoolset-10/root/usr/bin/:$PATH
         python -m pip install --upgrade pip
         pip install uv
-        pip install ${{ matrix.torch-spec }}
+        # Pre-install torch/vision's pure-python deps from the in-cluster pypi-cache for speed.
+        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+        # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+        # +cpu torch; the torch-spec's --index-url makes the literal nightly cu130 index the only source.
+        PIP_EXTRA_INDEX_URL= pip install ${{ matrix.torch-spec }}
         pip install -U --pre flashinfer-python --index-url https://flashinfer.ai/whl/nightly/ --no-deps
         pip install apache-tvm-ffi
         pip install nvidia-ml-py

--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -22,14 +22,14 @@ jobs:
       matrix:
         include:
           - name: H100
-            runs-on: linux.aws.h100.4
+            runs-on: mt-l-x86iamx-88-900-h100-4
             torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     with:
       timeout: 60
       runner: ${{ matrix.runs-on }}
@@ -43,7 +43,11 @@ jobs:
         export NCCL_NVLS_ENABLE=0
         python -m pip install --upgrade pip
         pip install uv
-        pip install ${{ matrix.torch-spec }}
+        # Pre-install torch/vision's pure-python deps from the in-cluster pypi-cache for speed.
+        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+        # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+        # +cpu torch; the torch-spec's --index-url makes the literal nightly cu126 index the only source.
+        PIP_EXTRA_INDEX_URL= pip install ${{ matrix.torch-spec }}
         uv pip install -r dev-requirements.txt
         pip install . --no-build-isolation
         ./test/float8/test_everything_multi_gpu.sh


### PR DESCRIPTION
## What

Switches torchao's H100 CI jobs from the EC2-based `linux_job_v2` to the OSDC (ARC) `linux_job_v3` reusable workflow, to evaluate running H100 tests on on-site data-center (EKS/ARC) runners.

- **`1xH100_tests.yml`**: `linux.aws.h100` → `mt-l-x86iamx-22-225-h100`
- **`4xH100_tests.yml`**: `linux.aws.h100.4` → `mt-l-x86iamx-88-900-h100-4`
- Both now call `pytorch/test-infra/.github/workflows/linux_job_v3.yml@linux-job-v3-osdc`.

## How v3 differs from v2

`linux_job_v3` runs the job **inside a job-level `container:`** on an ARC runner (instead of running on an EC2 host and launching a nested `docker run`). The script runs directly in the container; GPUs are exposed via `--gpus all` + NVIDIA driver capabilities. The almalinux-builder CUDA images (resolved from `gpu-arch-version`) are pre-built and pulled as the job container.

## Note on the pip guard

The ARC image injects a CPU-only pip mirror (`PIP_EXTRA_INDEX_URL=.../whl/cpu`), which otherwise resolves `torch` to a `+cpu` wheel even with `--index-url .../cuXXX`. The torch install line is prefixed with `PIP_CONFIG_FILE=/dev/null PIP_EXTRA_INDEX_URL=` so the CUDA index is the only source.

## Status

**Draft** — depends on `linux_job_v3.yml` landing in `pytorch/test-infra` (currently on branch `linux-job-v3-osdc`, validated by `test_linux_job_v3.yml`). The `@linux-job-v3-osdc` ref should be bumped to `@main` once that PR merges.