### PR TITLE
Add COAT FP8 optimizer with dynamic range expansion

### DIFF
--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -60,6 +60,7 @@ OPTIM_MAP = dict(
     AdamW8bitBnb=bnb.optim.AdamW8bit,
     AdamW8bitAo=optim.AdamW8bit,
     AdamWFp8Ao=optim.AdamWFp8,
+    AdamWFp8CoatAo=optim.AdamWFp8Coat,
     AdamW4bitAo=optim.AdamW4bit,
 )
 

--- a/test/test_low_bit_optim.py
+++ b/test/test_low_bit_optim.py
@@ -30,6 +30,7 @@ if common_utils.SEED is None:
     common_utils.SEED = 1234
 
 from packaging.version import Version
+
 from torchao import optim
 from torchao.optim.quant_utils import (
     _fp32_to_bf16_sr,
@@ -38,7 +39,8 @@ from torchao.optim.quant_utils import (
 )
 from torchao.optim.subclass_4bit import OptimState4bit
 from torchao.optim.subclass_8bit import OptimState8bit
-from torchao.optim.subclass_fp8 import OptimStateFp8
+from torchao.optim.subclass_coat_fp8 import OptimStateCoatFp8, quantize_coat_fp8
+from torchao.optim.subclass_fp8 import OptimStateFp8, quantize_fp8
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
     get_available_devices,
@@ -162,13 +164,22 @@ class TestQuantize(TestCase):
 class TestOptim(TestCase):
     @parametrize(
         "optim_name",
-        ["Adam8bit", "AdamW8bit", "Adam4bit", "AdamW4bit", "AdamFp8", "AdamWFp8"],
+        [
+            "Adam8bit",
+            "AdamW8bit",
+            "Adam4bit",
+            "AdamW4bit",
+            "AdamFp8",
+            "AdamWFp8",
+            "AdamFp8Coat",
+            "AdamWFp8Coat",
+        ],
     )
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize("device", _DEVICES)
     @skip_if_rocm("ROCm enablement in progress")
     def test_optim_smoke(self, optim_name, dtype, device):
-        if optim_name.endswith("Fp8") and device == "cuda":
+        if "Fp8" in optim_name and device == "cuda":
             if torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -255,11 +266,14 @@ class TestOptim(TestCase):
     # test 2 times with different world size, and persist checkpoint across the 2 runs.
     # thus, we only test for the required op. note that future implementations of dcp.load()
     # may use other ops.
-    @parametrize("subclass", [OptimState4bit, OptimState8bit, OptimStateFp8])
+    @parametrize(
+        "subclass",
+        [OptimState4bit, OptimState8bit, OptimStateFp8, OptimStateCoatFp8],
+    )
     @parametrize("shape", [(4096,), (256, 256)])
     @parametrize("device", _DEVICES)
     def test_subclass_slice(self, subclass, shape, device):
-        if subclass == OptimStateFp8:
+        if subclass in (OptimStateFp8, OptimStateCoatFp8):
             if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -274,7 +288,10 @@ class TestOptim(TestCase):
             tensor[offset : offset * 2].dequantize(),
         )
 
-    @parametrize("subclass", [OptimState4bit, OptimState8bit, OptimStateFp8])
+    @parametrize(
+        "subclass",
+        [OptimState4bit, OptimState8bit, OptimStateFp8, OptimStateCoatFp8],
+    )
     @parametrize("device", _DEVICES)
     def test_subclass_appearance_dtype(self, subclass, device):
         shape = (1024,)
@@ -299,6 +316,50 @@ class TestOptim(TestCase):
         # direct BF16 creation
         tensor_bf16 = subclass.zeros(shape, device=device, dtype=torch.bfloat16)
         self.assertEqual(tensor_bf16.dtype, torch.bfloat16)
+
+    @parametrize("device", _DEVICES)
+    def test_coat_fp8_reduces_quant_error(self, device):
+        # COAT dynamic range expansion targets tensors whose dynamic range is much
+        # smaller than FP8's, which is typical for optimizer states. On such tensors
+        # it should round-trip with less error than plain FP8 quantization.
+        if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("FP8 CUDA requires compute capability >= 8.9")
+
+        torch.manual_seed(2024)
+        block_size = 256
+        # small magnitudes with a modest dynamic range, e.g. an Adam 2nd moment buffer
+        x = torch.rand(32, block_size, device=device) * 1e-3 + 1e-6
+
+        codes, scale = quantize_fp8(x, block_size)
+        deq_fp8 = OptimStateFp8(codes, scale).dequantize()
+
+        codes, scale, k, sqrt_minmax = quantize_coat_fp8(x, block_size)
+        coat = OptimStateCoatFp8(codes, scale, k, sqrt_minmax)
+        deq_coat = coat.dequantize()
+
+        err_fp8 = (deq_fp8 - x).abs().mean()
+        err_coat = (deq_coat - x).abs().mean()
+
+        # expansion should be active (k > 1) and improve accuracy
+        assert (k >= 1).all()
+        assert k.max() > 1
+        assert err_coat < err_fp8
+
+    @parametrize("device", _DEVICES)
+    def test_coat_fp8_roundtrip(self, device):
+        if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("FP8 CUDA requires compute capability >= 8.9")
+
+        # signed values: sign must be preserved through the expansion transform
+        x = torch.randn(8, 256, device=device) * 0.01
+        codes, scale, k, sqrt_minmax = quantize_coat_fp8(x, 256)
+        deq = OptimStateCoatFp8(codes, scale, k, sqrt_minmax).dequantize()
+        assert (deq.sign() == x.sign()).all()
+        torch.testing.assert_close(deq, x, rtol=0.1, atol=1e-4)
+
+        # an all-zero state must round-trip exactly to zeros (identity transform)
+        zeros = OptimStateCoatFp8.zeros((4096,), device=device)
+        assert zeros.dequantize().abs().max() == 0
 
     @pytest.mark.skipif(bnb is None, reason="bitsandbytes is not available")
     @pytest.mark.skipif(
@@ -543,6 +604,7 @@ class TestFSDP2(FSDPTest):
         ]
         if torch.cuda.get_device_capability() >= (8, 9):
             args_list.append((optim.AdamWFp8, OffloadPolicy))
+            args_list.append((optim.AdamWFp8Coat, OffloadPolicy))
 
         self.run_subtests(
             {"args": args_list},
@@ -631,7 +693,7 @@ class TestFSDP2(FSDPTest):
         if dist.get_rank() == 0:
             shutil.rmtree(checkpoint_id)
 
-        subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
+        subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8, OptimStateCoatFp8)
 
         for v1, v2 in zip(
             pytree.tree_iter(resumed_fsdp_optim.state_dict()),

--- a/torchao/optim/README.md
+++ b/torchao/optim/README.md
@@ -5,6 +5,7 @@ This module implements:
 - 8-bit optimizers as outlined in https://arxiv.org/abs/2110.02861
 - 4-bit optimizers as outlined in https://arxiv.org/abs/2309.01507
 - FP8 optimizers using the native `torch.float8_e4m3fn` dtype (experimental)
+- FP8 optimizers with COAT dynamic range expansion as outlined in https://arxiv.org/abs/2410.19313 (experimental)
 - Stochastic rounding for BF16 weight (https://arxiv.org/abs/2010.06192, experimental)
 - CPU offload optimizers for single GPU training
 
@@ -24,6 +25,8 @@ optim = Adam8bit(model.parameters())
 To use 4-bit Adam, replace the above with `Adam4bit`. Similarly for `AdamFp8`. You can also change quantization block size by passing `block_size=value` to the optimizer. By default, block size is 256 for 8-bit and FP8 optimizers, and 128 for 4-bit optimizers.
 
 **Other optimizers**: AdamW is also available as `AdamW8bit`, `AdamW4bit`, and `AdamWFp8`. Other optimizers can be added based on demand.
+
+**COAT FP8 optimizers**: `AdamFp8Coat` and `AdamWFp8Coat` store the optimizer state in FP8 with [COAT](https://arxiv.org/abs/2410.19313) dynamic range expansion. The dynamic range of optimizer states is usually much smaller than FP8's representable range, so plain FP8 quantization wastes most of the exponent bits. COAT first applies an expansion function `f(x) = sign(x) * |x| ** k` per block, stretching the block's dynamic range to match FP8's before quantizing, which lowers the quantization error of the optimizer state. These are drop-in replacements for `AdamFp8` / `AdamWFp8`.
 
 NOTE:
 - The low-bit optimizers require PyTorch >= 2.3

--- a/torchao/optim/__init__.py
+++ b/torchao/optim/__init__.py
@@ -1,13 +1,25 @@
-from .adam import Adam4bit, Adam8bit, AdamFp8, AdamW4bit, AdamW8bit, AdamWFp8, _AdamW
+from .adam import (
+    Adam4bit,
+    Adam8bit,
+    AdamFp8,
+    AdamFp8Coat,
+    AdamW4bit,
+    AdamW8bit,
+    AdamWFp8,
+    AdamWFp8Coat,
+    _AdamW,
+)
 from .cpu_offload import CPUOffloadOptimizer
 
 __all__ = [
     "Adam4bit",
     "Adam8bit",
     "AdamFp8",
+    "AdamFp8Coat",
     "AdamW4bit",
     "AdamW8bit",
     "AdamWFp8",
+    "AdamWFp8Coat",
     "_AdamW",
     "CPUOffloadOptimizer",
 ]

--- a/torchao/optim/adam.py
+++ b/torchao/optim/adam.py
@@ -13,6 +13,7 @@ from torch.optim import Optimizer
 from .quant_utils import _fp32_to_bf16_sr
 from .subclass_4bit import OptimState4bit
 from .subclass_8bit import OptimState8bit
+from .subclass_coat_fp8 import OptimStateCoatFp8
 from .subclass_fp8 import OptimStateFp8
 
 
@@ -401,6 +402,76 @@ class AdamWFp8(_AdamBase):
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
         return OptimStateFp8.zeros(p.shape, block_size, p.device, dtype=p.dtype)
+
+
+class AdamFp8Coat(_AdamBase):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0,
+        amsgrad=False,
+        *,
+        block_size=256,
+        bf16_stochastic_round=False,
+    ) -> None:
+        """Adam with FP8 optimizer state quantized using COAT dynamic range
+        expansion (https://arxiv.org/abs/2410.19313). This expands each block's
+        dynamic range to match FP8's before quantizing, reducing the quantization
+        error of the optimizer state compared to ``AdamFp8``."""
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=False,
+        )
+        torch._C._log_api_usage_once("torchao.optim.AdamFp8Coat")
+
+    @staticmethod
+    def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
+        return OptimStateCoatFp8.zeros(p.shape, block_size, p.device, dtype=p.dtype)
+
+
+class AdamWFp8Coat(_AdamBase):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=1e-2,
+        amsgrad=False,
+        *,
+        block_size=256,
+        bf16_stochastic_round=False,
+    ) -> None:
+        """AdamW with FP8 optimizer state quantized using COAT dynamic range
+        expansion (https://arxiv.org/abs/2410.19313). This expands each block's
+        dynamic range to match FP8's before quantizing, reducing the quantization
+        error of the optimizer state compared to ``AdamWFp8``."""
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
+        torch._C._log_api_usage_once("torchao.optim.AdamWFp8Coat")
+
+    @staticmethod
+    def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
+        return OptimStateCoatFp8.zeros(p.shape, block_size, p.device, dtype=p.dtype)
 
 
 class _AdamW(_AdamBase):

--- a/torchao/optim/subclass_coat_fp8.py
+++ b/torchao/optim/subclass_coat_fp8.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import math
+
+import torch
+from torch import Tensor
+from torch.serialization import add_safe_globals
+from torch.utils._python_dispatch import return_and_correct_aliasing
+
+from torchao.utils import TorchAOBaseTensor, torch_version_at_least
+
+aten = torch.ops.aten
+c10d_functional = torch.ops.c10d_functional
+_c10d_functional = torch.ops._c10d_functional
+
+DTYPE = torch.float8_e4m3fn
+
+# Dynamic range of E4M3FN: largest representable (448) divided by smallest positive
+# subnormal (2 ** -9 = 1 / 512). See COAT https://arxiv.org/abs/2410.19313, Section 4.1.
+_RANGE_FP8_E4M3 = torch.finfo(DTYPE).max * 512  # 448 * 512 = 229376
+_LOG_RANGE_FP8_E4M3 = math.log(_RANGE_FP8_E4M3)
+
+
+def quantize_coat_fp8(input: Tensor, block_size: int):
+    """Block-wise FP8 quantization with COAT dynamic range expansion.
+
+    The dynamic range of optimizer states is typically much smaller than FP8's
+    representable range, so naive FP8 quantization wastes most of the available
+    exponent bits. COAT (https://arxiv.org/abs/2410.19313) first applies an
+    expansion function ``f(x) = sign(x) * |x| ** k`` that stretches each block's
+    dynamic range to match FP8's, then quantizes. ``k`` is chosen per block so
+    that ``R_x ** k == R_fp8`` where ``R`` denotes a dynamic range (max abs / min
+    abs). We only ever expand (``k >= 1``); a block whose dynamic range already
+    exceeds FP8's is left untouched.
+
+    To keep the expanded values centered (and avoid FP32 over/underflow when
+    ``k`` is large), each block is first divided by the geometric mean of its
+    min and max magnitudes before expansion. Both ``k`` and that geometric mean
+    are stored so dequantization can invert the transform.
+    """
+    shape = input.shape
+    input = input.view(-1, block_size)
+    abs_input = input.abs()
+
+    amax = abs_input.amax(-1).clip(1e-12)
+    # smallest non-zero magnitude per block; treat exact zeros as amax so they
+    # don't collapse the dynamic range to infinity.
+    amin = torch.where(abs_input > 0, abs_input, amax.view(-1, 1)).amin(-1).clip(1e-12)
+
+    # dynamic range per block, always >= 1
+    log_range = (amax / amin).log()
+    # k = log(R_fp8) / log(R_x), only expand (k >= 1), never compress
+    k = torch.where(
+        log_range > 0,
+        _LOG_RANGE_FP8_E4M3 / log_range.clip(1e-12),
+        torch.ones_like(log_range),
+    ).clip(1.0)
+    # geometric mean of the magnitude range, used to center the block
+    sqrt_minmax = (amin * amax).sqrt()
+
+    centered = input / sqrt_minmax.view(-1, 1)
+    expanded = centered.sign() * centered.abs().pow(k.view(-1, 1))
+
+    scale = expanded.abs().amax(-1).clip(1e-12) / torch.finfo(DTYPE).max
+    codes = (expanded / scale.view(-1, 1)).to(DTYPE).view(-1)
+    return codes.view(shape), scale, k, sqrt_minmax
+
+
+class OptimStateCoatFp8(TorchAOBaseTensor):
+    tensor_attrs = ["codes", "scale", "k", "sqrt_minmax"]
+
+    # dtype only acts as an appearance dtype to work with the rest of PyTorch
+    @staticmethod
+    def __new__(
+        cls,
+        codes: Tensor,
+        scale: Tensor,
+        k: Tensor,
+        sqrt_minmax: Tensor,
+        dtype: torch.dtype | None = None,
+    ):
+        return Tensor._make_wrapper_subclass(
+            cls, codes.shape, device=codes.device, dtype=dtype
+        )
+
+    def __init__(
+        self,
+        codes: Tensor,
+        scale: Tensor,
+        k: Tensor,
+        sqrt_minmax: Tensor,
+        dtype: torch.dtype | None = None,
+    ):
+        """Create FP8 optimizer state quantized with COAT dynamic range expansion.
+
+        Args
+            codes: quantized FP8 E4M3FN data. Has the same shape as the original float tensor.
+            scale: block-wise quantization scale (1D).
+            k: block-wise dynamic range expansion exponent (1D).
+            sqrt_minmax: block-wise geometric mean of the magnitude range, used to
+                center each block before expansion (1D).
+
+        NOTE: To get block-wise statistics, the original float tensor is first reshaped
+        to (-1, block_size). Thus, the last dimension of the original float tensor is not
+        necessarily divisible by block size. Given `codes` and `scale`, `block_size` is
+        calculated as `codes.numel() // scale.numel()`.
+        """
+        assert codes.dtype is DTYPE
+        assert scale.ndim == 1
+        assert k.ndim == 1
+        assert sqrt_minmax.ndim == 1
+        self.codes = codes
+        self.scale = scale
+        self.k = k
+        self.sqrt_minmax = sqrt_minmax
+        self.block_size = codes.numel() // scale.numel()
+
+    def __tensor_flatten__(self):
+        return self.tensor_attrs, [self.dtype]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size=None, outer_stride=None
+    ):
+        return cls(
+            *[tensor_data_dict[name] for name in cls.tensor_attrs], *tensor_attributes
+        )
+
+    def dequantize(self, output_dtype=None):
+        expanded = self.codes.float().view(-1, self.block_size) * self.scale.view(-1, 1)
+        # invert the expansion: f^-1(x) = sign(x) * |x| ** (1 / k)
+        centered = expanded.sign() * expanded.abs().pow((1.0 / self.k).view(-1, 1))
+        float_data = centered * self.sqrt_minmax.view(-1, 1)
+        float_data = float_data.view(self.codes.shape)
+
+        if output_dtype is not None:
+            float_data = float_data.to(output_dtype)
+        return float_data
+
+    @classmethod
+    def zeros(
+        cls,
+        shape,
+        block_size: int = 256,
+        device: torch.types.Device = None,
+        dtype: torch.dtype | None = None,
+    ):
+        codes = torch.zeros(shape, dtype=DTYPE, device=device)
+        n_blocks = codes.numel() // block_size
+        scale = torch.zeros(n_blocks, device=device)
+        # k=1 and sqrt_minmax=1 form an identity transform, so an all-zero state
+        # round-trips to zeros.
+        k = torch.ones(n_blocks, device=device)
+        sqrt_minmax = torch.ones(n_blocks, device=device)
+        return cls(codes, scale, k, sqrt_minmax, dtype=dtype)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(block_size={self.block_size}, "
+            f"shape={tuple(self.shape)}, dtype={self.dtype}, device={self.device}, "
+            f"requires_grad={self.requires_grad})"
+        )
+
+
+@OptimStateCoatFp8.implements(aten.copy_.default)
+def _(func, types, args, kwargs):
+    dst = args[0]
+    src = args[1]
+
+    if isinstance(dst, OptimStateCoatFp8) and isinstance(src, OptimStateCoatFp8):
+        assert dst.block_size == src.block_size
+        dst.codes.copy_(src.codes)
+        dst.scale.copy_(src.scale)
+        dst.k.copy_(src.k)
+        dst.sqrt_minmax.copy_(src.sqrt_minmax)
+
+    elif isinstance(dst, OptimStateCoatFp8):
+        codes, scale, k, sqrt_minmax = quantize_coat_fp8(src, dst.block_size)
+        dst.codes.copy_(codes)
+        dst.scale.copy_(scale)
+        dst.k.copy_(k)
+        dst.sqrt_minmax.copy_(sqrt_minmax)
+
+    else:
+        dst.copy_(src.dequantize())
+
+    return dst
+
+
+@OptimStateCoatFp8.implements(aten._to_copy.default)
+def _(func, types, args, kwargs):
+    # only change the appearance dtype
+    dtype = kwargs.get("dtype", args[0].dtype)
+    device = kwargs.get("device", None)
+    out = OptimStateCoatFp8(
+        args[0].codes.to(device=device),
+        args[0].scale.to(device=device),
+        args[0].k.to(device=device),
+        args[0].sqrt_minmax.to(device=device),
+        dtype=dtype,
+    )
+    return return_and_correct_aliasing(func, args, kwargs, out)
+
+
+@OptimStateCoatFp8.implements(aten.lerp.Scalar)
+def _(func, types, args, kwargs):
+    args = [x.dequantize() if isinstance(x, OptimStateCoatFp8) else x for x in args]
+    return func(*args, **kwargs)
+
+
+# this is needed for DTensor.from_local()
+@OptimStateCoatFp8.implements(aten.view.default)
+def _(func, types, args, kwargs):
+    x, shape = args
+    return OptimStateCoatFp8(x.codes.view(shape), x.scale, x.k, x.sqrt_minmax)
+
+
+# Build the list of c10d operations to implement
+_optim_state_coat_fp8_c10d_ops = [
+    # required by DTensor.full_tensor()
+    c10d_functional.all_gather_into_tensor.default,
+    _c10d_functional.all_gather_into_tensor.default,
+    c10d_functional.wait_tensor.default,
+    _c10d_functional.wait_tensor.default,
+    # required by torch.distributed.checkpoint.save
+    aten.detach.default,
+]
+# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+if torch_version_at_least("2.11.0.dev"):
+    _optim_state_coat_fp8_c10d_ops.append(
+        _c10d_functional._wrap_tensor_autograd.default
+    )
+
+
+@OptimStateCoatFp8.implements(_optim_state_coat_fp8_c10d_ops)
+def _(func, types, args, kwargs):
+    x = args[0]
+    if not isinstance(x, OptimStateCoatFp8):
+        raise ValueError(f"expecting a OptimStateCoatFp8 but found {type(x)}")
+
+    return OptimStateCoatFp8(
+        func(x.codes, *args[1:], **kwargs),
+        func(x.scale, *args[1:], **kwargs),
+        func(x.k, *args[1:], **kwargs),
+        func(x.sqrt_minmax, *args[1:], **kwargs),
+    )
+
+
+# required by torch.distributed.checkpoint.save
+# note that we don't actually implement pin memory for this tensor subclass
+# (pin_memory argument is ignored in aten._to_copy)
+@OptimStateCoatFp8.implements(aten.is_pinned.default)
+def _(func, types, args, kwargs):
+    return (
+        args[0].codes.is_pinned()
+        and args[0].scale.is_pinned()
+        and args[0].k.is_pinned()
+        and args[0].sqrt_minmax.is_pinned()
+    )
+
+
+# required by torch.distributed.checkpoint.load when world size changes i.e. re-sharding
+@OptimStateCoatFp8.implements(aten.slice.Tensor)
+def _(func, types, args, kwargs):
+    x, dim, start, end = args[:4]
+    step = args[4] if len(args) > 4 else 1
+
+    # input validation
+    if dim != 0:
+        raise ValueError("Only support aten.slice along the first dim")
+    if step != 1:
+        raise ValueError("Only support aten.slice with step=1")
+
+    block_size = x.block_size
+    stride = math.prod(x.shape[1:])
+
+    # for 1 increment in x along the first dim,
+    # (flattened) scale will increment by stride / block_size
+    if (start * stride) % block_size != 0 or (end * stride) % block_size != 0:
+        raise ValueError(
+            f"Invalid start or end for shape={x.shape} and block_size={block_size}. "
+            f"Make sure start and end align with block boundary. "
+            f"Received start={start}, end={end}."
+        )
+
+    block_start = start * stride // block_size
+    block_end = end * stride // block_size
+    return OptimStateCoatFp8(
+        x.codes[start:end],
+        x.scale[block_start:block_end],
+        x.k[block_start:block_end],
+        x.sqrt_minmax[block_start:block_end],
+    )
+
+
+add_safe_globals([OptimStateCoatFp8])


### PR DESCRIPTION
Closes #1190 

This adds an FP8 Adam/AdamW variant that uses COAT's dynamic range expansion ([arXiv:2410.19313](https://arxiv.org/abs/2410.19313)) for the optimizer state.

The motivation is pretty simple: optimizer states usually occupy a much smaller dynamic range than what FP8 E4M3 can actually represent (~229k), so plain FP8 quantization ends up wasting most of the exponent bits and loses precision. COAT fixes this by stretching each block's range to fill FP8's before quantizing — it applies f(x) = sign(x) * |x|^k per block, where k is picked so the block's dynamic range maps onto E4M3's, and inverts it on dequant. I only ever expand (k >= 1), so blocks that already span a wider range than FP8 are left alone. Each block is also divided by the geometric mean of its min/max magnitude before expansion, which keeps the expanded values centered and avoids FP32 over/underflow when k is large.

Implementation-wise this follows the existing OptimStateFp8 pretty closely:

New OptimStateCoatFp8 tensor subclass in torchao/optim/subclass_coat_fp8.py. Same shape/appearance-dtype handling as OptimStateFp8, just storing the extra per-block k and geometric mean alongside codes and scale. All the dispatch ops are implemented (copy_, _to_copy, lerp, view, slice, the c10d/DTensor ops, is_pinned) so it plays nicely with torch.compile, serialization, and FSDP.
New AdamFp8Coat / AdamWFp8Coat in adam.py, exported from torchao/optim/__init__.py. They're drop-in replacements for AdamFp8 / AdamWFp8 — same signatures, just a different state subclass under the hood.
Docs note in the optim README and an entry in the low-bit Adam benchmark so it can be compared against the existing FP8 optimizer.
I worked from the paper directly since the official NVLABS code isn't out yet, so the numerics can be cross-checked against that once it lands — happy to follow up when it does.

Testing

Added coverage in test/test_low_bit_optim.py:

the two new optimizers in the smoke test (step → save → load → resume-equivalence, fp32 and bf16);
OptimStateCoatFp8 added to the slice (re-sharding), appearance-dtype, and FSDP2 tests;
a dedicated test confirming the expansion is active (k > 1) and gives lower round-trip error than plain FP8 on a small-dynamic-range tensor, plus a round-trip/sign-preservation test and a check that an all-zero state round-trips to exactly zeros.
Lint is clean (ruff check / ruff format).

A couple of decisions I'd flag for review, in case you'd prefer otherwise:

I made these separate classes rather than a flag on AdamFp8, to keep the existing FP8 path untouched. Easy to switch to a dynamic_range_expansion=True arg if you'd rather.
Placed everything in stable torchao/optim/ next to the other FP8 optimizer code, since that's where it moved out of prototype.