### PR TITLE
Update docs to mark torchtune references as legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ We also support deployment to edge devices through ExecuTorch, for more detail, 
 
 ### Quantization-Aware Training
 
-Post-training quantization can result in a fast and compact model, but may also lead to accuracy degradation. We recommend exploring Quantization-Aware Training (QAT) to overcome this limitation, especially for lower bit-width dtypes such as int4. In collaboration with [TorchTune](https://github.com/pytorch/torchtune/blob/main/recipes/quantization.md#quantization-aware-training-qat), we've developed a QAT recipe that demonstrates significant accuracy improvements over traditional PTQ, recovering **96% of the accuracy degradation on hellaswag and 68% of the perplexity degradation on wikitext** for Llama3 compared to post-training quantization (PTQ). For more details, please refer to the [QAT README](torchao/quantization/qat/README.md) and the [original blog](https://pytorch.org/blog/quantization-aware-training/):
+Post-training quantization can result in a fast and compact model, but may also lead to accuracy degradation. We recommend exploring Quantization-Aware Training (QAT) to overcome this limitation, especially for lower bit-width dtypes such as int4. Our QAT support demonstrates significant accuracy improvements over traditional PTQ, recovering **96% of the accuracy degradation on hellaswag and 68% of the perplexity degradation on wikitext** for Llama3 compared to post-training quantization (PTQ). QAT is integrated with [Axolotl](https://docs.axolotl.ai/docs/qat.html) and [Unsloth](https://github.com/unslothai/unsloth), or can be used directly via the `quantize_` API. For more details, please refer to the [QAT README](torchao/quantization/qat/README.md) and the [original blog](https://pytorch.org/blog/quantization-aware-training/):
 
 ```python
 import torch
@@ -214,7 +214,7 @@ quantize_(my_model, QATConfig(base_config, step="prepare"))
 quantize_(my_model, QATConfig(base_config, step="convert"))
 ```
 
-Users can also combine LoRA + QAT to speed up training by [1.89x](https://dev-discuss.pytorch.org/t/speeding-up-qat-by-1-89x-with-lora/2700) compared to vanilla QAT using this [fine-tuning recipe](https://github.com/pytorch/torchtune/blob/main/recipes/qat_lora_finetune_distributed.py).
+Users can also combine LoRA + QAT to speed up training by [1.89x](https://dev-discuss.pytorch.org/t/speeding-up-qat-by-1-89x-with-lora/2700) compared to vanilla QAT.
 
 
 ### Quantized training
@@ -294,7 +294,7 @@ TorchAO is integrated into some of the leading open-source libraries including:
 * Axolotl for [QAT](https://docs.axolotl.ai/docs/qat.html) and [PTQ](https://docs.axolotl.ai/docs/quantize.html)
 * TorchTitan for [float8 pre-training](https://github.com/pytorch/torchtitan/blob/main/docs/float8.md)
 * HuggingFace PEFT for LoRA using TorchAO as their [quantization backend](https://huggingface.co/docs/peft/en/developer_guides/quantization#torchao-pytorch-architecture-optimization)
-* TorchTune for our NF4 [QLoRA](https://docs.pytorch.org/torchtune/main/tutorials/qlora_finetune.html), [QAT](https://docs.pytorch.org/torchtune/main/recipes/qat_distributed.html), and [float8 quantized fine-tuning](https://github.com/pytorch/torchtune/pull/2546) recipes
+* TorchTune (legacy, no longer actively maintained) for NF4 [QLoRA](https://docs.pytorch.org/torchtune/main/tutorials/qlora_finetune.html), [QAT](https://docs.pytorch.org/torchtune/main/recipes/qat_distributed.html), and [float8 quantized fine-tuning](https://github.com/pytorch/torchtune/pull/2546) recipes
 * SGLang for LLM serving: [usage](https://docs.sglang.ai/advanced_features/quantization.html#online-quantization)
 
 ## 🎥 Videos

--- a/docs/source/eager_tutorials/finetuning.rst
+++ b/docs/source/eager_tutorials/finetuning.rst
@@ -53,15 +53,22 @@ model with "real" quantization that does perform the dtype casting:
 
 There are multiple options for using TorchAO's QAT for fine-tuning:
 
-1. Use our integration with `TorchTune <https://github.com/pytorch/torchtune>`__
+1. Directly use our QAT APIs with your own training loop (recommended)
 2. Use our integration with `Axolotl <https://github.com/axolotl-ai-cloud/axolotl>`__
-3. Directly use our QAT APIs with your own training loop
+3. Use our integration with `Unsloth <https://github.com/unslothai/unsloth>`__
 
 
-Option 1: TorchTune QAT Integration
-===================================
+.. raw:: html
 
-TorchAO's QAT support is integrated into TorchTune's distributed fine-tuning recipe.
+   <details>
+   <summary><b>Legacy: TorchTune QAT Integration (no longer actively maintained)</b></summary>
+
+.. note::
+   Active development on TorchTune has stopped. The recipes and links below are
+   preserved for historical reference. For actively maintained integrations,
+   use Axolotl, Unsloth, or the TorchAO QAT API directly.
+
+TorchAO's QAT support was integrated into TorchTune's distributed fine-tuning recipe.
 Instead of the following command, which applies full distributed fine-tuning without QAT:
 
 .. code::
@@ -138,7 +145,11 @@ In addition to vanilla QAT as in the above example, TorchAO's QAT can also be co
   # Fine-tuning with QAT + LoRA
   tune run --nnodes 1 --nproc_per_node 4 qat_lora_finetune_distributed --config llama3_2/3B_qat_lora batch_size=16
 
-For more details about how QAT is set up in TorchTune, please refer to `this tutorial <https://docs.pytorch.org/torchtune/main/tutorials/qat_finetune.html>`__.
+For more details about how QAT was set up in TorchTune, please refer to `this tutorial <https://docs.pytorch.org/torchtune/main/tutorials/qat_finetune.html>`__.
+
+.. raw:: html
+
+   </details>
 
 
 Option 2: Axolotl QAT Integration
@@ -158,7 +169,7 @@ To get started, try fine-tuning Llama-3.2-3B with QAT using the following comman
 Please refer to the `Axolotl QAT documentation <https://docs.axolotl.ai/docs/qat.html>`__ for full details.
 
 
-Option 3: TorchAO QAT API
+Option 1: TorchAO QAT API (Recommended)
 =========================
 
 If you prefer to use a different training framework or your own custom training loop,
@@ -170,7 +181,17 @@ In this example, we will fine-tune a mini version of Llama3 on a single GPU:
 .. code:: py
 
   import torch
-  from torchtune.models.llama3 import llama3
+  from torch import nn
+
+  # Define a simple model for demonstration.
+  # In practice, load your model with transformers or your own code.
+  def llama3(**kwargs):
+      return nn.Transformer(
+          d_model=kwargs.get('embed_dim', 2048),
+          nhead=kwargs.get('num_heads', 16),
+          num_encoder_layers=kwargs.get('num_layers', 16),
+          num_decoder_layers=kwargs.get('num_layers', 16),
+      )
 
   # Set up a smaller version of llama3 to fit in a single A100 GPU
   # For smaller GPUs, adjust the model attributes accordingly
@@ -315,20 +336,27 @@ such as regular INT4 or even newer `MXFP4 or NVFP4 <https://github.com/pytorch/a
 targeting Blackwell GPUs to reap similar memory benefits with
 varying tradeoffs.
 
-Option 1: TorchTune Integration
-===============================
+.. raw:: html
 
-TorchTune incorporates the `NF4Tensor` in its QLoRA fine-tuning
+   <details>
+   <summary><b>Legacy: TorchTune QLoRA Integration (no longer actively maintained)</b></summary>
+
+.. note::
+   Active development on TorchTune has stopped. For QLoRA, use the
+   HuggingFace PEFT integration below instead.
+
+TorchTune incorporated the `NF4Tensor` in its QLoRA fine-tuning
 recipe through their implementation of `LoRALinear <https://github.com/pytorch/torchtune/blob/a6290a5b40758f13bca61c386bc8756a49ef417e/torchtune/modules/peft/lora.py#L19>`__.
-You can also try it out by running the following command,
-or refer to their `QLoRA tutorial <https://docs.pytorch.org/torchtune/stable/tutorials/qlora_finetune.html>`__
-for more details.
 
 .. code::
 
   tune run lora_finetune_single_device --config llama3_2/3B_qlora_single_device.yaml
 
-Option 2: HuggingFace PEFT Integration
+.. raw:: html
+
+   </details>
+
+HuggingFace PEFT Integration
 ======================================
 
 `HuggingFace PEFT <https://huggingface.co/docs/peft/main/en/developer_guides/quantization#torchao-pytorch-architecture-optimization>`__
@@ -357,10 +385,10 @@ Float8 Quantized Fine-tuning
 Similar to `pre-training <pretraining.html>`__, we can also
 leverage float8 in fine-tuning for higher training throughput
 with no accuracy degradation and no increase in memory usage.
-Float8 training is integrated into TorchTune's distributed
-full fine-tuning recipe, leveraging the same APIs as our
-integration with TorchTitan. Users can invoke this fine-tuning
-recipe as follows:
+Float8 training was integrated into TorchTune's distributed
+full fine-tuning recipe (note: TorchTune is no longer actively
+maintained). The same APIs are used in our integration with
+TorchTitan. The TorchTune recipe could be invoked as follows:
 
 .. code::
 

--- a/docs/source/workflows/qat.md
+++ b/docs/source/workflows/qat.md
@@ -40,7 +40,18 @@ For example, running QAT on a single GPU:
 
 ```python
 import torch
-from torchtune.models.llama3 import llama3
+from torch import nn
+
+# Define a simple transformer model for demonstration.
+# In practice, load your model using transformers or define your own.
+def llama3(**kwargs):
+    # Placeholder: replace with your actual model
+    return nn.Transformer(
+        d_model=kwargs.get('embed_dim', 2048),
+        nhead=kwargs.get('num_heads', 16),
+        num_encoder_layers=kwargs.get('num_layers', 16),
+        num_decoder_layers=kwargs.get('num_layers', 16),
+    )
 
 # Set up smaller version of llama3 to fit in a single GPU
 def get_model():
@@ -241,17 +252,22 @@ For a full notebook example, see [this QAT notebook](https://colab.research.goog
 
 
 <details>
-    <summary><h2>torchtune integration (legacy)</h2></summary>
+    <summary><h2>torchtune integration (legacy, no longer actively maintained)</h2></summary>
 
-torchao QAT is integrated with [torchtune](https://github.com/pytorch/torchtune)
+> **Note:** Active development on torchtune has stopped. The recipes and links
+> below are preserved for historical reference but may no longer work with the
+> latest versions of torchao. For actively maintained integrations, use
+> [Axolotl](#axolotl-integration) or [Unsloth](#unsloth-integration) above.
+
+torchao QAT was integrated with [torchtune](https://github.com/pytorch/torchtune)
 to allow users to run quantized-aware fine-tuning as follows:
 
 ```
 tune run --nproc_per_node 8 qat_distributed --config llama3/8B_qat_full
 ```
 
-torchtune also supports a [QAT + LoRA distributed training recipe](https://github.com/pytorch/torchtune/blob/main/recipes/qat_lora_finetune_distributed.py)
-that is 1.89x faster and uses 36.1% memory compared to vanilla QAT in our early experiments.
+torchtune also supported a [QAT + LoRA distributed training recipe](https://github.com/pytorch/torchtune/blob/main/recipes/qat_lora_finetune_distributed.py)
+that was 1.89x faster and used 36.1% less memory compared to vanilla QAT in early experiments.
 You can read more about it [here](https://dev-discuss.pytorch.org/t/speeding-up-qat-by-1-89x-with-lora/2700):
 
 ```


### PR DESCRIPTION
Update docs to mark torchtune references as legacy

Active development on torchtune has stopped, but the fine-tuning tutorial,
QAT workflow docs, and the README still referred to it as a current
integration. This misleads users into following recipes that may no
longer work with the latest versions of torchao.

## Changes

### `docs/source/eager_tutorials/finetuning.rst`
- Wrapped TorchTune QAT and QLoRA integration sections in collapsible
  `<details>` legacy blocks with deprecation notes
- Promoted the direct TorchAO `quantize_` API as the recommended
  approach (reordered from Option 3 to Option 1)
- Added Unsloth to the list of actively maintained integrations
- Replaced `from torchtune.models.llama3 import llama3` import with a
  simple PyTorch model definition
- Updated Float8 section to note torchtune is no longer actively maintained

### `docs/source/workflows/qat.md`
- Added deprecation notice to the existing legacy torchtune `<details>` section
- Replaced `from torchtune.models.llama3 import llama3` import with a
  simple PyTorch model definition
- Updated tense from present to past

### `README.md`
- Replaced torchtune as primary QAT collaboration partner with Axolotl and Unsloth
- Removed dead link to torchtune fine-tuning recipe
- Marked TorchTune as "legacy, no longer actively maintained" in the integrations list

The `torchao/optim/README.md` benchmark reference (pinned to a specific commit hash)
is intentionally left unchanged since it is historical context.

Fixes #4287

## Test Plan
Documentation-only change; no runtime behavior is affected. All modified files
were verified as valid RST/Markdown by visual inspection.

This change was authored with the assistance of an AI coding assistant.
