### PR TITLE
[mxfp8] Fix mx_mm backward crash on non-contiguous grad_output

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_linear.py
+++ b/test/prototype/moe_training/test_mxfp8_linear.py
@@ -95,6 +95,46 @@ def test_mxfp8_linear_fwd_bwd_sqnr(bias, wgrad_with_hp, kernel_preference):
         assert sqnr_bias_grad >= 40.0, f"Bias grad SQNR {sqnr_bias_grad} below 40.0"
 
 
+@pytest.mark.parametrize(
+    "kernel_preference", [KernelPreference.EMULATED, KernelPreference.AUTO]
+)
+def test_mxfp8_linear_noncontiguous_grad_output(kernel_preference):
+    """Regression: mx_mm.backward must accept a non-contiguous grad_output.
+
+    A non-contiguous incoming gradient (e.g. produced by a transposed or
+    otherwise strided downstream op) previously tripped the contiguity assert
+    in the dim0 MXFP8 cast (``MXTensor.to_mx`` / ``triton_to_mxfp8_dim0``) and
+    crashed the backward pass.
+    """
+    if kernel_preference == KernelPreference.AUTO and not is_sm_at_least_100():
+        pytest.skip("Real MXFP8 kernels require SM100+")
+
+    M, K, N = 256, 512, 1024
+    ref, mxfp8 = _build_linear_pair(
+        K,
+        N,
+        bias=False,
+        kernel_preference=kernel_preference,
+        wgrad_with_hp=False,
+    )
+
+    x_ref = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    x_mxfp8 = x_ref.clone().detach().requires_grad_(True)
+
+    # A non-contiguous (M, N) upstream gradient: materialize (N, M) then
+    # transpose so the view handed to backward is strided.
+    grad_output = torch.randn(N, M, dtype=torch.bfloat16, device="cuda").t()
+    assert not grad_output.is_contiguous()
+
+    ref(x_ref).backward(grad_output)
+    mxfp8(x_mxfp8).backward(grad_output)
+
+    assert x_mxfp8.grad is not None
+    assert torch.isfinite(x_mxfp8.grad).all()
+    sqnr_input_grad = compute_error(x_ref.grad, x_mxfp8.grad)
+    assert sqnr_input_grad >= 25.0, f"Input grad SQNR {sqnr_input_grad} below 25.0"
+
+
 def test_mxfp8_linear_3d_input():
     """MXFP8Linear should accept inputs with leading batch/sequence dims."""
     K, N = 1024, 2048

--- a/torchao/prototype/moe_training/mxfp8_linear.py
+++ b/torchao/prototype/moe_training/mxfp8_linear.py
@@ -154,6 +154,12 @@ class mx_mm(torch.autograd.Function):
         scale_calculation_mode = ctx.scale_calculation_mode
         wgrad_with_hp = ctx.wgrad_with_hp
 
+        # grad_output may be non-contiguous (e.g. produced by a transposed or
+        # otherwise strided downstream op). Both the dim0 cast (MXTensor.to_mx /
+        # triton_to_mxfp8_dim0) and the dim1 cast kernels assert a contiguous
+        # input, so normalize here. This is a no-op when grad_output is already
+        # contiguous.
+        grad_output_hp = grad_output_hp.contiguous()
         grad_output_orig_shape = grad_output_hp.shape
         grad_output_hp_r = grad_output_hp.reshape(-1, grad_output_orig_shape[-1])
 


### PR DESCRIPTION
## Summary

`mx_mm.backward` reshapes `grad_output` and casts it to MXFP8 with the dim0 cast, which requires a contiguous input:

- `KernelPreference.EMULATED` → `MXTensor.to_mx` asserts `data_hp.is_contiguous()` (message: "unsupported")
- `KernelPreference.AUTO` → `triton_to_mxfp8_dim0` asserts `x.is_contiguous()` (message: "x must be contiguous")

A same-shape `reshape` of a non-contiguous tensor is a no-op view, so a non-contiguous incoming gradient — e.g. produced by a transposed or otherwise strided downstream op — reaches the cast unchanged and crashes the backward pass. This is easy to hit in real models (for example a frozen-base LoRA / parallel-adapter setup where the gradient flows back through a transposed view).

The fix makes `grad_output` contiguous before the reshape/casts. `contiguous()` is a no-op when the tensor is already contiguous, so there is no cost on the common path. A single `contiguous()` covers both crash paths since they share the same root cause (the dim0 cast of the reshaped grad).

## Repro (on `main`)

```python
import torch
from torchao.prototype.moe_training.mxfp8_linear import MXFP8Linear
from torchao.quantization.quantize_.common.kernel_preference import KernelPreference

M, K, N = 256, 512, 1024
for kp in [KernelPreference.EMULATED, KernelPreference.AUTO]:
    m = MXFP8Linear(K, N, bias=False, device="cuda", dtype=torch.bfloat16, kernel_preference=kp)
    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
    g = torch.randn(N, M, dtype=torch.bfloat16, device="cuda").t()  # (M, N) non-contiguous
    m(x).backward(g)   # AssertionError before this PR
```

## Test

Added `test_mxfp8_linear_noncontiguous_grad_output` (parametrized over `EMULATED` and `AUTO`) that drives a non-contiguous `grad_output` through the backward and checks the input-grad SQNR against a bf16 reference. It crashes on `main` (both modes) and passes with this change.

Verified locally on SM120 (RTX 5060 Ti): the full `test_mxfp8_linear.py` suite passes (existing fwd/bwd SQNR matrix + 3D input + the new test), `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
