### PR TITLE
Fix test_x86inductor_fusion CI failure (test_qconv2d_maxpool2d_linear)

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_fusion.py
+++ b/test/quantization/pt2e/test_x86inductor_fusion.py
@@ -3671,7 +3671,12 @@ if RUN_CPU:
             func_inputs=[
                 [
                     "aoti_torch_cpu__qconv_pointwise_tensor",
-                    "torch.ops.quantized.max_pool2d",
+                    # quantized::max_pool2d has no AOTI C-shim and takes list
+                    # args, so cpp_wrapper emits a boxed dispatcher fallback
+                    # (c10::Dispatcher...findSchemaOrThrow("quantized::max_pool2d"))
+                    # rather than the Python-style torch.ops.quantized.max_pool2d.
+                    # See pytorch #184099.
+                    "quantized::max_pool2d",
                     "aoti_torch_cpu__qlinear_pointwise_tensor",
                 ]
             ],


### PR DESCRIPTION
The cpp_wrapper variant of test_qconv2d_maxpool2d_linear_dynamic asserts that the generated code contains "torch.ops.quantized.max_pool2d". This broke with recent PyTorch nightlies (pytorch/pytorch#184099). Update the expected substring to "quantized::max_pool2d" to match the new codegen.

Test plan: (fails before, now passes)

```
python test/quantization/pt2e/test_x86inductor_fusion.py \
  DynamicShapesCppWrapperCpuTests.test_qconv2d_maxpool2d_linear_dynamic_cpu_dynamic_shapes_cpp_wrapper
```