### PR TITLE
[moe training] Use non-atomic Triton scatter for permute_and_pad backward

### DIFF
--- a/benchmarks/prototype/moe_training/ep/bench_permute_backward.py
+++ b/benchmarks/prototype/moe_training/ep/bench_permute_backward.py
@@ -69,10 +69,18 @@ def bench(M, D, num_experts, ep_degree, warmup=20, iters=100):
 
 def main():
     print(f"Device: {torch.cuda.get_device_name(0)} | torch {torch.__version__}\n")
-    print("permute_and_pad backward: default indexing_backward vs Triton non-atomic scatter")
+    print(
+        "permute_and_pad backward: default indexing_backward vs Triton non-atomic scatter"
+    )
     hdr = ("M", "D", "experts", "ep", "default(ms)", "triton(ms)", "speedup")
-    print(f"{hdr[0]:>7}{hdr[1]:>7}{hdr[2]:>9}{hdr[3]:>4}{hdr[4]:>13}{hdr[5]:>12}{hdr[6]:>9}")
-    for M, D, ne, ep in [(4096, 7168, 256, 8), (8192, 7168, 256, 8), (16384, 7168, 256, 8)]:
+    print(
+        f"{hdr[0]:>7}{hdr[1]:>7}{hdr[2]:>9}{hdr[3]:>4}{hdr[4]:>13}{hdr[5]:>12}{hdr[6]:>9}"
+    )
+    for M, D, ne, ep in [
+        (4096, 7168, 256, 8),
+        (8192, 7168, 256, 8),
+        (16384, 7168, 256, 8),
+    ]:
         d, t = bench(M, D, ne, ep)
         print(f"{M:>7}{D:>7}{ne:>9}{ep:>4}{d:>13.4f}{t:>12.4f}{d / t:>8.2f}x")
 

--- a/benchmarks/prototype/moe_training/ep/bench_permute_backward.py
+++ b/benchmarks/prototype/moe_training/ep/bench_permute_backward.py
@@ -1,0 +1,81 @@
+"""Microbenchmark: permute_and_pad backward — Triton non-atomic scatter vs the
+default PyTorch indexing_backward_kernel (atomic scatter).
+
+The permute is applied to BF16 tokens upstream of FP8 quantization, so this
+kernel is identical for both fp8_rowwise and fp8_tensorwise recipes.
+
+Run (inside the training container, fresh torchao installed):
+  python bench_permute_backward.py
+"""
+
+import torch
+
+from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
+from torchao.prototype.moe_training.ep.permute import _PermuteBF16FwdBF16Bwd
+
+DEVICE = "cuda"
+ALIGNMENT = 16
+DTYPE = torch.bfloat16
+
+
+def _tokens_per_expert(M, n):
+    w = torch.rand(n, device=DEVICE)
+    c = (w / w.sum() * M).long()
+    c[0] += M - c.sum()
+    return c.clamp(min=0)
+
+
+def bench(M, D, num_experts, ep_degree, warmup=20, iters=100):
+    num_local = num_experts // ep_degree
+    tpe = _tokens_per_expert(M, num_experts)
+    padded_max = ((M + num_local * ALIGNMENT + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT
+    with torch.no_grad():
+        idx, _, _ = generate_permute_indices(
+            tpe, num_local, ep_degree, padded_max, ALIGNMENT
+        )
+    base = torch.randn(M, D, device=DEVICE, dtype=DTYPE)
+
+    def run_default():
+        x = base.clone().requires_grad_(True)
+        x_pad = torch.vstack((x, x.new_zeros((1, D))))
+        y = x_pad[idx, :]
+        x.grad = None
+        y.sum().backward()
+
+    def run_triton():
+        x = base.clone().requires_grad_(True)
+        y = _PermuteBF16FwdBF16Bwd.apply(x, idx)
+        x.grad = None
+        y.sum().backward()
+
+    for fn in (run_default, run_triton):
+        for _ in range(warmup):
+            fn()
+    torch.cuda.synchronize()
+
+    def timed(fn):
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        torch.cuda.synchronize()
+        s.record()
+        for _ in range(iters):
+            fn()
+        e.record()
+        torch.cuda.synchronize()
+        return s.elapsed_time(e) / iters
+
+    return timed(run_default), timed(run_triton)
+
+
+def main():
+    print(f"Device: {torch.cuda.get_device_name(0)} | torch {torch.__version__}\n")
+    print("permute_and_pad backward: default indexing_backward vs Triton non-atomic scatter")
+    hdr = ("M", "D", "experts", "ep", "default(ms)", "triton(ms)", "speedup")
+    print(f"{hdr[0]:>7}{hdr[1]:>7}{hdr[2]:>9}{hdr[3]:>4}{hdr[4]:>13}{hdr[5]:>12}{hdr[6]:>9}")
+    for M, D, ne, ep in [(4096, 7168, 256, 8), (8192, 7168, 256, 8), (16384, 7168, 256, 8)]:
+        d, t = bench(M, D, ne, ep)
+        print(f"{M:>7}{D:>7}{ne:>9}{ep:>4}{d:>13.4f}{t:>12.4f}{d / t:>8.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/prototype/moe_training/ep/test_permute_backward.py
+++ b/test/prototype/moe_training/ep/test_permute_backward.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("Test requires CUDA", allow_module_level=True)
+
+from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
+from torchao.prototype.moe_training.ep.permute import (
+    _PermuteBF16FwdBF16Bwd,
+    permute_and_pad,
+)
+
+DEVICE = "cuda"
+ALIGNMENT = 16
+
+
+def _setup(M, D, num_experts, ep_degree):
+    """Generate test fixtures: input tensor, permuted indices, and shapes."""
+    torch.manual_seed(42)
+    num_local = num_experts // ep_degree
+    weights = torch.rand(ep_degree * num_local, device=DEVICE)
+    tokens_per_expert = (weights / weights.sum() * M).long()
+    tokens_per_expert[0] += M - tokens_per_expert.sum()
+
+    padded_max = ((M + num_local * ALIGNMENT + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT
+    with torch.no_grad():
+        indices, sizes, offsets = generate_permute_indices(
+            tokens_per_expert, num_local, ep_degree, padded_max, ALIGNMENT
+        )
+    x = torch.randn(M, D, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    return x, indices, tokens_per_expert, num_local
+
+
+@pytest.mark.parametrize("M,D,ne,ep", [(64, 16, 4, 2), (4096, 128, 32, 8)])
+def test_permute_backward_matches_pytorch(M, D, ne, ep):
+    x, indices, _, _ = _setup(M, D, ne, ep)
+
+    # Reference: plain PyTorch autograd
+    x_pad = torch.vstack((x, x.new_zeros((1, D))))
+    y_ref = x_pad[indices, :]
+    y_ref.sum().backward()
+    grad_ref = x.grad.clone()
+
+    # Custom Triton backward
+    x2 = x.data.clone().requires_grad_(True)
+    y2 = _PermuteBF16FwdBF16Bwd.apply(x2, indices)
+    y2.sum().backward()
+
+    assert torch.equal(y_ref, y2)
+    assert torch.equal(grad_ref, x2.grad)
+
+
+@pytest.mark.parametrize("M,D,ne,ep", [(64, 16, 4, 2), (4096, 128, 32, 8)])
+def test_permute_and_pad_backward(M, D, ne, ep):
+    """End-to-end permute_and_pad: forward matches plain gather, backward matches
+    PyTorch's default indexing backward exactly (bijective indices)."""
+    x, indices, tpe, num_local = _setup(M, D, ne, ep)
+
+    x_ref = x.data.clone().requires_grad_(True)
+    x_pad = torch.vstack((x_ref, x_ref.new_zeros((1, D))))
+    y_ref = x_pad[indices, :]
+    y_ref.sum().backward()
+
+    x2 = x.data.clone().requires_grad_(True)
+    _, y2, _, _, _ = permute_and_pad(x2, tpe, ne // num_local, num_local, ALIGNMENT)
+    y2.sum().backward()
+
+    assert torch.equal(y_ref, y2)
+    assert torch.equal(x_ref.grad, x2.grad)
+
+
+def test_zero_token_experts():
+    D = 64
+    tpe = torch.tensor([10, 0, 5, 0, 8, 0, 3, 0], device=DEVICE, dtype=torch.int64)
+    M = int(tpe.sum())
+    padded_max = ((M + 4 * ALIGNMENT + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT
+    with torch.no_grad():
+        indices, _, _ = generate_permute_indices(tpe, 4, 2, padded_max, ALIGNMENT)
+
+    x = torch.randn(M, D, device=DEVICE, dtype=torch.bfloat16, requires_grad=True)
+    _PermuteBF16FwdBF16Bwd.apply(x, indices).sum().backward()
+    assert not x.grad.isnan().any()

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -239,7 +239,13 @@ def permute_and_pad(
     x_permuted = _PermuteBF16FwdBF16Bwd.apply(x, permuted_indices)
     input_shape = (x.shape[0] + 1, x.shape[1])
 
-    return input_shape, x_permuted, permuted_indices, num_tokens_per_expert_padded, group_offsets
+    return (
+        input_shape,
+        x_permuted,
+        permuted_indices,
+        num_tokens_per_expert_padded,
+        group_offsets,
+    )
 
 
 @conditional_nostrict_trace

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -164,6 +164,41 @@ class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
         return grad_input, None, None, None, None, None
 
 
+class _PermuteBF16FwdBF16Bwd(torch.autograd.Function):
+    """Permute+pad for BF16 tokens with a Triton backward kernel.
+
+    The forward is identical to the plain ``permute_and_pad``: append a
+    sentinel zero-row, gather with ``x[permuted_indices, :]``.  The default
+    PyTorch backward for that gather is ``indexing_backward_kernel`` which
+    uses atomic scatter.  Since ``permuted_indices`` is a bijection for
+    valid positions, we can replace the backward with the non-atomic
+    ``_triton_permute_bwd`` kernel for a significant speedup.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        permuted_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        x_padded = torch.vstack((x, x.new_zeros((1, x.shape[-1]))))
+        ctx.save_for_backward(permuted_indices)
+        ctx.padded_input_shape = x_padded.shape
+        return x_padded[permuted_indices, :]
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (permuted_indices,) = ctx.saved_tensors
+        input_rows, input_cols = ctx.padded_input_shape
+        grad_input = _triton_permute_bwd(
+            grad_output.contiguous(),
+            permuted_indices,
+            input_rows - 1,
+            input_cols,
+        )
+        return grad_input, None
+
+
 def permute_and_pad(
     x: torch.Tensor,
     num_tokens_per_expert: torch.Tensor,
@@ -201,11 +236,10 @@ def permute_and_pad(
             alignment,
         )
 
-    x = torch.vstack((x, x.new_zeros((1, x.shape[-1]))))
-    input_shape = x.shape
-    x = x[permuted_indices, :]
+    x_permuted = _PermuteBF16FwdBF16Bwd.apply(x, permuted_indices)
+    input_shape = (x.shape[0] + 1, x.shape[1])
 
-    return input_shape, x, permuted_indices, num_tokens_per_expert_padded, group_offsets
+    return input_shape, x_permuted, permuted_indices, num_tokens_per_expert_padded, group_offsets
 
 
 @conditional_nostrict_trace
@@ -254,15 +288,15 @@ def _triton_permute_bwd(
     original_rows: int,
     original_cols: int,
 ) -> torch.Tensor:
-    """
-    Backward pass for BF16 permute operation.
+    """Scatter grad_output back to original token positions (permute backward).
 
     Args:
         grad_output: bf16 gradient tensor from upstream
-        permuted_indices: permutation indices used in the forward pass
-        original_shape: original shape of the input (with extra padding row)
+        permuted_indices: permutation indices from the forward pass (-1 for padding)
+        original_rows: number of rows in the output (sentinel row excluded)
+        original_cols: number of columns
     Returns:
-        grad_input: bf16 gradient tensor (unpermuted)
+        grad_input: bf16 gradient tensor of shape (original_rows, original_cols)
     """
     grad_rows, grad_cols = grad_output.shape
     output_buffer = grad_output.new_zeros((original_rows, original_cols))
@@ -313,7 +347,7 @@ def _triton_permute_bwd_kernel(
     grad_values = tl.load(
         grad_ptr + row_offsets[:, None] * grad_cols + col_offsets[None, :],
         mask=read_mask,
-        other=PADDING_VALUE,
+        other=0.0,
     )
 
     write_mask = (dest_rows[:, None] != PADDING_VALUE) & (


### PR DESCRIPTION
## Summary

This is a **general, recipe-independent** optimization of the MoE token-permute
backward. `permute_and_pad` gathers `x_padded[permuted_indices, :]`; its autograd
backward is PyTorch's default `indexing_backward_kernel`, an **atomic** scatter.
Since `permuted_indices` is a bijection over valid (non-padding) positions, the
atomics are unnecessary. We replace the backward with `_PermuteBF16FwdBF16Bwd`,
whose backward is a **non-atomic Triton scatter** (`_triton_permute_bwd`). The
forward is unchanged.

Because the permute runs on **BF16 tokens upstream of quantization**, the fix is
independent of the scaling recipe — it benefits the **rowwise**, **tensorwise**,
and **MXFP8** paths alike (the MXFP8 permute path `_PermuteMXFP8FwdHPBwd` already
uses `_triton_permute_bwd`). No torchtitan changes are needed;
`TorchAOTokenDispatcher` already calls `permute_and_pad`.

This builds on the tensorwise grouped-GEMM path from #4389. Per the discussion
there, the goal of landing the tensorwise path is to establish a **working
tensorwise baseline on ROCm** to compare rowwise and the in-progress MXFP8
implementation against — not to beat BF16 with tensorwise. This permute fix is
shared infrastructure underneath all three recipes.

## What this fixes

In FP8 MoE training the routing tokens are padded to an alignment multiple for
the grouped GEMM, so the permute backward runs an atomic `indexing_backward`
over the **padded** tensor (grid `[8320,28,1]`). That makes FP8's routing
backward roughly **2x BF16's** — purely an artifact of padding + atomics, not
real work. This PR removes that FP8-specific penalty and restores **parity with
BF16's routing backward**.

## What changed

- Add `_PermuteBF16FwdBF16Bwd` + `_triton_permute_bwd` op/kernel (skips `-1`
  padding rows); `permute_and_pad` uses it.
- Fixes: load grad with `other=0.0` (not the `-1` sentinel); `.contiguous()`
  guards for non-contiguous autograd grads.
- **New test** `test/prototype/moe_training/ep/test_permute_backward.py`:
  backward parity vs the PyTorch reference (bit-exact gradients, incl.
  zero-token experts).
- **New benchmark** `benchmarks/prototype/moe_training/ep/bench_permute_backward.py`:
  reproduces the default-`indexing_backward`-vs-Triton speedup table below at
  DeepSeek-V3 shapes.

## Why scoped to the permute backward

We prototyped Triton backwards for the other two routing ops and dropped both —
PyTorch's defaults already handle them well:

- **Unpermute** (`out[idx] = routed; out[:-1]`): default backward is a plain
  **gather**, already efficient. The Triton version was ~break-even and required
  a torchtitan change. Redundant.
- **Dispatch gather** (`x[token_indices]` with top_k duplicates): a true
  scatter-add; PyTorch sorts the indices and does a non-atomic segmented
  reduction, which **beat** our atomic Triton kernel (~2x slower). Regressive.

Only the permute is a genuine win: an atomic scatter over a **bijection**, where
a non-atomic Triton scatter is strictly better.

## Performance (kernel-level)

MI355X (gfx950), DeepSeek-V3 671B 4-layer, D=7168, 256 experts, EP=8.

Microbenchmark — `permute_and_pad` backward, default `indexing_backward` vs Triton:

| M (tokens) | default (us) | Triton (us) | speedup |
|---:|---:|---:|---:|
| 4096  | 1137 | 149 | 7.7x |
| 8192  | 1321 | 274 | 4.8x |
| 16384 | 2121 | 547 | 3.9x |

E2E trace — routing-backward `indexing_backward`, restored to BF16 parity:

| config | `indexing_backward` in backward |
|---|---|
| BF16 (reference) | 9.5 ms |
| FP8 rowwise — before | 17.7 ms |
| FP8 rowwise — this PR | 9.4 ms + 0.9 ms Triton |
| FP8 tensorwise — before | 17.3 ms |
| FP8 tensorwise — this PR | 9.5 ms + 0.9 ms Triton |

Per step the permute backward drops from ~8.5 ms (4x atomic `indexing_backward`,
~2.1 ms/call) to ~1.1 ms (`_triton_permute_bwd`, ~9x per call).

**Scope note:** this removes the FP8-specific permute penalty (~7-9 ms/step
backward) and is a parity fix; it does not by itself close the FP8 vs BF16 E2E
gap. That remaining gap stems largely from the **layout requirements of
`torch._scaled_grouped_mm`** — column-major operands, 16-element alignment
padding, and materializing both row- and column-major FP8 copies — which drive
the extra `chunk_cat` and device-to-device copies in the FP8 path.

## Test plan

```
pytest -q test/prototype/moe_training/ep/test_permute_backward.py   # 5 passed (MI355X)
python benchmarks/prototype/moe_training/ep/bench_permute_backward.py
```
