### PR TITLE
fix(Int8DynActInt4WeightQuantizer): use scales_precision for runtime modules

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -269,14 +269,20 @@ class TestQuantFlow(TestCase):
             precision=torch.float32,
             scales_precision=torch.bfloat16,
         )
-        m = ToyLinearModel().eval()
+        m = ToyLinearModel(bias=True).eval()
         example_inputs = m.example_inputs()
         m = quantizer.quantize(m)
         for name in ("linear1", "linear2"):
             mod = getattr(m, name)
             assert isinstance(mod, Int8DynActInt4WeightLinear)
+            # scales/zeros buffers follow scales_precision...
             self.assertEqual(mod.scales.dtype, torch.bfloat16)
             self.assertEqual(mod.zeros.dtype, torch.bfloat16)
+            # ...while the activation precision and bias buffer still follow
+            # precision. Asserting these guards against a future change that
+            # over-corrects by routing everything through scales_precision.
+            self.assertEqual(mod.precision, torch.float32)
+            self.assertEqual(mod.bias.dtype, torch.float32)
         m(*example_inputs)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -255,6 +255,30 @@ class TestQuantFlow(TestCase):
         assert isinstance(m.linear2, Int8DynActInt4WeightLinear)
         m(*example_inputs)
 
+    def test_8da4w_quantizer_scales_precision(self):
+        # Regression test: _convert_for_runtime must build the runtime modules
+        # with scales_precision (not precision) for their scales/zeros buffers.
+        # It previously passed self.precision, so a quantizer configured with a
+        # distinct scales_precision silently produced runtime modules whose
+        # scales were cast to the activation precision instead.
+        from torchao.quantization.linear_quant_modules import Int8DynActInt4WeightLinear
+        from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
+
+        quantizer = Int8DynActInt4WeightQuantizer(
+            groupsize=32,
+            precision=torch.float32,
+            scales_precision=torch.bfloat16,
+        )
+        m = ToyLinearModel().eval()
+        example_inputs = m.example_inputs()
+        m = quantizer.quantize(m)
+        for name in ("linear1", "linear2"):
+            mod = getattr(m, name)
+            assert isinstance(mod, Int8DynActInt4WeightLinear)
+            self.assertEqual(mod.scales.dtype, torch.bfloat16)
+            self.assertEqual(mod.zeros.dtype, torch.bfloat16)
+        m(*example_inputs)
+
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_quantized_tensor_subclass_save_load(self):
         m = ToyLinearModel().eval().to(torch.bfloat16)

--- a/torchao/quantization/linear_quant_modules.py
+++ b/torchao/quantization/linear_quant_modules.py
@@ -606,8 +606,7 @@ class Int8DynActInt4WeightQuantizer:
             self.groupsize,
             self.padding_allowed,
             self.precision,
-            # TODO: this should be self.scales_precision?
-            self.precision,
+            self.scales_precision,
         )
         return model
 


### PR DESCRIPTION
## Summary

`Int8DynActInt4WeightQuantizer._convert_for_runtime` passed `self.precision` as the `scales_precision` argument of `replace_linear_8da4w`, so the runtime `Int8DynActInt4WeightLinear` modules were built with the wrong scales dtype. The code even carried a `# TODO: this should be self.scales_precision?` next to the line.

This diverges from `_create_quantized_state_dict`, which uses `self.scales_precision` for the scales. As reported in #2571, that mismatch makes `quantize(model).state_dict()` inconsistent with `_create_quantized_state_dict(model)` whenever `precision != scales_precision`.

## Fix

Pass `self.scales_precision` (instead of `self.precision`) as the `scales_precision` argument, matching `_create_quantized_state_dict`.

```python
 replace_linear_8da4w(
     model,
     self.groupsize,
     self.padding_allowed,
     self.precision,
-    # TODO: this should be self.scales_precision?
-    self.precision,
+    self.scales_precision,
 )
```

Fixes #2571

## Test plan
- [ ] Instantiate `Int8DynActInt4WeightQuantizer(precision=torch.float32, scales_precision=torch.bfloat16)`, quantize a small linear model, and confirm the runtime module scales dtype now matches `_create_quantized_state_dict` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)