### PR TITLE
Fix typo in benchmarks/benchmark_aq.py: tenosr -> tensor

### DIFF
--- a/benchmarks/benchmark_aq.py
+++ b/benchmarks/benchmark_aq.py
@@ -44,7 +44,7 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
+def _get_ref_change_linear_weights_to_woqtensors(deprecated_tensor_subclass):
     def _ref_change_linear_weights_to_woqtensors(model, filter_fn=None, **kwargs):
         """
         The deprecated implementation for weight only quant API, used as a reference for
@@ -57,7 +57,7 @@ def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
         _replace_with_custom_fn_if_matches_filter(
             model,
             _get_subclass_inserter(
-                deprecated_tenosr_subclass, enable_parametrization=True, **kwargs
+                deprecated_tensor_subclass, enable_parametrization=True, **kwargs
             ),
             filter_fn,
         )


### PR DESCRIPTION
## Summary

Fix typo in `benchmarks/benchmark_aq.py`: `deprecated_tenosr_subclass` -> `deprecated_tensor_subclass` (transposed 'n' and 'o').

Not a runtime bug since the variable is used consistently within the function, but confusing to readers.

Partial fix for #4335

## Test Plan

Typo-only change, no behavioral change.

This change was authored with the assistance of an AI coding assistant.
