### PR TITLE
[mxfp8] Skip weight gradient for frozen weights in mx_mm backward

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_linear.py
+++ b/test/prototype/moe_training/test_mxfp8_linear.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest.mock import patch
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -93,6 +95,110 @@ def test_mxfp8_linear_fwd_bwd_sqnr(bias, wgrad_with_hp, kernel_preference):
         # Bias grad is a simple sum over the batch dim and should match closely.
         sqnr_bias_grad = compute_error(ref.bias.grad, mxfp8.bias.grad)
         assert sqnr_bias_grad >= 40.0, f"Bias grad SQNR {sqnr_bias_grad} below 40.0"
+
+
+@pytest.mark.parametrize(
+    "kernel_preference", [KernelPreference.EMULATED, KernelPreference.AUTO]
+)
+def test_mxfp8_linear_frozen_weight_skips_wgrad(kernel_preference):
+    """A frozen weight (requires_grad=False) gets no grad_weight while
+    grad_input is unchanged, and the weight-gradient casts are skipped.
+
+    grad_weight is discarded by autograd for a non-trainable weight, so
+    computing it (the wgrad GEMM plus its two dim1 MXFP8 casts) is pure
+    overhead for a frozen base in LoRA / frozen-layer finetuning.
+    """
+    if kernel_preference == KernelPreference.AUTO and not is_sm_at_least_100():
+        pytest.skip("Real MXFP8 kernels require SM100+")
+
+    import torchao.prototype.moe_training.mxfp8_linear as mxfp8_mod
+
+    M, K, N = 256, 512, 1024
+    mxfp8 = MXFP8Linear(
+        K,
+        N,
+        bias=False,
+        device="cuda",
+        dtype=torch.bfloat16,
+        kernel_preference=kernel_preference,
+    )
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    grad_output = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+
+    def run(weight_requires_grad):
+        mxfp8.weight.requires_grad_(weight_requires_grad)
+        mxfp8.weight.grad = None
+        x_in = x.clone().requires_grad_(True)
+
+        n_dim1_casts = 0
+        real_dim1 = mxfp8_mod._to_mxfp8_dim1_kernel_wrapper
+
+        def counting_dim1(*args, **kwargs):
+            nonlocal n_dim1_casts
+            n_dim1_casts += 1
+            return real_dim1(*args, **kwargs)
+
+        with patch.object(mxfp8_mod, "_to_mxfp8_dim1_kernel_wrapper", counting_dim1):
+            mxfp8(x_in).backward(grad_output)
+        return x_in.grad, mxfp8.weight.grad, n_dim1_casts
+
+    grad_in_train, grad_w_train, casts_train = run(True)
+    grad_in_frozen, grad_w_frozen, casts_frozen = run(False)
+
+    # A trainable weight gets a grad; a frozen weight must not.
+    assert grad_w_train is not None
+    assert grad_w_frozen is None
+    # Skipping wgrad must not perturb the input gradient (dgrad).
+    torch.testing.assert_close(grad_in_frozen, grad_in_train, atol=0.0, rtol=0.0)
+    # The frozen path skips the weight-gradient dim1 casts.
+    assert casts_frozen < casts_train
+
+
+@pytest.mark.parametrize(
+    "kernel_preference", [KernelPreference.EMULATED, KernelPreference.AUTO]
+)
+def test_mxfp8_linear_frozen_weight_compile(kernel_preference):
+    """The frozen-weight backward must stay torch.compile-safe.
+
+    ``ctx.needs_input_grad`` is a tuple of Python bools, so skipping the weight
+    gradient is a trace-time-constant branch rather than data-dependent control
+    flow. ``fullgraph=True`` therefore traces without a graph break and the
+    compiled result must match eager.
+    """
+    if kernel_preference == KernelPreference.AUTO and not is_sm_at_least_100():
+        pytest.skip("Real MXFP8 kernels require SM100+")
+
+    M, K, N = 256, 512, 1024
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    grad_output = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+
+    def make_frozen():
+        m = MXFP8Linear(
+            K,
+            N,
+            bias=False,
+            device="cuda",
+            dtype=torch.bfloat16,
+            kernel_preference=kernel_preference,
+        )
+        m.weight.requires_grad_(False)
+        return m
+
+    eager = make_frozen()
+    x_eager = x.clone().requires_grad_(True)
+    eager(x_eager).backward(grad_output)
+
+    compiled_mod = make_frozen()
+    with torch.no_grad():
+        compiled_mod.weight.copy_(eager.weight)
+    x_compiled = x.clone().requires_grad_(True)
+    torch.compile(compiled_mod, fullgraph=True)(x_compiled).backward(grad_output)
+
+    # Frozen weight gets no grad in either mode, and grad_input must match.
+    assert eager.weight.grad is None
+    assert compiled_mod.weight.grad is None
+    assert x_compiled.grad is not None
+    torch.testing.assert_close(x_compiled.grad, x_eager.grad, atol=1e-2, rtol=1e-2)
 
 
 def test_mxfp8_linear_3d_input():

--- a/torchao/prototype/moe_training/mxfp8_linear.py
+++ b/torchao/prototype/moe_training/mxfp8_linear.py
@@ -200,7 +200,15 @@ class mx_mm(torch.autograd.Function):
         )
 
         # input_t @ grad_output = grad_weight
-        if wgrad_with_hp:
+        #
+        # Skip the weight gradient entirely when the weight does not require
+        # grad (e.g. a frozen base in LoRA / frozen-layer finetuning): autograd
+        # discards grad_weight in that case, so the wgrad GEMM and its two dim1
+        # MXFP8 casts are pure overhead. Same idiom as the int8_mixed_precision
+        # and bitnet training linears.
+        if not ctx.needs_input_grad[1]:
+            grad_weight = None
+        elif wgrad_with_hp:
             # Compute grad_weight in high precision if wgrad_with_hp is True
             grad_weight = torch.mm(grad_output_hp_r.t(), input_hp_r)
         else:


### PR DESCRIPTION
## Summary

When the weight does not require grad — a frozen base in LoRA or frozen-layer finetuning — autograd discards `grad_weight`, so computing it in `mx_mm.backward` (the wgrad GEMM plus its two `dim1` MXFP8 casts) is pure overhead.

This guards the weight-gradient computation on `ctx.needs_input_grad[1]` and returns `grad_weight=None` for a frozen weight. It's the same idiom already used by the `int8_mixed_precision` and `bitnet` training linears.

```python
# input_t @ grad_output = grad_weight
if not ctx.needs_input_grad[1]:
    grad_weight = None
elif wgrad_with_hp:
    ...
```

## Eager vs compile

This is an **eager-mode** win. Under `torch.compile`, AOTAutograd already specializes the backward on `requires_grad` and prunes the unused `grad_weight` subgraph via DCE, so the compiled frozen path is already optimal; this change just brings eager to parity. It does **not** change compiled behavior, and `ctx.needs_input_grad` is a Python bool (a trace-time constant), so the branch does not introduce a graph break.

Measured on an RTX 5060 Ti (sm120), frozen vs trainable `fwd+bwd` for a frozen linear, ratio = trainable / frozen (>1 means the wgrad work is skipped). Absolute numbers vary run-to-run with GPU clocks; the within-run ratio is the signal:

| path | shape (M, K, N) | eager (this PR) | eager (main) | compile (main) |
|---|---|---|---|---|
| LLaMA MLP up | 8192, 4096, 14336 | **1.54x** | 1.01x | 1.52x |
| LLaMA MLP dn | 8192, 14336, 4096 | **1.57x** | 1.00x | 1.24x |

So on `main` eager does not skip the wgrad (≈1.0x) while compile already does (≈1.2–1.5x); this PR closes the eager gap.

## Test

`test_mxfp8_linear_frozen_weight_skips_wgrad` (EMULATED + AUTO): a frozen weight gets `grad_weight=None`, a trainable one does not, `grad_input` is bit-identical between the two, and the frozen path performs strictly fewer `dim1` casts (verified by counting `_to_mxfp8_dim1_kernel_wrapper` calls). This fails on `main` (the frozen path still runs the wgrad casts) and passes here.

`test_mxfp8_linear_frozen_weight_compile` (EMULATED + AUTO): compiles the frozen module with `fullgraph=True` and checks the result matches eager and `weight.grad is None`, locking in compile-safety.

Verified locally on sm120: the full `test_mxfp8_linear.py` suite passes; `ruff check` and `ruff format --check` clean.

## Context

Frozen-base / parallel-adapter (LoRA) training on a quantized base is the motivating use case; see #4376 for the analogous float8 discussion and #4022 for the MXFP8 training roadmap. Touches the same `mx_mm.backward` as #4470 (a non-contiguous `grad_output` fix) but is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
