### PR TITLE
pt2e: raise clear errors for unresolvable SharedQuantizationSpec annotations (#4421)

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1412,6 +1412,163 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         assert len(observers) == 2
         self.assertIs(observers[0], observers[1])
 
+    def _get_shared_qspec_test_model_and_clones(self, num_clones):
+        """Returns an exported model with `num_clones` chained clone ops and
+        the list of clone nodes, used by the SharedQuantizationSpec validation tests
+        """
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                for _ in range(num_clones):
+                    x = x.clone()
+                return x
+
+        example_inputs = (torch.randn(1, 5),)
+        m = torch.export.export(M().eval(), example_inputs, strict=True).module()
+        clones = [n for n in m.graph.nodes if n.target is torch.ops.aten.clone.default]
+        assert len(clones) == num_clones
+        return m, clones
+
+    def test_shared_qspec_reference_appears_later_error(self):
+        """SharedQuantizationSpec that refers to an edge or node appearing later in
+        graph order should fail with a descriptive ValueError instead of an
+        AssertionError, see https://github.com/pytorch/ao/issues/4421
+        """
+        act_qspec = QuantizationSpec(
+            dtype=torch.uint8,
+            quant_min=0,
+            quant_max=255,
+            qscheme=torch.per_tensor_affine,
+            observer_or_fake_quant_ctr=observer.default_observer,
+        )
+
+        class BackendAQuantizer(Quantizer):
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                first, second = [
+                    n
+                    for n in model.graph.nodes
+                    if n.target is torch.ops.aten.clone.default
+                ]
+                # the first clone shares with the second clone, but the anchor
+                # (second clone) appears later in graph order
+                first.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(second),
+                    _annotated=True,
+                )
+                second.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=act_qspec,
+                    _annotated=True,
+                )
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                pass
+
+        m, _ = self._get_shared_qspec_test_model_and_clones(2)
+        with self.assertRaisesRegex(ValueError, "appears later in the graph"):
+            prepare_pt2e(m, BackendAQuantizer())
+
+    def test_shared_qspec_cycle_error(self):
+        """A cycle of SharedQuantizationSpecs with no concrete quantization spec should
+        fail with a descriptive ValueError instead of an AssertionError/RecursionError
+        """
+
+        class BackendAQuantizer(Quantizer):
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                first, second = [
+                    n
+                    for n in model.graph.nodes
+                    if n.target is torch.ops.aten.clone.default
+                ]
+                first.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(second),
+                    _annotated=True,
+                )
+                second.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(first),
+                    _annotated=True,
+                )
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                pass
+
+        m, _ = self._get_shared_qspec_test_model_and_clones(2)
+        with self.assertRaisesRegex(ValueError, "forms a cycle"):
+            prepare_pt2e(m, BackendAQuantizer())
+
+    def test_shared_qspec_unannotated_reference_error(self):
+        """SharedQuantizationSpec that refers to an edge or node without any
+        quantization annotation should fail with a descriptive ValueError instead
+        of a KeyError
+        """
+
+        class BackendAQuantizer(Quantizer):
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                first, second = [
+                    n
+                    for n in model.graph.nodes
+                    if n.target is torch.ops.aten.clone.default
+                ]
+                first.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(second),
+                    _annotated=True,
+                )
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                pass
+
+        m, _ = self._get_shared_qspec_test_model_and_clones(2)
+        with self.assertRaisesRegex(
+            ValueError, "not annotated with a quantization spec"
+        ):
+            prepare_pt2e(m, BackendAQuantizer())
+
+    def test_shared_qspec_chain_through_later_node(self):
+        """A chain of SharedQuantizationSpecs where an intermediate hop appears later
+        in graph order is still resolvable as long as the chain reaches a concrete
+        quantization spec, make sure validation doesn't reject it
+        """
+        act_qspec = QuantizationSpec(
+            dtype=torch.uint8,
+            quant_min=0,
+            quant_max=255,
+            qscheme=torch.per_tensor_affine,
+            observer_or_fake_quant_ctr=observer.default_observer,
+        )
+
+        class BackendAQuantizer(Quantizer):
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                first, second, third = [
+                    n
+                    for n in model.graph.nodes
+                    if n.target is torch.ops.aten.clone.default
+                ]
+                # second refers to third, which appears later in graph order, but
+                # the group's first member (first) has a concrete qspec so the
+                # sharing group is resolvable
+                first.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=act_qspec,
+                    _annotated=True,
+                )
+                second.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(third),
+                    _annotated=True,
+                )
+                third.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=SharedQuantizationSpec(first),
+                    _annotated=True,
+                )
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                pass
+
+        m, clones = self._get_shared_qspec_test_model_and_clones(3)
+        prepare_pt2e(m, BackendAQuantizer())
+        # all three clone outputs should use the same observer instance
+        output_obs = [getattr(m, next(iter(n.users)).target) for n in clones]
+        assert len(output_obs) == 3
+        self.assertIs(output_obs[0], output_obs[1])
+        self.assertIs(output_obs[0], output_obs[2])
+
     @parametrize("dtype", (torch.float32, torch.bfloat16))
     @parametrize("quant_dtype", (torch.int16, torch.float8_e5m2, torch.float8_e4m3fn))
     def test_quantization_dtype(self, dtype, quant_dtype):

--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -212,6 +212,40 @@ def _has_same_attr(
     ) or (not hasattr(qspec_a, attr_name) and not hasattr(qspec_b, attr_name))
 
 
+def _validate_shared_quantization_specs(
+    edge_or_node_to_qspec: dict[EdgeOrNode, QuantizationSpecBase],
+) -> None:
+    """Validate that all SharedQuantizationSpec in the annotations are resolvable, that is:
+      (1) every SharedQuantizationSpec refers to an edge or node that is annotated
+      (2) following the chain of SharedQuantizationSpec reaches a concrete (non shared)
+          quantization spec, i.e. the chain does not form a cycle
+
+    Raises a ValueError describing the offending annotation otherwise, so that quantizer
+    authors get an actionable error instead of a KeyError or RecursionError deeper in
+    the prepare flow
+    """
+    for edge_or_node, qspec in edge_or_node_to_qspec.items():
+        chain = [edge_or_node]
+        while isinstance(qspec, SharedQuantizationSpec):
+            referenced = qspec.edge_or_node
+            if referenced not in edge_or_node_to_qspec:
+                raise ValueError(
+                    f"SharedQuantizationSpec at '{chain[-1]}' refers to '{referenced}', "
+                    "which is not annotated with a quantization spec, please make sure "
+                    "SharedQuantizationSpec only refers to an edge or node that is annotated"
+                )
+            if referenced in chain:
+                chain_str = " -> ".join(str(c) for c in chain + [referenced])
+                raise ValueError(
+                    f"SharedQuantizationSpec chain forms a cycle: {chain_str}, so it never "
+                    "reaches a concrete quantization spec, please make sure each sharing "
+                    "group has one edge or node that is annotated with a concrete "
+                    "quantization spec that the others (transitively) refer to"
+                )
+            chain.append(referenced)
+            qspec = edge_or_node_to_qspec[referenced]
+
+
 def _get_edge_or_node_to_qspec(
     model: torch.fx.GraphModule,
 ) -> dict[EdgeOrNode, QuantizationSpecBase]:
@@ -317,6 +351,10 @@ def _get_edge_or_node_to_group_id(
         # everything are in the same group because (cat1) and (cat1, cat2) are implicitly shared, which
         # connects the two sharing group around cat1 and cat2 op due to transitive sharing
     """
+    # validate first so that unresolvable SharedQuantizationSpec configurations fail
+    # with a descriptive error instead of a KeyError/RecursionError during union find
+    _validate_shared_quantization_specs(edge_or_node_to_qspec)
+
     # means the observer of key should be shared with observer with value, by default it will
     # be shared with itself
     shared_with_map: dict[EdgeOrNode, EdgeOrNode] = {
@@ -407,6 +445,21 @@ def _get_obs_or_fq_map(
     for edge_or_node, qspec in edge_or_node_to_qspec.items():
         group_id = edge_or_node_to_group_id[edge_or_node]
         if group_id not in group_id_to_obs_or_fq:
+            if (
+                isinstance(qspec, SharedQuantizationSpec)
+                and qspec.edge_or_node not in obs_or_fq_map
+            ):
+                # the first member of the sharing group (in graph order) has a
+                # SharedQuantizationSpec, which means the edge or node it refers to
+                # appears later in the graph and doesn't have an observer/fake_quant yet
+                raise ValueError(
+                    f"SharedQuantizationSpec at '{edge_or_node}' refers to "
+                    f"'{qspec.edge_or_node}', which appears later in the graph, the edge "
+                    "or node that a sharing group is anchored on (the one annotated with "
+                    "a concrete quantization spec) is expected to come before all edges "
+                    "and nodes that share with it, please update the annotation so that "
+                    "SharedQuantizationSpec refers back to an earlier edge or node"
+                )
             # TODO: maybe edge_or_node_to_qspec should be edge_or_node_to_root_qspec, this will simplify
             # the implementation for _create_obs_or_fq_from_qspec
             group_id_to_obs_or_fq[group_id] = _create_obs_or_fq_from_qspec(


### PR DESCRIPTION
Fixes #4421.

Implements the detection jerryzh168 asked for there: unresolvable `SharedQuantizationSpec`
annotations now fail `prepare_pt2e` with a descriptive `ValueError` instead of a bare
`AssertionError`, `KeyError`, or `RecursionError`.

There are three distinct crash modes in `prepare.py`: (1) the sharing group's first member
in graph order has a `SharedQuantizationSpec`, so observer creation hits the bare assert in
`_create_obs_or_fq_from_qspec`; (2) a spec refers to an edge/node with no annotation at
all, which `KeyError`s in `_find_root_edge_or_node`; (3) the chain of shared specs forms a
cycle with no concrete qspec, which makes `_unwrap_shared_qspec` recurse forever — the
infinite-recursion mode from the issue thread.

This adds `_validate_shared_quantization_specs`, run before sharing-group resolution, which
checks that every shared spec refers to an annotated edge/node and that every chain
terminates at a concrete qspec, reporting the offending edge/node (and the full chain for
cycles). Quantizer authors can also call the helper directly after annotation. The ordering
case (1) is deliberately not validated as "anchor must always precede the edges/nodes
sharing with it": chains that hop through a later edge/node but still terminate at a
concrete qspec work fine today (a test pins this), so instead the exact crash condition in
`_get_obs_or_fq_map` now raises a `ValueError` naming both edges/nodes and explaining that
the anchor of a sharing group must come first.

No behavior change for resolvable annotations; sharing semantics are untouched. Added tests
for the three error modes (including the issue's repro) plus the still-working
chain-through-a-later-node case; existing shared-qspec/transitivity/implicit-sharing tests
in `test_quantize_pt2e.py` and the QAT suite pass.
