### PR TITLE
kernel: avoid partial Triton lazy initialization

### DIFF
--- a/torchao/kernel/blockwise_quantization.py
+++ b/torchao/kernel/blockwise_quantization.py
@@ -5,38 +5,43 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import Tuple
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable, Optional, Tuple
 
 import torch
 
-# Lazy initialization state
-_triton_initialized = False
-_triton_available = None
-_blockwise_fp8_gemm_impl = None
-_fp8_blockwise_act_quant_kernel = None
-_fp8_blockwise_weight_quant_kernel = None
-_fp8_blockwise_weight_dequant_kernel = None
+
+@dataclass(frozen=True)
+class _BlockwiseFp8Impls:
+    available: bool
+    gemm: Optional[Callable]
+    act_quant: Optional[Callable]
+    weight_quant: Optional[Callable]
+    weight_dequant: Optional[Callable]
 
 
-def _lazy_init_triton():
-    global _triton_initialized, _triton_available
-    global _blockwise_fp8_gemm_impl
-    global _fp8_blockwise_act_quant_kernel
-    global _fp8_blockwise_weight_quant_kernel
-    global _fp8_blockwise_weight_dequant_kernel
+_triton_impls: Optional[_BlockwiseFp8Impls] = None
+_triton_impls_lock = Lock()
 
-    if _triton_initialized:
-        return
 
-    _triton_initialized = True
+def _get_triton_impls() -> _BlockwiseFp8Impls:
+    global _triton_impls
+    impls = _triton_impls
+    if impls is None:
+        with _triton_impls_lock:
+            impls = _triton_impls
+            if impls is None:
+                impls = _build_triton_impls()
+                _triton_impls = impls
+    return impls
 
+
+def _build_triton_impls() -> _BlockwiseFp8Impls:
     from torch.utils._triton import has_triton
 
     if not has_triton():
-        _triton_available = False
-        return
-
-    _triton_available = True
+        return _BlockwiseFp8Impls(False, None, None, None, None)
 
     import triton
     import triton.language as tl
@@ -135,8 +140,6 @@ def _lazy_init_triton():
         c = a.new_empty(*a.size()[:-1], N, dtype=torch.bfloat16)
         return c
 
-    _blockwise_fp8_gemm_impl = _blockwise_fp8_gemm_op
-
     @triton.jit
     def _fp8_blockwise_act_quant_kernel_impl(
         x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr
@@ -161,8 +164,6 @@ def _lazy_init_triton():
         y = y.to(y_ptr.dtype.element_ty)
         tl.store(y_ptr + offs, y)
         tl.store(s_ptr + pid, s)
-
-    _fp8_blockwise_act_quant_kernel = _fp8_blockwise_act_quant_kernel_impl
 
     @triton.jit
     def _fp8_blockwise_weight_quant_kernel_impl(
@@ -192,8 +193,6 @@ def _lazy_init_triton():
         y = y.to(y_ptr.dtype.element_ty)
         tl.store(y_ptr + offs, y, mask=mask)
         tl.store(s_ptr + pid_m * n + pid_n, s)
-
-    _fp8_blockwise_weight_quant_kernel = _fp8_blockwise_weight_quant_kernel_impl
 
     @triton.jit
     def _fp8_blockwise_weight_dequant_kernel_impl(
@@ -225,7 +224,13 @@ def _lazy_init_triton():
         y = x * s
         tl.store(y_ptr + offs, y, mask=mask)
 
-    _fp8_blockwise_weight_dequant_kernel = _fp8_blockwise_weight_dequant_kernel_impl
+    return _BlockwiseFp8Impls(
+        available=True,
+        gemm=_blockwise_fp8_gemm_op,
+        act_quant=_fp8_blockwise_act_quant_kernel_impl,
+        weight_quant=_fp8_blockwise_weight_quant_kernel_impl,
+        weight_dequant=_fp8_blockwise_weight_dequant_kernel_impl,
+    )
 
 
 def blockwise_fp8_gemm(
@@ -235,10 +240,10 @@ def blockwise_fp8_gemm(
     b_s: torch.Tensor,
     block_size: int = 128,
 ) -> torch.Tensor:
-    _lazy_init_triton()
-    if not _triton_available:
+    impls = _get_triton_impls()
+    if not impls.available:
         raise AssertionError("unsupported without triton")
-    return _blockwise_fp8_gemm_impl(a, a_s, b, b_s, block_size)
+    return impls.gemm(a, a_s, b, b_s, block_size)
 
 
 def fp8_blockwise_act_quant(
@@ -258,8 +263,8 @@ def fp8_blockwise_act_quant(
             - The quantized tensor with dtype `dtype`.
             - A tensor of scaling factors with dtype `torch.float32`.
     """
-    _lazy_init_triton()
-    if not _triton_available:
+    impls = _get_triton_impls()
+    if not impls.available:
         raise AssertionError("unsupported without triton")
 
     import triton
@@ -275,7 +280,7 @@ def fp8_blockwise_act_quant(
     y = torch.empty_like(x, dtype=dtype)
     s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
     grid = lambda meta: (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
-    _fp8_blockwise_act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size)
+    impls.act_quant[grid](x, y, s, BLOCK_SIZE=block_size)
     return y, s
 
 
@@ -295,8 +300,8 @@ def fp8_blockwise_weight_quant(
             - The quantized weight tensor with dtype `dtype`.
             - A tensor of scaling factors with dtype `torch.float32`.
     """
-    _lazy_init_triton()
-    if not _triton_available:
+    impls = _get_triton_impls()
+    if not impls.available:
         raise AssertionError("unsupported without triton")
 
     import triton
@@ -317,7 +322,7 @@ def fp8_blockwise_weight_quant(
         triton.cdiv(M, meta["BLOCK_SIZE"]),
         triton.cdiv(N, meta["BLOCK_SIZE"]),
     )
-    _fp8_blockwise_weight_quant_kernel[grid](x, y, s, M, N, BLOCK_SIZE=block_size)
+    impls.weight_quant[grid](x, y, s, M, N, BLOCK_SIZE=block_size)
     return y, s
 
 
@@ -338,8 +343,8 @@ def fp8_blockwise_weight_dequant(
     Raises:
         AssertionError: If `x` or `s` are not contiguous or if their dimensions are not 2.
     """
-    _lazy_init_triton()
-    if not _triton_available:
+    impls = _get_triton_impls()
+    if not impls.available:
         raise AssertionError("unsupported without triton")
 
     import triton
@@ -352,5 +357,5 @@ def fp8_blockwise_weight_dequant(
         triton.cdiv(M, meta["BLOCK_SIZE"]),
         triton.cdiv(N, meta["BLOCK_SIZE"]),
     )
-    _fp8_blockwise_weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
+    impls.weight_dequant[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
     return y

--- a/torchao/kernel/bsr_triton_ops.py
+++ b/torchao/kernel/bsr_triton_ops.py
@@ -6,7 +6,9 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import os
-from typing import Optional
+from dataclasses import dataclass
+from threading import Lock
+from typing import Callable, Optional
 
 import torch
 from torch._dynamo.utils import warn_once
@@ -271,8 +273,9 @@ def bsr_dense_addmm(
     specified, otherwise, these are treated as tensors filled with
     ones.
     """
-    global _bsr_strided_addmm_kernel
-    _lazy_init_triton()
+    impls = _get_triton_impls()
+    if not impls.available:
+        raise AssertionError("unsupported without triton")
 
     f_name = "bsr_dense_addmm"
     values = bsr.values()
@@ -419,7 +422,7 @@ def bsr_dense_addmm(
     assert alpha != 0
 
     def kernel(grid, *sliced_tensors):
-        _bsr_strided_addmm_kernel[grid](
+        impls.kernel[grid](
             *ptr_stride_extractor(*sliced_tensors),
             beta,
             alpha,
@@ -446,19 +449,31 @@ def bsr_dense_addmm(
     return out_backup
 
 
-# Lazy initialization for triton kernel to avoid CUDA init at import time
-_triton_initialized = False
-_bsr_strided_addmm_kernel = None
+@dataclass(frozen=True)
+class _BsrTritonImpls:
+    available: bool
+    kernel: Optional[Callable]
 
 
-def _lazy_init_triton():
-    global _triton_initialized, _bsr_strided_addmm_kernel
-    if _triton_initialized:
-        return
-    _triton_initialized = True
+_triton_impls: Optional[_BsrTritonImpls] = None
+_triton_impls_lock = Lock()
 
+
+def _get_triton_impls() -> _BsrTritonImpls:
+    global _triton_impls
+    impls = _triton_impls
+    if impls is None:
+        with _triton_impls_lock:
+            impls = _triton_impls
+            if impls is None:
+                impls = _build_triton_impls()
+                _triton_impls = impls
+    return impls
+
+
+def _build_triton_impls() -> _BsrTritonImpls:
     if not has_triton():
-        return
+        return _BsrTritonImpls(False, None)
 
     import triton
     import triton.language as tl
@@ -679,4 +694,4 @@ def _lazy_init_triton():
             mask=col_block_arange[None, :] < BLOCKSIZE_COL,
         )
 
-    _bsr_strided_addmm_kernel = _bsr_strided_addmm_kernel_impl
+    return _BsrTritonImpls(True, _bsr_strided_addmm_kernel_impl)


### PR DESCRIPTION
`blockwise_quantization.py` and `bsr_triton_ops.py` both used a module-level `_triton_initialized = False` flag set to `True` before the kernel handles were assigned. Under free-threaded Python, one thread can set the flag and yield during the slow `import triton`, while another thread observes the flag set but the kernel globals still `None`.

Replace the bool-flag pattern with a lock-guarded builder that publishes an immutable dataclass of the built handles only once construction completes, so callers either see nothing or the fully-built set.