### PR TITLE
Fix TypeError bug in static quantization tutorial

### DIFF
--- a/docs/source/eager_tutorials/static_quantization.rst
+++ b/docs/source/eager_tutorials/static_quantization.rst
@@ -175,7 +175,7 @@ There are multiple ways to actually quantize the model. Here we walk through the
            return F.linear(qinput, self.qweight, self.bias)
 
        @classmethod
-       def from_observed(cls, observed_linear, target_dtype):
+       def from_observed(cls, observed_linear):
            quantized_linear = cls(
                observed_linear.in_features,
                observed_linear.out_features,
@@ -183,7 +183,6 @@ There are multiple ways to actually quantize the model. Here we walk through the
                observed_linear.weight_obs,
                observed_linear.weight,
                observed_linear.bias,
-               target_dtype,
            )
            return quantized_linear
 
@@ -201,7 +200,7 @@ This linear class computes the scales and zero points for both input activations
 
    @dataclass
    class StaticQuantConfig(AOBaseConfig):
-       target_dtype: torch.dtype
+       pass
 
    @register_quantize_module_handler(StaticQuantConfig)
    def _apply_static_quant(
@@ -209,16 +208,16 @@ This linear class computes the scales and zero points for both input activations
        config: StaticQuantConfig,
    ):
        """
-       Define a transformation associated with `StaticQuantConfig`.
-       This is called by `quantize_`, not by the user directly.
+       Define a transformation associated with ``StaticQuantConfig``.
+       This is called by ``quantize_``, not by the user directly.
        """
-       return QuantizedLinear.from_observed(module, config.target_dtype)
+       return QuantizedLinear.from_observed(module)
 
    # filter function to identify which modules to swap
    is_observed_linear = lambda m, fqn: isinstance(m, ObservedLinear)
 
    # perform static quantization
-   quantize_(m, StaticQuantConfig(torch.uint8), is_observed_linear)
+   quantize_(m, StaticQuantConfig(), is_observed_linear)
 
 Now, we will see that the linear layers in our model are swapped to our `QuantizedLinear` class, with a fixed input activation scale and a fixed quantized weight:
 


### PR DESCRIPTION
## Summary

Fix a TypeError bug in the static quantization tutorial. `QuantizedLinear.from_observed()` passes `target_dtype` to `__init__()` which doesn't accept it:

```python
# __init__ takes 6 positional args:
def __init__(self, in_features, out_features, act_obs, weight_obs, weight, bias):

# from_observed passes 7 args (extra target_dtype):
quantized_linear = cls(in_features, out_features, act_obs, weight_obs, weight, bias, target_dtype)
# TypeError: __init__() takes 7 positional arguments but 8 were given
```

Anyone copying this tutorial code would hit `TypeError` immediately. The `target_dtype` was unused since `QuantizedLinear` hardcodes int8 behavior via `Int8Tensor`.

### Fix
- Removed `target_dtype` from `from_observed()`
- Removed `target_dtype` field from `StaticQuantConfig` (now empty dataclass)
- Updated `quantize_()` call to match: `StaticQuantConfig()` instead of `StaticQuantConfig(torch.uint8)`

Partial fix for #3637

## Test Plan

Documentation-only change. Verified argument counts match between `__init__` (6 params) and `from_observed`'s `cls()` call (6 args).

This change was authored with the assistance of an AI coding assistant.
