### PR TITLE
Replace print() with logger.info() in fusion_utils.py

### DIFF
--- a/torchao/prototype/attention/shared_utils/fusion_utils.py
+++ b/torchao/prototype/attention/shared_utils/fusion_utils.py
@@ -965,9 +965,10 @@ def rope_sdpa_fusion_pass(
     fp8_sdpa_nodes = [n for n in graph.nodes if _is_fp8_sdpa_node(n, fp8_sdpa_op)]
 
     if not fp8_sdpa_nodes:
-        print(
-            f"[low_precision_attention] RoPE fusion pass ({backend_name}): "
-            f"found 0 FP8 SDPA nodes in graph"
+        logger.info(
+            "[low_precision_attention] RoPE fusion pass (%s): "
+            "found 0 FP8 SDPA nodes in graph",
+            backend_name,
         )
         return
 
@@ -1103,10 +1104,12 @@ def rope_sdpa_fusion_pass(
                 fused_count += 1
                 continue
 
-    print(
-        f"[low_precision_attention] RoPE fusion pass ({backend_name}): "
-        f"found {len(fp8_sdpa_nodes)} FP8 SDPA node(s), "
-        f"{fused_count} fused with RoPE"
+    logger.info(
+        "[low_precision_attention] RoPE fusion pass (%s): "
+        "found %d FP8 SDPA node(s), %d fused with RoPE",
+        backend_name,
+        len(fp8_sdpa_nodes),
+        fused_count,
     )
 
     if fused_count > 0:


### PR DESCRIPTION
## Summary

The `rope_sdpa_fusion_pass` function in `fusion_utils.py` uses `print()` for status messages, which produces unsilenceable console output on every `torch.compile` call. Changed to `logger.info()` so users can control output via standard logging configuration.

Also switched from f-strings to %-style formatting for lazy evaluation (standard practice for logger calls -- the format string is only evaluated if the log level is enabled).

Partial fix for #4333

## Test Plan

Behavioral change is only in output routing (stdout -> logging). The log messages and their content are unchanged.

This change was authored with the assistance of an AI coding assistant.
