### PR TITLE
Fix doc build warnings: Pygments lexer and RST title underline

### DIFF
--- a/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
+++ b/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst
@@ -1,5 +1,5 @@
 PyTorch 2 Export Quantization with Intel GPU Backend through Inductor
-==================================================================
+=====================================================================
 
 **Author**: `Yan Zhiwei <https://github.com/ZhiweiYan-96>`_, `Wang Eikan <https://github.com/EikanWang>`_, `Zhang Liangang <https://github.com/liangan1>`_, `Liu River <https://github.com/riverliuintel>`_, `Cui Yifeng <https://github.com/CuiYifeng>`_
 

--- a/docs/source/workflows/training.md
+++ b/docs/source/workflows/training.md
@@ -105,7 +105,7 @@ A common question about float8 training is "when is float8 linear faster vs bflo
 
 <img width="753" height="773" alt="Image" src="https://github.com/user-attachments/assets/e46c671a-ed35-41b4-b17c-50caf1629ecb" />
 
-```lang=shell
+```shell
 # reproduction: run the script below
 python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen_name sweep
 ```
@@ -114,7 +114,7 @@ python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen
 
 <img width="755" height="778" alt="Image" src="https://github.com/user-attachments/assets/7d70ba36-f480-459f-b5c0-797895332631" />
 
-```lang=shell
+```shell
 # reproduction: run the script below
 python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen_name sweep --float8_recipe_name rowwise
 ```
@@ -123,7 +123,7 @@ python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen
 
 <img width="750" height="797" alt="Image" src="https://github.com/user-attachments/assets/e4479abc-1aca-436d-a142-60e5e804ff10" />
 
-```lang=shell
+```shell
 # reproduction: run the script below
 python benchmarks/float8/float8_roofline.py your_output_filename.csv --shape_gen_name sweep --float8_recipe_name rowwise_with_gw_hp
 ```


### PR DESCRIPTION
## Summary

Resolves 4 of the 114 Sphinx doc build warnings tracked in #3863.

### Fixes

1. **`docs/source/workflows/training.md`** (3 warnings):
   Replace invalid Pygments lexer name `lang=shell` with `shell` in three code fence blocks. The `lang=` prefix is Phabricator/Diffusion syntax and is not recognized by Pygments, causing:
   \\\
   WARNING: Pygments lexer name 'lang=shell' is not known
   \\\

2. **`docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst`** (1 warning):
   Extend the title underline from 66 to 69 `=` characters to match the title length. RST requires the underline to be at least as long as the title text, causing:
   \\\
   WARNING: Title underline too short.
   \\\

Partial fix for #3863

## Test Plan

Documentation-only change. Verified the fixes match Sphinx/RST and MyST-Markdown specifications by inspection.

This change was authored with the assistance of an AI coding assistant.