### PR TITLE
Skip output observer when output qspec is None (weight-only PTQ)

### DIFF
--- a/torchao/quantization/pt2e/prepare.py
+++ b/torchao/quantization/pt2e/prepare.py
@@ -618,6 +618,13 @@ def _maybe_insert_output_observer_for_node(
 ) -> Optional[Node]:
     if node in obs_or_fq_map:
         output_act_obs_or_fq = obs_or_fq_map[node]
+        # A None observer means this output is intentionally left unquantized
+        # (e.g. weight-only PTQ recipes that set output_activation=None). Mirror
+        # the input-edge handling in
+        # _maybe_insert_input_observer_for_arg_or_kwarg and skip insertion rather
+        # than crashing inside _insert_obs_or_fq on `None.to(model_device)`.
+        if output_act_obs_or_fq is None:
+            return None
         # TODO: pass in model_device here after https://github.com/pytorch/pytorch/pull/159901
         new_output = _insert_obs_or_fq(
             node, output_act_obs_or_fq, model, named_modules, graph


### PR DESCRIPTION
Summary:
torchao PT2E `prepare` inserts an output activation observer for any node that produces an output, even when that node's output qspec is None. Weight-only PTQ -- int8 weights with fp32 (un-quantized) activations -- sets the output/activation qspec to None, so the spurious observer broke weight-only quantization. This skips inserting the output observer when the output qspec is None.

Required by the `cascade_detector_ceres_u55_w8_only` recipe (D108781360), which isolates the weight-quant contribution of the grip-force int8 collapse.

Differential Revision: D108781362


