### PR TITLE
fix: use `Int4WeightOnlyConfig.group_size` in fake quant configs

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1951,7 +1951,8 @@ class TestQAT(TestCase):
         self.assertEqual(weight_config.group_size, 128)
         self.assertEqual(weight_config.activation_dtype, e4m3_dtype)
 
-    def test_infer_int4_weight_only_config(self):
+    @parametrize("group_size", [256, 128, 64, 32])
+    def test_infer_int4_weight_only_config(self, group_size: int):
         """
         Test that fake quantize configs are correctly inferred from `Int4WeightOnlyConfig`.
         """
@@ -1959,11 +1960,11 @@ class TestQAT(TestCase):
             _infer_fake_quantize_configs,
         )
 
-        base_config = Int4WeightOnlyConfig(version=2)
+        base_config = Int4WeightOnlyConfig(version=2, group_size=group_size)
         (act_config, weight_config) = _infer_fake_quantize_configs(base_config)
         self.assertIsNone(act_config)
         self.assertIsInstance(weight_config, Int4WeightFakeQuantizeConfig)
-        self.assertEqual(weight_config.group_size, 128)
+        self.assertEqual(weight_config.group_size, group_size)
         self.assertEqual(weight_config.activation_dtype, torch.bfloat16)
 
     @unittest.skipIf(not is_sm_at_least_89(), "Need sm89+")

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -382,7 +382,7 @@ def _infer_fake_quantize_configs(
                     f"Packing format must be one of {supported_packing_formats}"
                 )
             weight_config = Int4WeightFakeQuantizeConfig(
-                group_size=128,
+                group_size=base_config.group_size,
                 activation_dtype=torch.bfloat16,
             )
         else:


### PR DESCRIPTION
Following the discussion with @andrewor14 in #3572, this PR updates the `Int4WeightOnlyConfig` QAT path to use the configured `group_size` instead of the hardcoded value `128`.

Previously, `_infer_fake_quantize_configs` always generated fake quantization configs with `group_size=128`, regardless of the value specified in `Int4WeightOnlyConfig`. As a result, QAT did not honor the configured group size, unlike the corresponding PTQ path.

Fixes #3572