### PR TITLE
[xpu][benchmarks] Enable microbenchmarks for Intel XPU

### DIFF
--- a/benchmarks/microbenchmarks/benchmark_inference.py
+++ b/benchmarks/microbenchmarks/benchmark_inference.py
@@ -1,0 +1,279 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Inference benchmark runner
+
+This script runs inference benchmarks and generates a micro-benchmarking report for it.
+- run() function is the main entry point for running inference benchmarks.
+"""
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+
+from benchmarks.microbenchmarks.profiler import (
+    generate_memory_profile,
+    generate_model_profile,
+    visualize_memory_profile,
+)
+from benchmarks.microbenchmarks.utils import (
+    BenchmarkConfig,
+    BenchmarkResult,
+    clean_caches,
+    model_inference_time_in_ms,
+    string_to_config,
+)
+from torchao.quantization import quantize_
+from torchao.sparsity.sparse_api import sparsify_
+from torchao.testing.model_architectures import (
+    create_model_and_input_data,
+)
+
+# -----------------------------------------------------------------------------
+# Baseline caching
+#
+# ``_BASELINE_CACHE`` maps a unique key constructed using _make_cache_key(config) -> (model_type, m, k, n, high_precision_dtype, device, torch_compile_mode) to a tuple
+# ``(eager_baseline_time, compile_baseline_time)``.  See ``_make_cache_key`` for the key
+# construction.  Users should not access this cache directly; it is
+# internal to this module.
+# Eg: (linear, 1024, 1024, 1024, torch.bfloat16, cuda, default) -> (95.00, 56.00)
+# The cache is used to store the baseline inference time for a given configuration, which is further used to calculate speedup metrics.
+# This helps in removing multiple baseline calculations, which in turn helps in reducing the benchmarking time.
+# -----------------------------------------------------------------------------
+
+_BASELINE_CACHE: Dict[Tuple, Tuple[float, float]] = {}
+
+
+def _make_cache_key(config: BenchmarkConfig) -> Tuple:
+    """Create a key for caching based on benchmark configuration.
+
+    Parameters that affect baseline performance are included:
+
+    * model type (e.g. ``linear`` or ``transformer_block``)
+    * shape dimensions (m, k, n)
+    * high precision dtype (bf16, fp16, etc.)
+    * device (cuda, cpu, mps)
+    * compile settings (whether compile is enabled and compile mode)
+
+    Sparsity and quantization settings are deliberately excluded
+    because the baseline (non‑quantized, non‑sparse) performance is
+    independent of those attributes.
+    """
+    return (
+        config.model_type,
+        config.m,
+        config.k,
+        config.n,
+        config.high_precision_dtype,
+        config.device,
+        config.torch_compile_mode,
+    )
+
+
+def run(config: BenchmarkConfig) -> BenchmarkResult:
+    """
+    Run inference benchmarks.
+
+    The function first checks if a baseline for the given configuration
+    already exists in the internal cache.  If not, it measures the baseline
+    inference time and stores the result.  When the baseline is cached,
+    the function reuses the cached baselines to calculate speedup metrics.
+
+    Args:
+        config (BenchmarkConfig): Benchmark configuration.
+
+    Returns:
+        BenchmarkResult: Result of the benchmark.
+    """
+    try:
+        clean_caches()  # Clean caches
+
+        # Create output directory if it doesn't exist
+        Path(config.output_dir).mkdir(parents=True, exist_ok=True)
+
+        # Prepare result container
+        result = BenchmarkResult(config=config)
+
+        # Create model and input data
+        base_model, input_data = create_model_and_input_data(
+            config.model_type,
+            config.m,
+            config.k,
+            config.n,
+            high_precision_dtype=config.high_precision_dtype,
+            device=config.device,
+        )
+
+        # Generate a cache key for the current configuration
+        cache_key = _make_cache_key(config)
+
+        # Check if the baseline for this configuration has been computed
+        if cache_key not in _BASELINE_CACHE:
+            # Switch model to eval and move to device
+            m_copy = deepcopy(base_model)
+            m_copy = m_copy.eval().to(config.device)
+            print("Benchmarking eager baseline inference.....")
+            eager_baseline_time = model_inference_time_in_ms(
+                model=m_copy, input_data=input_data
+            )
+
+            print("Benchmarking compile baseline inference.....")
+            m_copy = torch.compile(
+                m_copy, mode=config.torch_compile_mode, fullgraph=True
+            )
+            compile_baseline_time = model_inference_time_in_ms(
+                model=m_copy, input_data=input_data
+            )
+
+            # Store uncompiled model, input and baseline time
+            _BASELINE_CACHE[cache_key] = (eager_baseline_time, compile_baseline_time)
+
+            result.baseline_model_eager_inference_time_in_ms = eager_baseline_time
+            result.baseline_model_compiled_inference_time_in_ms = compile_baseline_time
+        else:
+            # Retrieve cached values
+            cached_eager_time, cached_compile_time = _BASELINE_CACHE[cache_key]
+            result.baseline_model_eager_inference_time_in_ms = cached_eager_time
+            result.baseline_model_compiled_inference_time_in_ms = cached_compile_time
+
+        # At this point, ``base_model`` is an uncompiled model ready for quantization,
+        # and ``input_data`` is the corresponding input tensor.  The baseline time
+        # has been stored in ``result.baseline_inference_time_in_ms``.
+
+        # Copy base model for quantizing/sparsifying
+        m_copy = deepcopy(base_model)
+
+        # Determine quantization/sparsity configuration
+        ao_base_config = string_to_config(
+            config.quantization,
+            config.sparsity,
+            high_precision_dtype=config.high_precision_dtype,
+        )
+
+        # Check if sparsity is requested and if the device is CUDA (sparsity operations require CUDA)
+        is_cuda = config.device == "cuda" and torch.cuda.is_available()
+        is_xpu = config.device == "xpu" and torch.xpu.is_available()
+
+        if config.sparsity is not None and (
+            config.quantization is None or "baseline" in config.quantization
+        ):
+            if is_cuda:
+                print(f"Applying {config.sparsity} sparsity to model")
+                sparsify_(m_copy, ao_base_config)
+            else:
+                print(
+                    f"Warning: Skipping {config.sparsity} sparsity as it requires CUDA, but device is {config.device}"
+                )
+        elif config.sparsity is None and (
+            config.quantization is None or "baseline" in config.quantization
+        ):
+            pass  # No quantization or sparsity specified, do nothing
+        else:
+            print("Quantizing model....")
+            m_copy = m_copy.eval().to(config.device)
+            quantize_(m_copy, ao_base_config)
+
+        # Store result in model for memory profiling
+        m_copy._benchmark_result = result
+
+        # Measure inference time for quantized model
+        print("Benchmarking eager quantized model.....")
+        result.quantized_model_eager_inference_time_in_ms = model_inference_time_in_ms(
+            model=m_copy, input_data=input_data
+        )
+
+        # Measure inference time for compiled quantized model
+        print("Benchmarking quantized model.....")
+        m_copy = torch.compile(m_copy, mode=config.torch_compile_mode, fullgraph=True)
+        result.quantized_model_compiled_inference_time_in_ms = (
+            model_inference_time_in_ms(model=m_copy, input_data=input_data)
+        )
+
+        # Compute eager speedup relative to baseline
+        result.eager_speedup_on_baseline = round(
+            result.baseline_model_eager_inference_time_in_ms
+            / result.quantized_model_eager_inference_time_in_ms,
+            ndigits=2,
+        )
+        # Compute compile speedup relative to baseline
+        result.compile_speedup_on_baseline = round(
+            result.baseline_model_compiled_inference_time_in_ms
+            / result.quantized_model_compiled_inference_time_in_ms,
+            ndigits=2,
+        )
+        # Compute compile speedup for quantized model relative to eager quantized model
+        result.compile_speedup_on_eager = round(
+            result.quantized_model_eager_inference_time_in_ms
+            / result.quantized_model_compiled_inference_time_in_ms,
+            ndigits=2,
+        )
+
+        # Run profiler if enabled
+        if config.enable_profiler:
+            print("Running profiler...")
+            try:
+                profiler_json_path = generate_model_profile(
+                    model=m_copy,
+                    input_data=input_data,
+                    profile_file_path=os.path.join(
+                        config.output_dir,
+                        "profiler",
+                        f"{config._file_name}_profile.json",
+                    ),
+                )
+                result.profiler_json_path = profiler_json_path
+            except Exception as e:
+                print(f"Error running profiler: {e}")
+
+        # Run memory profiler if enabled
+        if config.enable_memory_profiler:
+            print("Running memory profiler...")
+            try:
+                # Create memory profiler directory if it doesn't exist
+                memory_profiler_dir = os.path.join(
+                    config.output_dir, "memory_profiler/pickle"
+                )
+                os.makedirs(memory_profiler_dir, exist_ok=True)
+
+                # Save memory profile with .pickle extension
+                result.memory_profile_path, result.memory_stats = (
+                    generate_memory_profile(
+                        model=m_copy,
+                        input_data=input_data,
+                        profile_file_path=os.path.join(
+                            memory_profiler_dir,
+                            f"{config._file_name}_memory_profile.pickle",
+                        ),
+                    )
+                )
+
+                if result.memory_profile_path:
+                    if is_xpu:
+                        print(
+                            "Memory visualization is currently not supported for XPU. Skipping visualization step."
+                        )
+                    else:
+                        result.memory_visualization_path = visualize_memory_profile(
+                            result.memory_profile_path
+                        )
+            except ValueError as e:
+                if "not enough values to unpack" in str(e):
+                    print(
+                        "Failed due to existing bugs, re‑run the code to generate memory profile. Please raise an issue if it persists."
+                    )
+            except Exception as e:
+                print(f"Error running memory profiler: {e}")
+                import traceback
+
+                traceback.print_exc()
+
+        return result
+    except Exception as e:
+        print(f"Error in benchmark run: {config.name} with error: {e}")
+        return None

--- a/benchmarks/microbenchmarks/profiler.py
+++ b/benchmarks/microbenchmarks/profiler.py
@@ -79,7 +79,7 @@ def generate_model_profile(model, input_data, profile_file_path):
 
 
 def generate_memory_profile(model, input_data, profile_file_path):
-    """Function to generate CUDA memory profile.
+    """Function to generate CUDA/XPU memory profile.
 
     Args:
         model: The model to profile
@@ -92,11 +92,11 @@ def generate_memory_profile(model, input_data, profile_file_path):
     if torch.cuda.is_available():
         import torch.cuda as torch_accelerator
 
-        record_memory_enabled = None
+        record_memory_enabled = False
     elif torch.xpu.is_available():
         import torch.xpu as torch_accelerator
 
-        record_memory_enabled = False
+        record_memory_enabled = None
     else:
         print(
             "Warning: CUDA or XPU is not available. Memory profiling requires CUDA or XPU."

--- a/benchmarks/microbenchmarks/profiler.py
+++ b/benchmarks/microbenchmarks/profiler.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import pickle
+
+import torch
+from torch.profiler import ProfilerActivity
+
+
+def _validate_pickle_file(file_path):
+    """Validate if the pickle file is valid and can be read."""
+    try:
+        with open(file_path, "rb") as f:
+            pickle.load(f)
+    except (pickle.UnpicklingError, FileNotFoundError, EOFError) as e:
+        print(f"Error: Pickle file {file_path} is invalid or cannot be read. {e}")
+        return False
+    return True
+
+
+def generate_model_profile(model, input_data, profile_file_path):
+    """Function to benchmark model evaluation with profiling.
+
+    Args:
+        model: The model to profile
+        input_data: Input data for the model
+        profile_file_path: Path to save the profiler output
+
+    Returns:
+        profile_file_path
+    """
+    # Create parent directory if it doesn't exist
+    os.makedirs(os.path.dirname(profile_file_path), exist_ok=True)
+
+    # Set up profiler activities based on device
+    activities = [ProfilerActivity.CPU]
+    device = next(model.parameters()).device
+    if device.type == "cuda" and torch.cuda.is_available():
+        activities.append(ProfilerActivity.CUDA)
+    if device.type == "xpu" and torch.xpu.is_available():
+        activities.append(ProfilerActivity.XPU)
+
+    # Warm up
+    with torch.no_grad():
+        for _ in range(3):
+            _ = model(input_data)
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            if device.type == "xpu":
+                torch.xpu.synchronize()
+
+    # Run profiler with minimal settings to ensure compatibility
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        with_stack=True,
+        profile_memory=True,
+        with_flops=True,  # Experimental; might be unreliable for some layers
+    ) as prof:
+        with torch.no_grad():
+            for _ in range(3):
+                _ = model(input_data)
+                if device.type == "cuda":
+                    torch.cuda.synchronize()
+                if device.type == "xpu":
+                    torch.xpu.synchronize()
+
+    # Save profiling details
+    prof.export_chrome_trace(profile_file_path)
+    print(f"Chrome trace saved at: {profile_file_path}")
+    print("You can now visualize it using:")
+    print("1. Chrome Trace Viewer: chrome://tracing")
+    print("2. Perfetto UI: https://ui.perfetto.dev")
+
+    return profile_file_path
+
+
+def generate_memory_profile(model, input_data, profile_file_path):
+    """Function to generate CUDA memory profile.
+
+    Args:
+        model: The model to profile
+        input_data: Input data for the model
+        profile_file_path: Path to save the memory profile (.pickle)
+
+    Returns:
+        str: Path to the saved profile file.
+    """
+    if torch.cuda.is_available():
+        import torch.cuda as torch_accelerator
+
+        record_memory_enabled = None
+    elif torch.xpu.is_available():
+        import torch.xpu as torch_accelerator
+
+        record_memory_enabled = False
+    else:
+        print(
+            "Warning: CUDA or XPU is not available. Memory profiling requires CUDA or XPU."
+        )
+        return None
+    if model is None or input_data is None:
+        raise ValueError("Model and input_data must not be None.")
+
+    # Create parent directory if it doesn't exist
+    os.makedirs(os.path.dirname(profile_file_path), exist_ok=True)
+    memory_stats = dict()
+
+    try:
+        torch_accelerator.empty_cache()
+        torch_accelerator.reset_peak_memory_stats()
+
+        # Reset memory history to ensure clean slate
+        torch_accelerator.memory._record_memory_history(enabled=record_memory_enabled)
+        torch_accelerator.memory._record_memory_history(max_entries=100000)
+        # Warm-up
+        with torch.no_grad():
+            for _ in range(3):
+                _ = model(input_data)
+                torch_accelerator.synchronize()
+
+        for i in range(5):
+            try:
+                # Reset again to avoid warm-up effects in final stats
+                torch_accelerator.reset_peak_memory_stats()
+                torch_accelerator.memory._record_memory_history(
+                    enabled=record_memory_enabled
+                )
+                torch_accelerator.memory._record_memory_history(max_entries=100000)
+
+                # Run actual profiled inference
+                with torch.no_grad():
+                    _ = model(input_data)
+                    torch_accelerator.synchronize()
+
+                # Take memory snapshot after inference and save to temporary pickle file
+                torch_accelerator.memory._dump_snapshot(profile_file_path)
+
+                if _validate_pickle_file(profile_file_path):
+                    print(f"Saved memory profile to {profile_file_path}")
+                    break
+            except ValueError as e:
+                import time
+
+                print(f"Attempt {i + 1}/5: {e}, retrying...")
+                time.sleep(3.0)
+
+        # Record memory stats
+        _memory_stats = torch_accelerator.memory_stats()
+        memory_stats = {
+            "allocated_bytes.all.peak": _memory_stats["allocated_bytes.all.peak"] / 1e6,
+            "active_bytes.all.peak": _memory_stats["active_bytes.all.peak"] / 1e6,
+            "reserved_bytes.all.peak": _memory_stats["reserved_bytes.all.peak"] / 1e6,
+        }
+
+    except Exception as e:
+        print(f"Error in memory profiling: {e}")
+
+    # Return the file path for consistency with other profiler functions
+    return profile_file_path, memory_stats
+
+
+def visualize_memory_profile(profile_file_path):
+    """Visualize memory profile using matplotlib.
+
+    Args:
+        profile_file_path: Path to the memory profile file (.pickle)
+
+    Returns:
+        str: Path to the visualization HTML file
+    """
+    # Create parent directory if it doesn't exist
+    memory_visualization_path = profile_file_path.replace("pickle", "html")
+    os.makedirs(os.path.dirname(memory_visualization_path), exist_ok=True)
+    try:
+        # For pickle files (from actual profiling), use torch's visualization
+        from torch.cuda._memory_viz import trace_plot
+
+        with open(profile_file_path, "rb") as f:
+            data = pickle.load(f)
+        with open(memory_visualization_path, "w") as f:
+            f.write(trace_plot(data))
+
+        print(f"Memory visualization saved to: {memory_visualization_path}")
+
+    except Exception as e:
+        print(
+            f"Error in generating visualization: {e}\n",
+            "To view the memory visualization, upload the pickle file to https://pytorch.org/memory_viz or run the following command to convert that to a html file:\n",
+            "python pytorch/torch/cuda/_memory_viz.py trace_plot <pickle file> -o <desired output name>.html",
+        )
+
+    return memory_visualization_path

--- a/benchmarks/microbenchmarks/test/test_benchmark_profiler.py
+++ b/benchmarks/microbenchmarks/test/test_benchmark_profiler.py
@@ -22,13 +22,6 @@ from benchmarks.microbenchmarks.utils import (
 )
 from torchao.testing.model_architectures import ToySingleLinearModel
 
-_DEVICE = torch.accelerator.current_accelerator().type
-
-if _DEVICE == "xpu":
-    import torch.xpu as torch_accelerator
-else:
-    import torch.cuda as torch_accelerator
-
 
 class TestBenchmarkProfiler(unittest.TestCase):
     def setUp(self):
@@ -36,16 +29,21 @@ class TestBenchmarkProfiler(unittest.TestCase):
         self.results_dir = os.path.join(self.test_dir, "results")
         os.makedirs(self.results_dir, exist_ok=True)
 
+        self.device = (
+            torch.accelerator.current_accelerator().type
+            if torch.accelerator.is_available()
+            else "cpu"
+        )
+
         # Set up a simple model and input for testing
         self.m, self.k, self.n = 1024, 1024, 1024
         self.dtype = torch.bfloat16
         self.model = ToySingleLinearModel(
-            input_dim=self.m, output_dim=self.n, dtype=self.dtype, device=_DEVICE
+            input_dim=self.m, output_dim=self.n, dtype=self.dtype, device=self.device
         )
         self.input_data = torch.randn(1, self.k, dtype=self.dtype)
 
         # Move to appropriate device
-        self.device = _DEVICE if torch_accelerator.is_available() else "cpu"
         self.model = self.model.to(self.device)
         self.input_data = self.input_data.to(self.device)
 
@@ -129,7 +127,7 @@ class TestBenchmarkProfiler(unittest.TestCase):
         self.assertIn("ts", event)  # Timestamp
         self.assertIn("pid", event)  # Process ID
 
-    @unittest.skipIf(not torch_accelerator.is_available(), "Accelerator not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Accelerator not available")
     def test_accelerator_profiling(self):
         """Test accelerator profiling when available"""
         config = BenchmarkConfig(
@@ -166,7 +164,7 @@ class TestBenchmarkProfiler(unittest.TestCase):
         ]
         self.assertGreater(len(accelerator_events), 0)
 
-    @unittest.skipIf(not torch_accelerator.is_available(), "Accelerator not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Accelerator not available")
     def test_memory_profiler_enabled(self):
         """Test that memory profiler works when enabled and Accelerator is available"""
         config = BenchmarkConfig(
@@ -256,6 +254,11 @@ class TestBenchmarkProfiler(unittest.TestCase):
     def test_memory_profiler_accelerator_unavailable(self):
         """Test memory profiler behavior when accelerator is not available"""
         # Save original torch_accelerator.is_available function
+        if torch.xpu.is_available():
+            import torch.xpu as torch_accelerator
+        else:
+            import torch.cuda as torch_accelerator
+
         original_is_available = torch_accelerator.is_available
 
         try:

--- a/benchmarks/microbenchmarks/test/test_benchmark_profiler.py
+++ b/benchmarks/microbenchmarks/test/test_benchmark_profiler.py
@@ -1,0 +1,300 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import pickle
+import unittest
+
+import torch
+import torch.cuda
+
+from benchmarks.microbenchmarks.profiler import (
+    generate_memory_profile,
+    generate_model_profile,
+    visualize_memory_profile,
+)
+from benchmarks.microbenchmarks.utils import (
+    BenchmarkConfig,
+)
+from torchao.testing.model_architectures import ToySingleLinearModel
+
+_DEVICE = torch.accelerator.current_accelerator().type
+
+if _DEVICE == "xpu":
+    import torch.xpu as torch_accelerator
+else:
+    import torch.cuda as torch_accelerator
+
+
+class TestBenchmarkProfiler(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.dirname(os.path.abspath(__file__))
+        self.results_dir = os.path.join(self.test_dir, "results")
+        os.makedirs(self.results_dir, exist_ok=True)
+
+        # Set up a simple model and input for testing
+        self.m, self.k, self.n = 1024, 1024, 1024
+        self.dtype = torch.bfloat16
+        self.model = ToySingleLinearModel(
+            input_dim=self.m, output_dim=self.n, dtype=self.dtype, device=_DEVICE
+        )
+        self.input_data = torch.randn(1, self.k, dtype=self.dtype)
+
+        # Move to appropriate device
+        self.device = _DEVICE if torch_accelerator.is_available() else "cpu"
+        self.model = self.model.to(self.device)
+        self.input_data = self.input_data.to(self.device)
+
+    def tearDown(self):
+        # Clean up any generated files
+        import shutil
+
+        if os.path.exists(self.results_dir):
+            shutil.rmtree(self.results_dir)
+
+    def test_profiler_enabled(self):
+        """Test that profiler works when enabled"""
+        config = BenchmarkConfig(
+            quantization=None,
+            sparsity=None,
+            params={
+                "enable_profiler": True,
+                "device": self.device,
+            },
+            shape_name="test",
+            shape=[self.m, self.k, self.n],
+            output_dir=self.results_dir,
+            benchmark_mode="inference",
+        )
+
+        profile_path = os.path.join(
+            self.results_dir,
+            "profiler",
+            f"{config.name}_{self.m}_{self.k}_{self.n}_profile.json",
+        )
+
+        # Generate profile
+        result_path = generate_model_profile(self.model, self.input_data, profile_path)
+
+        # Check that profile file exists and is not empty
+        self.assertTrue(os.path.exists(result_path))
+        self.assertGreater(os.path.getsize(result_path), 0)
+
+        # Verify it's valid JSON
+        with open(result_path) as f:
+            profile_data = json.load(f)
+        self.assertIsInstance(profile_data, dict)
+
+    def test_profiler_basic_output(self):
+        """Test that profiler output contains expected basic fields"""
+        config = BenchmarkConfig(
+            quantization=None,
+            sparsity=None,
+            params={
+                "enable_profiler": True,
+                "device": self.device,
+            },
+            shape_name="test",
+            shape=[self.m, self.k, self.n],
+            output_dir=self.results_dir,
+            benchmark_mode="inference",
+        )
+
+        profile_path = os.path.join(
+            self.results_dir,
+            "profiler",
+            f"{config.name}_{self.m}_{self.k}_{self.n}_profile.json",
+        )
+
+        result_path = generate_model_profile(self.model, self.input_data, profile_path)
+
+        with open(result_path) as f:
+            data = json.load(f)
+
+        # Check for required Chrome Trace Event format fields
+        self.assertIn("traceEvents", data)
+        self.assertTrue(isinstance(data["traceEvents"], list))
+
+        # Check that we have some events
+        self.assertGreater(len(data["traceEvents"]), 0)
+
+        # Check event format
+        event = data["traceEvents"][0]
+        self.assertIn("name", event)
+        self.assertIn("ph", event)  # Phase
+        self.assertIn("ts", event)  # Timestamp
+        self.assertIn("pid", event)  # Process ID
+
+    @unittest.skipIf(not torch_accelerator.is_available(), "Accelerator not available")
+    def test_accelerator_profiling(self):
+        """Test accelerator profiling when available"""
+        config = BenchmarkConfig(
+            quantization=None,
+            sparsity=None,
+            params={
+                "enable_profiler": True,
+                "device": self.device,
+            },
+            shape_name="test",
+            shape=[self.m, self.k, self.n],
+            output_dir=self.results_dir,
+            benchmark_mode="inference",
+        )
+
+        profile_path = os.path.join(
+            self.results_dir,
+            "profiler",
+            f"{config.name}_{self.m}_{self.k}_{self.n}_profile.json",
+        )
+
+        result_path = generate_model_profile(
+            self.model.to(self.device), self.input_data.to(self.device), profile_path
+        )
+
+        with open(result_path) as f:
+            data = json.load(f)
+
+        # Check for accelerator events
+        accelerator_events = [
+            event
+            for event in data["traceEvents"]
+            if self.device in event.get("name", "")
+        ]
+        self.assertGreater(len(accelerator_events), 0)
+
+    @unittest.skipIf(not torch_accelerator.is_available(), "Accelerator not available")
+    def test_memory_profiler_enabled(self):
+        """Test that memory profiler works when enabled and Accelerator is available"""
+        config = BenchmarkConfig(
+            quantization=None,
+            sparsity=None,
+            params={
+                "enable_memory_profiler": True,
+                "device": self.device,
+            },
+            shape_name="test",
+            shape=[self.m, self.k, self.n],
+            output_dir=self.results_dir,
+            benchmark_mode="inference",
+        )
+
+        memory_profile_path = os.path.join(
+            self.results_dir,
+            "memory_profiler",
+            f"{config.name}_{self.m}_{self.k}_{self.n}_memory_profile.pickle",
+        )
+
+        # Generate memory profile
+        result_path, memory_stats = generate_memory_profile(
+            self.model, self.input_data, memory_profile_path
+        )
+
+        # Check that profile file exists and is not empty
+        self.assertTrue(os.path.exists(result_path))
+        self.assertGreater(os.path.getsize(result_path), 0)
+
+        # Verify it's a valid pickle file
+        try:
+            with open(result_path, "rb") as f:
+                pickle_data = pickle.load(f)
+            self.assertIsNotNone(pickle_data)
+        except Exception as e:
+            self.fail(f"Failed to load pickle file: {e}")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_memory_profiler_visualization(self):
+        """Test memory profile visualization"""
+        config = BenchmarkConfig(
+            quantization=None,
+            sparsity=None,
+            params={
+                "enable_memory_profiler": True,
+                "device": "cuda",
+            },
+            shape_name="test",
+            shape=[self.m, self.k, self.n],
+            output_dir=self.results_dir,
+            benchmark_mode="inference",
+        )
+
+        memory_profile_path = os.path.join(
+            self.results_dir,
+            "memory_profiler",
+            f"{config.name}_{self.m}_{self.k}_{self.n}_memory_profile.pickle",
+        )
+
+        # Create a simple mock memory profile as a pickle file
+        # This is a simplified structure that mimics what torch.cuda.memory._dump_snapshot produces
+        mock_profile_data = {
+            "segments": [
+                {
+                    "device": 0,
+                    "address": 1000,
+                    "size": 1024 * 1024,  # 1MB
+                    "stream": 0,
+                }
+            ],
+            "external_annotations": [],
+        }
+
+        # Save mock profile as pickle
+        os.makedirs(os.path.dirname(memory_profile_path), exist_ok=True)
+        with open(memory_profile_path, "wb") as f:
+            pickle.dump(mock_profile_data, f)
+
+        # Generate visualization
+        viz_path = visualize_memory_profile(memory_profile_path)
+
+        # Check that visualization file exists
+        self.assertTrue(os.path.exists(viz_path))
+        self.assertTrue(viz_path.endswith(".html"))
+
+    def test_memory_profiler_accelerator_unavailable(self):
+        """Test memory profiler behavior when accelerator is not available"""
+        # Save original torch_accelerator.is_available function
+        original_is_available = torch_accelerator.is_available
+
+        try:
+            # Mock torch_accelerator.is_available to return False
+            torch_accelerator.is_available = lambda: False
+
+            config = BenchmarkConfig(
+                quantization=None,
+                sparsity=None,
+                params={
+                    "enable_memory_profiler": True,
+                    "device": "cpu",  # Force CPU to test accelerator unavailable case
+                },
+                shape_name="test",
+                shape=[self.m, self.k, self.n],
+                output_dir=self.results_dir,
+                benchmark_mode="inference",
+            )
+
+            memory_profile_path = os.path.join(
+                self.results_dir,
+                "memory_profiler",
+                f"{config.name}_{self.m}_{self.k}_{self.n}_memory_profile.json",
+            )
+
+            # Should return None when accelerator is unavailable
+            self.assertIsNone(
+                generate_memory_profile(
+                    self.model, self.input_data, memory_profile_path
+                )
+            )
+
+            # Should not create file when accelerator is unavailable
+            self.assertFalse(os.path.exists(memory_profile_path))
+
+        finally:
+            # Restore original torch_accelerator.is_available function
+            torch_accelerator.is_available = original_is_available
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/microbenchmarks/test/test_utils.py
+++ b/benchmarks/microbenchmarks/test/test_utils.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from benchmarks.microbenchmarks.utils import (
+    BenchmarkConfig,
+    BenchmarkResult,
+    BlockSparseWeightConfig,
+    SemiSparseWeightConfig,
+    clean_caches,
+    generate_results_csv,
+    get_default_device,
+    string_to_config,
+)
+from torchao.testing.model_architectures import (
+    LNLinearActivationModel,
+    ToySingleLinearModel,
+    create_model_and_input_data,
+)
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.test_params = {
+            "name": "test_model",
+            "high_precision_dtype": "torch.bfloat16",
+            "torch_compile_mode": "max-autotune",
+            "device": "cpu",
+            "model_type": "linear",
+        }
+        self.test_shape = [1024, 1024, 1024]
+        self.test_output_dir = Path("test_output")
+
+    def test_benchmark_config(self):
+        config = BenchmarkConfig(
+            quantization="baseline",
+            sparsity=None,
+            params=self.test_params,
+            shape_name="custom",
+            shape=self.test_shape,
+            output_dir=str(self.test_output_dir),
+            benchmark_mode="inference",
+        )
+
+        self.assertEqual(config.quantization, "baseline")
+        self.assertEqual(config.m, 1024)
+        self.assertEqual(config.k, 1024)
+        self.assertEqual(config.n, 1024)
+        self.assertEqual(config.high_precision_dtype, torch.bfloat16)
+        self.assertEqual(config.torch_compile_mode, "max-autotune")
+        self.assertEqual(config.device, "cpu")
+        self.assertEqual(config.model_type, "linear")
+        self.assertEqual(config.benchmark_mode, "inference")
+
+    def test_benchmark_result(self):
+        config = BenchmarkConfig(
+            quantization="baseline",
+            sparsity=None,
+            params=self.test_params,
+            shape_name="custom",
+            shape=self.test_shape,
+            output_dir=str(self.test_output_dir),
+            benchmark_mode="inference",
+        )
+        result = BenchmarkResult(config=config)
+
+        self.assertEqual(result.config, config)
+        self.assertEqual(result.quantized_model_compiled_inference_time_in_ms, 0.0)
+
+    def test_get_default_device(self):
+        # Test CPU fallback
+        device = get_default_device("not_a_real_device")
+        self.assertEqual(device, "cpu")
+
+        # Test explicit CPU request
+        device = get_default_device("cpu")
+        self.assertEqual(device, "cpu")
+
+    def test_string_to_config(self):
+        # Test baseline
+        config = string_to_config("baseline", None)
+        self.assertIsNone(config)
+
+        # Test int8wo
+        config = string_to_config("int8wo", None)
+        self.assertIsNotNone(config)
+
+        # Test invalid config
+        config = string_to_config("not_a_real_config", None)
+        self.assertIsNone(config)
+
+    def test_string_to_config_sparsity(self):
+        """Test sparsity config generation"""
+        # Test semi-sparse config
+        config = string_to_config(None, "semi-sparse")
+        self.assertIsInstance(config, SemiSparseWeightConfig)
+
+        # Test block sparse config
+        config = string_to_config(None, "block")
+        self.assertIsInstance(config, BlockSparseWeightConfig)
+
+    def test_block_sparsity_with_baseline_quantization(self):
+        """Test that block sparsity with baseline quantization returns BlockSparseWeightConfig"""
+        config = string_to_config("baseline", "block")
+        self.assertIsInstance(config, BlockSparseWeightConfig)
+
+    def test_block_sparsity_with_non_baseline_quantization(self):
+        """Test that block sparsity with non-baseline quantization still returns BlockSparseWeightConfig"""
+        # Block sparsity should take precedence over any quantization method
+        config = string_to_config("int8wo", "block")
+        self.assertIsInstance(config, BlockSparseWeightConfig)
+
+        config = string_to_config("int4wo", "block")
+        self.assertIsInstance(config, BlockSparseWeightConfig)
+
+        config = string_to_config("marlin", "block")
+        self.assertIsInstance(config, BlockSparseWeightConfig)
+
+    def test_invalid_sparsity(self):
+        """Test invalid sparsity config generation"""
+        from benchmarks.microbenchmarks.benchmark_runner import (
+            get_quantization_sparsity_recipes,
+        )
+
+        with self.assertRaises(ValueError):
+            get_quantization_sparsity_recipes(["baseline"], ["invalid_sparsity"])
+
+    def test_toy_linear_model(self):
+        model = ToySingleLinearModel(
+            input_dim=64, output_dim=32, dtype=torch.float32, device="cpu"
+        )
+        x = torch.randn(16, 64)
+        out = model(x)
+        self.assertEqual(out.shape, (16, 32))
+        self.assertEqual(out.dtype, torch.float32)
+
+    def test_ln_linear_sigmoid(self):
+        model = LNLinearActivationModel(fc_dim1=64, fc_dim2=32, dtype=torch.float32)
+        x = torch.randn(16, 64)
+        out = model(x)
+        self.assertEqual(out.shape, (16, 32))
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertTrue(
+            torch.all((out >= 0) & (out <= 1))
+        )  # Check sigmoid output range
+
+    def test_create_model_and_input_data(self):
+        m, k, n = 16, 64, 32
+        model, input_data = create_model_and_input_data(
+            model_type="linear",
+            m=m,
+            k=k,
+            n=n,
+            high_precision_dtype=torch.float32,
+            device="cpu",
+        )
+        self.assertIsInstance(model, ToySingleLinearModel)
+        self.assertEqual(input_data.shape, (m, k))
+
+        model, input_data = create_model_and_input_data(
+            model_type="ln_linear_sigmoid",
+            m=m,
+            k=k,
+            n=n,
+            high_precision_dtype=torch.float32,
+            device="cpu",
+        )
+        self.assertIsInstance(model, LNLinearActivationModel)
+        self.assertEqual(input_data.shape, (m, k))
+
+    def test_generate_results_csv(self):
+        results = [
+            BenchmarkResult(
+                BenchmarkConfig(
+                    quantization="int8wo",
+                    sparsity=None,
+                    params={},
+                    shape_name="custom",
+                    shape=[1024, 1024, 1024],
+                    output_dir="test_output",
+                    benchmark_mode="inference",
+                ),
+            ),
+            BenchmarkResult(
+                BenchmarkConfig(
+                    quantization="int4wo",
+                    sparsity=None,
+                    params={},
+                    shape_name="custom",
+                    shape=[1024, 1024, 1024],
+                    output_dir="test_output",
+                    benchmark_mode="inference",
+                ),
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generate_results_csv(results, tmp_dir)
+
+            # Check if any CSV file with the timestamp-based naming pattern was created
+            csv_files = list(Path(tmp_dir).glob("results_*.csv"))
+            self.assertTrue(len(csv_files) > 0, "No results CSV file was created")
+
+    def test_clean_caches(self):
+        # Just test that it runs without error
+        clean_caches()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Enable `benchmarks/microbenchmarks/` to run on Intel XPU in addition to CUDA. CUDA behavior unchanged.

- Profiler: add `ProfilerActivity.XPU` and `torch.xpu.synchronize()` in `generate_model_profile()` alongside the existing CUDA paths.
- Memory profiling: generalize `generate_memory_profile()` to CUDA or XPU via a `torch_accelerator` alias; XPU uses `record_memory_enabled=False`.
- `benchmark_inference.py`: detect XPU (`torch.xpu.is_available()`); skip memory visualization on XPU (not yet supported).
- Tests: support device-agnostic "accelerator" (`torch.accelerator.current_accelerator()`); swap `ToyLinearModel` -> `ToySingleLinearModel`; drop the marlin/semi-sparse `Int4WeightOnlyConfig` combined case as it no longer exists.

## Test plan

Same commands for both backends (except *.yml, due to "device" field); CUDA output unchanged. For example:

```bash
pytest benchmarks/microbenchmarks/test/test_benchmark_profiler.py -v
pytest benchmarks/microbenchmarks/test/test_utils.py -v
python -m benchmarks.microbenchmarks.benchmark_runner /path/to/*.yml
```