### PR TITLE
support cat, chunk and split for MXTensor

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -572,6 +572,131 @@ def test_clone():
     )
 
 
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.parametrize(
+    "shapes,dim",
+    [
+        (((4, 64), (8, 64)), 0),
+        (((4, 64), (4, 96)), 1),
+        (((4, 64), (4, 96)), -1),
+        (((2, 4, 64), (3, 4, 64)), 0),
+        (((2, 4, 64), (2, 4, 32)), -1),
+    ],
+)
+def test_cat(elem_dtype, shapes, dim):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    block_size = 32
+    tensors_hp = [
+        torch.randn(*shape, device=device, dtype=torch.bfloat16) for shape in shapes
+    ]
+    tensors_mx = [MXTensor.to_mx(t, elem_dtype, block_size) for t in tensors_hp]
+
+    res = torch.cat(tensors_mx, dim=dim)
+    assert isinstance(res, MXTensor)
+
+    # since every input contributes whole blocks, the concatenation is exact
+    res_ref = torch.cat([t.dequantize() for t in tensors_mx], dim=dim)
+    torch.testing.assert_close(res.dequantize(), res_ref, atol=0, rtol=0)
+
+
+def test_cat_unsupported():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    block_size = 32
+    x_hp = torch.randn(64, 64, device=device, dtype=torch.bfloat16)
+
+    # the scaled dim of a transposed MXTensor is not last
+    x_mx_t = MXTensor.to_mx(x_hp, torch.float8_e4m3fn, block_size).t()
+    with pytest.raises(AssertionError, match="not yet supported"):
+        torch.cat([x_mx_t, x_mx_t], dim=0)
+
+    x_mx_swizzled = MXTensor.to_mx(
+        x_hp, torch.float8_e4m3fn, block_size, is_swizzled_scales=True
+    )
+    with pytest.raises(AssertionError, match="swizzled"):
+        torch.cat([x_mx_swizzled, x_mx_swizzled], dim=0)
+
+
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.parametrize("dim", [0, -1])
+def test_split(elem_dtype, dim):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    block_size = 32
+    x_hp = torch.randn(8, 128, device=device, dtype=torch.bfloat16)
+    x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size)
+    # use a split size which does not evenly divide the dim being split, to
+    # also exercise a smaller last split
+    split_size = 3 if dim == 0 else 96
+
+    if dim == -1 and elem_dtype == torch.float4_e2m1fn_x2:
+        # splitting the packed dim of fp4 qdata creates non-contiguous views,
+        # which `MXTensor.__new__` does not yet handle
+        with pytest.raises(AssertionError, match="packed fp4"):
+            torch.split(x_mx, split_size, dim=dim)
+        return
+
+    res = torch.split(x_mx, split_size, dim=dim)
+    res_ref = torch.split(x_mx.dequantize(), split_size, dim=dim)
+    assert len(res) == len(res_ref)
+    for chunk, chunk_ref in zip(res, res_ref):
+        assert isinstance(chunk, MXTensor)
+        assert chunk.shape == chunk_ref.shape
+        # blocks are preserved intact, so the split is exact. Note:
+        # `dequantize` does not yet support non-contiguous qdata (also true
+        # for the output of `aten.slice` along the last dim today), so
+        # make the chunk contiguous first
+        torch.testing.assert_close(
+            chunk.contiguous().dequantize(), chunk_ref, atol=0, rtol=0
+        )
+
+
+def test_split_unsupported():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    block_size = 32
+    x_hp = torch.randn(8, 128, device=device, dtype=torch.bfloat16)
+    x_mx = MXTensor.to_mx(x_hp, torch.float8_e4m3fn, block_size)
+
+    # split size not aligned with block boundaries on the scaled dim
+    with pytest.raises(AssertionError, match="multiple of"):
+        torch.split(x_mx, 16, dim=-1)
+
+    # the scaled dim of a transposed MXTensor is not last
+    with pytest.raises(AssertionError, match="not yet supported"):
+        torch.split(x_mx.t(), 32, dim=0)
+
+    x_mx_swizzled = MXTensor.to_mx(
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16),
+        torch.float8_e4m3fn,
+        block_size,
+        is_swizzled_scales=True,
+    )
+    with pytest.raises(AssertionError, match="swizzled"):
+        torch.split(x_mx_swizzled, 32, dim=0)
+
+
+@pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
+@pytest.mark.parametrize("dim", [0, -2])
+def test_chunk(elem_dtype, dim):
+    # `torch.chunk(t, n, dim=d)` lands in `aten.split.Tensor` with `dim` in
+    # `kwargs` (the path FSDP2's `_chunk_with_empty` takes)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    block_size = 32
+    x_hp = torch.randn(8, 4, 64, device=device, dtype=torch.bfloat16)
+    x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size)
+
+    if dim == -2 and elem_dtype == torch.float4_e2m1fn_x2:
+        # chunking fp4 qdata along a middle dim creates non-contiguous views,
+        # which `MXTensor.__new__` does not yet handle
+        with pytest.raises(AssertionError, match="packed fp4"):
+            torch.chunk(x_mx, 2, dim=dim)
+        return
+
+    chunks = torch.chunk(x_mx, 2, dim=dim)
+    recombined = torch.cat(chunks, dim=dim)
+    torch.testing.assert_close(
+        x_mx.dequantize(), recombined.dequantize(), atol=0, rtol=0
+    )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -997,6 +997,125 @@ def mx_select(func, types, args, kwargs):
     return return_and_correct_aliasing(func, args, kwargs, new_mx_tensor)
 
 
+def _has_blocked_last_dim_layout(t: "MXTensor") -> bool:
+    """
+    Returns True if `t.scale` holds one scale per `block_size` elements of
+    the last dim of `t`, with all other dims matching, which is the layout
+    `MXTensor.to_mx` creates. Returns False for other layouts, for example
+    the layout of a transposed MXTensor, where the scaled dim is not last.
+    """
+    if t.qdata.ndim != t.scale.ndim:
+        return False
+    return (
+        t.scale.shape[:-1] == t.shape[:-1]
+        and t.scale.shape[-1] * t.block_size == t.shape[-1]
+    )
+
+
+@implements([aten.cat.default])
+def mx_cat(func, types, args, kwargs):
+    tensors, dim = fill_defaults(args, 2, [[], 0])
+    if "dim" in kwargs:
+        dim = kwargs["dim"]
+    tensor_0 = tensors[0]
+    dim = dim % tensor_0.ndim
+
+    for t in tensors:
+        assert isinstance(t, MXTensor), "unsupported"
+        assert not t.is_swizzled_scales, (
+            "aten.cat with swizzled scales is not yet supported"
+        )
+        assert _has_blocked_last_dim_layout(t), (
+            f"aten.cat with {t.shape=} and {t.scale.shape=} is not yet supported"
+        )
+        assert t.elem_dtype == tensor_0.elem_dtype
+        assert t.block_size == tensor_0.block_size
+        assert t.orig_dtype == tensor_0.orig_dtype
+        assert t.kernel_preference == tensor_0.kernel_preference
+        assert t.act_quant_kwargs == tensor_0.act_quant_kwargs
+
+    # Since each tensor's last dim is a multiple of `block_size`, every input
+    # contributes whole blocks and the concatenation is exact for any `dim`:
+    # for the scaled (last) dim the scale columns of each input stay aligned
+    # with its qdata columns, and for other dims qdata and scale concatenate
+    # in lockstep. Note that for packed fp4 the qdata dim sizes are half of
+    # the corresponding MXTensor dim sizes, which `aten.cat` handles fine.
+    cat_qdata = func([t.qdata for t in tensors], dim)
+    cat_scale = func([t.scale for t in tensors], dim)
+
+    new = MXTensor(
+        cat_qdata,
+        cat_scale,
+        tensor_0.elem_dtype,
+        tensor_0.block_size,
+        tensor_0.orig_dtype,
+        tensor_0.kernel_preference,
+        tensor_0.act_quant_kwargs,
+        tensor_0.is_swizzled_scales,
+    )
+    return return_and_correct_aliasing(func, args, kwargs, new)
+
+
+@implements([aten.split.Tensor])
+def mx_split(func, types, args, kwargs):
+    # `dim` may arrive positionally or as a kwarg depending on the caller
+    # (e.g. `torch.chunk(t, n, dim=d)` keeps it in kwargs).
+    tensor, split_size = args[0], args[1]
+    dim = args[2] if len(args) > 2 else kwargs.get("dim", 0)
+    assert isinstance(split_size, int), "unsupported"
+    assert not tensor.is_swizzled_scales, (
+        "aten.split with swizzled scales is not yet supported"
+    )
+    assert _has_blocked_last_dim_layout(tensor), (
+        f"aten.split with {tensor.shape=} and {tensor.scale.shape=} is not yet supported"
+    )
+    dim = dim % tensor.ndim
+
+    if dim == tensor.ndim - 1:
+        # splitting the scaled dim, require split boundaries to be aligned
+        # with the block boundaries so each split keeps whole blocks
+        assert split_size % tensor.block_size == 0, (
+            f"aten.split along the scaled dim requires {split_size=} to be a "
+            f"multiple of {tensor.block_size=}"
+        )
+        qdata_split_size = split_size
+        if tensor.elem_dtype == torch.float4_e2m1fn_x2:
+            # qdata holds two fp4 values per byte in the last dim
+            qdata_split_size = qdata_split_size // 2
+        scale_split_size = split_size // tensor.block_size
+    else:
+        qdata_split_size = split_size
+        scale_split_size = split_size
+
+    new_qdatas = func(tensor.qdata, qdata_split_size, dim)
+    new_scales = func(tensor.scale, scale_split_size, dim)
+
+    if tensor.elem_dtype == torch.float4_e2m1fn_x2:
+        # `MXTensor.__new__` infers the unpacked fp4x2 size from
+        # `qdata.is_contiguous()`, which is only correct for contiguous qdata
+        # (see the note in `MXTensor.__new__`)
+        assert all(x.is_contiguous() for x in new_qdatas), (
+            "aten.split of a packed fp4 MXTensor is only supported when the "
+            "split outputs are contiguous"
+        )
+
+    new_tensors = []
+    for new_qdata, new_scale in zip(new_qdatas, new_scales):
+        new_tensor = MXTensor(
+            new_qdata,
+            new_scale,
+            tensor.elem_dtype,
+            tensor.block_size,
+            tensor.orig_dtype,
+            tensor.kernel_preference,
+            tensor.act_quant_kwargs,
+            tensor.is_swizzled_scales,
+        )
+        new_tensor = return_and_correct_aliasing(func, args, kwargs, new_tensor)
+        new_tensors.append(new_tensor)
+    return tuple(new_tensors)
+
+
 @implements([torch.ops._c10d_functional.all_gather_into_tensor.default])
 def mx_all_gather(func, types, args, kwargs):
     """


### PR DESCRIPTION
Fixes #3702.

Adds `aten.cat.default` and `aten.split.Tensor` dispatch handlers to `MXTensor`
(`torch.chunk` decomposes to `aten.split.Tensor`, so two handlers cover all three ops),
modeled on the `Float8Tensor` handlers and the existing `mx_slice`/`mx_select` style.
No dequantization: both handlers operate on qdata and the e8m0 scales directly.

Both ops are exact (`dequantize(op(mx)) == op(dequantize(mx))` bitwise, asserted in the
new tests): the scaled dim is inferred from `scale.shape` and `block_size`, and since
every MXTensor's scaled dim is a multiple of `block_size`, cat along any dim preserves
whole blocks. Splitting the scaled dim requires `split_size % block_size == 0`; other
dims accept any split size, including ragged final chunks. The split handler reads `dim`
from kwargs when needed, covering the `torch.chunk(t, n, dim=d)` form that FSDP2's
`_chunk_with_empty` uses (the same path fixed for `Float8Tensor` in #4429).

Kept explicitly unsupported, with clear asserts: swizzled scales, non-standard scale
layouts (e.g. transposed tensors), and splits of packed fp4 qdata into non-contiguous
views — for the latter, `MXTensor.__new__` infers the unpacked fp4x2 size from
`qdata.is_contiguous()` and would silently report a wrong shape. (That same inference
already mis-shapes fp4 column slices on main: `MXTensor.to_mx(torch.randn(4, 128),
torch.float4_e2m1fn_x2, 32)[:, 32:96]` reports shape `(8, 32)` instead of `(4, 64)` —
happy to file that separately.)

Tests parametrize all of `SUPPORTED_ELEM_DTYPES` over 2D/3D shapes and run on CPU or
CUDA; error paths (misaligned split size, transposed layout, swizzled scales) are
asserted as well.
