### PR TITLE
[test][xpu] Device agnostic test_config.py, test_model_architecture.py and test_utils.py

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -23,4 +23,7 @@ pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py 
         torchao/test/float8/ \
         torchao/test/integration/test_integration.py \
         torchao/test/prototype/ \
-        torchao/test/quantization/quantize_/workflows/
+        torchao/test/quantization/quantize_/workflows/ \
+        torchao/test/core/test_config.py \
+        torchao/test/test_model_architecture.py \
+        torchao/test/test_utils.py

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import torch
 import torch.nn.functional as F
 
-from torchao.testing.utils import skip_if_no_cuda
 from torchao.utils import TorchAOBaseTensor, torch_version_at_least
 
 
@@ -128,14 +127,15 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         self.assertTrue(torch.equal(lp_tensor.qdata, reconstructed.qdata))
         self.assertEqual(lp_tensor.attr, reconstructed.attr)
 
+        device = torch.accelerator.current_accelerator()
         # test _get_to_kwargs
-        _ = lp_tensor._get_to_kwargs(torch.strided, device="cuda")
-        _ = lp_tensor._get_to_kwargs(layout=torch.strided, device="cuda")
+        _ = lp_tensor._get_to_kwargs(torch.strided, device=device)
+        _ = lp_tensor._get_to_kwargs(layout=torch.strided, device=device)
 
         # `to` / `_to_copy`
         original_device = lp_tensor.device
-        lp_tensor = lp_tensor.to("cuda")
-        self.assertEqual(lp_tensor.device.type, "cuda")
+        lp_tensor = lp_tensor.to(device)
+        self.assertEqual(lp_tensor.device.type, device.type)
         lp_tensor = lp_tensor.to(original_device)
         self.assertEqual(lp_tensor.device, original_device)
 
@@ -218,7 +218,7 @@ class TestTorchAOBaseTensor(unittest.TestCase):
                 getattr(lp_tensor, tensor_attribute_name),
             )
 
-    @skip_if_no_cuda()
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need CUDA available")
     def test_default_impls(self):
         """Making sure some common functions has default implementations, such as
         __tensor_unflatten__, __tensor_flatten__, _apply_fn_to_data, __repr__, to
@@ -248,7 +248,7 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         lp_tensor_for_copy = MyTensor(another_tensor, "attr", None)
         self._test_default_impls_helper(lp_tensor, lp_tensor_for_copy)
 
-    @skip_if_no_cuda()
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_default_impls_with_optional_data(self):
         class MyTensorWithOptionalData(TorchAOBaseTensor):
             tensor_data_names = ["qdata"]
@@ -285,7 +285,7 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         )
         self._test_default_impls_helper(lp_tensor, lp_tensor_for_copy)
 
-    @skip_if_no_cuda()
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_default_impls_with_optional_attr(self):
         class MyTensorWithOptionalData(TorchAOBaseTensor):
             tensor_data_names = ["qdata"]


### PR DESCRIPTION
This PR is target to device agnostic test_utils.py and add test_config.py, test_model_architecture.py and test_utils.py in intel GPU CI