### PR TITLE
Integrate DeepGEMM FP8 blockwise MoE backend

### DIFF
--- a/benchmarks/prototype/blockwise_fp8_training/README.md
+++ b/benchmarks/prototype/blockwise_fp8_training/README.md
@@ -24,6 +24,52 @@ What it reports:
 By default, it runs the DSV3 16B/671B FFN shapes with the scaled-mm backend.
 Pass `--use_triton` to time the prototype Triton GEMM backend.
 
+## MoE Grouped-Kernel Benchmark
+
+Per-kernel benchmark for the blockwise FP8 MoE grouped-GEMM path with the
+DeepGEMM backend. It mirrors the linear kernel benchmarks: each kernel the MoE
+op dispatches is timed in isolation. Quantization (cast) kernels are
+memory-bound and reported in GB/s against the memory-bandwidth roofline; the
+DeepGEMM grouped GEMMs are compute-bound and reported in TFLOP/s against the FP8
+tensor-core roofline.
+
+```bash
+python -m benchmarks.prototype.blockwise_fp8_training.bench_moe_grouped_kernels
+```
+
+Requires the optional `deep_gemm` dependency and an SM90+ GPU. It times, per
+shape `(M, N, K, E)`:
+
+- forward: `act_quant_lhs`, `weight_quant_forward_rhs`, `deepgemm_grouped_mm`
+- dgrad: `act_quant_lhs(grad_out)`, `weight_quant_dgrad_rhs`,
+  `deepgemm_grouped_mm_dgrad`
+- wgrad: `wgrad_quant_lhs(grad_out)`, `wgrad_quant_rhs(A)` (each is the
+  K-grouped activation quant of one operand), `deepgemm_grouped_mm_wgrad`
+
+Each cast row reports memory bandwidth (input read + FP8 data write + FP32 scale
+write); each GEMM row reports both compute (TFLOP/s) and modeled memory traffic,
+so memory-bound GEMMs are visible. Offsets default to balanced per-expert token
+counts to isolate kernel efficiency from routing skew; pass `--jagged` for
+skewed (realistic) token distributions. Pass `--shapes M,N,K,E ...` to override
+the default DeepSeek-V3 FFN shapes. Offsets are 128-aligned so the DeepGEMM
+backend is selected without padding.
+
+### H100 results (balanced tokens, M=32768, E=8)
+
+DeepSeek-V3 FFN shape `N=2048, K=7168`:
+
+| kernel | us | TFLOP/s | %ach_compute | GB/s | %ach_bw |
+|---|--:|--:|--:|--:|--:|
+| fwd: act_quant_lhs | 253.5 | - | - | 2809 | 91.1 |
+| fwd: weight_quant_forward_rhs | 128.1 | - | - | 2750 | 89.2 |
+| fwd: deepgemm_grouped_mm | 779.3 | 1234 | 80.0 | 634 | 20.5 |
+| bwd: act_quant_lhs(grad_out) | 77.6 | - | - | 2621 | 85.0 |
+| bwd: weight_quant_dgrad_rhs | 126.3 | - | - | 2790 | 90.5 |
+| bwd: deepgemm_grouped_mm_dgrad | 778.6 | 1236 | 80.1 | 843 | 27.3 |
+| bwd: wgrad_quant_lhs(grad_out) [transposed] | 85.1 | - | - | 2390 | 77.5 |
+| bwd: wgrad_quant_rhs(A) [direct] | 275.3 | - | - | 2586 | 83.8 |
+| bwd: deepgemm_grouped_mm_wgrad | 2105.4 | 457 | 29.6 | 594 | 19.3 |
+
 ## Quantized Kernel Bandwidth Benchmark
 
 The kernel-path bandwidth utility is:

--- a/benchmarks/prototype/blockwise_fp8_training/bench_moe_grouped_kernels.py
+++ b/benchmarks/prototype/blockwise_fp8_training/bench_moe_grouped_kernels.py
@@ -1,0 +1,455 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Per-kernel benchmark for the blockwise FP8 MoE grouped-GEMM path.
+
+Mirrors the linear blockwise FP8 benchmarks: each kernel the MoE op dispatches
+is timed in isolation. Quantization (cast) kernels are memory-bound and reported
+against the memory-bandwidth roofline (GB/s, % of achievable). The DeepGEMM
+grouped GEMMs are compute-bound and reported against the FP8 tensor-core
+roofline (TFLOP/s, % of achievable); their modeled memory traffic is also shown
+so memory-bound cases (e.g. the K-grouped wgrad, which reads+writes FP32
+accumulators) are visible.
+
+Byte accounting for the cast kernels counts the high-precision input read plus
+the FP8 data and FP32 scale writes (the actual operand tensors produced).
+
+Kernels timed, matching torchao.prototype.moe_training.blockwise_fp8.grouped_mm:
+
+  forward
+    - act_quant_lhs                 (activations -> FP8 1x128)
+    - weight_quant_forward_rhs      (weights -> DeepGEMM (E,N,K) FP8 128x128)
+    - deepgemm_grouped_mm           (out = A @ B_t)
+  backward (dgrad)
+    - act_quant_lhs(grad_out)
+    - weight_quant_dgrad_rhs        (weights -> DeepGEMM (E,K,N) FP8 128x128)
+    - deepgemm_grouped_mm_dgrad     (grad_A = grad_out @ B)
+  backward (wgrad)
+    - wgrad_quant_lhs               (K-grouped activation quant of grad_out)
+    - wgrad_quant_rhs               (K-grouped activation quant of A)
+    - deepgemm_grouped_mm_wgrad     (grad_B = grad_out^T @ A, K-grouped)
+"""
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+from tabulate import tabulate
+from triton.testing import do_bench
+
+from torchao.float8.config import e4m3_dtype
+from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+    _quantize_wgrad_lhs,
+    _quantize_wgrad_rhs,
+    _should_quantize_k_grouped_directly,
+    deepgemm_blockwise_scaled_grouped_mm,
+    deepgemm_blockwise_scaled_grouped_mm_wgrad,
+    is_deep_gemm_available,
+    prepare_deepgemm_wgrad_plan,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    build_deepgemm_grouped_offset_plan,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+)
+from torchao.prototype.blockwise_fp8_training.kernels import (
+    BLOCKWISE_1X128_SCALING_TYPE,
+    BLOCKWISE_128X128_SCALING_TYPE,
+    _scaling_type_value,
+    triton_fp8_blockwise_act_quant_lhs,
+)
+from torchao.prototype.moe_training.utils import generate_jagged_offs
+from torchao.testing.training.roofline_utils import gpu_name_to_specs
+
+device = torch.device("cuda")
+
+
+def benchmark_cuda_function_in_microseconds(f, *args, **kwargs) -> float:
+    return do_bench(lambda: f(*args, **kwargs), return_mode="median") * 1e3
+
+
+class Kind:
+    MEM = "mem"  # memory-bound cast kernel -> GB/s
+    GEMM = "gemm"  # compute-bound GEMM -> TFLOP/s (+ modeled mem traffic)
+
+
+@dataclass
+class KernelMeasurement:
+    name: str
+    kind: str
+    us: float
+    bytes_moved: int
+    flops: float
+
+
+@dataclass(frozen=True)
+class Shape:
+    M: int
+    N: int
+    K: int
+    E: int
+
+
+def _lookup_specs(gpu_name: str) -> Optional[dict]:
+    specs = gpu_name_to_specs.get(gpu_name)
+    if specs is not None:
+        return specs
+    for known, candidate in gpu_name_to_specs.items():
+        if known in gpu_name or gpu_name in known:
+            return candidate
+    return None
+
+
+def _peak_mem_bw_from_device_properties() -> Optional[float]:
+    # Matches benchmark_quant_kernel_bandwidth.py: prefer the real device HBM
+    # peak over the roofline_utils value (which is a Meta-specific H100 variant).
+    props = torch.cuda.get_device_properties(0)
+    memory_clock_khz = getattr(props, "memory_clock_rate", 0)
+    memory_bus_width_bits = getattr(props, "memory_bus_width", 0)
+    if memory_clock_khz <= 0 or memory_bus_width_bits <= 0:
+        return None
+    return (memory_bus_width_bits / 8.0) * (memory_clock_khz * 1e3) * 2.0
+
+
+def _io_bytes(*tensors: torch.Tensor) -> int:
+    return sum(t.numel() * t.element_size() for t in tensors)
+
+
+def _make_offsets(E: int, M: int, block_size: int, jagged: bool) -> torch.Tensor:
+    if jagged:
+        # Skewed per-expert token counts (real routing). Stresses load balance,
+        # so the grouped GEMM rooflines reflect distribution, not just the kernel.
+        return generate_jagged_offs(E, M, multiple_of=block_size, device=device)
+    # Balanced: equal tokens per expert. Isolates kernel efficiency from skew.
+    assert M % E == 0, "balanced offsets require M divisible by E"
+    toks = M // E
+    assert toks % block_size == 0, "balanced per-expert tokens must be block-aligned"
+    return torch.arange(toks, M + 1, toks, dtype=torch.int32, device=device)
+
+
+def _bench_shape(
+    shape: Shape, block_size: int, jagged: bool
+) -> List[KernelMeasurement]:
+    M, N, K, E = shape.M, shape.N, shape.K, shape.E
+    out_dtype = torch.bfloat16
+    fp8 = e4m3_dtype
+    recipe_a = _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE)
+    recipe_b = _scaling_type_value(BLOCKWISE_128X128_SCALING_TYPE)
+
+    # Inputs in the layouts the MoE op uses.
+    A = torch.randn(M, K, dtype=out_dtype, device=device)
+    grad_out = torch.randn(M, N, dtype=out_dtype, device=device)
+    # B_t logical (E, K, N) in per-expert column-major layout.
+    weight = torch.randn(E, N, K, dtype=out_dtype, device=device)
+    B_t = weight.contiguous().transpose(-2, -1)
+
+    offs = _make_offsets(E, M, block_size, jagged)
+    offset_plan = build_deepgemm_grouped_offset_plan(offs, num_rows=M)
+    # Touch the cached host-side group sizes once, outside every timed region,
+    # so the K-grouped quant/GEMM kernels are not charged for the D2H sync.
+    group_sizes = offset_plan.group_sizes
+
+    measurements: List[KernelMeasurement] = []
+
+    def time_mem(name, fn, in_bytes, out_data, out_scale):
+        us = benchmark_cuda_function_in_microseconds(fn)
+        moved = in_bytes + _io_bytes(out_data, out_scale)
+        measurements.append(KernelMeasurement(name, Kind.MEM, us, moved, 0.0))
+
+    def time_gemm(name, fn, flops, bytes_moved):
+        us = benchmark_cuda_function_in_microseconds(fn)
+        measurements.append(KernelMeasurement(name, Kind.GEMM, us, bytes_moved, flops))
+
+    # ---- forward ----
+    A_fp8, A_scale = triton_fp8_blockwise_act_quant_lhs(
+        A.contiguous(), block_size=block_size, dtype=fp8
+    )
+    time_mem(
+        "fwd: act_quant_lhs",
+        lambda: triton_fp8_blockwise_act_quant_lhs(
+            A.contiguous(), block_size=block_size, dtype=fp8
+        ),
+        _io_bytes(A),
+        A_fp8,
+        A_scale,
+    )
+
+    B_fwd_fp8, B_fwd_scale = (
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+            B_t, block_size=block_size, dtype=fp8
+        )
+    )
+    time_mem(
+        "fwd: weight_quant_forward_rhs",
+        lambda: triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+            B_t, block_size=block_size, dtype=fp8
+        ),
+        _io_bytes(B_t),
+        B_fwd_fp8,
+        B_fwd_scale,
+    )
+
+    # GEMM mem traffic: read A_fp8 + scales + B_fp8 + scales, write bf16 out.
+    fwd_gemm_bytes = (
+        _io_bytes(A_fp8, A_scale, B_fwd_fp8, B_fwd_scale) + M * N * 2  # bf16 out
+    )
+    time_gemm(
+        "fwd: deepgemm_grouped_mm",
+        lambda: deepgemm_blockwise_scaled_grouped_mm(
+            A_fp8,
+            B_fwd_fp8,
+            A_scale,
+            recipe_a,
+            B_fwd_scale,
+            recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+            offset_plan=offset_plan,
+        ),
+        2.0 * M * N * K,
+        fwd_gemm_bytes,
+    )
+
+    # ---- backward: dgrad ----
+    gout_fp8, gout_scale = triton_fp8_blockwise_act_quant_lhs(
+        grad_out.contiguous(), block_size=block_size, dtype=fp8
+    )
+    time_mem(
+        "bwd: act_quant_lhs(grad_out)",
+        lambda: triton_fp8_blockwise_act_quant_lhs(
+            grad_out.contiguous(), block_size=block_size, dtype=fp8
+        ),
+        _io_bytes(grad_out),
+        gout_fp8,
+        gout_scale,
+    )
+
+    B_dgrad_fp8, B_dgrad_scale = triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
+        B_t, block_size=block_size, dtype=fp8
+    )
+    time_mem(
+        "bwd: weight_quant_dgrad_rhs",
+        lambda: triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
+            B_t, block_size=block_size, dtype=fp8
+        ),
+        _io_bytes(B_t),
+        B_dgrad_fp8,
+        B_dgrad_scale,
+    )
+
+    dgrad_gemm_bytes = (
+        _io_bytes(gout_fp8, gout_scale, B_dgrad_fp8, B_dgrad_scale) + M * K * 2
+    )
+    time_gemm(
+        "bwd: deepgemm_grouped_mm_dgrad",
+        lambda: deepgemm_blockwise_scaled_grouped_mm(
+            gout_fp8,
+            B_dgrad_fp8,
+            gout_scale,
+            recipe_a,
+            B_dgrad_scale,
+            recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+            offset_plan=offset_plan,
+        ),
+        2.0 * M * N * K,
+        dgrad_gemm_bytes,
+    )
+
+    # ---- backward: wgrad (K-grouped) ----
+    # Build the per-block quant metadata once, outside the timed region (it is a
+    # host-side python loop, not a kernel), so each quant row times only its
+    # kernel. Each operand picks the direct K-grouped quant for wide dims and
+    # TorchAO's transposed quant otherwise (see _DEEPGEMM_DIRECT..._MIN_DIM).
+    lhs_md = (
+        offset_plan.k_quant_metadata(block_size, N)
+        if _should_quantize_k_grouped_directly(N)
+        else None
+    )
+    rhs_md = (
+        offset_plan.k_quant_metadata(block_size, K)
+        if _should_quantize_k_grouped_directly(K)
+        else None
+    )
+    lhs_op = _quantize_wgrad_lhs(
+        grad_out, offset_plan.group_end_offsets, group_sizes, block_size, fp8, lhs_md
+    )
+    rhs_op = _quantize_wgrad_rhs(
+        A, offset_plan.group_end_offsets, group_sizes, block_size, fp8, rhs_md
+    )
+    lhs_path = "direct" if _should_quantize_k_grouped_directly(N) else "transposed"
+    rhs_path = "direct" if _should_quantize_k_grouped_directly(K) else "transposed"
+    time_mem(
+        f"bwd: wgrad_quant_lhs(grad_out) [{lhs_path}]",
+        lambda: _quantize_wgrad_lhs(
+            grad_out,
+            offset_plan.group_end_offsets,
+            group_sizes,
+            block_size,
+            fp8,
+            lhs_md,
+        ),
+        _io_bytes(grad_out),
+        lhs_op.data,
+        lhs_op.scale,
+    )
+    time_mem(
+        f"bwd: wgrad_quant_rhs(A) [{rhs_path}]",
+        lambda: _quantize_wgrad_rhs(
+            A, offset_plan.group_end_offsets, group_sizes, block_size, fp8, rhs_md
+        ),
+        _io_bytes(A),
+        rhs_op.data,
+        rhs_op.scale,
+    )
+
+    wgrad_plan = prepare_deepgemm_wgrad_plan(grad_out, A, offset_plan, block_size, fp8)
+    assert wgrad_plan is not None, "wgrad plan requires block-aligned groups"
+    # wgrad mem traffic: read lhs + rhs fp8 data + scales, read FP32 accum seed,
+    # write FP32 (E,N,K) output. The two FP32 (E,N,K) buffers dominate.
+    wgrad_gemm_bytes = (
+        _io_bytes(
+            wgrad_plan.lhs.data,
+            wgrad_plan.lhs.scale,
+            wgrad_plan.rhs.data,
+            wgrad_plan.rhs.scale,
+        )
+        + 2 * E * N * K * 4  # FP32 accum read + FP32 out write
+    )
+    time_gemm(
+        "bwd: deepgemm_grouped_mm_wgrad",
+        lambda: deepgemm_blockwise_scaled_grouped_mm_wgrad(
+            wgrad_plan.lhs,
+            wgrad_plan.rhs,
+            offset_plan,
+            out_dtype,
+            block_size,
+        ),
+        2.0 * M * N * K,
+        wgrad_gemm_bytes,
+    )
+
+    return measurements
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shapes",
+        type=str,
+        nargs="+",
+        # M, N, K, E. DeepSeek-V3 MoE FFN dims at a couple of token counts.
+        default=[
+            "16384,2048,7168,8",
+            "32768,2048,7168,8",
+            "16384,7168,2048,8",
+            "32768,7168,2048,8",
+        ],
+        help="Comma-separated M,N,K,E groups.",
+    )
+    parser.add_argument("--block-size", type=int, default=128)
+    parser.add_argument(
+        "--jagged",
+        action="store_true",
+        help="Use skewed per-expert token counts instead of balanced (default).",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required.")
+    if not is_deep_gemm_available():
+        raise RuntimeError(
+            "DeepGEMM is not importable; this benchmark targets the DeepGEMM backend."
+        )
+
+    gpu_name = torch.cuda.get_device_name(0)
+    specs = _lookup_specs(gpu_name)
+    if specs is None:
+        raise RuntimeError(f"No roofline specs for GPU: {gpu_name}")
+
+    device_peak_bw = _peak_mem_bw_from_device_properties()
+    peak_bw = device_peak_bw or specs["peak_mem_bw_bytes_sec"]
+    bw_source = "cuda_device_properties" if device_peak_bw else "roofline_utils"
+    ach_bw = peak_bw * specs.get("pct_achievable_mem_bw", 1.0)
+    peak_tops = specs["fp8_peak_tops"]
+    ach_tops = peak_tops * specs.get("pct_achievable_gemm_tops", 1.0)
+
+    print(f"GPU: {gpu_name}")
+    print(
+        f"Mem BW: peak {peak_bw / 1e9:.0f} GB/s (source: {bw_source}), "
+        f"achievable {ach_bw / 1e9:.0f} GB/s "
+        f"({specs.get('pct_achievable_mem_bw', 1.0) * 100:.0f}% of peak)"
+    )
+    print(
+        f"FP8 compute: peak {peak_tops / 1e12:.0f} TFLOP/s, "
+        f"achievable {ach_tops / 1e12:.0f} TFLOP/s "
+        f"({specs.get('pct_achievable_gemm_tops', 1.0) * 100:.0f}% of peak)"
+    )
+    print(
+        f"Tokens: {'jagged (skewed)' if args.jagged else 'balanced'}; "
+        "128-aligned (no padding); DeepGEMM backend.\n"
+    )
+
+    torch.manual_seed(123)
+    for shape_str in args.shapes:
+        M, N, K, E = (int(x) for x in shape_str.split(","))
+        shape = Shape(M, N, K, E)
+        measurements = _bench_shape(shape, args.block_size, args.jagged)
+
+        print(f"=== M={M} N={N} K={K} E={E} ===")
+        rows = []
+        for m in measurements:
+            gbps = m.bytes_moved / 1e9 / (m.us * 1e-6)
+            bw_pct = 100.0 * gbps * 1e9 / ach_bw
+            if m.kind == Kind.MEM:
+                rows.append(
+                    [
+                        m.name,
+                        f"{m.us:.1f}",
+                        "-",
+                        "-",
+                        f"{gbps:.0f}",
+                        f"{bw_pct:.1f}",
+                    ]
+                )
+            else:
+                tflops = m.flops / 1e12 / (m.us * 1e-6)
+                compute_pct = 100.0 * tflops * 1e12 / ach_tops
+                rows.append(
+                    [
+                        m.name,
+                        f"{m.us:.1f}",
+                        f"{tflops:.0f}",
+                        f"{compute_pct:.1f}",
+                        f"{gbps:.0f}",
+                        f"{bw_pct:.1f}",
+                    ]
+                )
+        print(
+            tabulate(
+                rows,
+                headers=[
+                    "kernel",
+                    "us",
+                    "TFLOP/s",
+                    "%ach_compute",
+                    "GB/s",
+                    "%ach_bw",
+                ],
+                tablefmt="github",
+            )
+        )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
@@ -8,6 +8,8 @@ import importlib
 
 import pytest
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import ShapeEnv, has_free_symbols
 
 pytest.importorskip("triton", reason="Triton required for blockwise FP8 modules")
 
@@ -81,7 +83,7 @@ def test_deepgemm_backend_reports_broken_install(monkeypatch, exc):
 
 def test_auto_backend_selection_falls_back_without_deepgemm(monkeypatch):
     from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
-        _GroupedMMBackend,
+        _GroupedMMBackendKind,
         _select_fp8_blockwise_grouped_mm_backend,
     )
 
@@ -98,12 +100,12 @@ def test_auto_backend_selection_falls_back_without_deepgemm(monkeypatch):
         torch.tensor([128], dtype=torch.int32),
     )
 
-    assert backend.plan.kind == _GroupedMMBackend.EMULATED
+    assert backend.kind == _GroupedMMBackendKind.EMULATED
 
 
 def test_auto_backend_selection_requires_full_deepgemm_training_symbols(monkeypatch):
     from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
-        _GroupedMMBackend,
+        _GroupedMMBackendKind,
         _select_fp8_blockwise_grouped_mm_backend,
     )
 
@@ -131,12 +133,12 @@ def test_auto_backend_selection_requires_full_deepgemm_training_symbols(monkeypa
         torch.tensor([128], dtype=torch.int32),
     )
 
-    assert backend.plan.kind == _GroupedMMBackend.EMULATED
+    assert backend.kind == _GroupedMMBackendKind.EMULATED
 
 
 def test_auto_backend_selection_prefers_deepgemm_when_training_supported(monkeypatch):
     from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
-        _GroupedMMBackend,
+        _GroupedMMBackendKind,
         _select_fp8_blockwise_grouped_mm_backend,
     )
 
@@ -170,9 +172,8 @@ def test_auto_backend_selection_prefers_deepgemm_when_training_supported(monkeyp
         num_rows=384,
     )
 
-    assert backend.plan.kind == _GroupedMMBackend.DEEPGEMM
-    assert backend.deepgemm_offset_plan is not None
-    layout = backend.deepgemm_offset_plan.grouped_layout
+    assert backend.kind == _GroupedMMBackendKind.DEEPGEMM
+    layout = backend.offset_plan.grouped_layout
     assert torch.equal(layout[:128], torch.full((128,), 0, dtype=torch.int32))
     assert torch.equal(layout[128:256], torch.full((128,), 1, dtype=torch.int32))
     assert torch.equal(layout[256:], torch.full((128,), -1, dtype=torch.int32))
@@ -288,6 +289,30 @@ def test_deepgemm_weight_quant_supports_compile_fullgraph():
     assert scale.shape == (1, 1, 1)
     assert scale.dtype == torch.float32
     assert compiled_frame_counter.frame_count == 1
+
+
+def test_deepgemm_k_grouped_activation_quant_fake_contract_tracks_valid_tokens():
+    from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+        triton_fp8_blockwise_act_quant_k_grouped_deepgemm,
+    )
+
+    x = torch.empty((896, 4096), dtype=torch.bfloat16)
+    offs = torch.tensor([256, 512, 640], dtype=torch.int32)
+    shape_env = ShapeEnv(allow_dynamic_output_shape_ops=True)
+
+    with FakeTensorMode(shape_env=shape_env) as mode:
+        x_fake = mode.from_tensor(x)
+        offs_fake = mode.from_tensor(offs)
+        q, scale = triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
+            x_fake,
+            offs_fake,
+        )
+
+    assert q.dtype == e4m3_dtype
+    assert scale.dtype == torch.float32
+    assert scale.shape[0] == x.shape[1]
+    assert has_free_symbols(q.shape[0])
+    assert has_free_symbols(scale.shape[1])
 
 
 @pytest.mark.skipif(

--- a/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
@@ -1,0 +1,405 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+
+pytest.importorskip("triton", reason="Triton required for blockwise FP8 modules")
+
+from torchao.float8.config import e4m3_dtype
+from torchao.prototype.blockwise_fp8_training import deepgemm_grouped_kernels
+from torchao.prototype.blockwise_fp8_training import grouped_kernels
+from torchao.quantization.utils import compute_error
+from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import is_sm_at_least_90
+
+
+@pytest.fixture(autouse=True)
+def _clear_deepgemm_capabilities():
+    deepgemm_grouped_kernels._clear_deepgemm_capability_cache()
+    yield
+    deepgemm_grouped_kernels._clear_deepgemm_capability_cache()
+
+
+def _make_column_major_weight_t(E: int, N: int, K: int) -> torch.Tensor:
+    weight = torch.randn(E, N, K, dtype=torch.bfloat16, device="cuda")
+    return weight.contiguous().transpose(-2, -1)
+
+
+def _hide_deep_gemm(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "deep_gemm":
+            raise ModuleNotFoundError(
+                "No module named 'deep_gemm'",
+                name="deep_gemm",
+            )
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+
+def test_deepgemm_backend_requires_optional_dependency(monkeypatch):
+    _hide_deep_gemm(monkeypatch)
+
+    with pytest.raises(ImportError, match="DeepGEMM backend selected"):
+        deepgemm_grouped_kernels._require_deep_gemm()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ModuleNotFoundError("No module named 'cutlass'", name="cutlass"),
+        ImportError("undefined symbol: _ZN3c104impl3cow23materialize_cow_storage"),
+    ],
+)
+def test_deepgemm_backend_reports_broken_install(monkeypatch, exc):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "deep_gemm":
+            raise exc
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match="active PyTorch and CUDA environment"):
+        deepgemm_grouped_kernels._require_deep_gemm()
+
+
+def test_auto_backend_selection_falls_back_without_deepgemm(monkeypatch):
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+        _GroupedMMBackend,
+        _select_fp8_blockwise_grouped_mm_backend,
+    )
+
+    _hide_deep_gemm(monkeypatch)
+
+    class CudaLikeTensor:
+        is_cuda = True
+
+    backend = _select_fp8_blockwise_grouped_mm_backend(
+        KernelPreference.AUTO,
+        CudaLikeTensor(),
+        torch.bfloat16,
+        128,
+    )
+
+    assert backend.kind == _GroupedMMBackend.EMULATED
+
+
+def test_auto_backend_selection_requires_deepgemm_m_grouped_symbol(monkeypatch):
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+        _GroupedMMBackend,
+        _select_fp8_blockwise_grouped_mm_backend,
+    )
+
+    class DeepGemmWithoutGroupedSymbols:
+        pass
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "deep_gemm":
+            return DeepGemmWithoutGroupedSymbols()
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    class CudaLikeTensor:
+        is_cuda = True
+
+    backend = _select_fp8_blockwise_grouped_mm_backend(
+        KernelPreference.AUTO,
+        CudaLikeTensor(),
+        torch.bfloat16,
+        128,
+    )
+
+    assert backend.kind == _GroupedMMBackend.EMULATED
+
+
+def test_deepgemm_grouped_layout_from_padded_offsets():
+    original_group_end_offsets = torch.tensor([129, 384, 500], dtype=torch.int32)
+    padded_group_start_offsets = torch.tensor([0, 256, 512], dtype=torch.int32)
+    padded_group_end_offsets = torch.tensor([256, 512, 640], dtype=torch.int32)
+
+    layout = deepgemm_grouped_kernels._grouped_layout_from_offsets(
+        padded_group_end_offsets,
+        768,
+        original_group_end_offsets=original_group_end_offsets,
+        padded_group_start_offsets=padded_group_start_offsets,
+    )
+
+    assert layout.dtype == torch.int32
+    assert layout.is_contiguous()
+    assert torch.equal(layout[:129], torch.full((129,), 0, dtype=torch.int32))
+    assert torch.equal(layout[129:256], torch.full((127,), -1, dtype=torch.int32))
+    assert torch.equal(layout[256:511], torch.full((255,), 1, dtype=torch.int32))
+    assert torch.equal(layout[511:512], torch.full((1,), -1, dtype=torch.int32))
+    assert torch.equal(layout[512:628], torch.full((116,), 2, dtype=torch.int32))
+    assert torch.equal(layout[628:], torch.full((140,), -1, dtype=torch.int32))
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm_at_least_90(),
+    reason="DeepGEMM FP8 kernels require CUDA SM90+",
+)
+def test_deepgemm_weight_quant_layouts_match_torchao_transposes():
+    from torchao.prototype.blockwise_fp8_training.grouped_kernels import (
+        triton_fp8_blockwise_weight_quant_grouped_rhs,
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs,
+    )
+    from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+        triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+    )
+
+    torch.manual_seed(123)
+    E, N, K = 3, 256, 384
+    B_t = _make_column_major_weight_t(E, N, K)
+
+    torchao_fwd_q, torchao_fwd_s = (
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs(B_t)
+    )
+    deepgemm_fwd_q, deepgemm_fwd_s = (
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(B_t)
+    )
+    assert deepgemm_fwd_q.is_contiguous()
+    assert deepgemm_fwd_s.is_contiguous()
+    assert torch.equal(deepgemm_fwd_q, torchao_fwd_q.transpose(-2, -1).contiguous())
+    torch.testing.assert_close(
+        deepgemm_fwd_s,
+        torchao_fwd_s.transpose(-2, -1).contiguous(),
+        rtol=0,
+        atol=0,
+    )
+
+    torchao_dgrad_q, torchao_dgrad_s = triton_fp8_blockwise_weight_quant_grouped_rhs(
+        B_t
+    )
+    deepgemm_dgrad_q, deepgemm_dgrad_s = (
+        triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(B_t)
+    )
+    assert deepgemm_dgrad_q.is_contiguous()
+    assert deepgemm_dgrad_s.is_contiguous()
+    assert torch.equal(
+        deepgemm_dgrad_q,
+        torchao_dgrad_q.transpose(-2, -1).contiguous(),
+    )
+    torch.testing.assert_close(
+        deepgemm_dgrad_s,
+        torchao_dgrad_s.transpose(-2, -1).contiguous(),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm_at_least_90(),
+    reason="DeepGEMM FP8 kernels require CUDA SM90+",
+)
+def test_deepgemm_weight_quant_supports_compile_fullgraph():
+    from torch._dynamo.testing import CompileCounterWithBackend
+
+    from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+    )
+
+    torch._dynamo.reset()
+    torch.manual_seed(123)
+    B_t = _make_column_major_weight_t(E=1, N=128, K=128)
+    compiled_frame_counter = CompileCounterWithBackend("inductor")
+
+    def fn(weight_t):
+        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+            weight_t
+        )
+
+    compiled_fn = torch.compile(
+        fn,
+        backend=compiled_frame_counter,
+        fullgraph=True,
+    )
+
+    q, scale = compiled_fn(B_t)
+    assert q.shape == (1, 128, 128)
+    assert q.dtype == e4m3_dtype
+    assert scale.shape == (1, 1, 1)
+    assert scale.dtype == torch.float32
+    assert compiled_frame_counter.frame_count == 1
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm_at_least_90(),
+    reason="DeepGEMM FP8 kernels require CUDA SM90+",
+)
+@pytest.mark.parametrize(
+    "offsets",
+    [
+        [256, 640, 768],
+        [256, 512, 768],
+        [128, 384, 512, 768, 1152, 1280, 1664, 2048],
+    ],
+)
+def test_deepgemm_k_grouped_activation_quant_matches_flattened_torchao_layouts(
+    offsets,
+):
+    from torchao.prototype.blockwise_fp8_training.kernels import (
+        triton_fp8_blockwise_act_quant_rhs,
+        triton_fp8_blockwise_act_quant_transposed_lhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+    group_sizes = deepgemm_grouped_kernels._group_sizes_from_offsets(offs)
+    x = torch.randn(offsets[-1], 384, dtype=torch.bfloat16, device="cuda")
+
+    direct_q, direct_s = (
+        deepgemm_grouped_kernels.triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
+            x,
+            offs,
+        )
+    )
+
+    x_t_q, x_t_s = triton_fp8_blockwise_act_quant_transposed_lhs(x)
+    expected_from_lhs = deepgemm_grouped_kernels._flatten_k_grouped_transposed_lhs(
+        x_t_q,
+        group_sizes,
+    )
+    assert torch.equal(direct_q, expected_from_lhs)
+    torch.testing.assert_close(direct_s, x_t_s.contiguous(), rtol=0, atol=0)
+
+    x_rhs_q, x_rhs_s = triton_fp8_blockwise_act_quant_rhs(x)
+    expected_from_rhs = deepgemm_grouped_kernels._flatten_k_grouped_rhs(
+        x_rhs_q,
+        group_sizes,
+    )
+    assert torch.equal(direct_q, expected_from_rhs)
+    torch.testing.assert_close(
+        direct_s,
+        x_rhs_s.transpose(-2, -1).contiguous(),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm_at_least_90(),
+    reason="DeepGEMM FP8 kernels require CUDA SM90+",
+)
+def test_deepgemm_k_grouped_wgrad_matches_emulated():
+    pytest.importorskip("deep_gemm", reason="DeepGEMM is an optional dependency")
+
+    from torchao.prototype.blockwise_fp8_training.kernels import (
+        BLOCKWISE_1X128_SCALING_TYPE,
+        _scaling_type_value,
+        triton_fp8_blockwise_act_quant_rhs,
+        triton_fp8_blockwise_act_quant_transposed_lhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor([256, 640, 768], dtype=torch.int32, device="cuda")
+    M = int(offs[-1].item())
+    N, K = 256, 384
+    grad_output = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+    A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+
+    grad_output_t_fp8, grad_output_t_scale = (
+        triton_fp8_blockwise_act_quant_transposed_lhs(grad_output.contiguous())
+    )
+    A_rhs_fp8, A_rhs_scale = triton_fp8_blockwise_act_quant_rhs(A.contiguous())
+
+    ref = grouped_kernels.emulated_blockwise_scaled_grouped_mm(
+        grad_output_t_fp8,
+        A_rhs_fp8,
+        grad_output_t_scale,
+        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+        A_rhs_scale,
+        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+        offs,
+        torch.bfloat16,
+        128,
+    )
+    plan = deepgemm_grouped_kernels.prepare_deepgemm_wgrad_plan(
+        grad_output,
+        A,
+        offs,
+        128,
+        e4m3_dtype,
+    )
+    assert plan is not None
+    out = deepgemm_grouped_kernels.deepgemm_blockwise_scaled_grouped_mm_wgrad(
+        plan.lhs,
+        plan.rhs,
+        offs,
+        torch.bfloat16,
+        128,
+    )
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    assert compute_error(ref, out) >= 35.0
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm_at_least_90(),
+    reason="DeepGEMM FP8 kernels require CUDA SM90+",
+)
+@pytest.mark.parametrize(
+    "offs,pad_token_groups_for_grouped_mm",
+    [
+        (torch.tensor([256, 512], dtype=torch.int32), False),
+        (torch.tensor([129, 384, 500], dtype=torch.int32), True),
+    ],
+)
+def test_deepgemm_matches_emulated_fp8_grouped_mm(
+    offs, pad_token_groups_for_grouped_mm
+):
+    pytest.importorskip("deep_gemm", reason="DeepGEMM is an optional dependency")
+
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+        _to_fp8_blockwise_then_emulated_scaled_grouped_mm,
+        _to_fp8_blockwise_then_scaled_grouped_mm,
+    )
+
+    torch.manual_seed(123)
+    offs = offs.cuda()
+    E = offs.numel()
+    M = int(offs[-1].item())
+    K, N = 256, 256
+    A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    B_t = _make_column_major_weight_t(E, N, K).requires_grad_(True)
+
+    A_ref = A.detach().clone().requires_grad_(True)
+    B_t_ref = B_t.detach().clone().requires_grad_(True)
+
+    out = _to_fp8_blockwise_then_scaled_grouped_mm(
+        A,
+        B_t,
+        offs,
+        kernel_preference=KernelPreference.AUTO,
+        pad_token_groups_for_grouped_mm=pad_token_groups_for_grouped_mm,
+    )
+    ref = _to_fp8_blockwise_then_emulated_scaled_grouped_mm(
+        A_ref,
+        B_t_ref,
+        offs,
+        pad_token_groups_for_grouped_mm=pad_token_groups_for_grouped_mm,
+    )
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    assert compute_error(ref, out) >= 35.0
+
+    out.float().square().mean().backward()
+    ref.float().square().mean().backward()
+
+    assert compute_error(A_ref.grad, A.grad) >= 35.0
+    assert compute_error(B_t_ref.grad, B_t.grad) >= 35.0

--- a/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_deepgemm_backend.py
@@ -12,10 +12,16 @@ import torch
 pytest.importorskip("triton", reason="Triton required for blockwise FP8 modules")
 
 from torchao.float8.config import e4m3_dtype
-from torchao.prototype.blockwise_fp8_training import deepgemm_grouped_kernels
-from torchao.prototype.blockwise_fp8_training import grouped_kernels
-from torchao.quantization.utils import compute_error
+from torchao.prototype.blockwise_fp8_training import (
+    deepgemm_grouped_kernels,
+    grouped_kernels,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    build_deepgemm_grouped_offset_plan,
+    group_sizes_from_offsets,
+)
 from torchao.quantization.quantize_.common import KernelPreference
+from torchao.quantization.utils import compute_error
 from torchao.utils import is_sm_at_least_90
 
 
@@ -74,7 +80,7 @@ def test_deepgemm_backend_reports_broken_install(monkeypatch, exc):
 
 
 def test_auto_backend_selection_falls_back_without_deepgemm(monkeypatch):
-    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
         _GroupedMMBackend,
         _select_fp8_blockwise_grouped_mm_backend,
     )
@@ -89,25 +95,27 @@ def test_auto_backend_selection_falls_back_without_deepgemm(monkeypatch):
         CudaLikeTensor(),
         torch.bfloat16,
         128,
+        torch.tensor([128], dtype=torch.int32),
     )
 
-    assert backend.kind == _GroupedMMBackend.EMULATED
+    assert backend.plan.kind == _GroupedMMBackend.EMULATED
 
 
-def test_auto_backend_selection_requires_deepgemm_m_grouped_symbol(monkeypatch):
-    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+def test_auto_backend_selection_requires_full_deepgemm_training_symbols(monkeypatch):
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
         _GroupedMMBackend,
         _select_fp8_blockwise_grouped_mm_backend,
     )
 
-    class DeepGemmWithoutGroupedSymbols:
-        pass
+    class DeepGemmWithoutKGroupedSymbol:
+        def m_grouped_fp8_gemm_nt_contiguous(self):
+            raise AssertionError("should not be called")
 
     real_import_module = importlib.import_module
 
     def fake_import_module(name, *args, **kwargs):
         if name == "deep_gemm":
-            return DeepGemmWithoutGroupedSymbols()
+            return DeepGemmWithoutKGroupedSymbol()
         return real_import_module(name, *args, **kwargs)
 
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
@@ -120,9 +128,54 @@ def test_auto_backend_selection_requires_deepgemm_m_grouped_symbol(monkeypatch):
         CudaLikeTensor(),
         torch.bfloat16,
         128,
+        torch.tensor([128], dtype=torch.int32),
     )
 
-    assert backend.kind == _GroupedMMBackend.EMULATED
+    assert backend.plan.kind == _GroupedMMBackend.EMULATED
+
+
+def test_auto_backend_selection_prefers_deepgemm_when_training_supported(monkeypatch):
+    from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
+        _GroupedMMBackend,
+        _select_fp8_blockwise_grouped_mm_backend,
+    )
+
+    class DeepGemmWithTrainingSymbols:
+        def m_grouped_fp8_gemm_nt_contiguous(self):
+            raise AssertionError("should not be called")
+
+        def k_grouped_fp8_gemm_nt_contiguous(self):
+            raise AssertionError("should not be called")
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "deep_gemm":
+            return DeepGemmWithTrainingSymbols()
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(
+        deepgemm_grouped_kernels,
+        "_is_cuda_sm90_or_newer",
+        lambda _: True,
+    )
+
+    backend = _select_fp8_blockwise_grouped_mm_backend(
+        KernelPreference.AUTO,
+        torch.empty(1),
+        torch.bfloat16,
+        128,
+        torch.tensor([128, 256], dtype=torch.int32),
+        num_rows=384,
+    )
+
+    assert backend.plan.kind == _GroupedMMBackend.DEEPGEMM
+    assert backend.deepgemm_offset_plan is not None
+    layout = backend.deepgemm_offset_plan.grouped_layout
+    assert torch.equal(layout[:128], torch.full((128,), 0, dtype=torch.int32))
+    assert torch.equal(layout[128:256], torch.full((128,), 1, dtype=torch.int32))
+    assert torch.equal(layout[256:], torch.full((128,), -1, dtype=torch.int32))
 
 
 def test_deepgemm_grouped_layout_from_padded_offsets():
@@ -130,12 +183,13 @@ def test_deepgemm_grouped_layout_from_padded_offsets():
     padded_group_start_offsets = torch.tensor([0, 256, 512], dtype=torch.int32)
     padded_group_end_offsets = torch.tensor([256, 512, 640], dtype=torch.int32)
 
-    layout = deepgemm_grouped_kernels._grouped_layout_from_offsets(
+    offset_plan = build_deepgemm_grouped_offset_plan(
         padded_group_end_offsets,
-        768,
         original_group_end_offsets=original_group_end_offsets,
         padded_group_start_offsets=padded_group_start_offsets,
+        num_rows=768,
     )
+    layout = offset_plan.grouped_layout
 
     assert layout.dtype == torch.int32
     assert layout.is_contiguous()
@@ -152,13 +206,13 @@ def test_deepgemm_grouped_layout_from_padded_offsets():
     reason="DeepGEMM FP8 kernels require CUDA SM90+",
 )
 def test_deepgemm_weight_quant_layouts_match_torchao_transposes():
+    from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+        triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+    )
     from torchao.prototype.blockwise_fp8_training.grouped_kernels import (
         triton_fp8_blockwise_weight_quant_grouped_rhs,
         triton_fp8_blockwise_weight_quant_grouped_transposed_rhs,
-    )
-    from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
-        triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
-        triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
     )
 
     torch.manual_seed(123)
@@ -208,7 +262,7 @@ def test_deepgemm_weight_quant_layouts_match_torchao_transposes():
 def test_deepgemm_weight_quant_supports_compile_fullgraph():
     from torch._dynamo.testing import CompileCounterWithBackend
 
-    from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+    from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
         triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
     )
 
@@ -251,6 +305,9 @@ def test_deepgemm_weight_quant_supports_compile_fullgraph():
 def test_deepgemm_k_grouped_activation_quant_matches_flattened_torchao_layouts(
     offsets,
 ):
+    from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+        triton_fp8_blockwise_act_quant_k_grouped_deepgemm,
+    )
     from torchao.prototype.blockwise_fp8_training.kernels import (
         triton_fp8_blockwise_act_quant_rhs,
         triton_fp8_blockwise_act_quant_transposed_lhs,
@@ -258,14 +315,12 @@ def test_deepgemm_k_grouped_activation_quant_matches_flattened_torchao_layouts(
 
     torch.manual_seed(123)
     offs = torch.tensor(offsets, dtype=torch.int32, device="cuda")
-    group_sizes = deepgemm_grouped_kernels._group_sizes_from_offsets(offs)
+    group_sizes = group_sizes_from_offsets(offs)
     x = torch.randn(offsets[-1], 384, dtype=torch.bfloat16, device="cuda")
 
-    direct_q, direct_s = (
-        deepgemm_grouped_kernels.triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
-            x,
-            offs,
-        )
+    direct_q, direct_s = triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
+        x,
+        offs,
     )
 
     x_t_q, x_t_s = triton_fp8_blockwise_act_quant_transposed_lhs(x)
@@ -306,6 +361,7 @@ def test_deepgemm_k_grouped_wgrad_matches_emulated():
 
     torch.manual_seed(123)
     offs = torch.tensor([256, 640, 768], dtype=torch.int32, device="cuda")
+    offset_plan = build_deepgemm_grouped_offset_plan(offs)
     M = int(offs[-1].item())
     N, K = 256, 384
     grad_output = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
@@ -330,7 +386,7 @@ def test_deepgemm_k_grouped_wgrad_matches_emulated():
     plan = deepgemm_grouped_kernels.prepare_deepgemm_wgrad_plan(
         grad_output,
         A,
-        offs,
+        offset_plan,
         128,
         e4m3_dtype,
     )
@@ -338,7 +394,7 @@ def test_deepgemm_k_grouped_wgrad_matches_emulated():
     out = deepgemm_grouped_kernels.deepgemm_blockwise_scaled_grouped_mm_wgrad(
         plan.lhs,
         plan.rhs,
-        offs,
+        offset_plan,
         torch.bfloat16,
         128,
     )

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
@@ -13,26 +13,20 @@ from typing import Optional
 import torch
 
 from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    DeepGemmGroupedOffsetPlan,
     DeepGemmKGroupedQuantMetadata,
-    build_deepgemm_k_grouped_quant_metadata,
-    group_sizes_from_offsets as _group_sizes_from_offsets,
 )
 from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
     _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes,
-    triton_fp8_blockwise_act_quant_k_grouped_deepgemm,
-    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
-    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
 )
 from torchao.prototype.blockwise_fp8_training.kernels import (
     BLOCKWISE_1X128_SCALING_TYPE,
     BLOCKWISE_128X128_SCALING_TYPE,
-    _is_column_major,
     _is_row_major,
     _scaling_type_value,
     triton_fp8_blockwise_act_quant_rhs,
     triton_fp8_blockwise_act_quant_transposed_lhs,
 )
-
 
 # H100 tuning on the DeepSeek-V3 MoE shapes showed direct flat quantization wins
 # for the wide K=4096/7168 operands, while the existing TorchAO quantizer plus
@@ -150,7 +144,7 @@ def _is_cuda_sm90_or_newer(x: torch.Tensor) -> bool:
     return major >= 9
 
 
-def can_use_deepgemm_m_grouped(
+def can_use_deepgemm_grouped_training(
     a: torch.Tensor,
     out_dtype: torch.dtype,
     block_size: int,
@@ -160,58 +154,9 @@ def can_use_deepgemm_m_grouped(
         block_size == 128
         and out_dtype == torch.bfloat16
         and capabilities.m_grouped_gemm is not None
+        and capabilities.k_grouped_gemm is not None
         and _is_cuda_sm90_or_newer(a)
     )
-
-
-def _grouped_layout_from_offsets(
-    group_end_offsets: torch.Tensor,
-    num_rows: int,
-    *,
-    original_group_end_offsets: Optional[torch.Tensor] = None,
-    padded_group_start_offsets: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
-    assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
-        "group_end_offsets must be int32"
-    )
-    if original_group_end_offsets is not None:
-        assert original_group_end_offsets.dtype == torch.int32, (
-            "original_group_end_offsets must be int32"
-        )
-        assert padded_group_start_offsets is not None, (
-            "padded_group_start_offsets must be provided with original_group_end_offsets"
-        )
-        assert padded_group_start_offsets.dtype == torch.int32, (
-            "padded_group_start_offsets must be int32"
-        )
-        assert original_group_end_offsets.numel() == group_end_offsets.numel(), (
-            "original and padded group offsets must have the same number of groups"
-        )
-
-    # Torch grouped GEMM uses cumulative expert end offsets. DeepGEMM's
-    # contiguous M-grouped kernel instead wants one int32 entry per row:
-    # grouped_layout[row] = expert_idx. When token groups were padded for
-    # block alignment, inserted padding rows are marked -1 so DeepGEMM skips
-    # them instead of routing them to an expert.
-    grouped_layout = torch.full(
-        (num_rows,),
-        -1,
-        dtype=torch.int32,
-        device=group_end_offsets.device,
-    )
-    start = 0
-    for group_idx in range(group_end_offsets.numel()):
-        if original_group_end_offsets is None:
-            end = int(group_end_offsets[group_idx].item())
-            grouped_layout[start:end] = group_idx
-            start = end
-        else:
-            original_end = int(original_group_end_offsets[group_idx].item())
-            group_size = original_end - start
-            padded_start = int(padded_group_start_offsets[group_idx].item())
-            grouped_layout[padded_start : padded_start + group_size] = group_idx
-            start = original_end
-    return grouped_layout.contiguous()
 
 
 def _flatten_k_grouped_transposed_lhs(
@@ -361,19 +306,16 @@ def _quantize_wgrad_rhs(
 def prepare_deepgemm_wgrad_plan(
     padded_grad_output: torch.Tensor,
     padded_a: torch.Tensor,
-    group_end_offsets: torch.Tensor,
+    offset_plan: DeepGemmGroupedOffsetPlan,
     block_size: int,
     dtype: torch.dtype,
 ) -> Optional[DeepGemmWgradPlan]:
-    if _get_deepgemm_capabilities().k_grouped_gemm is None:
-        return None
-
-    group_sizes = _group_sizes_from_offsets(group_end_offsets)
-    if any(group_size % block_size != 0 for group_size in group_sizes):
+    if not offset_plan.groups_are_block_aligned(block_size):
         # DeepGEMM's K-grouped FP8 kernel requires token counts to be aligned
         # because the token dimension is the GEMM K axis. Ragged no-padding
         # callers should keep using the emulated wgrad path for correctness.
         return None
+    group_sizes = offset_plan.group_sizes
     lhs_needs_direct_quant_metadata = _should_quantize_k_grouped_directly(
         padded_grad_output.shape[-1]
     )
@@ -381,29 +323,19 @@ def prepare_deepgemm_wgrad_plan(
         padded_a.shape[-1]
     )
     lhs_metadata = (
-        build_deepgemm_k_grouped_quant_metadata(
-            group_end_offsets,
-            group_sizes,
-            block_size,
-            padded_grad_output.shape[-1],
-        )
+        offset_plan.k_quant_metadata(block_size, padded_grad_output.shape[-1])
         if lhs_needs_direct_quant_metadata
         else None
     )
     rhs_metadata = (
-        build_deepgemm_k_grouped_quant_metadata(
-            group_end_offsets,
-            group_sizes,
-            block_size,
-            padded_a.shape[-1],
-        )
+        offset_plan.k_quant_metadata(block_size, padded_a.shape[-1])
         if rhs_needs_direct_quant_metadata
         else None
     )
     return DeepGemmWgradPlan(
         lhs=_quantize_wgrad_lhs(
             padded_grad_output,
-            group_end_offsets,
+            offset_plan.group_end_offsets,
             group_sizes,
             block_size,
             dtype,
@@ -411,7 +343,7 @@ def prepare_deepgemm_wgrad_plan(
         ),
         rhs=_quantize_wgrad_rhs(
             padded_a,
-            group_end_offsets,
+            offset_plan.group_end_offsets,
             group_sizes,
             block_size,
             dtype,
@@ -431,8 +363,7 @@ def deepgemm_blockwise_scaled_grouped_mm(
     out_dtype: torch.dtype,
     block_size: int = 128,
     *,
-    original_group_end_offsets: Optional[torch.Tensor] = None,
-    padded_group_start_offsets: Optional[torch.Tensor] = None,
+    offset_plan: DeepGemmGroupedOffsetPlan,
 ) -> torch.Tensor:
     assert block_size == 128, (
         "DeepGEMM FP8 blockwise grouped GEMM requires block_size=128"
@@ -456,35 +387,16 @@ def deepgemm_blockwise_scaled_grouped_mm(
             "DeepGEMM FP8 blockwise grouped GEMM requires CUDA tensors. "
             "Select KernelPreference.EMULATED for non-CUDA execution."
         )
-
-    if b.stride(-1) != 1:
-        assert _is_column_major(b), (
-            "deepgemm_blockwise_scaled_grouped_mm expected K-major or column-major B"
-        )
-        # TorchAO's blockwise grouped kernels pass RHS data in the local
-        # column-major contract, with shape (..., K_contract, N_out) and
-        # matching block scales (..., K_blocks, N_blocks). DeepGEMM's NT
-        # grouped kernel expects the contracting dimension to be the contiguous
-        # last dimension, i.e. RHS (..., N_out, K_contract). Transpose both the
-        # data and scale grids into DeepGEMM's layout before launching.
-        b = b.transpose(-2, -1).contiguous()
-        if b_s.ndim == 3:
-            b_s = b_s.transpose(-2, -1).contiguous()
     assert b.stride(-1) == 1, (
-        "deepgemm_blockwise_scaled_grouped_mm expected K-major B"
+        "deepgemm_blockwise_scaled_grouped_mm expected DeepGEMM RHS layout with K-major B"
     )
     assert a.shape[-1] == b.shape[-1], (
         f"shape {a.shape} and {b.shape} are not compatible"
     )
 
-    grouped_layout = _grouped_layout_from_offsets(
-        offs,
-        a.shape[0],
-        original_group_end_offsets=original_group_end_offsets,
-        padded_group_start_offsets=padded_group_start_offsets,
-    )
-    # After normalizing RHS for DeepGEMM, b is (..., N_out, K_contract);
-    # the output keeps TorchAO's grouped GEMM shape (M, N_out).
+    grouped_layout = offset_plan.m_grouped_layout(a.shape[0])
+    # DeepGEMM RHS is (..., N_out, K_contract); the output keeps TorchAO's
+    # grouped GEMM shape (M, N_out).
     out = torch.empty(
         (a.shape[0], b.shape[-2]),
         dtype=out_dtype,
@@ -565,7 +477,7 @@ def _prepare_k_grouped_rhs_operand(
 def deepgemm_blockwise_scaled_grouped_mm_wgrad(
     lhs: DeepGemmKGroupedOperand,
     rhs: DeepGemmKGroupedOperand,
-    offs: torch.Tensor,
+    offset_plan: DeepGemmGroupedOffsetPlan,
     out_dtype: torch.dtype,
     block_size: int = 128,
 ) -> torch.Tensor:
@@ -580,7 +492,6 @@ def deepgemm_blockwise_scaled_grouped_mm_wgrad(
         DeepGemmKGroupedLayout.FLAT,
         DeepGemmKGroupedLayout.TORCHAO_RHS,
     ), f"unsupported DeepGEMM wgrad RHS layout: {rhs.layout}"
-    assert offs is not None and offs.dtype == torch.int32, "offs must be int32"
     assert out_dtype in (torch.bfloat16, torch.float32), (
         "DeepGEMM FP8 blockwise grouped wgrad supports bfloat16 or float32 output"
     )
@@ -593,9 +504,9 @@ def deepgemm_blockwise_scaled_grouped_mm_wgrad(
             "Select KernelPreference.EMULATED for non-CUDA execution."
         )
 
-    total_tokens = int(offs[-1].item())
-    group_sizes = _group_sizes_from_offsets(offs)
-    if any(group_size % block_size != 0 for group_size in group_sizes):
+    total_tokens = offset_plan.total_tokens
+    group_sizes = offset_plan.group_sizes
+    if not offset_plan.groups_are_block_aligned(block_size):
         raise NotImplementedError(
             "DeepGEMM K-grouped FP8 wgrad requires every expert token count "
             f"to be divisible by {block_size}. Enable "
@@ -610,7 +521,7 @@ def deepgemm_blockwise_scaled_grouped_mm_wgrad(
             "with contiguous K-grouped FP8 GEMM support."
         )
 
-    valid_scale_blocks = sum(group_size // block_size for group_size in group_sizes)
+    valid_scale_blocks = offset_plan.valid_scale_blocks(block_size)
     a, a_s = _prepare_k_grouped_lhs_operand(
         lhs,
         group_sizes,
@@ -629,7 +540,7 @@ def deepgemm_blockwise_scaled_grouped_mm_wgrad(
     assert b.numel() == total_tokens * rhs.dim, (
         f"shape {b.shape} and RHS scales {b_s.shape} are not compatible"
     )
-    ks_tensor = torch.tensor(group_sizes, dtype=torch.int32, device=lhs.data.device)
+    ks_tensor = offset_plan.ks_tensor
 
     # SM90 DeepGEMM K-grouped FP8 accumulates into FP32 and asserts that the
     # output tensor is float. Cast after the launch to preserve TorchAO's

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass
@@ -542,9 +543,14 @@ def deepgemm_blockwise_scaled_grouped_mm_wgrad(
     )
     ks_tensor = offset_plan.ks_tensor
 
-    # SM90 DeepGEMM K-grouped FP8 accumulates into FP32 and asserts that the
-    # output tensor is float. Cast after the launch to preserve TorchAO's
-    # public grouped-mm output dtype contract.
+    # SM90 DeepGEMM K-grouped FP8 always runs with accumulation: the kernel
+    # hard-asserts `c.has_value()` and a float output (see
+    # sm90_k_grouped_fp8_gemm_1d1d in DeepGEMM), computing `d = c + A@B`. `c`
+    # (`accum`) is read and `d` (`out_fp32`) is written, so they must be
+    # distinct buffers and `c` must be zero-seeded since we do not accumulate
+    # across calls. Both FP32 allocations are therefore required by the kernel
+    # contract. Cast after the launch to preserve TorchAO's public grouped-mm
+    # output dtype.
     out_fp32 = torch.empty(
         (len(group_sizes), lhs.dim, rhs.dim),
         dtype=torch.float32,

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
@@ -38,6 +38,8 @@ _DEEPGEMM_DIRECT_K_GROUPED_QUANT_MIN_DIM = 4096
 
 
 class DeepGemmKGroupedLayout(str, Enum):
+    """How a K-grouped operand is represented before DeepGEMM dispatch."""
+
     FLAT = "flat"
     TORCHAO_TRANSPOSED_LHS = "torchao_transposed_lhs"
     TORCHAO_RHS = "torchao_rhs"
@@ -45,6 +47,16 @@ class DeepGemmKGroupedLayout(str, Enum):
 
 @dataclass(frozen=True)
 class DeepGemmKGroupedOperand:
+    """A quantized K-grouped operand plus enough layout info to dispatch it.
+
+    Args:
+        data: FP8 data buffer, either already flat in DeepGEMM order or in a
+            TorchAO intermediate layout.
+        scale: Float32 inverse scales for the operand.
+        dim: Logical non-token dimension used by DeepGEMM's K-grouped API.
+        layout: Current representation of ``data``.
+    """
+
     data: torch.Tensor
     scale: torch.Tensor
     dim: int
@@ -53,12 +65,16 @@ class DeepGemmKGroupedOperand:
 
 @dataclass(frozen=True)
 class DeepGemmWgradPlan:
+    """Quantized operands for DeepGEMM's K-grouped weight-gradient kernel."""
+
     lhs: DeepGemmKGroupedOperand
     rhs: DeepGemmKGroupedOperand
 
 
 @dataclass(frozen=True)
 class DeepGemmCapabilities:
+    """Cached import result and training symbols for the optional dependency."""
+
     module: object | None
     import_error: ImportError | None
     m_grouped_gemm: object | None

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_grouped_kernels.py
@@ -1,0 +1,653 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from typing import Optional
+
+import torch
+
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    DeepGemmKGroupedQuantMetadata,
+    build_deepgemm_k_grouped_quant_metadata,
+    group_sizes_from_offsets as _group_sizes_from_offsets,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+    _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes,
+    triton_fp8_blockwise_act_quant_k_grouped_deepgemm,
+    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+)
+from torchao.prototype.blockwise_fp8_training.kernels import (
+    BLOCKWISE_1X128_SCALING_TYPE,
+    BLOCKWISE_128X128_SCALING_TYPE,
+    _is_column_major,
+    _is_row_major,
+    _scaling_type_value,
+    triton_fp8_blockwise_act_quant_rhs,
+    triton_fp8_blockwise_act_quant_transposed_lhs,
+)
+
+
+# H100 tuning on the DeepSeek-V3 MoE shapes showed direct flat quantization wins
+# for the wide K=4096/7168 operands, while the existing TorchAO quantizer plus
+# flatten is faster for the common N=2048 operand. Keep the threshold here with
+# the DeepGEMM backend policy so future PyTorch grouped FP8 support can replace
+# the whole path without leaking this heuristic into the public MoE op.
+_DEEPGEMM_DIRECT_K_GROUPED_QUANT_MIN_DIM = 4096
+
+
+class DeepGemmKGroupedLayout(str, Enum):
+    FLAT = "flat"
+    TORCHAO_TRANSPOSED_LHS = "torchao_transposed_lhs"
+    TORCHAO_RHS = "torchao_rhs"
+
+
+@dataclass(frozen=True)
+class DeepGemmKGroupedOperand:
+    data: torch.Tensor
+    scale: torch.Tensor
+    dim: int
+    layout: DeepGemmKGroupedLayout
+
+
+@dataclass(frozen=True)
+class DeepGemmWgradPlan:
+    lhs: DeepGemmKGroupedOperand
+    rhs: DeepGemmKGroupedOperand
+
+
+@dataclass(frozen=True)
+class DeepGemmCapabilities:
+    module: object | None
+    import_error: ImportError | None
+    m_grouped_gemm: object | None
+    k_grouped_gemm: object | None
+
+
+def _deepgemm_import_error(exc: Exception) -> ImportError:
+    if isinstance(exc, ModuleNotFoundError) and exc.name == "deep_gemm":
+        return ImportError(
+            "DeepGEMM backend selected for FP8 blockwise MoE grouped GEMM, "
+            "but optional dependency `deep_gemm` is not installed. Install "
+            "DeepGEMM from https://github.com/deepseek-ai/DeepGEMM or select "
+            "KernelPreference.EMULATED."
+        )
+    if isinstance(exc, ModuleNotFoundError):
+        return ImportError(
+            "DeepGEMM backend selected for FP8 blockwise MoE grouped GEMM, "
+            "but the installed `deep_gemm` package failed to import one of "
+            f"its dependencies: {exc}. Reinstall DeepGEMM against the active "
+            "PyTorch and CUDA environment, or select KernelPreference.EMULATED."
+        )
+    return ImportError(
+        "DeepGEMM backend selected for FP8 blockwise MoE grouped GEMM, "
+        "but the installed `deep_gemm` package could not be imported. This "
+        "usually means DeepGEMM was built against a different PyTorch/CUDA "
+        f"ABI than the one currently imported. Original error: {exc}. "
+        "Reinstall DeepGEMM against the active PyTorch and CUDA environment, "
+        "or select KernelPreference.EMULATED."
+    )
+
+
+def _first_deepgemm_symbol(module: object, *names: str):
+    for name in names:
+        symbol = getattr(module, name, None)
+        if symbol is not None:
+            return symbol
+    return None
+
+
+@lru_cache(maxsize=1)
+def _get_deepgemm_capabilities() -> DeepGemmCapabilities:
+    try:
+        module = importlib.import_module("deep_gemm")
+    except (ImportError, OSError) as exc:
+        return DeepGemmCapabilities(
+            module=None,
+            import_error=_deepgemm_import_error(exc),
+            m_grouped_gemm=None,
+            k_grouped_gemm=None,
+        )
+
+    return DeepGemmCapabilities(
+        module=module,
+        import_error=None,
+        m_grouped_gemm=_first_deepgemm_symbol(
+            module,
+            "m_grouped_fp8_gemm_nt_contiguous",
+            "m_grouped_fp8_fp4_gemm_nt_contiguous",
+        ),
+        k_grouped_gemm=getattr(module, "k_grouped_fp8_gemm_nt_contiguous", None),
+    )
+
+
+def _clear_deepgemm_capability_cache() -> None:
+    _get_deepgemm_capabilities.cache_clear()
+
+
+def _require_deep_gemm():
+    capabilities = _get_deepgemm_capabilities()
+    if capabilities.import_error is not None:
+        raise capabilities.import_error
+    assert capabilities.module is not None
+    return capabilities.module
+
+
+def is_deep_gemm_available() -> bool:
+    return _get_deepgemm_capabilities().module is not None
+
+
+def _is_cuda_sm90_or_newer(x: torch.Tensor) -> bool:
+    if not x.is_cuda:
+        return False
+    major, _ = torch.cuda.get_device_capability(x.device)
+    return major >= 9
+
+
+def can_use_deepgemm_m_grouped(
+    a: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int,
+) -> bool:
+    capabilities = _get_deepgemm_capabilities()
+    return (
+        block_size == 128
+        and out_dtype == torch.bfloat16
+        and capabilities.m_grouped_gemm is not None
+        and _is_cuda_sm90_or_newer(a)
+    )
+
+
+def _grouped_layout_from_offsets(
+    group_end_offsets: torch.Tensor,
+    num_rows: int,
+    *,
+    original_group_end_offsets: Optional[torch.Tensor] = None,
+    padded_group_start_offsets: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
+        "group_end_offsets must be int32"
+    )
+    if original_group_end_offsets is not None:
+        assert original_group_end_offsets.dtype == torch.int32, (
+            "original_group_end_offsets must be int32"
+        )
+        assert padded_group_start_offsets is not None, (
+            "padded_group_start_offsets must be provided with original_group_end_offsets"
+        )
+        assert padded_group_start_offsets.dtype == torch.int32, (
+            "padded_group_start_offsets must be int32"
+        )
+        assert original_group_end_offsets.numel() == group_end_offsets.numel(), (
+            "original and padded group offsets must have the same number of groups"
+        )
+
+    # Torch grouped GEMM uses cumulative expert end offsets. DeepGEMM's
+    # contiguous M-grouped kernel instead wants one int32 entry per row:
+    # grouped_layout[row] = expert_idx. When token groups were padded for
+    # block alignment, inserted padding rows are marked -1 so DeepGEMM skips
+    # them instead of routing them to an expert.
+    grouped_layout = torch.full(
+        (num_rows,),
+        -1,
+        dtype=torch.int32,
+        device=group_end_offsets.device,
+    )
+    start = 0
+    for group_idx in range(group_end_offsets.numel()):
+        if original_group_end_offsets is None:
+            end = int(group_end_offsets[group_idx].item())
+            grouped_layout[start:end] = group_idx
+            start = end
+        else:
+            original_end = int(original_group_end_offsets[group_idx].item())
+            group_size = original_end - start
+            padded_start = int(padded_group_start_offsets[group_idx].item())
+            grouped_layout[padded_start : padded_start + group_size] = group_idx
+            start = original_end
+    return grouped_layout.contiguous()
+
+
+def _flatten_k_grouped_transposed_lhs(
+    a_t: torch.Tensor,
+    group_sizes: list[int],
+) -> torch.Tensor:
+    parts = []
+    start = 0
+    for group_size in group_sizes:
+        end = start + group_size
+        # TorchAO's wgrad LHS quantizer returns logical (N_out, M_tokens).
+        # DeepGEMM's K-grouped K-major buffer stores one expert at a time as
+        # (N_out, expert_tokens). Slice the token dimension per expert before
+        # flattening so each expert's K range is contiguous in DeepGEMM order.
+        parts.append(a_t[:, start:end].contiguous().view(-1))
+        start = end
+    return torch.cat(parts) if len(parts) > 1 else parts[0]
+
+
+def _flatten_k_grouped_rhs(
+    b: torch.Tensor,
+    group_sizes: list[int],
+) -> torch.Tensor:
+    parts = []
+    start = 0
+    for group_size in group_sizes:
+        end = start + group_size
+        # TorchAO's wgrad RHS quantizer returns logical (M_tokens, K_in) in a
+        # column-major physical layout for torch._grouped_mm. DeepGEMM's
+        # K-grouped K-major buffer stores each expert as (K_in, expert_tokens),
+        # so transpose the logical slice and make that DeepGEMM flat order.
+        parts.append(b[start:end].transpose(-2, -1).contiguous().view(-1))
+        start = end
+    return torch.cat(parts) if len(parts) > 1 else parts[0]
+
+
+def _deepgemm_flat_k_grouped_operand(
+    data: torch.Tensor,
+    scale: torch.Tensor,
+) -> DeepGemmKGroupedOperand:
+    assert data.ndim == 1, "DeepGEMM flat K-grouped data must be 1D"
+    assert scale.ndim == 2, "DeepGEMM flat K-grouped scale must be 2D"
+    return DeepGemmKGroupedOperand(
+        data=data,
+        scale=scale,
+        dim=scale.shape[0],
+        layout=DeepGemmKGroupedLayout.FLAT,
+    )
+
+
+def _torchao_transposed_lhs_operand(
+    data: torch.Tensor,
+    scale: torch.Tensor,
+) -> DeepGemmKGroupedOperand:
+    assert data.ndim == 2, "TorchAO transposed-LHS data must be 2D"
+    assert scale.ndim == 2, "TorchAO transposed-LHS scale must be 2D"
+    return DeepGemmKGroupedOperand(
+        data=data,
+        scale=scale,
+        dim=data.shape[0],
+        layout=DeepGemmKGroupedLayout.TORCHAO_TRANSPOSED_LHS,
+    )
+
+
+def _torchao_rhs_operand(
+    data: torch.Tensor,
+    scale: torch.Tensor,
+) -> DeepGemmKGroupedOperand:
+    assert data.ndim == 2, "TorchAO RHS data must be 2D"
+    assert scale.ndim == 2, "TorchAO RHS scale must be 2D"
+    return DeepGemmKGroupedOperand(
+        data=data,
+        scale=scale,
+        dim=data.shape[-1],
+        layout=DeepGemmKGroupedLayout.TORCHAO_RHS,
+    )
+
+
+def _should_quantize_k_grouped_directly(dim: int) -> bool:
+    return dim >= _DEEPGEMM_DIRECT_K_GROUPED_QUANT_MIN_DIM
+
+
+def _quantize_wgrad_lhs(
+    x: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    group_sizes: list[int],
+    block_size: int,
+    dtype: torch.dtype,
+    metadata: DeepGemmKGroupedQuantMetadata | None,
+) -> DeepGemmKGroupedOperand:
+    if _should_quantize_k_grouped_directly(x.shape[-1]):
+        q, scale = _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes(
+            x.contiguous(),
+            group_end_offsets,
+            group_sizes,
+            block_size=block_size,
+            dtype=dtype,
+            metadata=metadata,
+        )
+        # Direct quantization writes the DeepGEMM input contract directly:
+        # flat per-expert (dim, tokens) data with (dim, token_blocks) scales.
+        return _deepgemm_flat_k_grouped_operand(q, scale)
+
+    q, scale = triton_fp8_blockwise_act_quant_transposed_lhs(
+        x.contiguous(),
+        block_size=block_size,
+        dtype=dtype,
+    )
+    # For narrower LHS dimensions, TorchAO's transposed-LHS quantizer is
+    # faster; the DeepGEMM launcher later flattens (dim, all_tokens) into
+    # per-expert (dim, expert_tokens) chunks.
+    return _torchao_transposed_lhs_operand(q, scale)
+
+
+def _quantize_wgrad_rhs(
+    x: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    group_sizes: list[int],
+    block_size: int,
+    dtype: torch.dtype,
+    metadata: DeepGemmKGroupedQuantMetadata | None,
+) -> DeepGemmKGroupedOperand:
+    if _should_quantize_k_grouped_directly(x.shape[-1]):
+        q, scale = _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes(
+            x.contiguous(),
+            group_end_offsets,
+            group_sizes,
+            block_size=block_size,
+            dtype=dtype,
+            metadata=metadata,
+        )
+        # Direct quantization writes the DeepGEMM input contract directly:
+        # flat per-expert (dim, tokens) data with (dim, token_blocks) scales.
+        return _deepgemm_flat_k_grouped_operand(q, scale)
+
+    q, scale = triton_fp8_blockwise_act_quant_rhs(
+        x.contiguous(),
+        block_size=block_size,
+        dtype=dtype,
+    )
+    # For narrower RHS dimensions, keep TorchAO's grouped-mm RHS contract:
+    # logical (tokens, dim) data in column-major physical layout with
+    # (token_blocks, dim) scales, then convert at DeepGEMM launch time.
+    return _torchao_rhs_operand(q, scale)
+
+
+def prepare_deepgemm_wgrad_plan(
+    padded_grad_output: torch.Tensor,
+    padded_a: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int,
+    dtype: torch.dtype,
+) -> Optional[DeepGemmWgradPlan]:
+    if _get_deepgemm_capabilities().k_grouped_gemm is None:
+        return None
+
+    group_sizes = _group_sizes_from_offsets(group_end_offsets)
+    if any(group_size % block_size != 0 for group_size in group_sizes):
+        # DeepGEMM's K-grouped FP8 kernel requires token counts to be aligned
+        # because the token dimension is the GEMM K axis. Ragged no-padding
+        # callers should keep using the emulated wgrad path for correctness.
+        return None
+    lhs_needs_direct_quant_metadata = _should_quantize_k_grouped_directly(
+        padded_grad_output.shape[-1]
+    )
+    rhs_needs_direct_quant_metadata = _should_quantize_k_grouped_directly(
+        padded_a.shape[-1]
+    )
+    lhs_metadata = (
+        build_deepgemm_k_grouped_quant_metadata(
+            group_end_offsets,
+            group_sizes,
+            block_size,
+            padded_grad_output.shape[-1],
+        )
+        if lhs_needs_direct_quant_metadata
+        else None
+    )
+    rhs_metadata = (
+        build_deepgemm_k_grouped_quant_metadata(
+            group_end_offsets,
+            group_sizes,
+            block_size,
+            padded_a.shape[-1],
+        )
+        if rhs_needs_direct_quant_metadata
+        else None
+    )
+    return DeepGemmWgradPlan(
+        lhs=_quantize_wgrad_lhs(
+            padded_grad_output,
+            group_end_offsets,
+            group_sizes,
+            block_size,
+            dtype,
+            lhs_metadata,
+        ),
+        rhs=_quantize_wgrad_rhs(
+            padded_a,
+            group_end_offsets,
+            group_sizes,
+            block_size,
+            dtype,
+            rhs_metadata,
+        ),
+    )
+
+
+def deepgemm_blockwise_scaled_grouped_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_s: torch.Tensor,
+    scale_recipe_a: int,
+    b_s: torch.Tensor,
+    scale_recipe_b: int,
+    offs: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int = 128,
+    *,
+    original_group_end_offsets: Optional[torch.Tensor] = None,
+    padded_group_start_offsets: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    assert block_size == 128, (
+        "DeepGEMM FP8 blockwise grouped GEMM requires block_size=128"
+    )
+    assert _is_row_major(a), "deepgemm_blockwise_scaled_grouped_mm expected row-major A"
+    assert offs is not None and offs.dtype == torch.int32, "offs must be int32"
+    assert out_dtype == torch.bfloat16, (
+        "DeepGEMM FP8 blockwise grouped GEMM currently supports bfloat16 output"
+    )
+    assert _scaling_type_value(scale_recipe_a) == _scaling_type_value(
+        BLOCKWISE_1X128_SCALING_TYPE
+    ), "DeepGEMM FP8 blockwise grouped GEMM expects 1x128 LHS scales"
+    assert _scaling_type_value(scale_recipe_b) == _scaling_type_value(
+        BLOCKWISE_128X128_SCALING_TYPE
+    ), "DeepGEMM FP8 blockwise grouped GEMM expects 128x128 RHS scales"
+
+    _require_deep_gemm()
+    capabilities = _get_deepgemm_capabilities()
+    if not a.is_cuda:
+        raise NotImplementedError(
+            "DeepGEMM FP8 blockwise grouped GEMM requires CUDA tensors. "
+            "Select KernelPreference.EMULATED for non-CUDA execution."
+        )
+
+    if b.stride(-1) != 1:
+        assert _is_column_major(b), (
+            "deepgemm_blockwise_scaled_grouped_mm expected K-major or column-major B"
+        )
+        # TorchAO's blockwise grouped kernels pass RHS data in the local
+        # column-major contract, with shape (..., K_contract, N_out) and
+        # matching block scales (..., K_blocks, N_blocks). DeepGEMM's NT
+        # grouped kernel expects the contracting dimension to be the contiguous
+        # last dimension, i.e. RHS (..., N_out, K_contract). Transpose both the
+        # data and scale grids into DeepGEMM's layout before launching.
+        b = b.transpose(-2, -1).contiguous()
+        if b_s.ndim == 3:
+            b_s = b_s.transpose(-2, -1).contiguous()
+    assert b.stride(-1) == 1, (
+        "deepgemm_blockwise_scaled_grouped_mm expected K-major B"
+    )
+    assert a.shape[-1] == b.shape[-1], (
+        f"shape {a.shape} and {b.shape} are not compatible"
+    )
+
+    grouped_layout = _grouped_layout_from_offsets(
+        offs,
+        a.shape[0],
+        original_group_end_offsets=original_group_end_offsets,
+        padded_group_start_offsets=padded_group_start_offsets,
+    )
+    # After normalizing RHS for DeepGEMM, b is (..., N_out, K_contract);
+    # the output keeps TorchAO's grouped GEMM shape (M, N_out).
+    out = torch.empty(
+        (a.shape[0], b.shape[-2]),
+        dtype=out_dtype,
+        device=a.device,
+    )
+
+    grouped_gemm = capabilities.m_grouped_gemm
+    if grouped_gemm is None:
+        raise ImportError(
+            "Installed `deep_gemm` does not expose "
+            "`m_grouped_fp8_gemm_nt_contiguous` or "
+            "`m_grouped_fp8_fp4_gemm_nt_contiguous`. Install a DeepGEMM "
+            "version with contiguous M-grouped FP8 GEMM support."
+        )
+
+    grouped_gemm(
+        (a, a_s),
+        (b, b_s),
+        out,
+        grouped_layout,
+        recipe_a=(1, block_size),
+        recipe_b=(block_size, block_size),
+        disable_ue8m0_cast=True,
+    )
+    return out
+
+
+def _prepare_k_grouped_lhs_operand(
+    operand: DeepGemmKGroupedOperand,
+    group_sizes: list[int],
+    total_tokens: int,
+    valid_scale_blocks: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if operand.layout == DeepGemmKGroupedLayout.FLAT:
+        # Direct quantization already produced DeepGEMM's flat K-major
+        # contract. Trim scale columns to valid padded rows and ignore any
+        # upper-bound padding allocated for CUDA graph friendliness.
+        return operand.data, operand.scale[:, :valid_scale_blocks]
+
+    assert operand.layout == DeepGemmKGroupedLayout.TORCHAO_TRANSPOSED_LHS, (
+        f"unsupported DeepGEMM wgrad LHS layout: {operand.layout}"
+    )
+    assert operand.data.shape[-1] >= total_tokens, (
+        f"shape {operand.data.shape} and offs={total_tokens} are not compatible"
+    )
+    data = _flatten_k_grouped_transposed_lhs(operand.data, group_sizes)
+    scale = operand.scale[:, :valid_scale_blocks]
+    return data, scale
+
+
+def _prepare_k_grouped_rhs_operand(
+    operand: DeepGemmKGroupedOperand,
+    group_sizes: list[int],
+    total_tokens: int,
+    valid_scale_blocks: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if operand.layout == DeepGemmKGroupedLayout.FLAT:
+        # Direct quantization already produced DeepGEMM's flat K-major
+        # contract. Trim scale columns to valid padded rows and ignore any
+        # upper-bound padding allocated for CUDA graph friendliness.
+        return operand.data, operand.scale[:, :valid_scale_blocks]
+
+    assert operand.layout == DeepGemmKGroupedLayout.TORCHAO_RHS, (
+        f"unsupported DeepGEMM wgrad RHS layout: {operand.layout}"
+    )
+    assert operand.data.shape[-2] >= total_tokens, (
+        f"shape {operand.data.shape} and offs={total_tokens} are not compatible"
+    )
+    data = _flatten_k_grouped_rhs(operand.data, group_sizes)
+    scale = operand.scale[:valid_scale_blocks]
+    # TorchAO RHS 1x128 scales are stored as (M_blocks, K_in). DeepGEMM's
+    # K-grouped scale contract is (K_in, M_blocks), matching its flattened
+    # per-expert (K_in, expert_tokens) RHS data.
+    scale = scale.transpose(-2, -1)
+    return data, scale
+
+
+def deepgemm_blockwise_scaled_grouped_mm_wgrad(
+    lhs: DeepGemmKGroupedOperand,
+    rhs: DeepGemmKGroupedOperand,
+    offs: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int = 128,
+) -> torch.Tensor:
+    assert block_size == 128, (
+        "DeepGEMM FP8 blockwise grouped wgrad requires block_size=128"
+    )
+    assert lhs.layout in (
+        DeepGemmKGroupedLayout.FLAT,
+        DeepGemmKGroupedLayout.TORCHAO_TRANSPOSED_LHS,
+    ), f"unsupported DeepGEMM wgrad LHS layout: {lhs.layout}"
+    assert rhs.layout in (
+        DeepGemmKGroupedLayout.FLAT,
+        DeepGemmKGroupedLayout.TORCHAO_RHS,
+    ), f"unsupported DeepGEMM wgrad RHS layout: {rhs.layout}"
+    assert offs is not None and offs.dtype == torch.int32, "offs must be int32"
+    assert out_dtype in (torch.bfloat16, torch.float32), (
+        "DeepGEMM FP8 blockwise grouped wgrad supports bfloat16 or float32 output"
+    )
+
+    _require_deep_gemm()
+    capabilities = _get_deepgemm_capabilities()
+    if not lhs.data.is_cuda:
+        raise NotImplementedError(
+            "DeepGEMM FP8 blockwise grouped wgrad requires CUDA tensors. "
+            "Select KernelPreference.EMULATED for non-CUDA execution."
+        )
+
+    total_tokens = int(offs[-1].item())
+    group_sizes = _group_sizes_from_offsets(offs)
+    if any(group_size % block_size != 0 for group_size in group_sizes):
+        raise NotImplementedError(
+            "DeepGEMM K-grouped FP8 wgrad requires every expert token count "
+            f"to be divisible by {block_size}. Enable "
+            "pad_token_groups_for_grouped_mm or select KernelPreference.EMULATED."
+        )
+
+    k_grouped_gemm = capabilities.k_grouped_gemm
+    if k_grouped_gemm is None:
+        raise ImportError(
+            "Installed `deep_gemm` does not expose "
+            "`k_grouped_fp8_gemm_nt_contiguous`. Install a DeepGEMM version "
+            "with contiguous K-grouped FP8 GEMM support."
+        )
+
+    valid_scale_blocks = sum(group_size // block_size for group_size in group_sizes)
+    a, a_s = _prepare_k_grouped_lhs_operand(
+        lhs,
+        group_sizes,
+        total_tokens,
+        valid_scale_blocks,
+    )
+    b, b_s = _prepare_k_grouped_rhs_operand(
+        rhs,
+        group_sizes,
+        total_tokens,
+        valid_scale_blocks,
+    )
+    assert a.numel() == total_tokens * lhs.dim, (
+        f"shape {a.shape} and LHS scales {a_s.shape} are not compatible"
+    )
+    assert b.numel() == total_tokens * rhs.dim, (
+        f"shape {b.shape} and RHS scales {b_s.shape} are not compatible"
+    )
+    ks_tensor = torch.tensor(group_sizes, dtype=torch.int32, device=lhs.data.device)
+
+    # SM90 DeepGEMM K-grouped FP8 accumulates into FP32 and asserts that the
+    # output tensor is float. Cast after the launch to preserve TorchAO's
+    # public grouped-mm output dtype contract.
+    out_fp32 = torch.empty(
+        (len(group_sizes), lhs.dim, rhs.dim),
+        dtype=torch.float32,
+        device=lhs.data.device,
+    )
+    accum = torch.zeros_like(out_fp32)
+
+    k_grouped_gemm(
+        (a, a_s),
+        (b, b_s),
+        out_fp32,
+        group_sizes,
+        ks_tensor,
+        accum,
+        recipe=(1, 1, block_size),
+    )
+    return out_fp32 if out_dtype == torch.float32 else out_fp32.to(out_dtype)

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
@@ -25,6 +25,47 @@ class DeepGemmKGroupedQuantMetadata:
         return self.q_offset_by_block.numel()
 
 
+@dataclass(frozen=True)
+class DeepGemmGroupedOffsetPlan:
+    group_end_offsets: torch.Tensor
+    group_sizes: list[int]
+    ks_tensor: torch.Tensor
+    grouped_layout: torch.Tensor
+    original_group_sizes: list[int] | None = None
+    padded_group_start_offsets: torch.Tensor | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(self.group_sizes)
+
+    def groups_are_block_aligned(self, block_size: int) -> bool:
+        return all(group_size % block_size == 0 for group_size in self.group_sizes)
+
+    def valid_scale_blocks(self, block_size: int) -> int:
+        assert self.groups_are_block_aligned(block_size), (
+            "valid scale blocks require block-aligned group sizes"
+        )
+        return sum(group_size // block_size for group_size in self.group_sizes)
+
+    def k_quant_metadata(
+        self,
+        block_size: int,
+        dim: int,
+    ) -> DeepGemmKGroupedQuantMetadata:
+        return build_deepgemm_k_grouped_quant_metadata(
+            self.group_end_offsets,
+            self.group_sizes,
+            block_size,
+            dim,
+        )
+
+    def m_grouped_layout(self, num_rows: int) -> torch.Tensor:
+        assert self.grouped_layout.numel() == num_rows, (
+            "cached DeepGEMM grouped layout does not match operand rows"
+        )
+        return self.grouped_layout
+
+
 def group_sizes_from_offsets(group_end_offsets: torch.Tensor) -> list[int]:
     assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
         "group_end_offsets must be int32"
@@ -36,6 +77,94 @@ def group_sizes_from_offsets(group_end_offsets: torch.Tensor) -> list[int]:
         group_sizes.append(end - start)
         start = end
     return group_sizes
+
+
+def build_deepgemm_grouped_offset_plan(
+    group_end_offsets: torch.Tensor,
+    *,
+    original_group_end_offsets: torch.Tensor | None = None,
+    padded_group_start_offsets: torch.Tensor | None = None,
+    num_rows: int | None = None,
+) -> DeepGemmGroupedOffsetPlan:
+    group_sizes = group_sizes_from_offsets(group_end_offsets)
+    original_group_sizes = None
+    padded_group_starts = None
+    if original_group_end_offsets is not None:
+        assert original_group_end_offsets.dtype == torch.int32, (
+            "original_group_end_offsets must be int32"
+        )
+        assert padded_group_start_offsets is not None, (
+            "padded_group_start_offsets must be provided with original_group_end_offsets"
+        )
+        assert padded_group_start_offsets.dtype == torch.int32, (
+            "padded_group_start_offsets must be int32"
+        )
+        assert original_group_end_offsets.numel() == group_end_offsets.numel(), (
+            "original and padded group offsets must have the same number of groups"
+        )
+        original_group_sizes = group_sizes_from_offsets(original_group_end_offsets)
+        padded_group_starts = padded_group_start_offsets.tolist()
+
+    grouped_layout = _build_deepgemm_m_grouped_layout(
+        group_end_offsets.device,
+        group_sizes,
+        original_group_sizes=original_group_sizes,
+        padded_group_starts=padded_group_starts,
+        num_rows=num_rows,
+    )
+
+    return DeepGemmGroupedOffsetPlan(
+        group_end_offsets=group_end_offsets,
+        group_sizes=group_sizes,
+        ks_tensor=torch.tensor(
+            group_sizes,
+            dtype=torch.int32,
+            device=group_end_offsets.device,
+        ),
+        grouped_layout=grouped_layout,
+        original_group_sizes=original_group_sizes,
+        padded_group_start_offsets=padded_group_start_offsets,
+    )
+
+
+def _build_deepgemm_m_grouped_layout(
+    device: torch.device,
+    group_sizes: list[int],
+    *,
+    original_group_sizes: list[int] | None = None,
+    padded_group_starts: list[int] | None = None,
+    num_rows: int | None = None,
+) -> torch.Tensor:
+    # DeepGEMM's contiguous M-grouped kernel wants one int32 entry per row:
+    # grouped_layout[row] = expert_idx. Padded rows are marked -1 so the kernel
+    # skips them instead of routing them to an expert.
+    min_rows = sum(group_sizes)
+    if num_rows is None:
+        num_rows = min_rows
+    assert num_rows >= min_rows, "grouped layout must cover all padded groups"
+    grouped_layout = torch.full(
+        (num_rows,),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    if original_group_sizes is None:
+        start = 0
+        for group_idx, group_size in enumerate(group_sizes):
+            end = start + group_size
+            grouped_layout[start:end] = group_idx
+            start = end
+        return grouped_layout.contiguous()
+
+    assert padded_group_starts is not None, (
+        "padded_group_starts must be provided with original_group_sizes"
+    )
+    for group_idx, (group_size, padded_start) in enumerate(
+        zip(original_group_sizes, padded_group_starts)
+    ):
+        grouped_layout[padded_start : padded_start + group_size] = group_idx
+    return grouped_layout.contiguous()
 
 
 def build_deepgemm_k_grouped_quant_metadata(

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class DeepGemmKGroupedQuantMetadata:
+    dim: int
+    group_sizes: list[int]
+    q_offset_by_block: torch.Tensor
+    group_size_by_block: torch.Tensor
+
+    @property
+    def valid_tokens(self) -> int:
+        return sum(self.group_sizes)
+
+    @property
+    def valid_blocks(self) -> int:
+        return self.q_offset_by_block.numel()
+
+
+def group_sizes_from_offsets(group_end_offsets: torch.Tensor) -> list[int]:
+    assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
+        "group_end_offsets must be int32"
+    )
+    group_sizes = []
+    start = 0
+    for group_idx in range(group_end_offsets.numel()):
+        end = int(group_end_offsets[group_idx].item())
+        group_sizes.append(end - start)
+        start = end
+    return group_sizes
+
+
+def build_deepgemm_k_grouped_quant_metadata(
+    group_end_offsets: torch.Tensor,
+    group_sizes: list[int],
+    block_size: int,
+    dim: int,
+) -> DeepGemmKGroupedQuantMetadata:
+    q_offset_by_block = []
+    group_size_by_block = []
+    group_start = 0
+    for group_size in group_sizes:
+        assert group_size % block_size == 0, (
+            "DeepGEMM K-grouped activation quantization requires every group size "
+            f"to be divisible by block_size={block_size}"
+        )
+        for block_idx in range(group_size // block_size):
+            q_offset_by_block.append(group_start * dim + block_idx * block_size)
+            group_size_by_block.append(group_size)
+        group_start += group_size
+
+    device = group_end_offsets.device
+    return DeepGemmKGroupedQuantMetadata(
+        dim=dim,
+        group_sizes=group_sizes,
+        q_offset_by_block=torch.tensor(
+            q_offset_by_block,
+            dtype=torch.int32,
+            device=device,
+        ),
+        group_size_by_block=torch.tensor(
+            group_size_by_block,
+            dtype=torch.int32,
+            device=device,
+        ),
+    )

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
@@ -3,10 +3,20 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 
 import torch
+
+
+def _group_sizes_tensor(group_end_offsets: torch.Tensor) -> torch.Tensor:
+    assert group_end_offsets.dtype == torch.int32, "group_end_offsets must be int32"
+    return torch.diff(
+        group_end_offsets,
+        prepend=group_end_offsets.new_zeros(1),
+    )
 
 
 @dataclass(frozen=True)
@@ -28,18 +38,28 @@ class DeepGemmKGroupedQuantMetadata:
 @dataclass(frozen=True)
 class DeepGemmGroupedOffsetPlan:
     group_end_offsets: torch.Tensor
-    group_sizes: list[int]
-    ks_tensor: torch.Tensor
     grouped_layout: torch.Tensor
-    original_group_sizes: list[int] | None = None
-    padded_group_start_offsets: torch.Tensor | None = None
+    groups_block_aligned_by_construction: bool = False
+
+    @cached_property
+    def group_sizes(self) -> list[int]:
+        # DeepGEMM's K-grouped wgrad kernel requires the per-group sizes as a
+        # host-side `ks` sequence, so this lazy property reads them back once.
+        return _group_sizes_tensor(self.group_end_offsets).tolist()
+
+    @cached_property
+    def ks_tensor(self) -> torch.Tensor:
+        return _group_sizes_tensor(self.group_end_offsets)
 
     @property
     def total_tokens(self) -> int:
         return sum(self.group_sizes)
 
     def groups_are_block_aligned(self, block_size: int) -> bool:
-        return all(group_size % block_size == 0 for group_size in self.group_sizes)
+        if self.groups_block_aligned_by_construction:
+            return True
+        sizes = _group_sizes_tensor(self.group_end_offsets)
+        return bool((sizes % block_size == 0).all().item())
 
     def valid_scale_blocks(self, block_size: int) -> int:
         assert self.groups_are_block_aligned(block_size), (
@@ -70,13 +90,7 @@ def group_sizes_from_offsets(group_end_offsets: torch.Tensor) -> list[int]:
     assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
         "group_end_offsets must be int32"
     )
-    group_sizes = []
-    start = 0
-    for group_idx in range(group_end_offsets.numel()):
-        end = int(group_end_offsets[group_idx].item())
-        group_sizes.append(end - start)
-        start = end
-    return group_sizes
+    return _group_sizes_tensor(group_end_offsets).tolist()
 
 
 def build_deepgemm_grouped_offset_plan(
@@ -85,10 +99,8 @@ def build_deepgemm_grouped_offset_plan(
     original_group_end_offsets: torch.Tensor | None = None,
     padded_group_start_offsets: torch.Tensor | None = None,
     num_rows: int | None = None,
+    groups_block_aligned_by_construction: bool = False,
 ) -> DeepGemmGroupedOffsetPlan:
-    group_sizes = group_sizes_from_offsets(group_end_offsets)
-    original_group_sizes = None
-    padded_group_starts = None
     if original_group_end_offsets is not None:
         assert original_group_end_offsets.dtype == torch.int32, (
             "original_group_end_offsets must be int32"
@@ -102,69 +114,57 @@ def build_deepgemm_grouped_offset_plan(
         assert original_group_end_offsets.numel() == group_end_offsets.numel(), (
             "original and padded group offsets must have the same number of groups"
         )
-        original_group_sizes = group_sizes_from_offsets(original_group_end_offsets)
-        padded_group_starts = padded_group_start_offsets.tolist()
 
     grouped_layout = _build_deepgemm_m_grouped_layout(
-        group_end_offsets.device,
-        group_sizes,
-        original_group_sizes=original_group_sizes,
-        padded_group_starts=padded_group_starts,
+        group_end_offsets,
+        original_group_end_offsets=original_group_end_offsets,
+        padded_group_start_offsets=padded_group_start_offsets,
         num_rows=num_rows,
     )
 
     return DeepGemmGroupedOffsetPlan(
         group_end_offsets=group_end_offsets,
-        group_sizes=group_sizes,
-        ks_tensor=torch.tensor(
-            group_sizes,
-            dtype=torch.int32,
-            device=group_end_offsets.device,
-        ),
         grouped_layout=grouped_layout,
-        original_group_sizes=original_group_sizes,
-        padded_group_start_offsets=padded_group_start_offsets,
+        groups_block_aligned_by_construction=groups_block_aligned_by_construction,
     )
 
 
 def _build_deepgemm_m_grouped_layout(
-    device: torch.device,
-    group_sizes: list[int],
+    group_end_offsets: torch.Tensor,
     *,
-    original_group_sizes: list[int] | None = None,
-    padded_group_starts: list[int] | None = None,
+    original_group_end_offsets: torch.Tensor | None = None,
+    padded_group_start_offsets: torch.Tensor | None = None,
     num_rows: int | None = None,
 ) -> torch.Tensor:
     # DeepGEMM's contiguous M-grouped kernel wants one int32 entry per row:
     # grouped_layout[row] = expert_idx. Padded rows are marked -1 so the kernel
     # skips them instead of routing them to an expert.
-    min_rows = sum(group_sizes)
+    assert group_end_offsets.dtype == torch.int32, "group_end_offsets must be int32"
+    device = group_end_offsets.device
+
+    if original_group_end_offsets is None:
+        total = group_end_offsets[-1]
+        if num_rows is None:
+            num_rows = int(total.item())
+        row_ids = torch.arange(num_rows, dtype=torch.int32, device=device)
+        layout = torch.bucketize(row_ids, group_end_offsets, right=True).to(torch.int32)
+        layout[row_ids >= total] = -1
+        return layout.contiguous()
+
+    assert padded_group_start_offsets is not None, (
+        "padded_group_start_offsets must be provided with original_group_end_offsets"
+    )
+    original_sizes = _group_sizes_tensor(original_group_end_offsets)
+    padded_valid_ends = padded_group_start_offsets + original_sizes
     if num_rows is None:
-        num_rows = min_rows
-    assert num_rows >= min_rows, "grouped layout must cover all padded groups"
-    grouped_layout = torch.full(
-        (num_rows,),
-        -1,
-        dtype=torch.int32,
-        device=device,
-    )
-
-    if original_group_sizes is None:
-        start = 0
-        for group_idx, group_size in enumerate(group_sizes):
-            end = start + group_size
-            grouped_layout[start:end] = group_idx
-            start = end
-        return grouped_layout.contiguous()
-
-    assert padded_group_starts is not None, (
-        "padded_group_starts must be provided with original_group_sizes"
-    )
-    for group_idx, (group_size, padded_start) in enumerate(
-        zip(original_group_sizes, padded_group_starts)
-    ):
-        grouped_layout[padded_start : padded_start + group_size] = group_idx
-    return grouped_layout.contiguous()
+        num_rows = int(group_end_offsets[-1].item())
+    row_ids = torch.arange(num_rows, dtype=torch.int32, device=device)
+    expert = torch.bucketize(row_ids, padded_group_start_offsets, right=True) - 1
+    expert_clamped = expert.clamp(min=0)
+    valid = (expert >= 0) & (row_ids < padded_valid_ends[expert_clamped])
+    layout = expert_clamped.to(torch.int32)
+    layout[~valid] = -1
+    return layout.contiguous()
 
 
 def build_deepgemm_k_grouped_quant_metadata(

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_metadata.py
@@ -21,6 +21,16 @@ def _group_sizes_tensor(group_end_offsets: torch.Tensor) -> torch.Tensor:
 
 @dataclass(frozen=True)
 class DeepGemmKGroupedQuantMetadata:
+    """Launch metadata for DeepGEMM K-grouped activation quantization.
+
+    Args:
+        dim: Logical feature dimension of the activation being quantized.
+        group_sizes: Host-side token count for each expert group.
+        q_offset_by_block: Per-token-block base offset into DeepGEMM's flat
+            per-expert ``(dim, expert_tokens)`` output buffer.
+        group_size_by_block: Token count for the expert owning each token block.
+    """
+
     dim: int
     group_sizes: list[int]
     q_offset_by_block: torch.Tensor
@@ -37,6 +47,17 @@ class DeepGemmKGroupedQuantMetadata:
 
 @dataclass(frozen=True)
 class DeepGemmGroupedOffsetPlan:
+    """Offset metadata shared by DeepGEMM grouped GEMM calls.
+
+    Args:
+        group_end_offsets: Cumulative end offsets for the padded expert groups.
+        grouped_layout: Int32 row-to-expert mapping consumed by DeepGEMM's
+            M-grouped kernel. Padding rows are marked as ``-1``.
+        groups_block_aligned_by_construction: True when the caller has already
+            padded every expert group to the block size, so alignment checks can
+            skip a device-to-host reduction.
+    """
+
     group_end_offsets: torch.Tensor
     grouped_layout: torch.Tensor
     groups_block_aligned_by_construction: bool = False
@@ -87,6 +108,8 @@ class DeepGemmGroupedOffsetPlan:
 
 
 def group_sizes_from_offsets(group_end_offsets: torch.Tensor) -> list[int]:
+    """Convert cumulative int32 group end offsets to host-side group sizes."""
+
     assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
         "group_end_offsets must be int32"
     )
@@ -101,6 +124,16 @@ def build_deepgemm_grouped_offset_plan(
     num_rows: int | None = None,
     groups_block_aligned_by_construction: bool = False,
 ) -> DeepGemmGroupedOffsetPlan:
+    """Build the row layout and offsets required by DeepGEMM grouped kernels.
+
+    ``group_end_offsets`` describes the padded groups passed to grouped GEMM.
+    When padding was applied, ``original_group_end_offsets`` and
+    ``padded_group_start_offsets`` identify the live token ranges inside each
+    padded group so ``grouped_layout`` can route only real rows and mark padding
+    rows as ``-1``. ``num_rows`` controls the layout length; if omitted, the
+    last padded offset is used.
+    """
+
     if original_group_end_offsets is not None:
         assert original_group_end_offsets.dtype == torch.int32, (
             "original_group_end_offsets must be int32"
@@ -136,9 +169,10 @@ def _build_deepgemm_m_grouped_layout(
     padded_group_start_offsets: torch.Tensor | None = None,
     num_rows: int | None = None,
 ) -> torch.Tensor:
-    # DeepGEMM's contiguous M-grouped kernel wants one int32 entry per row:
-    # grouped_layout[row] = expert_idx. Padded rows are marked -1 so the kernel
-    # skips them instead of routing them to an expert.
+    """Build DeepGEMM's per-row expert map for M-grouped GEMM."""
+
+    # Padded rows are marked -1 so the kernel skips them instead of routing
+    # them to an expert.
     assert group_end_offsets.dtype == torch.int32, "group_end_offsets must be int32"
     device = group_end_offsets.device
 
@@ -173,6 +207,13 @@ def build_deepgemm_k_grouped_quant_metadata(
     block_size: int,
     dim: int,
 ) -> DeepGemmKGroupedQuantMetadata:
+    """Build dense per-block metadata for compact K-grouped quantization.
+
+    DeepGEMM's K-grouped wgrad operands concatenate each expert as a flat
+    ``(dim, expert_tokens)`` slice. This helper maps each valid token block to
+    the base offset and expert size needed by the compact Triton quantizer.
+    """
+
     q_offset_by_block = []
     group_size_by_block = []
     group_start = 0

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
@@ -15,6 +15,8 @@ from torchao.float8.config import e4m3_dtype
 from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
     DeepGemmKGroupedQuantMetadata,
     build_deepgemm_k_grouped_quant_metadata,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
     group_sizes_from_offsets as _group_sizes_from_offsets,
 )
 from torchao.prototype.blockwise_fp8_training.kernels import (
@@ -251,10 +253,9 @@ def triton_fp8_blockwise_act_quant_k_grouped_deepgemm_kernel(
     offs_d = pid_d * NUM_GROUPS + tl.arange(0, NUM_GROUPS)
     valid_group_block = pid_group_block * BLOCK_SIZE < group_size
 
-    x_offsets = (
-        (group_start + offs_m[:, None]) * x_stride_m
-        + offs_d[None, :] * x_stride_d
-    )
+    x_offsets = (group_start + offs_m[:, None]) * x_stride_m + offs_d[
+        None, :
+    ] * x_stride_d
     # Group sizes are asserted to be multiples of BLOCK_SIZE before launch.
     # Within a valid group block every row is live, so only mask off invalid
     # blocks from shorter experts and the tail of the D dimension.
@@ -263,9 +264,7 @@ def triton_fp8_blockwise_act_quant_k_grouped_deepgemm_kernel(
 
     # Compute one 1x128 scale per logical column over this expert's token
     # block, matching the existing transposed-LHS/RHS wgrad quantizers.
-    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(
-        tl.float64
-    )
+    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(tl.float64)
     scale = (FP8_MAX / amax).to(tl.float32)
     y = x * scale
     y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)
@@ -314,9 +313,7 @@ def triton_fp8_blockwise_act_quant_k_grouped_compact_deepgemm_kernel(
     x_offsets = (pid_block * BLOCK_SIZE + offs_m[:, None]) * D + offs_d[None, :]
     x = tl.load(x_ptr + x_offsets)
 
-    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(
-        tl.float64
-    )
+    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(tl.float64)
     scale = (FP8_MAX / amax).to(tl.float32)
     y = x * scale
     y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
@@ -27,7 +27,6 @@ from torchao.prototype.blockwise_fp8_training.kernels import (
     quant_kernel_configs,
     quant_kernel_configs_with_groups,
 )
-from torchao.utils import ceil_div
 
 
 def _should_use_traceable_triton_launch() -> bool:
@@ -276,7 +275,7 @@ def triton_fp8_blockwise_act_quant_k_grouped_deepgemm_kernel(
     # shaped as (D, group_size): q[group_start * D + d * group_size + local_m].
     q_offsets = group_start * D + offs_d[:, None] * group_size + offs_m[None, :]
     q_mask = valid_group_block & (offs_d[:, None] < D)
-    tl.store(q_ptr + q_offsets, y.trans(1, 0), mask=q_mask & valid_group_block)
+    tl.store(q_ptr + q_offsets, y.trans(1, 0), mask=q_mask)
 
     # Scales are concatenated along token-blocks in the same expert order:
     # (D, total_valid_token_blocks).
@@ -324,6 +323,8 @@ def triton_fp8_blockwise_act_quant_k_grouped_compact_deepgemm_kernel(
     # (D, expert_tokens) output. Precomputing it keeps this compact kernel
     # metadata-driven without paying a group_start * D multiply in every tile.
     q_offsets = q_offset + offs_d[:, None] * group_size + offs_m[None, :]
+    # The compact path only launches when D % 128 == 0; every NUM_GROUPS value
+    # divides 128, so offs_d never runs past D and these stores need no D mask.
     tl.store(q_ptr + q_offsets, y.trans(1, 0))
 
     s_offsets = offs_d * VALID_BLOCKS + pid_block
@@ -347,6 +348,9 @@ def triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
     a flat K-major DeepGEMM buffer: for each expert, data is stored as
     (D, expert_tokens), then concatenated with the next expert. Scales are
     stored as (D, total_valid_token_blocks).
+
+    The fake implementation treats the number of valid tokens as dynamic
+    because it cannot read ``group_end_offsets`` values from FakeTensors.
     """
     group_sizes = _group_sizes_from_offsets(group_end_offsets)
     return _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes(
@@ -464,10 +468,20 @@ def _(
     block_size: int = 128,
     dtype: torch.dtype = e4m3_dtype,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ctx = torch.library.get_ctx()
+    max_valid_tokens = x.shape[0] if type(x.shape[0]) is int else None
+    valid_tokens = (
+        ctx.new_dynamic_size(min=0, max=max_valid_tokens)
+        if max_valid_tokens is not None
+        else ctx.new_dynamic_size(min=0)
+    )
+    torch._check(valid_tokens <= x.shape[0])
+    torch._check(valid_tokens % block_size == 0)
+    valid_blocks = valid_tokens // block_size
     return (
-        torch.empty((x.shape[0] * x.shape[1],), dtype=dtype, device=x.device),
+        torch.empty((valid_tokens * x.shape[1],), dtype=dtype, device=x.device),
         torch.empty(
-            (x.shape[1], ceil_div(x.shape[0], block_size)),
+            (x.shape[1], valid_blocks),
             dtype=torch.float32,
             device=x.device,
         ),

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import Tuple
 
 import torch
@@ -29,7 +31,7 @@ from torchao.utils import ceil_div
 
 
 def _should_use_traceable_triton_launch() -> bool:
-    return torch.compiler.is_compiling() or torch._dynamo.is_compiling()
+    return torch.compiler.is_compiling()
 
 
 def _triton_launcher(kernel, traceable: bool):

--- a/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
+++ b/torchao/prototype/blockwise_fp8_training/deepgemm_quant.py
@@ -1,0 +1,475 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch.library import triton_op, wrap_triton
+
+from torchao.float8.config import e4m3_dtype
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    DeepGemmKGroupedQuantMetadata,
+    build_deepgemm_k_grouped_quant_metadata,
+    group_sizes_from_offsets as _group_sizes_from_offsets,
+)
+from torchao.prototype.blockwise_fp8_training.kernels import (
+    EPS,
+    FP8_E4M3_DTYPES,
+    quant_kernel_configs,
+    quant_kernel_configs_with_groups,
+)
+from torchao.utils import ceil_div
+
+
+def _should_use_traceable_triton_launch() -> bool:
+    return torch.compiler.is_compiling() or torch._dynamo.is_compiling()
+
+
+def _triton_launcher(kernel, traceable: bool):
+    return wrap_triton(kernel) if traceable else kernel
+
+
+@triton.autotune(configs=quant_kernel_configs, key=["M", "K"])
+@triton.jit
+def triton_fp8_blockwise_weight_quant_flat_fwd_deepgemm_kernel(
+    x_ptr,
+    q_ptr,
+    s_ptr,
+    M: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    EPS: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_m_block = tl.program_id(axis=0)
+    pid_k_block = tl.program_id(axis=1)
+
+    offs_m = pid_m_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_k = pid_k_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    # Forward receives TorchAO's saved weight_t as (E, K, N), but DeepGEMM
+    # consumes RHS as (E, N, K). The Python wrapper exposes a contiguous
+    # (E*N, K) view, so this kernel is just a dense row-major 128x128 cast.
+    # N is block-aligned, which keeps every row block inside one expert.
+    x_offsets = offs_m[:, None] * K + offs_k[None, :]
+    x = tl.load(x_ptr + x_offsets).to(tl.float32)
+
+    amax = tl.clamp(tl.max(tl.abs(x)), min=EPS, max=float("inf")).to(tl.float64)
+    scale = (FP8_MAX / amax).to(tl.float32)
+    y = x * scale
+    y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)
+
+    tl.store(q_ptr + x_offsets, y)
+    tl.store(
+        s_ptr + pid_m_block * (K // BLOCK_SIZE) + pid_k_block,
+        tl.div_rn(1.0, scale),
+    )
+
+
+@triton.autotune(configs=quant_kernel_configs, key=["N", "K"])
+@triton.jit
+def triton_fp8_blockwise_weight_quant_flat_dgrad_deepgemm_kernel(
+    x_ptr,
+    q_ptr,
+    s_ptr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    EPS: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_en_block = tl.program_id(axis=0)
+    pid_k_block = tl.program_id(axis=1)
+
+    n_blocks = N // BLOCK_SIZE
+    k_blocks = K // BLOCK_SIZE
+    expert_idx = pid_en_block // n_blocks
+    pid_n_block = pid_en_block - expert_idx * n_blocks
+
+    offs_n = pid_n_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_k = pid_k_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_m = pid_en_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    # dgrad needs DeepGEMM RHS as (E, K, N). We still read the contiguous
+    # forward weight view as (E*N, K), then transpose each 128x128 quant tile
+    # into DeepGEMM's row-major (K, N) expert slice.
+    x_offsets = offs_m[:, None] * K + offs_k[None, :]
+    x = tl.load(x_ptr + x_offsets).to(tl.float32)
+
+    amax = tl.clamp(tl.max(tl.abs(x)), min=EPS, max=float("inf")).to(tl.float64)
+    scale = (FP8_MAX / amax).to(tl.float32)
+    y = x * scale
+    y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)
+
+    q_offsets = expert_idx * K * N + offs_k[:, None] * N + offs_n[None, :]
+    tl.store(q_ptr + q_offsets, y.trans(1, 0))
+
+    s_offset = expert_idx * k_blocks * n_blocks + pid_k_block * n_blocks + pid_n_block
+    tl.store(s_ptr + s_offset, tl.div_rn(1.0, scale))
+
+
+@triton_op(
+    "torchao::triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm",
+    mutates_args={},
+)
+def triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+    weight_t: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = e4m3_dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize expert weights for DeepGEMM forward grouped GEMM.
+
+    Input is TorchAO's public (E, K, N) transposed expert weight tensor.
+    Output data is DeepGEMM's RHS layout (E, N, K), row-major with contiguous
+    K, and scales are (E, N // 128, K // 128).
+    """
+    assert weight_t.ndim == 3, "weight_t must be 3D"
+    assert dtype in FP8_E4M3_DTYPES, f"dtype must be one of {FP8_E4M3_DTYPES}"
+    E, K, N = weight_t.shape
+    assert K % block_size == 0 and N % block_size == 0, (
+        f"weight_t K and N must be divisible by block_size={block_size}"
+    )
+
+    q_out = torch.empty((E, N, K), dtype=dtype, device=weight_t.device)
+    scale_out = torch.empty(
+        (E, N // block_size, K // block_size),
+        dtype=torch.float32,
+        device=weight_t.device,
+    )
+
+    # `weight_t.transpose(-2, -1)` is a view back to the original row-major
+    # expert weights (E, N, K). Flattening expert and N rows lets the fast
+    # dense 2D cast write DeepGEMM's desired (E, N, K) data and
+    # (E, N_blocks, K_blocks) scales directly, with no layout-copy kernel.
+    weight = weight_t.transpose(-2, -1)
+    assert weight.is_contiguous(), "weight_t must be per-expert column-major"
+    # `triton_op` keeps this eager launch raw while making the wrapped Triton
+    # call visible to torch.compile/export decomposition.
+    wrap_triton(triton_fp8_blockwise_weight_quant_flat_fwd_deepgemm_kernel)[
+        (E * (N // block_size), K // block_size)
+    ](
+        weight.reshape(E * N, K),
+        q_out.reshape(E * N, K),
+        scale_out.reshape(E * (N // block_size), K // block_size),
+        M=E * N,
+        K=K,
+        BLOCK_SIZE=block_size,
+        EPS=EPS,
+        FP8_MAX=torch.finfo(dtype).max,
+    )
+    return q_out, scale_out
+
+
+@triton_op(
+    "torchao::triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm",
+    mutates_args={},
+)
+def triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
+    weight_t: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = e4m3_dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize expert weights for DeepGEMM dgrad grouped GEMM.
+
+    Input is TorchAO's public (E, K, N) transposed expert weight tensor.
+    Output data is DeepGEMM's RHS layout (E, K, N), row-major with contiguous
+    N, and scales are (E, K // 128, N // 128).
+    """
+    assert weight_t.ndim == 3, "weight_t must be 3D"
+    assert dtype in FP8_E4M3_DTYPES, f"dtype must be one of {FP8_E4M3_DTYPES}"
+    E, K, N = weight_t.shape
+    assert K % block_size == 0 and N % block_size == 0, (
+        f"weight_t K and N must be divisible by block_size={block_size}"
+    )
+
+    q_out = torch.empty((E, K, N), dtype=dtype, device=weight_t.device)
+    scale_out = torch.empty(
+        (E, K // block_size, N // block_size),
+        dtype=torch.float32,
+        device=weight_t.device,
+    )
+
+    # Read the same contiguous (E, N, K) forward-weight view used by the fast
+    # forward cast, but store each quantized block transposed into DeepGEMM's
+    # dgrad RHS contract: data (E, K, N), scales (E, K_blocks, N_blocks).
+    weight = weight_t.transpose(-2, -1)
+    assert weight.is_contiguous(), "weight_t must be per-expert column-major"
+    # `triton_op` keeps this eager launch raw while making the wrapped Triton
+    # call visible to torch.compile/export decomposition.
+    wrap_triton(triton_fp8_blockwise_weight_quant_flat_dgrad_deepgemm_kernel)[
+        (E * (N // block_size), K // block_size)
+    ](
+        weight.reshape(E * N, K),
+        q_out,
+        scale_out,
+        N=N,
+        K=K,
+        BLOCK_SIZE=block_size,
+        EPS=EPS,
+        FP8_MAX=torch.finfo(dtype).max,
+    )
+    return q_out, scale_out
+
+
+@triton.autotune(configs=quant_kernel_configs_with_groups, key=["D"])
+@triton.jit
+def triton_fp8_blockwise_act_quant_k_grouped_deepgemm_kernel(
+    x_ptr,
+    x_stride_m,
+    x_stride_d,
+    group_end_offsets_ptr,
+    q_ptr,
+    s_ptr,
+    s_stride_d,
+    s_stride_block,
+    D: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    EPS: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_group = tl.program_id(axis=0)
+    pid_group_block = tl.program_id(axis=1)
+    pid_d = tl.program_id(axis=2)
+
+    group_end = tl.load(group_end_offsets_ptr + pid_group)
+    group_start = tl.load(
+        group_end_offsets_ptr + pid_group - 1,
+        mask=pid_group > 0,
+        other=0,
+    )
+    group_size = group_end - group_start
+
+    offs_m = pid_group_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_d = pid_d * NUM_GROUPS + tl.arange(0, NUM_GROUPS)
+    valid_group_block = pid_group_block * BLOCK_SIZE < group_size
+
+    x_offsets = (
+        (group_start + offs_m[:, None]) * x_stride_m
+        + offs_d[None, :] * x_stride_d
+    )
+    # Group sizes are asserted to be multiples of BLOCK_SIZE before launch.
+    # Within a valid group block every row is live, so only mask off invalid
+    # blocks from shorter experts and the tail of the D dimension.
+    x_mask = valid_group_block & (offs_d[None, :] < D)
+    x = tl.load(x_ptr + x_offsets, mask=x_mask, other=0.0)
+
+    # Compute one 1x128 scale per logical column over this expert's token
+    # block, matching the existing transposed-LHS/RHS wgrad quantizers.
+    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(
+        tl.float64
+    )
+    scale = (FP8_MAX / amax).to(tl.float32)
+    y = x * scale
+    y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)
+
+    # DeepGEMM K-grouped K-major buffers are concatenated per expert. For an
+    # expert with `group_size` tokens and logical dimension D, its flat slice is
+    # shaped as (D, group_size): q[group_start * D + d * group_size + local_m].
+    q_offsets = group_start * D + offs_d[:, None] * group_size + offs_m[None, :]
+    q_mask = valid_group_block & (offs_d[:, None] < D)
+    tl.store(q_ptr + q_offsets, y.trans(1, 0), mask=q_mask & valid_group_block)
+
+    # Scales are concatenated along token-blocks in the same expert order:
+    # (D, total_valid_token_blocks).
+    block_idx = group_start // BLOCK_SIZE + pid_group_block
+    s_offsets = offs_d * s_stride_d + block_idx * s_stride_block
+    s_mask = (offs_d < D) & valid_group_block
+    tl.store(s_ptr + s_offsets, tl.div_rn(1.0, scale), mask=s_mask)
+
+
+@triton.autotune(configs=quant_kernel_configs_with_groups, key=["D"])
+@triton.jit
+def triton_fp8_blockwise_act_quant_k_grouped_compact_deepgemm_kernel(
+    x_ptr,
+    q_offset_by_block_ptr,
+    group_size_by_block_ptr,
+    q_ptr,
+    s_ptr,
+    D: tl.constexpr,
+    VALID_BLOCKS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    EPS: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_block = tl.program_id(axis=0)
+    pid_d = tl.program_id(axis=1)
+
+    q_offset = tl.load(q_offset_by_block_ptr + pid_block)
+    group_size = tl.load(group_size_by_block_ptr + pid_block)
+    offs_m = tl.arange(0, BLOCK_SIZE)
+    offs_d = pid_d * NUM_GROUPS + tl.arange(0, NUM_GROUPS)
+
+    # Dense block metadata keeps the kernel shape independent of expert count
+    # and routing skew: one program per valid token block, no empty expert
+    # blocks, and no source-level specialization for a particular topology.
+    x_offsets = (pid_block * BLOCK_SIZE + offs_m[:, None]) * D + offs_d[None, :]
+    x = tl.load(x_ptr + x_offsets)
+
+    amax = tl.clamp(tl.max(tl.abs(x), axis=0), min=EPS, max=float("inf")).to(
+        tl.float64
+    )
+    scale = (FP8_MAX / amax).to(tl.float32)
+    y = x * scale
+    y = tl.clamp(y, min=-FP8_MAX, max=FP8_MAX).to(q_ptr.dtype.element_ty)
+
+    # `q_offset` is the per-block base in DeepGEMM's flat per-expert
+    # (D, expert_tokens) output. Precomputing it keeps this compact kernel
+    # metadata-driven without paying a group_start * D multiply in every tile.
+    q_offsets = q_offset + offs_d[:, None] * group_size + offs_m[None, :]
+    tl.store(q_ptr + q_offsets, y.trans(1, 0))
+
+    s_offsets = offs_d * VALID_BLOCKS + pid_block
+    tl.store(s_ptr + s_offsets, tl.div_rn(1.0, scale))
+
+
+@torch.library.custom_op(
+    "torchao::triton_fp8_blockwise_act_quant_k_grouped_deepgemm",
+    mutates_args=(),
+)
+def triton_fp8_blockwise_act_quant_k_grouped_deepgemm(
+    x: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = e4m3_dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize activations directly for DeepGEMM K-grouped wgrad.
+
+    Input is logical (M_tokens, D), already padded/grouped by expert. Output is
+    a flat K-major DeepGEMM buffer: for each expert, data is stored as
+    (D, expert_tokens), then concatenated with the next expert. Scales are
+    stored as (D, total_valid_token_blocks).
+    """
+    group_sizes = _group_sizes_from_offsets(group_end_offsets)
+    return _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes(
+        x,
+        group_end_offsets,
+        group_sizes,
+        block_size,
+        dtype,
+    )
+
+
+def _triton_fp8_blockwise_act_quant_k_grouped_deepgemm_with_group_sizes(
+    x: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    group_sizes: list[int],
+    block_size: int = 128,
+    dtype: torch.dtype = e4m3_dtype,
+    traceable: bool | None = None,
+    metadata: DeepGemmKGroupedQuantMetadata | None = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.ndim == 2, "x must be 2D"
+    assert x.is_contiguous(), "x must be contiguous"
+    assert group_end_offsets is not None and group_end_offsets.dtype == torch.int32, (
+        "group_end_offsets must be int32"
+    )
+    assert dtype in FP8_E4M3_DTYPES, f"dtype must be one of {FP8_E4M3_DTYPES}"
+    valid_tokens = sum(group_sizes)
+    assert group_end_offsets.numel() == len(group_sizes), (
+        "group_sizes must have one entry per group"
+    )
+    assert x.shape[0] >= valid_tokens, (
+        f"x has {x.shape[0]} rows but offsets require {valid_tokens}"
+    )
+    assert all(group_size % block_size == 0 for group_size in group_sizes), (
+        "DeepGEMM K-grouped activation quantization requires every group size "
+        f"to be divisible by block_size={block_size}"
+    )
+
+    D = x.shape[1]
+    valid_blocks = valid_tokens // block_size
+    q_out = torch.empty((valid_tokens * D,), dtype=dtype, device=x.device)
+    scale_out = torch.empty((D, valid_blocks), dtype=torch.float32, device=x.device)
+    max_group_blocks = max(group_sizes) // block_size if group_sizes else 0
+    traceable = (
+        _should_use_traceable_triton_launch() if traceable is None else traceable
+    )
+
+    if group_sizes and D % 128 == 0:
+        if metadata is None:
+            metadata = build_deepgemm_k_grouped_quant_metadata(
+                group_end_offsets,
+                group_sizes,
+                block_size,
+                D,
+            )
+        assert metadata.dim == D, (
+            f"DeepGEMM K-grouped metadata was built for dim={metadata.dim}, "
+            f"but input dim is {D}"
+        )
+
+        def compact_grid(meta):
+            return (
+                valid_blocks,
+                triton.cdiv(D, meta["NUM_GROUPS"]),
+            )
+
+        _triton_launcher(
+            triton_fp8_blockwise_act_quant_k_grouped_compact_deepgemm_kernel,
+            traceable=traceable,
+        )[compact_grid](
+            x,
+            metadata.q_offset_by_block,
+            metadata.group_size_by_block,
+            q_out,
+            scale_out,
+            D=D,
+            VALID_BLOCKS=valid_blocks,
+            BLOCK_SIZE=block_size,
+            EPS=EPS,
+            FP8_MAX=torch.finfo(dtype).max,
+        )
+        return q_out, scale_out
+
+    def grid(meta):
+        return (
+            group_end_offsets.numel(),
+            max_group_blocks,
+            triton.cdiv(D, meta["NUM_GROUPS"]),
+        )
+
+    _triton_launcher(
+        triton_fp8_blockwise_act_quant_k_grouped_deepgemm_kernel,
+        traceable=traceable,
+    )[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        group_end_offsets,
+        q_out,
+        scale_out,
+        scale_out.stride(0),
+        scale_out.stride(1),
+        D=D,
+        BLOCK_SIZE=block_size,
+        EPS=EPS,
+        FP8_MAX=torch.finfo(dtype).max,
+    )
+    return q_out, scale_out
+
+
+@triton_fp8_blockwise_act_quant_k_grouped_deepgemm.register_fake
+def _(
+    x: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = e4m3_dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty((x.shape[0] * x.shape[1],), dtype=dtype, device=x.device),
+        torch.empty(
+            (x.shape[1], ceil_div(x.shape[0], block_size)),
+            dtype=torch.float32,
+            device=x.device,
+        ),
+    )

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
@@ -124,7 +124,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         else:
             padded_A = A
 
-        backend_selection = _select_fp8_blockwise_grouped_mm_backend(
+        backend = _select_fp8_blockwise_grouped_mm_backend(
             kernel_preference,
             A,
             out_dtype,
@@ -136,20 +136,18 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             padded_group_start_offsets=padded_group_start_offsets,
             num_rows=padded_A.shape[0],
         )
-        backend_plan = backend_selection.plan
-        deepgemm_offset_plan = backend_selection.deepgemm_offset_plan
 
         A_fp8, A_scale = triton_fp8_blockwise_act_quant_lhs(
             padded_A.contiguous(),
             block_size=block_size,
             dtype=float8_dtype,
         )
-        B_t_fp8, B_t_scale = backend_plan.quantize_forward_rhs(
+        B_t_fp8, B_t_scale = backend.quantize_forward_rhs(
             B_t,
             block_size,
             float8_dtype,
         )
-        out = backend_plan.grouped_mm(
+        out = backend.grouped_mm(
             A_fp8,
             B_t_fp8,
             A_scale,
@@ -159,7 +157,6 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
-            deepgemm_offset_plan=deepgemm_offset_plan,
         )
         if pad_token_groups_for_grouped_mm:
             out = unpad_token_groups(
@@ -182,8 +179,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         ctx.block_size = block_size
         ctx.pad_token_groups_for_grouped_mm = pad_token_groups_for_grouped_mm
         ctx.num_tokens = num_tokens
-        ctx.backend_plan = backend_plan
-        ctx.deepgemm_offset_plan = deepgemm_offset_plan
+        ctx.backend = backend
         return out
 
     @staticmethod
@@ -200,8 +196,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         block_size = ctx.block_size
         pad_token_groups_for_grouped_mm = ctx.pad_token_groups_for_grouped_mm
         num_tokens = ctx.num_tokens
-        backend_plan = ctx.backend_plan
-        deepgemm_offset_plan = ctx.deepgemm_offset_plan
+        backend = ctx.backend
 
         if pad_token_groups_for_grouped_mm:
             padded_grad_output, _, _ = pad_token_groups(
@@ -217,12 +212,12 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             block_size=block_size,
             dtype=float8_dtype,
         )
-        B_fp8, B_scale = backend_plan.quantize_dgrad_rhs(
+        B_fp8, B_scale = backend.quantize_dgrad_rhs(
             B_t,
             block_size,
             float8_dtype,
         )
-        grad_A = backend_plan.grouped_mm(
+        grad_A = backend.grouped_mm(
             grad_output_fp8,
             B_fp8,
             grad_output_scale,
@@ -232,7 +227,6 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
-            deepgemm_offset_plan=deepgemm_offset_plan,
         )
         if pad_token_groups_for_grouped_mm:
             grad_A = unpad_token_groups(
@@ -243,14 +237,13 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
                 alignment_size=block_size,
             )
 
-        grad_B = backend_plan.wgrad(
+        grad_B = backend.wgrad(
             padded_grad_output,
             padded_A,
             padded_group_end_offsets,
             out_dtype,
             block_size,
             float8_dtype,
-            deepgemm_offset_plan=deepgemm_offset_plan,
         )
         return (
             grad_A,

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
@@ -4,25 +4,11 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from enum import Enum
 from typing import Optional
 
 import torch
 
 from torchao.float8.config import e4m3_dtype
-from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
-    can_use_deepgemm_m_grouped,
-    deepgemm_blockwise_scaled_grouped_mm,
-    deepgemm_blockwise_scaled_grouped_mm_wgrad,
-    prepare_deepgemm_wgrad_plan,
-    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
-    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
-)
-from torchao.prototype.blockwise_fp8_training.grouped_kernels import (
-    emulated_blockwise_scaled_grouped_mm,
-    triton_fp8_blockwise_weight_quant_grouped_rhs,
-    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs,
-)
 from torchao.prototype.blockwise_fp8_training.kernels import (
     BLOCKWISE_1X128_SCALING_TYPE,
     BLOCKWISE_128X128_SCALING_TYPE,
@@ -30,8 +16,9 @@ from torchao.prototype.blockwise_fp8_training.kernels import (
     _is_row_major,
     _scaling_type_value,
     triton_fp8_blockwise_act_quant_lhs,
-    triton_fp8_blockwise_act_quant_rhs,
-    triton_fp8_blockwise_act_quant_transposed_lhs,
+)
+from torchao.prototype.moe_training.blockwise_fp8.grouped_mm_backend import (
+    _select_fp8_blockwise_grouped_mm_backend,
 )
 from torchao.prototype.moe_training.utils import (
     conditional_nostrict_trace,
@@ -39,225 +26,6 @@ from torchao.prototype.moe_training.utils import (
     unpad_token_groups,
 )
 from torchao.quantization.quantize_.common import KernelPreference
-
-
-class _GroupedMMBackend(str, Enum):
-    DEEPGEMM = "deepgemm"
-    EMULATED = "emulated"
-
-
-class _GroupedMMBackendPlan:
-    kind: _GroupedMMBackend
-
-    def quantize_forward_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def quantize_dgrad_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError
-
-    def grouped_mm(
-        self,
-        a: torch.Tensor,
-        b: torch.Tensor,
-        a_s: torch.Tensor,
-        scale_recipe_a: int,
-        b_s: torch.Tensor,
-        scale_recipe_b: int,
-        offs: torch.Tensor,
-        out_dtype: torch.dtype,
-        block_size: int,
-        *,
-        original_group_end_offsets: Optional[torch.Tensor] = None,
-        padded_group_start_offsets: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-    def prepare_wgrad_plan(
-        self,
-        padded_grad_output: torch.Tensor,
-        padded_a: torch.Tensor,
-        group_end_offsets: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ):
-        return None
-
-    def wgrad(
-        self,
-        wgrad_plan,
-        group_end_offsets: torch.Tensor,
-        out_dtype: torch.dtype,
-        block_size: int,
-    ) -> torch.Tensor:
-        raise NotImplementedError
-
-
-class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
-    kind = _GroupedMMBackend.EMULATED
-
-    def quantize_forward_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # The emulated backend consumes TorchAO's grouped RHS layout:
-        # (E, K, N) data with (E, K_blocks, N_blocks) scales.
-        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs(
-            B_t,
-            block_size=block_size,
-            dtype=dtype,
-        )
-
-    def quantize_dgrad_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # The emulated backend consumes TorchAO's grouped RHS layout for
-        # grad_output @ weight: (E, N, K) data with
-        # (E, N_blocks, K_blocks) scales.
-        return triton_fp8_blockwise_weight_quant_grouped_rhs(
-            B_t,
-            block_size=block_size,
-            dtype=dtype,
-        )
-
-    def grouped_mm(
-        self,
-        a: torch.Tensor,
-        b: torch.Tensor,
-        a_s: torch.Tensor,
-        scale_recipe_a: int,
-        b_s: torch.Tensor,
-        scale_recipe_b: int,
-        offs: torch.Tensor,
-        out_dtype: torch.dtype,
-        block_size: int,
-        *,
-        original_group_end_offsets: Optional[torch.Tensor] = None,
-        padded_group_start_offsets: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        return emulated_blockwise_scaled_grouped_mm(
-            a,
-            b,
-            a_s,
-            scale_recipe_a,
-            b_s,
-            scale_recipe_b,
-            offs,
-            out_dtype,
-            block_size,
-        )
-
-
-class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
-    kind = _GroupedMMBackend.DEEPGEMM
-
-    def quantize_forward_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # DeepGEMM forward consumes RHS as (E, N, K), with K contiguous and
-        # scales as (E, N_blocks, K_blocks). This quantizer writes that
-        # layout directly, avoiding a dispatch-time transpose/copy.
-        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
-            B_t,
-            block_size=block_size,
-            dtype=dtype,
-        )
-
-    def quantize_dgrad_rhs(
-        self,
-        B_t: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        # DeepGEMM dgrad consumes RHS as (E, K, N), with N contiguous and
-        # scales as (E, K_blocks, N_blocks). This quantizer writes that
-        # layout directly, avoiding a dispatch-time transpose/copy.
-        return triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
-            B_t,
-            block_size=block_size,
-            dtype=dtype,
-        )
-
-    def grouped_mm(
-        self,
-        a: torch.Tensor,
-        b: torch.Tensor,
-        a_s: torch.Tensor,
-        scale_recipe_a: int,
-        b_s: torch.Tensor,
-        scale_recipe_b: int,
-        offs: torch.Tensor,
-        out_dtype: torch.dtype,
-        block_size: int,
-        *,
-        original_group_end_offsets: Optional[torch.Tensor] = None,
-        padded_group_start_offsets: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        return deepgemm_blockwise_scaled_grouped_mm(
-            a,
-            b,
-            a_s,
-            scale_recipe_a,
-            b_s,
-            scale_recipe_b,
-            offs,
-            out_dtype,
-            block_size,
-            original_group_end_offsets=original_group_end_offsets,
-            padded_group_start_offsets=padded_group_start_offsets,
-        )
-
-    def prepare_wgrad_plan(
-        self,
-        padded_grad_output: torch.Tensor,
-        padded_a: torch.Tensor,
-        group_end_offsets: torch.Tensor,
-        block_size: int,
-        dtype: torch.dtype,
-    ):
-        return prepare_deepgemm_wgrad_plan(
-            padded_grad_output,
-            padded_a,
-            group_end_offsets,
-            block_size,
-            dtype,
-        )
-
-    def wgrad(
-        self,
-        wgrad_plan,
-        group_end_offsets: torch.Tensor,
-        out_dtype: torch.dtype,
-        block_size: int,
-    ) -> torch.Tensor:
-        return deepgemm_blockwise_scaled_grouped_mm_wgrad(
-            wgrad_plan.lhs,
-            wgrad_plan.rhs,
-            group_end_offsets,
-            out_dtype,
-            block_size,
-        )
-
-
-_EMULATED_GROUPED_MM_BACKEND_PLAN = _EmulatedGroupedMMBackendPlan()
-_DEEPGEMM_GROUPED_MM_BACKEND_PLAN = _DeepGemmGroupedMMBackendPlan()
 
 
 @conditional_nostrict_trace
@@ -319,56 +87,6 @@ def _to_fp8_blockwise_then_emulated_scaled_grouped_mm(
     )
 
 
-def _select_fp8_blockwise_grouped_mm_backend(
-    kernel_preference: KernelPreference,
-    A: torch.Tensor,
-    out_dtype: torch.dtype,
-    block_size: int,
-) -> _GroupedMMBackendPlan:
-    if kernel_preference == KernelPreference.EMULATED:
-        return _EMULATED_GROUPED_MM_BACKEND_PLAN
-
-    assert kernel_preference == KernelPreference.AUTO, (
-        "kernel_preference must be AUTO or EMULATED"
-    )
-    if can_use_deepgemm_m_grouped(A, out_dtype, block_size):
-        return _DEEPGEMM_GROUPED_MM_BACKEND_PLAN
-    return _EMULATED_GROUPED_MM_BACKEND_PLAN
-
-
-def _emulated_wgrad(
-    padded_grad_output: torch.Tensor,
-    padded_a: torch.Tensor,
-    group_end_offsets: torch.Tensor,
-    out_dtype: torch.dtype,
-    block_size: int,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    grad_output_t_fp8, grad_output_t_scale = (
-        triton_fp8_blockwise_act_quant_transposed_lhs(
-            padded_grad_output.contiguous(),
-            block_size=block_size,
-            dtype=dtype,
-        )
-    )
-    A_rhs_fp8, A_rhs_scale = triton_fp8_blockwise_act_quant_rhs(
-        padded_a.contiguous(),
-        block_size=block_size,
-        dtype=dtype,
-    )
-    return emulated_blockwise_scaled_grouped_mm(
-        grad_output_t_fp8,
-        A_rhs_fp8,
-        grad_output_t_scale,
-        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
-        A_rhs_scale,
-        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
-        group_end_offsets,
-        out_dtype,
-        block_size,
-    )
-
-
 class _Float8BlockwiseGroupedMM(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -396,12 +114,6 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         assert _is_row_major(A), "A must be row-major"
         assert _is_column_major(B_t), "B_t must be per-expert column-major"
 
-        backend_plan = _select_fp8_blockwise_grouped_mm_backend(
-            kernel_preference,
-            A,
-            out_dtype,
-            block_size,
-        )
         num_tokens = A.shape[0]
         padded_group_start_offsets = None
         padded_group_end_offsets = offs
@@ -411,6 +123,21 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             )
         else:
             padded_A = A
+
+        backend_selection = _select_fp8_blockwise_grouped_mm_backend(
+            kernel_preference,
+            A,
+            out_dtype,
+            block_size,
+            padded_group_end_offsets,
+            original_group_end_offsets=offs
+            if pad_token_groups_for_grouped_mm
+            else None,
+            padded_group_start_offsets=padded_group_start_offsets,
+            num_rows=padded_A.shape[0],
+        )
+        backend_plan = backend_selection.plan
+        deepgemm_offset_plan = backend_selection.deepgemm_offset_plan
 
         A_fp8, A_scale = triton_fp8_blockwise_act_quant_lhs(
             padded_A.contiguous(),
@@ -432,10 +159,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
-            original_group_end_offsets=offs
-            if pad_token_groups_for_grouped_mm
-            else None,
-            padded_group_start_offsets=padded_group_start_offsets,
+            deepgemm_offset_plan=deepgemm_offset_plan,
         )
         if pad_token_groups_for_grouped_mm:
             out = unpad_token_groups(
@@ -459,6 +183,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         ctx.pad_token_groups_for_grouped_mm = pad_token_groups_for_grouped_mm
         ctx.num_tokens = num_tokens
         ctx.backend_plan = backend_plan
+        ctx.deepgemm_offset_plan = deepgemm_offset_plan
         return out
 
     @staticmethod
@@ -476,6 +201,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
         pad_token_groups_for_grouped_mm = ctx.pad_token_groups_for_grouped_mm
         num_tokens = ctx.num_tokens
         backend_plan = ctx.backend_plan
+        deepgemm_offset_plan = ctx.deepgemm_offset_plan
 
         if pad_token_groups_for_grouped_mm:
             padded_grad_output, _, _ = pad_token_groups(
@@ -506,10 +232,7 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
-            original_group_end_offsets=original_group_end_offsets
-            if pad_token_groups_for_grouped_mm
-            else None,
-            padded_group_start_offsets=padded_group_start_offsets,
+            deepgemm_offset_plan=deepgemm_offset_plan,
         )
         if pad_token_groups_for_grouped_mm:
             grad_A = unpad_token_groups(
@@ -520,30 +243,15 @@ class _Float8BlockwiseGroupedMM(torch.autograd.Function):
                 alignment_size=block_size,
             )
 
-        wgrad_plan = backend_plan.prepare_wgrad_plan(
+        grad_B = backend_plan.wgrad(
             padded_grad_output,
             padded_A,
             padded_group_end_offsets,
+            out_dtype,
             block_size,
             float8_dtype,
+            deepgemm_offset_plan=deepgemm_offset_plan,
         )
-
-        if wgrad_plan is None:
-            grad_B = _emulated_wgrad(
-                padded_grad_output,
-                padded_A,
-                padded_group_end_offsets,
-                out_dtype,
-                block_size,
-                float8_dtype,
-            )
-        else:
-            grad_B = backend_plan.wgrad(
-                wgrad_plan,
-                padded_group_end_offsets,
-                out_dtype,
-                block_size,
-            )
         return (
             grad_A,
             grad_B.transpose(-2, -1),

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
@@ -4,11 +4,20 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+from enum import Enum
 from typing import Optional
 
 import torch
 
 from torchao.float8.config import e4m3_dtype
+from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+    can_use_deepgemm_m_grouped,
+    deepgemm_blockwise_scaled_grouped_mm,
+    deepgemm_blockwise_scaled_grouped_mm_wgrad,
+    prepare_deepgemm_wgrad_plan,
+    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+)
 from torchao.prototype.blockwise_fp8_training.grouped_kernels import (
     emulated_blockwise_scaled_grouped_mm,
     triton_fp8_blockwise_weight_quant_grouped_rhs,
@@ -29,6 +38,260 @@ from torchao.prototype.moe_training.utils import (
     pad_token_groups,
     unpad_token_groups,
 )
+from torchao.quantization.quantize_.common import KernelPreference
+
+
+class _GroupedMMBackend(str, Enum):
+    DEEPGEMM = "deepgemm"
+    EMULATED = "emulated"
+
+
+class _GroupedMMBackendPlan:
+    kind: _GroupedMMBackend
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        original_group_end_offsets: Optional[torch.Tensor] = None,
+        padded_group_start_offsets: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    def prepare_wgrad_plan(
+        self,
+        padded_grad_output: torch.Tensor,
+        padded_a: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ):
+        return None
+
+    def wgrad(
+        self,
+        wgrad_plan,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
+    kind = _GroupedMMBackend.EMULATED
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The emulated backend consumes TorchAO's grouped RHS layout:
+        # (E, K, N) data with (E, K_blocks, N_blocks) scales.
+        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The emulated backend consumes TorchAO's grouped RHS layout for
+        # grad_output @ weight: (E, N, K) data with
+        # (E, N_blocks, K_blocks) scales.
+        return triton_fp8_blockwise_weight_quant_grouped_rhs(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        original_group_end_offsets: Optional[torch.Tensor] = None,
+        padded_group_start_offsets: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return emulated_blockwise_scaled_grouped_mm(
+            a,
+            b,
+            a_s,
+            scale_recipe_a,
+            b_s,
+            scale_recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+        )
+
+
+class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
+    kind = _GroupedMMBackend.DEEPGEMM
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # DeepGEMM forward consumes RHS as (E, N, K), with K contiguous and
+        # scales as (E, N_blocks, K_blocks). This quantizer writes that
+        # layout directly, avoiding a dispatch-time transpose/copy.
+        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # DeepGEMM dgrad consumes RHS as (E, K, N), with N contiguous and
+        # scales as (E, K_blocks, N_blocks). This quantizer writes that
+        # layout directly, avoiding a dispatch-time transpose/copy.
+        return triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        original_group_end_offsets: Optional[torch.Tensor] = None,
+        padded_group_start_offsets: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return deepgemm_blockwise_scaled_grouped_mm(
+            a,
+            b,
+            a_s,
+            scale_recipe_a,
+            b_s,
+            scale_recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+            original_group_end_offsets=original_group_end_offsets,
+            padded_group_start_offsets=padded_group_start_offsets,
+        )
+
+    def prepare_wgrad_plan(
+        self,
+        padded_grad_output: torch.Tensor,
+        padded_a: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ):
+        return prepare_deepgemm_wgrad_plan(
+            padded_grad_output,
+            padded_a,
+            group_end_offsets,
+            block_size,
+            dtype,
+        )
+
+    def wgrad(
+        self,
+        wgrad_plan,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+    ) -> torch.Tensor:
+        return deepgemm_blockwise_scaled_grouped_mm_wgrad(
+            wgrad_plan.lhs,
+            wgrad_plan.rhs,
+            group_end_offsets,
+            out_dtype,
+            block_size,
+        )
+
+
+_EMULATED_GROUPED_MM_BACKEND_PLAN = _EmulatedGroupedMMBackendPlan()
+_DEEPGEMM_GROUPED_MM_BACKEND_PLAN = _DeepGemmGroupedMMBackendPlan()
+
+
+@conditional_nostrict_trace
+def _to_fp8_blockwise_then_scaled_grouped_mm(
+    A: torch.Tensor,
+    B_t: torch.Tensor,
+    offs: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = torch.bfloat16,
+    float8_dtype: torch.dtype = e4m3_dtype,
+    block_size: int = 128,
+    pad_token_groups_for_grouped_mm: bool = True,
+    kernel_preference: KernelPreference = KernelPreference.AUTO,
+) -> torch.Tensor:
+    """
+    Differentiable FP8 blockwise grouped matrix multiplication.
+
+    A has shape (M, K). B_t has shape (E, K, N), transposed and in
+    per-expert column-major layout.
+    """
+    assert block_size == 128, "Only block_size=128 is supported"
+    assert kernel_preference in (
+        KernelPreference.AUTO,
+        KernelPreference.EMULATED,
+    ), "kernel_preference must be AUTO or EMULATED"
+    return _Float8BlockwiseGroupedMM.apply(
+        A,
+        B_t,
+        offs,
+        out_dtype,
+        float8_dtype,
+        block_size,
+        pad_token_groups_for_grouped_mm,
+        kernel_preference,
+    )
 
 
 @conditional_nostrict_trace
@@ -43,12 +306,8 @@ def _to_fp8_blockwise_then_emulated_scaled_grouped_mm(
 ) -> torch.Tensor:
     """
     Differentiable FP8 blockwise grouped matrix multiplication using an emulated GEMM.
-
-    A has shape (M, K). B_t has shape (E, K, N), transposed and in
-    per-expert column-major layout.
     """
-    assert block_size == 128, "Only block_size=128 is supported"
-    return _Float8BlockwiseEmulatedGroupedMM.apply(
+    return _to_fp8_blockwise_then_scaled_grouped_mm(
         A,
         B_t,
         offs,
@@ -56,10 +315,61 @@ def _to_fp8_blockwise_then_emulated_scaled_grouped_mm(
         float8_dtype,
         block_size,
         pad_token_groups_for_grouped_mm,
+        KernelPreference.EMULATED,
     )
 
 
-class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
+def _select_fp8_blockwise_grouped_mm_backend(
+    kernel_preference: KernelPreference,
+    A: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int,
+) -> _GroupedMMBackendPlan:
+    if kernel_preference == KernelPreference.EMULATED:
+        return _EMULATED_GROUPED_MM_BACKEND_PLAN
+
+    assert kernel_preference == KernelPreference.AUTO, (
+        "kernel_preference must be AUTO or EMULATED"
+    )
+    if can_use_deepgemm_m_grouped(A, out_dtype, block_size):
+        return _DEEPGEMM_GROUPED_MM_BACKEND_PLAN
+    return _EMULATED_GROUPED_MM_BACKEND_PLAN
+
+
+def _emulated_wgrad(
+    padded_grad_output: torch.Tensor,
+    padded_a: torch.Tensor,
+    group_end_offsets: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    grad_output_t_fp8, grad_output_t_scale = (
+        triton_fp8_blockwise_act_quant_transposed_lhs(
+            padded_grad_output.contiguous(),
+            block_size=block_size,
+            dtype=dtype,
+        )
+    )
+    A_rhs_fp8, A_rhs_scale = triton_fp8_blockwise_act_quant_rhs(
+        padded_a.contiguous(),
+        block_size=block_size,
+        dtype=dtype,
+    )
+    return emulated_blockwise_scaled_grouped_mm(
+        grad_output_t_fp8,
+        A_rhs_fp8,
+        grad_output_t_scale,
+        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+        A_rhs_scale,
+        _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+        group_end_offsets,
+        out_dtype,
+        block_size,
+    )
+
+
+class _Float8BlockwiseGroupedMM(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
@@ -70,6 +380,7 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
         float8_dtype: torch.dtype = e4m3_dtype,
         block_size: int = 128,
         pad_token_groups_for_grouped_mm: bool = True,
+        kernel_preference: KernelPreference = KernelPreference.AUTO,
     ) -> torch.Tensor:
         assert A.ndim == 2, "A must be 2D"
         assert B_t.ndim == 3, "B_t must be 3D"
@@ -85,6 +396,12 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
         assert _is_row_major(A), "A must be row-major"
         assert _is_column_major(B_t), "B_t must be per-expert column-major"
 
+        backend_plan = _select_fp8_blockwise_grouped_mm_backend(
+            kernel_preference,
+            A,
+            out_dtype,
+            block_size,
+        )
         num_tokens = A.shape[0]
         padded_group_start_offsets = None
         padded_group_end_offsets = offs
@@ -100,12 +417,12 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
             block_size=block_size,
             dtype=float8_dtype,
         )
-        B_t_fp8, B_t_scale = triton_fp8_blockwise_weight_quant_grouped_transposed_rhs(
+        B_t_fp8, B_t_scale = backend_plan.quantize_forward_rhs(
             B_t,
-            block_size=block_size,
-            dtype=float8_dtype,
+            block_size,
+            float8_dtype,
         )
-        out = emulated_blockwise_scaled_grouped_mm(
+        out = backend_plan.grouped_mm(
             A_fp8,
             B_t_fp8,
             A_scale,
@@ -115,6 +432,10 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
+            original_group_end_offsets=offs
+            if pad_token_groups_for_grouped_mm
+            else None,
+            padded_group_start_offsets=padded_group_start_offsets,
         )
         if pad_token_groups_for_grouped_mm:
             out = unpad_token_groups(
@@ -137,6 +458,7 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
         ctx.block_size = block_size
         ctx.pad_token_groups_for_grouped_mm = pad_token_groups_for_grouped_mm
         ctx.num_tokens = num_tokens
+        ctx.backend_plan = backend_plan
         return out
 
     @staticmethod
@@ -153,6 +475,7 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
         block_size = ctx.block_size
         pad_token_groups_for_grouped_mm = ctx.pad_token_groups_for_grouped_mm
         num_tokens = ctx.num_tokens
+        backend_plan = ctx.backend_plan
 
         if pad_token_groups_for_grouped_mm:
             padded_grad_output, _, _ = pad_token_groups(
@@ -168,12 +491,12 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
             block_size=block_size,
             dtype=float8_dtype,
         )
-        B_fp8, B_scale = triton_fp8_blockwise_weight_quant_grouped_rhs(
+        B_fp8, B_scale = backend_plan.quantize_dgrad_rhs(
             B_t,
-            block_size=block_size,
-            dtype=float8_dtype,
+            block_size,
+            float8_dtype,
         )
-        grad_A = emulated_blockwise_scaled_grouped_mm(
+        grad_A = backend_plan.grouped_mm(
             grad_output_fp8,
             B_fp8,
             grad_output_scale,
@@ -183,6 +506,10 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
             padded_group_end_offsets,
             out_dtype,
             block_size,
+            original_group_end_offsets=original_group_end_offsets
+            if pad_token_groups_for_grouped_mm
+            else None,
+            padded_group_start_offsets=padded_group_start_offsets,
         )
         if pad_token_groups_for_grouped_mm:
             grad_A = unpad_token_groups(
@@ -193,32 +520,34 @@ class _Float8BlockwiseEmulatedGroupedMM(torch.autograd.Function):
                 alignment_size=block_size,
             )
 
-        grad_output_t_fp8, grad_output_t_scale = (
-            triton_fp8_blockwise_act_quant_transposed_lhs(
-                padded_grad_output.contiguous(),
-                block_size=block_size,
-                dtype=float8_dtype,
-            )
-        )
-        A_rhs_fp8, A_rhs_scale = triton_fp8_blockwise_act_quant_rhs(
-            padded_A.contiguous(),
-            block_size=block_size,
-            dtype=float8_dtype,
-        )
-        grad_B = emulated_blockwise_scaled_grouped_mm(
-            grad_output_t_fp8,
-            A_rhs_fp8,
-            grad_output_t_scale,
-            _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
-            A_rhs_scale,
-            _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+        wgrad_plan = backend_plan.prepare_wgrad_plan(
+            padded_grad_output,
+            padded_A,
             padded_group_end_offsets,
-            out_dtype,
             block_size,
+            float8_dtype,
         )
+
+        if wgrad_plan is None:
+            grad_B = _emulated_wgrad(
+                padded_grad_output,
+                padded_A,
+                padded_group_end_offsets,
+                out_dtype,
+                block_size,
+                float8_dtype,
+            )
+        else:
+            grad_B = backend_plan.wgrad(
+                wgrad_plan,
+                padded_group_end_offsets,
+                out_dtype,
+                block_size,
+            )
         return (
             grad_A,
             grad_B.transpose(-2, -1),
+            None,
             None,
             None,
             None,

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
@@ -318,11 +318,13 @@ def _select_fp8_blockwise_grouped_mm_backend(
             deepgemm_offset_plan=None,
         )
 
+    groups_block_aligned_by_construction = original_group_end_offsets is not None
     deepgemm_offset_plan = build_deepgemm_grouped_offset_plan(
         group_end_offsets,
         original_group_end_offsets=original_group_end_offsets,
         padded_group_start_offsets=padded_group_start_offsets,
         num_rows=num_rows,
+        groups_block_aligned_by_construction=groups_block_aligned_by_construction,
     )
     if not deepgemm_offset_plan.groups_are_block_aligned(block_size):
         return _GroupedMMBackendSelection(

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
@@ -38,19 +38,17 @@ from torchao.prototype.blockwise_fp8_training.kernels import (
 from torchao.quantization.quantize_.common import KernelPreference
 
 
-class _GroupedMMBackend(str, Enum):
+class _GroupedMMBackendKind(str, Enum):
+    """Grouped GEMM backend selected for the FP8 MoE training op."""
+
     DEEPGEMM = "deepgemm"
     EMULATED = "emulated"
 
 
-@dataclass(frozen=True)
-class _GroupedMMBackendSelection:
-    plan: "_GroupedMMBackendPlan"
-    deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None
+class _GroupedMMBackend:
+    """Backend-specific quantization and grouped GEMM implementation."""
 
-
-class _GroupedMMBackendPlan:
-    kind: _GroupedMMBackend
+    kind: _GroupedMMBackendKind
 
     def quantize_forward_rhs(
         self,
@@ -79,8 +77,6 @@ class _GroupedMMBackendPlan:
         offs: torch.Tensor,
         out_dtype: torch.dtype,
         block_size: int,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
         raise NotImplementedError
 
@@ -92,14 +88,14 @@ class _GroupedMMBackendPlan:
         out_dtype: torch.dtype,
         block_size: int,
         dtype: torch.dtype,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
         raise NotImplementedError
 
 
-class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
-    kind = _GroupedMMBackend.EMULATED
+class _EmulatedGroupedMMBackend(_GroupedMMBackend):
+    """TorchAO emulated backend that preserves the original grouped_mm path."""
+
+    kind = _GroupedMMBackendKind.EMULATED
 
     def quantize_forward_rhs(
         self,
@@ -141,8 +137,6 @@ class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
         offs: torch.Tensor,
         out_dtype: torch.dtype,
         block_size: int,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
         return emulated_blockwise_scaled_grouped_mm(
             a,
@@ -164,8 +158,6 @@ class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
         out_dtype: torch.dtype,
         block_size: int,
         dtype: torch.dtype,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
         grad_output_t_fp8, grad_output_t_scale = (
             triton_fp8_blockwise_act_quant_transposed_lhs(
@@ -192,8 +184,12 @@ class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
         )
 
 
-class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
-    kind = _GroupedMMBackend.DEEPGEMM
+@dataclass(frozen=True)
+class _DeepGemmGroupedMMBackend(_GroupedMMBackend):
+    """DeepGEMM backend plus the offset metadata shared by its kernels."""
+
+    kind = _GroupedMMBackendKind.DEEPGEMM
+    offset_plan: DeepGemmGroupedOffsetPlan
 
     def quantize_forward_rhs(
         self,
@@ -236,12 +232,7 @@ class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
         offs: torch.Tensor,
         out_dtype: torch.dtype,
         block_size: int,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
-        assert deepgemm_offset_plan is not None, (
-            "DeepGEMM backend requires grouped offset metadata"
-        )
         return deepgemm_blockwise_scaled_grouped_mm(
             a,
             b,
@@ -252,7 +243,7 @@ class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
             offs,
             out_dtype,
             block_size,
-            offset_plan=deepgemm_offset_plan,
+            offset_plan=self.offset_plan,
         )
 
     def wgrad(
@@ -263,16 +254,11 @@ class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
         out_dtype: torch.dtype,
         block_size: int,
         dtype: torch.dtype,
-        *,
-        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
     ) -> torch.Tensor:
-        assert deepgemm_offset_plan is not None, (
-            "DeepGEMM backend requires grouped offset metadata"
-        )
         wgrad_plan = prepare_deepgemm_wgrad_plan(
             padded_grad_output,
             padded_a,
-            deepgemm_offset_plan,
+            self.offset_plan,
             block_size,
             dtype,
         )
@@ -282,14 +268,13 @@ class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
         return deepgemm_blockwise_scaled_grouped_mm_wgrad(
             wgrad_plan.lhs,
             wgrad_plan.rhs,
-            deepgemm_offset_plan,
+            self.offset_plan,
             out_dtype,
             block_size,
         )
 
 
-_EMULATED_GROUPED_MM_BACKEND_PLAN = _EmulatedGroupedMMBackendPlan()
-_DEEPGEMM_GROUPED_MM_BACKEND_PLAN = _DeepGemmGroupedMMBackendPlan()
+_EMULATED_GROUPED_MM_BACKEND = _EmulatedGroupedMMBackend()
 
 
 def _select_fp8_blockwise_grouped_mm_backend(
@@ -302,37 +287,36 @@ def _select_fp8_blockwise_grouped_mm_backend(
     original_group_end_offsets: Optional[torch.Tensor] = None,
     padded_group_start_offsets: Optional[torch.Tensor] = None,
     num_rows: Optional[int] = None,
-) -> _GroupedMMBackendSelection:
+) -> _GroupedMMBackend:
+    """Select the grouped GEMM backend for one forward/backward pass.
+
+    ``KernelPreference.EMULATED`` always selects the TorchAO emulated backend.
+    ``KernelPreference.AUTO`` selects DeepGEMM only when the optional dependency
+    exposes both M-grouped and K-grouped training kernels, the input is on
+    CUDA SM90+, ``out_dtype`` is bf16, ``block_size`` is 128, and every expert
+    group is block-aligned. Any unsupported AUTO case falls back to emulated.
+    When DeepGEMM is selected, the returned backend owns the offset/layout plan
+    reused by forward, dgrad, and wgrad.
+    """
+
     if kernel_preference == KernelPreference.EMULATED:
-        return _GroupedMMBackendSelection(
-            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
-            deepgemm_offset_plan=None,
-        )
+        return _EMULATED_GROUPED_MM_BACKEND
 
     assert kernel_preference == KernelPreference.AUTO, (
         "kernel_preference must be AUTO or EMULATED"
     )
     if not can_use_deepgemm_grouped_training(A, out_dtype, block_size):
-        return _GroupedMMBackendSelection(
-            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
-            deepgemm_offset_plan=None,
-        )
+        return _EMULATED_GROUPED_MM_BACKEND
 
     groups_block_aligned_by_construction = original_group_end_offsets is not None
-    deepgemm_offset_plan = build_deepgemm_grouped_offset_plan(
+    offset_plan = build_deepgemm_grouped_offset_plan(
         group_end_offsets,
         original_group_end_offsets=original_group_end_offsets,
         padded_group_start_offsets=padded_group_start_offsets,
         num_rows=num_rows,
         groups_block_aligned_by_construction=groups_block_aligned_by_construction,
     )
-    if not deepgemm_offset_plan.groups_are_block_aligned(block_size):
-        return _GroupedMMBackendSelection(
-            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
-            deepgemm_offset_plan=None,
-        )
+    if not offset_plan.groups_are_block_aligned(block_size):
+        return _EMULATED_GROUPED_MM_BACKEND
 
-    return _GroupedMMBackendSelection(
-        plan=_DEEPGEMM_GROUPED_MM_BACKEND_PLAN,
-        deepgemm_offset_plan=deepgemm_offset_plan,
-    )
+    return _DeepGemmGroupedMMBackend(offset_plan=offset_plan)

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm_backend.py
@@ -1,0 +1,336 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import torch
+
+from torchao.prototype.blockwise_fp8_training.deepgemm_grouped_kernels import (
+    can_use_deepgemm_grouped_training,
+    deepgemm_blockwise_scaled_grouped_mm,
+    deepgemm_blockwise_scaled_grouped_mm_wgrad,
+    prepare_deepgemm_wgrad_plan,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_metadata import (
+    DeepGemmGroupedOffsetPlan,
+    build_deepgemm_grouped_offset_plan,
+)
+from torchao.prototype.blockwise_fp8_training.deepgemm_quant import (
+    triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm,
+    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm,
+)
+from torchao.prototype.blockwise_fp8_training.grouped_kernels import (
+    emulated_blockwise_scaled_grouped_mm,
+    triton_fp8_blockwise_weight_quant_grouped_rhs,
+    triton_fp8_blockwise_weight_quant_grouped_transposed_rhs,
+)
+from torchao.prototype.blockwise_fp8_training.kernels import (
+    BLOCKWISE_1X128_SCALING_TYPE,
+    _scaling_type_value,
+    triton_fp8_blockwise_act_quant_rhs,
+    triton_fp8_blockwise_act_quant_transposed_lhs,
+)
+from torchao.quantization.quantize_.common import KernelPreference
+
+
+class _GroupedMMBackend(str, Enum):
+    DEEPGEMM = "deepgemm"
+    EMULATED = "emulated"
+
+
+@dataclass(frozen=True)
+class _GroupedMMBackendSelection:
+    plan: "_GroupedMMBackendPlan"
+    deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None
+
+
+class _GroupedMMBackendPlan:
+    kind: _GroupedMMBackend
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    def wgrad(
+        self,
+        padded_grad_output: torch.Tensor,
+        padded_a: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        dtype: torch.dtype,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class _EmulatedGroupedMMBackendPlan(_GroupedMMBackendPlan):
+    kind = _GroupedMMBackend.EMULATED
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The emulated backend consumes TorchAO's grouped RHS layout:
+        # (E, K, N) data with (E, K_blocks, N_blocks) scales.
+        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # The emulated backend consumes TorchAO's grouped RHS layout for
+        # grad_output @ weight: (E, N, K) data with
+        # (E, N_blocks, K_blocks) scales.
+        return triton_fp8_blockwise_weight_quant_grouped_rhs(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        return emulated_blockwise_scaled_grouped_mm(
+            a,
+            b,
+            a_s,
+            scale_recipe_a,
+            b_s,
+            scale_recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+        )
+
+    def wgrad(
+        self,
+        padded_grad_output: torch.Tensor,
+        padded_a: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        dtype: torch.dtype,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        grad_output_t_fp8, grad_output_t_scale = (
+            triton_fp8_blockwise_act_quant_transposed_lhs(
+                padded_grad_output.contiguous(),
+                block_size=block_size,
+                dtype=dtype,
+            )
+        )
+        A_rhs_fp8, A_rhs_scale = triton_fp8_blockwise_act_quant_rhs(
+            padded_a.contiguous(),
+            block_size=block_size,
+            dtype=dtype,
+        )
+        return emulated_blockwise_scaled_grouped_mm(
+            grad_output_t_fp8,
+            A_rhs_fp8,
+            grad_output_t_scale,
+            _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+            A_rhs_scale,
+            _scaling_type_value(BLOCKWISE_1X128_SCALING_TYPE),
+            group_end_offsets,
+            out_dtype,
+            block_size,
+        )
+
+
+class _DeepGemmGroupedMMBackendPlan(_GroupedMMBackendPlan):
+    kind = _GroupedMMBackend.DEEPGEMM
+
+    def quantize_forward_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # DeepGEMM forward consumes RHS as (E, N, K), with K contiguous and
+        # scales as (E, N_blocks, K_blocks). This quantizer writes that
+        # layout directly, avoiding a dispatch-time transpose/copy.
+        return triton_fp8_blockwise_weight_quant_grouped_transposed_rhs_deepgemm(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def quantize_dgrad_rhs(
+        self,
+        B_t: torch.Tensor,
+        block_size: int,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # DeepGEMM dgrad consumes RHS as (E, K, N), with N contiguous and
+        # scales as (E, K_blocks, N_blocks). This quantizer writes that
+        # layout directly, avoiding a dispatch-time transpose/copy.
+        return triton_fp8_blockwise_weight_quant_grouped_rhs_deepgemm(
+            B_t,
+            block_size=block_size,
+            dtype=dtype,
+        )
+
+    def grouped_mm(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_s: torch.Tensor,
+        scale_recipe_a: int,
+        b_s: torch.Tensor,
+        scale_recipe_b: int,
+        offs: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        assert deepgemm_offset_plan is not None, (
+            "DeepGEMM backend requires grouped offset metadata"
+        )
+        return deepgemm_blockwise_scaled_grouped_mm(
+            a,
+            b,
+            a_s,
+            scale_recipe_a,
+            b_s,
+            scale_recipe_b,
+            offs,
+            out_dtype,
+            block_size,
+            offset_plan=deepgemm_offset_plan,
+        )
+
+    def wgrad(
+        self,
+        padded_grad_output: torch.Tensor,
+        padded_a: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        out_dtype: torch.dtype,
+        block_size: int,
+        dtype: torch.dtype,
+        *,
+        deepgemm_offset_plan: DeepGemmGroupedOffsetPlan | None,
+    ) -> torch.Tensor:
+        assert deepgemm_offset_plan is not None, (
+            "DeepGEMM backend requires grouped offset metadata"
+        )
+        wgrad_plan = prepare_deepgemm_wgrad_plan(
+            padded_grad_output,
+            padded_a,
+            deepgemm_offset_plan,
+            block_size,
+            dtype,
+        )
+        assert wgrad_plan is not None, (
+            "DeepGEMM backend requires block-aligned group sizes for wgrad"
+        )
+        return deepgemm_blockwise_scaled_grouped_mm_wgrad(
+            wgrad_plan.lhs,
+            wgrad_plan.rhs,
+            deepgemm_offset_plan,
+            out_dtype,
+            block_size,
+        )
+
+
+_EMULATED_GROUPED_MM_BACKEND_PLAN = _EmulatedGroupedMMBackendPlan()
+_DEEPGEMM_GROUPED_MM_BACKEND_PLAN = _DeepGemmGroupedMMBackendPlan()
+
+
+def _select_fp8_blockwise_grouped_mm_backend(
+    kernel_preference: KernelPreference,
+    A: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int,
+    group_end_offsets: torch.Tensor,
+    *,
+    original_group_end_offsets: Optional[torch.Tensor] = None,
+    padded_group_start_offsets: Optional[torch.Tensor] = None,
+    num_rows: Optional[int] = None,
+) -> _GroupedMMBackendSelection:
+    if kernel_preference == KernelPreference.EMULATED:
+        return _GroupedMMBackendSelection(
+            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
+            deepgemm_offset_plan=None,
+        )
+
+    assert kernel_preference == KernelPreference.AUTO, (
+        "kernel_preference must be AUTO or EMULATED"
+    )
+    if not can_use_deepgemm_grouped_training(A, out_dtype, block_size):
+        return _GroupedMMBackendSelection(
+            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
+            deepgemm_offset_plan=None,
+        )
+
+    deepgemm_offset_plan = build_deepgemm_grouped_offset_plan(
+        group_end_offsets,
+        original_group_end_offsets=original_group_end_offsets,
+        padded_group_start_offsets=padded_group_start_offsets,
+        num_rows=num_rows,
+    )
+    if not deepgemm_offset_plan.groups_are_block_aligned(block_size):
+        return _GroupedMMBackendSelection(
+            plan=_EMULATED_GROUPED_MM_BACKEND_PLAN,
+            deepgemm_offset_plan=None,
+        )
+
+    return _GroupedMMBackendSelection(
+        plan=_DEEPGEMM_GROUPED_MM_BACKEND_PLAN,
+        deepgemm_offset_plan=deepgemm_offset_plan,
+    )


### PR DESCRIPTION
## Summary

Adds an optional **DeepGEMM backend** for the FP8 blockwise MoE grouped GEMM, alongside the existing emulated path. When DeepGEMM is installed, `KernelPreference.AUTO` dispatches the forward, dgrad, and wgrad grouped GEMMs to DeepGEMM; otherwise it falls back to the emulated kernels. 

Two main parts are added here: backend-selection layer and DeepGEMM-layout FP8 quantization kernels that write DeepGEMM's exact data/scale contracts directly (no dispatch-time transpose/copy).

## DeepGEMM layout/scale contract vs TorchAO

DeepGEMM's grouped FP8 kernels are expect a different operand memory layout and scale orientation and differ from the layouts of TorchAO's existing blockwise quantizers (and `torch._grouped_mm`) produce. 
- TorchAO's public expert weight is `(E, K, N)` transposed in per-expert column-major layout, its 1x128 activation scales are stored as `(M_blocks, K)` (column-major-friendly for `torch._scaled_mm`), and its grouped RHS scales follow the `torch._grouped_mm` convention. 
- DeepGEMM instead wants: the **forward RHS** as `(E, N, K)` row-major with contiguous `K` and `(E, N//128, K//128)` scales; the **dgrad RHS** as `(E, K, N)` row-major with contiguous `N` and `(E, K//128, N//128)` scales; and for the **K-grouped wgrad**, each operand as a flat per-expert `(D, expert_tokens)` 
- K-major buffer (experts concatenated) with scales as `(D, total_valid_token_blocks)` — i.e. the token dimension becomes the GEMM's contraction axis and the scale axes are transposed relative to TorchAO's.

Rather than quantize in the TorchAO layout and then transpose/copy at dispatch time, we add kernels that write DeepGEMM's exact contract directly. 
- The weight quantizers read the contiguous `(E*N, K)` view of the column-major weight and emit DeepGEMM's `(E, N, K)`/`(E, K, N)` data and block-transposed scales straight from the cast — no separate layout-copy kernel. 
- For the wgrad operands there are two routes selected per operand by `_DEEPGEMM_DIRECT_K_GROUPED_QUANT_MIN_DIM`: wide operands take the **direct K-grouped quant** that writes the flat `(D, expert_tokens)` K-major buffer and `(D, blocks)` scales in one pass; narrower operands reuse TorchAO's existing transposed-LHS/RHS quantizers and are then flattened per-expert and have their scales transposed (`(M_blocks, K) → (K, M_blocks)`) at launch time to match DeepGEMM's K-major contract. The on-device `grouped_layout` (one int32 expert id per row, `-1` for padding) is what tells DeepGEMM's contiguous M-grouped kernel which expert each row belongs to.

### H100 per-kernel roofline (balanced tokens, M=32768, E=8, N=2048, K=7168)

Roofline refs: mem BW peak 3352 GB/s / achievable 3084 GB/s (92%); FP8 compute peak 1979 TFLOP/s / achievable 1544 TFLOP/s (78%).

Quant/cast kernels are reported as % of achievable memory bandwidth; DeepGEMM grouped GEMMs as % of achievable FP8 compute.

| kernel | µs | % of achievable roofline |
|---|--:|--:|
| fwd: act_quant_lhs | 253.5 | 91.1 (BW) |
| fwd: weight_quant_forward_rhs | 128.1 | 89.2 (BW) |
| **fwd: deepgemm_grouped_mm** | 779.3 | **80.0 (compute)** |
| bwd: act_quant_lhs(grad_out) | 77.6 | 85.0 (BW) |
| bwd: weight_quant_dgrad_rhs | 126.3 | 90.5 (BW) |
| **bwd: deepgemm_grouped_mm_dgrad** | 778.6 | **80.1 (compute)** |
| bwd: wgrad_quant_lhs(grad_out) [transposed] | 85.1 | 77.5 (BW) |
| bwd: wgrad_quant_rhs(A) [direct] | 275.3 | 83.8 (BW) |
| **bwd: deepgemm_grouped_mm_wgrad** | 2105.4 | **29.6 (compute)** |
