### PR TITLE
docs(finetuning): remove deprecated torchtune references in QLoRA and float8 sections

### DIFF
--- a/docs/source/eager_tutorials/finetuning.rst
+++ b/docs/source/eager_tutorials/finetuning.rst
@@ -290,20 +290,7 @@ such as regular INT4 or even newer `MXFP4 or NVFP4 <https://github.com/pytorch/a
 targeting Blackwell GPUs to reap similar memory benefits with
 varying tradeoffs.
 
-Option 1: TorchTune Integration
-===============================
-
-TorchTune incorporates the `NF4Tensor` in its QLoRA fine-tuning
-recipe through their implementation of `LoRALinear <https://github.com/pytorch/torchtune/blob/a6290a5b40758f13bca61c386bc8756a49ef417e/torchtune/modules/peft/lora.py#L19>`__.
-You can also try it out by running the following command,
-or refer to their `QLoRA tutorial <https://docs.pytorch.org/torchtune/stable/tutorials/qlora_finetune.html>`__
-for more details.
-
-.. code::
-
-  tune run lora_finetune_single_device --config llama3_2/3B_qlora_single_device.yaml
-
-Option 2: HuggingFace PEFT Integration
+Option 1: HuggingFace PEFT Integration
 ======================================
 
 `HuggingFace PEFT <https://huggingface.co/docs/peft/main/en/developer_guides/quantization#torchao-pytorch-architecture-optimization>`__
@@ -332,18 +319,8 @@ Float8 Quantized Fine-tuning
 Similar to `pre-training <pretraining.html>`__, we can also
 leverage float8 in fine-tuning for higher training throughput
 with no accuracy degradation and no increase in memory usage.
-Float8 training is integrated into TorchTune's distributed
-full fine-tuning recipe, leveraging the same APIs as our
-integration with TorchTitan. Users can invoke this fine-tuning
-recipe as follows:
-
-.. code::
-
-  tune run --nnodes 1 --nproc_per_node 4 full_finetune_distributed --config llama3_2/3B_full
-    enable_fp8_training=true \
-    fp8_recipe_name=tensorwise \
-    compile=True
-
+Float8 fine-tuning leverages the same float8 training APIs as our
+integration with `TorchTitan <https://github.com/pytorch/torchtitan>`__.
 Initial experiments saw up to 16.5% throughput improvement
 for fine-tuning Llama3.2-3B in float8:
 


### PR DESCRIPTION
Follow-up to #4312, addressing @andrewor14's review request:

> Looks like there are still references to torchtune in the QLoRA and quantized finetuning sections. When you get a chance can you fix these as well (in a separate PR)?

[torchtune development wound down in 2025](https://github.com/meta-pytorch/torchtune/issues/2883) and the library is no longer actively maintained, so this removes the remaining torchtune-specific recipes from `finetuning.rst`:

**QLoRA section**
- Removed the deprecated *"Option 1: TorchTune Integration"* recipe (`tune run lora_finetune_single_device`).
- Promoted *"HuggingFace PEFT Integration"* to **Option 1** (heading underline length is unchanged, since `Option 1:`/`Option 2:` are equal length).
- I intentionally did **not** swap this to Unsloth (unlike the QAT section in #4312): Unsloth's QLoRA uses bitsandbytes 4-bit rather than torchao's NF4, so it wouldn't illustrate torchao NF4 in a downstream framework. torchao's NF4 usage is still demonstrated directly via the `FrozenNF4Linear` / `to_nf4` example just above the options.

**Float8 Quantized Fine-tuning section**
- Removed the deprecated `tune run full_finetune_distributed ... enable_fp8_training=true` recipe.
- Reworded to point at the shared float8 training APIs (TorchTitan). The measured throughput/accuracy results table and the pre-training tutorial pointer are kept.

**One remaining reference, left out of scope:** `Option 3: TorchAO QAT API` still imports `from torchtune.models.llama3 import llama3` purely to build a toy model for the runnable example. That's in the QAT section (not the QLoRA/float8 sections you flagged), and replacing the model constructor risks breaking the example, so I left it for now — happy to follow up if you'd like it swapped for a plain `nn.Module`/transformers model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
