### PR TITLE
Fix spelling typo in 'deprecated_tenosr_subclass'

### DIFF
--- a/benchmarks/benchmark_aq.py
+++ b/benchmarks/benchmark_aq.py
@@ -44,7 +44,7 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
+def _get_ref_change_linear_weights_to_woqtensors(deprecated_tensor_subclass):
     def _ref_change_linear_weights_to_woqtensors(model, filter_fn=None, **kwargs):
         """
         The deprecated implementation for weight only quant API, used as a reference for
@@ -57,7 +57,7 @@ def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
         _replace_with_custom_fn_if_matches_filter(
             model,
             _get_subclass_inserter(
-                deprecated_tenosr_subclass, enable_parametrization=True, **kwargs
+                deprecated_tensor_subclass, enable_parametrization=True, **kwargs
             ),
             filter_fn,
         )

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -132,7 +132,7 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
-def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
+def _get_ref_change_linear_weights_to_woqtensors(deprecated_tensor_subclass):
     def _ref_change_linear_weights_to_woqtensors(model, filter_fn=None, **kwargs):
         """
         The deprecated implementation for weight only quant API, used as a reference for
@@ -145,7 +145,7 @@ def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
         _replace_with_custom_fn_if_matches_filter(
             model,
             _get_subclass_inserter(
-                deprecated_tenosr_subclass, enable_parametrization=True, **kwargs
+                deprecated_tensor_subclass, enable_parametrization=True, **kwargs
             ),
             filter_fn,
         )


### PR DESCRIPTION
### Description
This PR corrects a spelling typo in the parameter `deprecated_tenosr_subclass` (renamed to `deprecated_tensor_subclass`) in both the test and benchmark suites:
* `test/quantization/test_quant_api.py`
* `benchmarks/benchmark_aq.py`

Fixes #4505

### Test Plan
1. Verified that the modified files conform to the project's formatting and linting guidelines:
   ```bash
   ruff check benchmarks/benchmark_aq.py test/quantization/test_quant_api.py
   ruff format --check benchmarks/benchmark_aq.py test/quantization/test_quant_api.py
   ```
2. Both files passed checks successfully.

### Contributor Checklist
- [x] I have forked the repo and created my branch from `main`.
- [x] I have ensured the code lints using `ruff check` and `ruff format`.
- [x] I will complete the Meta Contributor License Agreement (CLA) at https://code.facebook.com/cla.
