### PR TITLE
pt2e: preserve mutable buffer inputs during prepare

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -3328,7 +3328,12 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         result = m(*example_inputs)
         self.assertIsNotNone(result)
 
-    def test_quantize_in_place_index_put(self):
+    def _test_quantize_in_place_index_put_buffers_to_mutate(
+        self,
+        module: torch.nn.Module,
+        example_inputs: tuple[torch.Tensor, torch.Tensor],
+        expected_buffers_to_mutate: dict[str, str],
+    ) -> None:
         class IndexPutQuantizer(Quantizer):
             def __init__(self) -> None:
                 super().__init__()
@@ -3367,21 +3372,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             def validate(self, model: torch.fx.GraphModule) -> None:
                 return None
 
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.register_buffer("buf", torch.zeros(4, dtype=torch.float32))
-
-            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
-                updated = self.buf.index_put_((idx,), x)
-                return updated.clone()
-
-        m = M().eval()
+        m = module.eval()
         quantizer = IndexPutQuantizer()
-        example_inputs = (
-            torch.tensor([1.0, 2.0], dtype=torch.float32),
-            torch.tensor([1, 3], dtype=torch.int64),
-        )
         m = torch.export.export(m, example_inputs, strict=True).module()
 
         m = prepare_pt2e(m, quantizer)
@@ -3392,9 +3384,56 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         # If it folded it will be named _frozen_param0
         self.assertTrue("buf" in dict(m.named_buffers()))
 
+        # Downstream consumers rely on export metadata to identify mutated buffers.
+        exported = torch.export.export(m, example_inputs, strict=True)
+        exported = exported.run_decompositions({})
+        self.assertEqual(
+            exported.graph_signature.buffers_to_mutate,
+            expected_buffers_to_mutate,
+        )
+
         # Verify the quantized model works
         result = m(*example_inputs)
         self.assertIsNotNone(result)
+
+    def test_quantize_in_place_index_put(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(4, dtype=torch.float32))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put_((idx,), x)
+                return updated.clone()
+
+        example_inputs = (
+            torch.tensor([1.0, 2.0], dtype=torch.float32),
+            torch.tensor([1, 3], dtype=torch.int64),
+        )
+
+        self._test_quantize_in_place_index_put_buffers_to_mutate(
+            M(), example_inputs, {"index_put": "buf"}
+        )
+
+    def test_quantize_in_place_index_put_view(self):
+        class ViewM(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(2, 4, dtype=torch.float32))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                row = self.buf.select(0, 0)
+                updated = row.index_put_((idx,), x)
+                return updated.clone()
+
+        example_inputs = (
+            torch.tensor([1.0, 2.0], dtype=torch.float32),
+            torch.tensor([1, 3], dtype=torch.int64),
+        )
+
+        self._test_quantize_in_place_index_put_buffers_to_mutate(
+            ViewM(), example_inputs, {"select_scatter": "buf"}
+        )
 
     def test_scan_op_quantization(self):
         """Test that prepare_pt2e and convert_pt2e correctly quantize ops

--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -432,6 +432,7 @@ def _is_mutable_buffer_arg(
         return False
 
     schema = node.target._schema
+    # This covers in-place ops such as copy_, put_, scatter_, fill_, add_
     if (
         not schema.arguments
         or not schema.arguments[0].alias_info

--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -418,9 +418,9 @@ def _get_obs_or_fq_map(
 
 
 def _is_mutable_buffer_arg(
-    model: torch.nn.Module,
     node: Node,
     arg: Node,
+    buffer_names: set[str],
 ) -> bool:
     """Return whether arg is a mutating op destination backed by a module buffer."""
     if (
@@ -431,16 +431,22 @@ def _is_mutable_buffer_arg(
     ):
         return False
 
-    if "copy_" not in str(node.target) and "put_" not in str(node.target):
+    schema = node.target._schema
+    if (
+        not schema.arguments
+        or not schema.arguments[0].alias_info
+        or not schema.arguments[0].alias_info.is_write
+    ):
         return False
 
     producer_nodes = collect_producer_nodes(arg)
     if producer_nodes is None:
+        # If arg0 depends on a model input, it is not a buffer-only mutation
+        # destination, so fall back to normal observer insertion.
         return False
 
-    named_buffers = dict(model.named_buffers(remove_duplicate=False))
     return any(
-        producer.op == "get_attr" and str(producer.target) in named_buffers
+        producer.op == "get_attr" and str(producer.target) in buffer_names
         for producer in producer_nodes
     )
 
@@ -452,6 +458,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     model: torch.nn.Module,
     named_modules: dict[str, torch.nn.Module],
     obs_or_fq_map: dict[EdgeOrNode, ObserverOrFakeQuantize],
+    buffer_names: set[str],
     is_qat: bool,
     model_device: Optional[torch.device] = None,
 ) -> Argument:
@@ -471,6 +478,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
                 model,
                 named_modules,
                 obs_or_fq_map,
+                buffer_names,
                 is_qat,
                 model_device,
             )
@@ -495,7 +503,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     if input_edge not in obs_or_fq_map:
         return new_arg
 
-    if _is_mutable_buffer_arg(model, node, original_arg):
+    if _is_mutable_buffer_arg(node, original_arg, buffer_names):
         return new_arg
 
     # input_edge needs to be observed
@@ -542,6 +550,7 @@ def _maybe_insert_input_observers_for_node(
     model: torch.nn.Module,
     named_modules: dict[str, torch.nn.Module],
     obs_or_fq_map: dict[EdgeOrNode, ObserverOrFakeQuantize],
+    buffer_names: set[str],
     is_qat: bool,
     model_device: Optional[torch.device] = None,
 ) -> None:
@@ -569,6 +578,7 @@ def _maybe_insert_input_observers_for_node(
             model,
             named_modules,
             obs_or_fq_map,
+            buffer_names,
             is_qat,
             model_device,
         )
@@ -627,6 +637,7 @@ def _maybe_insert_input_and_output_observers_for_node(
     model: torch.fx.GraphModule,
     obs_or_fq_map: dict[EdgeOrNode, ObserverOrFakeQuantize],
     named_modules: dict[str, torch.nn.Module],
+    buffer_names: set[str],
     is_qat: bool,
     model_device: Optional[torch.device] = None,
 ):
@@ -642,6 +653,7 @@ def _maybe_insert_input_and_output_observers_for_node(
         model,
         named_modules,
         obs_or_fq_map,
+        buffer_names,
         is_qat,
         model_device,
     )
@@ -708,6 +720,7 @@ def prepare(
         obs_or_fq_callback(model, obs_or_fq_map)
     model_device = _assert_and_get_unique_device(model)
     named_modules = dict(model.named_modules(remove_duplicate=False))
+    buffer_names = {name for name, _ in model.named_buffers(remove_duplicate=False)}
 
     for node in nodes_before_observation:
         # TODO: simplify logic for inserting observers
@@ -716,6 +729,7 @@ def prepare(
             model,
             obs_or_fq_map,
             named_modules,
+            buffer_names,
             is_qat,
             model_device,
         )

--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -25,6 +25,7 @@ from torchao.quantization.pt2e import (
     ObserverOrFakeQuantize,
 )
 from torchao.quantization.pt2e.fake_quantize import FixedQParamsFakeQuantize
+from torchao.quantization.pt2e.graph_utils import collect_producer_nodes
 from torchao.quantization.pt2e.observer import (
     FixedQParamsObserver,
     PartialWrapper,
@@ -416,6 +417,34 @@ def _get_obs_or_fq_map(
     return obs_or_fq_map
 
 
+def _is_mutable_buffer_arg(
+    model: torch.nn.Module,
+    node: Node,
+    arg: Node,
+) -> bool:
+    """Return whether arg is a mutating op destination backed by a module buffer."""
+    if (
+        node.op != "call_function"
+        or not hasattr(node.target, "_schema")
+        or len(node.args) == 0
+        or node.args[0] is not arg
+    ):
+        return False
+
+    if "copy_" not in str(node.target) and "put_" not in str(node.target):
+        return False
+
+    producer_nodes = collect_producer_nodes(arg)
+    if producer_nodes is None:
+        return False
+
+    named_buffers = dict(model.named_buffers(remove_duplicate=False))
+    return any(
+        producer.op == "get_attr" and str(producer.target) in named_buffers
+        for producer in producer_nodes
+    )
+
+
 def _maybe_insert_input_observer_for_arg_or_kwarg(
     node: Union[Node, Any],
     arg: Argument,
@@ -465,6 +494,10 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     input_edge = (original_arg, node)
     if input_edge not in obs_or_fq_map:
         return new_arg
+
+    if _is_mutable_buffer_arg(model, node, original_arg):
+        return new_arg
+
     # input_edge needs to be observed
     input_edge_obs_or_fq = obs_or_fq_map[input_edge]
     if input_edge_obs_or_fq is None:


### PR DESCRIPTION
Skip inserting observers on arg0 of mutating ops when that argument traces back to a named buffer. Arg0 is the tensor being mutated, so it must remain the original module buffer.

Without this, prepare+convert rewrites:

res = index_put_(dequantize(quantize(buf)), idx, dequantized_x)

instead of:

res = index_put_(buf, idx, dequantized_x)

The first form mutates a dequantized temporary rather than the buffer, so re-export no longer reports buffers_to_mutate. Add coverage for index_put_ to verify buffers_to_mutate is preserved after convert_pt2e.

Co-Authored-By: Tom Allsop <tom.allsop@arm.com>

Fix for: https://github.com/pytorch/ao/issues/4138