### PR TITLE
Document Float8DynamicActivationFloat8WeightConfig as inference-only

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1140,6 +1140,14 @@ class Float8DynamicActivationFloat8WeightConfig(AOBaseConfig):
     """
     Configuration for applying float8 dynamic symmetric quantization to both activations and weights of linear layers.
 
+    .. note::
+
+        This config is **inference-only**. Calling ``loss.backward()`` on the
+        output of a model quantized with this config will raise
+        ``RuntimeError: derivative for aten::_scaled_mm is not implemented``.
+        For float8 training, use :func:`torchao.float8.convert_to_float8_training`
+        instead.
+
     Args:
         activation_dtype (torch.dtype): The target data type for activation quantization. Default is torch.float8_e4m3fn.
         weight_dtype (torch.dtype): The target data type for weight quantization. Default is torch.float8_e4m3fn.


### PR DESCRIPTION
## Summary

Users attempting LoRA training on fp8-quantized bases hit an opaque `RuntimeError: derivative for aten::_scaled_mm is not implemented` with no guidance. The docstring did not mention that this config only supports inference.

Added a `.. note::` block making the inference-only limitation explicit and pointing users to `convert_to_float8_training` for the training path.

### Before
Users discover the limitation only at runtime via a cryptic error.

### After
The docstring clearly states:
> This config is **inference-only**. Calling `loss.backward()` on the output of a model quantized with this config will raise `RuntimeError: derivative for aten::_scaled_mm is not implemented`. For float8 training, use `torchao.float8.convert_to_float8_training` instead.

Addresses #4376

## Test Plan

Documentation-only change. Verified RST note syntax renders correctly by inspection.

This change was authored with the assistance of an AI coding assistant.