### PR TITLE
Fix unclosed file handle in benchmarks/intmm.py

### DIFF
--- a/benchmarks/intmm.py
+++ b/benchmarks/intmm.py
@@ -98,8 +98,8 @@ if __name__ == "__main__":
     file_path = pathlib.Path(file_path)
     assert file_path.is_file()
 
-    # Format is (m, k, n)
-    shapes = list(csv.reader(open(file_path, "r")))[1:]
+    with open(file_path, "r") as f:
+        shapes = list(csv.reader(f))[1:]
     # Turn into list of int tuples
     shapes = list(map(lambda x: tuple(map(int, x)), shapes))
 


### PR DESCRIPTION
## Summary

`csv.reader(open(file_path, "r"))` opens a file but never closes it, leaking a file descriptor on every run. Changed to use a `with` statement.

```diff
-    shapes = list(csv.reader(open(file_path, "r")))[1:]
+    with open(file_path, "r") as f:
+        shapes = list(csv.reader(f))[1:]
```

Partial fix for #4335

## Test Plan

Trivially correct refactor from `open()` to `with`-statement context manager. No behavioral change.

This change was authored with the assistance of an AI coding assistant.
