### PR TITLE
[PT2E][X86] Extend reused-module fallback to nn.Conv2d (follow-up to #4480)

### DIFF
--- a/test/quantization/pt2e/test_x86inductor_quantizer.py
+++ b/test/quantization/pt2e/test_x86inductor_quantizer.py
@@ -56,6 +56,43 @@ class TestHelperModules:
                 x = self.bn(x)
             return x
 
+    class SharedConvModule(torch.nn.Module):
+        """One Conv2d module with multiple call sites (e.g. an unrolled loop).
+
+        With non-strict export the reused conv collapses into a single source
+        partition with one output node per call site. ``post_op`` selects which
+        annotation path the reused (multi-output) conv exercises:
+
+        - ``"none"``: plain ``_annotate_conv2d``
+        - ``"relu"``: ``_annotate_conv2d_unary`` (an ``nn.ReLU`` *module* so a
+          ``[Conv2d, ReLU]`` sequential partition forms)
+        - ``"add"``: ``_annotate_conv2d_binary``
+        - ``"add_relu"``: ``_annotate_conv2d_binary_unary``
+        """
+
+        def __init__(self, post_op: str = "relu") -> None:
+            super().__init__()
+            # in_channels == out_channels and padding keeps the shape so the
+            # module can be applied repeatedly in the loop.
+            self.conv = torch.nn.Conv2d(
+                in_channels=3, out_channels=3, kernel_size=3, stride=1, padding=1
+            )
+            self.relu = torch.nn.ReLU()
+            self.post_op = post_op
+
+        def forward(self, x):
+            for _ in range(2):
+                y = self.conv(x)
+                if self.post_op == "relu":
+                    x = self.relu(y)
+                elif self.post_op == "add":
+                    x = x + y
+                elif self.post_op == "add_relu":
+                    x = self.relu(x + y)
+                else:  # "none"
+                    x = y
+            return x
+
     class Conv2dUnaryModule(torch.nn.Module):
         def __init__(self, post_op, use_bias: bool = False, with_bn=False) -> None:
             super().__init__()
@@ -760,6 +797,61 @@ class TestQuantizePT2EX86Inductor(X86InductorQuantTestCase):
                 node_occurrence,
                 node_list,
             )
+
+    @skipIfNoX86
+    def test_conv2d_reused_with_fusable_post_op(self):
+        """
+        One Conv2d module with multiple call sites (e.g. an unrolled loop),
+        optionally followed by a fusable post op. With non-strict export the
+        reused conv's source partition has one output node per call site, so
+        fusion is skipped and each call site falls back to plain conv
+        annotation instead of raising during prepare_pt2e. Same class of bug as
+        the reused nn.Linear fix, extended to conv. See
+        https://github.com/pytorch/ao/issues/4478
+        """
+        aten = torch.ops.aten
+        example_inputs = (torch.randn(2, 3, 16, 16),)
+        with override_quantized_engine("x86"), torch.no_grad():
+            # relu exercises _annotate_conv2d_unary, add exercises
+            # _annotate_conv2d_binary, add_relu exercises
+            # _annotate_conv2d_binary_unary; in every case fusion is skipped for
+            # the reused (multi-output) conv and each call site falls back to the
+            # plain _annotate_conv2d path.
+            for post_op in ["relu", "add", "add_relu"]:
+                m = TestHelperModules.SharedConvModule(post_op=post_op).eval()
+                quantizer = X86InductorQuantizer().set_global(
+                    xiq.get_default_x86_inductor_quantization_config()
+                )
+                # One q-dq pair for the input of each conv call site and one dq
+                # of the shared weight per call site; the post op is not fused.
+                node_occurrence = {
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 2,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default: 2,
+                    # quantize_per_channel for weights are const propagated
+                    torch.ops.quantized_decomposed.quantize_per_channel.default: 0,
+                    torch.ops.quantized_decomposed.dequantize_per_channel.default: 2,
+                }
+                node_list = [
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
+                    torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+                    torch.ops.aten.conv2d.default,
+                ]
+                fq_m = self._test_quantizer(
+                    m,
+                    example_inputs,
+                    quantizer,
+                    node_occurrence,
+                    node_list,
+                    strict=False,
+                )[-1]
+                # Both call sites are annotated as plain conv without fusion.
+                expected_annotation_stat = {
+                    aten.conv2d.default: {
+                        "annotated": 2,
+                        "is_quant_out": 2,
+                    },
+                }
+                self._check_annotation_stat(fq_m, expected_annotation_stat)
 
     @skipIfNoX86
     def test_conv2d_unary(self):

--- a/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
+++ b/torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py
@@ -1062,6 +1062,12 @@ class X86InductorQuantizer(Quantizer):
             gm, [torch.nn.Conv2d, operator.add, torch.nn.ReLU]
         )
         for fused_partition in fused_partitions:
+            if any(len(p.output_nodes) > 1 for p in fused_partition):
+                # A reused conv module (e.g. called inside an unrolled loop)
+                # yields a partition with multiple output nodes. The fusion
+                # paths assume a single call site, so skip fusion and let
+                # `_annotate_conv2d` annotate each call site instead.
+                continue
             conv_partition, binary_partition, unary_partition = fused_partition
             conv_node, binary_node, unary_node = self._get_output_nodes_of_partitions(
                 [conv_partition, binary_partition, unary_partition]
@@ -1115,6 +1121,12 @@ class X86InductorQuantizer(Quantizer):
             gm, [torch.nn.Conv2d, operator.add]
         )
         for fused_partition in fused_partitions:
+            if any(len(p.output_nodes) > 1 for p in fused_partition):
+                # A reused conv module (e.g. called inside an unrolled loop)
+                # yields a partition with multiple output nodes. The fusion
+                # paths assume a single call site, so skip fusion and let
+                # `_annotate_conv2d` annotate each call site instead.
+                continue
             conv_partition, binary_partition = fused_partition
             conv_node, binary_node = self._get_output_nodes_of_partitions(
                 [conv_partition, binary_partition]
@@ -1177,6 +1189,12 @@ class X86InductorQuantizer(Quantizer):
                 fused_partitions.extend(partitions)
 
         for fused_partition in fused_partitions:
+            if any(len(p.output_nodes) > 1 for p in fused_partition):
+                # A reused conv module (e.g. called inside an unrolled loop)
+                # yields a partition with multiple output nodes. The fusion
+                # paths assume a single call site, so skip fusion and let
+                # `_annotate_conv2d` annotate each call site instead.
+                continue
             conv_partition, unary_partition = fused_partition
             conv_node, unary_node = self._get_output_nodes_of_partitions(
                 [conv_partition, unary_partition]
@@ -1210,18 +1228,21 @@ class X86InductorQuantizer(Quantizer):
         )
         conv_partitions = list(itertools.chain.from_iterable(conv_partitions.values()))
         for conv_partition in conv_partitions:
-            if len(conv_partition.output_nodes) > 1:
-                raise ValueError("conv partition has more than one output node")
-            conv_node = conv_partition.output_nodes[0]
-            if (
-                conv_node.op != "call_function"
-                or conv_node.target != torch.ops.aten.conv2d.default
-            ):
-                raise ValueError(f"{conv_node} is not an aten conv2d operator")
-            # skip annotation if it is already annotated
-            if _skip_annotate([conv_node], filter_fn):
-                continue
-            self._annotate_conv_node_helper(conv_node, True, quantization_config)
+            # A partition may have multiple output nodes when one nn.Conv2d
+            # module has multiple call sites in the exported graph (e.g. it is
+            # called inside an unrolled loop). Annotate each call site.
+            for conv_node in conv_partition.output_nodes:
+                if (
+                    conv_node.op != "call_function"
+                    or conv_node.target != torch.ops.aten.conv2d.default
+                ):
+                    raise ValueError(f"{conv_node} is not an aten conv2d operator")
+                # skip annotation if it is already annotated
+                if _skip_annotate([conv_node], filter_fn):
+                    continue
+                self._annotate_conv_node_helper(
+                    conv_node, True, quantization_config
+                )
 
     def _annotate_maxpool2d(
         self,


### PR DESCRIPTION
## Summary

Follow-up to #4480 (reused `nn.Linear` fix), extending the same fix to `nn.Conv2d`. As @claude noted in the #4480 review, the conv annotation paths share the single-call-site assumption, so a **reused `nn.Conv2d`** (e.g. called inside an unrolled loop) under non-strict export still crashes `prepare_pt2e`:

- plain path → `ValueError: conv partition has more than one output node` (`_annotate_conv2d`)
- fusion paths → `ValueError: Input partition has more than one output node` (`_get_output_nodes_of_partitions`)

> **Stacked on #4480.** This branch is based on `fix-4478-reused-linear-fusion` because the new test relies on `_test_quantizer(..., strict=False)` introduced there. Until #4480 merges, the diff here also shows the linear commits; I'll rebase onto `main` (conv-only) once #4480 lands. Happy to instead fold this into #4480 if you'd prefer a single PR.

## Modifications

Mirror the linear fix:
- `_annotate_conv2d_binary_unary` / `_annotate_conv2d_binary` / `_annotate_conv2d_unary`: skip fusion when any partition has multiple output nodes, so a reused conv falls back to plain annotation.
- `_annotate_conv2d`: iterate `partition.output_nodes` and annotate each call site instead of raising on multi-output partitions.

## Test

Adds `SharedConvModule` + `test_conv2d_reused_with_fusable_post_op`, covering the unary (`relu`), binary (`add`) and binary+unary (`add+relu`) fusion guards plus the plain fallback.

Coverage is real, not just "passes": with the fix reverted the test crashes with `Input partition has more than one output node`; with it, each call site is annotated as plain conv and `prepare_pt2e` succeeds (`node_occurrence` 2×q/dq-per-tensor + 2× weight dq, conv annotated at both sites, post-op unfused). Validated on torch 2.12 (CPU); `ruff check`/`format` clean.

---

This PR was written with the assistance of Claude (AI); I have reviewed and validated all changes on real hardware.
