### PR TITLE
Fix raise with bare string in benchmark_hqq.py

### DIFF
--- a/benchmarks/benchmark_hqq.py
+++ b/benchmarks/benchmark_hqq.py
@@ -8,9 +8,9 @@ try:
     import triton
 
     if int(triton.__version__.split(".")[0]) < 3:
-        raise "triton >= 3.0.0 is required to run this test"
+        raise RuntimeError("triton >= 3.0.0 is required to run this benchmark")
 except ImportError:
-    raise "triton and hqq required to run this benchmark"
+    raise RuntimeError("triton and hqq required to run this benchmark")
 
 from io import StringIO
 


### PR DESCRIPTION
## Summary

Python 3 does not allow `raise` with a bare string argument. The two `raise "..."` statements in `benchmark_hqq.py` raise `TypeError: exceptions must derive from BaseException` instead of showing the intended error message about missing dependencies.

Fixed by changing to `raise RuntimeError("...")`.

```diff
-        raise "triton >= 3.0.0 is required to run this test"
+        raise RuntimeError("triton >= 3.0.0 is required to run this benchmark")
 except ImportError:
-    raise "triton and hqq required to run this benchmark"
+    raise RuntimeError("triton and hqq required to run this benchmark")
```

Partial fix for #4335

## Test Plan

The fix is trivially correct. `raise RuntimeError(msg)` is the standard Python 3 pattern.

This change was authored with the assistance of an AI coding assistant.
