### PR TITLE
Fix broken import of nonexistent config module in fp8_fa3/setup.py

### DIFF
--- a/torchao/prototype/attention/fp8_fa3/setup.py
+++ b/torchao/prototype/attention/fp8_fa3/setup.py
@@ -8,20 +8,16 @@
 
 import torch.nn as nn
 
-from torchao.prototype.attention.config import LowPrecisionAttentionConfig
 from torchao.prototype.attention.shared_utils.setup import setup_fp8_backend
 
 
 def setup_fp8_fa3(
     model: nn.Module,
-    config: LowPrecisionAttentionConfig,
+    hadamard: str = "NONE",
 ) -> nn.Module:
     """Set up FP8 FA3 attention on *model* and wrap it."""
-    from torchao.prototype.attention.fp8_fa3.attention import fp8_fa3_sdpa
-
     return setup_fp8_backend(
         model,
-        config,
         flash_impl_name="FA3",
-        sdpa_fn=fp8_fa3_sdpa,
+        hadamard=hadamard,
     )


### PR DESCRIPTION
## Summary

`setup_fp8_fa3()` in `torchao/prototype/attention/fp8_fa3/setup.py` imports `LowPrecisionAttentionConfig` from `torchao.prototype.attention.config`, but this module does not exist. Importing or calling this function crashes immediately with a `ModuleNotFoundError`.

## Root Cause

The `setup_fp8_backend()` function in `shared_utils/setup.py` was refactored to accept `(model, flash_impl_name, hadamard)` instead of the old `(model, config, flash_impl_name, sdpa_fn)` signature. The `api.py` entry point was updated to use the new API, but `fp8_fa3/setup.py` was not updated to match.

## Fix

- Removed the stale import of `LowPrecisionAttentionConfig` from the nonexistent `config` module
- Updated `setup_fp8_fa3()` signature and body to match the current `setup_fp8_backend()` API

Fixes #4318

## Test Plan

Verified the import resolves correctly by inspecting the module structure. This is a prototype module without a dedicated test suite. The fix is a straightforward import/signature alignment.

This change was authored with the assistance of an AI coding assistant.