### PR TITLE
Add fused MXFP4 (E2M1) + Random Hadamard Transform CuTe DSL quantize cast (SM100)

### DIFF
--- a/benchmarks/mx_formats/cast_bench.py
+++ b/benchmarks/mx_formats/cast_bench.py
@@ -114,6 +114,27 @@ def benchmark_cuda_function_in_microseconds(f, *args):
         return ((end - start) / 100) * 1e6  # Convert to microseconds
 
 
+def benchmark_cuda_function_device_time_us(f, *args, iters=100, warmup=20):
+    """Mean true on-GPU kernel time in microseconds (CUPTI device time).
+
+    Unlike ``benchmark_cuda_function_in_microseconds`` (a GPU-timeline span that
+    still captures per-call host launch/alloc overhead), this sums the CUDA
+    kernel self-times so the result reflects kernel throughput. Use for kernels
+    whose Python wrapper has non-trivial host cost (e.g. the CuTeDSL casts). The
+    warmup also covers the one-time CuTeDSL JIT compile.
+    """
+    from torch.profiler import ProfilerActivity, profile
+
+    for _ in range(warmup):
+        f(*args)
+    torch.cuda.synchronize()
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        for _ in range(iters):
+            f(*args)
+        torch.cuda.synchronize()
+    return sum(k.self_device_time_total for k in prof.key_averages()) / iters
+
+
 def run(
     M: int = 16384,
     K: int = 16384,
@@ -150,6 +171,7 @@ def run(
         "dim1_mxfp8_cutedsl_2d_floor",
         "dim1_mxfp8_cutedsl_2d_rceil",
         "dim1_mxfp4_rht_cutedsl_floor",
+        "dim1_mxfp4_rht_cutedsl_rceil",
     )
 
     x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 1000
@@ -618,26 +640,32 @@ def run(
         bytes_w = (y_d0.numel() + s_d0.numel()) * bytes_per_el_fp8
         bps = (bytes_r + bytes_w) / (time_us / 1e6)
 
-    elif mode == "dim1_mxfp4_rht_cutedsl_floor":
+    elif mode in (
+        "dim1_mxfp4_rht_cutedsl_floor",
+        "dim1_mxfp4_rht_cutedsl_rceil",
+    ):
+        # The cutedsl MXFP4 + RHT op is the max-bandwidth streaming kernel
+        # (thread-local FWHT32 + wide 128-bit stores + ILP; no smem/TMA).
         from torchao.prototype.mx_formats.cutedsl import mxfp4_rht_quantize_cutedsl_2d
+
+        scaling_mode = "rceil" if mode.endswith("rceil") else "floor"
 
         # Generate sign vector: 32 random signs
         sign = (
             (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32).tolist()
         )
 
-        # Warmup
-        for _ in range(2):
-            __ = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True)
-
-        # Benchmark
-        time_us = benchmark_cuda_function_in_microseconds(
-            lambda x: mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True),
+        # Benchmark true on-GPU kernel time (CUPTI device time) -- the CuTeDSL
+        # wrapper has non-trivial per-call host cost (output alloc, sign tensor,
+        # JIT-cache lookup) that a wall-clock / GPU-span timer would fold in; the
+        # helper also warms up the one-time JIT compile.
+        time_us = benchmark_cuda_function_device_time_us(
+            lambda x: mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, scaling_mode, True),
             x,
         )
 
         # Validate output types
-        y_d1, s_d1 = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True)
+        y_d1, s_d1 = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, scaling_mode, True)
         assert y_d1.dtype == torch.uint8
         assert s_d1.dtype == torch.float8_e8m0fnu
 

--- a/benchmarks/mx_formats/cast_bench.py
+++ b/benchmarks/mx_formats/cast_bench.py
@@ -8,8 +8,13 @@ from typing import Tuple
 
 import fire
 import torch
-import triton
-from triton.testing import do_bench
+
+try:
+    import triton
+    from triton.testing import do_bench
+except ImportError:
+    triton = None
+    do_bench = None
 
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import (
@@ -94,7 +99,19 @@ def to_nvfp4_reference_triton_swizzle(x_hp):
 
 
 def benchmark_cuda_function_in_microseconds(f, *args):
-    return do_bench(lambda: f(*args), return_mode="median") * 1e3
+    if do_bench is not None:
+        return do_bench(lambda: f(*args), return_mode="median") * 1e3
+    else:
+        # Fallback timing when triton is not available
+        import time
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(100):
+            f(*args)
+        torch.cuda.synchronize()
+        end = time.perf_counter()
+        return ((end - start) / 100) * 1e6  # Convert to microseconds
 
 
 def run(
@@ -106,7 +123,9 @@ def run(
     print(f"M {M} K {K} BLOCK_SIZE {BLOCK_SIZE}")
     print(f"GPU: {torch.cuda.get_device_name(0)}")
     print(f"torch version: {torch.__version__}")
-    print(f"triton version: {triton.__version__}")
+    print(
+        f"triton version: {triton.__version__ if triton is not None else 'not available'}"
+    )
     print(f"mode: {mode}")
     assert mode in (
         "memcpy",
@@ -130,6 +149,7 @@ def run(
         "dim0_mxfp8_cutedsl_2d_rceil",
         "dim1_mxfp8_cutedsl_2d_floor",
         "dim1_mxfp8_cutedsl_2d_rceil",
+        "dim1_mxfp4_rht_cutedsl_floor",
     )
 
     x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 1000
@@ -597,6 +617,35 @@ def run(
         bytes_r = x.numel() * bytes_per_el_bf16
         bytes_w = (y_d0.numel() + s_d0.numel()) * bytes_per_el_fp8
         bps = (bytes_r + bytes_w) / (time_us / 1e6)
+
+    elif mode == "dim1_mxfp4_rht_cutedsl_floor":
+        from torchao.prototype.mx_formats.cutedsl import mxfp4_rht_quantize_cutedsl_2d
+
+        # Generate sign vector: 32 random signs
+        sign = (
+            (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32).tolist()
+        )
+
+        # Warmup
+        for _ in range(2):
+            __ = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True)
+
+        # Benchmark
+        time_us = benchmark_cuda_function_in_microseconds(
+            lambda x: mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True),
+            x,
+        )
+
+        # Validate output types
+        y_d1, s_d1 = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True)
+        assert y_d1.dtype == torch.uint8
+        assert s_d1.dtype == torch.float8_e8m0fnu
+
+        # Throughput accounting: input bf16, output packed fp4 (uint8) + scales (fp8)
+        bytes_r = x.numel() * bytes_per_el_bf16
+        bytes_w = (y_d1.numel() + s_d1.numel()) * bytes_per_el_fp8
+        bps = (bytes_r + bytes_w) / (time_us / 1e6)
+
     else:
         raise AssertionError(f"unknown mode {mode}")
 

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -55,3 +55,28 @@ class TestE2M1Packing:
             pack_uint4(f32_to_f4_unpacked(x.reshape(1, 32))).view(torch.uint8).flatten()
         )  # (16,)
         torch.testing.assert_close(ours, ref, rtol=0, atol=0)
+
+
+class TestFp4Scale:
+    @pytest.mark.parametrize("mode", ["floor", "rceil"])
+    def test_scale_bytes_match_eager(self, mode):
+        from torchao.prototype.mx_formats.cutedsl.cute_utils import (
+            compute_block_scale_e8m0_fp4,
+        )
+        from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
+
+        torch.manual_seed(0)
+        x = torch.randn(64, 32, dtype=torch.bfloat16, device="cuda") * 7.0
+        m = {
+            "floor": ScaleCalculationMode.FLOOR,
+            "rceil": ScaleCalculationMode.RCEIL,
+        }[mode]
+        # plain (unswizzled) e8m0 scales, shape (64, 1)
+        s_ref, _ = to_mx(x, torch.float4_e2m1fn_x2, block_size=32, scaling_mode=m)
+        s_ours = compute_block_scale_e8m0_fp4(x, mode)  # (64, 1) float8_e8m0fnu
+        torch.testing.assert_close(
+            s_ours.view(torch.uint8).flatten(),
+            s_ref.view(torch.uint8).flatten(),
+            rtol=0,
+            atol=0,
+        )

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -204,3 +204,59 @@ class TestMxfp4RhtE2E:
 
         sqnr = compute_error(rht_true, deq).item()
         assert sqnr >= 13.0, f"SQNR {sqnr} dB below 13 dB for mode={mode}"
+
+
+class TestMxTensorThreading:
+    @pytest.mark.parametrize("mode", ["floor", "rceil"])
+    def test_mxtensor_cutedsl_matches_standalone(self, mode):
+        # The opt-in CUTEDSL path through MXTensor.to_mx must produce qdata/scale
+        # bit-identical to the standalone op called with the same arguments
+        # (same is_swizzled_scales=True -> apples-to-apples).
+        from torchao.prototype.mx_formats.config import MXFP4CastKernelChoice
+        from torchao.prototype.mx_formats.cutedsl import (
+            mxfp4_rht_quantize_cutedsl_2d,
+        )
+        from torchao.prototype.mx_formats.mx_tensor import (
+            MXTensor,
+            ScaleCalculationMode,
+        )
+
+        torch.manual_seed(0)
+        M, K = 256, 512
+        x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+        sign = (
+            (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32).tolist()
+        )
+        sm = {
+            "floor": ScaleCalculationMode.FLOOR,
+            "rceil": ScaleCalculationMode.RCEIL,
+        }[mode]
+        mxt = MXTensor.to_mx(
+            x,
+            torch.float4_e2m1fn_x2,
+            block_size=32,
+            scaling_mode=sm,
+            is_swizzled_scales=True,
+            mxfp4_cast_kernel_choice=MXFP4CastKernelChoice.CUTEDSL,
+            rht_sign_vector=sign,
+        )
+        q_ref, s_ref = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, mode, True)
+        torch.testing.assert_close(
+            mxt.qdata.view(torch.uint8), q_ref.view(torch.uint8), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            mxt.scale.view(torch.uint8).flatten(),
+            s_ref.view(torch.uint8).flatten(),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_default_path_unchanged(self):
+        # The default (TORCH) fp4 cast still works and does NOT require a sign
+        # vector -- the new trailing params are opt-in only.
+        from torchao.prototype.mx_formats.mx_tensor import MXTensor
+
+        torch.manual_seed(0)
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        mxt = MXTensor.to_mx(x, torch.float4_e2m1fn_x2, block_size=32)
+        assert mxt.qdata.shape == (128, 128)

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -80,3 +80,18 @@ class TestFp4Scale:
             rtol=0,
             atol=0,
         )
+
+
+class TestFwht32:
+    def test_fwht32_sign_matches_dense(self):
+        from torchao.prototype.mx_formats.cutedsl.fwht import fwht32_sign_host
+        from torchao.prototype.spinquant.hadamard_utils import hadamard_matrix
+
+        torch.manual_seed(0)
+        x = torch.randn(128, 32, dtype=torch.float32, device="cuda")
+        sign = (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32)
+        # normalized (1/sqrt(32)), symmetric Sylvester/Walsh-Hadamard matrix
+        H = hadamard_matrix(32, device="cuda").to(torch.float32)
+        ref = (x @ H) * sign.to(torch.float32)
+        ours = fwht32_sign_host(x, sign)  # (128, 32) f32
+        torch.testing.assert_close(ours, ref, rtol=1e-3, atol=1e-3)

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
+
+# This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 import pytest

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -95,3 +95,21 @@ class TestFwht32:
         ref = (x @ H) * sign.to(torch.float32)
         ours = fwht32_sign_host(x, sign)  # (128, 32) f32
         torch.testing.assert_close(ours, ref, rtol=1e-3, atol=1e-3)
+
+
+class TestMxfp4RhtSmoke:
+    def test_runs_and_shapes(self):
+        from torchao.prototype.mx_formats.cutedsl import (
+            mxfp4_rht_quantize_cutedsl_2d,
+        )
+
+        torch.manual_seed(0)
+        M, K = 128, 256
+        x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+        sign = [1, -1] * 16
+        q, s = mxfp4_rht_quantize_cutedsl_2d(x, sign, 32, "floor", True)
+        assert q.shape == (M, K // 2)
+        assert q.dtype == torch.uint8
+        assert q.stride() == (K // 2, 1)
+        assert s.dtype == torch.float8_e8m0fnu
+        assert int((s.view(torch.uint8) != 0).sum()) > 0

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -113,3 +113,94 @@ class TestMxfp4RhtSmoke:
         assert q.stride() == (K // 2, 1)
         assert s.dtype == torch.float8_e8m0fnu
         assert int((s.view(torch.uint8) != 0).sum()) > 0
+
+
+class TestMxfp4RhtE2E:
+    @pytest.mark.parametrize("mode", ["floor", "rceil"])
+    @pytest.mark.parametrize("shape", [(128, 256), (256, 512), (512, 128)])
+    def test_bitexact_vs_emulated_same_rht(self, mode, shape):
+        # (A) Feed the SAME RHT values to both sides via the validated
+        # ``fwht32_sign_host`` helper (the EXACT transform the kernel applies
+        # internally). This isolates quant/pack/scale/swizzle: since the FWHT is
+        # identical on both sides and Tasks 1-2 validated quant/pack/scale
+        # bit-exactly, this must be bit-exact -- any diff is a real kernel bug.
+        from torchao.prototype.mx_formats.cutedsl import (
+            mxfp4_rht_quantize_cutedsl_2d,
+        )
+        from torchao.prototype.mx_formats.cutedsl.fwht import fwht32_sign_host
+        from torchao.prototype.mx_formats.mx_tensor import ScaleCalculationMode, to_mx
+        from torchao.prototype.mx_formats.utils import to_blocked
+
+        torch.manual_seed(0)
+        M, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+        sign = (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32)
+
+        # The kernel TMA-loads the bf16 input and widens each element to fp32
+        # before the FWHT, so the reference must apply the FWHT to the SAME
+        # bf16-rounded-then-widened values (``x.float()``). ``fwht32_sign_host``
+        # is bit-identical to the device ``fwht32_sign`` the kernel inlines.
+        rht = fwht32_sign_host(x.float().reshape(-1, 32), sign).reshape(M, K)
+
+        sm = {
+            "floor": ScaleCalculationMode.FLOOR,
+            "rceil": ScaleCalculationMode.RCEIL,
+        }[mode]
+        # to_mx returns (scale, data) in that order.
+        s_ref, q_ref = to_mx(
+            rht, torch.float4_e2m1fn_x2, block_size=32, scaling_mode=sm
+        )
+        s_ref_sw = to_blocked(s_ref.view(M, K // 32))
+
+        q, s = mxfp4_rht_quantize_cutedsl_2d(x, sign.tolist(), 32, mode, True)
+
+        torch.testing.assert_close(
+            q.view(torch.uint8), q_ref.view(torch.uint8), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            s.view(torch.uint8).flatten()[: s_ref_sw.numel()],
+            s_ref_sw.view(torch.uint8).flatten(),
+            rtol=0,
+            atol=0,
+        )
+        assert q.stride() == (K // 2, 1)
+
+    @pytest.mark.parametrize("mode", ["floor", "rceil"])
+    def test_sqnr_vs_dense_reference(self, mode):
+        # (B) Faithfulness of the WHOLE fused pipeline (incl. the FWHT) vs the
+        # true high-precision dense RHT ``(x @ H) * sign``.
+        from torchao.prototype.mx_formats.cutedsl import (
+            mxfp4_rht_quantize_cutedsl_2d,
+        )
+        from torchao.prototype.mx_formats.kernels import (
+            f4_unpacked_to_f32,
+            unpack_uint4,
+        )
+        from torchao.prototype.spinquant.hadamard_utils import hadamard_matrix
+        from torchao.quantization.utils import compute_error
+
+        torch.manual_seed(0)
+        M, K = 256, 512
+        x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+        sign = (torch.randint(0, 2, (32,), device="cuda") * 2 - 1).to(torch.int32)
+
+        # True high-precision dense RHT on the (bf16-rounded) input the kernel
+        # sees: (x @ H) * sign. hadamard_matrix(32) is normalized (1/sqrt(32)).
+        H = hadamard_matrix(32, device="cuda").to(torch.float32)
+        rht_true = ((x.float().reshape(-1, 32) @ H) * sign.float()).reshape(M, K)
+
+        # Plain (unswizzled) scales of shape (M, K // 32) for easy dequant.
+        q, s = mxfp4_rht_quantize_cutedsl_2d(x, sign.tolist(), 32, mode, False)
+
+        # Dequant: unpack two nibbles/byte -> e2m1 codes (low nibble first),
+        # decode to fp32 values, then multiply by 2^(e8m0_byte - 127) per block.
+        codes = unpack_uint4(q)  # (M, K) uint8 fp4 codes in bits 0-3
+        vals = f4_unpacked_to_f32(codes).reshape(M, K)
+        e8 = s.view(torch.uint8).to(torch.int32).reshape(M, K // 32)
+        scale = torch.pow(
+            torch.tensor(2.0, device="cuda"), (e8 - 127).float()
+        ).repeat_interleave(32, dim=1)
+        deq = vals * scale
+
+        sqnr = compute_error(rht_true, deq).item()
+        assert sqnr >= 13.0, f"SQNR {sqnr} dB below 13 dB for mode={mode}"

--- a/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
+++ b/test/prototype/mx_formats/test_mxfp4_rht_cutedsl.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from torchao.prototype.mx_formats.cutedsl import _mxfp4_rht_cutedsl_kernels_available
+
+pytestmark = pytest.mark.skipif(
+    not _mxfp4_rht_cutedsl_kernels_available,
+    reason="mxfp4 rht cutedsl unavailable (needs SM10.x, CUDA>=12.8, nvidia-cutlass-dsl)",
+)
+
+
+class TestE2M1Packing:
+    def test_pack_bitexact_vs_reference(self):
+        from torchao.prototype.mx_formats.cutedsl.cute_utils import (
+            pack32_e2m1_to_bytes,
+        )
+        from torchao.prototype.mx_formats.kernels import (
+            f32_to_f4_unpacked,
+            pack_uint4,
+        )
+
+        torch.manual_seed(0)
+        # len 32, spans the E2M1 grid + saturation + both parities/signs
+        x = torch.tensor(
+            [
+                0.0,
+                0.5,
+                1.0,
+                1.5,
+                2.0,
+                3.0,
+                4.0,
+                6.0,
+                -0.5,
+                -1.0,
+                -6.0,
+                7.0,
+                -7.0,
+                0.25,
+                5.0,
+                -2.5,
+            ]
+            * 2,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        ours = pack32_e2m1_to_bytes(x)  # (16,) uint8
+        ref = (
+            pack_uint4(f32_to_f4_unpacked(x.reshape(1, 32))).view(torch.uint8).flatten()
+        )  # (16,)
+        torch.testing.assert_close(ours, ref, rtol=0, atol=0)

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -33,6 +33,19 @@ class MXFP8Dim1CastKernelChoice(Enum):
     CUTEDSL = "cutedsl"
 
 
+class MXFP4CastKernelChoice(str, Enum):
+    """
+    Defines which kernel to use for mxfp4 casting.
+
+    TORCH: emulated PyTorch cast (default).
+    CUTEDSL: fused Random Hadamard Transform + E2M1 quantize CuTeDSL kernel
+        (requires CUDA SM10.x, CUDA>=12.8, and nvidia-cutlass-dsl).
+    """
+
+    TORCH = "torch"
+    CUTEDSL = "cutedsl"
+
+
 # register as pytree constant so we can use dynamo nonstrict trace in torchao.prototype.moe_training.ep
 @register_as_pytree_constant
 class ScaleCalculationMode(Enum):

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -39,7 +39,8 @@ class MXFP4CastKernelChoice(str, Enum):
 
     TORCH: emulated PyTorch cast (default).
     CUTEDSL: fused Random Hadamard Transform + E2M1 quantize CuTeDSL kernel
-        (requires CUDA SM10.x, CUDA>=12.8, and nvidia-cutlass-dsl).
+        (max-bandwidth streaming kernel; requires CUDA SM10.x, CUDA>=12.8, and
+        nvidia-cutlass-dsl).
     """
 
     TORCH = "torch"

--- a/torchao/prototype/mx_formats/cutedsl/__init__.py
+++ b/torchao/prototype/mx_formats/cutedsl/__init__.py
@@ -46,8 +46,47 @@ def pack32_e2m1_to_bytes(x: torch.Tensor) -> torch.Tensor:
     return _impl(x)
 
 
+def mxfp4_rht_quantize_cutedsl_2d(
+    x,
+    sign_vector,
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+):
+    """Lazily re-exported gated wrapper for the fused MXFP4 + RHT cast.
+
+    See ``mxfp4_rht_quantize.mxfp4_rht_quantize_cutedsl_2d``. Imported lazily so
+    that importing this package does not require the CuTeDSL runtime.
+    """
+    from .mxfp4_rht_quantize import mxfp4_rht_quantize_cutedsl_2d as _impl
+
+    return _impl(x, sign_vector, block_size, scaling_mode, is_swizzled_scales)
+
+
+def mxfp4_rht_quantize_cutedsl(
+    x,
+    sign_vector,
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+    stage_count: int = 2,
+):
+    """Lazily re-exported custom op for the fused MXFP4 + RHT cast.
+
+    See ``mxfp4_rht_quantize.mxfp4_rht_quantize_cutedsl``. Imported lazily so
+    that importing this package does not require the CuTeDSL runtime.
+    """
+    from .mxfp4_rht_quantize import mxfp4_rht_quantize_cutedsl as _impl
+
+    return _impl(
+        x, sign_vector, block_size, scaling_mode, is_swizzled_scales, stage_count
+    )
+
+
 __all__ = [
     "_is_sm_10x",
     "_mxfp4_rht_cutedsl_kernels_available",
     "pack32_e2m1_to_bytes",
+    "mxfp4_rht_quantize_cutedsl_2d",
+    "mxfp4_rht_quantize_cutedsl",
 ]

--- a/torchao/prototype/mx_formats/cutedsl/__init__.py
+++ b/torchao/prototype/mx_formats/cutedsl/__init__.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused MXFP4 + Random Hadamard Transform CuTeDSL quantize cast.
+
+This subpackage holds an optional, self-contained CuTeDSL implementation of an
+MXFP4 (E2M1, block 32, E8M0 scales) quantize cast fused with a Random Hadamard
+Transform. It is gated behind:
+
+* a Blackwell-family GPU (SM 10.x),
+* CUDA >= 12.8,
+* the CuTeDSL runtime packages (``nvidia-cutlass-dsl`` and friends).
+
+No ``cutlass`` import happens at module scope so importing this package is safe
+on machines without the CuTeDSL runtime (the gate flag simply evaluates False).
+"""
+
+import torch
+
+from torchao.utils import is_cuda_version_at_least
+
+from .cute_utils import _cutedsl_runtime_available
+
+
+def _is_sm_10x() -> bool:
+    """Return True iff a Blackwell-family (SM 10.x) GPU is available."""
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+
+_mxfp4_rht_cutedsl_kernels_available = (
+    _is_sm_10x() and is_cuda_version_at_least(12, 8) and _cutedsl_runtime_available()
+)
+
+
+def pack32_e2m1_to_bytes(x: torch.Tensor) -> torch.Tensor:
+    """Lazily re-exported test/validation entry for E2M1 packing.
+
+    See ``cute_utils.pack32_e2m1_to_bytes``. Imported lazily so that importing
+    this package does not require the CuTeDSL runtime.
+    """
+    from .cute_utils import pack32_e2m1_to_bytes as _impl
+
+    return _impl(x)
+
+
+__all__ = [
+    "_is_sm_10x",
+    "_mxfp4_rht_cutedsl_kernels_available",
+    "pack32_e2m1_to_bytes",
+]

--- a/torchao/prototype/mx_formats/cutedsl/__init__.py
+++ b/torchao/prototype/mx_formats/cutedsl/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
+
+# This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 """Fused MXFP4 + Random Hadamard Transform CuTeDSL quantize cast.

--- a/torchao/prototype/mx_formats/cutedsl/cute_utils.py
+++ b/torchao/prototype/mx_formats/cutedsl/cute_utils.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared utilities for the MXFP4 + RHT CuTeDSL quantize kernels."""
+
+import importlib.util
+
+import torch
+
+# Runtime package detection
+_CUTEDSL_RUNTIME_PACKAGES = {
+    "cuda.bindings.driver": "cuda-python",
+    "cutlass": "nvidia-cutlass-dsl",
+    "cutlass.cute": "nvidia-cutlass-dsl",
+    "tvm_ffi": "apache-tvm-ffi",
+}
+
+
+def _missing_cutedsl_runtime_packages() -> list[str]:
+    """Check which CuTeDSL runtime packages are missing.
+
+    Returns:
+        List of missing package names
+    """
+    missing = []
+    for module_name, package_name in _CUTEDSL_RUNTIME_PACKAGES.items():
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except (ModuleNotFoundError, ValueError):
+            # ModuleNotFoundError: parent module doesn't exist (e.g., 'cuda' on CPU)
+            # ValueError: can occur with malformed module names
+            spec = None
+
+        if spec is None and package_name not in missing:
+            missing.append(package_name)
+    return missing
+
+
+def _cutedsl_runtime_available() -> bool:
+    """Check if all CuTeDSL runtime packages are available.
+
+    Returns:
+        True if all required packages are installed
+    """
+    return len(_missing_cutedsl_runtime_packages()) == 0
+
+
+if _cutedsl_runtime_available():
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass._mlir.dialects import llvm
+    from cutlass.cutlass_dsl import T, dsl_user_op
+
+    # FP4 (E2M1) constants. F4_E2M1_MAX == 6.0.
+    INV_F4_E2M1_MAX = cutlass.Float32(1.0 / 6.0)
+
+    @dsl_user_op
+    def _cvt_rn_satfinite_e2m1x2_f32(
+        hi: cutlass.Float32,
+        lo: cutlass.Float32,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cutlass.Uint8:
+        """PTX inline assembly that packs two f32 values into one E2M1x2 byte.
+
+        Uses inline PTX on Blackwell-family targets because CuTeDSL does not
+        currently lower the float32 -> E2M1 pair conversion to
+        ``cvt.rn.satfinite.e2m1x2.f32`` on its own.
+
+        The PTX result of ``cvt.rn.satfinite.e2m1x2.f32 d, a, b`` is a ``.b8``
+        value, but inline-asm output registers must be at least 16-bit and
+        ptxas rejects a 16-bit register directly as the ``cvt`` destination. So
+        (mirroring cutlass's ``cvt.rn.f16x2.e2m1x2`` wrappers in
+        ``cute/arch/nvvm_wrappers.py``) we ``cvt`` into a ``.reg .b8`` and
+        assemble it into a ``.b16`` output via ``mov.b16 $0, {d, z}`` with a
+        zero high byte. The low byte is then masked out and returned.
+
+        Convention (validated bit-exactly by ``test_mxfp4_rht_cutedsl``): the
+        second PTX operand ``b`` (``lo``) lands in the LOW nibble and the first
+        operand ``a`` (``hi``) lands in the HIGH nibble, i.e. the returned byte
+        is ``(e2m1(hi) << 4) | e2m1(lo)``.
+        """
+        packed = cutlass.Uint16(
+            llvm.inline_asm(
+                T.i16(),
+                [
+                    cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                    cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+                ],
+                "{\n\t"
+                ".reg .b8 d, z, w;\n\t"
+                ".reg .b16 zero16;\n\t"
+                "mov.u16 zero16, 0;\n\t"
+                "mov.b16 {z, w}, zero16;\n\t"
+                "cvt.rn.satfinite.e2m1x2.f32 d, $1, $2;\n\t"
+                "mov.b16 $0, {d, z};\n\t"
+                "}",
+                "=h,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+        return cutlass.Uint8(packed & cutlass.Uint16(0xFF))
+
+    @cute.kernel
+    def _pack32_e2m1_kernel(
+        gx: cute.Tensor,
+        gout: cute.Tensor,
+    ):
+        """One-block, single-thread kernel: pack 32 f32 -> 16 E2M1x2 bytes.
+
+        For ``p`` in ``0..15`` it emits
+        ``_cvt_rn_satfinite_e2m1x2_f32(hi=x[2p+1], lo=x[2p])`` so that the even
+        column ``2p`` lands in the low nibble and the odd column ``2p+1`` in the
+        high nibble of output byte ``p``.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        if tidx == 0:
+            for p in cutlass.range_constexpr(16):
+                lo = cutlass.Float32(gx[2 * p])
+                hi = cutlass.Float32(gx[2 * p + 1])
+                gout[p] = _cvt_rn_satfinite_e2m1x2_f32(hi, lo)
+
+    @cute.jit
+    def _pack32_e2m1_launch(
+        gx: cute.Tensor,
+        gout: cute.Tensor,
+        stream,
+    ):
+        _pack32_e2m1_kernel(gx, gout).launch(
+            grid=(1, 1, 1),
+            block=(32, 1, 1),
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    def pack32_e2m1_to_bytes(x: torch.Tensor) -> torch.Tensor:
+        """Pack a length-32 fp32 CUDA vector into 16 E2M1x2 bytes.
+
+        Test/validation entry only -- the production kernel inlines the same
+        ``_cvt_rn_satfinite_e2m1x2_f32`` logic. Even input columns go to the low
+        nibble, odd columns to the high nibble (matching torchao's packed-fp4
+        byte order).
+
+        Args:
+            x: 1D float32 CUDA tensor of length 32.
+
+        Returns:
+            A ``(16,)`` uint8 CUDA tensor.
+        """
+        import cuda.bindings.driver as cuda
+        from cutlass.cute.runtime import from_dlpack
+
+        assert x.is_cuda, "input must be a CUDA tensor"
+        assert x.dtype == torch.float32, "input must be float32"
+        assert x.numel() == 32, "input must have exactly 32 elements"
+        x = x.contiguous()
+        out = torch.empty((16,), device=x.device, dtype=torch.uint8)
+
+        gx = from_dlpack(x)
+        gout = from_dlpack(out)
+        stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+        _pack32_e2m1_launch(gx, gout, stream)
+        return out

--- a/torchao/prototype/mx_formats/cutedsl/cute_utils.py
+++ b/torchao/prototype/mx_formats/cutedsl/cute_utils.py
@@ -52,10 +52,18 @@ if _cutedsl_runtime_available():
     import cutlass
     import cutlass.cute as cute
     from cutlass._mlir.dialects import llvm
+    from cutlass.base_dsl._mlir_helpers import arith as _dsl_arith
     from cutlass.cutlass_dsl import T, dsl_user_op
 
     # FP4 (E2M1) constants. F4_E2M1_MAX == 6.0.
     INV_F4_E2M1_MAX = cutlass.Float32(1.0 / 6.0)
+
+    # FP4 E8M0 scale constants. NOTE: these are the FP4 values, NOT the FP8
+    # ones -- `F4_E2M1_MAX_POW2 == 2` (the FP8 helper uses 8), and the RCEIL
+    # descale divisor is `F4_E2M1_MAX == 6.0` (the FP8 helper uses 448).
+    F4_E2M1_MAX_POW2 = 2  # log2 of the largest power-of-two <= F4_E2M1_MAX (6.0)
+    E8M0_EXPONENT_BIAS = 127
+    E8M0_EXPONENT_NAN_VAL = 255
 
     @dsl_user_op
     def _cvt_rn_satfinite_e2m1x2_f32(
@@ -167,3 +175,187 @@ if _cutedsl_runtime_available():
         stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
         _pack32_e2m1_launch(gx, gout, stream)
         return out
+
+    # ------------------------------------------------------------------
+    # FP4 E8M0 block-scale helpers
+    # ------------------------------------------------------------------
+
+    @dsl_user_op
+    def _cvt_rp_satfinite_ue8m0x2_f32(
+        a: cutlass.Float32,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cutlass.Uint16:
+        """PTX inline assembly for RCEIL E8M0 conversion (Blackwell SM10.x).
+
+        ``cvt.rp.satfinite.ue8m0x2.f32 $0, 0.0, descale`` packs two e8m0
+        results into a uint16; the low byte holds the e8m0 of ``descale``.
+        Hardware handles NaN -> 255, Inf -> 254, subnormals -> 0.
+        """
+        return cutlass.Uint16(
+            llvm.inline_asm(
+                T.i16(),
+                [cutlass.Float32(a).ir_value(loc=loc, ip=ip)],
+                "cvt.rp.satfinite.ue8m0x2.f32 $0, 0.0, $1;",
+                "=h,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @cute.jit
+    def compute_amax(vals_block: cute.Tensor):
+        """Compute the absolute maximum of a block of values as Float32."""
+        vals_vec = vals_block.load()
+        abs_vec = cute.where(vals_vec < 0, -vals_vec, vals_vec)
+        return cutlass.Float32(
+            abs_vec.reduce(cute.ReductionOp.MAX, cutlass.Float32(0.0), 0)
+        )
+
+    @cute.jit
+    def compute_scale_floor_fp4(amax: cutlass.Float32):
+        """FP4 FLOOR-mode E8M0 biased scale byte.
+
+        Mirrors torchao eager ``to_mx`` (FLOOR branch) for
+        ``elem_dtype=torch.float4_e2m1fn_x2``:
+
+            extracted_pow2     = ((bits(amax) >> 23) & 0xFF) - 127
+            scale_unbiased     = extracted_pow2 - F4_E2M1_MAX_POW2    # -2, NOT -8
+            scale_unbiased     = clamp(scale_unbiased, -127, 128)
+            scale_biased(byte) = scale_unbiased + 127
+
+        Returns the biased E8M0 byte as Int32 (caller stores low 8 bits).
+        """
+        bits = _dsl_arith.bitcast(amax.ir_value(), _dsl_arith.T.i32())
+        exp_i = ((bits >> cutlass.Int32(23)) & cutlass.Int32(0xFF)) - cutlass.Int32(
+            E8M0_EXPONENT_BIAS
+        )
+        scale_exp_unbiased = exp_i - cutlass.Int32(F4_E2M1_MAX_POW2)
+        if scale_exp_unbiased < -E8M0_EXPONENT_BIAS:
+            scale_exp_unbiased = cutlass.Int32(-E8M0_EXPONENT_BIAS)
+        if scale_exp_unbiased > E8M0_EXPONENT_BIAS + 1:
+            scale_exp_unbiased = cutlass.Int32(E8M0_EXPONENT_BIAS + 1)
+        scale_biased = scale_exp_unbiased + E8M0_EXPONENT_BIAS
+        return scale_biased
+
+    @cute.jit
+    def compute_scale_rceil_fp4(amax: cutlass.Float32):
+        """FP4 RCEIL-mode E8M0 biased scale byte.
+
+        Mirrors torchao eager ``_to_mx_rceil`` for
+        ``elem_dtype=torch.float4_e2m1fn_x2`` (``max_pos == F4_E2M1_MAX == 6.0``):
+
+            descale = amax / 6.0   (i.e. amax * INV_F4_E2M1_MAX, NOT 1/448)
+            biased  = cvt.rp.satfinite.ue8m0x2.f32(0.0, descale)  # low byte
+
+        Hardware saturates / handles NaN -> 255, Inf -> 254. Returns the biased
+        E8M0 byte as Int32 (caller stores low 8 bits).
+        """
+        descale = amax * INV_F4_E2M1_MAX
+        scale_biased = cutlass.Int32(_cvt_rp_satfinite_ue8m0x2_f32(descale))
+        return scale_biased
+
+    @cute.jit
+    def compute_scale_byte_fp4(
+        amax: cutlass.Float32,
+        USE_RCEIL: cutlass.Constexpr[bool],
+    ):
+        """Dispatch to the FP4 FLOOR / RCEIL E8M0 biased scale byte.
+
+        Matches eager ``to_mx``: a NaN ``amax`` maps to the E8M0 NaN byte
+        (255). For FLOOR a non-NaN ``amax`` always uses the bit-extraction
+        path (an all-zero block yields byte ``-2 + 127 = 125``, the same as
+        eager, since ``floor(log2(0)) = -127`` clamps and ``0 -> extracted
+        pow2 = -127``... handled by clamp). RCEIL uses the saturating PTX cvt,
+        which itself maps subnormal/zero descale -> 0.
+        """
+        # NaN amax -> E8M0 NaN byte, matching eager to_mx.
+        scale_biased = cutlass.Int32(E8M0_EXPONENT_NAN_VAL)
+        if amax == amax:  # not NaN
+            if cutlass.const_expr(USE_RCEIL):
+                scale_biased = compute_scale_rceil_fp4(amax)
+            else:
+                scale_biased = compute_scale_floor_fp4(amax)
+        return scale_biased
+
+    @cute.kernel
+    def _block_scale_e8m0_fp4_kernel(
+        gx: cute.Tensor,
+        gscale: cute.Tensor,
+        num_blocks: cutlass.Int32,
+        USE_RCEIL: cutlass.Constexpr[bool],
+    ):
+        """One thread per 32-element block: amax -> E8M0 biased scale byte.
+
+        ``gx`` is a 2D ``(num_blocks, 32)`` float32 view; ``gscale`` is a 1D
+        ``(num_blocks,)`` uint8 view (the flattened ``(N, K//32)`` scales).
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        bdim, _, _ = cute.arch.block_dim()
+        block = bidx * bdim + tidx
+        if block < num_blocks:
+            vals = cute.make_rmem_tensor((32,), cutlass.Float32)
+            for j in cutlass.range_constexpr(32):
+                vals[j] = cutlass.Float32(gx[block, j])
+            amax = compute_amax(vals)
+            scale_biased = compute_scale_byte_fp4(amax, USE_RCEIL)
+            gscale[block] = cutlass.Uint8(scale_biased & cutlass.Int32(0xFF))
+
+    @cute.jit
+    def _block_scale_e8m0_fp4_launch(
+        gx: cute.Tensor,
+        gscale: cute.Tensor,
+        num_blocks: cutlass.Int32,
+        stream,
+        USE_RCEIL: cutlass.Constexpr[bool],
+    ):
+        threads = 128
+        grid = (num_blocks + threads - 1) // threads
+        _block_scale_e8m0_fp4_kernel(gx, gscale, num_blocks, USE_RCEIL).launch(
+            grid=(grid, 1, 1),
+            block=(threads, 1, 1),
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    def compute_block_scale_e8m0_fp4(x: torch.Tensor, mode: str) -> torch.Tensor:
+        """Compute per-32-block E8M0 biased scale bytes for FP4.
+
+        Bit-exact (validated by ``test_mxfp4_rht_cutedsl``) against torchao
+        eager ``to_mx(..., elem_dtype=torch.float4_e2m1fn_x2, block_size=32)``
+        plain (unswizzled) scales, for FLOOR and RCEIL modes.
+
+        Args:
+            x: 2D CUDA tensor ``[N, K]`` (bf16 or fp32) with ``K % 32 == 0``.
+            mode: ``"floor"`` or ``"rceil"``.
+
+        Returns:
+            ``(N, K // 32)`` ``torch.float8_e8m0fnu`` CUDA tensor of scale bytes.
+        """
+        import cuda.bindings.driver as cuda
+        from cutlass.cute.runtime import from_dlpack
+
+        assert x.is_cuda, "input must be a CUDA tensor"
+        assert x.dim() == 2, "input must be 2D [N, K]"
+        n, k = x.shape
+        assert k % 32 == 0, "K must be divisible by 32"
+        mode = mode.lower()
+        assert mode in ("floor", "rceil"), f"unsupported scaling mode: {mode}"
+        use_rceil = mode == "rceil"
+
+        kb = k // 32
+        num_blocks = n * kb
+        # float32 [num_blocks, 32] view of the per-block elements.
+        x_f32 = x.to(torch.float32).contiguous().reshape(num_blocks, 32)
+        scale_u8 = torch.empty((num_blocks,), device=x.device, dtype=torch.uint8)
+
+        gx = from_dlpack(x_f32)
+        gscale = from_dlpack(scale_u8)
+        stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+        _block_scale_e8m0_fp4_launch(
+            gx, gscale, cutlass.Int32(num_blocks), stream, use_rceil
+        )
+        return scale_u8.view(torch.float8_e8m0fnu).reshape(n, kb)

--- a/torchao/prototype/mx_formats/cutedsl/cute_utils.py
+++ b/torchao/prototype/mx_formats/cutedsl/cute_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
+
+# This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 """Shared utilities for the MXFP4 + RHT CuTeDSL quantize kernels."""

--- a/torchao/prototype/mx_formats/cutedsl/cute_utils.py
+++ b/torchao/prototype/mx_formats/cutedsl/cute_utils.py
@@ -216,7 +216,7 @@ if _cutedsl_runtime_available():
 
     @cute.jit
     def compute_scale_floor_fp4(amax: cutlass.Float32):
-        """FP4 FLOOR-mode E8M0 biased scale byte.
+        """FP4 FLOOR-mode E8M0 biased scale byte + fp32 inverse scale.
 
         Mirrors torchao eager ``to_mx`` (FLOOR branch) for
         ``elem_dtype=torch.float4_e2m1fn_x2``:
@@ -225,8 +225,17 @@ if _cutedsl_runtime_available():
             scale_unbiased     = extracted_pow2 - F4_E2M1_MAX_POW2    # -2, NOT -8
             scale_unbiased     = clamp(scale_unbiased, -127, 128)
             scale_biased(byte) = scale_unbiased + 127
+            inv_scale          = 2 ** (-scale_unbiased)
 
-        Returns the biased E8M0 byte as Int32 (caller stores low 8 bits).
+        The ``inv_scale`` is the value the quantizer multiplies each element by
+        before the E2M1 conversion (it is ``1 / 2**scale_unbiased``). The eager
+        FLOOR path floors the divisor to ``2**-126``; the matching cap here is
+        ``inv_scale <= 2**126`` (i.e. ``scale_unbiased >= -126``), so we clamp
+        the exponent used for ``inv_scale`` at the bottom.
+
+        Returns ``(scale_biased, inv_scale)`` where ``scale_biased`` is the
+        biased E8M0 byte as Int32 (caller stores low 8 bits) and ``inv_scale``
+        is a ``Float32``.
         """
         bits = _dsl_arith.bitcast(amax.ir_value(), _dsl_arith.T.i32())
         exp_i = ((bits >> cutlass.Int32(23)) & cutlass.Int32(0xFF)) - cutlass.Int32(
@@ -238,31 +247,51 @@ if _cutedsl_runtime_available():
         if scale_exp_unbiased > E8M0_EXPONENT_BIAS + 1:
             scale_exp_unbiased = cutlass.Int32(E8M0_EXPONENT_BIAS + 1)
         scale_biased = scale_exp_unbiased + E8M0_EXPONENT_BIAS
-        return scale_biased
+        # inv_scale = 2 ** (-scale_unbiased); divisor floored to 2**-126, so the
+        # inverse is capped at 2**126 (scale_exp_unbiased >= -126).
+        inv_exp = -scale_exp_unbiased
+        if inv_exp > cutlass.Int32(126):
+            inv_exp = cutlass.Int32(126)
+        inv_scale = cute.exp2(cutlass.Float32(inv_exp))
+        return scale_biased, inv_scale
 
     @cute.jit
     def compute_scale_rceil_fp4(amax: cutlass.Float32):
-        """FP4 RCEIL-mode E8M0 biased scale byte.
+        """FP4 RCEIL-mode E8M0 biased scale byte + fp32 inverse scale.
 
         Mirrors torchao eager ``_to_mx_rceil`` for
         ``elem_dtype=torch.float4_e2m1fn_x2`` (``max_pos == F4_E2M1_MAX == 6.0``):
 
             descale = amax / 6.0   (i.e. amax * INV_F4_E2M1_MAX, NOT 1/448)
             biased  = cvt.rp.satfinite.ue8m0x2.f32(0.0, descale)  # low byte
+            inv_scale = 2 ** (127 - biased)
 
-        Hardware saturates / handles NaN -> 255, Inf -> 254. Returns the biased
-        E8M0 byte as Int32 (caller stores low 8 bits).
+        Hardware saturates / handles NaN -> 255, Inf -> 254. The ``inv_scale``
+        is derived from the biased byte exactly like the mxfp8 RCEIL helper:
+        byte ``0xFF`` (NaN) -> 0.0, byte ``0`` -> ``2**126`` (subnormal floor),
+        else ``2**(127 - biased)``.
+
+        Returns ``(scale_biased, inv_scale)`` where ``scale_biased`` is the
+        biased E8M0 byte as Int32 (caller stores low 8 bits) and ``inv_scale``
+        is a ``Float32``.
         """
         descale = amax * INV_F4_E2M1_MAX
         scale_biased = cutlass.Int32(_cvt_rp_satfinite_ue8m0x2_f32(descale))
-        return scale_biased
+        inv_scale = cutlass.Float32(1.0)
+        if scale_biased == 0xFF:
+            inv_scale = cutlass.Float32(0.0)
+        elif scale_biased == 0:
+            inv_scale = cute.exp2(cutlass.Float32(126.0))
+        else:
+            inv_scale = cute.exp2(cutlass.Float32(127 - scale_biased))
+        return scale_biased, inv_scale
 
     @cute.jit
     def compute_scale_byte_fp4(
         amax: cutlass.Float32,
         USE_RCEIL: cutlass.Constexpr[bool],
     ):
-        """Dispatch to the FP4 FLOOR / RCEIL E8M0 biased scale byte.
+        """Dispatch to the FP4 FLOOR / RCEIL E8M0 biased scale byte + inv_scale.
 
         Matches eager ``to_mx``: a NaN ``amax`` maps to the E8M0 NaN byte
         (255). For FLOOR a non-NaN ``amax`` always uses the bit-extraction
@@ -270,15 +299,19 @@ if _cutedsl_runtime_available():
         eager, since ``floor(log2(0)) = -127`` clamps and ``0 -> extracted
         pow2 = -127``... handled by clamp). RCEIL uses the saturating PTX cvt,
         which itself maps subnormal/zero descale -> 0.
+
+        Returns ``(scale_biased, inv_scale)``. For a NaN ``amax`` the
+        ``inv_scale`` is ``0.0`` (matching the E8M0 NaN byte).
         """
         # NaN amax -> E8M0 NaN byte, matching eager to_mx.
         scale_biased = cutlass.Int32(E8M0_EXPONENT_NAN_VAL)
+        inv_scale = cutlass.Float32(0.0)
         if amax == amax:  # not NaN
             if cutlass.const_expr(USE_RCEIL):
-                scale_biased = compute_scale_rceil_fp4(amax)
+                scale_biased, inv_scale = compute_scale_rceil_fp4(amax)
             else:
-                scale_biased = compute_scale_floor_fp4(amax)
-        return scale_biased
+                scale_biased, inv_scale = compute_scale_floor_fp4(amax)
+        return scale_biased, inv_scale
 
     @cute.kernel
     def _block_scale_e8m0_fp4_kernel(
@@ -301,7 +334,7 @@ if _cutedsl_runtime_available():
             for j in cutlass.range_constexpr(32):
                 vals[j] = cutlass.Float32(gx[block, j])
             amax = compute_amax(vals)
-            scale_biased = compute_scale_byte_fp4(amax, USE_RCEIL)
+            scale_biased, _ = compute_scale_byte_fp4(amax, USE_RCEIL)
             gscale[block] = cutlass.Uint8(scale_biased & cutlass.Int32(0xFF))
 
     @cute.jit

--- a/torchao/prototype/mx_formats/cutedsl/fwht.py
+++ b/torchao/prototype/mx_formats/cutedsl/fwht.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Register-resident FWHT(32) + sign transform for the MXFP4 + RHT cast.
+
+Implements, per 32-element block, the normalized Fast Walsh-Hadamard Transform
+followed by an elementwise sign multiply:
+
+    out = (FWHT(vals) / sqrt(32)) * sign
+
+This equals ``vals @ hadamard_matrix(32) * sign`` where ``hadamard_matrix(32)``
+is torchao's normalized (1/sqrt(32)) symmetric Sylvester/Walsh-Hadamard matrix
+(see ``torchao/prototype/spinquant/hadamard_utils.py``).
+
+The transform is a pure device helper (``fwht32_sign``) so the fused Task 4
+kernel can call it per block from registers. ``fwht32_sign_host`` is a tiny
+one-block-per-row kernel used only to validate the device helper against a dense
+torch reference.
+"""
+
+import math
+
+import torch
+
+from .cute_utils import _cutedsl_runtime_available
+
+# 1 / sqrt(32); applied once after the 5 butterfly stages.
+_INV_SQRT_32 = 1.0 / math.sqrt(32.0)
+
+
+if _cutedsl_runtime_available():
+    import cutlass
+    import cutlass.cute as cute
+
+    # Normalization scalar as a device Float32 constant.
+    INV_SQRT_32 = cutlass.Float32(_INV_SQRT_32)
+
+    @cute.jit
+    def fwht32_sign(vals: cute.Tensor, sign: cute.Tensor) -> cute.Tensor:
+        """In-register normalized FWHT(32) followed by an elementwise sign mul.
+
+        Computes, for the length-32 register fragment ``vals``::
+
+            out[j] = (FWHT(vals) / sqrt(32))[j] * sign[j]
+
+        which equals ``(vals @ hadamard_matrix(32))[j] * sign[j]``.
+
+        The transform is the standard radix-2 decimation-in-time Walsh-Hadamard
+        butterfly over strides ``s in {1, 2, 4, 8, 16}``. For each stride, every
+        pair ``(i, i + s)`` with ``(i & s) == 0`` is touched exactly once::
+
+            a, b = vals[i] + vals[i + s], vals[i] - vals[i + s]
+            vals[i], vals[i + s] = a, b
+
+        All pair indices are compile-time constants (the 5 stages and their
+        pairings are fixed for a length-32 block), so the loops are unrolled via
+        ``cutlass.range_constexpr``. This pairing/orientation is validated
+        bit-for-bit-close against ``hadamard_matrix(32)`` by
+        ``test_mxfp4_rht_cutedsl``.
+
+        Args:
+            vals: length-32 ``Float32`` register fragment (modified in place and
+                also returned).
+            sign: length-32 register fragment of ``{-1, +1}`` values (any
+                arithmetic dtype; cast to ``Float32`` for the multiply).
+
+        Returns:
+            The transformed length-32 ``Float32`` fragment (the same ``vals``).
+        """
+        # 5-stage in-register butterfly. Strides are powers of two up to 16.
+        for stage in cutlass.range_constexpr(5):
+            s = 1 << stage
+            for i in cutlass.range_constexpr(32):
+                if cutlass.const_expr((i & s) == 0):
+                    a = cutlass.Float32(vals[i])
+                    b = cutlass.Float32(vals[i + s])
+                    vals[i] = a + b
+                    vals[i + s] = a - b
+
+        # Normalize then apply the sign vector.
+        for j in cutlass.range_constexpr(32):
+            vals[j] = cutlass.Float32(vals[j]) * INV_SQRT_32 * cutlass.Float32(sign[j])
+
+        return vals
+
+    @cute.kernel
+    def _fwht32_sign_kernel(
+        gx: cute.Tensor,
+        gsign: cute.Tensor,
+        gout: cute.Tensor,
+        num_rows: cutlass.Int32,
+    ):
+        """One thread per row: load 32 f32 + sign, apply ``fwht32_sign``, store.
+
+        ``gx`` / ``gout`` are 2D ``(num_rows, 32)`` float32 views; ``gsign`` is a
+        1D ``(32,)`` int32 view broadcast across all rows.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        bdim, _, _ = cute.arch.block_dim()
+        row = bidx * bdim + tidx
+        if row < num_rows:
+            vals = cute.make_rmem_tensor((32,), cutlass.Float32)
+            sign = cute.make_rmem_tensor((32,), cutlass.Float32)
+            for j in cutlass.range_constexpr(32):
+                vals[j] = cutlass.Float32(gx[row, j])
+                sign[j] = cutlass.Float32(gsign[j])
+            fwht32_sign(vals, sign)
+            for j in cutlass.range_constexpr(32):
+                gout[row, j] = cutlass.Float32(vals[j])
+
+    @cute.jit
+    def _fwht32_sign_launch(
+        gx: cute.Tensor,
+        gsign: cute.Tensor,
+        gout: cute.Tensor,
+        num_rows: cutlass.Int32,
+        stream,
+    ):
+        threads = 128
+        grid = (num_rows + threads - 1) // threads
+        _fwht32_sign_kernel(gx, gsign, gout, num_rows).launch(
+            grid=(grid, 1, 1),
+            block=(threads, 1, 1),
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    def fwht32_sign_host(x: torch.Tensor, sign: torch.Tensor) -> torch.Tensor:
+        """Apply the normalized FWHT(32) + sign transform to each row of ``x``.
+
+        Test/validation entry only -- the production kernel inlines the same
+        ``fwht32_sign`` device helper per block. Matches (to fp32 rounding)
+        ``(x @ hadamard_matrix(32)) * sign`` row-by-row.
+
+        Args:
+            x: 2D float32 CUDA tensor ``[N, 32]``.
+            sign: length-32 integer CUDA tensor of ``{-1, +1}`` values.
+
+        Returns:
+            A ``(N, 32)`` float32 CUDA tensor.
+        """
+        import cuda.bindings.driver as cuda
+        from cutlass.cute.runtime import from_dlpack
+
+        assert x.is_cuda, "input must be a CUDA tensor"
+        assert x.dim() == 2 and x.shape[1] == 32, "input must be 2D [N, 32]"
+        assert x.dtype == torch.float32, "input must be float32"
+        assert sign.is_cuda, "sign must be a CUDA tensor"
+        assert sign.numel() == 32, "sign must have exactly 32 elements"
+
+        num_rows = x.shape[0]
+        x = x.contiguous()
+        sign_i32 = sign.to(torch.int32).contiguous()
+        out = torch.empty((num_rows, 32), device=x.device, dtype=torch.float32)
+
+        gx = from_dlpack(x)
+        gsign = from_dlpack(sign_i32)
+        gout = from_dlpack(out)
+        stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+        _fwht32_sign_launch(gx, gsign, gout, cutlass.Int32(num_rows), stream)
+        return out

--- a/torchao/prototype/mx_formats/cutedsl/fwht.py
+++ b/torchao/prototype/mx_formats/cutedsl/fwht.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
+
+# This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 """Register-resident FWHT(32) + sign transform for the MXFP4 + RHT cast.

--- a/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
+++ b/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
@@ -6,17 +6,16 @@
 
 """Fused MXFP4 (E2M1, block 32, E8M0) + Random Hadamard Transform CuTeDSL cast.
 
-Clones the structure of the MXFP8 1x32 CuTeDSL quantize kernel
-(``torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py``)
-and applies the MXFP4 + RHT deltas:
+A max-bandwidth streaming quantize kernel: each thread owns one full 32-element
+block (= 16 packed E2M1x2 output bytes = one wide 128-bit store + one E8M0 scale
+byte), reads it with forced 128-bit loads, applies the optional register-resident
+FWHT(32) + sign transform (``fwht.fwht32_sign``), computes amax + the E8M0 scale,
+packs the 16 bytes, and writes them with a single 128-bit store; heavy per-thread
+ILP hides the load latency and the e2m1/e8m0 conversions.
 
-* the E2M1 output is two codes per byte, so the output smem / global qdata are
-  half-width ``[M, K // 2]`` ``uint8``;
-* per 32-element block the consumer applies the register-resident FWHT(32) +
-  sign transform (``fwht.fwht32_sign``) before computing amax / scale / packing;
-* values are clamped to ``+-6.0`` (``F4_E2M1_MAX``) before the E2M1 cvt in FLOOR
-  mode (RCEIL's cvt saturates on its own);
-* 16 E2M1x2 bytes per block are assembled and written as 4 ``uint32`` stores;
+* the E2M1 output is two codes per byte -> half-width ``[M, K // 2]`` ``uint8``;
+* ``scaling_mode`` ``"floor"`` or ``"rceil"`` (E8M0 via ``compute_scale_byte_fp4``);
+  no explicit ``+-6`` clamp is needed -- ``cvt.rn.satfinite`` already saturates;
 * the biased E8M0 scale byte is written either in the cuBLAS-blocked padded
   layout (``is_swizzled_scales=True``) or as a plain ``(M, K // 32)`` tensor.
 
@@ -38,618 +37,313 @@ from .cute_utils import (
 )
 from .fwht import fwht32_sign
 
-# Config format:
-# (compute_warps, tile_m, tile_k, k_tiles_per_cta)
-_CUTEDSL_CONFIGS = {
-    "bf16_default": (4, 128, 32, 4),
-    "fallback": (6, 128, 32, 2),
-}
-
-
-def _select_cutedsl_config(
-    input_dtype: torch.dtype,
-    scaling_mode: str,
-) -> Tuple[str, Tuple[int, int, int, int]]:
-    """Select kernel configuration based on input dtype."""
-    if input_dtype == torch.bfloat16:
-        config_name = "bf16_default"
-    else:
-        config_name = "fallback"
-    return config_name, _CUTEDSL_CONFIGS[config_name]
-
-
-def _make_tile_smem_layouts(tile_m: int, tile_k: int):
-    """Row-major smem layouts for the input ``(TILE_M, TILE_K)`` and the
-    half-width output ``(TILE_M, TILE_K // 2)`` tiles."""
-    import cutlass.cute as cute
-
-    smem_layout_in = cute.make_layout(
-        (tile_m, tile_k),
-        stride=(tile_k, 1),
-    )
-    smem_layout_out = cute.make_layout(
-        (tile_m, tile_k // 2),
-        stride=(tile_k // 2, 1),
-    )
-    return smem_layout_in, smem_layout_out
+# ============================================================================
+# Max-bandwidth streaming quantize kernel
+# ============================================================================
+# The fused MXFP4 (+/- RHT) quantize kernel (no smem, no TMA). Streaming design:
+# each thread owns ONE full 32-block (= 32 input
+# elems = 16 output bytes = one wide 128-bit ``STG`` + one E8M0 scale byte),
+# reads it with forced 128-bit ``LDG`` (``CopyUniversalOp`` num_bits_per_copy=128
+# + ``cute.assume`` on the offset -- a plain ``iterator + dynamic_offset``
+# silently degrades to scalar loads), runs the FWHT32+sign thread-locally, and
+# uses heavy per-thread ILP. No explicit ``+-6`` clamps (``cvt.rn.satfinite``
+# already saturates, bit-exact). 2D ``(row, group-in-row)`` map keeps
+# ``(row, kb)`` division-free for the swizzled scale offset.
+#
+# IMPORTANT: compiled with CONCRETE ``from_dlpack`` tensors, not
+# ``make_fake_tensor`` -- the symbolic AOT path mis-lowers the single-byte scale
+# store. Cached on (dtype, scaling_mode, swizzled, threads, ilp).
+#
+# NOTE: the RHT path is FWHT32-compute-bound; the plain (no-RHT) path reaches
+# the HBM roofline.
+_MAXBW_JIT_CACHE: dict = {}
 
 
 @functools.cache
-def _compile_mxfp4_rht_quantize_2d_cutedsl(
-    input_dtype_name: str,
-    scaling_mode: str,
-    compute_warps: int,
-    tile_m: int,
-    tile_k: int,
-    requested_stage_count: int,
-    k_tiles_per_cta: int,
-    blocked_scale_output: bool,
-):
-    """Compile the fused 2D MXFP4 + RHT quantize kernel using CuTeDSL.
+def _get_maxbw_launch():
+    """Define and return the (uncompiled) ``@cute.jit`` max-bandwidth launcher.
 
-    Warp-specialized TMA kernel mirroring the MXFP8 1x32 template:
-    - warp 0: producer (TMA global->shared input, shared->global half-width
-      output);
-    - warps [1..compute_warps]: consumers (FWHT + quantize + E2M1 pack).
+    Gated behind the CuTeDSL runtime (cutlass imports + kernel definition live
+    inside this function). Reuses the module-level ``compute_amax`` /
+    ``compute_scale_byte_fp4`` / ``_cvt_rn_satfinite_e2m1x2_f32`` / ``fwht32_sign``.
+    """
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.cute.nvgpu as nv
+
+    F4_MAX = cutlass.Float32(6.0)
+
+    @cute.kernel
+    def _maxbw_kernel(
+        gx: cute.Tensor,  # (M*K,) input flat (bf16 or fp32)
+        gq: cute.Tensor,  # (M*K // 2,) uint8 flat (packed E2M1x2)
+        gscale: cute.Tensor,  # scale buffer flat uint8 (E8M0 bytes)
+        gsign: cute.Tensor,  # (32,) int32 sign vector (RHT only)
+        M: cutlass.Int32,
+        K: cutlass.Int32,
+        GPR: cutlass.Int32,  # groups per row = K // 32
+        pad_cols: cutlass.Int32,  # padded scale cols = ceil(K // 32, 4) * 4
+        ILP: cutlass.Constexpr[int],
+        APPLY_RHT: cutlass.Constexpr[bool],
+        SWIZZLED: cutlass.Constexpr[bool],
+        USE_RCEIL: cutlass.Constexpr[bool],
+        DROP_CLAMP: cutlass.Constexpr[bool],
+        LDWIDTH: cutlass.Constexpr[int],  # elems per 128-bit load (8 bf16, 4 fp32)
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy_init, _ = cute.arch.block_idx()
+        bdim, _, _ = cute.arch.block_dim()
+        gid = bidx * bdim + tidx
+        nthreads_x = cute.arch.grid_dim()[0] * bdim
+
+        in_dt = gx.element_type
+        ld = cute.make_copy_atom(nv.CopyUniversalOp(), in_dt, num_bits_per_copy=128)
+        st = cute.make_copy_atom(
+            nv.CopyUniversalOp(), cutlass.Uint8, num_bits_per_copy=128
+        )
+
+        # number of 128-bit loads to cover 32 input elems
+        NLD = 32 // LDWIDTH
+
+        # Load the length-32 sign vector once (RHT only).
+        sign_reg = cute.make_rmem_tensor((32,), cutlass.Float32)
+        if cutlass.const_expr(APPLY_RHT):
+            for j in cutlass.range_constexpr(32):
+                sign_reg[j] = cutlass.Float32(gsign[j])
+
+        # 2D grid-stride over (row, gcol). grid.y indexes rows.
+        row = bidy_init
+        while row < M:
+            base = gid
+            while base < GPR:
+                # ---- issue ALL loads first (ILP) into a flat (ILP, 32) buffer ----
+                fragbuf = cute.make_rmem_tensor((ILP * 32,), in_dt)
+                for jj in cutlass.range_constexpr(ILP):
+                    gc = base + jj * nthreads_x
+                    if gc < GPR:
+                        off = cute.assume(row * K + gc * cutlass.Int32(32), divby=32)
+                        for w in cutlass.range_constexpr(NLD):
+                            s = cute.make_tensor(
+                                gx.iterator + off + w * LDWIDTH,
+                                cute.make_layout((LDWIDTH,), stride=(1,)),
+                            )
+                            f = cute.make_tensor(
+                                fragbuf.iterator + jj * 32 + w * LDWIDTH,
+                                cute.make_layout((LDWIDTH,), stride=(1,)),
+                            )
+                            cute.copy(ld, s, f)
+
+                # ---- consume: FWHT/scale/pack + wide store per 32-block ----
+                for jj in cutlass.range_constexpr(ILP):
+                    gc = base + jj * nthreads_x
+                    if gc < GPR:
+                        vals = cute.make_rmem_tensor((32,), cutlass.Float32)
+                        for i in cutlass.range_constexpr(32):
+                            vals[i] = cutlass.Float32(fragbuf[jj * 32 + i])
+                        blk = cute.make_tensor(
+                            vals.iterator, cute.make_layout((32,), stride=(1,))
+                        )
+                        if cutlass.const_expr(APPLY_RHT):
+                            fwht32_sign(blk, sign_reg)
+                        amax = compute_amax(blk)
+                        scale_biased, inv = compute_scale_byte_fp4(amax, USE_RCEIL)
+                        kb = gc  # one block per group
+                        scale_byte = cutlass.Uint8(scale_biased & cutlass.Int32(0xFF))
+                        # scale store
+                        if cutlass.const_expr(SWIZZLED):
+                            r128 = row // cutlass.Int32(128)
+                            r32 = row % cutlass.Int32(32)
+                            r32_4 = (row // cutlass.Int32(32)) % cutlass.Int32(4)
+                            kb4 = kb // cutlass.Int32(4)
+                            kbm = kb % cutlass.Int32(4)
+                            soff = (
+                                r128 * cutlass.Int32(128) * pad_cols
+                                + kb4 * cutlass.Int32(512)
+                                + r32 * cutlass.Int32(16)
+                                + r32_4 * cutlass.Int32(4)
+                                + kbm
+                            )
+                            gscale[soff] = scale_byte
+                        else:
+                            gscale[row * GPR + kb] = scale_byte
+                        packed = cute.make_rmem_tensor((16,), cutlass.Uint8)
+                        for p in cutlass.range_constexpr(16):
+                            lo = blk[2 * p] * inv
+                            hi = blk[2 * p + 1] * inv
+                            if cutlass.const_expr(not DROP_CLAMP and not USE_RCEIL):
+                                if lo > F4_MAX:
+                                    lo = F4_MAX
+                                if lo < -F4_MAX:
+                                    lo = -F4_MAX
+                                if hi > F4_MAX:
+                                    hi = F4_MAX
+                                if hi < -F4_MAX:
+                                    hi = -F4_MAX
+                            packed[p] = _cvt_rn_satfinite_e2m1x2_f32(hi, lo)
+                        offq = cute.assume(
+                            row * (K // cutlass.Int32(2)) + gc * cutlass.Int32(16),
+                            divby=16,
+                        )
+                        d = cute.make_tensor(
+                            gq.iterator + offq, cute.make_layout((16,), stride=(1,))
+                        )
+                        cute.copy(st, packed, d)
+
+                base = base + nthreads_x * cutlass.Int32(ILP)
+            row = row + cute.arch.grid_dim()[1]
+
+    @cute.jit
+    def _maxbw_launch(
+        gx,
+        gq,
+        gscale,
+        gsign,
+        M,
+        K,
+        GPR,
+        pad_cols,
+        threads,
+        ncta_x,
+        ncta_y,
+        stream,
+        ILP: cutlass.Constexpr[int],
+        APPLY_RHT: cutlass.Constexpr[bool],
+        SWIZZLED: cutlass.Constexpr[bool],
+        USE_RCEIL: cutlass.Constexpr[bool],
+        DROP_CLAMP: cutlass.Constexpr[bool],
+        LDWIDTH: cutlass.Constexpr[int],
+    ):
+        _maxbw_kernel(
+            gx,
+            gq,
+            gscale,
+            gsign,
+            M,
+            K,
+            GPR,
+            pad_cols,
+            ILP,
+            APPLY_RHT,
+            SWIZZLED,
+            USE_RCEIL,
+            DROP_CLAMP,
+            LDWIDTH,
+        ).launch(
+            grid=(ncta_x, ncta_y, 1),
+            block=(threads, 1, 1),
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    return _maxbw_launch
+
+
+def _maxbw_quantize(
+    x: torch.Tensor,
+    sign_vector,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+    threads: int = 128,
+    ilp: int = 2,
+    drop_clamp: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Host wrapper: launch the max-bandwidth MXFP4 (+/- RHT) quantize kernel.
+
+    Output contract matches the warp-specialized TMA path exactly: ``qdata`` is
+    row-major ``(M, K // 2)`` uint8 (packed E2M1x2); ``scales`` is
+    ``float8_e8m0fnu`` in the cuBLAS-blocked padded layout (``is_swizzled_scales``)
+    or a plain ``(M, K // 32)`` tensor.
     """
     import cuda.bindings.driver as cuda
     import cutlass
     import cutlass.cute as cute
-    import cutlass.utils as utils
-    from cutlass.cute.nvgpu import cpasync, tcgen05
-    from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+    from cutlass.cute.runtime import from_dlpack
 
-    if input_dtype_name == "torch.float32":
-        INPUT_CUTLASS_DTYPE = cutlass.Float32
-    elif input_dtype_name == "torch.bfloat16":
-        INPUT_CUTLASS_DTYPE = cutlass.BFloat16
-    else:
-        raise ValueError(
-            f"Unsupported input dtype for CuTeDSL mxfp4 quantize_2d: {input_dtype_name}"
-        )
+    assert x.is_cuda and x.dim() == 2 and x.is_contiguous()
+    assert x.dtype in (torch.float32, torch.bfloat16)
+    M, K = x.shape
+    assert M % 128 == 0 and K % 128 == 0
+    k_blocks = K // 32
+    apply_rht = sign_vector is not None and len(sign_vector) > 0
+    if apply_rht:
+        assert len(sign_vector) == 32
+    use_rceil = scaling_mode.lower() == "rceil"
 
-    COMPUTE_WARPS = compute_warps
-    TILE_M = tile_m
-    TILE_K = tile_k
-    TILE_K_HALF = tile_k // 2
-    K_TILES_PER_CTA = k_tiles_per_cta
-    BLOCKED_SCALE_OUTPUT_VALUE = blocked_scale_output
-
-    THREADS_PER_BLOCK = (1 + COMPUTE_WARPS) * 32
-    assert COMPUTE_WARPS >= 1
-    assert TILE_M > 0 and TILE_K > 0
-    assert TILE_K % 32 == 0
-
-    SCALE_DIM_K_VALUE = 32
-    SCALE_DIM_K_HALF = SCALE_DIM_K_VALUE // 2  # 16 packed bytes per block
-    K_BLOCKS_PER_TILE = TILE_K // SCALE_DIM_K_VALUE
-    assert K_BLOCKS_PER_TILE > 0
-    assert requested_stage_count >= 1
-    assert requested_stage_count <= 2
-    assert K_TILES_PER_CTA >= 1
-    STAGE_COUNT_VALUE = min(requested_stage_count, K_TILES_PER_CTA)
-
-    input_elem_bytes = 4 if input_dtype_name == "torch.float32" else 2
-    TILE_COPY_BYTES_IN = TILE_M * TILE_K * input_elem_bytes
-    # Half-width uint8 output: 1 byte per packed E2M1 pair.
-    TILE_COPY_BYTES_OUT = TILE_M * TILE_K_HALF  # noqa: F841 (documented contract)
-    M_THREADS = COMPUTE_WARPS * 32
-    M_ITERS_PER_LANE = ceil_div(TILE_M, M_THREADS)
-
-    USE_RCEIL_VALUE = scaling_mode == "rceil"
-    # F4_E2M1_MAX == 6.0; clamp pre-cvt values for FLOOR (RCEIL cvt saturates).
-    F4_MAX = cutlass.Float32(6.0)
-
-    @cute.struct
-    class SharedStorage:
-        tma_mbar_ptr: cute.struct.MemRange[cutlass.Int64, STAGE_COUNT_VALUE]
-        in_smem: cute.struct.Align[
-            cute.struct.MemRange[
-                INPUT_CUTLASS_DTYPE, STAGE_COUNT_VALUE * TILE_M * TILE_K
-            ],
-            128,
-        ]
-        out_smem: cute.struct.Align[
-            cute.struct.MemRange[
-                cutlass.Uint8, STAGE_COUNT_VALUE * TILE_M * TILE_K_HALF
-            ],
-            128,
-        ]
-
-    class Mxfp4RhtQuantize2dKernel:
-        @cute.jit
-        def _load_block_full_smem_to_reg(
-            self,
-            sIN_tile: cute.Tensor,
-            m_rel: cutlass.Int32,
-            k_base: cutlass.Int32,
-        ):
-            """Load a full 32-element quantization block from smem to registers."""
-            vals_block = cute.make_rmem_tensor((SCALE_DIM_K_VALUE,), cutlass.Float32)
-            for i in cutlass.range_constexpr(SCALE_DIM_K_VALUE):
-                vals_block[i] = cutlass.Float32(sIN_tile[m_rel, k_base + i])
-            return vals_block
-
-        @cute.jit
-        def _store_scales_reg_to_gmem_vec(
-            self,
-            scales_tensor: cute.Tensor,
-            m: cutlass.Int64,
-            k_block_base: cutlass.Int64,
-            scale_buffer: cute.Tensor,
-            num_scales: cutlass.Int32,
-            BLOCKED_SCALE_OUTPUT: cutlass.Constexpr[bool],
-        ):
-            """Store scales from registers to gmem (uint32 vectorized for blocked)."""
-            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT):
-                if num_scales == 4:
-                    scales_tensor_u32 = cute.recast_tensor(
-                        scales_tensor, cutlass.Uint32
-                    )
-                    scale_buffer_u32 = cute.recast_tensor(scale_buffer, cutlass.Uint32)
-                    scales_tensor_u32[m, k_block_base // cutlass.Int64(4)] = (
-                        scale_buffer_u32[0]
-                    )
-                else:
-                    for i in range(num_scales):
-                        k_block = k_block_base + i
-                        scales_tensor[m, k_block] = scale_buffer[i]
-            else:
-                for i in range(num_scales):
-                    k_block = k_block_base + i
-                    scales_tensor[m, k_block] = scale_buffer[i]
-
-        @cute.jit
-        def _store_q_e2m1_block_to_smem(
-            self,
-            packed_bytes: cute.Tensor,
-            sOUT_tile: cute.Tensor,
-            m_rel: cutlass.Int32,
-            sout_base: cutlass.Int32,
-        ):
-            """Store the 16 packed E2M1x2 bytes of a block via 4 uint32 writes.
-
-            ``packed_bytes`` is a length-16 ``Uint8`` register fragment holding
-            the bytes for one 32-element block. ``sout_base`` is the byte offset
-            of the block within the half-width output tile (``k_base // 2``).
-            """
-            sOUT_tile_u32 = cute.recast_tensor(sOUT_tile, cutlass.Uint32)
-            packed_u32 = cute.recast_tensor(packed_bytes, cutlass.Uint32)
-            base_u32 = sout_base // cutlass.Int32(4)
-            for w in cutlass.range_constexpr(SCALE_DIM_K_HALF // 4):
-                sOUT_tile_u32[m_rel, base_u32 + w] = packed_u32[w]
-
-        @cute.jit
-        def _quantize_block_then_store_reg_to_smem_full(
-            self,
-            rht_block: cute.Tensor,
-            inv_scale: cutlass.Float32,
-            sOUT_tile: cute.Tensor,
-            m_rel: cutlass.Int32,
-            k_base: cutlass.Int32,
-            USE_RCEIL: cutlass.Constexpr[bool],
-        ):
-            """Scale, (clamp for FLOOR), pack 32 RHT values to 16 E2M1x2 bytes.
-
-            ``rht_block`` is the post-FWHT length-32 ``Float32`` fragment. Even
-            column ``2p`` -> low nibble, odd column ``2p + 1`` -> high nibble of
-            output byte ``p`` (validated bit-exactly in Task 1).
-            """
-            packed_bytes = cute.make_rmem_tensor((SCALE_DIM_K_HALF,), cutlass.Uint8)
-            for p in cutlass.range_constexpr(SCALE_DIM_K_HALF):
-                lo = cutlass.Float32(rht_block[2 * p]) * inv_scale
-                hi = cutlass.Float32(rht_block[2 * p + 1]) * inv_scale
-                if not cutlass.const_expr(USE_RCEIL):
-                    # FLOOR: clamp to +-F4_E2M1_MAX before the cvt.
-                    if lo > F4_MAX:
-                        lo = F4_MAX
-                    if lo < -F4_MAX:
-                        lo = -F4_MAX
-                    if hi > F4_MAX:
-                        hi = F4_MAX
-                    if hi < -F4_MAX:
-                        hi = -F4_MAX
-                packed_bytes[p] = _cvt_rn_satfinite_e2m1x2_f32(hi, lo)
-            sout_base = k_base // cutlass.Int32(2)
-            self._store_q_e2m1_block_to_smem(packed_bytes, sOUT_tile, m_rel, sout_base)
-
-        @cute.jit
-        def _issue_tma_load(
-            self,
-            tma_atom_in: cute.CopyAtom,
-            gIN_tile: cute.Tensor,
-            sIN_tile: cute.Tensor,
-            tma_mbar_ptr: cutlass.Int64,
-            warp_idx: cutlass.Int32,
-        ):
-            """Issue TMA load from global to shared memory (producer warp only)."""
-            if warp_idx == 0:
-                cta_layout = cute.make_layout((1,))
-                sIN_for_tma_partition = cute.group_modes(sIN_tile, 0, 1)
-                gIN_for_tma_partition = cute.group_modes(gIN_tile, 0, 1)
-                tINs, tINg = cpasync.tma_partition(
-                    tma_atom_in,
-                    0,
-                    cta_layout,
-                    sIN_for_tma_partition,
-                    gIN_for_tma_partition,
-                )
-                tINg_stage0 = tINg[(None, 0)]
-                tINs_stage0 = tINs[(None, 0)]
-                with cute.arch.elect_one():
-                    cute.arch.mbarrier_arrive_and_expect_tx(
-                        tma_mbar_ptr, TILE_COPY_BYTES_IN
-                    )
-                cute.copy(
-                    tma_atom_in,
-                    tINg_stage0,
-                    tINs_stage0,
-                    tma_bar_ptr=tma_mbar_ptr,
-                )
-
-        @cute.jit
-        def _issue_tma_store(
-            self,
-            tma_atom_out: cute.CopyAtom,
-            gOUT_tile: cute.Tensor,
-            sOUT_tile: cute.Tensor,
-            warp_idx: cutlass.Int32,
-        ):
-            """Issue TMA store from shared to global memory (producer warp only)."""
-            cute.arch.fence_proxy(
-                "async.shared",
-                space="cta",
-            )
-            cute.arch.sync_threads()
-            if warp_idx == 0:
-                cta_layout = cute.make_layout((1,))
-                sOUT_for_tma_partition = cute.group_modes(sOUT_tile, 0, 1)
-                gOUT_for_tma_partition = cute.group_modes(gOUT_tile, 0, 1)
-                tOUTs, tOUTg = cpasync.tma_partition(
-                    tma_atom_out,
-                    0,
-                    cta_layout,
-                    sOUT_for_tma_partition,
-                    gOUT_for_tma_partition,
-                )
-                tOUTs_stage0 = tOUTs[(None, 0)]
-                tOUTg_stage0 = tOUTg[(None, 0)]
-                cute.copy(
-                    tma_atom_out,
-                    tOUTs_stage0,
-                    tOUTg_stage0,
-                )
-
-        @cute.kernel
-        def kernel(
-            self,
-            inp_mk: cute.Tensor,
-            tma_atom_in: cute.CopyAtom,
-            tma_tensor_in: cute.Tensor,
-            out_mk: cute.Tensor,
-            tma_atom_out: cute.CopyAtom,
-            tma_tensor_out: cute.Tensor,
-            scales_out_u8: cute.Tensor,
-            sign_vec: cute.Tensor,
-            M: cutlass.Int64,
-            K: cutlass.Int64,
-            k_blocks: cutlass.Int64,
-            m_cta_tiles: cutlass.Int64,
-            k_cta_tiles: cutlass.Int64,
-            blocked_scale_layout: cute.Layout,
-            SCALE_DIM_K: cutlass.Constexpr[int],
-            USE_RCEIL: cutlass.Constexpr[bool],
-            STAGE_COUNT: cutlass.Constexpr[int],
-        ):
-            """Main fused MXFP4 + RHT quantize kernel (warp-specialized TMA)."""
-            tidx, _, _ = cute.arch.thread_idx()
-            warp_idx = cute.arch.warp_idx()
-            warp_idx = cute.arch.make_warp_uniform(warp_idx)
-            bidx, bidy, _ = cute.arch.block_idx()
-
-            smem_allocator = utils.SmemAllocator()
-            storage = smem_allocator.allocate(SharedStorage)
-            tma_mbar_ptr0 = storage.tma_mbar_ptr.data_ptr()
-            tma_mbar_ptr1 = tma_mbar_ptr0
-            if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
-                tma_mbar_ptr1 = tma_mbar_ptr0 + 1
-
-            smem_layout_in, smem_layout_out = _make_tile_smem_layouts(TILE_M, TILE_K)
-            staged_layout_in = cute.make_layout(
-                (STAGE_COUNT_VALUE, TILE_M, TILE_K),
-                stride=(TILE_M * TILE_K, TILE_K, 1),
-            )
-            staged_layout_out = cute.make_layout(
-                (STAGE_COUNT_VALUE, TILE_M, TILE_K_HALF),
-                stride=(TILE_M * TILE_K_HALF, TILE_K_HALF, 1),
-            )
-            sIN_staged = storage.in_smem.get_tensor(staged_layout_in)
-            sOUT_staged = storage.out_smem.get_tensor(staged_layout_out)
-            stage_elems_in = TILE_M * TILE_K
-            stage_elems_out = TILE_M * TILE_K_HALF
-            sIN_tile0 = cute.make_tensor(
-                sIN_staged.iterator + 0 * stage_elems_in, smem_layout_in
-            )
-            sOUT_tile0 = cute.make_tensor(
-                sOUT_staged.iterator + 0 * stage_elems_out, smem_layout_out
-            )
-            sIN_tile1 = sIN_tile0
-            sOUT_tile1 = sOUT_tile0
-            if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
-                sIN_tile1 = cute.make_tensor(
-                    sIN_staged.iterator + 1 * stage_elems_in, smem_layout_in
-                )
-                sOUT_tile1 = cute.make_tensor(
-                    sOUT_staged.iterator + 1 * stage_elems_out, smem_layout_out
-                )
-
-            if tidx == 0:
-                cpasync.prefetch_descriptor(tma_atom_in)
-                cpasync.prefetch_descriptor(tma_atom_out)
-                cute.arch.mbarrier_init(tma_mbar_ptr0, 1)
-                if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
-                    cute.arch.mbarrier_init(tma_mbar_ptr1, 1)
-            cute.arch.mbarrier_init_fence()
-            cute.arch.sync_threads()
-
-            # Load the length-32 sign vector into registers (broadcast over rows).
-            sign_reg = cute.make_rmem_tensor((SCALE_DIM_K_VALUE,), cutlass.Float32)
-            for j in cutlass.range_constexpr(SCALE_DIM_K_VALUE):
-                sign_reg[j] = cutlass.Float32(sign_vec[j])
-
-            k_tile_group_idx = cutlass.Int64(bidx)
-            m_tile = cutlass.Int64(bidy)
-            m0 = m_tile * TILE_M
-            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT_VALUE):
-                scales_tensor = cute.make_tensor(
-                    scales_out_u8.iterator,
-                    blocked_scale_layout,
-                )
-            else:
-                scales_tensor = scales_out_u8
-
-            for tile_step in cutlass.range_constexpr(K_TILES_PER_CTA):
-                k_tile_eff = k_tile_group_idx * K_TILES_PER_CTA + tile_step
-
-                stage_idx = tile_step % STAGE_COUNT
-
-                sIN_tile = sIN_tile0
-                sOUT_tile = sOUT_tile0
-                tma_mbar_ptr = tma_mbar_ptr0
-                if cutlass.const_expr(STAGE_COUNT > 1):
-                    tma_mbar_ptr = tma_mbar_ptr0 + stage_idx
-                if cutlass.const_expr(STAGE_COUNT > 1):
-                    if stage_idx == 1:
-                        sIN_tile = sIN_tile1
-                        sOUT_tile = sOUT_tile1
-
-                tma_phase = (tile_step // STAGE_COUNT) % 2
-
-                if cutlass.const_expr(
-                    tile_step == 0 or not (STAGE_COUNT > 1 and K_TILES_PER_CTA > 1)
-                ):
-                    gIN_tile = cute.local_tile(
-                        tma_tensor_in, (TILE_M, TILE_K), (m_tile, k_tile_eff)
-                    )
-                    self._issue_tma_load(
-                        tma_atom_in,
-                        gIN_tile,
-                        sIN_tile,
-                        tma_mbar_ptr,
-                        warp_idx,
-                    )
-
-                if cutlass.const_expr(STAGE_COUNT > 1 and K_TILES_PER_CTA > 1):
-                    if cutlass.const_expr(tile_step + 1 < K_TILES_PER_CTA):
-                        k_tile_next = k_tile_group_idx * K_TILES_PER_CTA + tile_step + 1
-                        next_stage_idx = (tile_step + 1) % STAGE_COUNT
-                        sIN_tile_next = sIN_tile0
-                        tma_mbar_ptr_next = tma_mbar_ptr0
-                        if cutlass.const_expr(STAGE_COUNT > 1):
-                            tma_mbar_ptr_next = tma_mbar_ptr0 + next_stage_idx
-                        if cutlass.const_expr(STAGE_COUNT > 1):
-                            if next_stage_idx == 1:
-                                sIN_tile_next = sIN_tile1
-
-                        gIN_tile_next = cute.local_tile(
-                            tma_tensor_in, (TILE_M, TILE_K), (m_tile, k_tile_next)
-                        )
-                        self._issue_tma_load(
-                            tma_atom_in,
-                            gIN_tile_next,
-                            sIN_tile_next,
-                            tma_mbar_ptr_next,
-                            warp_idx,
-                        )
-
-                if warp_idx >= 1 and warp_idx <= compute_warps:
-                    cute.arch.mbarrier_wait(tma_mbar_ptr, tma_phase)
-                    lane = tidx % 32
-                    m_lane = (warp_idx - 1) * 32 + lane
-
-                    for mm in cutlass.range_constexpr(M_ITERS_PER_LANE):
-                        m_rel = m_lane + mm * M_THREADS
-                        m = m0 + m_rel
-                        if m_rel < TILE_M:
-                            scale_buffer = cute.make_rmem_tensor(
-                                (K_BLOCKS_PER_TILE,), cutlass.Uint8
-                            )
-
-                            for kb in cutlass.range_constexpr(K_BLOCKS_PER_TILE):
-                                k_base = kb * SCALE_DIM_K_VALUE
-                                vals_block = self._load_block_full_smem_to_reg(
-                                    sIN_tile,
-                                    m_rel,
-                                    k_base,
-                                )
-
-                                # Fused RHT: in-register FWHT(32) + sign.
-                                fwht32_sign(vals_block, sign_reg)
-
-                                amax = compute_amax(vals_block)
-                                scale_biased, inv_scale = compute_scale_byte_fp4(
-                                    amax, USE_RCEIL
-                                )
-                                scale_buffer[kb] = cutlass.Uint8(
-                                    scale_biased & cutlass.Int32(0xFF)
-                                )
-
-                                self._quantize_block_then_store_reg_to_smem_full(
-                                    vals_block,
-                                    inv_scale,
-                                    sOUT_tile,
-                                    m_rel,
-                                    k_base,
-                                    USE_RCEIL,
-                                )
-
-                            k_block_base = k_tile_eff * K_BLOCKS_PER_TILE
-                            self._store_scales_reg_to_gmem_vec(
-                                scales_tensor,
-                                m,
-                                k_block_base,
-                                scale_buffer,
-                                cutlass.Int32(K_BLOCKS_PER_TILE),
-                                BLOCKED_SCALE_OUTPUT_VALUE,
-                            )
-
-                gOUT_tile = cute.local_tile(
-                    tma_tensor_out, (TILE_M, TILE_K_HALF), (m_tile, k_tile_eff)
-                )
-                self._issue_tma_store(
-                    tma_atom_out,
-                    gOUT_tile,
-                    sOUT_tile,
-                    warp_idx,
-                )
-
-        @cute.jit
-        def __call__(
-            self,
-            inp_mk: cute.Tensor,
-            out_mk: cute.Tensor,
-            scales_out_u8: cute.Tensor,
-            sign_vec: cute.Tensor,
-            M: cutlass.Int64,
-            K: cutlass.Int64,
-            k_blocks: cutlass.Int64,
-            m_cta_tiles: cutlass.Int64,
-            k_cta_tiles: cutlass.Int64,
-            stream: cuda.CUstream,
-        ):
-            """Kernel launcher: set up TMA descriptors and blocked scale layout."""
-            smem_layout_in, smem_layout_out = _make_tile_smem_layouts(TILE_M, TILE_K)
-            g2s_op = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
-            tma_atom_in, tma_tensor_in = cpasync.make_tiled_tma_atom(
-                g2s_op,
-                inp_mk,
-                smem_layout_in,
-                (TILE_M, TILE_K),
-            )
-            tma_atom_out, tma_tensor_out = cpasync.make_tiled_tma_atom(
-                cpasync.CopyBulkTensorTileS2GOp(),
-                out_mk,
-                smem_layout_out,
-                (TILE_M, TILE_K_HALF),
-            )
-
-            blocked_scale_layout = cute.make_layout((1,))
-            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT_VALUE):
-                padded_scale_cols = cute.round_up(k_blocks, 4)
-                m_block_tiles = cute.ceil_div(M, 128)
-                k_block_tiles = padded_scale_cols // cutlass.Int64(4)
-                blocked_scale_layout = cute.make_layout(
-                    ((32, 4, m_block_tiles), (4, k_block_tiles)),
-                    stride=(
-                        (16, 4, cutlass.Int64(128) * padded_scale_cols),
-                        (1, cutlass.Int64(512)),
-                    ),
-                )
-
-            self.kernel(
-                inp_mk,
-                tma_atom_in,
-                tma_tensor_in,
-                out_mk,
-                tma_atom_out,
-                tma_tensor_out,
-                scales_out_u8,
-                sign_vec,
-                M,
-                K,
-                k_blocks,
-                m_cta_tiles,
-                k_cta_tiles,
-                blocked_scale_layout,
-                SCALE_DIM_K=SCALE_DIM_K_VALUE,
-                USE_RCEIL=USE_RCEIL_VALUE,
-                STAGE_COUNT=STAGE_COUNT_VALUE,
-            ).launch(
-                grid=(k_cta_tiles, m_cta_tiles, 1),
-                block=(THREADS_PER_BLOCK, 1, 1),
-                cluster=(1, 1, 1),
-                smem=SharedStorage.size_in_bytes(),  # pyrefly: ignore [missing-attribute]
-                stream=stream,
-            )
-
-    kernel = Mxfp4RhtQuantize2dKernel()
-
-    m = cute.sym_int(divisibility=128)
-    k = cute.sym_int(divisibility=128)
-    k_half = cute.sym_int(divisibility=64)
-    kb = cute.sym_int()
-    inp_stride0 = cute.sym_int()
-    inp_stride1 = cute.sym_int()
-    out_stride0 = cute.sym_int()
-    out_stride1 = cute.sym_int()
-    scale_stride0 = cute.sym_int()
-    scale_stride1 = cute.sym_int()
-    sign_stride0 = cute.sym_int()
-
-    fake_inp = make_fake_tensor(
-        INPUT_CUTLASS_DTYPE,
-        (m, k),
-        stride=(inp_stride0, inp_stride1),
+    q_data = torch.empty_strided(
+        (M, K // 2), (K // 2, 1), device=x.device, dtype=torch.uint8
     )
-    fake_out = make_fake_tensor(
-        cutlass.Uint8,
-        (m, k_half),
-        stride=(out_stride0, out_stride1),
-    )
-    if blocked_scale_output:
-        scale_flat = cute.sym_int()
-        fake_scales = make_fake_tensor(
-            cutlass.Uint8,
-            (scale_flat,),
-            stride=(scale_stride0,),
+    padded_scale_rows = ceil_div(M, 128) * 128
+    padded_scale_cols = ceil_div(k_blocks, 4) * 4
+    if is_swizzled_scales:
+        scales_u8 = torch.empty(
+            (padded_scale_rows * padded_scale_cols,),
+            device=x.device,
+            dtype=torch.uint8,
         )
     else:
-        fake_scales = make_fake_tensor(
-            cutlass.Uint8,
-            (m, kb),
-            stride=(scale_stride0, scale_stride1),
-        )
-    fake_sign = make_fake_tensor(
-        cutlass.Int32,
-        (32,),
-        stride=(sign_stride0,),
-    )
-    fake_stream = make_fake_stream()
+        scales_u8 = torch.empty((M, k_blocks), device=x.device, dtype=torch.uint8)
 
-    return cute.compile(
-        kernel,
-        inp_mk=fake_inp,
-        out_mk=fake_out,
-        scales_out_u8=fake_scales,
-        sign_vec=fake_sign,
-        M=0,
-        K=0,
-        k_blocks=0,
-        m_cta_tiles=1,
-        k_cta_tiles=1,
-        stream=fake_stream,
-        options="--enable-tvm-ffi",
+    sign_src = sign_vector if apply_rht else [0] * 32
+    sign_dev = torch.tensor(
+        [int(s) for s in sign_src], device=x.device, dtype=torch.int32
     )
+
+    GPR = K // 32
+    nthreads_needed = (GPR + ilp - 1) // ilp
+    ncta_x = (nthreads_needed + threads - 1) // threads
+    ncta_y = M
+    ldwidth = 4 if x.dtype == torch.float32 else 8
+
+    launch = _get_maxbw_launch()
+    stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+
+    def _args():
+        return (
+            from_dlpack(x.view(-1), assumed_align=16),
+            from_dlpack(q_data.view(-1), assumed_align=16),
+            from_dlpack(scales_u8.view(-1), assumed_align=16),
+            from_dlpack(sign_dev, assumed_align=16),
+            cutlass.Int32(M),
+            cutlass.Int32(K),
+            cutlass.Int32(GPR),
+            cutlass.Int32(padded_scale_cols),
+            threads,
+            ncta_x,
+            ncta_y,
+            stream,
+        )
+
+    key = (
+        str(x.dtype),
+        apply_rht,
+        is_swizzled_scales,
+        use_rceil,
+        drop_clamp,
+        threads,
+        ilp,
+    )
+    compiled = _MAXBW_JIT_CACHE.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            launch,
+            *_args(),
+            ilp,
+            apply_rht,
+            is_swizzled_scales,
+            use_rceil,
+            drop_clamp,
+            ldwidth,
+        )
+        _MAXBW_JIT_CACHE[key] = compiled
+    compiled(*_args())
+
+    scales = scales_u8.view(torch.float8_e8m0fnu)
+    scales = (
+        scales.view(padded_scale_rows, padded_scale_cols)
+        if is_swizzled_scales
+        else scales.view(M, k_blocks)
+    )
+    return q_data, scales
 
 
 def _mxfp4_rht_quantize_cutedsl_impl(
@@ -658,7 +352,6 @@ def _mxfp4_rht_quantize_cutedsl_impl(
     block_size: int = 32,
     scaling_mode: str = "floor",
     is_swizzled_scales: bool = True,
-    stage_count: int = 2,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Host wrapper: launch the fused MXFP4 + RHT CuTeDSL quantize kernel.
 
@@ -670,15 +363,12 @@ def _mxfp4_rht_quantize_cutedsl_impl(
         scaling_mode: ``"floor"`` or ``"rceil"``.
         is_swizzled_scales: write scales in the cuBLAS-blocked padded layout
             (``True``) or a plain ``(M, K // 32)`` tensor (``False``).
-        stage_count: pipeline stages (1 or 2).
 
     Returns:
         ``(qdata, scales)`` where ``qdata`` is row-major ``(M, K // 2)`` uint8
         (packed E2M1x2) and ``scales`` is ``float8_e8m0fnu`` in the requested
         layout.
     """
-    import cuda.bindings.driver as cuda
-
     assert x.is_cuda, "Input tensor must be CUDA"
     assert x.dim() == 2, "Input tensor must be 2D"
     assert x.is_contiguous(), "Input tensor must be contiguous"
@@ -695,78 +385,15 @@ def _mxfp4_rht_quantize_cutedsl_impl(
 
     M, K = x.shape
     assert K % 32 == 0, "K must be divisible by 32"
-    assert M % 128 == 0, "M must be divisible by 128 (TMA tiling)"
-    assert K % 128 == 0, "K must be divisible by 128 (TMA tiling)"
+    assert M % 128 == 0, "M must be divisible by 128"
+    assert K % 128 == 0, "K must be divisible by 128"
 
-    _, config = _select_cutedsl_config(x.dtype, scaling_mode)
-    compute_warps, tile_m, tile_k, k_tiles_per_cta = config
-    assert stage_count >= 1, "stage_count must be >= 1"
-    assert stage_count <= 2, "stage_count must be <= 2"
-
-    k_blocks = K // block_size
-
-    # Half-width row-major packed output: stride (K // 2, 1).
-    q_data = torch.empty_strided(
-        (M, K // 2),
-        (K // 2, 1),
-        device=x.device,
-        dtype=torch.uint8,
-    )
-
-    padded_scale_rows = ceil_div(M, 128) * 128
-    padded_scale_cols = ceil_div(k_blocks, 4) * 4
-    if is_swizzled_scales:
-        scales_u8 = torch.empty(
-            (padded_scale_rows * padded_scale_cols,),
-            device=x.device,
-            dtype=torch.uint8,
-        )
-    else:
-        scales_u8 = torch.empty(
-            (M, k_blocks),
-            device=x.device,
-            dtype=torch.uint8,
-        )
-
-    sign_dev = torch.tensor(
-        [int(s) for s in sign_vector], device=x.device, dtype=torch.int32
-    )
-
-    compiled = _compile_mxfp4_rht_quantize_2d_cutedsl(
-        str(x.dtype),
-        scaling_mode,
-        compute_warps,
-        tile_m,
-        tile_k,
-        stage_count,
-        k_tiles_per_cta,
-        is_swizzled_scales,
-    )
-
-    stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
-    m_cta_tiles = ceil_div(M, tile_m)
-    k_cta_tiles = ceil_div(K, tile_k * k_tiles_per_cta)
-
-    compiled(
+    return _maxbw_quantize(
         x,
-        q_data,
-        scales_u8,
-        sign_dev,
-        int(M),
-        int(K),
-        int(k_blocks),
-        int(m_cta_tiles),
-        int(k_cta_tiles),
-        stream,
+        sign_vector,
+        scaling_mode=scaling_mode,
+        is_swizzled_scales=is_swizzled_scales,
     )
-
-    scales = scales_u8.view(torch.float8_e8m0fnu)
-    scales = (
-        scales.view(padded_scale_rows, padded_scale_cols)
-        if is_swizzled_scales
-        else scales.view(M, k_blocks)
-    )
-    return q_data, scales
 
 
 @torch.library.custom_op("torchao::mxfp4_rht_quantize_cutedsl", mutates_args=())
@@ -776,7 +403,6 @@ def mxfp4_rht_quantize_cutedsl(
     block_size: int = 32,
     scaling_mode: str = "floor",
     is_swizzled_scales: bool = True,
-    stage_count: int = 2,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     return _mxfp4_rht_quantize_cutedsl_impl(
         x,
@@ -784,7 +410,6 @@ def mxfp4_rht_quantize_cutedsl(
         block_size=block_size,
         scaling_mode=scaling_mode,
         is_swizzled_scales=is_swizzled_scales,
-        stage_count=stage_count,
     )
 
 
@@ -795,7 +420,6 @@ def _(
     block_size: int = 32,
     scaling_mode: str = "floor",
     is_swizzled_scales: bool = True,
-    stage_count: int = 2,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     m, k = x.shape
     q = torch.empty_strided(

--- a/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
+++ b/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
@@ -1,0 +1,842 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused MXFP4 (E2M1, block 32, E8M0) + Random Hadamard Transform CuTeDSL cast.
+
+Clones the structure of the MXFP8 1x32 CuTeDSL quantize kernel
+(``torchao/prototype/moe_training/kernels/mxfp8/cutedsl_quantize_2d_1x32.py``)
+and applies the MXFP4 + RHT deltas:
+
+* the E2M1 output is two codes per byte, so the output smem / global qdata are
+  half-width ``[M, K // 2]`` ``uint8``;
+* per 32-element block the consumer applies the register-resident FWHT(32) +
+  sign transform (``fwht.fwht32_sign``) before computing amax / scale / packing;
+* values are clamped to ``+-6.0`` (``F4_E2M1_MAX``) before the E2M1 cvt in FLOOR
+  mode (RCEIL's cvt saturates on its own);
+* 16 E2M1x2 bytes per block are assembled and written as 4 ``uint32`` stores;
+* the biased E8M0 scale byte is written either in the cuBLAS-blocked padded
+  layout (``is_swizzled_scales=True``) or as a plain ``(M, K // 32)`` tensor.
+
+The op is gated behind a Blackwell (SM 10.x) GPU, CUDA >= 12.8, and the CuTeDSL
+runtime packages (see ``cutedsl/__init__.py``).
+"""
+
+import functools
+from typing import Tuple
+
+import torch
+
+from torchao.utils import ceil_div
+
+from .cute_utils import (
+    _cvt_rn_satfinite_e2m1x2_f32,
+    compute_amax,
+    compute_scale_byte_fp4,
+)
+from .fwht import fwht32_sign
+
+# Config format:
+# (compute_warps, tile_m, tile_k, k_tiles_per_cta)
+_CUTEDSL_CONFIGS = {
+    "bf16_default": (4, 128, 32, 4),
+    "fallback": (6, 128, 32, 2),
+}
+
+
+def _select_cutedsl_config(
+    input_dtype: torch.dtype,
+    scaling_mode: str,
+) -> Tuple[str, Tuple[int, int, int, int]]:
+    """Select kernel configuration based on input dtype."""
+    if input_dtype == torch.bfloat16:
+        config_name = "bf16_default"
+    else:
+        config_name = "fallback"
+    return config_name, _CUTEDSL_CONFIGS[config_name]
+
+
+def _make_tile_smem_layouts(tile_m: int, tile_k: int):
+    """Row-major smem layouts for the input ``(TILE_M, TILE_K)`` and the
+    half-width output ``(TILE_M, TILE_K // 2)`` tiles."""
+    import cutlass.cute as cute
+
+    smem_layout_in = cute.make_layout(
+        (tile_m, tile_k),
+        stride=(tile_k, 1),
+    )
+    smem_layout_out = cute.make_layout(
+        (tile_m, tile_k // 2),
+        stride=(tile_k // 2, 1),
+    )
+    return smem_layout_in, smem_layout_out
+
+
+@functools.cache
+def _compile_mxfp4_rht_quantize_2d_cutedsl(
+    input_dtype_name: str,
+    scaling_mode: str,
+    compute_warps: int,
+    tile_m: int,
+    tile_k: int,
+    requested_stage_count: int,
+    k_tiles_per_cta: int,
+    blocked_scale_output: bool,
+):
+    """Compile the fused 2D MXFP4 + RHT quantize kernel using CuTeDSL.
+
+    Warp-specialized TMA kernel mirroring the MXFP8 1x32 template:
+    - warp 0: producer (TMA global->shared input, shared->global half-width
+      output);
+    - warps [1..compute_warps]: consumers (FWHT + quantize + E2M1 pack).
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.utils as utils
+    from cutlass.cute.nvgpu import cpasync, tcgen05
+    from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+
+    if input_dtype_name == "torch.float32":
+        INPUT_CUTLASS_DTYPE = cutlass.Float32
+    elif input_dtype_name == "torch.bfloat16":
+        INPUT_CUTLASS_DTYPE = cutlass.BFloat16
+    else:
+        raise ValueError(
+            f"Unsupported input dtype for CuTeDSL mxfp4 quantize_2d: {input_dtype_name}"
+        )
+
+    COMPUTE_WARPS = compute_warps
+    TILE_M = tile_m
+    TILE_K = tile_k
+    TILE_K_HALF = tile_k // 2
+    K_TILES_PER_CTA = k_tiles_per_cta
+    BLOCKED_SCALE_OUTPUT_VALUE = blocked_scale_output
+
+    THREADS_PER_BLOCK = (1 + COMPUTE_WARPS) * 32
+    assert COMPUTE_WARPS >= 1
+    assert TILE_M > 0 and TILE_K > 0
+    assert TILE_K % 32 == 0
+
+    SCALE_DIM_K_VALUE = 32
+    SCALE_DIM_K_HALF = SCALE_DIM_K_VALUE // 2  # 16 packed bytes per block
+    K_BLOCKS_PER_TILE = TILE_K // SCALE_DIM_K_VALUE
+    assert K_BLOCKS_PER_TILE > 0
+    assert requested_stage_count >= 1
+    assert requested_stage_count <= 2
+    assert K_TILES_PER_CTA >= 1
+    STAGE_COUNT_VALUE = min(requested_stage_count, K_TILES_PER_CTA)
+
+    input_elem_bytes = 4 if input_dtype_name == "torch.float32" else 2
+    TILE_COPY_BYTES_IN = TILE_M * TILE_K * input_elem_bytes
+    # Half-width uint8 output: 1 byte per packed E2M1 pair.
+    TILE_COPY_BYTES_OUT = TILE_M * TILE_K_HALF  # noqa: F841 (documented contract)
+    M_THREADS = COMPUTE_WARPS * 32
+    M_ITERS_PER_LANE = ceil_div(TILE_M, M_THREADS)
+
+    USE_RCEIL_VALUE = scaling_mode == "rceil"
+    # F4_E2M1_MAX == 6.0; clamp pre-cvt values for FLOOR (RCEIL cvt saturates).
+    F4_MAX = cutlass.Float32(6.0)
+
+    @cute.struct
+    class SharedStorage:
+        tma_mbar_ptr: cute.struct.MemRange[cutlass.Int64, STAGE_COUNT_VALUE]
+        in_smem: cute.struct.Align[
+            cute.struct.MemRange[
+                INPUT_CUTLASS_DTYPE, STAGE_COUNT_VALUE * TILE_M * TILE_K
+            ],
+            128,
+        ]
+        out_smem: cute.struct.Align[
+            cute.struct.MemRange[
+                cutlass.Uint8, STAGE_COUNT_VALUE * TILE_M * TILE_K_HALF
+            ],
+            128,
+        ]
+
+    class Mxfp4RhtQuantize2dKernel:
+        @cute.jit
+        def _load_block_full_smem_to_reg(
+            self,
+            sIN_tile: cute.Tensor,
+            m_rel: cutlass.Int32,
+            k_base: cutlass.Int32,
+        ):
+            """Load a full 32-element quantization block from smem to registers."""
+            vals_block = cute.make_rmem_tensor((SCALE_DIM_K_VALUE,), cutlass.Float32)
+            for i in cutlass.range_constexpr(SCALE_DIM_K_VALUE):
+                vals_block[i] = cutlass.Float32(sIN_tile[m_rel, k_base + i])
+            return vals_block
+
+        @cute.jit
+        def _store_scales_reg_to_gmem_vec(
+            self,
+            scales_tensor: cute.Tensor,
+            m: cutlass.Int64,
+            k_block_base: cutlass.Int64,
+            scale_buffer: cute.Tensor,
+            num_scales: cutlass.Int32,
+            BLOCKED_SCALE_OUTPUT: cutlass.Constexpr[bool],
+        ):
+            """Store scales from registers to gmem (uint32 vectorized for blocked)."""
+            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT):
+                if num_scales == 4:
+                    scales_tensor_u32 = cute.recast_tensor(
+                        scales_tensor, cutlass.Uint32
+                    )
+                    scale_buffer_u32 = cute.recast_tensor(scale_buffer, cutlass.Uint32)
+                    scales_tensor_u32[m, k_block_base // cutlass.Int64(4)] = (
+                        scale_buffer_u32[0]
+                    )
+                else:
+                    for i in range(num_scales):
+                        k_block = k_block_base + i
+                        scales_tensor[m, k_block] = scale_buffer[i]
+            else:
+                for i in range(num_scales):
+                    k_block = k_block_base + i
+                    scales_tensor[m, k_block] = scale_buffer[i]
+
+        @cute.jit
+        def _store_q_e2m1_block_to_smem(
+            self,
+            packed_bytes: cute.Tensor,
+            sOUT_tile: cute.Tensor,
+            m_rel: cutlass.Int32,
+            sout_base: cutlass.Int32,
+        ):
+            """Store the 16 packed E2M1x2 bytes of a block via 4 uint32 writes.
+
+            ``packed_bytes`` is a length-16 ``Uint8`` register fragment holding
+            the bytes for one 32-element block. ``sout_base`` is the byte offset
+            of the block within the half-width output tile (``k_base // 2``).
+            """
+            sOUT_tile_u32 = cute.recast_tensor(sOUT_tile, cutlass.Uint32)
+            packed_u32 = cute.recast_tensor(packed_bytes, cutlass.Uint32)
+            base_u32 = sout_base // cutlass.Int32(4)
+            for w in cutlass.range_constexpr(SCALE_DIM_K_HALF // 4):
+                sOUT_tile_u32[m_rel, base_u32 + w] = packed_u32[w]
+
+        @cute.jit
+        def _quantize_block_then_store_reg_to_smem_full(
+            self,
+            rht_block: cute.Tensor,
+            inv_scale: cutlass.Float32,
+            sOUT_tile: cute.Tensor,
+            m_rel: cutlass.Int32,
+            k_base: cutlass.Int32,
+            USE_RCEIL: cutlass.Constexpr[bool],
+        ):
+            """Scale, (clamp for FLOOR), pack 32 RHT values to 16 E2M1x2 bytes.
+
+            ``rht_block`` is the post-FWHT length-32 ``Float32`` fragment. Even
+            column ``2p`` -> low nibble, odd column ``2p + 1`` -> high nibble of
+            output byte ``p`` (validated bit-exactly in Task 1).
+            """
+            packed_bytes = cute.make_rmem_tensor((SCALE_DIM_K_HALF,), cutlass.Uint8)
+            for p in cutlass.range_constexpr(SCALE_DIM_K_HALF):
+                lo = cutlass.Float32(rht_block[2 * p]) * inv_scale
+                hi = cutlass.Float32(rht_block[2 * p + 1]) * inv_scale
+                if not cutlass.const_expr(USE_RCEIL):
+                    # FLOOR: clamp to +-F4_E2M1_MAX before the cvt.
+                    if lo > F4_MAX:
+                        lo = F4_MAX
+                    if lo < -F4_MAX:
+                        lo = -F4_MAX
+                    if hi > F4_MAX:
+                        hi = F4_MAX
+                    if hi < -F4_MAX:
+                        hi = -F4_MAX
+                packed_bytes[p] = _cvt_rn_satfinite_e2m1x2_f32(hi, lo)
+            sout_base = k_base // cutlass.Int32(2)
+            self._store_q_e2m1_block_to_smem(packed_bytes, sOUT_tile, m_rel, sout_base)
+
+        @cute.jit
+        def _issue_tma_load(
+            self,
+            tma_atom_in: cute.CopyAtom,
+            gIN_tile: cute.Tensor,
+            sIN_tile: cute.Tensor,
+            tma_mbar_ptr: cutlass.Int64,
+            warp_idx: cutlass.Int32,
+        ):
+            """Issue TMA load from global to shared memory (producer warp only)."""
+            if warp_idx == 0:
+                cta_layout = cute.make_layout((1,))
+                sIN_for_tma_partition = cute.group_modes(sIN_tile, 0, 1)
+                gIN_for_tma_partition = cute.group_modes(gIN_tile, 0, 1)
+                tINs, tINg = cpasync.tma_partition(
+                    tma_atom_in,
+                    0,
+                    cta_layout,
+                    sIN_for_tma_partition,
+                    gIN_for_tma_partition,
+                )
+                tINg_stage0 = tINg[(None, 0)]
+                tINs_stage0 = tINs[(None, 0)]
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        tma_mbar_ptr, TILE_COPY_BYTES_IN
+                    )
+                cute.copy(
+                    tma_atom_in,
+                    tINg_stage0,
+                    tINs_stage0,
+                    tma_bar_ptr=tma_mbar_ptr,
+                )
+
+        @cute.jit
+        def _issue_tma_store(
+            self,
+            tma_atom_out: cute.CopyAtom,
+            gOUT_tile: cute.Tensor,
+            sOUT_tile: cute.Tensor,
+            warp_idx: cutlass.Int32,
+        ):
+            """Issue TMA store from shared to global memory (producer warp only)."""
+            cute.arch.fence_proxy(
+                "async.shared",
+                space="cta",
+            )
+            cute.arch.sync_threads()
+            if warp_idx == 0:
+                cta_layout = cute.make_layout((1,))
+                sOUT_for_tma_partition = cute.group_modes(sOUT_tile, 0, 1)
+                gOUT_for_tma_partition = cute.group_modes(gOUT_tile, 0, 1)
+                tOUTs, tOUTg = cpasync.tma_partition(
+                    tma_atom_out,
+                    0,
+                    cta_layout,
+                    sOUT_for_tma_partition,
+                    gOUT_for_tma_partition,
+                )
+                tOUTs_stage0 = tOUTs[(None, 0)]
+                tOUTg_stage0 = tOUTg[(None, 0)]
+                cute.copy(
+                    tma_atom_out,
+                    tOUTs_stage0,
+                    tOUTg_stage0,
+                )
+
+        @cute.kernel
+        def kernel(
+            self,
+            inp_mk: cute.Tensor,
+            tma_atom_in: cute.CopyAtom,
+            tma_tensor_in: cute.Tensor,
+            out_mk: cute.Tensor,
+            tma_atom_out: cute.CopyAtom,
+            tma_tensor_out: cute.Tensor,
+            scales_out_u8: cute.Tensor,
+            sign_vec: cute.Tensor,
+            M: cutlass.Int64,
+            K: cutlass.Int64,
+            k_blocks: cutlass.Int64,
+            m_cta_tiles: cutlass.Int64,
+            k_cta_tiles: cutlass.Int64,
+            blocked_scale_layout: cute.Layout,
+            SCALE_DIM_K: cutlass.Constexpr[int],
+            USE_RCEIL: cutlass.Constexpr[bool],
+            STAGE_COUNT: cutlass.Constexpr[int],
+        ):
+            """Main fused MXFP4 + RHT quantize kernel (warp-specialized TMA)."""
+            tidx, _, _ = cute.arch.thread_idx()
+            warp_idx = cute.arch.warp_idx()
+            warp_idx = cute.arch.make_warp_uniform(warp_idx)
+            bidx, bidy, _ = cute.arch.block_idx()
+
+            smem_allocator = utils.SmemAllocator()
+            storage = smem_allocator.allocate(SharedStorage)
+            tma_mbar_ptr0 = storage.tma_mbar_ptr.data_ptr()
+            tma_mbar_ptr1 = tma_mbar_ptr0
+            if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
+                tma_mbar_ptr1 = tma_mbar_ptr0 + 1
+
+            smem_layout_in, smem_layout_out = _make_tile_smem_layouts(TILE_M, TILE_K)
+            staged_layout_in = cute.make_layout(
+                (STAGE_COUNT_VALUE, TILE_M, TILE_K),
+                stride=(TILE_M * TILE_K, TILE_K, 1),
+            )
+            staged_layout_out = cute.make_layout(
+                (STAGE_COUNT_VALUE, TILE_M, TILE_K_HALF),
+                stride=(TILE_M * TILE_K_HALF, TILE_K_HALF, 1),
+            )
+            sIN_staged = storage.in_smem.get_tensor(staged_layout_in)
+            sOUT_staged = storage.out_smem.get_tensor(staged_layout_out)
+            stage_elems_in = TILE_M * TILE_K
+            stage_elems_out = TILE_M * TILE_K_HALF
+            sIN_tile0 = cute.make_tensor(
+                sIN_staged.iterator + 0 * stage_elems_in, smem_layout_in
+            )
+            sOUT_tile0 = cute.make_tensor(
+                sOUT_staged.iterator + 0 * stage_elems_out, smem_layout_out
+            )
+            sIN_tile1 = sIN_tile0
+            sOUT_tile1 = sOUT_tile0
+            if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
+                sIN_tile1 = cute.make_tensor(
+                    sIN_staged.iterator + 1 * stage_elems_in, smem_layout_in
+                )
+                sOUT_tile1 = cute.make_tensor(
+                    sOUT_staged.iterator + 1 * stage_elems_out, smem_layout_out
+                )
+
+            if tidx == 0:
+                cpasync.prefetch_descriptor(tma_atom_in)
+                cpasync.prefetch_descriptor(tma_atom_out)
+                cute.arch.mbarrier_init(tma_mbar_ptr0, 1)
+                if cutlass.const_expr(STAGE_COUNT_VALUE > 1):
+                    cute.arch.mbarrier_init(tma_mbar_ptr1, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.sync_threads()
+
+            # Load the length-32 sign vector into registers (broadcast over rows).
+            sign_reg = cute.make_rmem_tensor((SCALE_DIM_K_VALUE,), cutlass.Float32)
+            for j in cutlass.range_constexpr(SCALE_DIM_K_VALUE):
+                sign_reg[j] = cutlass.Float32(sign_vec[j])
+
+            k_tile_group_idx = cutlass.Int64(bidx)
+            m_tile = cutlass.Int64(bidy)
+            m0 = m_tile * TILE_M
+            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT_VALUE):
+                scales_tensor = cute.make_tensor(
+                    scales_out_u8.iterator,
+                    blocked_scale_layout,
+                )
+            else:
+                scales_tensor = scales_out_u8
+
+            for tile_step in cutlass.range_constexpr(K_TILES_PER_CTA):
+                k_tile_eff = k_tile_group_idx * K_TILES_PER_CTA + tile_step
+
+                stage_idx = tile_step % STAGE_COUNT
+
+                sIN_tile = sIN_tile0
+                sOUT_tile = sOUT_tile0
+                tma_mbar_ptr = tma_mbar_ptr0
+                if cutlass.const_expr(STAGE_COUNT > 1):
+                    tma_mbar_ptr = tma_mbar_ptr0 + stage_idx
+                if cutlass.const_expr(STAGE_COUNT > 1):
+                    if stage_idx == 1:
+                        sIN_tile = sIN_tile1
+                        sOUT_tile = sOUT_tile1
+
+                tma_phase = (tile_step // STAGE_COUNT) % 2
+
+                if cutlass.const_expr(
+                    tile_step == 0 or not (STAGE_COUNT > 1 and K_TILES_PER_CTA > 1)
+                ):
+                    gIN_tile = cute.local_tile(
+                        tma_tensor_in, (TILE_M, TILE_K), (m_tile, k_tile_eff)
+                    )
+                    self._issue_tma_load(
+                        tma_atom_in,
+                        gIN_tile,
+                        sIN_tile,
+                        tma_mbar_ptr,
+                        warp_idx,
+                    )
+
+                if cutlass.const_expr(STAGE_COUNT > 1 and K_TILES_PER_CTA > 1):
+                    if cutlass.const_expr(tile_step + 1 < K_TILES_PER_CTA):
+                        k_tile_next = k_tile_group_idx * K_TILES_PER_CTA + tile_step + 1
+                        next_stage_idx = (tile_step + 1) % STAGE_COUNT
+                        sIN_tile_next = sIN_tile0
+                        tma_mbar_ptr_next = tma_mbar_ptr0
+                        if cutlass.const_expr(STAGE_COUNT > 1):
+                            tma_mbar_ptr_next = tma_mbar_ptr0 + next_stage_idx
+                        if cutlass.const_expr(STAGE_COUNT > 1):
+                            if next_stage_idx == 1:
+                                sIN_tile_next = sIN_tile1
+
+                        gIN_tile_next = cute.local_tile(
+                            tma_tensor_in, (TILE_M, TILE_K), (m_tile, k_tile_next)
+                        )
+                        self._issue_tma_load(
+                            tma_atom_in,
+                            gIN_tile_next,
+                            sIN_tile_next,
+                            tma_mbar_ptr_next,
+                            warp_idx,
+                        )
+
+                if warp_idx >= 1 and warp_idx <= compute_warps:
+                    cute.arch.mbarrier_wait(tma_mbar_ptr, tma_phase)
+                    lane = tidx % 32
+                    m_lane = (warp_idx - 1) * 32 + lane
+
+                    for mm in cutlass.range_constexpr(M_ITERS_PER_LANE):
+                        m_rel = m_lane + mm * M_THREADS
+                        m = m0 + m_rel
+                        if m_rel < TILE_M:
+                            scale_buffer = cute.make_rmem_tensor(
+                                (K_BLOCKS_PER_TILE,), cutlass.Uint8
+                            )
+
+                            for kb in cutlass.range_constexpr(K_BLOCKS_PER_TILE):
+                                k_base = kb * SCALE_DIM_K_VALUE
+                                vals_block = self._load_block_full_smem_to_reg(
+                                    sIN_tile,
+                                    m_rel,
+                                    k_base,
+                                )
+
+                                # Fused RHT: in-register FWHT(32) + sign.
+                                fwht32_sign(vals_block, sign_reg)
+
+                                amax = compute_amax(vals_block)
+                                scale_biased, inv_scale = compute_scale_byte_fp4(
+                                    amax, USE_RCEIL
+                                )
+                                scale_buffer[kb] = cutlass.Uint8(
+                                    scale_biased & cutlass.Int32(0xFF)
+                                )
+
+                                self._quantize_block_then_store_reg_to_smem_full(
+                                    vals_block,
+                                    inv_scale,
+                                    sOUT_tile,
+                                    m_rel,
+                                    k_base,
+                                    USE_RCEIL,
+                                )
+
+                            k_block_base = k_tile_eff * K_BLOCKS_PER_TILE
+                            self._store_scales_reg_to_gmem_vec(
+                                scales_tensor,
+                                m,
+                                k_block_base,
+                                scale_buffer,
+                                cutlass.Int32(K_BLOCKS_PER_TILE),
+                                BLOCKED_SCALE_OUTPUT_VALUE,
+                            )
+
+                gOUT_tile = cute.local_tile(
+                    tma_tensor_out, (TILE_M, TILE_K_HALF), (m_tile, k_tile_eff)
+                )
+                self._issue_tma_store(
+                    tma_atom_out,
+                    gOUT_tile,
+                    sOUT_tile,
+                    warp_idx,
+                )
+
+        @cute.jit
+        def __call__(
+            self,
+            inp_mk: cute.Tensor,
+            out_mk: cute.Tensor,
+            scales_out_u8: cute.Tensor,
+            sign_vec: cute.Tensor,
+            M: cutlass.Int64,
+            K: cutlass.Int64,
+            k_blocks: cutlass.Int64,
+            m_cta_tiles: cutlass.Int64,
+            k_cta_tiles: cutlass.Int64,
+            stream: cuda.CUstream,
+        ):
+            """Kernel launcher: set up TMA descriptors and blocked scale layout."""
+            smem_layout_in, smem_layout_out = _make_tile_smem_layouts(TILE_M, TILE_K)
+            g2s_op = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+            tma_atom_in, tma_tensor_in = cpasync.make_tiled_tma_atom(
+                g2s_op,
+                inp_mk,
+                smem_layout_in,
+                (TILE_M, TILE_K),
+            )
+            tma_atom_out, tma_tensor_out = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                out_mk,
+                smem_layout_out,
+                (TILE_M, TILE_K_HALF),
+            )
+
+            blocked_scale_layout = cute.make_layout((1,))
+            if cutlass.const_expr(BLOCKED_SCALE_OUTPUT_VALUE):
+                padded_scale_cols = cute.round_up(k_blocks, 4)
+                m_block_tiles = cute.ceil_div(M, 128)
+                k_block_tiles = padded_scale_cols // cutlass.Int64(4)
+                blocked_scale_layout = cute.make_layout(
+                    ((32, 4, m_block_tiles), (4, k_block_tiles)),
+                    stride=(
+                        (16, 4, cutlass.Int64(128) * padded_scale_cols),
+                        (1, cutlass.Int64(512)),
+                    ),
+                )
+
+            self.kernel(
+                inp_mk,
+                tma_atom_in,
+                tma_tensor_in,
+                out_mk,
+                tma_atom_out,
+                tma_tensor_out,
+                scales_out_u8,
+                sign_vec,
+                M,
+                K,
+                k_blocks,
+                m_cta_tiles,
+                k_cta_tiles,
+                blocked_scale_layout,
+                SCALE_DIM_K=SCALE_DIM_K_VALUE,
+                USE_RCEIL=USE_RCEIL_VALUE,
+                STAGE_COUNT=STAGE_COUNT_VALUE,
+            ).launch(
+                grid=(k_cta_tiles, m_cta_tiles, 1),
+                block=(THREADS_PER_BLOCK, 1, 1),
+                cluster=(1, 1, 1),
+                smem=SharedStorage.size_in_bytes(),  # pyrefly: ignore [missing-attribute]
+                stream=stream,
+            )
+
+    kernel = Mxfp4RhtQuantize2dKernel()
+
+    m = cute.sym_int(divisibility=128)
+    k = cute.sym_int(divisibility=128)
+    k_half = cute.sym_int(divisibility=64)
+    kb = cute.sym_int()
+    inp_stride0 = cute.sym_int()
+    inp_stride1 = cute.sym_int()
+    out_stride0 = cute.sym_int()
+    out_stride1 = cute.sym_int()
+    scale_stride0 = cute.sym_int()
+    scale_stride1 = cute.sym_int()
+    sign_stride0 = cute.sym_int()
+
+    fake_inp = make_fake_tensor(
+        INPUT_CUTLASS_DTYPE,
+        (m, k),
+        stride=(inp_stride0, inp_stride1),
+    )
+    fake_out = make_fake_tensor(
+        cutlass.Uint8,
+        (m, k_half),
+        stride=(out_stride0, out_stride1),
+    )
+    if blocked_scale_output:
+        scale_flat = cute.sym_int()
+        fake_scales = make_fake_tensor(
+            cutlass.Uint8,
+            (scale_flat,),
+            stride=(scale_stride0,),
+        )
+    else:
+        fake_scales = make_fake_tensor(
+            cutlass.Uint8,
+            (m, kb),
+            stride=(scale_stride0, scale_stride1),
+        )
+    fake_sign = make_fake_tensor(
+        cutlass.Int32,
+        (32,),
+        stride=(sign_stride0,),
+    )
+    fake_stream = make_fake_stream()
+
+    return cute.compile(
+        kernel,
+        inp_mk=fake_inp,
+        out_mk=fake_out,
+        scales_out_u8=fake_scales,
+        sign_vec=fake_sign,
+        M=0,
+        K=0,
+        k_blocks=0,
+        m_cta_tiles=1,
+        k_cta_tiles=1,
+        stream=fake_stream,
+        options="--enable-tvm-ffi",
+    )
+
+
+def _mxfp4_rht_quantize_cutedsl_impl(
+    x: torch.Tensor,
+    sign_vector: list[int],
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+    stage_count: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Host wrapper: launch the fused MXFP4 + RHT CuTeDSL quantize kernel.
+
+    Args:
+        x: 2D contiguous bf16/fp32 input ``(M, K)`` with ``M % 128 == 0`` and
+            ``K % 128 == 0``.
+        sign_vector: length-32 list of ``{-1, +1}`` for the RHT sign multiply.
+        block_size: only 32 is supported.
+        scaling_mode: ``"floor"`` or ``"rceil"``.
+        is_swizzled_scales: write scales in the cuBLAS-blocked padded layout
+            (``True``) or a plain ``(M, K // 32)`` tensor (``False``).
+        stage_count: pipeline stages (1 or 2).
+
+    Returns:
+        ``(qdata, scales)`` where ``qdata`` is row-major ``(M, K // 2)`` uint8
+        (packed E2M1x2) and ``scales`` is ``float8_e8m0fnu`` in the requested
+        layout.
+    """
+    import cuda.bindings.driver as cuda
+
+    assert x.is_cuda, "Input tensor must be CUDA"
+    assert x.dim() == 2, "Input tensor must be 2D"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert x.dtype in (
+        torch.float32,
+        torch.bfloat16,
+    ), "Input tensor must be float32 or bfloat16"
+    assert block_size == 32, "Only block_size=32 is supported"
+    scaling_mode = scaling_mode.lower()
+    assert scaling_mode in ("floor", "rceil"), (
+        f"Unsupported scaling_mode={scaling_mode!r}; expected 'floor' or 'rceil'"
+    )
+    assert len(sign_vector) == 32, "sign_vector must have length 32"
+
+    M, K = x.shape
+    assert K % 32 == 0, "K must be divisible by 32"
+    assert M % 128 == 0, "M must be divisible by 128 (TMA tiling)"
+    assert K % 128 == 0, "K must be divisible by 128 (TMA tiling)"
+
+    _, config = _select_cutedsl_config(x.dtype, scaling_mode)
+    compute_warps, tile_m, tile_k, k_tiles_per_cta = config
+    assert stage_count >= 1, "stage_count must be >= 1"
+    assert stage_count <= 2, "stage_count must be <= 2"
+
+    k_blocks = K // block_size
+
+    # Half-width row-major packed output: stride (K // 2, 1).
+    q_data = torch.empty_strided(
+        (M, K // 2),
+        (K // 2, 1),
+        device=x.device,
+        dtype=torch.uint8,
+    )
+
+    padded_scale_rows = ceil_div(M, 128) * 128
+    padded_scale_cols = ceil_div(k_blocks, 4) * 4
+    if is_swizzled_scales:
+        scales_u8 = torch.empty(
+            (padded_scale_rows * padded_scale_cols,),
+            device=x.device,
+            dtype=torch.uint8,
+        )
+    else:
+        scales_u8 = torch.empty(
+            (M, k_blocks),
+            device=x.device,
+            dtype=torch.uint8,
+        )
+
+    sign_dev = torch.tensor(
+        [int(s) for s in sign_vector], device=x.device, dtype=torch.int32
+    )
+
+    compiled = _compile_mxfp4_rht_quantize_2d_cutedsl(
+        str(x.dtype),
+        scaling_mode,
+        compute_warps,
+        tile_m,
+        tile_k,
+        stage_count,
+        k_tiles_per_cta,
+        is_swizzled_scales,
+    )
+
+    stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+    m_cta_tiles = ceil_div(M, tile_m)
+    k_cta_tiles = ceil_div(K, tile_k * k_tiles_per_cta)
+
+    compiled(
+        x,
+        q_data,
+        scales_u8,
+        sign_dev,
+        int(M),
+        int(K),
+        int(k_blocks),
+        int(m_cta_tiles),
+        int(k_cta_tiles),
+        stream,
+    )
+
+    scales = scales_u8.view(torch.float8_e8m0fnu)
+    scales = (
+        scales.view(padded_scale_rows, padded_scale_cols)
+        if is_swizzled_scales
+        else scales.view(M, k_blocks)
+    )
+    return q_data, scales
+
+
+@torch.library.custom_op("torchao::mxfp4_rht_quantize_cutedsl", mutates_args=())
+def mxfp4_rht_quantize_cutedsl(
+    x: torch.Tensor,
+    sign_vector: list[int],
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+    stage_count: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return _mxfp4_rht_quantize_cutedsl_impl(
+        x,
+        sign_vector,
+        block_size=block_size,
+        scaling_mode=scaling_mode,
+        is_swizzled_scales=is_swizzled_scales,
+        stage_count=stage_count,
+    )
+
+
+@mxfp4_rht_quantize_cutedsl.register_fake
+def _(
+    x: torch.Tensor,
+    sign_vector: list[int],
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+    stage_count: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    m, k = x.shape
+    q = torch.empty_strided(
+        (m, k // 2), (k // 2, 1), device=x.device, dtype=torch.uint8
+    )  # row-major pinned
+    kb = k // block_size
+    if is_swizzled_scales:
+        scales = x.new_empty(
+            (ceil_div(m, 128) * 128, ceil_div(kb, 4) * 4),
+            dtype=torch.float8_e8m0fnu,
+        )
+    else:
+        scales = x.new_empty((m, kb), dtype=torch.float8_e8m0fnu)
+    return q, scales
+
+
+def mxfp4_rht_quantize_cutedsl_2d(
+    x: torch.Tensor,
+    sign_vector,
+    block_size: int = 32,
+    scaling_mode: str = "floor",
+    is_swizzled_scales: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Gated public wrapper for the fused MXFP4 + RHT CuTeDSL quantize op.
+
+    Raises ``NotImplementedError`` (with the missing-runtime detail) when the
+    CuTeDSL runtime / SM 10.x / CUDA >= 12.8 requirements are not met.
+    """
+    from torchao.prototype.mx_formats.cutedsl import (
+        _mxfp4_rht_cutedsl_kernels_available,
+    )
+
+    if not _mxfp4_rht_cutedsl_kernels_available:
+        from torchao.prototype.mx_formats.cutedsl.cute_utils import (
+            _missing_cutedsl_runtime_packages,
+        )
+
+        raise NotImplementedError(
+            "mxfp4_rht_quantize_cutedsl requires CUDA SM10.x, CUDA>=12.8, and: "
+            f"{_missing_cutedsl_runtime_packages() or 'nvidia-cutlass-dsl'}"
+        )
+    return mxfp4_rht_quantize_cutedsl(
+        x, list(sign_vector), block_size, scaling_mode, is_swizzled_scales
+    )

--- a/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
+++ b/torchao/prototype/mx_formats/cutedsl/mxfp4_rht_quantize.py
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
+
+# This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 """Fused MXFP4 (E2M1, block 32, E8M0) + Random Hadamard Transform CuTeDSL cast.

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -39,6 +39,7 @@ if torch_version_at_least("2.12.0.dev0"):
 from torch.nn.functional import ScalingType, SwizzleType
 
 from torchao.prototype.mx_formats.config import (
+    MXFP4CastKernelChoice,
     MXFP8Dim0CastKernelChoice,
     ScaleCalculationMode,
 )
@@ -643,13 +644,58 @@ class MXTensor(TorchAOBaseTensor):
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
         is_swizzled_scales: bool = False,
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
+        mxfp4_cast_kernel_choice: MXFP4CastKernelChoice = MXFP4CastKernelChoice.TORCH,
+        rht_sign_vector: Optional[list[int]] = None,
     ):
+        """
+        Quantize ``data_hp`` to an ``MXTensor``.
+
+        ``mxfp4_cast_kernel_choice`` / ``rht_sign_vector`` (both trailing, defaulted):
+            When ``elem_dtype == torch.float4_e2m1fn_x2`` and
+            ``mxfp4_cast_kernel_choice == MXFP4CastKernelChoice.CUTEDSL``, a fused
+            per-32-block Random Hadamard Transform (using ``rht_sign_vector``, which
+            must have length ``block_size``) is applied before quantization. The
+            resulting ``MXTensor`` therefore represents ``RHT(x)`` and dequantizes to
+            ``≈RHT(x)``; the caller is responsible for applying the inverse rotation
+            after dequantize (RHT is caller-managed; no inverse is stored on the
+            tensor). The default ``MXFP4CastKernelChoice.TORCH`` path is unchanged and
+            does not require ``rht_sign_vector``.
+        """
         assert mxfp8_dim0_cast_kernel_choice in (
             MXFP8Dim0CastKernelChoice.TRITON,
             MXFP8Dim0CastKernelChoice.TORCH,
         ), (
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
+
+        if (
+            elem_dtype == torch.float4_e2m1fn_x2
+            and mxfp4_cast_kernel_choice == MXFP4CastKernelChoice.CUTEDSL
+        ):
+            assert rht_sign_vector is not None and len(rht_sign_vector) == block_size, (
+                "MXFP4 CUTEDSL cast requires rht_sign_vector of length block_size"
+            )
+            from torchao.prototype.mx_formats.cutedsl import (
+                mxfp4_rht_quantize_cutedsl_2d,
+            )
+
+            data_lp, scale_e8m0 = mxfp4_rht_quantize_cutedsl_2d(
+                data_hp,
+                rht_sign_vector,
+                block_size,
+                scaling_mode.value.lower(),
+                is_swizzled_scales,
+            )
+            return MXTensor(
+                data_lp,
+                scale_e8m0,
+                elem_dtype,
+                block_size,
+                data_hp.dtype,
+                kernel_preference,
+                act_quant_kwargs,
+                is_swizzled_scales,
+            )
 
         triton_kernel_supported = (
             elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales


### PR DESCRIPTION
**What:** A single-pass, max-bandwidth CuTe DSL kernel that applies a per-32-block Random Hadamard Transform
  (register FWHT(32) + sign vector) and quantizes to MXFP4 — E2M1 data (2 codes/byte) + E8M0 block scales — writing
  packed `[M, K//2]` qdata and cuBLAS-blocked (or plain) scales in one streaming pass. Each thread owns one full
  32-element block: it reads the 32 inputs with forced 128-bit loads, runs FWHT+sign in registers, computes the
  E8M0 scale, and writes the 16 packed output bytes with a single 128-bit store plus one scale byte. No shared
  memory, no TMA, no warp specialization; heavy per-thread ILP hides the load latency and the E2M1/E8M0
  conversions; the saturating `cvt.rn.satfinite.e2m1x2` removes the need for explicit ±6 clamps. Lives in
  `torchao/prototype/mx_formats/cutedsl/`; opt-in via `MXTensor.to_mx(..., mxfp4_cast_kernel_choice=CUTEDSL,
  rht_sign_vector=...)`. Self-contained (own E2M1 PTX pack + register FWHT); reuses only existing torchao infra
  (`to_blocked`, `ScaleCalculationMode`, the CuTe DSL runtime gate, shared E8M0/cvt helpers). RHT is fused into the
  cast to suppress outliers before 4-bit quant without a separate transform pass.

  ### Accuracy
  - **Bit-exact** (`rtol=0, atol=0`) packed qdata **and** swizzled scales — validated byte-for-byte across
  scaling_mode {FLOOR, RCEIL} × swizzled {on, off} × dtype {bf16, fp32} × shapes {128×128, 128×384, 256×512, 
  1024×2048} (incl. single-tile / OOB). `test_mxfp4_rht_cutedsl.py` (16 tests) passes; the op is bit-exact vs
  torchao's emulated `to_mx(torch.float4_e2m1fn_x2)` on identical RHT input.
  - **SQNR** vs the high-precision dense `(x @ H)·sign` reference: ~18.8 dB (FLOOR / RCEIL).
  - **Component-level:** register FWHT matches the dense Hadamard to ~7e-7; the FP4 E8M0 scale helpers are 
  bit-exact vs eager `to_mx`.

  ### Performance (B200, CUPTI device time, bf16 in; RHT path)
  | Shape (M×K)  | Latency | Effective BW |
  |--------------|---------|--------------|
  | 8192 × 8192  | ~53 µs  | ~3.2 TB/s    |
  | 2048 × 8192  | ~15 µs  | ~2.9 TB/s    |
  | 4096 × 4096  | ~18 µs  | ~2.4 TB/s    |

  Reported as CUPTI kernel self-time (true kernel throughput), excluding the per-call host dispatch/alloc overhead
  a wall-clock timer would fold in — `benchmarks/mx_formats/cast_bench.py` was switched to device time for the
  cutedsl MXFP4 modes. The RHT path is FWHT(32)-compute-bound (~2.4–3.2 TB/s, ~30–40% of HBM peak); the plain
  no-RHT cast (not exposed by this RHT-only op) reaches ~5 TB/s (≈ HBM roofline).

  **Note:** Ships FLOOR + RCEIL; EVEN/CEIL are not included.