### PR TITLE
Remove dead code: unused _is_blackwell() in attention/utils.py

### DIFF
--- a/torchao/prototype/attention/utils.py
+++ b/torchao/prototype/attention/utils.py
@@ -16,12 +16,6 @@ def _is_hopper() -> bool:
     return major == 9
 
 
-def _is_blackwell() -> bool:
-    if not torch.cuda.is_available():
-        return False
-    major, _ = torch.cuda.get_device_capability()
-    return major == 10
-
 
 def _is_fa3_available() -> bool:
     try:


### PR DESCRIPTION
## Summary

Remove dead code: `_is_blackwell()` in `torchao/prototype/attention/utils.py` is defined but never imported or called anywhere in the codebase.

Verified by searching the entire repository -- only one hit exists (the definition itself at line 19). No callers, imports, or references.

Partial fix for #4333 (item #7)

## Test Plan

```powershell
Get-ChildItem -Path torchao -Recurse -Include *.py |
  Select-String -Pattern "_is_blackwell" |
  Select-Object Path, LineNumber
# Result: only utils.py:19 (the definition)
```

This change was authored with the assistance of an AI coding assistant.
