### PR TITLE
[xpu][benchmarks] Enable float8 roofline benchmarks for Intel XPU

### DIFF
--- a/benchmarks/float8/bench_matmul.py
+++ b/benchmarks/float8/bench_matmul.py
@@ -34,14 +34,21 @@ def run(
     use_gpu_kernel_time: bool = True,
     recipe: str = "tensorwise",
 ):
-    device = "cuda"
+    device = torch.accelerator.current_accelerator().type
     # TODO(future PR): this is ugly
-    assert recipe in (
-        "tensorwise",
-        "rowwise",
-        "mxfp4_cutlass",
-        "nvfp4",
-    ), "unsupported"
+
+    if device == "xpu":
+        assert recipe in (
+            "tensorwise",
+            "rowwise",
+        ), "Currently only tensorwise and rowwise quantization are supported on XPU."
+    else:
+        assert recipe in (
+            "tensorwise",
+            "rowwise",
+            "mxfp4_cutlass",
+            "nvfp4",
+        ), "unsupported"
     use_fp4 = recipe in ("mxfp4_cutlass", "nvfp4")
 
     specs = get_specs()
@@ -49,7 +56,12 @@ def run(
     fp8_peak_tops = specs["fp8_peak_tops"]
     fp4_peak_tops = specs.get("fp4_peak_tops", 0.0)  # only on sm120
     print(f"recipe: {recipe}")
-    print(f"gpu_name: {torch.cuda.get_device_name(0)}")
+
+    if device == "xpu":
+        gpu_name = torch.xpu.get_device_name(0)
+    else:
+        gpu_name = torch.cuda.get_device_name(0)
+    print(f"gpu_name: {gpu_name}")
     print(
         f"peak tops: bf16 {bf16_peak_tops:.2e}, fp8 {fp8_peak_tops:.2e}, fp4 {fp4_peak_tops:.2e}"
     )

--- a/benchmarks/float8/float8_inference_roofline.py
+++ b/benchmarks/float8/float8_inference_roofline.py
@@ -60,13 +60,6 @@ from torchao.testing.training.roofline_utils import (
 )
 from torchao.utils import _is_mslk_available, is_MI300, is_sm_at_least_100
 
-_DEVICE = torch.accelerator.current_accelerator().type
-
-if _DEVICE == "xpu":
-    import torch.xpu as torch_accelerator
-else:
-    import torch.cuda as torch_accelerator
-
 # Import mslk.conv to register the fp8 conv operator
 if _is_mslk_available():
     import mslk.conv  # noqa: F401
@@ -78,8 +71,10 @@ def get_gpu_kernel_time(m, x, trace_filename=None):
     for _ in range(2):
         __ = m(x)
 
+    device = torch.accelerator.current_accelerator().type
+
     # capture a profiling run
-    if _DEVICE == "xpu":
+    if device == "xpu":
         activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
     else:
         activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
@@ -88,7 +83,7 @@ def get_gpu_kernel_time(m, x, trace_filename=None):
     with profile(activities=activities) as prof:
         for _ in range(n_iter):
             __ = m(x)
-            torch_accelerator.synchronize()
+            torch.accelerator.synchronize()
 
     # save a trace, if requested
     if trace_filename is not None:
@@ -111,7 +106,7 @@ def get_gemm_times(
     fast_accum: bool,
     recipe_name: Optional[str],
 ):
-    device = torch.device(_DEVICE)
+    device = torch.accelerator.current_accelerator()
 
     # bf16 time
     x_bf16 = torch.randn(M, K, dtype=torch.bfloat16, device=device)
@@ -222,7 +217,7 @@ def get_conv_times(
 
     This measures only the conv kernel time itself, without quantization overhead.
     """
-    device = torch.device(_DEVICE)
+    device = torch.accelerator.current_accelerator()
 
     # Create input tensors
     if op_name == "conv2d":
@@ -420,7 +415,7 @@ def _create_model_and_input(
     """
     Build the model and its corresponding input tensor for benchmarking.
     """
-    device = _DEVICE
+    device = torch.accelerator.current_accelerator()
 
     def _stack_layers_conv(
         core_layer: nn.Module, add_post_relu: bool = False
@@ -545,7 +540,7 @@ def run(
             "Expected kernel_size to be specified for conv3d"
         )
 
-    device = _DEVICE
+    device = torch.accelerator.current_accelerator().type
 
     if device == "xpu":
         assert recipe_name in (
@@ -559,8 +554,13 @@ def run(
                 "To skip fp8 conv benchmarking, set --do_benchmarks=False to run roofline model only."
             )
 
+    if device == "xpu":
+        gpu_name = torch.xpu.get_device_name(0)
+    else:
+        gpu_name = torch.cuda.get_device_name(0)
+
     config_table = [
-        ["GPU", torch_accelerator.get_device_name(0)],
+        ["GPU", gpu_name],
         ["torch version", torch.__version__],
         ["torchao version", torchao.__version__],
         ["recipe_name", recipe_name],

--- a/benchmarks/float8/float8_inference_roofline.py
+++ b/benchmarks/float8/float8_inference_roofline.py
@@ -60,6 +60,13 @@ from torchao.testing.training.roofline_utils import (
 )
 from torchao.utils import _is_mslk_available, is_MI300, is_sm_at_least_100
 
+_DEVICE = torch.accelerator.current_accelerator().type
+
+if _DEVICE == "xpu":
+    import torch.xpu as torch_accelerator
+else:
+    import torch.cuda as torch_accelerator
+
 # Import mslk.conv to register the fp8 conv operator
 if _is_mslk_available():
     import mslk.conv  # noqa: F401
@@ -72,12 +79,16 @@ def get_gpu_kernel_time(m, x, trace_filename=None):
         __ = m(x)
 
     # capture a profiling run
-    activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+    if _DEVICE == "xpu":
+        activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
+    else:
+        activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+
     n_iter = 5
     with profile(activities=activities) as prof:
         for _ in range(n_iter):
             __ = m(x)
-            torch.cuda.synchronize()
+            torch_accelerator.synchronize()
 
     # save a trace, if requested
     if trace_filename is not None:
@@ -100,7 +111,7 @@ def get_gemm_times(
     fast_accum: bool,
     recipe_name: Optional[str],
 ):
-    device = torch.device("cuda")
+    device = torch.device(_DEVICE)
 
     # bf16 time
     x_bf16 = torch.randn(M, K, dtype=torch.bfloat16, device=device)
@@ -139,7 +150,10 @@ def get_gemm_times(
             .t()
         )
 
-    if recipe_name == "rowwise":
+    if recipe_name == "tensorwise":
+        scale_a = torch.tensor([1.0], device=device)
+        scale_b = torch.tensor([1.0], device=device)
+    elif recipe_name == "rowwise":
         scale_a = torch.ones(M, 1, device=device)
         scale_b = torch.ones(1, N, device=device)
     elif recipe_name == "mxfp8_cublas":
@@ -208,7 +222,7 @@ def get_conv_times(
 
     This measures only the conv kernel time itself, without quantization overhead.
     """
-    device = torch.device("cuda")
+    device = torch.device(_DEVICE)
 
     # Create input tensors
     if op_name == "conv2d":
@@ -406,6 +420,7 @@ def _create_model_and_input(
     """
     Build the model and its corresponding input tensor for benchmarking.
     """
+    device = _DEVICE
 
     def _stack_layers_conv(
         core_layer: nn.Module, add_post_relu: bool = False
@@ -429,7 +444,7 @@ def _create_model_and_input(
         )
         memory_format = torch.channels_last
         x = torch.randn(
-            batch, in_channels, H, W, dtype=torch.bfloat16, device="cuda"
+            batch, in_channels, H, W, dtype=torch.bfloat16, device=device
         ).to(memory_format=memory_format)
         m_orig = _stack_layers_conv(core_layer)
     elif op_name == "conv3d":
@@ -443,7 +458,7 @@ def _create_model_and_input(
         )
         memory_format = torch.channels_last_3d
         x = torch.randn(
-            batch, in_channels, D, H, W, dtype=torch.bfloat16, device="cuda"
+            batch, in_channels, D, H, W, dtype=torch.bfloat16, device=device
         ).to(memory_format=memory_format)
         m_orig = _stack_layers_conv(core_layer)
     else:
@@ -455,12 +470,12 @@ def _create_model_and_input(
             )
         memory_format = None
         x = torch.randn(
-            batch, in_channels, dtype=torch.bfloat16, device="cuda"
+            batch, in_channels, dtype=torch.bfloat16, device=device
         ).requires_grad_()
 
     if memory_format is not None:
         m_orig = m_orig.to(memory_format=memory_format)
-    m_orig = m_orig.cuda().bfloat16()
+    m_orig = m_orig.to(device).bfloat16()
 
     return m_orig, x
 
@@ -530,8 +545,22 @@ def run(
             "Expected kernel_size to be specified for conv3d"
         )
 
+    device = _DEVICE
+
+    if device == "xpu":
+        assert recipe_name in (
+            "tensorwise",
+            "rowwise",
+        ), "Currently only tensorwise and rowwise quantization are supported on XPU."
+
+        if op_name in ("conv2d", "conv3d") and do_benchmarks:
+            raise NotImplementedError(
+                "FP8 convolution benchmarking is not yet implemented for XPU. "
+                "To skip fp8 conv benchmarking, set --do_benchmarks=False to run roofline model only."
+            )
+
     config_table = [
-        ["GPU", torch.cuda.get_device_name(0)],
+        ["GPU", torch_accelerator.get_device_name(0)],
         ["torch version", torch.__version__],
         ["torchao version", torchao.__version__],
         ["recipe_name", recipe_name],
@@ -733,7 +762,11 @@ def run(
         b_bf16_e2e_time_s, b_fp8_e2e_time_s = 0, 0
 
         if do_benchmarks:
-            if op_name in ("conv2d", "conv3d") and not is_sm_at_least_100():
+            if (
+                device == "cuda"
+                and op_name in ("conv2d", "conv3d")
+                and not is_sm_at_least_100()
+            ):
                 print(
                     f"WARNING: Skipping {op_name} benchmarks for shape ({M_val}, {K_val}, {N_val}). "
                     f"Float8 convolution requires SM 10.0+ (Blackwell/B100 GPUs). "
@@ -815,7 +848,7 @@ def run(
                     # this benchmark is performance-only, so a toy datum is fine
                     quantize_(m_fp8_dyn, config_calib)
                     toy_datum = torch.randn(
-                        M_val, K_val, dtype=torch.bfloat16, device="cuda"
+                        M_val, K_val, dtype=torch.bfloat16, device=device
                     )
                     m_fp8_dyn(toy_datum)
 

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -72,13 +72,6 @@ from torchao.testing.training.roofline_utils import (
 )
 from torchao.utils import is_MI300, round_up
 
-_DEVICE = torch.accelerator.current_accelerator().type
-
-if _DEVICE == "xpu":
-    import torch.xpu as torch_accelerator
-else:
-    import torch.cuda as torch_accelerator
-
 
 class LNLinearSigmoid(torch.nn.Module):
     def __init__(self, fc_dim1, fc_dim2):
@@ -100,8 +93,10 @@ def get_gpu_kernel_time(m, x, grad_output):
         y = m(x)
         y.backward(grad_output)
 
+    device = torch.accelerator.current_accelerator().type
+
     # capture a profiling run
-    if _DEVICE == "xpu":
+    if device == "xpu":
         activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
     else:
         activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
@@ -111,7 +106,7 @@ def get_gpu_kernel_time(m, x, grad_output):
         for _ in range(n_iter):
             y = m(x)
             y.backward(grad_output)
-            torch_accelerator.synchronize()
+            torch.accelerator.synchronize()
     # get the gpu kernel time and aggregate it
     num_leaf_tensors = 1 + len(list(m.parameters()))
     ref_times = profiler_output_to_filtered_time_by_kernel_name(
@@ -156,7 +151,7 @@ def get_gemm_times(
     if key in cache:
         return cache[key]
 
-    device = torch.device(_DEVICE)
+    device = torch.accelerator.current_accelerator()
 
     # bf16 time
     x_bf16 = torch.randn(M, K, dtype=torch.bfloat16, device=device)
@@ -250,7 +245,7 @@ def run(
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
     """
-    device = _DEVICE
+    device = torch.accelerator.current_accelerator().type
 
     assert not ((float8_recipe_name is not None) and (mx_recipe_name is not None)), (
         "unsupported"
@@ -258,7 +253,12 @@ def run(
     if float8_recipe_name is None and mx_recipe_name is None:
         float8_recipe_name = "tensorwise"
 
-    print(f"GPU: {torch_accelerator.get_device_name(0)}")
+    if device == "xpu":
+        gpu_name = torch.xpu.get_device_name(0)
+    else:
+        gpu_name = torch.cuda.get_device_name(0)
+
+    print(f"GPU: {gpu_name}")
     print(f"torch version: {torch.__version__}")
     print(f"torchao version: {torchao.__version__}")
     print(f"do_benchmarks: {do_benchmarks}")

--- a/benchmarks/float8/float8_roofline.py
+++ b/benchmarks/float8/float8_roofline.py
@@ -72,6 +72,13 @@ from torchao.testing.training.roofline_utils import (
 )
 from torchao.utils import is_MI300, round_up
 
+_DEVICE = torch.accelerator.current_accelerator().type
+
+if _DEVICE == "xpu":
+    import torch.xpu as torch_accelerator
+else:
+    import torch.cuda as torch_accelerator
+
 
 class LNLinearSigmoid(torch.nn.Module):
     def __init__(self, fc_dim1, fc_dim2):
@@ -94,13 +101,17 @@ def get_gpu_kernel_time(m, x, grad_output):
         y.backward(grad_output)
 
     # capture a profiling run
-    activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+    if _DEVICE == "xpu":
+        activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
+    else:
+        activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+
     n_iter = 5
     with profile(activities=activities) as prof:
         for _ in range(n_iter):
             y = m(x)
             y.backward(grad_output)
-            torch.cuda.synchronize()
+            torch_accelerator.synchronize()
     # get the gpu kernel time and aggregate it
     num_leaf_tensors = 1 + len(list(m.parameters()))
     ref_times = profiler_output_to_filtered_time_by_kernel_name(
@@ -145,7 +156,7 @@ def get_gemm_times(
     if key in cache:
         return cache[key]
 
-    device = torch.device("cuda")
+    device = torch.device(_DEVICE)
 
     # bf16 time
     x_bf16 = torch.randn(M, K, dtype=torch.bfloat16, device=device)
@@ -239,6 +250,7 @@ def run(
     * `mx_recipe_name (optional)`: MX format recipe
     * `enable_fusion_modeling`: if False uses Linear, if True uses LNLinearSigmoid and models the fusion of float8 overhead
     """
+    device = _DEVICE
 
     assert not ((float8_recipe_name is not None) and (mx_recipe_name is not None)), (
         "unsupported"
@@ -246,7 +258,7 @@ def run(
     if float8_recipe_name is None and mx_recipe_name is None:
         float8_recipe_name = "tensorwise"
 
-    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"GPU: {torch_accelerator.get_device_name(0)}")
     print(f"torch version: {torch.__version__}")
     print(f"torchao version: {torchao.__version__}")
     print(f"do_benchmarks: {do_benchmarks}")
@@ -254,6 +266,9 @@ def run(
     print(f"float8_recipe_name: {float8_recipe_name}")
     print(f"mx_recipe_name: {mx_recipe_name}")
     print(f"enable_fusion_modeling: {enable_fusion_modeling}")
+
+    if device == "xpu" and mx_recipe_name is not None:
+        raise NotImplementedError("MXFP8TrainingRecipe is not supported on XPU yet")
 
     assert mx_recipe_name in (
         None,
@@ -402,17 +417,19 @@ def run(
         if do_benchmarks:
             # create the model
             if enable_fusion_modeling:
-                m_orig = LNLinearSigmoid(K_val, N_val).cuda().bfloat16()
+                m_orig = LNLinearSigmoid(K_val, N_val).to(device).bfloat16()
             else:
                 m_orig = (
-                    nn.Sequential(nn.Linear(K_val, N_val, bias=False)).cuda().bfloat16()
+                    nn.Sequential(nn.Linear(K_val, N_val, bias=False))
+                    .to(device)
+                    .bfloat16()
                 )
             x = torch.randn(
-                M_val, K_val, dtype=torch.bfloat16, device="cuda"
+                M_val, K_val, dtype=torch.bfloat16, device=device
             ).requires_grad_()
 
             # get the gradient of the right shape
-            grad_output = torch.randn(M_val, N_val, dtype=torch.bfloat16, device="cuda")
+            grad_output = torch.randn(M_val, N_val, dtype=torch.bfloat16, device=device)
 
             # get the bf16 gpu kernel time
             torch._dynamo.reset()

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -456,7 +456,14 @@ def get_gpu_kernel_conv_time_s(f, *args, **kwargs):
     # warmup
     f(*args, **kwargs)
     n_iter = 5
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+
+    device = args[0].device.type
+    if device == "xpu":
+        activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
+    else:
+        activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+
+    with profile(activities=activities) as prof:
         for idx in range(n_iter):
             f(*args, **kwargs)
     data = profiler_output_to_filtered_time_by_kernel_name(
@@ -468,6 +475,7 @@ def get_gpu_kernel_conv_time_s(f, *args, **kwargs):
         "aten::conv2d",
         "aten::conv3d",
         "aten::convolution",
+        "aten::convolution_overrideable",
         "aten::cudnn_convolution",
         "aten::slow_conv_dilated2d",
         "aten::slow_conv_dilated3d",

--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -87,6 +87,9 @@ def profiler_output_to_filtered_time_by_kernel_name(
             continue
         elif e.key in ("cudaDeviceSynchronize", "hipDeviceSynchronize"):
             continue
+        elif e.key == "zeCommandListHostSynchronize":
+            # Level Zero (Intel XPU) host-side synchronization
+            continue
         elif e.key == "Activity Buffer Request":
             continue
         elif e.key == "Unrecognized":
@@ -423,7 +426,14 @@ def get_gpu_kernel_gemm_time_s(f, *args, **kwargs):
     # warmup
     f(*args, **kwargs)
     n_iter = 5
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+
+    device = args[0].device.type
+    if device == "xpu":
+        activities = [ProfilerActivity.CPU, ProfilerActivity.XPU]
+    else:
+        activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+
+    with profile(activities=activities) as prof:
         for idx in range(n_iter):
             f(*args, **kwargs)
     data = profiler_output_to_filtered_time_by_kernel_name(

--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -98,6 +98,7 @@ gpu_name_to_specs = {
     "Intel(R) Arc(TM) B580 Graphics": {
         # https://www.intel.com/content/www/us/en/products/sku/241598/intel-arc-b580-graphics/specifications.html
         "bf16_peak_tops": 116.5e12,
+        # Same as bf16, since Intel Arc B580 does not support float8
         "fp8_peak_tops": 116.5e12,
         "peak_mem_bw_bytes_sec": 456e9,
         # From measurement on hardware

--- a/torchao/testing/training/roofline_utils.py
+++ b/torchao/testing/training/roofline_utils.py
@@ -95,13 +95,27 @@ gpu_name_to_specs = {
         "fp4_peak_tops": 1676e12,
         "peak_mem_bw_bytes_sec": 1.792e15,
     },
+    "Intel(R) Arc(TM) B580 Graphics": {
+        # https://www.intel.com/content/www/us/en/products/sku/241598/intel-arc-b580-graphics/specifications.html
+        "bf16_peak_tops": 116.5e12,
+        "fp8_peak_tops": 116.5e12,
+        "peak_mem_bw_bytes_sec": 456e9,
+        # From measurement on hardware
+        "pct_achievable_gemm_tops": 0.915,
+        # From measurement on hardware
+        "pct_achievable_mem_bw": 0.871,
+    },
     # TODO(future): more GPU names
 }
 
 
 def get_roofline_gpu_name(gpu_name: Optional[str] = None):
     if gpu_name is None:
-        gpu_name = torch.cuda.get_device_name(0)
+        device = torch.accelerator.current_accelerator().type
+        if device == "xpu":
+            gpu_name = torch.xpu.get_device_name(0)
+        else:
+            gpu_name = torch.cuda.get_device_name(0)
     if gpu_name in gpu_name_to_specs:
         return gpu_name
     for known_gpu_name in gpu_name_to_specs:


### PR DESCRIPTION
## Summary

Enable a subset of benchmarks/float8/ scripts to run on **Intel GPU (XPU)** via the `torch.accelerator` API. CUDA behavior unchanged.

- Device-agnostic selection (`torch.accelerator` instead of hardcoded `"cuda"`); `torch_accelerator` alias for `synchronize()` / `get_device_name()`.
- XPU profiler activity (`ProfilerActivity.XPU`) + Level Zero sync-event filtering;
- Added **Intel Arc B580** spec to `roofline_utils.py`; `get_roofline_gpu_name()` now resolves XPU device names.
- XPU guardrails: restrict recipes to `tensorwise`/`rowwise`; `NotImplementedError` for MX recipes and fp8 conv (not yet supported); skip the SM-100 conv check on non-CUDA.
- Fix: add missing `tensorwise` scale branch in `get_gemm_times()` (inference roofline).

## Test plan

Same commands for both backends; CUDA output unchanged:
```bash
python benchmarks/float8/bench_matmul.py --shape_gen_name llama
python benchmarks/float8/bench_matmul.py --recipe rowwise --shape_gen_name llama
python benchmarks/float8/float8_roofline.py results_tensorwise.csv --float8_recipe_name tensorwise --n_limit 1
python benchmarks/float8/float8_inference_roofline.py --recipe_name tensorwise --n_limit 1
python benchmarks/float8/float8_inference_roofline.py --recipe_name rowwise --do_benchmarks False --shape_gen_name llama
```