### PR TITLE
Fix _is_128_128_scaled false-positive for PerTensor on 128x128 tensors

### DIFF
--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -211,7 +211,7 @@ def _is_128_128_scaled(x: torch.Tensor) -> bool:
     """
     assert hasattr(x, "block_size"), "Expecting input to have `block_size` attribute"
     b = x.block_size
-    return len(b) == 2 and b[0] == 128 and b[1] == 128
+    return len(b) == 2 and b[0] == 128 and b[1] == 128 and not _is_tensorwise_scaled(x)
 
 
 def _granularity_is_a_1_128_w_128_128(


### PR DESCRIPTION
## Summary

`Float8DynamicActivationFloat8WeightConfig()` with default `PerTensor` granularity on a 128x128 linear layer causes `_is_128_128_scaled` to false-positive, since the `block_size` ends up matching the tensor shape `(128, 128)`. The code path then incorrectly assumes 128x128 blockwise scaling is in use.

## Root Cause

`_is_128_128_scaled` only checked whether `block_size == (128, 128)`, which is ambiguous: it matches both:
- `PerBlock([128, 128])` blockwise scaling (intended)
- `PerTensor` on a tensor that happens to be 128x128 (false positive)

## Fix

Added `not _is_tensorwise_scaled(x)` guard to disambiguate the two cases. `_is_tensorwise_scaled` checks whether `block_size` equals the tensor shape for all dimensions, which is exactly the PerTensor case.

\\\diff
-    return len(b) == 2 and b[0] == 128 and b[1] == 128
+    return len(b) == 2 and b[0] == 128 and b[1] == 128 and not _is_tensorwise_scaled(x)
\\\

This is the minimal fix. An alternative would be to store the original granularity enum on the tensor, but that's a larger refactor.

Fixes #4089

## Test Plan

The issue reporter's repro can be verified:
\\\python
from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_
model = ToyLinearModel()  # contains 128x128 linear
config = Float8DynamicActivationFloat8WeightConfig()  # default PerTensor
quantize_(model, config)
\\\

Should now correctly use the tensorwise path instead of the blockwise path.

This change was authored with the assistance of an AI coding assistant.