### PR TITLE
[PT2E][X86] Fall back to plain linear annotation for reused nn.Linear with fusable post op

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -470,6 +470,24 @@ class TestHelperModules:
                 tmp = self.linear(x)
                 return tmp + self.linear2(tmp)
 
+    class SharedLinearModule(torch.nn.Module):
+        """One Linear module with multiple call sites (e.g. an unrolled loop),
+        each followed by a fusable post op (add or relu).
+        """
+
+        def __init__(self, post_op: str = "add") -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(in_features=16, out_features=16)
+            self.post_op = post_op
+
+        def forward(self, x):
+            for _ in range(2):
+                if self.post_op == "add":
+                    x = x + self.linear(x)
+                else:
+                    x = torch.relu(self.linear(x))
+            return x
+
     class Conv2dAddModule2(torch.nn.Module):
         def __init__(
             self,
@@ -668,12 +686,13 @@ class X86InductorQuantTestCase(QuantizationTestCase):
         is_qat=False,
         debug=False,
         lower=False,
+        strict=True,
     ):
         m_eager = model.train() if is_qat else model.eval()
 
         # program capture
         m = copy.deepcopy(m_eager)
-        m = torch.export.export(m, example_inputs, strict=True).module()
+        m = torch.export.export(m, example_inputs, strict=strict).module()
 
         # QAT Model failed to deepcopy
         export_model = m if is_qat else copy.deepcopy(m)
@@ -1729,6 +1748,60 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                         "is_quant_out": 1,
                     },
                     add_op: {"annotated": 1, "is_quant_out": 1},
+                }
+                self._check_annotation_stat(fq_m, expected_annotation_stat)
+
+    @skipIfNoX86
+    def test_linear_reused_with_fusable_post_op(self):
+        """
+        Test one Linear module with multiple call sites (e.g. an unrolled
+        loop), each followed by a fusable post op (add or relu).
+        With non-strict export, the source partition of the reused linear has
+        one output node per call site, so fusion is skipped and each call site
+        falls back to plain linear annotation instead of raising during
+        prepare_pt2e. See https://github.com/pytorch/ao/issues/4478
+        """
+        aten = torch.ops.aten
+        example_inputs = (torch.randn(2, 16),)
+        with override_quantized_engine("x86"), torch.no_grad():
+            for post_op in ["add", "relu"]:
+                m = TestHelperModules.SharedLinearModule(post_op=post_op).eval()
+                quantizer = X86InductorQuantizer().set_global(
+                    xiq.get_default_x86_inductor_quantization_config()
+                )
+                post_op_aten = (
+                    aten.add.Tensor if post_op == "add" else aten.relu.default
+                )
+                # One q-dq pair for the input of each linear call site,
+                # and one dq of the shared weight per call site
+                node_occurrence = {
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 2,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 2,
+                    # quantize_per_channel for weights are const propagated
+                    torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
+                    torch.ops.quantized_decomposed.dequantize_per_channel.default: 2,
+                }
+                node_list = [
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+                    torch.ops.aten.linear.default,
+                    post_op_aten,
+                ]
+                fq_m = self._test_quantizer(
+                    m,
+                    example_inputs,
+                    quantizer,
+                    node_occurrence,
+                    node_list,
+                    strict=False,
+                )[-1]
+                # Both call sites are annotated as plain linear without fusion
+                expected_annotation_stat = {
+                    aten.linear.default: {
+                        "annotated": 2,
+                        "is_quant_out": 2,
+                    },
+                    post_op_aten: {"annotated": 0, "is_quant_out": 0},
                 }
                 self._check_annotation_stat(fq_m, expected_annotation_stat)
 

--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -472,20 +472,28 @@ class TestHelperModules:
 
     class SharedLinearModule(torch.nn.Module):
         """One Linear module with multiple call sites (e.g. an unrolled loop),
-        each followed by a fusable post op (add or relu).
+        each followed by a fusable post op.
+
+        ``post_op="add"`` exercises the multi-output guard in
+        ``_annotate_linear_binary_unary``; ``post_op="relu"`` uses an
+        ``nn.ReLU`` *module* (not functional ``torch.relu``) so that a
+        ``[Linear, ReLU]`` sequential partition actually forms and the guard in
+        ``_annotate_linear_unary`` is exercised.
         """
 
         def __init__(self, post_op: str = "add") -> None:
             super().__init__()
             self.linear = torch.nn.Linear(in_features=16, out_features=16)
             self.post_op = post_op
+            # Reused module post op so [Linear, ReLU] forms a source partition.
+            self.relu = torch.nn.ReLU()
 
         def forward(self, x):
             for _ in range(2):
                 if self.post_op == "add":
                     x = x + self.linear(x)
                 else:
-                    x = torch.relu(self.linear(x))
+                    x = self.relu(self.linear(x))
             return x
 
     class Conv2dAddModule2(torch.nn.Module):

--- a/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
+++ b/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
@@ -1441,19 +1441,20 @@ class X86InductorQuantizer(Quantizer):
             itertools.chain.from_iterable(linear_partitions.values())
         )
         for partition in linear_partitions:
-            if len(partition.output_nodes) > 1:
-                raise ValueError(
-                    "Linear partition cannot have more than one output node"
+            # A partition may have multiple output nodes when one nn.Linear
+            # module has multiple call sites in the exported graph (e.g. it is
+            # called inside an unrolled loop). Annotate each call site.
+            for linear_node in partition.output_nodes:
+                if linear_node.op != "call_function" or linear_node.target not in (
+                    torch.ops.aten.linear.default,
+                ):
+                    raise ValueError(f"{linear_node} is not an aten linear operator")
+                # skip annotation if it is already annotated
+                if _skip_annotate([linear_node], filter_fn):
+                    continue
+                self._annotate_linear_node_helper(
+                    linear_node, True, quantization_config
                 )
-            linear_node = partition.output_nodes[0]
-            if linear_node.op != "call_function" or linear_node.target not in (
-                torch.ops.aten.linear.default,
-            ):
-                raise ValueError(f"{linear_node} is not an aten linear operator")
-            # skip annotation if it is already annotated
-            if _skip_annotate([linear_node], filter_fn):
-                continue
-            self._annotate_linear_node_helper(linear_node, True, quantization_config)
 
     def _annotate_linear_unary(
         self,
@@ -1473,6 +1474,12 @@ class X86InductorQuantizer(Quantizer):
                 gm, [torch.nn.Linear, postop]
             )
         for fused_partition in fused_partitions:
+            if any(len(partition.output_nodes) > 1 for partition in fused_partition):
+                # Fusion patterns assume each module has a single call site. A
+                # reused module (e.g. called inside an unrolled loop) yields a
+                # partition with multiple output nodes; skip fusion and let
+                # `_annotate_linear` annotate its call sites instead.
+                continue
             linear_partition, unary_partition = fused_partition
             linear_node, unary_node = self._get_output_nodes_of_partitions(
                 [linear_partition, unary_partition]
@@ -1511,6 +1518,15 @@ class X86InductorQuantizer(Quantizer):
                 seq_partition.append(unary_op)
             fused_partitions = find_sequential_partitions(gm, seq_partition)
             for fused_partition in fused_partitions:
+                if any(
+                    len(partition.output_nodes) > 1 for partition in fused_partition
+                ):
+                    # Fusion patterns assume each module has a single call
+                    # site. A reused module (e.g. called inside an unrolled
+                    # loop) yields a partition with multiple output nodes; skip
+                    # fusion and let `_annotate_linear` annotate its call sites
+                    # instead.
+                    continue
                 unary_partition, unary_node = None, None
                 if has_unary:
                     (


### PR DESCRIPTION
Fixes #4478

## Problem

`prepare_pt2e` with `X86InductorQuantizer` raises a `ValueError` whenever a single `nn.Linear` module has multiple call sites in the exported graph (e.g. it is called inside an unrolled loop — common for unrolled sampling loops of diffusion / flow-matching models) and any call site is followed by a fusable `add`/`relu`:

```
ValueError: Input partition has more than one output node          # linear + add
ValueError: Linear partition cannot have more than one output node # linear + relu
```

Root cause: under non-strict export (the current `torch.export.export` default), `get_source_partitions` groups all call sites of one module instance into a single `SourcePartition`, so the partition has one output node per call site. The linear fusion annotation passes (`_annotate_linear_unary`, `_annotate_linear_binary_unary` via `_get_output_nodes_of_partitions`) assume exactly one output node and raise, aborting quantization of the whole model. (Under `strict=True` each call site gets its own partition, which is why existing tests never hit this.)

## Fix

- `_annotate_linear_unary` / `_annotate_linear_binary_unary`: skip fused partition candidates where any partition has more than one output node (same `continue` style as the other pattern checks in this file) instead of raising.
- `_annotate_linear`: annotate each linear call site (output node) of a partition instead of raising on multi-output partitions, so the skipped call sites still get plain (non-fused) linear annotation.

Behavior change: a reused linear with a fusable neighbor is now quantized without fusion (input q/dq per call site, per-channel weight dq per call site) instead of crashing `prepare_pt2e`. Fusion behavior for single-call-site modules is unchanged.

Note: the conv fusion paths share the same single-call-site assumption and would crash the same way for a reused conv; this PR is scoped to the linear paths reported in the issue, and I'm happy to extend to conv in a follow-up if desired.

## Before / after

Minimal repro from the issue (`x = x + self.projection(x)` twice with one shared `nn.Linear`):

- Before: `ValueError: Input partition has more than one output node` (and the relu variant fails with `Linear partition cannot have more than one output node`)
- After: `prepare_pt2e` / `convert_pt2e` succeed; converted graph contains 2 quantized linear call sites (2 input q/dq pairs, 2 per-channel weight dq)

## Test

- Added `TestHelperModules.SharedLinearModule` and `test_linear_reused_with_fusable_post_op` in `test/quantization/pt2e/test_x86inductor_quantizer.py`, covering both `add` and `relu` post ops. The test checks node occurrence and annotation statistics (both call sites annotated as plain quantized linears, post ops unannotated).
- `_test_quantizer` gained a `strict` parameter (default `True`, all existing callers unchanged); the new test uses `strict=False` since only non-strict export produces multi-output partitions.
- The new test fails with the exact `ValueError`s from the issue without the source change and passes with it.
- Full `test/quantization/pt2e/test_x86inductor_quantizer.py`: 51 passed (CPU, torch 2.12).
- `ruff check` / `ruff format` (0.11.6, per pre-commit) clean.

> **Note on export mode:** this targets the **default (non-strict)** `torch.export.export` path. PT2E docs never pass `strict=` (all use `torch.export.export(m, example_inputs).module()`), and recent PyTorch defaults export to non-strict — so the documented happy path for any model that reuses an `nn.Linear` in a loop hits this crash. The prior tests only avoided it because `_test_quantizer` hard-codes `strict=True`.

---

This PR was written with the assistance of Claude (AI); I have reviewed and validated all changes.

 Generated with [Claude Code](https://claude.com/claude-code)