### PR TITLE
Fix more doc build warnings: orphan page and MyST cross-references

### DIFF
--- a/docs/source/contributing/benchmarking_api_guide.md
+++ b/docs/source/contributing/benchmarking_api_guide.md
@@ -7,6 +7,7 @@ This tutorial will guide you through using the TorchAO benchmarking framework. T
 3. [Add an HF model to benchmarking recipes](#add-an-hf-model-to-benchmarking-recipes)
 4. [Add an API to micro-benchmarking CI dashboard](#add-an-api-to-benchmarking-ci-dashboard)
 
+(add-an-api-to-benchmarking-recipes)=
 ## Add an API to Benchmarking Recipes
 
 The framework currently supports quantization and sparsity recipes, which can be run using the quantize_() or sparsity_() functions:
@@ -33,6 +34,7 @@ Now we can use this recipe throughout the benchmarking framework.
 
 **Note:** If the `AOBaseConfig` uses input parameters, like bit-width, group-size etc, you can pass them appended to the string config in input. For example, for `Float8DynamicActivationFloat8WeightConfig` we can pass granularity as `float8dq-tensor` or `float8dq-row`.
 
+(add-a-model-to-benchmarking-recipes)=
 ## Add a Model to Benchmarking Recipes
 
 To add a new model architecture to the benchmarking system, you need to modify `torchao/testing/model_architectures.py`.
@@ -91,9 +93,11 @@ When adding new models:
 
 - **Quantization Compatibility**: Design your model to work with TorchAO quantization methods
 
+(add-an-hf-model-to-benchmarking-recipes)=
 ## Add an HF model to benchmarking recipes
 (Coming soon!!!)
 
+(add-an-api-to-benchmarking-ci-dashboard)=
 ## Add an API to Benchmarking CI Dashboard
 
 To integrate your API with the CI [dashboard](https://hud.pytorch.org/benchmark/llms?repoName=pytorch%2Fao&benchmarkName=micro-benchmark+api):

--- a/docs/source/performant_kernels.rst
+++ b/docs/source/performant_kernels.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Performant Kernels
 ==================
 


### PR DESCRIPTION
## Summary

Resolves 5 more Sphinx doc build warnings tracked in #3863, complementing PR #4490.

### Fixes

1. **`docs/source/performant_kernels.rst`** (1 warning):
   Mark as `:orphan:` since it is a placeholder page (contains only 'TBA') not included in any toctree. Suppresses:
   \\\
   WARNING: document isn't included in any toctree
   \\\

2. **`docs/source/contributing/benchmarking_api_guide.md`** (4 warnings):
   Add explicit MyST target labels `(add-an-api-to-benchmarking-recipes)=` etc. before section headers so the table-of-contents cross-reference links resolve. Fixes:
   \\\
   WARNING: 'myst' cross-reference target not found: 'add-an-api-to-benchmarking-recipes'
   WARNING: 'myst' cross-reference target not found: 'add-a-model-to-benchmarking-recipes'
   WARNING: 'myst' cross-reference target not found: 'add-an-hf-model-to-benchmarking-recipes'
   WARNING: 'myst' cross-reference target not found: 'add-an-api-to-benchmarking-ci-dashboard'
   \\\

Combined with PR #4490, this resolves **9 of the 114 warnings** from #3863.

Partial fix for #3863

## Test Plan

Documentation-only change. Verified the MyST target syntax and `:orphan:` directive match Sphinx/MyST specifications by inspection.

This change was authored with the assistance of an AI coding assistant.