### PR TITLE
Re-enable building under a free-threaded Python interpreter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -541,7 +541,9 @@ def get_extensions():
 
     maybe_cpython_limited_api = []
     if not is_freethreaded():
-        maybe_cpython_limited_api += [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
+        maybe_cpython_limited_api += [
+            f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"
+        ]
 
     extra_link_args = []
     extra_compile_args = {
@@ -789,7 +791,8 @@ def get_extensions():
                             "-DUSE_CUDA",
                             # define TORCH_TARGET_VERSION with min version 2.11 for ABI stable Float8_e8m0fnu
                             "-DTORCH_TARGET_VERSION=0x020b000000000000",
-                        ] + maybe_cpython_limited_api,
+                        ]
+                        + maybe_cpython_limited_api,
                         "nvcc": nvcc_args
                         + [
                             "-gencode=arch=compute_100,code=sm_100",
@@ -911,5 +914,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch/ao",
     cmdclass={"build_ext": TorchAOBuildExt, "build_py": TorchAOBuildPy},
-    options={"bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}},
+    options={
+        "bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import pickle
 import re
 import subprocess
 import sys
+import sysconfig
 import time
 from datetime import datetime
 from pathlib import Path
@@ -496,6 +497,10 @@ def add_options_for_x86(extra_compile_args):
             )
 
 
+def is_freethreaded():
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
 def get_extensions():
     # Skip building C++ extensions if USE_CPP is set to "0"
     if use_cpp == "0":
@@ -534,10 +539,13 @@ def get_extensions():
     if use_rocm and detect_hipify_v2():
         maybe_hipify_v2_flag = ["-DHIPIFY_V2"]
 
+    maybe_cpython_limited_api = []
+    if not is_freethreaded():
+        maybe_cpython_limited_api += [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
+
     extra_link_args = []
     extra_compile_args = {
-        "cxx": [f"-DPy_LIMITED_API={min_supported_cpython_hexcode}"]
-        + maybe_hipify_v2_flag,
+        "cxx": maybe_cpython_limited_api + maybe_hipify_v2_flag,
         "nvcc": nvcc_args if use_cuda else rocm_args + maybe_hipify_v2_flag,
     }
 
@@ -744,7 +752,7 @@ def get_extensions():
             extension(
                 "torchao._C",
                 sources,
-                py_limited_api=True,
+                py_limited_api=not is_freethreaded(),
                 extra_compile_args=extra_compile_args,
                 extra_link_args=extra_link_args,
             )
@@ -776,13 +784,12 @@ def get_extensions():
                     ],
                     extra_compile_args={
                         "cxx": [
-                            f"-DPy_LIMITED_API={min_supported_cpython_hexcode}",
                             "-std=c++20",
                             "-O3",
                             "-DUSE_CUDA",
                             # define TORCH_TARGET_VERSION with min version 2.11 for ABI stable Float8_e8m0fnu
                             "-DTORCH_TARGET_VERSION=0x020b000000000000",
-                        ],
+                        ] + maybe_cpython_limited_api,
                         "nvcc": nvcc_args
                         + [
                             "-gencode=arch=compute_100,code=sm_100",
@@ -823,7 +830,7 @@ def get_extensions():
             extension(
                 "torchao._C_cutlass_90a",
                 cutlass_90a_sources,
-                py_limited_api=True,
+                py_limited_api=not is_freethreaded(),
                 extra_compile_args=cutlass_90a_extra_compile_args,
                 extra_link_args=extra_link_args,
             )
@@ -904,5 +911,5 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pytorch/ao",
     cmdclass={"build_ext": TorchAOBuildExt, "build_py": TorchAOBuildPy},
-    options={"bdist_wheel": {"py_limited_api": "cp310"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"} if not is_freethreaded() else {}},
 )


### PR DESCRIPTION
This PR re-applies the changes from #4428.

Free-threaded interpreters do not support the CPython Limited C API, and hence use of the limited API has to be disabled. With this one change, `torchao` builds fine.

The `is_freethreaded` function is in widespread use, and documented as the canonical way of doing this check here:
https://py-free-threading.github.io/running-gil-disabled/#check-if-using-a-free-threaded-build

PR #4428 (commit f43befe6b) was inadvertently reverted by #4446 ("Back out D105996100 — breaks `fbpkg build light_cli`"). That back-out was meant to revert only the multi-ISA work in #4159 (D105996100), but instead of computing a reverse diff it restored a whole-file snapshot of setup.py that predated both #4159 and #4428, silently clobbering the free-threading support.

Re-applied on top of the current `add_options_for_x86` base; the only adaptation from the original is the placement of `is_freethreaded()` (both functions are kept).

(cherry picked from commit f43befe6b7b8a75776bfe905dfa8ddbc287fa9fd)