### PR TITLE
Implement aten.cat for Int8QuantizedTrainingLinearWeight (#2619)

### DIFF
--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -98,6 +98,37 @@ class TestQuantizedTraining(TestCase):
         if bias:
             torch.testing.assert_close(linear_fp32.bias.grad, linear_int8.bias.grad)
 
+    @parametrize("device", _DEVICES)
+    def test_int8_weight_only_cat(self, device):
+        from torchao.prototype.quantized_training.int8 import (
+            Int8QuantizedTrainingLinearWeight,
+        )
+
+        w1 = Int8QuantizedTrainingLinearWeight.from_float(
+            torch.randn(4, 8, device=device)
+        )
+        w2 = Int8QuantizedTrainingLinearWeight.from_float(
+            torch.randn(6, 8, device=device)
+        )
+
+        out = torch.cat([w1, w2], dim=0)
+        self.assertIsInstance(out, Int8QuantizedTrainingLinearWeight)
+        self.assertEqual(out.shape, (10, 8))
+        # row-wise scales are preserved, so the cat is exact (no requantization)
+        torch.testing.assert_close(
+            out.dequantize(),
+            torch.cat([w1.dequantize(), w2.dequantize()], dim=0),
+        )
+
+        # negative dim resolves to the row dim
+        torch.testing.assert_close(
+            torch.cat([w1, w2], dim=-2).dequantize(), out.dequantize()
+        )
+
+        # cat along the feature dim is not representable with per-row scales
+        with self.assertRaises(NotImplementedError):
+            torch.cat([w1, w1], dim=1)
+
     @parametrize("leading_dims", [(), (2,), (2, 4)])
     @parametrize("bias", [False, True])
     @parametrize("device", _DEVICES)

--- a/torchao/prototype/quantized_training/int8.py
+++ b/torchao/prototype/quantized_training/int8.py
@@ -278,6 +278,31 @@ def _(func, types, args, kwargs):
     return out
 
 
+# Inverse of aten.split.Tensor above. Needed for distributed training, where
+# wrapping a model with DDP / `accelerator.prepare()` concatenates parameters.
+# With row-wise quantization each row carries its own scale, so concatenating
+# along dim 0 (the row dim) just concatenates int_data and scale and needs no
+# dequantization. Concatenating along dim 1 would mix columns governed by
+# different per-row scales, which cannot be represented as a single
+# Int8QTLinearWeight, so we only support dim 0 (mirroring split).
+@implements(aten.cat.default)
+def _(func, types, args, kwargs):
+    tensors = args[0]
+    dim = args[1] if len(args) > 1 else kwargs.get("dim", 0)
+    if dim < 0:
+        dim += 2  # int_data is always 2D
+    if dim != 0:
+        raise NotImplementedError("Int8QTLinearWeight only supports cat at dim=0")
+    if not all(isinstance(t, Int8QuantizedTrainingLinearWeight) for t in tensors):
+        raise NotImplementedError(
+            "Int8QTLinearWeight.cat only supports a list of Int8QTLinearWeight"
+        )
+
+    int_data = func([t.int_data for t in tensors], dim)
+    scale = func([t.scale for t in tensors], 0)
+    return Int8QuantizedTrainingLinearWeight(int_data, scale)
+
+
 @implements(aten.new_zeros.default)
 def _(func, types, args, kwargs):
     size = args[1]


### PR DESCRIPTION
### Problem (#2619)

Wrapping an int8-quantized-training model for distributed training — e.g. `accelerator.prepare(model)` or DDP — calls `torch.cat` on the parameters, but `Int8QuantizedTrainingLinearWeight` had no `aten.cat.default` handler, so it raised:

```
NotImplementedError: ... attempting to run unimplemented operator/function: aten.cat.default ...
```

### Fix

Add an `aten.cat` handler as the inverse of the existing `aten.split.Tensor` handler. The subclass uses **row-wise** quantization (`int_data` is `[rows, cols]` int8, `scale` is `[rows]`), so concatenating along **dim 0** (the row dim) just concatenates `int_data` and `scale` — each row keeps its own scale, so the result is **exact with no dequantization**.

`dim != 0` (and mixed input types) raise `NotImplementedError`, mirroring `split`'s dim-0-only contract: a column-wise cat would mix columns governed by different per-row scales and can't be represented as a single `Int8QTLinearWeight`. (This matches the concern raised in the issue thread.)

### Testing done

Added `test_int8_weight_only_cat`, parametrized over `_DEVICES` (runs on CPU here and CUDA in CI). Verified locally on CPU with the repo source:

- **Before** (no handler): `torch.cat([w1, w2], dim=0)` → `NotImplementedError`.
- **After**: returns `Int8QuantizedTrainingLinearWeight(shape=(10, 8))`, and `out.dequantize()` matches `torch.cat([w1.dequantize(), w2.dequantize()], dim=0)` exactly; `dim=-2` resolves to the row dim; `dim=1` raises.

```
test_int8_weight_only_cat_device_cpu PASSED
```

`ruff check` and `ruff format --check` (0.11.6) clean on both files.

The INT8 quantized-training path has no compute-capability gate, so this runs identically on CPU and on older GPUs. AI assistance (Claude Code) was used; I reviewed the change and ran the test.

Fixes #2619
