### PR TITLE
Use smallest_normal instead of eps to clamp quant scales

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -589,7 +589,7 @@ class TestQuantPrimitives(unittest.TestCase):
         scale, zero_point = choose_qparams_affine(
             input, mapping_type, block_size, dtype
         )
-        eps = torch.finfo(torch.float32).eps
+        eps = torch.finfo(torch.float32).smallest_normal
         self.assertEqual(scale, eps)
 
     @unittest.skipIf(

--- a/torchao/prototype/parq/quant/uniform_torchao.py
+++ b/torchao/prototype/parq/quant/uniform_torchao.py
@@ -86,7 +86,7 @@ class UnifTorchaoQuantizer(Quantizer):
     ) -> tuple[Tensor, Tensor]:
         self._init_quant_min_max(b)
         if self.eps is None:
-            self.eps = torch.finfo(p.dtype).eps
+            self.eps = torch.finfo(p.dtype).smallest_normal
 
         # assume that p has already been grouped in QuantOptimizer.step
         block_size = (1, p.size(-1)) if dim is not None else p.size()

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -1313,7 +1313,7 @@ def _choose_qparams_affine_tinygemm(
     if scale_dtype is None:
         scale_dtype = input.dtype
     if eps is None:
-        eps = torch.finfo(input.dtype).eps
+        eps = torch.finfo(input.dtype).smallest_normal
 
     assert len(block_size) == input.dim(), (
         f"Got input dim:{input.dim()}, block_size: {block_size}"
@@ -1384,7 +1384,7 @@ def _choose_qparams_affine_dont_preserve_zero(
     if scale_dtype is None:
         scale_dtype = input.dtype
     if eps is None:
-        eps = torch.finfo(input.dtype).eps
+        eps = torch.finfo(input.dtype).smallest_normal
 
     assert len(block_size) == input.dim(), (
         f"Got input dim:{input.dim()}, block_size: {block_size}"
@@ -1453,7 +1453,7 @@ def choose_qparams_affine_with_min_max(
     if scale_dtype is None:
         scale_dtype = min_val.dtype
     if eps is None:
-        eps = torch.finfo(min_val.dtype).eps
+        eps = torch.finfo(min_val.dtype).smallest_normal
 
     min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
     max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
@@ -1529,7 +1529,7 @@ def _choose_qparams_affine(
     if scale_dtype is None:
         scale_dtype = input.dtype
     if eps is None:
-        eps = torch.finfo(input.dtype).eps
+        eps = torch.finfo(input.dtype).smallest_normal
 
     assert len(block_size) == input.dim(), (
         f"Got input dim:{input.dim()}, block_size: {block_size}"

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -282,7 +282,7 @@ def dynamically_quantize_per_channel(x, quant_min, quant_max, target_dtype):
 
     assert x.dim() == 2, "only support 2d Tensors"
 
-    eps = torch.finfo(torch.float32).eps
+    eps = torch.finfo(torch.float32).smallest_normal
     block_size = (1, x.shape[1])
     zero_point_dtype = torch.int64
 
@@ -579,7 +579,7 @@ def get_group_qparams_symmetric(
 
     block_size = (1, groupsize)
     if eps is None:
-        eps = torch.finfo(w.dtype).eps
+        eps = torch.finfo(w.dtype).smallest_normal
     ranges = {}
     ranges[1] = (-1, 0)
     # generating ranges for bit 2 to 8


### PR DESCRIPTION
In _choose_qparams_affine, set the default eps (used to clamp scales to avoid zero) to finfo smallest_normal instead of eps. This significantly improves accuracy on some models when using bf16 scales.

This is because eps is the delta from 1 to the next representable value. This can be significantly larger than the actual smallest non-zero value. For bf16, it ends up clamping at 2^-7, which very course. Bf16 can represent much smaller values. In practice, this means small scales in bf16 get clamped to a much larger value, which degrades accuracy.

The issue doesn't really arise with f16/f32 because the eps is pretty small, even if it is many orders of magnitude larger than the smallest non-zero value that can be represented. Bf16 is particularly vulnerable due to the tiny fraction. 

**Question for reviewers: Is there any other reason to clamp to eps other than to avoid zero scales?**

End-to-end perplexity numbers:
Gemma3-1b, quantized to int4, GS=32/256, wikitext, 40k tokens, 1024-token windows:
| Activations | Group size | Before | After | Delta |
|---|---|---|---|---|
| f32  | 32  | 29.9809 | 29.9809 | 0.000 |
| f16  | 32  | 29.4767 | 29.4741 | −0.003 |
| bf16 | 32  | 40.5104 | 29.9401 | −10.57 |
| f32  | 256 | 66.6410 | 66.6410 | 0.000 |
| f16  | 256 | 64.8682 | 64.8673 | −0.001 |
| bf16 | 256 | 90.9888 | 63.5593 | −27.43 |

On Gemma3-1b, about 52% of scales get clamped up currently in bf16, often by orders of magnitude. Post-fix, no scales are clamped as there are legitimate bf16 representations that are greater than zero.