### PR TITLE
test: skip semi-structured sparse test on pre-Ampere GPUs

### DIFF
--- a/test/sparsity/test_sparse_api.py
+++ b/test/sparsity/test_sparse_api.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 from torch import nn
 from torch.testing._internal import common_utils
+from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_utils import skipIfRocmVersionLessThan
 
 from torchao.sparsity import apply_fake_sparsity, semi_sparse_weight, sparsify_
@@ -21,6 +22,7 @@ logging.basicConfig(
 
 class TestSemiStructuredSparse(common_utils.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(not SM80OrLater, "Need Ampere or newer (SM 8.0+) for 2:4 sparsity")
     @skipIfRocmVersionLessThan((7, 0))
     def test_sparse(self):
         if not torch.backends.cusparselt.is_available():


### PR DESCRIPTION
## What

Adds a compute-capability skip to `TestSemiStructuredSparse.test_sparse` so it skips on GPUs older than Ampere (SM < 8.0) instead of failing with a CUDA runtime error.

Uses the existing `SM80OrLater` helper from `torch.testing._internal.common_cuda` to stay consistent with how the rest of the PyTorch test suite gates Ampere-only features.

## Why

`torch.backends.cusparselt.is_available()` only checks that the cuSPARSELt library is loadable and that PyTorch was built against it. It does **not** check whether the current GPU's architecture supports 2:4 sparse tensor cores. As a result, on Turing (SM 7.5) the test passes the existing skip guards, then hard-fails when `cusparseLtInit` is called.

2:4 semi-structured sparsity requires Ampere or newer (SM 8.0+).

## Repro

Running `pytest test/sparsity/test_sparse_api.py::TestSemiStructuredSparse::test_sparse` on a Turing GPU (e.g. T4, RTX 20-series) produces: `RuntimeError: CUDA error: architecture mismatch when calling cusparseLtInit(&handle)`


Full traceback originates from `torch/sparse/semi_structured.py` → `torch._cslt_compress(original_tensor)`.

## Test plan

- [x] Ran locally on a Turing GPU — test now skips cleanly instead of erroring.
- [ ] CI will verify the test still runs (and passes) on Ampere/Hopper runners.

No behavior change on supported hardware; this is a test-only change.