### PR TITLE
Add public API exports to embedding/__init__.py

### DIFF
--- a/torchao/prototype/quantization/embedding/__init__.py
+++ b/torchao/prototype/quantization/embedding/__init__.py
@@ -1,0 +1,9 @@
+from .api import (
+    EmbeddingQuantizer,
+    TiedEmbeddingQuantizer,
+)
+
+__all__ = [
+    "EmbeddingQuantizer",
+    "TiedEmbeddingQuantizer",
+]


### PR DESCRIPTION
## Summary

The `torchao/prototype/quantization/embedding/__init__.py` was empty, forcing users to import from `api.py` directly (e.g., `from torchao.prototype.quantization.embedding.api import EmbeddingQuantizer`).

Added public API exports for `EmbeddingQuantizer` and `TiedEmbeddingQuantizer`, consistent with the `int4/__init__.py` pattern. Users can now write:

```python
from torchao.prototype.quantization.embedding import EmbeddingQuantizer
```

Partial fix for #4333 (item #6)

## Test Plan

Follows the same pattern as `int4/__init__.py`. The exported classes exist in `api.py` and are the module's public API.

This change was authored with the assistance of an AI coding assistant.
