### PR TITLE
 Refactor NVFP4Tensor: align the swizzle execution with the configured swizzle setting

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -126,7 +126,9 @@ def test_inference_workflow_mx(
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
 @pytest.mark.parametrize("quant_type", ["dynamic", "weight_only"])
@@ -165,13 +167,18 @@ def test_inference_workflow_nvfp4(
     Test NVFP4 recipe with scale_dtype=float8_e4m3fn and block_size=16
     Tests both DYNAMIC and WEIGHT_ONLY mm_config modes
     """
-    # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
-    if quant_type == "dynamic" and not is_sm_at_least_100():
+    device = torch.accelerator.current_accelerator()
+    is_cuda = device.type == "cuda"
+
+    # DYNAMIC mode requires SM100+ on CUDA, but works on XPU
+    if is_cuda and quant_type == "dynamic" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only quant currently errors w/ compile")
     if quant_type == "weight_only" and use_triton_kernel:
         pytest.skip("unsupported configuration")
+    if not is_cuda and use_triton_kernel:
+        pytest.skip("Triton kernel only supported on CUDA")
 
     if use_inference_mode and (
         shapes != (128, 64, 256) or inpt_dtype != torch.bfloat16 or use_triton_kernel
@@ -184,24 +191,26 @@ def test_inference_workflow_nvfp4(
 
     batch_size, in_features, out_features = shapes
 
-    m = nn.Linear(in_features, out_features, bias=bias, dtype=inpt_dtype, device="cuda")
+    m = nn.Linear(in_features, out_features, bias=bias, dtype=inpt_dtype, device=device)
     m_mx = copy.deepcopy(m)
 
     if quant_type == "dynamic":
         config = NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=use_triton_kernel,
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
+            is_swizzled=is_cuda,
         )
     else:
         config = NVFP4WeightOnlyConfig(
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
+            is_swizzled=is_cuda,
         )
     quantize_(m_mx, config=config)
 
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True, backend="aot_eager")
 
-    x = torch.randn(batch_size, in_features, device="cuda", dtype=inpt_dtype)
+    x = torch.randn(batch_size, in_features, device=device, dtype=inpt_dtype)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -127,7 +127,8 @@ def test_inference_workflow_mx(
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -138,8 +138,7 @@ def test_inference_workflow_mx(
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA or XPU not available",
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
 )
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -189,8 +188,8 @@ def test_inference_workflow_nvfp4(
         pytest.skip("TODO: weight_only quant currently errors w/ compile")
     if quant_type == "weight_only" and use_triton_kernel:
         pytest.skip("unsupported configuration")
-    if not is_cuda and use_triton_kernel:
-        pytest.skip("Triton kernel only supported on CUDA")
+    if device.type == "xpu" and use_triton_kernel:
+        pytest.skip("use_triton_kernel is not supported on XPU")
 
     if use_inference_mode and (
         shapes != (128, 64, 256) or inpt_dtype != torch.bfloat16 or use_triton_kernel
@@ -210,12 +209,16 @@ def test_inference_workflow_nvfp4(
         config = NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=use_triton_kernel,
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
-            is_swizzled=is_cuda,
+            swizzled_type=SwizzleType.SWIZZLE_32_4_4
+            if is_cuda and not is_ROCM()
+            else SwizzleType.NO_SWIZZLE,
         )
     else:
         config = NVFP4WeightOnlyConfig(
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
-            is_swizzled=is_cuda,
+            swizzled_type=SwizzleType.SWIZZLE_32_4_4
+            if is_cuda and not is_ROCM()
+            else SwizzleType.NO_SWIZZLE,
         )
     quantize_(m_mx, config=config)
 
@@ -272,9 +275,12 @@ class VLLMIntegrationTestCase(TorchAOIntegrationTestCase):
         self._test_narrow_similar_to_vllm(config)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for NVFP4"
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for NVFP4",
 )
 @pytest.mark.parametrize("bias", [True, False])
 @torch.no_grad()
@@ -293,12 +299,24 @@ def test_nvfp4_static_quantization_flow(
     """
     from torchao.prototype.mx_formats.inference_workflow import NVFP4ObservedLinear
 
+    device = torch.accelerator.current_accelerator().type
+    # swizzled (blocked) scales are only supported on real CUDA hardware;
+    # ROCm (reported as device == "cuda") and XPU both require unswizzled
+    # scales
+    swizzled_type = (
+        SwizzleType.SWIZZLE_32_4_4
+        if device == "cuda" and not is_ROCM()
+        else SwizzleType.NO_SWIZZLE
+    )
+    # the triton kernel only supports swizzled scales, so tie it to the same
+    # condition instead of hardcoding it off (CUDA can still use it)
+    use_triton_kernel = swizzled_type == SwizzleType.SWIZZLE_32_4_4
     in_features, out_features = 64, 256
     batch_size = 128
 
     m = nn.Sequential(
         nn.Linear(
-            in_features, out_features, bias=bias, dtype=torch.bfloat16, device="cuda"
+            in_features, out_features, bias=bias, dtype=torch.bfloat16, device=device
         ),
     )
     m_ref = copy.deepcopy(m)
@@ -306,7 +324,11 @@ def test_nvfp4_static_quantization_flow(
     # Step 1: Prepare - insert observers
     quantize_(
         m,
-        NVFP4DynamicActivationNVFP4WeightConfig(step="prepare"),
+        NVFP4DynamicActivationNVFP4WeightConfig(
+            step="prepare",
+            use_triton_kernel=use_triton_kernel,
+            swizzled_type=swizzled_type,
+        ),
     )
 
     # Verify observers were inserted
@@ -314,7 +336,7 @@ def test_nvfp4_static_quantization_flow(
 
     # Step 2: Calibrate with representative data
     calibration_data = [
-        torch.randn(batch_size, in_features, device="cuda", dtype=torch.bfloat16)
+        torch.randn(batch_size, in_features, device=device, dtype=torch.bfloat16)
         for _ in range(5)
     ]
     for data in calibration_data:
@@ -323,7 +345,11 @@ def test_nvfp4_static_quantization_flow(
     # Step 3: Convert - extract scale and quantize
     quantize_(
         m,
-        NVFP4DynamicActivationNVFP4WeightConfig(step="convert"),
+        NVFP4DynamicActivationNVFP4WeightConfig(
+            step="convert",
+            use_triton_kernel=use_triton_kernel,
+            swizzled_type=swizzled_type,
+        ),
     )
 
     # Verify quantization was applied
@@ -340,7 +366,7 @@ def test_nvfp4_static_quantization_flow(
     )
 
     # Step 4: Verify inference produces reasonable results
-    x = torch.randn(batch_size, in_features, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(batch_size, in_features, device=device, dtype=torch.bfloat16)
     y_ref = m_ref(x)
     y_static = m(x)
 
@@ -351,9 +377,12 @@ def test_nvfp4_static_quantization_flow(
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for NVFP4"
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for NVFP4",
 )
 @torch.no_grad()
 @skip_if_rocm("ROCm float4 gemm require gfx950")
@@ -364,12 +393,21 @@ def test_nvfp4_static_vs_dynamic_quantization():
     per_tensor_scale statically, calibrating on the exact test input should
     produce the same per_tensor_scale as the dynamic path, yielding identical results.
     """
+    device = torch.accelerator.current_accelerator().type
+    # swizzled (blocked) scales are only supported on real CUDA hardware;
+    # ROCm (reported as device == "cuda") and XPU both require unswizzled
+    # scales
+    swizzled_type = (
+        SwizzleType.SWIZZLE_32_4_4
+        if device == "cuda" and not is_ROCM()
+        else SwizzleType.NO_SWIZZLE
+    )
     in_features, out_features = 64, 256
     batch_size = 128
 
     m_dynamic = nn.Sequential(
         nn.Linear(
-            in_features, out_features, bias=True, dtype=torch.bfloat16, device="cuda"
+            in_features, out_features, bias=True, dtype=torch.bfloat16, device=device
         ),
     )
     m_static = copy.deepcopy(m_dynamic)
@@ -380,11 +418,12 @@ def test_nvfp4_static_vs_dynamic_quantization():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
             use_dynamic_per_tensor_scale=True,
+            swizzled_type=swizzled_type,
         ),
     )
 
     # Create the test input upfront so we can use it for calibration too
-    x = torch.randn(batch_size, in_features, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(batch_size, in_features, device=device, dtype=torch.bfloat16)
 
     # Static quantization: prepare -> calibrate -> convert
     quantize_(
@@ -392,6 +431,7 @@ def test_nvfp4_static_vs_dynamic_quantization():
         NVFP4DynamicActivationNVFP4WeightConfig(
             step="prepare",
             use_triton_kernel=False,
+            swizzled_type=swizzled_type,
         ),
     )
     # Calibrate with the same input used for testing
@@ -402,6 +442,7 @@ def test_nvfp4_static_vs_dynamic_quantization():
         NVFP4DynamicActivationNVFP4WeightConfig(
             step="convert",
             use_triton_kernel=False,
+            swizzled_type=swizzled_type,
         ),
     )
 
@@ -497,9 +538,12 @@ class BatchedMMModel(nn.Module):
         return torch.bmm(x, self.weight.transpose(-2, -1))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for NVFP4"
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for NVFP4",
 )
 @torch.no_grad()
 @skip_if_rocm("ROCm float4 gemm require gfx950")
@@ -508,7 +552,7 @@ def test_bmm_nvfp4():
     E, K, N = 4, 128, 256
     M = 16
 
-    device = "cuda"
+    device = torch.accelerator.current_accelerator().type
     dtype = torch.bfloat16
 
     model_ref = BatchedMMModel(E, K, N, device=device, dtype=dtype)
@@ -526,6 +570,10 @@ def test_bmm_nvfp4():
         model,
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
+            # swizzled scales are only supported on CUDA
+            swizzled_type=SwizzleType.SWIZZLE_32_4_4
+            if device == "cuda" and not is_ROCM()
+            else SwizzleType.NO_SWIZZLE,
         ),
         filter_fn=lambda mod, *args: (
             isinstance(mod, BatchedMMModel) and hasattr(mod, "weight")

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -137,7 +137,9 @@ def test_inference_workflow_mx(
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
 @pytest.mark.parametrize("quant_type", ["dynamic", "weight_only"])
@@ -176,13 +178,18 @@ def test_inference_workflow_nvfp4(
     Test NVFP4 recipe with scale_dtype=float8_e4m3fn and block_size=16
     Tests both DYNAMIC and WEIGHT_ONLY mm_config modes
     """
-    # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
-    if quant_type == "dynamic" and not is_sm_at_least_100():
+    device = torch.accelerator.current_accelerator()
+    is_cuda = device.type == "cuda"
+
+    # DYNAMIC mode requires SM100+ on CUDA, but works on XPU
+    if is_cuda and quant_type == "dynamic" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only quant currently errors w/ compile")
     if quant_type == "weight_only" and use_triton_kernel:
         pytest.skip("unsupported configuration")
+    if not is_cuda and use_triton_kernel:
+        pytest.skip("Triton kernel only supported on CUDA")
 
     if use_inference_mode and (
         shapes != (128, 64, 256) or inpt_dtype != torch.bfloat16 or use_triton_kernel
@@ -195,24 +202,26 @@ def test_inference_workflow_nvfp4(
 
     batch_size, in_features, out_features = shapes
 
-    m = nn.Linear(in_features, out_features, bias=bias, dtype=inpt_dtype, device="cuda")
+    m = nn.Linear(in_features, out_features, bias=bias, dtype=inpt_dtype, device=device)
     m_mx = copy.deepcopy(m)
 
     if quant_type == "dynamic":
         config = NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=use_triton_kernel,
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
+            is_swizzled=is_cuda,
         )
     else:
         config = NVFP4WeightOnlyConfig(
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
+            is_swizzled=is_cuda,
         )
     quantize_(m_mx, config=config)
 
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True, backend="aot_eager")
 
-    x = torch.randn(batch_size, in_features, device="cuda", dtype=inpt_dtype)
+    x = torch.randn(batch_size, in_features, device=device, dtype=inpt_dtype)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -138,7 +138,8 @@ def test_inference_workflow_mx(
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
 )
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -562,7 +562,6 @@ def test_bmm_nvfp4():
         model,
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
-            # swizzled scales are only supported on CUDA
             swizzled_type=SwizzleType.SWIZZLE_32_4_4
             if device == "cuda" and not is_ROCM()
             else SwizzleType.NO_SWIZZLE,

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -300,16 +300,11 @@ def test_nvfp4_static_quantization_flow(
     from torchao.prototype.mx_formats.inference_workflow import NVFP4ObservedLinear
 
     device = torch.accelerator.current_accelerator().type
-    # swizzled (blocked) scales are only supported on real CUDA hardware;
-    # ROCm (reported as device == "cuda") and XPU both require unswizzled
-    # scales
     swizzled_type = (
         SwizzleType.SWIZZLE_32_4_4
         if device == "cuda" and not is_ROCM()
         else SwizzleType.NO_SWIZZLE
     )
-    # the triton kernel only supports swizzled scales, so tie it to the same
-    # condition instead of hardcoding it off (CUDA can still use it)
     use_triton_kernel = swizzled_type == SwizzleType.SWIZZLE_32_4_4
     in_features, out_features = 64, 256
     batch_size = 128
@@ -394,9 +389,6 @@ def test_nvfp4_static_vs_dynamic_quantization():
     produce the same per_tensor_scale as the dynamic path, yielding identical results.
     """
     device = torch.accelerator.current_accelerator().type
-    # swizzled (blocked) scales are only supported on real CUDA hardware;
-    # ROCm (reported as device == "cuda") and XPU both require unswizzled
-    # scales
     swizzled_type = (
         SwizzleType.SWIZZLE_32_4_4
         if device == "cuda" and not is_ROCM()

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -385,7 +385,9 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="Accelerator not available"
+)
 @pytest.mark.parametrize("use_gelu", [True, False])
 @pytest.mark.parametrize(
     "quant_type",
@@ -410,9 +412,6 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
 )
 @torch.no_grad()
 @skip_if_rocm("ROCm float4 gemm require gfx950")
-@pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for fp4"
-)
 def test_nvfp4_matmul_with_amax(
     use_gelu: bool,
     quant_type: str,
@@ -422,9 +421,15 @@ def test_nvfp4_matmul_with_amax(
     use_triton_kernel: bool,
     shapes: tuple,
 ):
-    # DYNAMIC mode requires SM100+, but WEIGHT_ONLY works on older GPUs
-    if quant_type == "dynamic" and not is_sm_at_least_100():
+    device = torch.accelerator.current_accelerator()
+    is_cuda = device.type == "cuda"
+
+    # DYNAMIC mode requires SM100+ on CUDA, but works on XPU
+    if is_cuda and quant_type == "dynamic" and not is_sm_at_least_100():
         pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
+
+    if is_cuda and not is_sm_at_least_100():
+        pytest.skip("CUDA capability >= 10.0 required for fp4")
 
     if bias and inpt_dtype == torch.float32:
         pytest.xfail("Bias is not supported when module weight is in fp32")
@@ -432,17 +437,22 @@ def test_nvfp4_matmul_with_amax(
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only currently errors w/ compile")
 
+    if not is_cuda and use_triton_kernel:
+        pytest.skip("Triton kernel only supported on CUDA")
+
+    is_swizzled_scales = is_cuda
+
     m, k, n = shapes
 
     # Create activation tensor
     if use_gelu:
-        x = torch.randn(m, k, dtype=inpt_dtype, device="cuda")
+        x = torch.randn(m, k, dtype=inpt_dtype, device=device)
         A = torch.nn.functional.gelu(x)
     else:
-        A = torch.randn(m, k, dtype=inpt_dtype, device="cuda")
+        A = torch.randn(m, k, dtype=inpt_dtype, device=device)
 
-    B = torch.randn(n, k, dtype=inpt_dtype, device="cuda")
-    bias_tensor = torch.randn(n, dtype=inpt_dtype, device="cuda") if bias else None
+    B = torch.randn(n, k, dtype=inpt_dtype, device=device)
+    bias_tensor = torch.randn(n, dtype=inpt_dtype, device=device) if bias else None
 
     # Compute reference
     C_ref = F.linear(A, B, bias_tensor)
@@ -451,17 +461,19 @@ def test_nvfp4_matmul_with_amax(
     b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
     act_quant_kwargs = None
     if quant_type == "dynamic":
-        act_quant_kwargs = QuantizeTensorToNVFP4Kwargs()
+        act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
+            is_swizzled_scales=is_swizzled_scales,
+        )
     A_nvfp4 = NVFP4Tensor.to_nvfp4(
         A,
         per_tensor_scale=a_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         use_triton_kernel=use_triton_kernel,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         use_triton_kernel=use_triton_kernel,
         act_quant_kwargs=act_quant_kwargs,
     )

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -386,7 +386,12 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
 
 
 @pytest.mark.skipif(
-    not torch.accelerator.is_available(), reason="Accelerator not available"
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for fp4",
 )
 @pytest.mark.parametrize("use_gelu", [True, False])
 @pytest.mark.parametrize(
@@ -423,13 +428,6 @@ def test_nvfp4_matmul_with_amax(
 ):
     device = torch.accelerator.current_accelerator()
     is_cuda = device.type == "cuda"
-
-    # DYNAMIC mode requires SM100+ on CUDA, but works on XPU
-    if is_cuda and quant_type == "dynamic" and not is_sm_at_least_100():
-        pytest.skip("CUDA capability >= 10.0 required for DYNAMIC float4 gemm")
-
-    if is_cuda and not is_sm_at_least_100():
-        pytest.skip("CUDA capability >= 10.0 required for fp4")
 
     if bias and inpt_dtype == torch.float32:
         pytest.xfail("Bias is not supported when module weight is in fp32")

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -21,7 +21,7 @@ from torchao.prototype.mx_formats.nvfp4_tensor import (
 from torchao.prototype.mx_formats.utils import ceil_div
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import skip_if_rocm
-from torchao.utils import is_sm_at_least_100
+from torchao.utils import is_ROCM, is_sm_at_least_100
 
 torch.manual_seed(2)
 
@@ -36,9 +36,12 @@ torch.manual_seed(2)
         (torch.bfloat16, (1, 32, 64), False),
     ],
 )
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
 def test_nvfp4_reconstruction(dtype, shape, use_per_tensor_scale):
-    x = torch.randn(shape, dtype=dtype, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    x = torch.randn(shape, dtype=dtype, device=device)
     if use_per_tensor_scale:
         tensor_amax = torch.max(torch.abs(x))
         scale = per_tensor_amax_to_scale(tensor_amax)
@@ -386,8 +389,7 @@ def test_triton_nvfp4_quantize_equivalence(M, N, use_per_tensor_scale, dtype):
 
 
 @pytest.mark.skipif(
-    not (torch.cuda.is_available() or torch.xpu.is_available()),
-    reason="CUDA or XPU not available",
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
 )
 @pytest.mark.skipif(
     torch.cuda.is_available() and not is_sm_at_least_100(),
@@ -427,7 +429,6 @@ def test_nvfp4_matmul_with_amax(
     shapes: tuple,
 ):
     device = torch.accelerator.current_accelerator()
-    is_cuda = device.type == "cuda"
 
     if bias and inpt_dtype == torch.float32:
         pytest.xfail("Bias is not supported when module weight is in fp32")
@@ -435,10 +436,13 @@ def test_nvfp4_matmul_with_amax(
     if quant_type == "weight_only" and compile:
         pytest.skip("TODO: weight_only currently errors w/ compile")
 
-    if not is_cuda and use_triton_kernel:
-        pytest.skip("Triton kernel only supported on CUDA")
+    if device.type == "xpu" and use_triton_kernel:
+        pytest.skip("use_triton_kernel is not supported on XPU")
 
-    is_swizzled_scales = is_cuda
+    # swizzled (blocked) scales are only supported on real CUDA hardware;
+    # ROCm (reported as device.type == "cuda") and XPU both require
+    # unswizzled scales
+    is_swizzled_scales = device.type == "cuda" and not is_ROCM()
 
     m, k, n = shapes
 
@@ -490,9 +494,12 @@ def test_nvfp4_matmul_with_amax(
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for fp4"
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for fp4",
 )
 @pytest.mark.parametrize("use_dynamic_per_tensor_scale", [True, False])
 @pytest.mark.parametrize("leading", [(), (1,)], ids=["2d", "3d_b1"])
@@ -506,20 +513,27 @@ def test_nvfp4_linear_prequantized_activation(
     NVFP4Tensor). Mirrors nvfp4_mm's guard; act_quant_kwargs is irrelevant once
     the activation is pre-quantized.
     """
+    device = torch.accelerator.current_accelerator().type
+    # swizzled (blocked) scales are only supported on real CUDA hardware;
+    # ROCm (reported as device == "cuda") and XPU both require unswizzled
+    # scales
+    is_swizzled_scales = device == "cuda" and not is_ROCM()
     m, k, n = 128, 64, 256
-    A = torch.randn(*leading, m, k, dtype=torch.bfloat16, device="cuda")
-    B = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
+    A = torch.randn(*leading, m, k, dtype=torch.bfloat16, device=device)
+    B = torch.randn(n, k, dtype=torch.bfloat16, device=device)
     C_ref = F.linear(A, B)
 
     a_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(A)))
     b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
-    A_nvfp4 = NVFP4Tensor.to_nvfp4(A, per_tensor_scale=a_scale, is_swizzled_scales=True)
+    A_nvfp4 = NVFP4Tensor.to_nvfp4(
+        A, per_tensor_scale=a_scale, is_swizzled_scales=is_swizzled_scales
+    )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         act_quant_kwargs=QuantizeTensorToNVFP4Kwargs(
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
         ),
     )
@@ -535,9 +549,12 @@ def test_nvfp4_linear_prequantized_activation(
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
 def test_nvfp4_to_copy():
-    x = NVFP4Tensor.to_nvfp4(torch.randn((32, 128))).cuda()
+    device = torch.accelerator.current_accelerator().type
+    x = NVFP4Tensor.to_nvfp4(torch.randn((32, 128))).to(device)
     y = torch.ops.aten._to_copy(x, dtype=torch.bfloat16)
     assert torch.equal(x.qdata, y.qdata)
     assert torch.equal(x.scale, y.scale)
@@ -634,10 +651,13 @@ def test_3d_transpose(dims, is_swizzled_scales):
     assert x_hp_t.shape == x_nvfp4_t.shape
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
 @pytest.mark.parametrize("use_per_tensor_scale", [True, False])
 def test_nvfp4_pin_memory(use_per_tensor_scale):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     per_tensor_scale = (
         per_tensor_amax_to_scale(torch.max(torch.abs(x_hp)))
         if use_per_tensor_scale
@@ -669,9 +689,12 @@ def test_nvfp4_pin_memory(use_per_tensor_scale):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="requires sm100+ for nvfp4 triton kernel"
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for fp4",
 )
 @pytest.mark.parametrize(
     "shapes",
@@ -691,10 +714,19 @@ def test_nvfp4_pin_memory(use_per_tensor_scale):
 @skip_if_rocm("ROCm float4 gemm require gfx950")
 def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_kernel):
     """Test NVFP4 matmul works when per_tensor_scale is None for activation but always set for weight."""
+    device = torch.accelerator.current_accelerator().type
+    if use_triton_kernel and device == "xpu":
+        pytest.skip("use_triton_kernel is not supported on XPU")
+    if use_triton_kernel and not is_sm_at_least_100():
+        pytest.skip("CUDA capability >= 10.0 required for nvfp4 triton kernel")
+    # swizzled (blocked) scales are only supported on real CUDA hardware;
+    # ROCm (reported as device == "cuda") and XPU both require unswizzled
+    # scales
+    is_swizzled_scales = device == "cuda" and not is_ROCM()
     m, k, n = shapes
 
-    A = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
-    B = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
+    A = torch.randn(m, k, dtype=torch.bfloat16, device=device)
+    B = torch.randn(n, k, dtype=torch.bfloat16, device=device)
 
     C_ref = F.linear(A, B)
 
@@ -703,18 +735,20 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     )
     b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
 
-    act_quant_kwargs = QuantizeTensorToNVFP4Kwargs()
+    act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
+        is_swizzled_scales=is_swizzled_scales
+    )
 
     A_nvfp4 = NVFP4Tensor.to_nvfp4(
         A,
         per_tensor_scale=a_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         use_triton_kernel=use_triton_kernel,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         use_triton_kernel=use_triton_kernel,
         act_quant_kwargs=act_quant_kwargs,
     )
@@ -727,12 +761,15 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     assert sqnr >= SQNR_THRESHOLD, f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD}, {a_has_scale=}"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="CUDA or XPU not available"
+)
 def test_nvfp4_per_expert_scale():
+    device = torch.accelerator.current_accelerator().type
     # per-tensor scale reference
     E, K, N = 2, 64, 128
-    x0 = torch.randn(N, K, dtype=torch.bfloat16, device="cuda")
-    x1 = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 2
+    x0 = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    x1 = torch.randn(N, K, dtype=torch.bfloat16, device=device) * 2
     tensor_amax_x0 = torch.max(torch.abs(x0))
     per_tensor_scale_x0 = per_tensor_amax_to_scale(tensor_amax_x0)
     tensor_amax_x1 = torch.max(torch.abs(x1))

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -439,10 +439,7 @@ def test_nvfp4_matmul_with_amax(
     if device.type == "xpu" and use_triton_kernel:
         pytest.skip("use_triton_kernel is not supported on XPU")
 
-    # swizzled (blocked) scales are only supported on real CUDA hardware;
-    # ROCm (reported as device.type == "cuda") and XPU both require
-    # unswizzled scales
-    is_swizzled_scales = device.type == "cuda" and not is_ROCM()
+    is_swizzled = device.type == "cuda" and not is_ROCM()
 
     m, k, n = shapes
 
@@ -464,18 +461,18 @@ def test_nvfp4_matmul_with_amax(
     act_quant_kwargs = None
     if quant_type == "dynamic":
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
         )
     A_nvfp4 = NVFP4Tensor.to_nvfp4(
         A,
         per_tensor_scale=a_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         use_triton_kernel=use_triton_kernel,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         use_triton_kernel=use_triton_kernel,
         act_quant_kwargs=act_quant_kwargs,
     )
@@ -514,10 +511,7 @@ def test_nvfp4_linear_prequantized_activation(
     the activation is pre-quantized.
     """
     device = torch.accelerator.current_accelerator().type
-    # swizzled (blocked) scales are only supported on real CUDA hardware;
-    # ROCm (reported as device == "cuda") and XPU both require unswizzled
-    # scales
-    is_swizzled_scales = device == "cuda" and not is_ROCM()
+    is_swizzled = device == "cuda" and not is_ROCM()
     m, k, n = 128, 64, 256
     A = torch.randn(*leading, m, k, dtype=torch.bfloat16, device=device)
     B = torch.randn(n, k, dtype=torch.bfloat16, device=device)
@@ -526,14 +520,14 @@ def test_nvfp4_linear_prequantized_activation(
     a_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(A)))
     b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
     A_nvfp4 = NVFP4Tensor.to_nvfp4(
-        A, per_tensor_scale=a_scale, is_swizzled_scales=is_swizzled_scales
+        A, per_tensor_scale=a_scale, is_swizzled_scales=is_swizzled
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         act_quant_kwargs=QuantizeTensorToNVFP4Kwargs(
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
             use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
         ),
     )
@@ -717,10 +711,7 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     device = torch.accelerator.current_accelerator().type
     if use_triton_kernel and device == "xpu":
         pytest.skip("use_triton_kernel is not supported on XPU")
-    # swizzled (blocked) scales are only supported on real CUDA hardware;
-    # ROCm (reported as device == "cuda") and XPU both require unswizzled
-    # scales
-    is_swizzled_scales = device == "cuda" and not is_ROCM()
+    is_swizzled = device == "cuda" and not is_ROCM()
     m, k, n = shapes
 
     A = torch.randn(m, k, dtype=torch.bfloat16, device=device)
@@ -733,20 +724,18 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     )
     b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
 
-    act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
-        is_swizzled_scales=is_swizzled_scales
-    )
+    act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(is_swizzled_scales=is_swizzled)
 
     A_nvfp4 = NVFP4Tensor.to_nvfp4(
         A,
         per_tensor_scale=a_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         use_triton_kernel=use_triton_kernel,
     )
     B_nvfp4 = NVFP4Tensor.to_nvfp4(
         B,
         per_tensor_scale=b_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         use_triton_kernel=use_triton_kernel,
         act_quant_kwargs=act_quant_kwargs,
     )

--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -717,8 +717,6 @@ def test_nvfp4_matmul_optional_per_tensor_scale(shapes, a_has_scale, use_triton_
     device = torch.accelerator.current_accelerator().type
     if use_triton_kernel and device == "xpu":
         pytest.skip("use_triton_kernel is not supported on XPU")
-    if use_triton_kernel and not is_sm_at_least_100():
-        pytest.skip("CUDA capability >= 10.0 required for nvfp4 triton kernel")
     # swizzled (blocked) scales are only supported on real CUDA hardware;
     # ROCm (reported as device == "cuda") and XPU both require unswizzled
     # scales

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -221,6 +221,7 @@ class NVFP4DynamicActivationNVFP4WeightConfig(AOBaseConfig):
     use_triton_kernel: bool = True
     use_dynamic_per_tensor_scale: bool = True
     step: Optional["QuantizationStep"] = None
+    is_swizzled: bool = True
 
     def __post_init__(self):
         if isinstance(self.step, str):
@@ -245,6 +246,7 @@ def _nvfp4_inference_linear_transform(
     - None (default): Original dynamic quantization behavior
     """
     weight = getattr(module, parameter_name)
+    is_swizzled_scales = config.is_swizzled
     if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
         raise RuntimeError(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
@@ -270,14 +272,14 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=False,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=weight_per_tensor_scale,
             act_per_tensor_scale=act_per_tensor_scale.detach(),
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -298,8 +300,8 @@ def _nvfp4_inference_linear_transform(
 
     elif step is None:
         # Dynamic quantization
-        assert is_sm_at_least_100(), (
-            "NVFP4 DYNAMIC mode is only supported on sm100+ machines"
+        assert is_sm_at_least_100() or torch.xpu.is_available(), (
+            "NVFP4 DYNAMIC mode is only supported on sm100+ machines or XPU"
         )
 
         weight = getattr(module, parameter_name)
@@ -321,13 +323,13 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=config.use_dynamic_per_tensor_scale,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=per_tensor_scale,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -368,6 +370,7 @@ class NVFP4WeightOnlyConfig(AOBaseConfig):
     """
 
     use_dynamic_per_tensor_scale: bool = True
+    is_swizzled: bool = True
 
 
 @register_quantize_module_handler(NVFP4WeightOnlyConfig)
@@ -383,6 +386,8 @@ def _nvfp4_weight_only_linear_transform(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
+    is_swizzled_scales = config.is_swizzled
+
     per_tensor_scale = None
     if config.use_dynamic_per_tensor_scale:
         tensor_amax = torch.max(torch.abs(weight))
@@ -391,7 +396,7 @@ def _nvfp4_weight_only_linear_transform(
     quantized_weight = NVFP4Tensor.to_nvfp4(
         weight,
         per_tensor_scale=per_tensor_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         act_quant_kwargs=None,
     )
     # Set triton preference after construction

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -250,13 +250,13 @@ def _nvfp4_inference_linear_transform(
     - None (default): Original dynamic quantization behavior
     """
     weight = getattr(module, parameter_name)
-    is_swizzled = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
     if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
         raise RuntimeError(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
     step = config.step
+    is_swizzled = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
     if step == QuantizationStep.PREPARE or step == "prepare":
         return NVFP4ObservedLinear.from_float(module)
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -225,7 +225,7 @@ class NVFP4DynamicActivationNVFP4WeightConfig(AOBaseConfig):
     use_triton_kernel: bool = True
     use_dynamic_per_tensor_scale: bool = True
     step: Optional["QuantizationStep"] = None
-    is_swizzled: bool = True
+    swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):
         if isinstance(self.step, str):
@@ -250,7 +250,7 @@ def _nvfp4_inference_linear_transform(
     - None (default): Original dynamic quantization behavior
     """
     weight = getattr(module, parameter_name)
-    is_swizzled_scales = config.is_swizzled
+    is_swizzled_scales = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
     if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
         raise RuntimeError(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
@@ -374,7 +374,8 @@ class NVFP4WeightOnlyConfig(AOBaseConfig):
     """
 
     use_dynamic_per_tensor_scale: bool = True
-    is_swizzled: bool = True
+    # How to store block scales.
+    swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
 
 @register_quantize_module_handler(NVFP4WeightOnlyConfig)
@@ -390,7 +391,7 @@ def _nvfp4_weight_only_linear_transform(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
-    is_swizzled_scales = config.is_swizzled
+    is_swizzled_scales = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
 
     per_tensor_scale = None
     if config.use_dynamic_per_tensor_scale:

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -250,7 +250,7 @@ def _nvfp4_inference_linear_transform(
     - None (default): Original dynamic quantization behavior
     """
     weight = getattr(module, parameter_name)
-    is_swizzled_scales = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
+    is_swizzled = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
     if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
         raise RuntimeError(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
@@ -276,14 +276,14 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=False,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=weight_per_tensor_scale,
             act_per_tensor_scale=act_per_tensor_scale.detach(),
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -327,13 +327,13 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=config.use_dynamic_per_tensor_scale,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=per_tensor_scale,
-            is_swizzled_scales=is_swizzled_scales,
+            is_swizzled_scales=is_swizzled,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -391,7 +391,7 @@ def _nvfp4_weight_only_linear_transform(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
-    is_swizzled_scales = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
+    is_swizzled = config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
 
     per_tensor_scale = None
     if config.use_dynamic_per_tensor_scale:
@@ -401,7 +401,7 @@ def _nvfp4_weight_only_linear_transform(
     quantized_weight = NVFP4Tensor.to_nvfp4(
         weight,
         per_tensor_scale=per_tensor_scale,
-        is_swizzled_scales=is_swizzled_scales,
+        is_swizzled_scales=is_swizzled,
         act_quant_kwargs=None,
     )
     # Set triton preference after construction

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -225,6 +225,7 @@ class NVFP4DynamicActivationNVFP4WeightConfig(AOBaseConfig):
     use_triton_kernel: bool = True
     use_dynamic_per_tensor_scale: bool = True
     step: Optional["QuantizationStep"] = None
+    is_swizzled: bool = True
 
     def __post_init__(self):
         if isinstance(self.step, str):
@@ -249,6 +250,7 @@ def _nvfp4_inference_linear_transform(
     - None (default): Original dynamic quantization behavior
     """
     weight = getattr(module, parameter_name)
+    is_swizzled_scales = config.is_swizzled
     if weight.shape[-2] % 16 != 0 or weight.shape[-1] % 16 != 0:
         raise RuntimeError(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
@@ -274,14 +276,14 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=False,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=weight_per_tensor_scale,
             act_per_tensor_scale=act_per_tensor_scale.detach(),
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -302,8 +304,8 @@ def _nvfp4_inference_linear_transform(
 
     elif step is None:
         # Dynamic quantization
-        assert is_sm_at_least_100(), (
-            "NVFP4 DYNAMIC mode is only supported on sm100+ machines"
+        assert is_sm_at_least_100() or torch.xpu.is_available(), (
+            "NVFP4 DYNAMIC mode is only supported on sm100+ machines or XPU"
         )
 
         weight = getattr(module, parameter_name)
@@ -325,13 +327,13 @@ def _nvfp4_inference_linear_transform(
         act_quant_kwargs = QuantizeTensorToNVFP4Kwargs(
             use_dynamic_per_tensor_scale=config.use_dynamic_per_tensor_scale,
             use_triton_kernel=config.use_triton_kernel,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
         )
 
         quantized_weight = NVFP4Tensor.to_nvfp4(
             weight,
             per_tensor_scale=per_tensor_scale,
-            is_swizzled_scales=True,
+            is_swizzled_scales=is_swizzled_scales,
             use_triton_kernel=False,  # Always use traditional construction for weights
             act_quant_kwargs=act_quant_kwargs,
         )
@@ -372,6 +374,7 @@ class NVFP4WeightOnlyConfig(AOBaseConfig):
     """
 
     use_dynamic_per_tensor_scale: bool = True
+    is_swizzled: bool = True
 
 
 @register_quantize_module_handler(NVFP4WeightOnlyConfig)
@@ -387,6 +390,8 @@ def _nvfp4_weight_only_linear_transform(
             f"NVFP4 only supports weight shape with last 2 dims divisible by 16, got {weight.shape}"
         )
 
+    is_swizzled_scales = config.is_swizzled
+
     per_tensor_scale = None
     if config.use_dynamic_per_tensor_scale:
         tensor_amax = torch.max(torch.abs(weight))
@@ -395,7 +400,7 @@ def _nvfp4_weight_only_linear_transform(
     quantized_weight = NVFP4Tensor.to_nvfp4(
         weight,
         per_tensor_scale=per_tensor_scale,
-        is_swizzled_scales=True,
+        is_swizzled_scales=is_swizzled_scales,
         act_quant_kwargs=None,
     )
     # Set triton preference after construction

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -504,15 +504,21 @@ def _addmm_nvfp4_dispatch(
     M, K = a.shape[0], a.shape[1]
     N = b.shape[1]
 
-    # Swizzle Dizzle
+    is_xpu = a.qdata.device.type == "xpu"
+
+    # Prepare scales
     if a.is_swizzled_scales:
         a_scale_blocked = a.scale  # Already swizzled
+    elif is_xpu:
+        a_scale_blocked = a.scale  # XPU doesn't use blocked scale format
     else:
         a_scale = a.scale.view(M, K // a.block_size)
         a_scale_blocked = to_blocked(a_scale)
 
     if b.is_swizzled_scales:
         b_scale_blocked = b.scale.t()  # Already swizzled
+    elif is_xpu:
+        b_scale_blocked = b.scale  # XPU doesn't use blocked scale format
     else:
         b_scale = b.scale.t().view(N, K // b.block_size)
         b_scale_blocked = to_blocked(b_scale)
@@ -539,7 +545,9 @@ def _addmm_nvfp4_dispatch(
     should_add_bias_separately = (
         scale_result is not None or a.orig_dtype == torch.float32
     ) and (bias is not None)
-    # should_add_bias_separately = bias is not None
+    # TODO: remove this WA once we support quantized bias in _scaled_mm
+    if is_xpu and bias is not None:
+        should_add_bias_separately = True
 
     # For gemm(A, B) with original high precision inputs A and B:
     #

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -539,7 +539,7 @@ def _addmm_nvfp4_dispatch(
     # since bias is not quantized
     #
     # (2) RuntimeError: Bias is not supported when out_dtype is set to Float32
-    # This is not supported by _scaled_mm
+    # This is not supported by F.scaled_mm
     should_add_bias_separately = (
         scale_result is not None or a.orig_dtype == torch.float32
     ) and (bias is not None)
@@ -549,13 +549,13 @@ def _addmm_nvfp4_dispatch(
     #
     # 1. A and B are always cast to fp32 before being quantized and packed
     #    into uint8 (2 fp4 values per byte)
-    # 2. _scaled_mm (cublas) always accumulates in fp32 since use_fast_accum=False
+    # 2. F.scaled_mm (cublas) always accumulates in fp32 since use_fast_accum=False
     # 3. Outputs are cast to A.dtype before returning
-    # 4. Bias is added outside _scaled_mm if per_tensor_scale exists
+    # 4. Bias is added outside F.scaled_mm if per_tensor_scale exists
     #    or output dtype is fp32
     #
     # -----------------------------------------------------------------------------
-    # | A.dtype | B.dtype | Accum dtype | Out dtype | Bias added in _scaled_mm?   |
+    # | A.dtype | B.dtype | Accum dtype | Out dtype | Bias added in F.scaled_mm?   |
     # -----------------------------------------------------------------------------
     # | fp32    | fp32    | fp32        | fp32      | No                          |
     # | fp32    | bf16    | fp32        | fp32      | No                          |

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
+from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 from torchao.prototype.mx_formats.constants import F4_E2M1_MAX, F8E4M3_MAX
@@ -498,30 +500,34 @@ def _addmm_nvfp4_dispatch(
     assert a.block_size == 16, f"NVFP4 requires block_size=16, got {a.block_size}"
     assert b.block_size == 16, f"NVFP4 requires block_size=16, got {b.block_size}"
     assert len(a.shape) == 2 and len(b.shape) == 2
+    assert a.is_swizzled_scales == b.is_swizzled_scales
     _assert_no_per_expert_scale(a)
     _assert_no_per_expert_scale(b)
 
     M, K = a.shape[0], a.shape[1]
     N = b.shape[1]
 
-    is_xpu = a.qdata.device.type == "xpu"
-
-    # Prepare scales
+    # NVFP4Tensor stores its scales pre-swizzled (blocked) at quantization
+    # time when `is_swizzled_scales=True`, so they can be used as-is here.
+    # When False, the scales stay in their natural (row-major) layout, and
+    # the layout is instead communicated explicitly to `F.scaled_mm` via
+    # `swizzle_a`/`swizzle_b` below. This lets ao inherit pytorch's own
+    # per-backend support matrix (e.g. CUDA expects swizzled scales while
+    # XPU expects unswizzled ones) instead of ao re-encoding backend-specific
+    # behavior here.
     if a.is_swizzled_scales:
         a_scale_blocked = a.scale  # Already swizzled
-    elif is_xpu:
-        a_scale_blocked = a.scale  # XPU doesn't use blocked scale format
     else:
-        a_scale = a.scale.view(M, K // a.block_size)
-        a_scale_blocked = to_blocked(a_scale)
+        a_scale_blocked = a.scale.view(M, K // a.block_size)
 
     if b.is_swizzled_scales:
         b_scale_blocked = b.scale.t()  # Already swizzled
-    elif is_xpu:
-        b_scale_blocked = b.scale  # XPU doesn't use blocked scale format
     else:
-        b_scale = b.scale.t().view(N, K // b.block_size)
-        b_scale_blocked = to_blocked(b_scale)
+        b_scale_blocked = b.scale.t().view(N, K // b.block_size)
+
+    swizzle = (
+        SwizzleType.SWIZZLE_32_4_4 if a.is_swizzled_scales else SwizzleType.NO_SWIZZLE
+    )
 
     # Merge double quant scales into 1 scale for Scale_In^D
     # When per_tensor_scale is None for an operand, it's treated as 1.0
@@ -545,9 +551,6 @@ def _addmm_nvfp4_dispatch(
     should_add_bias_separately = (
         scale_result is not None or a.orig_dtype == torch.float32
     ) and (bias is not None)
-    # TODO: remove this WA once we support quantized bias in _scaled_mm
-    if is_xpu and bias is not None:
-        should_add_bias_separately = True
 
     # For gemm(A, B) with original high precision inputs A and B:
     #
@@ -566,13 +569,17 @@ def _addmm_nvfp4_dispatch(
     # | bf16    | fp32    | fp32        | bf16      | Only if no per_tensor_scale |
     # | bf16    | bf16    | fp32        | bf16      | Only if no per_tensor_scale |
     # -----------------------------------------------------------------------------
-    result = torch._scaled_mm(
+    result = F.scaled_mm(
         a.qdata.view(torch.float4_e2m1fn_x2),
         b.qdata.view(torch.float4_e2m1fn_x2),
-        a_scale_blocked.view(torch.float8_e4m3fn),
-        b_scale_blocked.view(torch.float8_e4m3fn),
+        scale_a=a_scale_blocked.view(torch.float8_e4m3fn),
+        scale_recipe_a=ScalingType.BlockWise1x16,
+        scale_b=b_scale_blocked.view(torch.float8_e4m3fn),
+        scale_recipe_b=ScalingType.BlockWise1x16,
+        swizzle_a=swizzle,
+        swizzle_b=swizzle,
         bias=None if should_add_bias_separately else bias,
-        out_dtype=a.orig_dtype,
+        output_dtype=a.orig_dtype,
         # scale_result=scale_result,  # Not supported yet
     )
 
@@ -716,8 +723,6 @@ def nvfp4_addmm(func, types, args, kwargs):
 
 @implements([aten._grouped_mm.default])
 def nvfp4_grouped_mm(func, types, args, kwargs):
-    from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
-
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert offs is not None, "offs is required for nvfp4 grouped_mm"

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -715,7 +715,7 @@ def nvfp4_addmm(func, types, args, kwargs):
 
 @implements([aten._grouped_mm.default])
 def nvfp4_grouped_mm(func, types, args, kwargs):
-    from torch.nn.functional import ScalingType, SwizzleType
+    from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
 
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from torch.nn.functional import ScalingType, SwizzleType, scaled_grouped_mm
+from torch.nn.functional import ScalingType, SwizzleType
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 from torchao.prototype.mx_formats.constants import F4_E2M1_MAX, F8E4M3_MAX
@@ -543,6 +543,7 @@ def _addmm_nvfp4_dispatch(
     should_add_bias_separately = (
         scale_result is not None or a.orig_dtype == torch.float32
     ) and (bias is not None)
+    # should_add_bias_separately = bias is not None
 
     # For gemm(A, B) with original high precision inputs A and B:
     #

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -507,14 +507,6 @@ def _addmm_nvfp4_dispatch(
     M, K = a.shape[0], a.shape[1]
     N = b.shape[1]
 
-    # NVFP4Tensor stores its scales pre-swizzled (blocked) at quantization
-    # time when `is_swizzled_scales=True`, so they can be used as-is here.
-    # When False, the scales stay in their natural (row-major) layout, and
-    # the layout is instead communicated explicitly to `F.scaled_mm` via
-    # `swizzle_a`/`swizzle_b` below. This lets ao inherit pytorch's own
-    # per-backend support matrix (e.g. CUDA expects swizzled scales while
-    # XPU expects unswizzled ones) instead of ao re-encoding backend-specific
-    # behavior here.
     if a.is_swizzled_scales:
         a_scale_blocked = a.scale  # Already swizzled
     else:
@@ -525,7 +517,7 @@ def _addmm_nvfp4_dispatch(
     else:
         b_scale_blocked = b.scale.t().view(N, K // b.block_size)
 
-    swizzle = (
+    swizzle_type = (
         SwizzleType.SWIZZLE_32_4_4 if a.is_swizzled_scales else SwizzleType.NO_SWIZZLE
     )
 
@@ -576,8 +568,8 @@ def _addmm_nvfp4_dispatch(
         scale_recipe_a=ScalingType.BlockWise1x16,
         scale_b=b_scale_blocked.view(torch.float8_e4m3fn),
         scale_recipe_b=ScalingType.BlockWise1x16,
-        swizzle_a=swizzle,
-        swizzle_b=swizzle,
+        swizzle_a=swizzle_type,
+        swizzle_b=swizzle_type,
         bias=None if should_add_bias_separately else bias,
         output_dtype=a.orig_dtype,
         # scale_result=scale_result,  # Not supported yet
@@ -723,6 +715,8 @@ def nvfp4_addmm(func, types, args, kwargs):
 
 @implements([aten._grouped_mm.default])
 def nvfp4_grouped_mm(func, types, args, kwargs):
+    from torch.nn.functional import ScalingType, SwizzleType
+
     mat_a, mat_b = args[0], args[1]
     offs = args[2] if len(args) > 2 else kwargs.get("offs", None)
     assert offs is not None, "offs is required for nvfp4 grouped_mm"


### PR DESCRIPTION
## Summary

This applies the same principle introduced in [pytorch/ao#4844](https://github.com/pytorch/ao/pull/4844) ("Refactor MXTensor: align the swizzle execution with the configured swizzle setting", now merged into `main`) to `NVFP4Tensor`.

Previous designs always produced swizzled scales regardless of the config. This silently ignored the configured swizzle setting on non-CUDA backends and re-encoded backend-specific behavior instead of relying on PyTorch's own contract: `F.scaled_mm` already takes the scale layout as explicit `swizzle_a` / `swizzle_b` arguments.

## Config changes

Per review feedback on #4844 (swizzle knobs on user-facing configs should be a `SwizzleType` enum, not a bare `bool`; tensor-internal attributes stay `bool`), renamed:

- `NVFP4DynamicActivationNVFP4WeightConfig.is_swizzled: bool = True` → `swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4`
- `NVFP4WeightOnlyConfig.is_swizzled: bool = True` → `swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4`

**What each backend accepts (matches PyTorch's own support matrix):**

| | CUDA (SM100+) | ROCm | XPU |
|---|---|---|---|
| `swizzle_a` / `swizzle_b` | `SWIZZLE_32_4_4` | `NO_SWIZZLE` | `NO_SWIZZLE` |

### Usage

```python
# default — blocked/swizzled scales (CUDA)
config = NVFP4DynamicActivationNVFP4WeightConfig(
    swizzled_type=SwizzleType.SWIZZLE_32_4_4,
)

# no swizzle (ROCm / XPU)
config = NVFP4DynamicActivationNVFP4WeightConfig(
    swizzled_type=SwizzleType.NO_SWIZZLE,
)
```
