### PR TITLE
[XPU] Add MXTensor Support on Intel GPU

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -29,6 +29,11 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
+if not torch.accelerator.is_available():
+    pytest.skip("No accelerator available", allow_module_level=True)
+
+device = torch.accelerator.current_accelerator().type
+
 
 # source: https://stackoverflow.com/a/22638709
 @pytest.fixture(autouse=True)
@@ -57,27 +62,6 @@ def cuda_kernel_profiler(kernel_pattern):
     result["found"] = any(kernel_pattern in name for name in kernel_names)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA or XPU not available",
-)
-@pytest.mark.parametrize(
-    "device",
-    [
-        pytest.param(
-            "cuda",
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available(), reason="CUDA not available"
-            ),
-        ),
-        pytest.param(
-            "xpu",
-            marks=pytest.mark.skipif(
-                not torch.xpu.is_available(), reason="XPU not available"
-            ),
-        ),
-    ],
-)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -95,7 +79,6 @@ def test_inference_workflow_mx(
     emulate: bool,
     use_inference_mode: bool,
     x_rank: int,
-    device: str,
 ):
     """
     Smoke test for inference compile
@@ -116,8 +99,6 @@ def test_inference_workflow_mx(
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
-    if compile and device == "xpu":
-        pytest.skip("compile is not yet supported on XPU for MX")
 
     m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device=device)
     m_mx = copy.deepcopy(m)
@@ -130,6 +111,7 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
+        swizzle_scales=(device != "xpu"),
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -57,7 +57,27 @@ def cuda_kernel_profiler(kernel_pattern):
     result["found"] = any(kernel_pattern in name for name in kernel_names)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param(
+            "cuda",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA not available"
+            ),
+        ),
+        pytest.param(
+            "xpu",
+            marks=pytest.mark.skipif(
+                not torch.xpu.is_available(), reason="XPU not available"
+            ),
+        ),
+    ],
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -75,25 +95,31 @@ def test_inference_workflow_mx(
     emulate: bool,
     use_inference_mode: bool,
     x_rank: int,
+    device: str,
 ):
     """
     Smoke test for inference compile
     """
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
-    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if (
+        elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+        and device == "cuda"
+    ):
         if not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
         elif not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp8 gemm")
-    elif elem_dtype == torch.float4_e2m1fn_x2:
+    elif elem_dtype == torch.float4_e2m1fn_x2 and device == "cuda":
         if not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
+    if compile and device == "xpu":
+        pytest.skip("compile is not yet supported on XPU for MX")
 
-    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device=device)
     m_mx = copy.deepcopy(m)
 
     if emulate:
@@ -109,7 +135,7 @@ def test_inference_workflow_mx(
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True)
 
-    x = torch.randn(128, 32, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(128, 32, device=device, dtype=torch.bfloat16)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -29,11 +29,6 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
-if not torch.accelerator.is_available():
-    pytest.skip("No accelerator available", allow_module_level=True)
-
-device = torch.accelerator.current_accelerator().type
-
 
 # source: https://stackoverflow.com/a/22638709
 @pytest.fixture(autouse=True)
@@ -62,6 +57,9 @@ def cuda_kernel_profiler(kernel_pattern):
     result["found"] = any(kernel_pattern in name for name in kernel_names)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -83,6 +81,7 @@ def test_inference_workflow_mx(
     """
     Smoke test for inference compile
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
     if (

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn.functional import SwizzleType
 from torch.profiler import ProfilerActivity, profile
 
 from torchao.prototype.mx_formats.inference_workflow import (
@@ -108,7 +109,9 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
-        swizzle_scales=(device != "xpu"),
+        swizzle_type=SwizzleType.NO_SWIZZLE
+        if device == "xpu"
+        else SwizzleType.SWIZZLE_32_4_4,
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -58,7 +58,8 @@ def cuda_kernel_profiler(kernel_pattern):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
@@ -84,10 +85,7 @@ def test_inference_workflow_mx(
     device = torch.accelerator.current_accelerator().type
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
-    if (
-        elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-        and device == "cuda"
-    ):
+    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2) and device == "cuda":
         if not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
         elif not is_sm_at_least_100() and not emulate:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -58,7 +58,7 @@ def cuda_kernel_profiler(kernel_pattern):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
-from functools import partial
 
 import pytest
 import torch
@@ -15,38 +14,13 @@ from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
+if not torch.accelerator.is_available():
+    pytest.skip("No accelerator available", allow_module_level=True)
+
+device = torch.accelerator.current_accelerator().type
 
 
-def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
-    """Wrapper for F.scaled_mm with MXFP4 configuration."""
-    return F.scaled_mm(
-        a_data.view(torch.float4_e2m1fn_x2),
-        b_data.view(torch.float4_e2m1fn_x2),
-        scale_a=a_scale_block,
-        scale_recipe_a=ScalingType.BlockWise1x32,
-        scale_b=b_scale_block,
-        scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-        output_dtype=torch.bfloat16,
-    )
-
-
-def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
+def run_matrix_test(M: int, K: int, N: int, format) -> float:
     dtype = torch.bfloat16
     is_xpu = device == "xpu"
 
@@ -54,15 +28,6 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-
-    if is_xpu:
-        mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-    else:
-        mx_func = (
-            partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-            if format == "fp8"
-            else _mxfp4_scaled_mm
-        )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -77,7 +42,7 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
 
     if is_xpu:
         a_scale_block = a_scale.contiguous()
-        b_scale_block = b_scale.t().contiguous()
+        b_scale_block = b_scale.contiguous()
     else:
         a_scale_block = to_blocked(a_scale)
         b_scale_block = to_blocked(b_scale)
@@ -86,27 +51,36 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
         torch.bfloat16
     ).transpose(-1, -2)
 
-    if is_xpu and format == "fp4":
-        out = mx_func(
-            a_data.view(torch.float4_e2m1fn_x2),
-            b_data.view(torch.float4_e2m1fn_x2),
-            a_scale_block,
-            b_scale_block,
+    swizzle = None if is_xpu else SwizzleType.SWIZZLE_32_4_4
+    if format == "fp8":
+        out = F.scaled_mm(
+            a_data,
+            b_data,
+            scale_a=a_scale_block,
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_b=b_scale_block,
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            output_dtype=torch.bfloat16,
         )
     else:
-        out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+        out = F.scaled_mm(
+            a_data.view(torch.float4_e2m1fn_x2),
+            b_data.view(torch.float4_e2m1fn_x2),
+            scale_a=a_scale_block,
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_b=b_scale_block,
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_a=swizzle,
+            swizzle_b=swizzle,
+            output_dtype=torch.bfloat16,
+        )
 
     return compute_error(out_hp, out).item()
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-@pytest.mark.skipif(
-    not (is_sm_at_least_100() or torch.xpu.is_available()),
-    reason="CUDA capability >= 10.0 or XPU required for mxfloat8",
+    device == "cuda" and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -126,9 +100,9 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
-def test_matrix_multiplication(size, format, device):
+def test_matrix_multiplication(size, format):
     M, K, N = size
-    sqnr = run_matrix_test(M, K, N, format, device=device)
+    sqnr = run_matrix_test(M, K, N, format)
     threshold = 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -15,6 +15,21 @@ from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
+
 
 def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
@@ -31,19 +46,23 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     )
 
 
-def run_matrix_test(M: int, K: int, N: int, format) -> float:
+def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    device = torch.device("cuda")
+    is_xpu = device == "xpu"
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-    mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-        if format == "fp8"
-        else _mxfp4_scaled_mm
-    )
+
+    if is_xpu:
+        mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+    else:
+        mx_func = (
+            partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+            if format == "fp8"
+            else _mxfp4_scaled_mm
+        )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -56,20 +75,38 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if is_xpu:
+        a_scale_block = a_scale.contiguous()
+        b_scale_block = b_scale.t().contiguous()
+    else:
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+
+    if is_xpu and format == "fp4":
+        out = mx_func(
+            a_data.view(torch.float4_e2m1fn_x2),
+            b_data.view(torch.float4_e2m1fn_x2),
+            a_scale_block,
+            b_scale_block,
+        )
+    else:
+        out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
 
     return compute_error(out_hp, out).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    not (is_sm_at_least_100() or torch.xpu.is_available()),
+    reason="CUDA capability >= 10.0 or XPU required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -89,9 +126,9 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
-def test_matrix_multiplication(size, format):
+def test_matrix_multiplication(size, format, device):
     M, K, N = size
-    sqnr = run_matrix_test(M, K, N, format)
+    sqnr = run_matrix_test(M, K, N, format, device=device)
     threshold = 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+from functools import partial
 
 import pytest
 import torch
@@ -14,20 +15,35 @@ from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
-if not torch.accelerator.is_available():
-    pytest.skip("No accelerator available", allow_module_level=True)
 
-device = torch.accelerator.current_accelerator().type
+def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
+    """Wrapper for F.scaled_mm with MXFP4 configuration."""
+    return F.scaled_mm(
+        a_data.view(torch.float4_e2m1fn_x2),
+        b_data.view(torch.float4_e2m1fn_x2),
+        scale_a=a_scale_block,
+        scale_recipe_a=ScalingType.BlockWise1x32,
+        scale_b=b_scale_block,
+        scale_recipe_b=ScalingType.BlockWise1x32,
+        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+        output_dtype=torch.bfloat16,
+    )
 
 
 def run_matrix_test(M: int, K: int, N: int, format) -> float:
     dtype = torch.bfloat16
-    is_xpu = device == "xpu"
+    device = torch.accelerator.current_accelerator().type
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
+    mx_func = (
+        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+        if format == "fp8"
+        else _mxfp4_scaled_mm
+    )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -40,47 +56,19 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    if is_xpu:
-        a_scale_block = a_scale.contiguous()
-        b_scale_block = b_scale.contiguous()
-    else:
-        a_scale_block = to_blocked(a_scale)
-        b_scale_block = to_blocked(b_scale)
+    a_scale_block = to_blocked(a_scale)
+    b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-
-    swizzle = None if is_xpu else SwizzleType.SWIZZLE_32_4_4
-    if format == "fp8":
-        out = F.scaled_mm(
-            a_data,
-            b_data,
-            scale_a=a_scale_block,
-            scale_recipe_a=ScalingType.BlockWise1x32,
-            scale_b=b_scale_block,
-            scale_recipe_b=ScalingType.BlockWise1x32,
-            output_dtype=torch.bfloat16,
-        )
-    else:
-        out = F.scaled_mm(
-            a_data.view(torch.float4_e2m1fn_x2),
-            b_data.view(torch.float4_e2m1fn_x2),
-            scale_a=a_scale_block,
-            scale_recipe_a=ScalingType.BlockWise1x32,
-            scale_b=b_scale_block,
-            scale_recipe_b=ScalingType.BlockWise1x32,
-            swizzle_a=swizzle,
-            swizzle_b=swizzle,
-            output_dtype=torch.bfloat16,
-        )
+    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
 
     return compute_error(out_hp, out).item()
 
 
 @pytest.mark.skipif(
-    device == "cuda" and not is_sm_at_least_100(),
-    reason="CUDA capability >= 10.0 required for mxfloat8",
+    not torch.accelerator.is_available(), reason="Accelerator not available"
 )
 @pytest.mark.parametrize(
     "size",
@@ -101,6 +89,11 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):
+    device = torch.accelerator.current_accelerator().type
+    if device == "xpu":
+        pytest.skip("to_blocked() requires CUDA")
+    if device == "cuda" and not is_sm_at_least_100():
+        pytest.skip("CUDA capability >= 10.0 required for mxfloat8")
     M, K, N = size
     sqnr = run_matrix_test(M, K, N, format)
     threshold = 80.0

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -18,6 +18,7 @@ from torchao.utils import is_sm_at_least_100
 
 def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
+    swizzle = None if a_data.is_xpu else SwizzleType.SWIZZLE_32_4_4
     return F.scaled_mm(
         a_data.view(torch.float4_e2m1fn_x2),
         b_data.view(torch.float4_e2m1fn_x2),
@@ -25,8 +26,8 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
         scale_recipe_a=ScalingType.BlockWise1x32,
         scale_b=b_scale_block,
         scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_a=swizzle,
+        swizzle_b=swizzle,
         output_dtype=torch.bfloat16,
     )
 
@@ -34,6 +35,7 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
 def run_matrix_test(M: int, K: int, N: int, format) -> float:
     dtype = torch.bfloat16
     device = torch.accelerator.current_accelerator().type
+    is_xpu = device == "xpu"
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
@@ -56,8 +58,16 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if is_xpu:
+        # XPU: row-major 2D scales, no swizzling
+        a_scale_block = a_scale
+        b_scale_block = b_scale
+        if format == "fp8":
+            # XPU expects scale_b as (K//32, N) for _scaled_mm
+            b_scale_block = b_scale_block.t().contiguous()
+    else:
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
@@ -68,7 +78,7 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize(
     "size",
@@ -90,8 +100,6 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):
     device = torch.accelerator.current_accelerator().type
-    if device == "xpu":
-        pytest.skip("to_blocked() requires CUDA")
     if device == "cuda" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for mxfloat8")
     M, K, N = size

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -78,7 +78,8 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize(
     "size",
@@ -97,11 +98,12 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     ],
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
 )
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
+)
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):
-    device = torch.accelerator.current_accelerator().type
-    if device == "cuda" and not is_sm_at_least_100():
-        pytest.skip("CUDA capability >= 10.0 required for mxfloat8")
     M, K, N = size
     sqnr = run_matrix_test(M, K, N, format)
     threshold = 80.0

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -15,21 +15,6 @@ from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
-
 
 def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
@@ -103,7 +88,6 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_100(),
     reason="CUDA capability >= 10.0 required for mxfloat8",
@@ -126,7 +110,8 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
-def test_matrix_multiplication(size, format, device):
+def test_matrix_multiplication(size, format):
+    device = torch.accelerator.current_accelerator().type
     M, K, N = size
     sqnr = run_matrix_test(M, K, N, format, device=device)
     threshold = 80.0

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -81,6 +81,10 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
+)
 @pytest.mark.parametrize(
     "size",
     [
@@ -97,10 +101,6 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
         (133, 512, 528),  # Non-aligned
     ],
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
-)
-@pytest.mark.skipif(
-    torch.cuda.is_available() and not is_sm_at_least_100(),
-    reason="CUDA capability >= 10.0 required for mxfloat8",
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -15,6 +15,21 @@ from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
+
 
 def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
@@ -31,19 +46,23 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     )
 
 
-def run_matrix_test(M: int, K: int, N: int, format) -> float:
+def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    device = torch.device("cuda")
+    is_xpu = device == "xpu"
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-    mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-        if format == "fp8"
-        else _mxfp4_scaled_mm
-    )
+
+    if is_xpu:
+        mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+    else:
+        mx_func = (
+            partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+            if format == "fp8"
+            else _mxfp4_scaled_mm
+        )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -56,20 +75,38 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if is_xpu:
+        a_scale_block = a_scale.contiguous()
+        b_scale_block = b_scale.t().contiguous()
+    else:
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+
+    if is_xpu and format == "fp4":
+        out = mx_func(
+            a_data.view(torch.float4_e2m1fn_x2),
+            b_data.view(torch.float4_e2m1fn_x2),
+            a_scale_block,
+            b_scale_block,
+        )
+    else:
+        out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
 
     return compute_error(out_hp, out).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -89,9 +126,9 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     ids=lambda x: f"{x[0]}x{x[1]}x{x[2]}",
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
-def test_matrix_multiplication(size, format):
+def test_matrix_multiplication(size, format, device):
     M, K, N = size
-    sqnr = run_matrix_test(M, K, N, format)
+    sqnr = run_matrix_test(M, K, N, format, device=device)
     threshold = 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -20,33 +20,18 @@ from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
+if not torch.accelerator.is_available():
+    pytest.skip("No accelerator available", allow_module_level=True)
+
+device = torch.accelerator.current_accelerator().type
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-@pytest.mark.skipif(
-    not (is_sm_at_least_100() or torch.xpu.is_available()),
-    reason="needs CUDA capability 10.0+ or XPU",
+    device == "cuda" and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
 )
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
-def test_serialization(recipe_name, device):
+def test_serialization(recipe_name):
     if recipe_name == "nvfp4" and device == "xpu":
         pytest.skip("NVFP4 is not supported on XPU")
     """

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -20,17 +20,41 @@ from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_100(), reason="needs CUDA capability 10.0+")
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    not (is_sm_at_least_100() or torch.xpu.is_available()),
+    reason="needs CUDA capability 10.0+ or XPU",
+)
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
-def test_serialization(recipe_name):
+def test_serialization(recipe_name, device):
+    if recipe_name == "nvfp4" and device == "xpu":
+        pytest.skip("NVFP4 is not supported on XPU")
     """
     Ensure that only `import torchao.prototype.mx_formats` is needed to load MX
     and NV checkpoints.
     """
 
-    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device=device)
     fname = None
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
         if recipe_name == "mxfp8":

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -20,18 +20,15 @@ from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
-if not torch.accelerator.is_available():
-    pytest.skip("No accelerator available", allow_module_level=True)
-
-device = torch.accelerator.current_accelerator().type
-
 
 @pytest.mark.skipif(
-    device == "cuda" and not is_sm_at_least_100(),
-    reason="needs CUDA capability 10.0+",
+    not torch.accelerator.is_available(), reason="Accelerator not available"
 )
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):
+    device = torch.accelerator.current_accelerator().type
+    if device == "cuda" and not is_sm_at_least_100():
+        pytest.skip("needs CUDA capability 10.0+")
     if recipe_name == "nvfp4" and device == "xpu":
         pytest.skip("NVFP4 is not supported on XPU")
     """

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -22,13 +22,16 @@ from torchao.utils import is_sm_at_least_100
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
+)
 def test_serialization(recipe_name):
     device = torch.accelerator.current_accelerator().type
-    if device == "cuda" and not is_sm_at_least_100():
-        pytest.skip("needs CUDA capability 10.0+")
     if recipe_name == "nvfp4" and device == "xpu":
         pytest.skip("NVFP4 is not supported on XPU")
     """

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -20,37 +20,22 @@ from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
-
 
 @pytest.mark.skipif(
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_100(),
     reason="needs CUDA capability 10.0+",
 )
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
-def test_serialization(recipe_name, device):
+def test_serialization(recipe_name):
     """
     Ensure that only `import torchao.prototype.mx_formats` is needed to load MX
     and NV checkpoints.
     """
+    device = torch.accelerator.current_accelerator().type
     if recipe_name == "nvfp4" and device == "xpu":
         pytest.skip("NVFP4 is not supported on XPU")
 

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -20,17 +20,41 @@ from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_100(), reason="needs CUDA capability 10.0+")
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
-def test_serialization(recipe_name):
+def test_serialization(recipe_name, device):
     """
     Ensure that only `import torchao.prototype.mx_formats` is needed to load MX
     and NV checkpoints.
     """
+    if recipe_name == "nvfp4" and device == "xpu":
+        pytest.skip("NVFP4 is not supported on XPU")
 
-    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device=device)
     fname = None
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
         if recipe_name == "mxfp8":

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -22,7 +22,7 @@ from torchao.utils import is_sm_at_least_100
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -25,11 +25,11 @@ from torchao.utils import is_sm_at_least_100
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_100(),
-    reason="CUDA capability >= 10.0 required for mxfloat8",
+    reason="needs CUDA capability 10.0+",
 )
+@pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):
     device = torch.accelerator.current_accelerator().type
     if recipe_name == "nvfp4" and device == "xpu":

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -37,11 +37,6 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
-if not torch.accelerator.is_available():
-    pytest.skip("No accelerator available", allow_module_level=True)
-
-device = torch.accelerator.current_accelerator().type
-
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():
@@ -86,30 +81,46 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_realistic_numerics(elem_dtype, scale_calculation_mode):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
@@ -325,6 +336,7 @@ def test_exponent_nan_in(elem_dtype):
     If high precision block values has a NaN, the exponent block
     value is set to is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.tensor(
         [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
@@ -334,6 +346,9 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
     """
@@ -341,6 +356,7 @@ def test_all_nan_blocks(elem_dtype):
     - Mixed real + NaN: scale = NaN
     - All NaN: scale = NaN
     """
+    device = torch.accelerator.current_accelerator().type
     block_size = 4
 
     # Test case 1: Mixed NaN + real values
@@ -399,11 +415,15 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     scale_e8m0 = torch.tensor(
         [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
@@ -441,11 +461,15 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
     """
+    device = torch.accelerator.current_accelerator().type
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
@@ -453,12 +477,16 @@ def test_ranks(elem_dtype):
         _test_mx(tensor_hp, elem_dtype, B)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
 def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
     """
+    device = torch.accelerator.current_accelerator().type
     if B == 1 and elem_dtype == torch.float4_e2m1fn_x2:
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
@@ -467,7 +495,11 @@ def test_block_sizes(elem_dtype, B):
     _test_mx(tensor_hp, elem_dtype, B)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 def test_from_qdata_and_scales_round_trip():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -490,7 +522,11 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -507,7 +543,11 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -524,11 +564,15 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
+    device = torch.accelerator.current_accelerator().type
     M, K = 128, 256
     block_size = 32
     tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
@@ -546,15 +590,23 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 def test_clone():
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
@@ -567,6 +619,9 @@ def test_clone():
     )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
@@ -574,6 +629,7 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
+    device = torch.accelerator.current_accelerator().type
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         if device == "cuda" and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
@@ -617,14 +673,16 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
 
 
 @pytest.mark.skipif(
-    device == "cuda" and not is_sm_at_least_89(),
-    reason="float8 in triton requires CUDA capability 8.9 or greater",
+    not torch.accelerator.is_available(), reason="Accelerator not available"
 )
 def test_to_mx_inductor_single_kernel():
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
+    device = torch.accelerator.current_accelerator().type
+    if device == "cuda" and not is_sm_at_least_89():
+        pytest.skip("float8 in triton requires CUDA capability 8.9 or greater")
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
     x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
@@ -635,7 +693,7 @@ def test_to_mx_inductor_single_kernel():
 
 
 @pytest.mark.skipif(
-    device == "cuda" and not is_sm_at_least_90(), reason="Need sm90+"
+    not torch.accelerator.is_available(), reason="Accelerator not available"
 )
 def test_index_select():
     """
@@ -644,7 +702,9 @@ def test_index_select():
     a single 3D parameter when converting between model definitions that
     use 2D and 3D parameters for their expert weights.
     """
-
+    device = torch.accelerator.current_accelerator().type
+    if device == "cuda" and not is_sm_at_least_90():
+        pytest.skip("Need sm90+")
     E, K, N = 128, 256, 512
     x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
@@ -656,14 +716,16 @@ def test_index_select():
 
 
 @pytest.mark.skipif(
-    device == "cuda" and not is_sm_at_least_89(),
-    reason="float8 in triton requires CUDA capability 8.9 or greater",
+    not torch.accelerator.is_available(), reason="Accelerator not available"
 )
 @pytest.mark.skipif(
     not torch_version_at_least("2.12.0.dev0"),
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
 )
 def test_cast_to_float8_e4m3fn_saturation_behavior():
+    device = torch.accelerator.current_accelerator().type
+    if device == "cuda" and not is_sm_at_least_89():
+        pytest.skip("float8 in triton requires CUDA capability 8.9 or greater")
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -742,6 +804,9 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -751,6 +816,7 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -794,6 +860,9 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -804,6 +873,7 @@ def test_scale_shape_matches_qdata(transpose, shape):
     ),
 )
 def test_swizzle(elem_dtype, transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -857,8 +927,12 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -37,20 +37,10 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
+if not torch.accelerator.is_available():
+    pytest.skip("No accelerator available", allow_module_level=True)
+
+device = torch.accelerator.current_accelerator().type
 
 
 @pytest.fixture(autouse=True)
@@ -96,50 +86,30 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_hello_world(elem_dtype, device):
+def test_hello_world(elem_dtype):
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_realistic_numerics(elem_dtype, scale_calculation_mode, device):
+def test_realistic_numerics(elem_dtype, scale_calculation_mode):
     data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_zeros(elem_dtype, device):
+def test_all_zeros(elem_dtype):
     data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_some_zeros(elem_dtype, device):
+def test_some_zeros(elem_dtype):
     data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
@@ -147,10 +117,6 @@ def test_some_zeros(elem_dtype, device):
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -368,13 +334,8 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_nan_blocks(elem_dtype, device):
+def test_all_nan_blocks(elem_dtype):
     """
     Test NaN handling for blocks with all NaN values vs mixed NaN + real values.
     - Mixed real + NaN: scale = NaN
@@ -438,13 +399,8 @@ def test_all_nan_blocks(elem_dtype, device):
     )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_out(elem_dtype, device):
+def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
@@ -485,13 +441,8 @@ def test_exponent_nan_out(elem_dtype, device):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_ranks(elem_dtype, device):
+def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
     """
@@ -502,14 +453,9 @@ def test_ranks(elem_dtype, device):
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
-def test_block_sizes(elem_dtype, B, device):
+def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
     """
@@ -521,12 +467,7 @@ def test_block_sizes(elem_dtype, B, device):
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_round_trip(device):
+def test_from_qdata_and_scales_round_trip():
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -549,12 +490,7 @@ def test_from_qdata_and_scales_round_trip(device):
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
+def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -571,12 +507,7 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
         )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
+def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -593,13 +524,8 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
         )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_transpose(elem_dtype, device):
+def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
@@ -620,25 +546,15 @@ def test_transpose(elem_dtype, device):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_view(elem_dtype, device):
+def test_view(elem_dtype):
     x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_clone(device):
+def test_clone():
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
@@ -651,20 +567,15 @@ def test_clone(device):
     )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
-def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device):
+def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not (is_sm_at_least_89() or torch.xpu.is_available()):
+        if device == "cuda" and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
@@ -706,15 +617,10 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device)
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-@pytest.mark.skipif(
-    not (is_sm_at_least_89() or torch.xpu.is_available()),
+    device == "cuda" and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
-def test_to_mx_inductor_single_kernel(device):
+def test_to_mx_inductor_single_kernel():
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
@@ -729,14 +635,9 @@ def test_to_mx_inductor_single_kernel(device):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
+    device == "cuda" and not is_sm_at_least_90(), reason="Need sm90+"
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-@pytest.mark.skipif(
-    not (is_sm_at_least_90() or torch.xpu.is_available()), reason="Need sm90+"
-)
-def test_index_select(device):
+def test_index_select():
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
     useful when stitching checkpoints of `num_experts` 2D parameters into
@@ -755,19 +656,14 @@ def test_index_select(device):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-@pytest.mark.skipif(
-    not (is_sm_at_least_89() or torch.xpu.is_available()),
+    device == "cuda" and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
     not torch_version_at_least("2.12.0.dev0"),
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
 )
-def test_cast_to_float8_e4m3fn_saturation_behavior(device):
+def test_cast_to_float8_e4m3fn_saturation_behavior():
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -830,9 +726,9 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(device):
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    test_device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
+    original = torch.randint(0, 255, (rows, cols), device=test_device, dtype=torch.uint8)
 
     blocked = to_blocked(original, use_triton_kernel=use_triton_kernel)
     reconstructed = from_blocked(blocked, rows, cols)
@@ -846,11 +742,6 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -859,7 +750,7 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
         (1, 128, 64),
     ),
 )
-def test_scale_shape_matches_qdata(transpose, shape, device):
+def test_scale_shape_matches_qdata(transpose, shape):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -903,11 +794,6 @@ def test_scale_shape_matches_qdata(transpose, shape, device):
     )
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -917,7 +803,7 @@ def test_scale_shape_matches_qdata(transpose, shape, device):
         (1, 128, 64),
     ),
 )
-def test_swizzle(elem_dtype, transpose, shape, device):
+def test_swizzle(elem_dtype, transpose, shape):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -971,13 +857,8 @@ def test_swizzle(elem_dtype, transpose, shape, device):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA and XPU not available",
-)
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-def test_mx_pin_memory(elem_dtype, device):
+def test_mx_pin_memory(elem_dtype):
     x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -82,7 +82,7 @@ def _test_mx(
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
@@ -93,7 +93,7 @@ def test_hello_world(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
@@ -105,7 +105,7 @@ def test_realistic_numerics(elem_dtype, scale_calculation_mode):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
@@ -116,7 +116,7 @@ def test_all_zeros(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
@@ -328,7 +328,7 @@ def test_to_mx_rceil():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
@@ -347,7 +347,7 @@ def test_exponent_nan_in(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
@@ -416,7 +416,7 @@ def test_all_nan_blocks(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
@@ -462,7 +462,7 @@ def test_exponent_nan_out(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
@@ -478,7 +478,7 @@ def test_ranks(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
@@ -496,7 +496,7 @@ def test_block_sizes(elem_dtype, B):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_from_qdata_and_scales_round_trip():
     device = torch.accelerator.current_accelerator().type
@@ -523,7 +523,7 @@ def test_from_qdata_and_scales_round_trip():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
     device = torch.accelerator.current_accelerator().type
@@ -544,7 +544,7 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
     device = torch.accelerator.current_accelerator().type
@@ -565,7 +565,7 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_transpose(elem_dtype):
@@ -591,7 +591,7 @@ def test_transpose(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
@@ -603,7 +603,7 @@ def test_view(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_clone():
     device = torch.accelerator.current_accelerator().type
@@ -620,7 +620,7 @@ def test_clone():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
@@ -673,7 +673,7 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_to_mx_inductor_single_kernel():
     """
@@ -693,7 +693,7 @@ def test_to_mx_inductor_single_kernel():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 def test_index_select():
     """
@@ -716,7 +716,7 @@ def test_index_select():
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.skipif(
     not torch_version_at_least("2.12.0.dev0"),
@@ -805,7 +805,7 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -861,7 +861,7 @@ def test_scale_shape_matches_qdata(transpose, shape):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not torch.cuda.is_available(), reason="CUDA required"
 )
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
@@ -928,7 +928,7 @@ def test_swizzle(elem_dtype, transpose, shape):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
 )
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -9,9 +9,7 @@ import math
 
 import pytest
 import torch
-from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
-from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 from torchao.prototype.mx_formats.constants import (
@@ -23,7 +21,6 @@ from torchao.prototype.mx_formats.kernels import pack_uint4
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     ScaleCalculationMode,
-    _to_mx_rceil,
     to_dtype,
 )
 from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
@@ -82,7 +79,8 @@ def _test_mx(
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
@@ -93,7 +91,8 @@ def test_hello_world(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
@@ -105,7 +104,8 @@ def test_realistic_numerics(elem_dtype, scale_calculation_mode):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
@@ -116,7 +116,8 @@ def test_all_zeros(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
@@ -328,7 +329,8 @@ def test_to_mx_rceil():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
@@ -347,7 +349,8 @@ def test_exponent_nan_in(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
@@ -416,7 +419,8 @@ def test_all_nan_blocks(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
@@ -462,7 +466,8 @@ def test_exponent_nan_out(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
@@ -478,7 +483,8 @@ def test_ranks(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
@@ -496,7 +502,8 @@ def test_block_sizes(elem_dtype, B):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 def test_from_qdata_and_scales_round_trip():
     device = torch.accelerator.current_accelerator().type
@@ -523,7 +530,8 @@ def test_from_qdata_and_scales_round_trip():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
     device = torch.accelerator.current_accelerator().type
@@ -544,7 +552,8 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
     device = torch.accelerator.current_accelerator().type
@@ -565,7 +574,8 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_transpose(elem_dtype):
@@ -591,7 +601,8 @@ def test_transpose(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
@@ -603,7 +614,8 @@ def test_view(elem_dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 def test_clone():
     device = torch.accelerator.current_accelerator().type
@@ -620,7 +632,8 @@ def test_clone():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
@@ -673,7 +686,8 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 def test_to_mx_inductor_single_kernel():
     """
@@ -693,7 +707,12 @@ def test_to_mx_inductor_single_kernel():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    reason="Need sm90+",
 )
 def test_index_select():
     """
@@ -703,8 +722,6 @@ def test_index_select():
     use 2D and 3D parameters for their expert weights.
     """
     device = torch.accelerator.current_accelerator().type
-    if device == "cuda" and not is_sm_at_least_90():
-        pytest.skip("Need sm90+")
     E, K, N = 128, 256, 512
     x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
@@ -716,16 +733,19 @@ def test_index_select():
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.skipif(
     not torch_version_at_least("2.12.0.dev0"),
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
 )
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
+    reason="float8 in triton requires CUDA capability 8.9 or greater",
+)
 def test_cast_to_float8_e4m3fn_saturation_behavior():
     device = torch.accelerator.current_accelerator().type
-    if device == "cuda" and not is_sm_at_least_89():
-        pytest.skip("float8 in triton requires CUDA capability 8.9 or greater")
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -788,9 +808,9 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    test_device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    original = torch.randint(0, 255, (rows, cols), device=test_device, dtype=torch.uint8)
+    original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 
     blocked = to_blocked(original, use_triton_kernel=use_triton_kernel)
     reconstructed = from_blocked(blocked, rows, cols)
@@ -805,7 +825,8 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -860,9 +881,7 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA required"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -928,7 +947,8 @@ def test_swizzle(elem_dtype, transpose, shape):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()), reason="CUDA or XPU required"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -48,7 +48,6 @@ torch.manual_seed(2)
 
 
 def test_f32_to_e8m0_rceil():
-    torch.accelerator.current_accelerator().type
     values, expected = make_f32_to_e8m0_rceil_cases(device="cpu")
     assert torch.equal(_f32_to_e8m0_rceil(values), expected)
 
@@ -66,12 +65,15 @@ def test_e8m0_scale_to_reciprocal_fp32(monkeypatch, use_direct_cast):
     assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
-def test_e8m0_scale_to_reciprocal_fp32_cuda_fallback(monkeypatch, use_compile):
-    torch.accelerator.current_accelerator().type
+def test_e8m0_scale_to_reciprocal_fp32_gpu_fallback(monkeypatch, use_compile):
+    device = torch.accelerator.current_accelerator().type
     monkeypatch.setattr(mx_tensor_module, "_TORCH_VERSION_AT_LEAST_2_14", False)
-    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device="cuda")
+    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device=device)
     convert = (
         torch.compile(_e8m0_scale_to_reciprocal_fp32, fullgraph=True)
         if use_compile
@@ -939,9 +941,11 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
     "use_triton_kernel", [False, True] if torch.cuda.is_available() else [False]
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
-    device = torch.accelerator.current_accelerator().type
     rows, cols = shape
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available() or torch.xpu.is_available():
+        device = torch.accelerator.current_accelerator().type
+    else:
+        device = "cpu"
 
     original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -200,19 +200,27 @@ def test_some_zeros(elem_dtype, device):
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
-def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile):
-    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device="cuda")
+def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile, device):
+    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device=device)
     quantize = torch.compile(to_mx, fullgraph=True) if use_compile else to_mx
     scales, qdata = quantize(cases.inputs, torch.float8_e4m3fn, 32, scaling_mode)
     assert_mxfp8_semantics(qdata, scales, cases)
 
 
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -465,8 +473,9 @@ def test_to_mx_rceil_fallback_nan_branch_is_cse_compatible(monkeypatch):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_in(elem_dtype):
+def test_exponent_nan_in(elem_dtype, device):
     """
     If high precision block values has a NaN, the exponent block
     value is set to is NaN

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -9,7 +9,9 @@ import math
 
 import pytest
 import torch
+from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 from torchao.prototype.mx_formats.constants import (
@@ -21,6 +23,7 @@ from torchao.prototype.mx_formats.kernels import pack_uint4
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     ScaleCalculationMode,
+    _to_mx_rceil,
     to_dtype,
 )
 from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
@@ -326,6 +329,34 @@ def test_to_mx_rceil():
     )
     torch.testing.assert_close(data_mx.scale, ground_truth_scale)
     torch.testing.assert_close(data_mx.qdata, ground_truth_fp8)
+
+
+def test_to_mx_rceil_nan_branch_is_cse_compatible():
+    def repeated_rceil(data_hp, max_abs):
+        first = _to_mx_rceil(data_hp, max_abs, 448.0)
+        second = _to_mx_rceil(data_hp, max_abs, 448.0)
+        return *first, *second
+
+    data_hp = torch.randn(4, 32)
+    max_abs = data_hp.abs().amax(dim=-1, keepdim=True)
+    gm = make_fx(repeated_rceil)(data_hp, max_abs)
+    gm.graph = fx_graph_cse(gm.graph)
+
+    nan_branches = []
+    for node in gm.graph.nodes:
+        if node.target != torch.ops.aten.where.self:
+            continue
+        condition = node.args[0]
+        if (
+            isinstance(condition, torch.fx.Node)
+            and condition.target == torch.ops.aten.eq.Scalar
+            and condition.args[1] == 255
+        ):
+            nan_branches.append(node.args[1])
+
+    assert len(nan_branches) == 2
+    assert nan_branches[0] is nan_branches[1]
+    assert nan_branches[0].target == torch.ops.aten.div.Tensor
 
 
 @pytest.mark.skipif(
@@ -689,14 +720,16 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
+    reason="float8 in triton requires CUDA capability 8.9 or greater",
+)
 def test_to_mx_inductor_single_kernel():
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
     device = torch.accelerator.current_accelerator().type
-    if device == "cuda" and not is_sm_at_least_89():
-        pytest.skip("float8 in triton requires CUDA capability 8.9 or greater")
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
     x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
@@ -737,12 +770,12 @@ def test_index_select():
     reason="CUDA or XPU not available",
 )
 @pytest.mark.skipif(
-    not torch_version_at_least("2.12.0.dev0"),
-    reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
-)
-@pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
+)
+@pytest.mark.skipif(
+    not torch_version_at_least("2.12.0.dev0"),
+    reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
 )
 def test_cast_to_float8_e4m3fn_saturation_behavior():
     device = torch.accelerator.current_accelerator().type

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -12,6 +12,7 @@ import torch
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.nn.functional import SwizzleType
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
@@ -588,7 +589,7 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        False,
+        SwizzleType.NO_SWIZZLE,
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
@@ -1051,7 +1052,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        is_swizzled_scales=True,
+        swizzle_type=SwizzleType.SWIZZLE_32_4_4,
     )
 
     if transpose:

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -37,6 +37,21 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
+
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():
@@ -81,42 +96,61 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_hello_world(elem_dtype):
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+def test_hello_world(elem_dtype, device):
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_realistic_numerics(elem_dtype, scale_calculation_mode):
-    data = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+def test_realistic_numerics(elem_dtype, scale_calculation_mode, device):
+    data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_zeros(elem_dtype):
-    data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
+def test_all_zeros(elem_dtype, device):
+    data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_some_zeros(elem_dtype):
-    data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+def test_some_zeros(elem_dtype, device):
+    data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -316,35 +350,9 @@ def test_to_mx_rceil():
     torch.testing.assert_close(data_mx.qdata, ground_truth_fp8)
 
 
-def test_to_mx_rceil_nan_branch_is_cse_compatible():
-    def repeated_rceil(data_hp, max_abs):
-        first = _to_mx_rceil(data_hp, max_abs, 448.0)
-        second = _to_mx_rceil(data_hp, max_abs, 448.0)
-        return *first, *second
-
-    data_hp = torch.randn(4, 32)
-    max_abs = data_hp.abs().amax(dim=-1, keepdim=True)
-    gm = make_fx(repeated_rceil)(data_hp, max_abs)
-    gm.graph = fx_graph_cse(gm.graph)
-
-    nan_branches = []
-    for node in gm.graph.nodes:
-        if node.target != torch.ops.aten.where.self:
-            continue
-        condition = node.args[0]
-        if (
-            isinstance(condition, torch.fx.Node)
-            and condition.target == torch.ops.aten.eq.Scalar
-            and condition.args[1] == 255
-        ):
-            nan_branches.append(node.args[1])
-
-    assert len(nan_branches) == 2
-    assert nan_branches[0] is nan_branches[1]
-    assert nan_branches[0].target == torch.ops.aten.div.Tensor
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
@@ -352,7 +360,7 @@ def test_exponent_nan_in(elem_dtype):
     value is set to is NaN
     """
     tensor_hp = torch.tensor(
-        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device="cuda", dtype=torch.bfloat16
+        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
     block_size = 4
     tensor_mx = MXTensor.to_mx(tensor_hp, elem_dtype, block_size)
@@ -360,9 +368,13 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_nan_blocks(elem_dtype):
+def test_all_nan_blocks(elem_dtype, device):
     """
     Test NaN handling for blocks with all NaN values vs mixed NaN + real values.
     - Mixed real + NaN: scale = NaN
@@ -373,7 +385,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 1: Mixed NaN + real values
     mixed_tensor = torch.tensor(
         [float("nan"), 2.0, float("nan"), 4.0, 1.0, 3.0, 5.0, 2.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     mixed_mx = MXTensor.to_mx(mixed_tensor, elem_dtype, block_size)
@@ -389,7 +401,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 2: All NaN blocks (should return NaN scale)
     all_nan_tensor = torch.tensor(
         [float("nan"), float("nan"), float("nan"), float("nan"), 1.0, 2.0, 3.0, 4.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     all_nan_mx = MXTensor.to_mx(all_nan_tensor, elem_dtype, block_size)
@@ -415,7 +427,7 @@ def test_all_nan_blocks(elem_dtype):
             float("nan"),
             float("nan"),
         ],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     completely_nan_mx = MXTensor.to_mx(completely_nan_tensor, elem_dtype, block_size)
@@ -426,29 +438,33 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_out(elem_dtype):
+def test_exponent_nan_out(elem_dtype, device):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
     scale_e8m0 = torch.tensor(
-        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device="cuda"
+        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
 
     block_size = 4
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device=device
         )  # noqa: E501
     elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
     elif elem_dtype == torch.float4_e2m1fn_x2:
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
         data_bits = pack_uint4(data_bits)
     else:
@@ -469,23 +485,31 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_ranks(elem_dtype):
+def test_ranks(elem_dtype, device):
     """
     The reshaping logic works for various ranks
     """
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
-        tensor_hp = torch.randn(*s, device="cuda", dtype=torch.bfloat16)
+        tensor_hp = torch.randn(*s, device=device, dtype=torch.bfloat16)
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
-def test_block_sizes(elem_dtype, B):
+def test_block_sizes(elem_dtype, B, device):
     """
     Smoke test for various block sizes
     """
@@ -493,13 +517,17 @@ def test_block_sizes(elem_dtype, B):
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
         pytest.skip("unsupported configuration")
-    tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(B, device=device, dtype=torch.bfloat16)
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_round_trip():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_round_trip(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -521,9 +549,13 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -539,9 +571,13 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -557,15 +593,19 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_transpose(elem_dtype):
+def test_transpose(elem_dtype, device):
     """
     Verify that transposing an MX tensor works
     """
     M, K = 128, 256
     block_size = 32
-    tensor_hp = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         elem_dtype,
@@ -580,18 +620,26 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_view(elem_dtype):
-    x = torch.randn(1, 2, 4, device="cuda")
+def test_view(elem_dtype, device):
+    x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_clone():
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_clone(device):
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
     data_mx_c = data_mx.clone()
@@ -603,24 +651,28 @@ def test_clone():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
-def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
+def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device):
     """
     Verifies that compile does not change numerics of MX casts
     """
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if not (is_sm_at_least_89() or torch.xpu.is_available()):
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:
-        x = torch.randn(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.randn(*shape, dtype=hp_dtype, device=device)
     else:
-        x = torch.zeros(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.zeros(*shape, dtype=hp_dtype, device=device)
     block_size = 4
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
 
@@ -653,28 +705,38 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     torch.testing.assert_close(x_mx_dq, x_mx_c_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    not (is_sm_at_least_89() or torch.xpu.is_available()),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
-def test_to_mx_inductor_single_kernel():
+def test_to_mx_inductor_single_kernel(device):
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
-    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
     block_size = 32
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
     out, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
     FileCheck().check("def call(").check_count(".run(", 1, exactly=True).run(code[0])
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Need sm90+")
-def test_index_select():
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    not (is_sm_at_least_90() or torch.xpu.is_available()), reason="Need sm90+"
+)
+def test_index_select(device):
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
     useful when stitching checkpoints of `num_experts` 2D parameters into
@@ -683,7 +745,7 @@ def test_index_select():
     """
 
     E, K, N = 128, 256, 512
-    x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
 
     x_mx_1 = x_mx[1]
@@ -692,16 +754,20 @@ def test_index_select():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    not (is_sm_at_least_89() or torch.xpu.is_available()),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
     not torch_version_at_least("2.12.0.dev0"),
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.12+",
 )
-def test_cast_to_float8_e4m3fn_saturation_behavior():
+def test_cast_to_float8_e4m3fn_saturation_behavior(device):
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -711,7 +777,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
             -1 * max_val,
         ],
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
 
     # create example data outside the representable range
@@ -721,7 +787,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior():
             -1 * (max_val * 2),
         ],
         dtype=torch.bfloat16,
-        device="cuda",
+        device=device,
     )
 
     # PyTorch core saturates finite-overflow e4m3fn casts as of
@@ -780,7 +846,11 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -789,13 +859,13 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
         (1, 128, 64),
     ),
 )
-def test_scale_shape_matches_qdata(transpose, shape):
+def test_scale_shape_matches_qdata(transpose, shape, device):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -833,7 +903,11 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -843,13 +917,13 @@ def test_scale_shape_matches_qdata(transpose, shape):
         (1, 128, 64),
     ),
 )
-def test_swizzle(elem_dtype, transpose, shape):
+def test_swizzle(elem_dtype, transpose, shape, device):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         elem_dtype,
@@ -897,10 +971,14 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA and XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-def test_mx_pin_memory(elem_dtype):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+def test_mx_pin_memory(elem_dtype, device):
+    x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -46,23 +46,9 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
-_DEVICE_PARAMS = [
-    pytest.param(
-        "cuda",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA not available"
-        ),
-    ),
-    pytest.param(
-        "xpu",
-        marks=pytest.mark.skipif(
-            not torch.xpu.is_available(), reason="XPU not available"
-        ),
-    ),
-]
-
 
 def test_f32_to_e8m0_rceil():
+    torch.accelerator.current_accelerator().type
     values, expected = make_f32_to_e8m0_rceil_cases(device="cpu")
     assert torch.equal(_f32_to_e8m0_rceil(values), expected)
 
@@ -83,6 +69,7 @@ def test_e8m0_scale_to_reciprocal_fp32(monkeypatch, use_direct_cast):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
 def test_e8m0_scale_to_reciprocal_fp32_cuda_fallback(monkeypatch, use_compile):
+    torch.accelerator.current_accelerator().type
     monkeypatch.setattr(mx_tensor_module, "_TORCH_VERSION_AT_LEAST_2_14", False)
     scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device="cuda")
     convert = (
@@ -153,9 +140,9 @@ def _test_mx(
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_hello_world(elem_dtype, device):
+def test_hello_world(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
@@ -165,10 +152,10 @@ def test_hello_world(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_realistic_numerics(elem_dtype, scale_calculation_mode, device):
+def test_realistic_numerics(elem_dtype, scale_calculation_mode):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
@@ -178,9 +165,9 @@ def test_realistic_numerics(elem_dtype, scale_calculation_mode, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_zeros(elem_dtype, device):
+def test_all_zeros(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
@@ -190,9 +177,9 @@ def test_all_zeros(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_some_zeros(elem_dtype, device):
+def test_some_zeros(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
@@ -204,13 +191,13 @@ def test_some_zeros(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
-def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile, device):
+def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile):
+    device = torch.accelerator.current_accelerator().type
     cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device=device)
     quantize = torch.compile(to_mx, fullgraph=True) if use_compile else to_mx
     scales, qdata = quantize(cases.inputs, torch.float8_e4m3fn, 32, scaling_mode)
@@ -473,13 +460,13 @@ def test_to_mx_rceil_fallback_nan_branch_is_cse_compatible(monkeypatch):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_in(elem_dtype, device):
+def test_exponent_nan_in(elem_dtype):
     """
     If high precision block values has a NaN, the exponent block
     value is set to is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.tensor(
         [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
@@ -493,14 +480,14 @@ def test_exponent_nan_in(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_nan_blocks(elem_dtype, device):
+def test_all_nan_blocks(elem_dtype):
     """
     Test NaN handling for blocks with all NaN values vs mixed NaN + real values.
     - Mixed real + NaN: scale = NaN
     - All NaN: scale = NaN
     """
+    device = torch.accelerator.current_accelerator().type
     block_size = 4
 
     # Test case 1: Mixed NaN + real values
@@ -563,12 +550,12 @@ def test_all_nan_blocks(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_out(elem_dtype, device):
+def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     scale_e8m0 = torch.tensor(
         [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
@@ -610,12 +597,12 @@ def test_exponent_nan_out(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_ranks(elem_dtype, device):
+def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
     """
+    device = torch.accelerator.current_accelerator().type
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
@@ -627,13 +614,13 @@ def test_ranks(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
-def test_block_sizes(elem_dtype, B, device):
+def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
     """
+    device = torch.accelerator.current_accelerator().type
     if B == 1 and elem_dtype == torch.float4_e2m1fn_x2:
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
@@ -646,8 +633,8 @@ def test_block_sizes(elem_dtype, B, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_round_trip(device):
+def test_from_qdata_and_scales_round_trip():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -674,8 +661,8 @@ def test_from_qdata_and_scales_round_trip(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
+def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -696,8 +683,8 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
+def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
@@ -718,12 +705,12 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_transpose(elem_dtype, device):
+def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
+    device = torch.accelerator.current_accelerator().type
     M, K = 128, 256
     block_size = 32
     tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
@@ -745,9 +732,9 @@ def test_transpose(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_view(elem_dtype, device):
+def test_view(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
@@ -758,8 +745,8 @@ def test_view(elem_dtype, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
-def test_clone(device):
+def test_clone():
+    device = torch.accelerator.current_accelerator().type
     data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
@@ -776,14 +763,14 @@ def test_clone(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
-def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device):
+def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
+    device = torch.accelerator.current_accelerator().type
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         if torch.cuda.is_available() and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
@@ -830,16 +817,16 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device)
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
-def test_to_mx_inductor_single_kernel(device):
+def test_to_mx_inductor_single_kernel():
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
     x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
@@ -853,18 +840,18 @@ def test_to_mx_inductor_single_kernel(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_90(),
     reason="Need sm90+",
 )
-def test_index_select(device):
+def test_index_select():
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
     useful when stitching checkpoints of `num_experts` 2D parameters into
     a single 3D parameter when converting between model definitions that
     use 2D and 3D parameters for their expert weights.
     """
+    device = torch.accelerator.current_accelerator().type
 
     E, K, N = 128, 256, 512
     x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
@@ -880,7 +867,6 @@ def test_index_select(device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
@@ -890,7 +876,8 @@ def test_index_select(device):
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.13+",
 )
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
-def test_cast_to_float8_e4m3fn_saturation_behavior(device, input_dtype):
+def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
+    device = torch.accelerator.current_accelerator().type
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -952,6 +939,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(device, input_dtype):
     "use_triton_kernel", [False, True] if torch.cuda.is_available() else [False]
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
+    device = torch.accelerator.current_accelerator().type
     rows, cols = shape
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -973,7 +961,6 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -982,7 +969,8 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
         (1, 128, 64),
     ),
 )
-def test_scale_shape_matches_qdata(transpose, shape, device):
+def test_scale_shape_matches_qdata(transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -1030,7 +1018,6 @@ def test_scale_shape_matches_qdata(transpose, shape, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -1040,7 +1027,8 @@ def test_scale_shape_matches_qdata(transpose, shape, device):
         (1, 128, 64),
     ),
 )
-def test_swizzle(elem_dtype, transpose, shape, device):
+def test_swizzle(elem_dtype, transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
@@ -1098,9 +1086,9 @@ def test_swizzle(elem_dtype, transpose, shape, device):
     not (torch.cuda.is_available() or torch.xpu.is_available()),
     reason="CUDA or XPU not available",
 )
-@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-def test_mx_pin_memory(elem_dtype, device):
+def test_mx_pin_memory(elem_dtype):
+    device = torch.accelerator.current_accelerator().type
     x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -46,6 +46,21 @@ from torchao.utils import (
 
 torch.manual_seed(2)
 
+_DEVICE_PARAMS = [
+    pytest.param(
+        "cuda",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(), reason="CUDA not available"
+        ),
+    ),
+    pytest.param(
+        "xpu",
+        marks=pytest.mark.skipif(
+            not torch.xpu.is_available(), reason="XPU not available"
+        ),
+    ),
+]
+
 
 def test_f32_to_e8m0_rceil():
     values, expected = make_f32_to_e8m0_rceil_cases(device="cpu")
@@ -134,35 +149,51 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_hello_world(elem_dtype):
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+def test_hello_world(elem_dtype, device):
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_realistic_numerics(elem_dtype, scale_calculation_mode):
-    data = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+def test_realistic_numerics(elem_dtype, scale_calculation_mode, device):
+    data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_zeros(elem_dtype):
-    data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
+def test_all_zeros(elem_dtype, device):
+    data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_some_zeros(elem_dtype):
-    data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+def test_some_zeros(elem_dtype, device):
+    data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
     block_size = 4
@@ -182,7 +213,6 @@ def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile):
     assert_mxfp8_semantics(qdata, scales, cases)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -431,7 +461,10 @@ def test_to_mx_rceil_fallback_nan_branch_is_cse_compatible(monkeypatch):
     assert nan_branches[0].args[0] == 0x7F800001
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
@@ -439,7 +472,7 @@ def test_exponent_nan_in(elem_dtype):
     value is set to is NaN
     """
     tensor_hp = torch.tensor(
-        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device="cuda", dtype=torch.bfloat16
+        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
     block_size = 4
     tensor_mx = MXTensor.to_mx(tensor_hp, elem_dtype, block_size)
@@ -447,9 +480,13 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_all_nan_blocks(elem_dtype):
+def test_all_nan_blocks(elem_dtype, device):
     """
     Test NaN handling for blocks with all NaN values vs mixed NaN + real values.
     - Mixed real + NaN: scale = NaN
@@ -460,7 +497,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 1: Mixed NaN + real values
     mixed_tensor = torch.tensor(
         [float("nan"), 2.0, float("nan"), 4.0, 1.0, 3.0, 5.0, 2.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     mixed_mx = MXTensor.to_mx(mixed_tensor, elem_dtype, block_size)
@@ -476,7 +513,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 2: All NaN blocks (should return NaN scale)
     all_nan_tensor = torch.tensor(
         [float("nan"), float("nan"), float("nan"), float("nan"), 1.0, 2.0, 3.0, 4.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     all_nan_mx = MXTensor.to_mx(all_nan_tensor, elem_dtype, block_size)
@@ -502,7 +539,7 @@ def test_all_nan_blocks(elem_dtype):
             float("nan"),
             float("nan"),
         ],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     completely_nan_mx = MXTensor.to_mx(completely_nan_tensor, elem_dtype, block_size)
@@ -513,29 +550,33 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_exponent_nan_out(elem_dtype):
+def test_exponent_nan_out(elem_dtype, device):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
     scale_e8m0 = torch.tensor(
-        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device="cuda"
+        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
 
     block_size = 4
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device=device
         )  # noqa: E501
     elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
     elif elem_dtype == torch.float4_e2m1fn_x2:
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
         data_bits = pack_uint4(data_bits)
     else:
@@ -556,23 +597,31 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_ranks(elem_dtype):
+def test_ranks(elem_dtype, device):
     """
     The reshaping logic works for various ranks
     """
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
-        tensor_hp = torch.randn(*s, device="cuda", dtype=torch.bfloat16)
+        tensor_hp = torch.randn(*s, device=device, dtype=torch.bfloat16)
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
-def test_block_sizes(elem_dtype, B):
+def test_block_sizes(elem_dtype, B, device):
     """
     Smoke test for various block sizes
     """
@@ -580,13 +629,17 @@ def test_block_sizes(elem_dtype, B):
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
         pytest.skip("unsupported configuration")
-    tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(B, device=device, dtype=torch.bfloat16)
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_round_trip():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_round_trip(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -608,9 +661,13 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -626,9 +683,13 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_from_qdata_and_scales_rejects_packed_uint8_qdata(device):
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -644,15 +705,19 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_transpose(elem_dtype):
+def test_transpose(elem_dtype, device):
     """
     Verify that transposing an MX tensor works
     """
     M, K = 128, 256
     block_size = 32
-    tensor_hp = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         elem_dtype,
@@ -667,18 +732,26 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
-def test_view(elem_dtype):
-    x = torch.randn(1, 2, 4, device="cuda")
+def test_view(elem_dtype, device):
+    x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_clone():
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+def test_clone(device):
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
     data_mx_c = data_mx.clone()
@@ -690,24 +763,28 @@ def test_clone():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
-def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
+def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros, device):
     """
     Verifies that compile does not change numerics of MX casts
     """
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if torch.cuda.is_available() and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:
-        x = torch.randn(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.randn(*shape, dtype=hp_dtype, device=device)
     else:
-        x = torch.zeros(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.zeros(*shape, dtype=hp_dtype, device=device)
     block_size = 4
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
 
@@ -740,28 +817,39 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     torch.testing.assert_close(x_mx_dq, x_mx_c_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
-def test_to_mx_inductor_single_kernel():
+def test_to_mx_inductor_single_kernel(device):
     """
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
-    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
     block_size = 32
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
     out, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
     FileCheck().check("def call(").check_count(".run(", 1, exactly=True).run(code[0])
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Need sm90+")
-def test_index_select():
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    reason="Need sm90+",
+)
+def test_index_select(device):
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
     useful when stitching checkpoints of `num_experts` 2D parameters into
@@ -770,7 +858,7 @@ def test_index_select():
     """
 
     E, K, N = 128, 256, 512
-    x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
 
     x_mx_1 = x_mx[1]
@@ -779,9 +867,13 @@ def test_index_select():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
@@ -789,7 +881,7 @@ def test_index_select():
     reason="eager float8_e4m3fn casts saturate in PyTorch 2.13+",
 )
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
-def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
+def test_cast_to_float8_e4m3fn_saturation_behavior(device, input_dtype):
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -799,7 +891,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * max_val,
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # create example data outside the representable range
@@ -809,7 +901,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * (max_val * 2),
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # PyTorch core saturates finite-overflow e4m3fn casts as of
@@ -868,7 +960,11 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -877,13 +973,13 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
         (1, 128, 64),
     ),
 )
-def test_scale_shape_matches_qdata(transpose, shape):
+def test_scale_shape_matches_qdata(transpose, shape, device):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -921,7 +1017,11 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -931,13 +1031,13 @@ def test_scale_shape_matches_qdata(transpose, shape):
         (1, 128, 64),
     ),
 )
-def test_swizzle(elem_dtype, transpose, shape):
+def test_swizzle(elem_dtype, transpose, shape, device):
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         elem_dtype,
@@ -985,10 +1085,14 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.parametrize("device", _DEVICE_PARAMS)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-def test_mx_pin_memory(elem_dtype):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+def test_mx_pin_memory(elem_dtype, device):
+    x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()
 

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,5 +1,6 @@
 import torch
 import torch.distributed as dist
+from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
@@ -37,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
 
     local_rank = torch.distributed.get_rank()
@@ -57,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
 
     # Perform all_gather

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -85,7 +85,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     This module provides support for running inference with float8 quantization using MX formats.
 
     Requirements:
-    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
+    - NVIDIA SM100+ hardware (Blackwell or newer) or Intel XPU (BMG or newer)
     - PyTorch 2.5+ for proper serialization support
 
     Example (mxfp8):
@@ -111,6 +111,10 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
+    # Whether to store scales in swizzled (blocked) format.
+    # CUDA uses True (SWIZZLE_32_4_4 layout), XPU uses False (row-major 2D).
+    swizzle_scales: bool = True
+
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
             "For now - we only support matching input/weight dtypes."
@@ -131,7 +135,7 @@ def _mx_inference_linear_transform(
     parameter_name: str = "weight",
 ):
     weight = getattr(module, parameter_name)
-    is_swizzled_scales = False if weight.is_xpu else True
+    is_swizzled_scales = config.swizzle_scales
 
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -131,6 +131,7 @@ def _mx_inference_linear_transform(
     parameter_name: str = "weight",
 ):
     weight = getattr(module, parameter_name)
+    is_swizzled_scales = False if weight.is_xpu else True
 
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"
@@ -139,7 +140,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 
@@ -150,7 +151,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -12,6 +12,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn.functional import SwizzleType
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import _validate_elem_dtype
@@ -111,9 +112,9 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
-    # Whether to store scales in swizzled (blocked) format.
-    # CUDA uses True (SWIZZLE_32_4_4 layout), XPU uses False (row-major 2D).
-    swizzle_scales: bool = True
+    # How to store block scales.
+    # CUDA uses SWIZZLE_32_4_4 (blocked layout), XPU uses NO_SWIZZLE.
+    swizzle_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -135,11 +136,6 @@ def _mx_inference_linear_transform(
     parameter_name: str = "weight",
 ):
     weight = getattr(module, parameter_name)
-    is_swizzled_scales = config.swizzle_scales
-
-    assert not (weight.device.type == "xpu" and is_swizzled_scales), (
-        "swizzle_scales must be False on XPU. Set swizzle_scales=False in your config."
-    )
 
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"
@@ -148,7 +144,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=is_swizzled_scales,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 
@@ -159,7 +155,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=is_swizzled_scales,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -138,8 +138,7 @@ def _mx_inference_linear_transform(
     is_swizzled_scales = config.swizzle_scales
 
     assert not (weight.device.type == "xpu" and is_swizzled_scales), (
-        "swizzle_scales must be False on XPU."
-        "Set swizzle_scales=False in your config."
+        "swizzle_scales must be False on XPU.Set swizzle_scales=False in your config."
     )
 
     assert weight.dtype == torch.bfloat16, (

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -137,6 +137,11 @@ def _mx_inference_linear_transform(
     weight = getattr(module, parameter_name)
     is_swizzled_scales = config.swizzle_scales
 
+    assert not (weight.device.type == "xpu" and is_swizzled_scales), (
+        "swizzle_scales must be False on XPU."
+        "Set swizzle_scales=False in your config."
+    )
+
     assert weight.dtype == torch.bfloat16, (
         f"Only supporting bf16 out dtype for now, got {weight.dtype}"
     )

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -138,7 +138,7 @@ def _mx_inference_linear_transform(
     is_swizzled_scales = config.swizzle_scales
 
     assert not (weight.device.type == "xpu" and is_swizzled_scales), (
-        "swizzle_scales must be False on XPU.Set swizzle_scales=False in your config."
+        "swizzle_scales must be False on XPU. Set swizzle_scales=False in your config."
     )
 
     assert weight.dtype == torch.bfloat16, (

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -807,15 +807,18 @@ def _addmm_mx_dispatch(
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            res = F.scaled_mm(
+            a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
+            b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
+            if is_xpu:
+                # v1 API expects scale_b as (K//32, N), but b_scale_block is (N, K//32)
+                b_scale_v1 = b_scale_v1.t().contiguous()
+            res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
-                scale_a=a_scale_block.view(torch.float8_e8m0fnu),
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block.view(torch.float8_e8m0fnu),
-                scale_recipe_b=ScalingType.BlockWise1x32,
+                a_scale_v1,
+                b_scale_v1,
                 bias=bias,
-                output_dtype=torch.bfloat16,
+                out_dtype=torch.bfloat16,
             )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -782,6 +782,9 @@ def _addmm_mx_dispatch(
         # real MX gemm backed by torchao's CUTLASS kernels
         M, K, N = a.shape[0], a.shape[1], b.shape[1]
         is_xpu = a.qdata.is_xpu and b.qdata.is_xpu
+        assert a.qdata.device.type == b.qdata.device.type, (
+            f"Operand device mismatch: a is on {a.qdata.device}, b is on {b.qdata.device}"
+        )
         assert a.qdata.is_contiguous()
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
@@ -792,7 +795,7 @@ def _addmm_mx_dispatch(
         else:
             a_scale = a.scale.view(M, K // a.block_size)
             if is_xpu:
-                a_scale_block = a_scale
+                a_scale_block = a_scale.contiguous()
             else:
                 a_scale_block = maybe_dtensor_to_blocked(a_scale)
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -801,48 +801,40 @@ def _addmm_mx_dispatch(
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
+            b_scale = b.scale.t().view(N, K // b.block_size)
             if is_xpu:
-                b_scale_block = b.scale.contiguous()
+                b_scale_block = b_scale.contiguous()
             else:
-                b_scale = b.scale.t().view(N, K // b.block_size)
                 b_scale_block = maybe_dtensor_to_blocked(b_scale)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            res = torch._scaled_mm(
+            res = F.scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
+                scale_a=a_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_b=ScalingType.BlockWise1x32,
                 bias=bias,
-                out_dtype=torch.bfloat16,
+                output_dtype=torch.bfloat16,
             )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            if is_xpu:
-                res = torch._scaled_mm(
-                    a.qdata.view(torch.float4_e2m1fn_x2),
-                    b.qdata.view(torch.float4_e2m1fn_x2),
-                    a_scale_block,
-                    b_scale_block,
-                    bias=bias,
-                    out_dtype=torch.bfloat16,
-                )
-            else:
-                # FP4 operations using F.scaled_mm
-                res = F.scaled_mm(
-                    a.qdata.view(torch.float4_e2m1fn_x2),
-                    b.qdata.view(torch.float4_e2m1fn_x2),
-                    scale_a=a_scale_block,
-                    scale_recipe_a=ScalingType.BlockWise1x32,
-                    scale_b=b_scale_block,
-                    scale_recipe_b=ScalingType.BlockWise1x32,
-                    swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                    swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-                    bias=bias,
-                    output_dtype=torch.bfloat16,
-                )
+            swizzle = None if is_xpu else SwizzleType.SWIZZLE_32_4_4
+            res = F.scaled_mm(
+                a.qdata.view(torch.float4_e2m1fn_x2),
+                b.qdata.view(torch.float4_e2m1fn_x2),
+                scale_a=a_scale_block,
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_block,
+                scale_recipe_b=ScalingType.BlockWise1x32,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
+                bias=bias,
+                output_dtype=torch.bfloat16,
+            )
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -781,6 +781,7 @@ def _addmm_mx_dispatch(
     if gemm_choice == KernelPreference.AUTO:
         # real MX gemm backed by torchao's CUTLASS kernels
         M, K, N = a.shape[0], a.shape[1], b.shape[1]
+        is_xpu = a.qdata.is_xpu and b.qdata.is_xpu
         assert a.qdata.is_contiguous()
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
@@ -790,13 +791,19 @@ def _addmm_mx_dispatch(
             a_scale_block = a.scale
         else:
             a_scale = a.scale.view(M, K // a.block_size)
-            a_scale_block = maybe_dtensor_to_blocked(a_scale)
+            if is_xpu:
+                a_scale_block = a_scale
+            else:
+                a_scale_block = maybe_dtensor_to_blocked(a_scale)
 
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            b_scale_block = maybe_dtensor_to_blocked(b_scale)
+            if is_xpu:
+                b_scale_block = b.scale.contiguous()
+            else:
+                b_scale = b.scale.t().view(N, K // b.block_size)
+                b_scale_block = maybe_dtensor_to_blocked(b_scale)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
@@ -811,19 +818,29 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            # FP4 operations using F.scaled_mm
-            res = F.scaled_mm(
-                a.qdata.view(torch.float4_e2m1fn_x2),
-                b.qdata.view(torch.float4_e2m1fn_x2),
-                scale_a=a_scale_block,
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block,
-                scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-                bias=bias,
-                output_dtype=torch.bfloat16,
-            )
+            if is_xpu:
+                res = torch._scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    a_scale_block,
+                    b_scale_block,
+                    bias=bias,
+                    out_dtype=torch.bfloat16,
+                )
+            else:
+                # FP4 operations using F.scaled_mm
+                res = F.scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    scale_a=a_scale_block,
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b_scale_block,
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                    swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                    bias=bias,
+                    output_dtype=torch.bfloat16,
+                )
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -783,6 +783,7 @@ def _addmm_mx_dispatch(
     if gemm_choice == KernelPreference.AUTO:
         # real MX gemm backed by torchao's CUTLASS kernels
         M, K, N = a.shape[0], a.shape[1], b.shape[1]
+        is_xpu = a.qdata.is_xpu and b.qdata.is_xpu
         assert a.qdata.is_contiguous()
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
@@ -792,13 +793,19 @@ def _addmm_mx_dispatch(
             a_scale_block = a.scale
         else:
             a_scale = a.scale.view(M, K // a.block_size)
-            a_scale_block = maybe_dtensor_to_blocked(a_scale)
+            if is_xpu:
+                a_scale_block = a_scale
+            else:
+                a_scale_block = maybe_dtensor_to_blocked(a_scale)
 
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            b_scale_block = maybe_dtensor_to_blocked(b_scale)
+            if is_xpu:
+                b_scale_block = b.scale.contiguous()
+            else:
+                b_scale = b.scale.t().view(N, K // b.block_size)
+                b_scale_block = maybe_dtensor_to_blocked(b_scale)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
@@ -813,19 +820,29 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            # FP4 operations using F.scaled_mm
-            res = F.scaled_mm(
-                a.qdata.view(torch.float4_e2m1fn_x2),
-                b.qdata.view(torch.float4_e2m1fn_x2),
-                scale_a=a_scale_block,
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block,
-                scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-                bias=bias,
-                output_dtype=torch.bfloat16,
-            )
+            if is_xpu:
+                res = torch._scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    a_scale_block,
+                    b_scale_block,
+                    bias=bias,
+                    out_dtype=torch.bfloat16,
+                )
+            else:
+                # FP4 operations using F.scaled_mm
+                res = F.scaled_mm(
+                    a.qdata.view(torch.float4_e2m1fn_x2),
+                    b.qdata.view(torch.float4_e2m1fn_x2),
+                    scale_a=a_scale_block,
+                    scale_recipe_a=ScalingType.BlockWise1x32,
+                    scale_b=b_scale_block,
+                    scale_recipe_b=ScalingType.BlockWise1x32,
+                    swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                    swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                    bias=bias,
+                    output_dtype=torch.bfloat16,
+                )
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,7 +36,15 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
+from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
+    _rebuild_swizzle_type,
+)
 from torch.nn.functional import ScalingType, SwizzleType
+
+# pybind11 SwizzleType can't be pickled by default. The inductor import
+# above patches __reduce__; register the reconstructor as safe for
+# weights_only torch.load.
+torch.serialization.add_safe_globals([_rebuild_swizzle_type])
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
@@ -105,7 +113,7 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    is_swizzled_scales: bool = False
+    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -230,7 +238,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    is_swizzled_scales: bool = False,
+    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -399,10 +407,10 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if is_swizzled_scales:
+    if swizzle_type != SwizzleType.NO_SWIZZLE:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
-        scale = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
         scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
         scale_e8m0_biased = scale.view(*leading_dims, scale_M, scale_K)
 
@@ -513,7 +521,7 @@ class MXTensor(TorchAOBaseTensor):
         "orig_dtype",
         "kernel_preference",
         "act_quant_kwargs",
-        "is_swizzled_scales",
+        "swizzle_type",
     ]
 
     def __new__(
@@ -525,7 +533,7 @@ class MXTensor(TorchAOBaseTensor):
         orig_dtype,
         kernel_preference,
         act_quant_kwargs,
-        is_swizzled_scales,
+        swizzle_type,
     ):
         new_size = qdata.size()
         if elem_dtype == torch.float4_e2m1fn_x2:
@@ -566,22 +574,29 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        self.is_swizzled_scales = is_swizzled_scales
+        # Accept SwizzleType, int, or bool — normalize to SwizzleType.
+        # int/bool needed for torch.compile (@allow_in_graph) compatibility.
+        self.swizzle_type = SwizzleType(int(swizzle_type))
         return self
 
     def __repr__(self):
         # TODO better elem dtype print for fp4
-        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, is_swizzled_scales={self.is_swizzled_scales}"  # noqa: E501
+        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, swizzle_type={self.swizzle_type}"  # noqa: E501
 
     def _quantization_type(self):
         return f"{self.elem_dtype=}, {self.block_size=}, {self.orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
+
+    @property
+    def is_swizzled_scales(self):
+        """Backward-compat property for shared code in utils.py."""
+        return self.swizzle_type != SwizzleType.NO_SWIZZLE
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:
             output_dtype = self.dtype
 
         scale = self.scale
-        if self.is_swizzled_scales:
+        if self.swizzle_type != SwizzleType.NO_SWIZZLE:
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -613,7 +628,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -629,7 +644,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            int(swizzle_type),  # int for dynamo compat
         )
 
     @staticmethod
@@ -643,7 +658,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -654,18 +669,18 @@ class MXTensor(TorchAOBaseTensor):
         )
 
         triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
+            elem_dtype == torch.float8_e4m3fn and swizzle_type == SwizzleType.NO_SWIZZLE
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
             or kernel_preference == KernelPreference.EMULATED
         ):
             scale_e8m0_biased, data_lp = to_mx(
-                data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+                data_hp, elem_dtype, block_size, scaling_mode, swizzle_type
             )
         else:
             assert triton_kernel_supported, (
-                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
+                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {swizzle_type=}"
             )
             data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
                 data_hp,
@@ -680,7 +695,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            int(swizzle_type),  # int for dynamo compat
         )
 
     # Do not force the MXTensor type on the returned tensor
@@ -713,7 +728,7 @@ def mx_pin_memory(func, types, args, kwargs):
         tensor.orig_dtype,
         tensor.kernel_preference,
         tensor.act_quant_kwargs,
-        tensor.is_swizzled_scales,
+        tensor.swizzle_type,
     )
 
 
@@ -773,7 +788,7 @@ def _addmm_mx_dispatch(
             k.block_size,
             k.scaling_mode,
             k.kernel_preference,
-            k.is_swizzled_scales,
+            swizzle_type=k.swizzle_type,
         )
 
     gemm_choice = _get_gemm_choice(a.kernel_preference, b.kernel_preference)
@@ -781,39 +796,27 @@ def _addmm_mx_dispatch(
     if gemm_choice == KernelPreference.AUTO:
         # real MX gemm backed by torchao's CUTLASS kernels
         M, K, N = a.shape[0], a.shape[1], b.shape[1]
-        is_xpu = a.qdata.is_xpu and b.qdata.is_xpu
-        assert a.qdata.device.type == b.qdata.device.type, (
-            f"Operand device mismatch: a is on {a.qdata.device}, b is on {b.qdata.device}"
-        )
         assert a.qdata.is_contiguous()
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.is_swizzled_scales:
+        if a.swizzle_type != SwizzleType.NO_SWIZZLE:
             a_scale_block = a.scale
         else:
-            a_scale = a.scale.view(M, K // a.block_size)
-            if is_xpu:
-                a_scale_block = a_scale.contiguous()
-            else:
-                a_scale_block = maybe_dtensor_to_blocked(a_scale)
+            a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if b.is_swizzled_scales:
+        if b.swizzle_type != SwizzleType.NO_SWIZZLE:
             b_scale_block = b.scale.t()
         else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            if is_xpu:
-                b_scale_block = b_scale.contiguous()
-            else:
-                b_scale_block = maybe_dtensor_to_blocked(b_scale)
+            b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if is_xpu:
-                # v1 API expects scale_b as (K//32, N), but b_scale_block is (N, K//32)
+            if b.swizzle_type == SwizzleType.NO_SWIZZLE:
+                # Row-major scales: v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
                 a.qdata,
@@ -826,7 +829,7 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            swizzle = None if is_xpu else SwizzleType.SWIZZLE_32_4_4
+            swizzle = a.swizzle_type
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -909,7 +912,7 @@ def mx_t(func, types, args, kwargs):
         old.orig_dtype,
         old.kernel_preference,
         old.act_quant_kwargs,
-        old.is_swizzled_scales,
+        old.swizzle_type,
     )
     return new
 
@@ -950,7 +953,7 @@ def mx_view_op(func, types, args, kwargs):
         args[0].orig_dtype,
         args[0].kernel_preference,
         args[0].act_quant_kwargs,
-        args[0].is_swizzled_scales,
+        args[0].swizzle_type,
     )
 
 
@@ -975,7 +978,7 @@ def mx_slice(func, types, args, kwargs):
             x.orig_dtype,
             x.kernel_preference,
             x.act_quant_kwargs,
-            x.is_swizzled_scales,
+            x.swizzle_type,
         ),
     )
 
@@ -1000,7 +1003,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert not old_mx_tensor.is_swizzled_scales, "unsupported"
+    assert old_mx_tensor.swizzle_type == SwizzleType.NO_SWIZZLE, "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],
@@ -1009,7 +1012,7 @@ def mx_select(func, types, args, kwargs):
         old_mx_tensor.orig_dtype,
         old_mx_tensor.kernel_preference,
         old_mx_tensor.act_quant_kwargs,
-        old_mx_tensor.is_swizzled_scales,
+        old_mx_tensor.swizzle_type,
     )
     return return_and_correct_aliasing(func, args, kwargs, new_mx_tensor)
 
@@ -1058,7 +1061,7 @@ def mx_all_gather(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )
 
 
@@ -1089,5 +1092,5 @@ def mx_wait_tensor(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -799,48 +799,40 @@ def _addmm_mx_dispatch(
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
+            b_scale = b.scale.t().view(N, K // b.block_size)
             if is_xpu:
-                b_scale_block = b.scale.contiguous()
+                b_scale_block = b_scale.contiguous()
             else:
-                b_scale = b.scale.t().view(N, K // b.block_size)
                 b_scale_block = maybe_dtensor_to_blocked(b_scale)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            res = torch._scaled_mm(
+            res = F.scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
+                scale_a=a_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_block.view(torch.float8_e8m0fnu),
+                scale_recipe_b=ScalingType.BlockWise1x32,
                 bias=bias,
-                out_dtype=torch.bfloat16,
+                output_dtype=torch.bfloat16,
             )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            if is_xpu:
-                res = torch._scaled_mm(
-                    a.qdata.view(torch.float4_e2m1fn_x2),
-                    b.qdata.view(torch.float4_e2m1fn_x2),
-                    a_scale_block,
-                    b_scale_block,
-                    bias=bias,
-                    out_dtype=torch.bfloat16,
-                )
-            else:
-                # FP4 operations using F.scaled_mm
-                res = F.scaled_mm(
-                    a.qdata.view(torch.float4_e2m1fn_x2),
-                    b.qdata.view(torch.float4_e2m1fn_x2),
-                    scale_a=a_scale_block,
-                    scale_recipe_a=ScalingType.BlockWise1x32,
-                    scale_b=b_scale_block,
-                    scale_recipe_b=ScalingType.BlockWise1x32,
-                    swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                    swizzle_b=SwizzleType.SWIZZLE_32_4_4,
-                    bias=bias,
-                    output_dtype=torch.bfloat16,
-                )
+            swizzle = None if is_xpu else SwizzleType.SWIZZLE_32_4_4
+            res = F.scaled_mm(
+                a.qdata.view(torch.float4_e2m1fn_x2),
+                b.qdata.view(torch.float4_e2m1fn_x2),
+                scale_a=a_scale_block,
+                scale_recipe_a=ScalingType.BlockWise1x32,
+                scale_b=b_scale_block,
+                scale_recipe_b=ScalingType.BlockWise1x32,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
+                bias=bias,
+                output_dtype=torch.bfloat16,
+            )
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -809,15 +809,18 @@ def _addmm_mx_dispatch(
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            res = F.scaled_mm(
+            a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
+            b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
+            if is_xpu:
+                # v1 API expects scale_b as (K//32, N), but b_scale_block is (N, K//32)
+                b_scale_v1 = b_scale_v1.t().contiguous()
+            res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
-                scale_a=a_scale_block.view(torch.float8_e8m0fnu),
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block.view(torch.float8_e8m0fnu),
-                scale_recipe_b=ScalingType.BlockWise1x32,
+                a_scale_v1,
+                b_scale_v1,
                 bias=bias,
-                output_dtype=torch.bfloat16,
+                out_dtype=torch.bfloat16,
             )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -8,6 +8,7 @@ import sys
 from typing import Tuple
 
 import torch
+from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
@@ -158,7 +159,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    is_swizzled_scales = False
+    swizzle_type = SwizzleType.NO_SWIZZLE
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -207,9 +208,9 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        is_swizzled_scales = True
+        swizzle_type = SwizzleType.SWIZZLE_32_4_4
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
-        # AMD via FlyDSL. FlyDSL kernels leave is_swizzled_scales=False
+        # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NO_SWIZZLE
         # (no tcgen05 blocked layout on AMD).
         assert scale_calculation_mode in (
             ScaleCalculationMode.FLOOR,
@@ -239,7 +240,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
         hp_dtype,
         kernel_preference,
         None,
-        is_swizzled_scales,
+        swizzle_type,
     )
     return mx_tensor
 


### PR DESCRIPTION
## Summary

This PR enables MXTensor support (MXFP8 and MXFP4) on Intel XPU devices, as part of the [XPU Enabling Plan for TorchAO](https://github.com/pytorch/ao/issues/3576).

The XPU backend leverages `torch._scaled_mm` with BlockWise 1x32 scaling (the same kernel dispatch path as CUDA's v1 API) for both MXFP8 and MXFP4 matmul operations. Scale tensors are kept in row-major 2D format (no CUDA-style swizzled/blocked layout).
