### PR TITLE
[CI] Move H100/A100 benchmark & tutorial jobs to OSDC (ARC)

### DIFF
--- a/.github/workflows/dashboard_perf_test.yml
+++ b/.github/workflows/dashboard_perf_test.yml
@@ -11,7 +11,14 @@ on:
 jobs:
   benchmark:
     timeout-minutes: 500
-    runs-on: linux.aws.a100
+    runs-on: mt-l-x86iavx512-11-125-a100
+    permissions:
+      id-token: write
+      contents: read
+    # OSDC (ARC): run inside a CUDA container; --gpus all exposes the A100.
+    container:
+      image: pytorch/almalinux-builder:cuda13.0
+      options: --gpus all
     strategy:
       matrix:
         torch-spec:
@@ -24,12 +31,22 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          aws-region: us-east-1
+
       - name: Run benchmark
         shell: bash
         run: |
           set -eux
           ${CONDA_RUN} python -m pip install --upgrade pip
-          ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
+          # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+          ${CONDA_RUN} pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+          # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+          # +cpu torch; the torch-spec's --index-url makes the literal nightly cu126 index the only source.
+          PIP_EXTRA_INDEX_URL= ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
           ${CONDA_RUN} pip install . --no-build-isolation
           # SAM 2.1

--- a/.github/workflows/run_microbenchmarks.yml
+++ b/.github/workflows/run_microbenchmarks.yml
@@ -11,7 +11,14 @@ on:
 
 jobs:
   benchmark:
-    runs-on: linux.aws.h100
+    runs-on: mt-l-x86iamx-22-225-h100
+    permissions:
+      id-token: write
+      contents: read
+    # OSDC (ARC): run inside a CUDA container; --gpus all exposes the H100.
+    container:
+      image: pytorch/almalinux-builder:cuda13.0
+      options: --gpus all
     strategy:
       matrix:
         torch-spec:
@@ -23,6 +30,12 @@ jobs:
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: "3.10"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          aws-region: us-east-1
 
       - name: Run benchmark
         shell: bash
@@ -37,7 +50,11 @@ jobs:
           ${CONDA_RUN} bash -c 'echo $PYTHONPATH'
 
           # Install dependencies
-          ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
+          # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+          ${CONDA_RUN} pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+          # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+          # +cpu torch; the torch-spec's --index-url makes the literal nightly cu126 index the only source.
+          PIP_EXTRA_INDEX_URL= ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
           ${CONDA_RUN} pip install . --no-build-isolation
 

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   run_tutorials:
-    runs-on: linux.aws.a100
+    runs-on: mt-l-x86iavx512-11-125-a100
+    # OSDC (ARC): run inside a CUDA container; --gpus all exposes the A100.
+    container:
+      image: pytorch/almalinux-builder:cuda13.0
+      options: --gpus all
     strategy:
       matrix:
         torch-spec:
@@ -26,7 +30,11 @@ jobs:
         run: |
           set -eux
           ${CONDA_RUN} python -m pip install --upgrade pip
-          ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
+          # Pre-install torch's pure-python deps from the in-cluster pypi-cache for speed.
+          ${CONDA_RUN} pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+          # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
+          # +cpu torch; the torch-spec's --index-url makes the literal nightly cu126 index the only source.
+          PIP_EXTRA_INDEX_URL= ${CONDA_RUN} pip install ${{ matrix.torch-spec }}
           ${CONDA_RUN} pip install -r dev-requirements.txt
           ${CONDA_RUN} pip install . --no-build-isolation
           cd tutorials


### PR DESCRIPTION
## What

Moves the direct `runs-on:` H100/A100 jobs onto OSDC (ARC). These don't use `linux_job`, so per the agreed approach they get a job-level `container:` added in place rather than being converted to the reusable workflow.

| Workflow | Runner: EC2 → ARC | Upload |
|---|---|---|
| `run_microbenchmarks.yml` | `linux.aws.h100` → `mt-l-x86iamx-22-225-h100` | yes |
| `dashboard_perf_test.yml` | `linux.aws.a100` → `mt-l-x86iavx512-11-125-a100` | yes |
| `run_tutorials.yml` | `linux.aws.a100` → `mt-l-x86iavx512-11-125-a100` | no |

Each job now runs inside `pytorch/almalinux-builder:cuda13.0` with `options: --gpus all` (the container CUDA version is independent of the pip-installed cu126 torch; cuda13.0 matches the ARC nodes' driver). torch's pure-python deps are pre-installed from the in-cluster pypi-cache, and `PIP_EXTRA_INDEX_URL` is cleared on the torch install so the default cpu index can't supply a `+cpu` torch (same pattern as the H100 PRs).

The two upload jobs get `id-token: write` + a `configure-aws-credentials` step using `role/gha_workflow_upload-benchmark-results` (ARC pods have no EC2 instance profile).

Scope: **H100/A100 only** — regular GPU (g5/g6/L4) and CPU jobs are intentionally left on EC2. Companion PRs: #4456 (1x/4xH100), #4457 (release_model). Depends on `linux_job_v3`-era infra (now on `pytorch/test-infra@main`).

## Needs validation
- `setup-miniconda` + benchmark uploads inside the ARC container (esp. that `role/gha_workflow_upload-benchmark-results` is assumable from these pods).
- `actions/checkout`/JS actions inside `almalinux-builder` (git present; node provided by the ARC container hook).