### PR TITLE
Preserve device index in safe_int_mm fallback

### DIFF
--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -49,6 +49,30 @@ class TestQuantFlow(unittest.TestCase):
         assert out32_2.dtype == out32_1.dtype
         torch.testing.assert_allclose(out32_1, out32_2)
 
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        "Need at least 2 CUDA devices",
+    )
+    def test_safe_int_mm_fallback_preserves_cuda_device_index(self):
+        from torchao.kernel import intmm
+
+        original_device = torch.cuda.current_device()
+        try:
+            torch.cuda.set_device(0)
+            input_device = torch.device("cuda:1")
+            x = torch.randint(-128, 127, (4, 7), dtype=torch.int8, device=input_device)
+            w = torch.randint(-128, 127, (7, 5), dtype=torch.int8, device=input_device)
+
+            actual = intmm.safe_int_mm(x, w)
+            expected = torch.matmul(
+                x.cpu().to(torch.int32), w.cpu().to(torch.int32)
+            ).to(input_device)
+        finally:
+            torch.cuda.set_device(original_device)
+
+        self.assertEqual(actual.device, input_device)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
     @parameterized.expand(
         [
             ("cuda", torch.bfloat16),

--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -71,7 +71,7 @@ def safe_int_mm(input: torch.Tensor, mat2: torch.Tensor) -> torch.Tensor:
     if device_cpu or bad_dimensions_for_cublas:
         # fallback path
         return torch.matmul(input.cpu().to(torch.int32), mat2.cpu().to(torch.int32)).to(
-            input.device.type
+            input.device
         )
 
     # cublas paths


### PR DESCRIPTION
## Summary

- Return the CPU fallback result to the full input device instead of just the device type.
- Add a regression test for a two-CUDA-device setup where the current CUDA device differs from the input tensor device.

## Why

The fallback path computes on CPU and then used `.to(input.device.type)`, which preserves `cuda` but drops the device index. If `safe_int_mm` receives tensors on `cuda:1` while the current default CUDA device is `cuda:0`, the fallback output can land on the wrong GPU.

## Validation

- `python3 -m py_compile torchao/kernel/intmm.py test/kernel/test_autotuner.py`
- `uv run --isolated --no-project --with ruff==0.11.6 ruff format --check torchao/kernel/intmm.py test/kernel/test_autotuner.py`
- `uv run --isolated --no-project --with ruff==0.11.6 ruff check torchao/kernel/intmm.py test/kernel/test_autotuner.py`
- `uv run --isolated --no-project --with torch --with parameterized python -m unittest test.kernel.test_autotuner.TestQuantFlow.test_safe_int_mm_fallback_preserves_cuda_device_index` (skips locally without two CUDA devices)