### PR TITLE
Fix constant_fold crash when multiple get_attr nodes share the same target

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -1911,6 +1911,39 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             m_not_fold.code
         )
 
+    def test_constant_fold_shared_get_attr(self):
+        """constant_fold must not delete an attribute that is still referenced
+        by a live get_attr node when another get_attr for the same target is
+        dead. Regression test for https://github.com/pytorch/ao/issues/4420"""
+        from torchao.quantization.pt2e.constant_fold import constant_fold
+
+        class Root(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("shared", torch.arange(4.0))
+
+        root = Root().eval()
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+
+        shared0 = g.get_attr("shared")
+        folded = g.call_function(torch.ops.aten.neg.default, (shared0,))
+
+        shared1 = g.get_attr("shared")
+        live = g.call_function(torch.ops.aten.add.Tensor, (x, shared1))
+
+        g.output((folded, live))
+        gm = torch.fx.GraphModule(root, g)
+
+        constant_fold(gm)
+
+        self.assertTrue(
+            hasattr(gm, "shared"),
+            "shared attribute was deleted even though a live get_attr still references it",
+        )
+        result = gm(torch.ones(4))
+        self.assertEqual(result[1], torch.ones(4) + torch.arange(4.0))
+
     def test_save_load(self):
         """Test save/load a quantized model"""
         m = self._get_pt2e_quantized_linear()

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -352,13 +352,16 @@ def constant_fold(
             replace_node_with_constant(gm, node, constant)
 
         erased_params = []
+        live_targets: set[str] = set()
         for node in gm.graph.find_nodes(op="get_attr"):
             if len(node.users) == 0:
-                if hasattr(gm, node.target):
-                    delattr(gm, node.target)
                 erased_params.append(node)
+            else:
+                live_targets.add(node.target)
 
         for node in erased_params:
+            if node.target not in live_targets and hasattr(gm, node.target):
+                delattr(gm, node.target)
             gm.graph.erase_node(node)
 
         gm.graph.eliminate_dead_code()


### PR DESCRIPTION
## Summary

Fixes #4420

`constant_fold` crashes with `RuntimeError: Node ... target ... references nonexistent attribute ...` when an FX graph contains multiple `get_attr` nodes pointing at the same attribute target and only some of them become dead after folding.

**Root cause:** The cleanup loop in `constant_fold()` calls `delattr(gm, node.target)` as soon as it encounters the first dead `get_attr` node for a given target, without checking whether other *live* `get_attr` nodes still reference the same target. When `graph.lint()` runs afterwards, the surviving node fails validation.

**Fix:** Collect all targets that are still referenced by live `get_attr` nodes before deleting anything. Only `delattr` a target when *no* live `get_attr` references it.

## Test plan

- Added `test_constant_fold_shared_get_attr` that reproduces the exact scenario from the issue (two `get_attr` nodes sharing a target, one folded away, one live) and verifies:
  - The shared attribute is preserved after `constant_fold`
  - The resulting graph module produces correct output
- Verified existing `test_constant_folding_pass` still passes