### PR TITLE
[XPU][CI] Add test/low_bit_optim.py to XPU CI

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -23,4 +23,5 @@ pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py 
         torchao/test/float8/ \
         torchao/test/integration/test_integration.py \
         torchao/test/prototype/ \
-        torchao/test/quantization/quantize_/workflows/
+        torchao/test/quantization/quantize_/workflows/ \
+        torchao/test/test_low_bit_optim.py


### PR DESCRIPTION
Adds test/test_low_bit_optim.py test as part of XPUs CI.
The test takes about 150 seconds on BMG B570. 