### PR TITLE
[pt2e] Fuse and fold linear + bn in QAT like conv + bn

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -204,6 +204,7 @@ class PT2EQATTestCase(QuantizationTestCase):
         has_bias: bool = True,
         is_cuda: bool = False,
         expected_conv_literal_args: Optional[tuple[Any, ...]] = None,
+        is_linear: bool = False,
         # TODO: set this to true by default
         verify_convert: bool = False,
     ):
@@ -215,6 +216,7 @@ class PT2EQATTestCase(QuantizationTestCase):
             has_bias=has_bias,
             is_cuda=is_cuda,
             expected_conv_literal_args=expected_conv_literal_args,
+            is_linear=is_linear,
             verify_convert=verify_convert,
         )
         self._verify_symmetric_xnnpack_qat_graph_helper(
@@ -225,6 +227,7 @@ class PT2EQATTestCase(QuantizationTestCase):
             has_bias=has_bias,
             is_cuda=is_cuda,
             expected_conv_literal_args=expected_conv_literal_args,
+            is_linear=is_linear,
             verify_convert=verify_convert,
         )
 
@@ -237,6 +240,7 @@ class PT2EQATTestCase(QuantizationTestCase):
         has_bias: bool = True,
         is_cuda: bool = False,
         expected_conv_literal_args: Optional[tuple[Any, ...]] = None,
+        is_linear: bool = False,
         verify_convert: bool = False,
     ):
         """
@@ -290,7 +294,10 @@ class PT2EQATTestCase(QuantizationTestCase):
         (conv_node, scale_factor_reshape_node) = div_scale_factor_node.args
         conv_op = conv_node.target
         self.assertEqual(div_scale_factor_node.target, torch.ops.aten.div.Tensor)
-        self.assertTrue(_is_conv_node(conv_node))
+        if is_linear:
+            self.assertEqual(conv_node.target, torch.ops.aten.linear.default)
+        else:
+            self.assertTrue(_is_conv_node(conv_node))
         self.assertEqual(
             scale_factor_reshape_node.target, torch.ops.aten.reshape.default
         )
@@ -929,6 +936,153 @@ class TestQuantizePT2EQAT_ConvBn2d(TestQuantizePT2EQAT_ConvBn_Base):
         assert num_batch_norm_nodes_checked == 2, (
             f"bad test setup, didn't check 2 bns, only checked these: {nodes_to_check}"
         )
+
+
+@skipIfNoQNNPACK
+class TestQuantizePT2EQAT_LinearBn(PT2EQATTestCase):
+    """
+    TestCase for QAT fusion and folding of the linear-bn[-relu] pattern.
+
+    See https://github.com/pytorch/ao/issues/4463.
+    """
+
+    example_inputs = (torch.randn(3, 8),)
+
+    class _LinearBnModel(torch.nn.Module):
+        def __init__(self, has_linear_bias: bool = True, has_relu: bool = False):
+            super().__init__()
+            self.linear = torch.nn.Linear(8, 16, bias=has_linear_bias)
+            self.bn = torch.nn.BatchNorm1d(16)
+            self.relu = torch.nn.ReLU() if has_relu else None
+
+        def forward(self, x):
+            x = self.linear(x)
+            x = self.bn(x)
+            if self.relu is not None:
+                x = self.relu(x)
+            return x
+
+    def _get_linear_bn_nodes(self, m: torch.fx.GraphModule):
+        """
+        Return a 2-tuple of (linear, bn) nodes from the graph.
+        """
+        m.graph.eliminate_dead_code()
+        m.recompile()
+        linear_node = None
+        bn_node = None
+        for n in m.graph.nodes:
+            if n.target == torch.ops.aten.linear.default:
+                linear_node = n
+            if n.target in (
+                torch.ops.aten._native_batch_norm_legit.default,
+                torch.ops.aten._native_batch_norm_legit_no_training.default,
+                torch.ops.aten.batch_norm.default,
+            ):
+                bn_node = n
+        assert linear_node is not None, "bad test setup"
+        return (linear_node, bn_node)
+
+    def _prepare_qat_linear_bn(
+        self,
+        m: torch.nn.Module,
+        example_inputs: tuple[Any, ...],
+        is_per_channel: bool,
+    ) -> torch.fx.GraphModule:
+        quantizer = XNNPACKQuantizer()
+        quantizer.set_global(
+            get_symmetric_quantization_config(is_per_channel, is_qat=True)
+        )
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        return prepare_qat_pt2e(m, quantizer)
+
+    def test_qat_linear_bn_fusion(self):
+        m = self._LinearBnModel()
+        self._verify_symmetric_xnnpack_qat_graph(
+            m,
+            self.example_inputs,
+            has_relu=False,
+            is_linear=True,
+            verify_convert=True,
+        )
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
+
+    def test_qat_linear_bn_fusion_no_linear_bias(self):
+        m = self._LinearBnModel(has_linear_bias=False)
+        self._verify_symmetric_xnnpack_qat_graph(
+            m,
+            self.example_inputs,
+            has_relu=False,
+            has_bias=False,
+            is_linear=True,
+            verify_convert=True,
+        )
+        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
+
+    def test_qat_linear_bn_relu_fusion(self):
+        # Note: We don't verify FX numerics here since FX has no fused
+        # LinearBnReLU1d module (unlike ConvBnReLU2d), so FX inserts an
+        # extra fake quantize between the bn and the relu and the numerics
+        # legitimately differ
+        m = self._LinearBnModel(has_relu=True)
+        self._verify_symmetric_xnnpack_qat_graph(
+            m,
+            self.example_inputs,
+            has_relu=True,
+            is_linear=True,
+            verify_convert=True,
+        )
+
+    def test_qat_linear_bn_fold_erases_bn_node(self):
+        """
+        Ensure the BN node is erased from the graph after folding
+        it into linear in `convert_pt2e`.
+        """
+        for is_per_channel in [True, False]:
+            for has_linear_bias in [True, False]:
+                m = self._LinearBnModel(has_linear_bias=has_linear_bias)
+                m = self._prepare_qat_linear_bn(m, self.example_inputs, is_per_channel)
+                m(*self.example_inputs)
+                m = convert_pt2e(m)
+                m(*self.example_inputs)
+                (_, bn_node) = self._get_linear_bn_nodes(m)
+                self.assertTrue(bn_node is None)
+
+    def test_qat_linear_bn_3d_input_not_fused(self):
+        """
+        Linear + BN should not be fused or folded when the linear input is
+        not 2-D, since Linear operates on the last dim while BatchNorm1d
+        operates on dim 1, and the two only coincide for 2-D (N, C) inputs.
+        See https://github.com/pytorch/ao/issues/4116.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(8, 6)
+                self.bn = torch.nn.BatchNorm1d(5)
+
+            def forward(self, x):
+                return self.bn(self.linear(x))
+
+        example_inputs = (torch.randn(4, 5, 8),)
+        m = self._prepare_qat_linear_bn(M(), example_inputs, is_per_channel=True)
+
+        # Verify that linear and bn were not fused into the QAT pattern
+        # during prepare. The fused QAT pattern scales the linear weights
+        # and undoes the scaling with a div after the linear, so the
+        # absence of any div node means no fusion happened.
+        (_, bn_node) = self._get_linear_bn_nodes(m)
+        self.assertTrue(bn_node is not None)
+        self.assertTrue(
+            all(n.target != torch.ops.aten.div.Tensor for n in m.graph.nodes)
+        )
+
+        # Verify that bn was not folded into linear during convert
+        m(*example_inputs)
+        m = convert_pt2e(m)
+        m(*example_inputs)
+        (_, bn_node) = self._get_linear_bn_nodes(m)
+        self.assertTrue(bn_node is not None)
 
 
 def _is_conv_node(n: torch.fx.Node):

--- a/torchao/quantization/pt2e/qat_utils.py
+++ b/torchao/quantization/pt2e/qat_utils.py
@@ -9,6 +9,7 @@ import copy
 import dataclasses
 import itertools
 import operator
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
@@ -29,7 +30,9 @@ from torchao.quantization.pt2e.utils import (
     _is_bn_node,
     _is_conv_or_conv_transpose_node,
     _is_conv_transpose_fn,
+    _is_linear_node,
     fold_bn_weights_into_conv_node,
+    fold_bn_weights_into_linear_node,
 )
 
 if TYPE_CHECKING:
@@ -319,6 +322,13 @@ def _get_folded_quantized_qat_conv_bn_pattern(
     return WrapperModule(_folded_quantized_qat_conv_bn_pattern)
 
 
+def _is_conv_or_linear_node(n: Node) -> bool:
+    """
+    Return whether the node refers to an aten conv, conv transpose, or linear op.
+    """
+    return _is_conv_or_conv_transpose_node(n) or _is_linear_node(n)
+
+
 def _has_conv_bias_filter(
     match: "InternalMatch",
     original_graph: Graph,
@@ -329,7 +339,7 @@ def _has_conv_bias_filter(
     the original graph has bias.
     """
     for n in match.nodes_map.values():
-        if _is_conv_or_conv_transpose_node(n):
+        if _is_conv_or_linear_node(n):
             return len(n.args) > 2 and n.args[2] is not None
     raise ValueError("Could not find conv node in matched conv + bn pattern")
 
@@ -344,6 +354,38 @@ def _no_conv_bias_filter(
     the original graph does NOT have bias.
     """
     return not _has_conv_bias_filter(match, original_graph, pattern_graph)
+
+
+def _linear_bn_input_is_2d_filter(
+    match: "InternalMatch",
+    original_graph: Graph,
+    pattern_graph: Graph,
+) -> bool:
+    """
+    Match filter for the subgraph rewriter that returns True if the input to
+    the linear node in the original graph is 2-D.
+
+    Linear + BN fusion is only valid when both layers operate on the same
+    dimension. Linear always acts on the last dim while BatchNorm1d acts on
+    the channel dim (dim 1). These two coincide only when the linear input
+    is 2-D (N, C). For higher-rank inputs, fusing would silently produce
+    incorrect results. See https://github.com/pytorch/ao/issues/4116
+    """
+    for n in match.nodes_map.values():
+        if not (isinstance(n, Node) and _is_linear_node(n)):
+            continue
+        linear_input = n.args[0]
+        assert isinstance(linear_input, Node)
+        linear_input_val = linear_input.meta.get("val")
+        if isinstance(linear_input_val, torch.Tensor) and linear_input_val.ndim != 2:
+            warnings.warn(
+                f"Not fusing linear+bn for node '{n.name}': the linear input "
+                f"is {linear_input_val.ndim}-D so Linear and BatchNorm operate "
+                f"on different dimensions"
+            )
+            return False
+        return True
+    raise ValueError("Could not find linear node in matched linear + bn pattern")
 
 
 def _is_quantize(n: Node) -> bool:
@@ -388,7 +430,7 @@ def _get_conv_bn_pattern_nodes(r: ReplacedPatterns) -> dict[str, tuple[Node, Nod
         for n in nodes:
             if n.op != "call_function":
                 continue
-            if _is_conv_or_conv_transpose_node(n):
+            if _is_conv_or_linear_node(n):
                 assert conv_node is None
                 conv_node = n
             if _is_bn_node(n):
@@ -508,9 +550,12 @@ def _copy_over_literal_conv_args(original_node: Node, new_node: Node):
 
     Note: Unlike other tensor args like conv weights and biases, literal args are
     preserved in the original nodes after replacement, so we can access them here.
+
+    Note: For linear, there are no literal args to copy over, so this just
+    normalizes the bias arg.
     """
-    assert _is_conv_or_conv_transpose_node(original_node)
-    assert _is_conv_or_conv_transpose_node(new_node)
+    assert _is_conv_or_linear_node(original_node)
+    assert _is_conv_or_linear_node(new_node)
     # x, weight, bias, [stride, padding, dilation, transposed, output_padding, groups]
     new_args = list(new_node.args)
     if len(new_args) < 3:
@@ -529,8 +574,8 @@ def _update_conv_input_qspec_map_after_replacement(
     so the keys in the `input_qspec_map` will need to be updated to reflect
     the corresponding nodes in the replacement graph.
     """
-    assert _is_conv_or_conv_transpose_node(original_node)
-    assert _is_conv_or_conv_transpose_node(replacement_node)
+    assert _is_conv_or_linear_node(original_node)
+    assert _is_conv_or_linear_node(replacement_node)
     if "quantization_annotation" not in original_node.meta:
         return
     original_input_qspec_map = original_node.meta[
@@ -626,6 +671,17 @@ def _fuse_conv_bn_qat(m: GraphModule) -> GraphModule:
         torch.randn(1),  # bn_running_var
     )
 
+    # Example inputs for linear-bn1d patterns
+    _linear_bn_example_inputs = (
+        torch.randn(2, 1),  # x
+        torch.randn(1, 1),  # linear_weight
+        torch.randn(1),  # linear_bias
+        torch.randn(1),  # bn_weight
+        torch.randn(1),  # bn_bias
+        torch.randn(1),  # bn_running_mean
+        torch.randn(1),  # bn_running_var
+    )
+
     has_bn = any(_is_bn_node(n) for n in m.graph.nodes)
     if not has_bn:
         return m
@@ -642,6 +698,9 @@ def _fuse_conv_bn_qat(m: GraphModule) -> GraphModule:
         )
         m = _fuse_conv_bn_qat_helper(
             m, F.conv_transpose2d, _conv2d_bn_example_inputs, is_cuda=is_cuda
+        )
+        m = _fuse_conv_bn_qat_helper(
+            m, F.linear, _linear_bn_example_inputs, is_cuda=is_cuda
         )
     return m
 
@@ -670,6 +729,13 @@ def _fuse_conv_bn_qat_helper(
         is_cuda,
     )
 
+    # For linear + bn, only fuse if the linear input is 2-D, since Linear
+    # and BatchNorm1d operate on different dimensions otherwise
+    if conv_fn is F.linear:
+        extra_match_filters = [_linear_bn_input_is_2d_filter]
+    else:
+        extra_match_filters = []
+
     # Step (1): Replace patterns with conv bias
     #
     # Here we do replacement separately for cases with and without conv bias, since
@@ -686,7 +752,7 @@ def _fuse_conv_bn_qat_helper(
         m,
         match_pattern,
         replacement_pattern_with_conv_bias,
-        match_filters=[_has_conv_bias_filter],
+        match_filters=[_has_conv_bias_filter] + extra_match_filters,
         ignore_literals=True,
     )
     m.recompile()
@@ -703,7 +769,7 @@ def _fuse_conv_bn_qat_helper(
         m,
         match_pattern,
         replacement_pattern_no_conv_bias,
-        match_filters=[_no_conv_bias_filter],
+        match_filters=[_no_conv_bias_filter] + extra_match_filters,
         ignore_literals=True,
     )
     m.recompile()
@@ -743,7 +809,7 @@ def _fuse_conv_bn_qat_helper(
                 and "nn_module_stack" not in replacement_node.meta
             ):
                 replacement_node.meta["nn_module_stack"] = copy.deepcopy(conv_nn_module)
-            if _is_conv_or_conv_transpose_node(original_node):
+            if _is_conv_or_linear_node(original_node):
                 # Step (3b): Copy over conv literal args
                 _copy_over_literal_conv_args(original_node, replacement_node)
                 # Step (3c): Update old references in the conv node's input_qspec_map
@@ -867,6 +933,16 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
         torch.randn(1),  # bn_running_var
     )
 
+    # Example inputs for quantized and folded linear-bn1d patterns used in convert
+    _quantized_linear_bn_example_inputs = (
+        torch.randn(2, 1),  # x
+        torch.randn(1, 1),  # linear_weight
+        torch.randn(1),  # bn_weight
+        torch.randn(1),  # bn_bias
+        torch.randn(1),  # bn_running_mean
+        torch.randn(1),  # bn_running_var
+    )
+
     has_bn = any(_is_bn_node(n) for n in m.graph.nodes)
     if not has_bn:
         return m
@@ -884,6 +960,9 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
         m = _fold_conv_bn_qat_helper(
             m, F.conv_transpose2d, _quantized_conv2d_bn_example_inputs, is_cuda=is_cuda
         )
+        m = _fold_conv_bn_qat_helper(
+            m, F.linear, _quantized_linear_bn_example_inputs, is_cuda=is_cuda
+        )
 
     # remove in place add from batchnorm tracking traning stats
     for node in m.graph.nodes:
@@ -891,8 +970,14 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
             node.target == torch.ops.aten.add_.Tensor
             and node.args[0].op == "get_attr"
             and node.args[1] == 1
-            and "torch.nn.modules.batchnorm.BatchNorm2d"
-            in [val[1] for _, val in node.meta["nn_module_stack"].items()]
+            and any(
+                val[1]
+                in (
+                    "torch.nn.modules.batchnorm.BatchNorm1d",
+                    "torch.nn.modules.batchnorm.BatchNorm2d",
+                )
+                for _, val in node.meta["nn_module_stack"].items()
+            )
         ):
             m.graph.erase_node(node)
 
@@ -988,7 +1073,14 @@ def _fold_conv_bn_qat_helper(
         (_, conv_weight) = node_map["conv_weight"]
         if "conv_bias" in node_map:
             (_, conv_bias) = node_map["conv_bias"]
-        fold_bn_weights_into_conv_node(conv_node, conv_weight, conv_bias, bn_node, m)
+        if _is_linear_node(conv_node):
+            fold_bn_weights_into_linear_node(
+                conv_node, conv_weight, conv_bias, bn_node, m
+            )
+        else:
+            fold_bn_weights_into_conv_node(
+                conv_node, conv_weight, conv_bias, bn_node, m
+            )
 
         # Copy over literal args for conv
         for original_node in _filter_nodes_map(r.nodes_map).values():

--- a/torchao/testing/pt2e/_xnnpack_quantizer.py
+++ b/torchao/testing/pt2e/_xnnpack_quantizer.py
@@ -260,6 +260,8 @@ class XNNPACKQuantizer(Quantizer):
         "conv_bn",
         "conv_transpose_bn_relu",
         "conv_transpose_bn",
+        "linear_bn_relu",
+        "linear_bn",
     ]
 
     # static quantization ops (both PTQ and QAT)

--- a/torchao/testing/pt2e/_xnnpack_quantizer_utils.py
+++ b/torchao/testing/pt2e/_xnnpack_quantizer_utils.py
@@ -293,6 +293,151 @@ def _annotate_linear_relu(
     return annotated_partitions
 
 
+@register_annotator("linear_bn")
+def _annotate_linear_bn(
+    gm: torch.fx.GraphModule,
+    quantization_config: Optional[QuantizationConfig],
+    filter_fn: Optional[Callable[[Node], bool]] = None,
+) -> Optional[list[list[Node]]]:
+    """
+    Find linear + batchnorm parititions
+    Note: This is only used for QAT. In PTQ, batchnorm should already be fused into the linear.
+    """
+    return _do_annotate_linear_bn(gm, quantization_config, filter_fn, has_relu=False)
+
+
+@register_annotator("linear_bn_relu")
+def _annotate_linear_bn_relu(
+    gm: torch.fx.GraphModule,
+    quantization_config: Optional[QuantizationConfig],
+    filter_fn: Optional[Callable[[Node], bool]] = None,
+) -> Optional[list[list[Node]]]:
+    """
+    Find linear + batchnorm + relu parititions
+    Note: This is only used for QAT. In PTQ, batchnorm should already be fused into the linear.
+    """
+    return _do_annotate_linear_bn(gm, quantization_config, filter_fn, has_relu=True)
+
+
+def _do_annotate_linear_bn(
+    gm: torch.fx.GraphModule,
+    quantization_config: Optional[QuantizationConfig],
+    filter_fn: Optional[Callable[[Node], bool]],
+    has_relu: bool,
+) -> list[list[Node]]:
+    """
+    Find linear + batchnorm [+ relu] partitions and annotate them, mirroring
+    `_do_annotate_conv_bn` below.
+
+    Linear + BN is only fused when the linear input is 2-D, since Linear
+    operates on the last dim while BatchNorm1d operates on dim 1, and the
+    two only coincide for 2-D (N, C) inputs.
+    See https://github.com/pytorch/ao/issues/4116
+    """
+
+    # Example inputs for linear-bn1d patterns
+    _linear_bn_example_inputs = (
+        torch.randn(2, 1),  # x
+        torch.randn(1, 1),  # linear_weight
+        torch.randn(1),  # linear_bias
+        torch.randn(1),  # bn_weight
+        torch.randn(1),  # bn_bias
+        torch.randn(1),  # bn_running_mean
+        torch.randn(1),  # bn_running_var
+    )
+
+    def get_pattern(relu_is_inplace: bool):
+        def _linear_bn(x, linear_weight, linear_bias, bn_weight, bn_bias, bn_rm, bn_rv):
+            linear = F.linear(x, linear_weight, linear_bias)
+            bn = F.batch_norm(linear, bn_rm, bn_rv, bn_weight, bn_bias, training=True)
+            if has_relu:
+                output = F.relu_(bn) if relu_is_inplace else F.relu(bn)
+            else:
+                output = bn
+            return output, {
+                "input": x,
+                "linear": linear,
+                "weight": linear_weight,
+                "bias": linear_bias,
+                "output": output,
+            }
+
+        return WrapperModule(_linear_bn)
+
+    # Needed for matching, otherwise the matches gets filtered out due to unused
+    # nodes returned by batch norm
+    gm.graph.eliminate_dead_code()
+    gm.recompile()
+
+    matches = []
+    combinations = itertools.product(
+        [True, False] if torch.cuda.is_available() else [False],  # is_cuda
+        [True, False] if has_relu else [False],  # relu_is_inplace
+    )
+
+    for is_cuda, relu_is_inplace in combinations:
+        pattern = get_pattern(relu_is_inplace)
+        pattern = _get_aten_graph_module_for_pattern(
+            pattern, _linear_bn_example_inputs, is_cuda
+        )
+        pattern.graph.eliminate_dead_code()
+        pattern.recompile()
+        matcher = SubgraphMatcherWithNameNodeMap(pattern, ignore_literals=True)
+        matches.extend(matcher.match(gm.graph))
+
+    # Annotate nodes returned in the matches
+    annotated_partitions = []
+    for match in matches:
+        name_node_map = match.name_node_map
+        input_node = name_node_map["input"]
+        linear_node = name_node_map["linear"]
+        weight_node = name_node_map["weight"]
+        bias_node = name_node_map["bias"]
+        output_node = name_node_map["output"]
+
+        # Validate linear args
+        if linear_node.args[0] is not input_node:
+            raise ValueError("Linear arg did not contain input node ", input_node)
+        if linear_node.args[1] is not weight_node:
+            raise ValueError("Linear arg did not contain weight node ", weight_node)
+        if len(linear_node.args) > 2 and linear_node.args[2] is not bias_node:
+            raise ValueError("Linear arg did not contain bias node ", bias_node)
+
+        # Skip if the linear input is not 2-D, since linear + bn won't be
+        # fused in this case (see above), and the pattern should instead be
+        # annotated by the plain "linear" annotator
+        input_val = input_node.meta.get("val")
+        if isinstance(input_val, torch.Tensor) and input_val.ndim != 2:
+            continue
+
+        # Skip if the partition is already annotated or is filtered out by the user
+        partition = [linear_node, weight_node]
+        if bias_node is not None:
+            partition.append(bias_node)
+        if _is_annotated(partition):
+            continue
+        if filter_fn and any(not filter_fn(n) for n in partition):
+            continue
+
+        # Annotate linear inputs and pattern output
+        input_qspec_map = {}
+        input_qspec_map[input_node] = get_input_act_qspec(quantization_config)
+        input_qspec_map[weight_node] = get_weight_qspec(quantization_config)
+        if bias_node is not None:
+            input_qspec_map[bias_node] = get_bias_qspec(quantization_config)
+        linear_node.meta["quantization_annotation"] = QuantizationAnnotation(
+            input_qspec_map=input_qspec_map,
+            _annotated=True,
+        )
+        output_node.meta["quantization_annotation"] = QuantizationAnnotation(
+            output_qspec=get_output_act_qspec(quantization_config),  # type: ignore[arg-type]
+            _annotated=True,
+        )
+        _mark_nodes_as_annotated(partition)
+        annotated_partitions.append(partition)
+    return annotated_partitions
+
+
 @register_annotator("conv")
 def _annotate_conv(
     gm: torch.fx.GraphModule,


### PR DESCRIPTION
Fixes #4463.

`prepare_qat_pt2e`/`convert_pt2e` only register conv variants in the QAT
fuse/fold passes, so a `batch_norm` node survives convert for
Linear+BatchNorm1d. This mirrors the conv path for `F.linear` in
`qat_utils.py`, as discussed in the issue: the pattern helpers are already
parameterized by `conv_fn`, the approximate-fusion math yields the right
broadcast shapes for a 2-D weight (matching `nniqat.LinearBn1d`), and the
convert step reuses the existing `fold_bn_weights_into_linear_node` from the
PTQ work. The 2-D-input-only guard from #4116/#4242 is enforced as a match
filter at prepare time (skip + warn), which is sufficient — an unfused linear
never produces the quantized QAT pattern at convert.

One thing the issue didn't surface: the `qat_utils.py` changes alone aren't
enough for the repro to fold. Since QAT annotates **before** fusing (PTQ fuses
before annotating), the quantizer must place the output qspec at the BN/relu
like `conv_bn`/`conv_bn_relu` do; the plain `linear` annotator instead inserts
an output fake-quantize between the linear and the rescaling `div` inside the
fused subgraph, and the convert-time pattern never matches. So this also adds
`linear_bn`/`linear_bn_relu` QAT-only annotators to the testing
XNNPACKQuantizer, mirroring `_do_annotate_conv_bn`. Backend quantizers that
want the fold need the same annotation shape.

Also extended the convert-time `num_batches_tracked` `add_` cleanup to match
BatchNorm1d in addition to BatchNorm2d — this is needed for linear+bn1d and
also removes the dangling `add_` previously left behind for conv1d+bn1d folds.

Added `TestQuantizePT2EQAT_LinearBn` covering: prepared/converted graph
structure and exact numerics parity with FX QAT (`nniqat.LinearBn1d`) for
bias/no-bias and per-channel/per-tensor, relu variant, BN erasure at convert,
and the 3-D input skip. Full `test_quantize_pt2e_qat.py` passes on CPU.
