### PR TITLE
optim: cache qmap values as tuples

### DIFF
--- a/torchao/optim/subclass_4bit.py
+++ b/torchao/optim/subclass_4bit.py
@@ -33,12 +33,12 @@ from functools import lru_cache
 
 @lru_cache(maxsize=1)
 def get_qmap_signed():
-    return create_dynamic_map(True, 3, 4)
+    return tuple(create_dynamic_map(True, 3, 4))
 
 
 @lru_cache(maxsize=1)
 def get_qmap_unsigned():
-    return torch.linspace(0, 1, 17, device="cpu")[1:].tolist()  # no zero
+    return tuple(torch.linspace(0, 1, 17, device="cpu")[1:].tolist())  # no zero
 
 
 class OptimState4bit(TorchAOBaseTensor):

--- a/torchao/optim/subclass_8bit.py
+++ b/torchao/optim/subclass_8bit.py
@@ -29,12 +29,12 @@ from functools import lru_cache
 
 @lru_cache(maxsize=1)
 def get_qmap_signed():
-    return create_dynamic_map(signed=True)
+    return tuple(create_dynamic_map(signed=True))
 
 
 @lru_cache(maxsize=1)
 def get_qmap_unsigned():
-    return create_dynamic_map(signed=False)
+    return tuple(create_dynamic_map(signed=False))
 
 
 class OptimState8bit(TorchAOBaseTensor):


### PR DESCRIPTION
Free-threading audit finding: `get_qmap_signed`/`get_qmap_unsigned` in `subclass_4bit.py` and `subclass_8bit.py` cache a `list` via `lru_cache(maxsize=1)`. The list is returned by reference to every caller, so it's shared mutable state under free-threaded Python. Wrap the cached value in `tuple(...)` -- `torch.tensor(...)` accepts any iterable, so no call site changes are needed.