### PR TITLE
make nvfp4_linear handle a pre-quantized activation (#4504)

### DIFF
--- a/test/prototype/mx_formats/test_nvfp4_tensor.py
+++ b/test/prototype/mx_formats/test_nvfp4_tensor.py
@@ -481,6 +481,51 @@ def test_nvfp4_matmul_with_amax(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for fp4"
+)
+@pytest.mark.parametrize("use_dynamic_per_tensor_scale", [True, False])
+@pytest.mark.parametrize("leading", [(), (1,)], ids=["2d", "3d_b1"])
+@torch.no_grad()
+def test_nvfp4_linear_prequantized_activation(
+    use_dynamic_per_tensor_scale: bool,
+    leading: tuple,
+) -> None:
+    """nvfp4_linear must accept an already-NVFP4 activation and run the GEMM
+    directly instead of re-quantizing it (which dispatches aten.abs onto the
+    NVFP4Tensor). Mirrors nvfp4_mm's guard; act_quant_kwargs is irrelevant once
+    the activation is pre-quantized.
+    """
+    m, k, n = 128, 64, 256
+    A = torch.randn(*leading, m, k, dtype=torch.bfloat16, device="cuda")
+    B = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
+    C_ref = F.linear(A, B)
+
+    a_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(A)))
+    b_scale = per_tensor_amax_to_scale(torch.amax(torch.abs(B)))
+    A_nvfp4 = NVFP4Tensor.to_nvfp4(A, per_tensor_scale=a_scale, is_swizzled_scales=True)
+    B_nvfp4 = NVFP4Tensor.to_nvfp4(
+        B,
+        per_tensor_scale=b_scale,
+        is_swizzled_scales=True,
+        act_quant_kwargs=QuantizeTensorToNVFP4Kwargs(
+            is_swizzled_scales=True,
+            use_dynamic_per_tensor_scale=use_dynamic_per_tensor_scale,
+        ),
+    )
+
+    C_nvfp4 = F.linear(A_nvfp4, B_nvfp4)
+
+    assert C_nvfp4.shape == C_ref.shape, f"{C_nvfp4.shape} != {C_ref.shape}"
+    sqnr = compute_error(C_ref, C_nvfp4)
+    SQNR_THRESHOLD = 16.0
+    assert sqnr >= SQNR_THRESHOLD, (
+        f"SQNR {sqnr:.2f} < {SQNR_THRESHOLD}, "
+        f"{use_dynamic_per_tensor_scale=}, {leading=}"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_nvfp4_to_copy():
     x = NVFP4Tensor.to_nvfp4(torch.randn((32, 128))).cuda()
     y = torch.ops.aten._to_copy(x, dtype=torch.bfloat16)

--- a/torchao/prototype/mx_formats/nvfp4_tensor.py
+++ b/torchao/prototype/mx_formats/nvfp4_tensor.py
@@ -597,20 +597,23 @@ def nvfp4_linear(func, types, args, kwargs):
     else:
         # dynamic quant
         k = weight_tensor.act_quant_kwargs
-        if k.use_dynamic_per_tensor_scale:
-            tensor_amax = torch.max(torch.abs(input_tensor))
-            per_tensor_scale = per_tensor_amax_to_scale(tensor_amax)
-        else:
-            per_tensor_scale = weight_tensor.act_per_tensor_scale
         orig_shape = input_tensor.shape
-        input_tensor = input_tensor.view(-1, orig_shape[-1])
-        input_tensor = NVFP4Tensor.to_nvfp4(
-            input_tensor,
-            block_size=k.block_size,
-            per_tensor_scale=per_tensor_scale,
-            is_swizzled_scales=k.is_swizzled_scales,
-            use_triton_kernel=k.use_triton_kernel,
-        )
+        if isinstance(input_tensor, NVFP4Tensor):
+            # already NVFP4 (pre-quantized): use as-is, like nvfp4_mm
+            input_tensor = input_tensor.view(-1, orig_shape[-1])
+        else:
+            if k.use_dynamic_per_tensor_scale:
+                tensor_amax = torch.max(torch.abs(input_tensor))
+                per_tensor_scale = per_tensor_amax_to_scale(tensor_amax)
+            else:
+                per_tensor_scale = weight_tensor.act_per_tensor_scale
+            input_tensor = NVFP4Tensor.to_nvfp4(
+                input_tensor.view(-1, orig_shape[-1]),
+                block_size=k.block_size,
+                per_tensor_scale=per_tensor_scale,
+                is_swizzled_scales=k.is_swizzled_scales,
+                use_triton_kernel=k.use_triton_kernel,
+            )
         res = _addmm_nvfp4_dispatch(input_tensor, weight_tensor.t(), func, bias=bias)
         res = res.reshape(*orig_shape[:-1], res.shape[-1])
         return res


### PR DESCRIPTION
Summary:

`nvfp4_linear` always quantizes its activation — `NVFP4Tensor.to_nvfp4(input)`, preceded by `torch.max(torch.abs(input))` when `use_dynamic_per_tensor_scale` is set — so an activation that is already an `NVFP4Tensor` dispatches those ops onto the subclass (`aten.abs` is unimplemented) and raises `NotImplementedError`. `nvfp4_mm` already handles this with an `if not isinstance(input_tensor, NVFP4Tensor)` guard; `nvfp4_linear` should follow the same example. With the guard, an already-NVFP4 activation skips re-quantization and goes straight to `_addmm_nvfp4_dispatch` (flattening to 2D via the existing view op); a high-precision activation takes the existing path unchanged.

Reviewed By: jbschlosser

Differential Revision: D108711759


