### PR TITLE
[xpu][float8] Enable fsdp tests for Intel XPU

### DIFF
--- a/test/float8/test_float8_utils.py
+++ b/test/float8/test_float8_utils.py
@@ -14,7 +14,7 @@ from torchao.testing.utils import skip_if_rocm
 
 # source for notable single-precision cases:
 # https://en.wikipedia.org/wiki/Single-precision_floating-point_format
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -36,10 +36,11 @@ from torchao.testing.utils import skip_if_rocm
 def test_round_scale_down_to_power_of_2_valid_inputs(
     test_case: dict,
 ):
+    device = torch.accelerator.current_accelerator()
     test_case_name, input, expected_result = test_case
     input_tensor, expected_tensor = (
-        torch.tensor(input, dtype=torch.float32).cuda(),
-        torch.tensor(expected_result, dtype=torch.float32).cuda(),
+        torch.tensor(input, dtype=torch.float32).to(device),
+        torch.tensor(expected_result, dtype=torch.float32).to(device),
     )
     result = _round_scale_down_to_power_of_2(input_tensor)
 

--- a/test/float8/test_fsdp.py
+++ b/test/float8/test_fsdp.py
@@ -46,7 +46,9 @@ def setup(rank, world_size):
     os.environ["MASTER_PORT"] = "12355"
 
     # initialize the process group
-    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device_type = torch.accelerator.current_accelerator().type
+    backend = dist.get_default_backend_for_device(device_type)
+    dist.init_process_group(backend, rank=rank, world_size=world_size)
 
 
 def cleanup():
@@ -67,11 +69,13 @@ def get_model(K, N, base_dtype=torch.float32):
 # and modified
 def fsdp_main(rank, world_size, args):
     setup(rank, world_size)
-    torch.cuda.set_device(rank)
+    device_type = torch.accelerator.current_accelerator().type
+    torch.accelerator.set_device_index(rank)
+    device = f"{device_type}:{rank}"
     print("args", args)
 
     emulate, base_dtype, compile = args
-    model = get_model(K, N, base_dtype=base_dtype).to(rank)
+    model = get_model(K, N, base_dtype=base_dtype).to(device)
     model_fp8 = copy.deepcopy(model)
 
     config = Float8LinearConfig()
@@ -97,12 +101,12 @@ def fsdp_main(rank, world_size, args):
     # populate the buffers
     # TODO(future PR): delete ^, since we deleted delayed scaling
     ref_input_global = [
-        torch.randn(B, M, K).cuda().to(base_dtype),
-        torch.randn(B, M, K).cuda().to(base_dtype),
+        torch.randn(B, M, K).to(device).to(base_dtype),
+        torch.randn(B, M, K).to(device).to(base_dtype),
     ]
     ref_grad_global = [
-        torch.randn(B, M, N).cuda().to(base_dtype),
-        torch.randn(B, M, N).cuda().to(base_dtype),
+        torch.randn(B, M, N).to(device).to(base_dtype),
+        torch.randn(B, M, N).to(device).to(base_dtype),
     ]
     ref_input_local = []
     ref_grad_local = []
@@ -113,10 +117,10 @@ def fsdp_main(rank, world_size, args):
     bsz_local_end = int((rank + 1) / world_size * B)
     for idx in range(N_ITER):
         ref_input_local.append(
-            ref_input_global[idx][bsz_local_start:bsz_local_end].to(rank)
+            ref_input_global[idx][bsz_local_start:bsz_local_end].to(device)
         )
         ref_grad_local.append(
-            ref_grad_global[idx][bsz_local_start:bsz_local_end].to(rank)
+            ref_grad_global[idx][bsz_local_start:bsz_local_end].to(device)
         )
 
     def forward_backward(model, optim, is_fp8, i):
@@ -140,13 +144,13 @@ def fsdp_main(rank, world_size, args):
 
     # get global y
     y_global = [
-        torch.zeros(*y_local.shape, dtype=base_dtype).to(rank)
+        torch.zeros(*y_local.shape, dtype=base_dtype).to(device)
         for r in range(world_size)
     ]
     dist.all_gather(y_global, y_local)
     y_global = torch.cat(y_global, dim=0)
     y_global_fp8 = [
-        torch.zeros(*y_local_fp8.shape, dtype=base_dtype).to(rank)
+        torch.zeros(*y_local_fp8.shape, dtype=base_dtype).to(device)
         for r in range(world_size)
     ]
     dist.all_gather(y_global_fp8, y_local_fp8)
@@ -177,16 +181,16 @@ def run(compile_fsdp: bool = False):
     base_dtype = torch.bfloat16
 
     emulate = False
-    if not torch.cuda.is_available():
-        warnings.warn("CUDA not available, running in emulation_mode")
+    if not torch.accelerator.is_available():
+        warnings.warn("GPU not available, running in emulation_mode")
         emulate = True
-    elif torch.cuda.get_device_capability() < (8, 9):
+    elif torch.cuda.is_available() and torch.cuda.get_device_capability() < (8, 9):
         warnings.warn(
             f"CUDA capability {torch.cuda.get_device_capability()} < (8.9), running in emulation mode"
         )
         emulate = True
 
-    WORLD_SIZE = torch.cuda.device_count()
+    WORLD_SIZE = torch.accelerator.device_count()
     args = (emulate, base_dtype, compile_fsdp)
     mp.spawn(fsdp_main, args=(WORLD_SIZE, args), nprocs=WORLD_SIZE, join=True)
 

--- a/test/float8/test_fsdp.sh
+++ b/test/float8/test_fsdp.sh
@@ -13,14 +13,14 @@ launch() {
 
     # the NCCL_DEBUG setting is to avoid log spew
     # the CUDA_VISIBLE_DEVICES setting is for easy debugging
-    NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/float8/test_fsdp.py \
+    CCL_LOG_LEVEL=info NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/float8/test_fsdp.py \
         --compile_fsdp $COMPILE
 
     echo "✅ All Tests Passed ✅"
 }
 
-if python -c 'import torch;print(torch.cuda.is_available())' | grep -q "False"; then
-    echo "Skipping test_fsdp.sh because no CUDA devices are available."
+if python -c 'import torch;print(torch.accelerator.is_available())' | grep -q "False"; then
+    echo "Skipping test_fsdp.sh because no accelerator devices are available."
     exit
 fi
 

--- a/test/float8/test_fsdp.sh
+++ b/test/float8/test_fsdp.sh
@@ -13,7 +13,7 @@ launch() {
 
     # the NCCL_DEBUG setting is to avoid log spew
     # the CUDA_VISIBLE_DEVICES setting is for easy debugging
-    CCL_LOG_LEVEL=info NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/float8/test_fsdp.py \
+    CCL_LOG_LEVEL=warn NCCL_DEBUG=WARN CUDA_VISIBLE_DEVICES=0,1 python test/float8/test_fsdp.py \
         --compile_fsdp $COMPILE
 
     echo "✅ All Tests Passed ✅"


### PR DESCRIPTION
This PR enables float8 fsdp for Intel XPU tests for Intel XPU as part of the https://github.com/pytorch/ao/issues/3576.

Details:
- The PR does not add any new test logic.
- It introduces a device parameter to allow running the tests on XPU.
- Source code modifications fix failing tests.