### PR TITLE
Fix parametrized dtype override in test_autotuner and wrong variable in test_integration

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -637,7 +637,7 @@ class TestSaveLoadMeta(unittest.TestCase):
         test = model_qc(x).detach()
 
         assert SQNR(ref_f, test) > min_sqnr, (
-            f"got sqnr: {SQNR(ref_f, ref_q)}, expected: {min_sqnr}"
+            f"got sqnr: {SQNR(ref_f, test)}, expected: {min_sqnr}"
         )
         self.assertTrue(torch.equal(ref_q, test))
 

--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -37,7 +37,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -59,7 +58,6 @@ class TestQuantFlow(unittest.TestCase):
     def test_int_mm_float8(self, device, dtype):
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         w = torch.randn(n, k, dtype=dtype, device=device).t()
@@ -85,7 +83,6 @@ class TestQuantFlow(unittest.TestCase):
 
         from torchao.kernel import intmm
 
-        dtype = torch.bfloat16
         m, k, n = (128, 64, 16)
         x = torch.randn(m, k, dtype=dtype, device=device)
         scales = x.sum(-1, keepdim=True)
@@ -93,7 +90,7 @@ class TestQuantFlow(unittest.TestCase):
         x_int = x.to(dtype=torch.int8)
         w_int = w.to(dtype=torch.int8)
         out32_1 = intmm.safe_int_mm(x_int, w_int) * scales
-        assert out32_1.dtype == torch.bfloat16
+        assert out32_1.dtype == dtype
         out32_2 = intmm.int_scaled_matmul(x_int, w_int, scales)
         assert out32_2.dtype == out32_1.dtype
         torch.testing.assert_allclose(out32_1, out32_2)


### PR DESCRIPTION
## Summary

Fixes two test bugs reported in #4339.

### Bug 1: Parametrized dtype silently overridden (test_autotuner.py)

All three test methods in `TestQuantFlow` are parametrized over `dtype` (both `torch.bfloat16` and `torch.float16`), but each immediately overwrites it with `dtype = torch.bfloat16`. This means the float16 test cases never actually test float16 — they silently run with bfloat16 instead, giving false test coverage.

**Fix:** Removed the three hardcoded `dtype = torch.bfloat16` overrides (lines 40, 62, 88) and changed the hardcoded `assert out32_1.dtype == torch.bfloat16` to `assert out32_1.dtype == dtype`.

### Bug 2: Wrong variable in error message (test_integration.py)

The assertion checks `SQNR(ref_f, test)` but the error message prints `SQNR(ref_f, ref_q)` — showing the SQNR between the float reference and the *compiled quantized reference*, not the actual test output. This makes debugging misleading when the assertion fails.

**Fix:** Changed `SQNR(ref_f, ref_q)` to `SQNR(ref_f, test)` in the error message.

Fixes #4339

## Test Plan

These are test-only changes:
- Bug 1: Run `pytest test/kernel/test_autotuner.py -v` and confirm float16 variants produce different results from bfloat16 variants
- Bug 2: No runtime effect unless the assertion fails; verified by inspection

This change was authored with the assistance of an AI coding assistant.