### PR TITLE
test: skip int8/bf16 integration tests on pre-Ampere GPUs

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -18,6 +18,7 @@ from parameterized import parameterized
 from torch._dynamo import config
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
+from torch.testing._internal.common_cuda import SM80OrLater
 
 import torchao
 from torchao.quantization import safe_int_mm
@@ -293,6 +294,7 @@ class PythonQuantUtilOpUnitTest(unittest.TestCase):
         torch.testing.assert_close(y_ref, y_opt, atol=0, rtol=0)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @unittest.skipIf(not SM80OrLater, "Need Ampere or newer (SM 8.0+)")
     def test__int_mm_eager_and_torch_compile_numerics(self):
         def __int_mm_ref(x, w):
             x = x.cpu().to(torch.int32)
@@ -881,6 +883,7 @@ class TestBenchmarkModel(unittest.TestCase):
         return benchmark_model(m_bf16, num_runs, example_inputs)
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
+    @unittest.skipIf(not SM80OrLater, "Need Ampere or newer (SM 8.0+)")
     def test_benchmark_model_cuda(self):
         device = get_current_accelerator_device()
         assert self.run_benchmark_model(device) is not None


### PR DESCRIPTION
## What

Adds two `SM80OrLater` skip decorators to tests in `test/integration/test_integration.py` that fail on pre-Ampere CUDA hardware:

1. `test__int_mm_eager_and_torch_compile_numerics` — uses `torch._int_mm`, which requires int8 tensor cores (Ampere+).
2. `test_benchmark_model_cuda` — compiles a bfloat16 model with `torch.compile`, but bf16 compilation requires Ampere+ (Inductor itself emits `SkipFrame: BF16 is not supported` and warns explicitly).

Uses the existing `SM80OrLater` helper from `torch.testing._internal.common_cuda` for consistency with how the rest of the PyTorch test suite gates Ampere-only features.

## Why

Both tests have always required Ampere features, but the existing skip guards only check `torch.cuda.is_available()` — they don't check compute capability. As a result, on pre-Ampere CUDA hardware (Turing, Volta, Pascal) they hard-fail instead of skipping cleanly.

### Reproduction

Running on a **GTX 1650 (Turing, SM 7.5)** without these skips:

**`test__int_mm_eager_and_torch_compile_numerics`:**

```
RuntimeError: CUDA error: CUBLAS_STATUS_NOT_SUPPORTED when calling cublasLtMatmul
  with ... abType 3 cType 10 computeType 72 scaleType 10
```

Root cause: `_int_mm` (int8 × int8 → int32) requires tensor cores, which the GTX 16-series lacks.

**`test_benchmark_model_cuda`:**

```
torch._inductor.exc.InductorError: SkipFrame: BF16 is not supported
UserWarning: NVIDIA GeForce GTX 1650 does not support bfloat16 compilation natively
```

Root cause: bf16 compilation requires SM 8.0+.

## Bonus: also transitively fixes downstream test pollution

Skipping `test__int_mm_eager_and_torch_compile_numerics` **also fixes** `test_int8_weight_only_quant_subclass_api_3` and `_4`, which were previously failing with:

```
AssertionError at torch/_inductor/cudagraph_trees.py:2648
    assert len(node.tensor_weakrefs) == len(node.stack_traces)
```

These tests are **not actually broken** on pre-Ampere hardware. Verified empirically by running them in isolation:

```bash
pytest test/integration/test_integration.py::TestSubclass::test_int8_weight_only_quant_subclass_api_3 -v
# 1 passed

pytest test/integration/test_integration.py::TestSubclass::test_int8_weight_only_quant_subclass_api_4 -v
# 1 passed
```

**Reviewer note:** I did not add explicit skips on `_3` and `_4` because they do pass on pre-Ampere hardware when not poisoned by an earlier failure.

## Test plan

- [x] Ran full `pytest test/integration -v` locally on a GTX 1650 — all four previously-failing tests now either skip cleanly or pass.
- [x] Verified `_3` and `_4` pass in isolation (proving they're not actually broken on Turing).
- [x] CPU variants (`_0_cpu`, `_1_cpu`, `_2_cpu`) continue to pass unaffected.
- [x] CI will verify that the gated tests still run (and pass) on Ampere/Hopper runners.

No behavior change on supported hardware; this is a test-only change.
