### PR TITLE
Fix H100 CI spmd-types install failure

### DIFF
--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -45,7 +45,18 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         # Pre-install torch/vision's pure-python deps from the in-cluster pypi-cache for speed.
-        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+        #
+        # spmd-types is appended on purpose: the torch nightly hard-depends on it, but the pytorch
+        # index only re-links to files.pythonhosted.org, which the OSDC H100 pool can't reach.
+        # Installing it now via the reachable cache means the cache-bypassing torch install below
+        # (--index-url only) never has to fetch it.
+        #
+        # Also affects release_model/run_microbenchmarks/dashboard_perf_test; only the H100 test
+        # workflows are patched for now since they are the ones failing.
+        #
+        # TODO: remove once the OSDC pool can reach files.pythonhosted.org (or spmd-types is
+        # mirrored on download.pytorch.org). Egress owned by PyTorch dev infra.
+        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow spmd-types
         # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
         # +cpu torch; the torch-spec's --index-url makes the literal nightly cu130 index the only source.
         PIP_EXTRA_INDEX_URL= pip install ${{ matrix.torch-spec }}

--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -44,7 +44,18 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         # Pre-install torch/vision's pure-python deps from the in-cluster pypi-cache for speed.
-        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow
+        #
+        # spmd-types is appended on purpose: the torch nightly hard-depends on it, but the pytorch
+        # index only re-links to files.pythonhosted.org, which the OSDC H100 pool can't reach.
+        # Installing it now via the reachable cache means the cache-bypassing torch install below
+        # (--index-url only) never has to fetch it.
+        #
+        # Also affects release_model/run_microbenchmarks/dashboard_perf_test; only the H100 test
+        # workflows are patched for now since they are the ones failing.
+        #
+        # TODO: remove once the OSDC pool can reach files.pythonhosted.org (or spmd-types is
+        # mirrored on download.pytorch.org). Egress owned by PyTorch dev infra.
+        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy pillow spmd-types
         # Clear PIP_EXTRA_INDEX_URL (the runner's default cpu /whl/cpu/) so it can't supply a
         # +cpu torch; the torch-spec's --index-url makes the literal nightly cu126 index the only source.
         PIP_EXTRA_INDEX_URL= pip install ${{ matrix.torch-spec }}


### PR DESCRIPTION
The torch nightly hard-depends on spmd-types, but the pytorch index only re-links to files.pythonhosted.org for it, which the OSDC H100 pool can't reach -- so the --index-url-only torch install fails to download it.

Pre-install spmd-types with the other pure-python deps (which resolve via the reachable in-cluster pypi-cache) so the torch install finds it satisfied.

Patch 1xH100/4xH100 only for now since they're the ones failing. Temporary until PyTorch dev infra fixes egress or mirrors spmd-types on download.pytorch.org