### PR TITLE
Add scale and zero-point dimension validation to quantization primitives

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -625,8 +625,9 @@ class TestQuantPrimitives(unittest.TestCase):
 
         # block_size and scale/zero_point shape mismatch
         block_size = (1, 1)
-        with self.assertRaisesRegex(RuntimeError, "is invalid for input of size 1"):
+        with self.assertRaisesRegex(ValueError, "scale must have exactly 100 elements"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
+
 
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)
@@ -911,6 +912,45 @@ class TestQuantPrimitives(unittest.TestCase):
         assert scale.shape == (B, 1, N)
         assert data.shape == (B, K, N)
 
+    def test_validate_scale_zero_point(self):
+        input_tensor = torch.randn(4, 16, dtype=torch.float32)
+        
+        # 1. Valid case
+        # For block_size=(1, 4), expected_numel = 4 * (16 // 4) = 16 elements
+        block_size = (1, 4)
+        valid_scale = torch.ones(4, 4, dtype=torch.float32)
+        valid_zp = torch.zeros(4, 4, dtype=torch.int32)
+        
+        # Should not raise any error
+        q = quantize_affine(input_tensor, block_size, valid_scale, valid_zp, torch.int8)
+        dq = dequantize_affine(q, block_size, valid_scale, valid_zp, torch.int8)
+        self.assertEqual(q.shape, input_tensor.shape)
+        self.assertEqual(dq.shape, input_tensor.shape)
+        
+        # 2. Invalid block_size length
+        invalid_block_size_len = (1,)
+        with self.assertRaises(AssertionError):
+            quantize_affine(input_tensor, invalid_block_size_len, valid_scale, valid_zp, torch.int8)
+            
+        # 3. Invalid scale shape/elements
+        invalid_scale = torch.ones(4, 3, dtype=torch.float32) # 12 elements instead of 16
+        with self.assertRaises(ValueError) as ctx:
+            quantize_affine(input_tensor, block_size, invalid_scale, valid_zp, torch.int8)
+        self.assertIn("scale must have exactly 16 elements", str(ctx.exception))
+        
+        # 4. Invalid zero_point shape/elements
+        invalid_zp = torch.zeros(4, 3, dtype=torch.int32) # 12 elements instead of 16
+        with self.assertRaises(ValueError) as ctx:
+            quantize_affine(input_tensor, block_size, valid_scale, invalid_zp, torch.int8)
+        self.assertIn("zero_point must have exactly 16 elements", str(ctx.exception))
+        
+        # 5. Non-divisible block_size
+        non_divisible_block_size = (1, 5) # 16 is not divisible by 5
+        with self.assertRaises(AssertionError) as ctx:
+            quantize_affine(input_tensor, non_divisible_block_size, valid_scale, valid_zp, torch.int8)
+        self.assertIn("must be divisible by block_size", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -628,7 +628,6 @@ class TestQuantPrimitives(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "scale must have exactly 100 elements"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
 
-
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)
         n_bit = 4
@@ -914,43 +913,56 @@ class TestQuantPrimitives(unittest.TestCase):
 
     def test_validate_scale_zero_point(self):
         input_tensor = torch.randn(4, 16, dtype=torch.float32)
-        
+
         # 1. Valid case
         # For block_size=(1, 4), expected_numel = 4 * (16 // 4) = 16 elements
         block_size = (1, 4)
         valid_scale = torch.ones(4, 4, dtype=torch.float32)
         valid_zp = torch.zeros(4, 4, dtype=torch.int32)
-        
+
         # Should not raise any error
         q = quantize_affine(input_tensor, block_size, valid_scale, valid_zp, torch.int8)
         dq = dequantize_affine(q, block_size, valid_scale, valid_zp, torch.int8)
         self.assertEqual(q.shape, input_tensor.shape)
         self.assertEqual(dq.shape, input_tensor.shape)
-        
+
         # 2. Invalid block_size length
         invalid_block_size_len = (1,)
         with self.assertRaises(AssertionError):
-            quantize_affine(input_tensor, invalid_block_size_len, valid_scale, valid_zp, torch.int8)
-            
+            quantize_affine(
+                input_tensor, invalid_block_size_len, valid_scale, valid_zp, torch.int8
+            )
+
         # 3. Invalid scale shape/elements
-        invalid_scale = torch.ones(4, 3, dtype=torch.float32) # 12 elements instead of 16
+        invalid_scale = torch.ones(
+            4, 3, dtype=torch.float32
+        )  # 12 elements instead of 16
         with self.assertRaises(ValueError) as ctx:
-            quantize_affine(input_tensor, block_size, invalid_scale, valid_zp, torch.int8)
+            quantize_affine(
+                input_tensor, block_size, invalid_scale, valid_zp, torch.int8
+            )
         self.assertIn("scale must have exactly 16 elements", str(ctx.exception))
-        
+
         # 4. Invalid zero_point shape/elements
-        invalid_zp = torch.zeros(4, 3, dtype=torch.int32) # 12 elements instead of 16
+        invalid_zp = torch.zeros(4, 3, dtype=torch.int32)  # 12 elements instead of 16
         with self.assertRaises(ValueError) as ctx:
-            quantize_affine(input_tensor, block_size, valid_scale, invalid_zp, torch.int8)
+            quantize_affine(
+                input_tensor, block_size, valid_scale, invalid_zp, torch.int8
+            )
         self.assertIn("zero_point must have exactly 16 elements", str(ctx.exception))
-        
+
         # 5. Non-divisible block_size
-        non_divisible_block_size = (1, 5) # 16 is not divisible by 5
+        non_divisible_block_size = (1, 5)  # 16 is not divisible by 5
         with self.assertRaises(AssertionError) as ctx:
-            quantize_affine(input_tensor, non_divisible_block_size, valid_scale, valid_zp, torch.int8)
+            quantize_affine(
+                input_tensor,
+                non_divisible_block_size,
+                valid_scale,
+                valid_zp,
+                torch.int8,
+            )
         self.assertIn("must be divisible by block_size", str(ctx.exception))
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -431,6 +431,46 @@ def _quantize_affine(
     ).to(output_dtype)
 
 
+def _validate_scale_zero_point(
+    input: torch.Tensor,
+    block_size: Union[List[int], Tuple[int, ...]],
+    scale: torch.Tensor,
+    zero_point: Optional[torch.Tensor],
+) -> None:
+    """Validate that scale and zero_point dimensions are compatible with block_size and input tensor."""
+    assert isinstance(input, torch.Tensor), "input must be a torch.Tensor"
+    assert isinstance(scale, torch.Tensor), "scale must be a torch.Tensor"
+    assert len(block_size) == input.dim(), (
+        f"block_size length {len(block_size)} must match input dimensions {input.dim()}"
+    )
+
+    expected_numel = 1
+    for i, (s, b) in enumerate(zip(input.shape, block_size)):
+        if b == 1:
+            expected_numel *= s
+        elif b > 1:
+            assert s % b == 0, (
+                f"Dimension {i} of input ({s}) must be divisible by block_size ({b})"
+            )
+            expected_numel *= s // b
+        else:
+            raise ValueError(f"block_size elements must be >= 1, got {b} at index {i}")
+
+    if scale.numel() != expected_numel:
+        raise ValueError(
+            f"scale must have exactly {expected_numel} elements to be compatible with "
+            f"input shape {list(input.shape)} and block_size {list(block_size)}, but got {scale.numel()} elements."
+        )
+
+    if zero_point is not None and zero_point.numel() > 0:
+        assert isinstance(zero_point, torch.Tensor), "zero_point must be a torch.Tensor"
+        if zero_point.numel() != expected_numel:
+            raise ValueError(
+                f"zero_point must have exactly {expected_numel} elements to be compatible with "
+                f"input shape {list(input.shape)} and block_size {list(block_size)}, but got {zero_point.numel()} elements."
+            )
+
+
 def _quantize_affine_no_dtype_cast(
     input: torch.Tensor,
     block_size: List[int],
@@ -460,16 +500,12 @@ def _quantize_affine_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale and zero_point with zero_point_domain = INT
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     assert input.dtype in [
         torch.float32,
         torch.float16,
         torch.bfloat16,
     ], f"Unsupported input dtype: {input.dtype}"
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )
@@ -574,16 +610,12 @@ def _quantize_affine_tinygemm_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale and zero_point with zero_point_domain = FLOAT
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     assert input.dtype in [
         torch.float32,
         torch.float16,
         torch.bfloat16,
     ], f"Unsupported input dtype: {input.dtype}"
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )
@@ -689,16 +721,12 @@ def _quantize_affine_no_zero_point_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale with zero_point_domain = NONE
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     assert input.dtype in [
         torch.float32,
         torch.float16,
         torch.bfloat16,
     ], f"Unsupported input dtype: {input.dtype}"
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )
@@ -843,9 +871,7 @@ def _dequantize_affine_no_dtype_check(
     2. Dequantize the input based on the quantization parameters scale and zero_point
     3. Reshape the quantized result to original shape and change dtype to the output_dtype
     """
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )
@@ -900,9 +926,7 @@ def _dequantize_affine_no_zero_point_no_dtype_check(
     2. Dequantize the input based on the quantization parameters scale (no zero point)
     3. Reshape the quantized result to original shape and change dtype to the output_dtype
     """
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )
@@ -989,9 +1013,7 @@ def _dequantize_affine_tinygemm_no_dtype_check(
     2. dequantize the input based on the quantization parameters scale and zero_point and args like zero_point_domain
     3. reshape the quantized result to origianl shape and change dtype to the output_dtype
     """
-    assert len(block_size) == input.dim(), (
-        f"Got input dim:{input.dim()}, block_size: {block_size}"
-    )
+    _validate_scale_zero_point(input, block_size, scale, zero_point)
     shape_for_reduction, reduction_dims = _get_reduction_params(
         block_size, input.size()
     )


### PR DESCRIPTION
### Description

This PR implements upfront shape and size validation for the `scale` and `zero_point` tensors in low-level affine quantization and dequantization primitives under `torchao/quantization/quant_primitives.py`. 

It resolves several `# TODO: validate scale/zero_point dimensions are compatible with block_size` comments in the codebase.

By checking these dimensions before entering `.view()` calls, we prevent generic PyTorch `RuntimeError: shape [...] is invalid for input of size ...` and instead raise clear, actionable `ValueError` and `AssertionError` messages when dimensions or number of elements are incompatible.

Closes #4538

### Test Plan

Added unit tests in `test/quantization/test_quant_primitives.py` (`test_validate_scale_zero_point`) and updated `test_raises` to expect the new `ValueError` instead of the old `RuntimeError`.

To run the tests:
```bash
python3 -m pytest test/quantization/test_quant_primitives.py -k "test_raises or test_validate_scale_zero_point"
```

Output:
```
============================= test session starts ==============================
platform darwin -- Python 3.11.9, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/mynimbus/ao
configfile: pyproject.toml
plugins: zarr-3.1.6, requests-mock-1.12.1, anyio-4.13.0
collected 27 items / 25 deselected / 2 selected

test/quantization/test_quant_primitives.py ..                            [100%]

======================= 2 passed, 25 deselected in 2.05s =======================
```
