### PR TITLE
docs(quant_api): fix RST warnings in FqnToConfig and Int8DynamicActivationIntxWeightConfig docstrings (#3863)

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -356,15 +356,17 @@ class Int8DynamicActivationIntxWeightConfig(AOBaseConfig):
 
     args:
         `weight_dtype`: The dtype to use for weight quantization.  Must be torch.intx, where 1 <= x <= 8.
-       ` weight_granularity`: The granularity to use for weight quantization.  Must be PerGroup or PerAxis(axis=0).
+        `weight_granularity`: The granularity to use for weight quantization.  Must be PerGroup or PerAxis(axis=0).
         `weight_mapping_type`: The type of mapping to use for the weight quantization.
             Must be one of MappingType.ASYMMETRIC or MappingType.SYMMETRIC.  MappingType.SYMMETRIC requires ZeroPointDomain.NONE
         `weight_scale_dtype`: The dtype to use for the weight scale.
         `act_mapping_type`: The type of mapping to use for the activation quantization.
             Must be one of MappingType.ASYMMETRIC or MappingType.SYMMETRIC.
         `intx_packing_format`: The format to use for the packed weight tensor (version 2 only).
+
             - unpacked_to_int8: this format is the default and is intended for export applications like ExecuTorch.
             - opaque_torchao_auto: this format is optimized for CPU performance.
+
         `intx_choose_qparams_algorithm`: The algorithm to use for choosing the quantization parameters.
         `version`: version of the config to use, only subset of above args are valid based on version, see note for more details.
 
@@ -1502,23 +1504,25 @@ class FqnToConfig(AOBaseConfig):
 
     Args:
         `fqn_to_config`: typing.OrderedDict[str, Optional[AOBaseConfig]]: an
-         ordered dictionary from
-             (1). fully qualified name (fqn) of module or parameter
-             (2). regex of fully qualified name (in python `re` module regex format), should
-                  start with prefix "re:" or
-             (3). "_default"
-         to the config that we want to apply to the module/param or None
+            ordered dictionary from a key to the config that we want to apply
+            to the module/param (or None). A key is one of:
 
-         Config key ordered by precedence:
-           * fully qualified parameter name, e.g. `language.layers.0.q_proj.weight`
-           * fully qualified module name, e.g. `language.layers.0.q_proj`
-           * regex for parameter names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj.weight`.
-             The first regex that matches will be applied.
-           * regex for module names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj`,
-             whichever regex fully matches the module fqn first will be applied
-             (order of keys for dictionary are kept consistent since we are using OrderedDict)
-           * "_default", fallback if no match for all previous keys
-             (Note, when using `_default`, the config is applied to all modules, to apply
+            1. fully qualified name (fqn) of module or parameter
+            2. regex of fully qualified name (in python `re` module regex format), should
+               start with prefix "re:" or
+            3. "_default"
+
+            Config key ordered by precedence:
+
+            * fully qualified parameter name, e.g. `language.layers.0.q_proj.weight`
+            * fully qualified module name, e.g. `language.layers.0.q_proj`
+            * regex for parameter names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj.weight`.
+              The first regex that matches will be applied.
+            * regex for module names, must start with `re:`, e.g. `re:language\.layers\..+\.q_proj`,
+              whichever regex fully matches the module fqn first will be applied
+              (order of keys for dictionary are kept consistent since we are using OrderedDict)
+            * "_default", fallback if no match for all previous keys
+              (Note, when using `_default`, the config is applied to all modules, to apply
               it to only a subset of modules, e.g. with some types, it's better to filter
               the modules that we don't want to quantize before hand and configure them to
               None, e.g. `{"re:.+norm.+": None, "_default": linear_config}`) "_default" is not supported when filter_fn is not specified.


### PR DESCRIPTION
Resolves several Sphinx doc-build warnings tracked in #3863, in two `quant_api.py` docstrings.

### `Int8DynamicActivationIntxWeightConfig`
- Fix a stray-backtick typo in the `weight_granularity` arg (a backtick preceded a leading space, breaking the inline-literal markup).
- Add the blank line required before (and after) the `intx_packing_format` sub-bullet list, which fixed `Definition list ends without a blank line; unexpected unindent`.

### `FqnToConfig`
- Reflow the `fqn_to_config` arg body into valid RST: the `(1)/(2)/(3)` enumerated list and the `*` precedence bullet list previously had no preceding blank line and inconsistent indentation, producing `Unexpected indentation` and `Block quote ends without a blank line; unexpected unindent`. Converted to a proper numbered list + bullet list with blank-line separators and aligned continuation lines.

Wording, regex examples, and backtick style are preserved; only the RST structure/indentation changed. No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
