### PR TITLE
Add weight-only quantization MoE example

### DIFF
--- a/examples/quantize_moe.py
+++ b/examples/quantize_moe.py
@@ -1,0 +1,166 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+A script demonstrating weight-only quantization of a Mixture-of-Experts (MoE)
+model with `quantize_()`.
+
+It builds a small token-choice top-2 MoE block (a router plus ``nn.Linear``
+experts), quantizes only the expert weights — the router is left in high
+precision so routing decisions are unchanged — and verifies the result:
+expert weights become quantized tensor subclasses, the serialized model
+shrinks roughly 4x (int8), and a forward pass stays numerically close to the
+float32 baseline (SQNR).
+
+Run on CPU (default, int8 weight-only):
+
+    python examples/quantize_moe.py
+
+Run int4 weight-only (requires CUDA and the `mslk` package):
+
+    python examples/quantize_moe.py --dtype int4 --device cuda
+
+Note: real MoE checkpoints (e.g. `meta-llama/Llama-4-Scout-17B-16E-Instruct`)
+often store experts as fused 3D ``(num_experts, K, N)`` parameters instead of
+``nn.Linear`` modules. For those, configure quantization per-parameter with
+``FqnToConfig`` and ``PerRow(1)`` granularity — see
+``examples/quantize_llama_4.py`` for a complete float8 version of that flow.
+"""
+
+import argparse
+import copy
+import io
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig, quantize_
+from torchao.quantization.utils import compute_error
+
+
+class Expert(nn.Module):
+    """A standard FFN expert: up-projection, SiLU, down-projection."""
+
+    def __init__(self, dim, hidden_dim):
+        super().__init__()
+        self.up = nn.Linear(dim, hidden_dim, bias=False)
+        self.down = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.down(F.silu(self.up(x)))
+
+
+class MoEBlock(nn.Module):
+    """A token-choice top-k MoE block: softmax router + ``nn.Linear`` experts."""
+
+    def __init__(self, dim=256, hidden_dim=512, num_experts=8, top_k=2):
+        super().__init__()
+        self.router = nn.Linear(dim, num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            Expert(dim, hidden_dim) for _ in range(num_experts)
+        )
+        self.top_k = top_k
+
+    def forward(self, x):
+        batch, seq, dim = x.shape
+        flat = x.reshape(-1, dim)
+        probs = F.softmax(self.router(flat), dim=-1)
+        weights, expert_idx = probs.topk(self.top_k, dim=-1)
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+        out = torch.zeros_like(flat)
+        for e, expert in enumerate(self.experts):
+            routed = expert_idx == e
+            token_idx = routed.any(dim=-1).nonzero(as_tuple=True)[0]
+            if token_idx.numel() == 0:
+                continue
+            gate = (weights * routed).sum(dim=-1)[token_idx].unsqueeze(-1)
+            out[token_idx] += gate * expert(flat[token_idx])
+        return out.reshape(batch, seq, dim)
+
+
+def serialized_size_bytes(model):
+    buffer = io.BytesIO()
+    torch.save(model.state_dict(), buffer)
+    return buffer.getbuffer().nbytes
+
+
+def is_expert_linear(module, fqn):
+    return isinstance(module, nn.Linear) and "experts" in fqn
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Weight-only quantization of an MoE model with quantize_()"
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["int8", "int4"],
+        default="int8",
+        help="weight dtype: int8 runs anywhere, int4 requires CUDA and mslk",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="device to run on (default: cpu)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.dtype == "int4" and args.device == "cpu":
+        print(
+            "warning: the default int4 weight-only path targets CUDA "
+            "(tinygemm) and requires the `mslk` package; expect a failure "
+            "on CPU"
+        )
+
+    torch.manual_seed(0)
+    model = MoEBlock().eval().to(args.device)
+    x = torch.randn(4, 64, 256, device=args.device)
+    with torch.no_grad():
+        baseline_out = model(x)
+    baseline_bytes = serialized_size_bytes(model)
+    baseline_weight = model.experts[0].up.weight
+    print(
+        f"baseline | expert weight: {type(baseline_weight).__name__} "
+        f"({baseline_weight.dtype}) | serialized: {baseline_bytes / 1e6:.2f} MB"
+    )
+
+    config = Int8WeightOnlyConfig() if args.dtype == "int8" else Int4WeightOnlyConfig()
+    quantized_model = copy.deepcopy(model)
+    # quantize only the expert weights; the router keeps full precision so
+    # that token-to-expert assignments are identical to the baseline model
+    quantize_(quantized_model, config, filter_fn=is_expert_linear)
+
+    quantized_bytes = serialized_size_bytes(quantized_model)
+    quantized_weight = quantized_model.experts[0].up.weight
+    with torch.no_grad():
+        quantized_out = quantized_model(x)
+    sqnr = compute_error(baseline_out, quantized_out)
+    print(
+        f"{args.dtype} wo  | expert weight: {type(quantized_weight).__name__} | "
+        f"router: {type(quantized_model.router.weight).__name__} "
+        f"({quantized_model.router.weight.dtype}) | "
+        f"serialized: {quantized_bytes / 1e6:.2f} MB "
+        f"({baseline_bytes / quantized_bytes:.2f}x smaller) | "
+        f"SQNR vs float32: {sqnr:.1f} dB"
+    )
+
+    assert type(quantized_weight) is not nn.Parameter, (
+        "expert weights were not quantized"
+    )
+    assert type(quantized_model.router.weight) is nn.Parameter, (
+        "router should not be quantized"
+    )
+    assert baseline_bytes / quantized_bytes > 1.5, "model did not shrink"
+    assert sqnr > 25, f"SQNR too low: {sqnr:.1f} dB"
+    print("quantization of the MoE model succeeded")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -132,6 +132,44 @@ class ToyLinearModel(torch.nn.Module):
         return x
 
 
+class ToyMoEModel(torch.nn.Module):
+    """Token-choice top-k MoE block: a softmax router plus linear experts."""
+
+    def __init__(self, dim=64, hidden_dim=128, num_experts=4, top_k=2):
+        super().__init__()
+        self.router = torch.nn.Linear(dim, num_experts, bias=False)
+        self.experts = torch.nn.ModuleList(
+            torch.nn.Sequential(
+                torch.nn.Linear(dim, hidden_dim, bias=False),
+                torch.nn.SiLU(),
+                torch.nn.Linear(hidden_dim, dim, bias=False),
+            )
+            for _ in range(num_experts)
+        )
+        self.top_k = top_k
+
+    def example_inputs(self, batch_size=8, dtype=torch.float, device="cpu"):
+        return (
+            torch.randn(
+                batch_size, self.router.in_features, dtype=dtype, device=device
+            ),
+        )
+
+    def forward(self, x):
+        probs = torch.softmax(self.router(x), dim=-1)
+        weights, expert_idx = probs.topk(self.top_k, dim=-1)
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+        out = torch.zeros_like(x)
+        for e, expert in enumerate(self.experts):
+            routed = expert_idx == e
+            token_idx = routed.any(dim=-1).nonzero(as_tuple=True)[0]
+            if token_idx.numel() == 0:
+                continue
+            gate = (weights * routed).sum(dim=-1)[token_idx].unsqueeze(-1)
+            out[token_idx] += gate * expert(x[token_idx])
+        return out
+
+
 def _get_ref_change_linear_weights_to_woqtensors(deprecated_tenosr_subclass):
     def _ref_change_linear_weights_to_woqtensors(model, filter_fn=None, **kwargs):
         """
@@ -199,6 +237,33 @@ class TestQuantFlow(TestCase):
         m = torch.compile(m, mode="max-autotune")
         compiled = m(*example_inputs)
         torch.testing.assert_close(quantized, compiled, atol=0, rtol=0)
+
+    def test_int8_weight_only_moe_experts_only(self):
+        # MoE pattern from https://github.com/pytorch/ao/issues/729: quantize
+        # the expert weights only, keeping the router in high precision so
+        # token-to-expert routing decisions are unchanged
+        m = ToyMoEModel().eval()
+        example_inputs = m.example_inputs()
+        with torch.no_grad():
+            y_ref = m(*example_inputs)
+
+        quantize_(
+            m,
+            Int8WeightOnlyConfig(),
+            filter_fn=lambda mod, fqn: isinstance(mod, torch.nn.Linear)
+            and "experts" in fqn,
+        )
+
+        for expert in m.experts:
+            for layer in expert:
+                if isinstance(layer, torch.nn.Linear):
+                    self.assertIsInstance(layer.weight, Int8Tensor)
+        self.assertNotIsInstance(m.router.weight, Int8Tensor)
+
+        with torch.no_grad():
+            y_q = m(*example_inputs)
+        sqnr = compute_error(y_ref, y_q)
+        self.assertGreater(sqnr, 25, f"SQNR {sqnr} is too low")
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_int8_wo_quant_save_load(self):


### PR DESCRIPTION
### Why this PR

Issue #729 notes that `quantize_()` should already support Mixture-of-Experts (MoE) models, but there is no example or tutorial demonstrating weight-only quantization on an MoE — users have no reference for the workflow even though the API reportedly covers it. The existing `examples/quantize_llama_4.py` quantizes routed experts to **float8 w8a8 dynamic** (activation + weight), not weight-only, and `torchao/prototype/moe_training/` is MoE *training*, a different feature. So the weight-only-MoE showcase gap is real.

I verified the maintainer's claim before writing anything: applying `Int8WeightOnlyConfig` to an MoE block's expert linears works unmodified — expert weights become `Int8Tensor`, the model shrinks ~3.9x, and outputs stay within ~45 dB SQNR of fp32. The contribution is therefore purely additive: a runnable example plus a unit test, with no core changes.

### What this PR does

Adds `examples/quantize_moe.py`: it builds a small token-choice top-2 MoE block (a softmax router plus `nn.Linear` experts) and quantizes **only the expert weights** via `quantize_(model, Int8WeightOnlyConfig(), filter_fn=is_expert_linear)`. The router is deliberately left in high precision — quantizing it would change token-to-expert routing decisions, not just numerics.

The script is self-verifying: it prints before/after weight types and serialized sizes, runs a forward pass, reports SQNR vs the fp32 baseline, and asserts (experts quantized, router not, ≥1.5x smaller, SQNR > 25 dB), exiting non-zero on any failure.

- `--dtype int8|int4` and `--device` flags; int4 is gated behind a hardware/dependency warning.
- The docstring points users with real fused-3D-expert checkpoints (e.g. `meta-llama/Llama-4-Scout-17B-16E-Instruct`) at the `FqnToConfig` + `PerRow(1)` pattern, mirroring `examples/quantize_llama_4.py`.

It also adds a unit test — `TestQuantFlow.test_int8_weight_only_moe_experts_only` in `test/quantization/test_quant_api.py` (with a module-level `ToyMoEModel` modeled on the file's `ToyLinearModel`) — since CI lints examples but does not execute them, so without a test MoE support stays demonstrated-but-unguarded.

### Relevant issues

Closes #729

### Test plan / evidence

CI lints `examples/` but does not execute them (only `tutorials/` run via `run_tutorials.yml`), so the example is self-asserting and the unit test provides the regression guard.

**CPU (macOS, torch 2.12):** example runs twice identically — experts → `Int8Tensor`, router `float32`, serialized 8.40 → 2.15 MB (3.90x), SQNR 45.1 dB, all asserts pass. `pytest test/quantization/test_quant_api.py -k moe` → 1 passed.

**CUDA (RTX 3090, SM 8.6, torch 2.12.1+cu130):**

```
$ python examples/quantize_moe.py --device cuda
baseline | expert weight: Parameter (torch.float32) | serialized: 8.40 MB
int8 wo  | expert weight: Int8Tensor | router: Parameter (torch.float32) | serialized: 2.15 MB (3.90x smaller) | SQNR vs float32: 45.1 dB
quantization of the MoE model succeeded

$ pytest test/quantization/test_quant_api.py -k moe -q
1 passed

$ pytest test/quantization/test_quant_api.py
18 passed, 28 skipped, 0 failed
```

The 28 skips are all hardware-gated (`Need SM 8.9+` / `Checkpoints are produced in SM90+` — float8 paths on this SM 8.6 card) or pre-existing unconditional skips; none are introduced by this change.

### Acceptance criteria

- [x] Tests added for new behavior (`test_int8_weight_only_moe_experts_only` + `ToyMoEModel`)
- [x] All tests passing (CPU and CUDA; pre-existing skips/failures unrelated, verified via `git stash`)
- [x] Follows project style guide (`ruff check` + `ruff format` clean, ruff 0.11.6; BSD-3 header via `scripts/check_copyright_header.py`)
- [x] No breaking changes (purely additive — new example + new test, no core changes)
- [x] Documentation updated where applicable (example docstring with run instructions, hardware note, and fused-3D-expert pointer)

### Open questions for maintainers

1. **Example location** — top-level `examples/quantize_moe.py` (matching `examples/quantize_llama_4.py`, added in #3408) vs `examples/inference/` (hinted by the `literalinclude` in `quant_api.py`)?
2. **Keep or drop the unit test?** #3408 was single-file. Since CI never runs examples, I added the test so MoE support is regression-checked — happy to drop it if you prefer the single-file shape.
3. **`examples/README.md` entry** — should I add one? #3408 didn't.
4. **Supported public path for int4?** The int4 default path requires `mslk >= 1.0.0`, but the `mslk` package on public PyPI is a `0.0.0` placeholder and `torchao/utils.py:1226` gates real availability on `is_fbcode()`. On a fresh RTX 3090 with the public wheel, `--dtype int4` raises `ImportError: Requires mslk >= 1.0.0` (same on CPU and CUDA). What's the supported public way to exercise int4 weight-only? (The example gates int4 behind a flag + warning, so the int8 showcase is unaffected.)

### Note

Minor and separate from this PR: `torchao/quantization/quant_api.py:1499` has an invalid escape `'\.'` in a docstring that triggers `SyntaxWarning: invalid escape sequence` on import under Python ≥ 3.12. Happy to send a one-line `r"""` micro-fix as its own PR.
