### PR TITLE
kernel: synchronize autotuner cache updates

### DIFF
--- a/torchao/kernel/autotuner.py
+++ b/torchao/kernel/autotuner.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import pathlib
+import threading
 
 import torch
 import triton
@@ -100,7 +101,19 @@ def do_bench_triton(
     return getattr(torch, return_mode)(times).item()
 
 
-BEST_CONFIGS = None
+# Guards initialization and writes to the autotune cache. Reads use single-key
+# dict semantics (atomic) so no lock is needed on the read path after init.
+_best_configs_lock = threading.Lock()
+_best_configs = None
+
+
+def _get_best_configs() -> dict:
+    global _best_configs
+    with _best_configs_lock:
+        if _best_configs is None:
+            loaded = _load_best_configs()
+            _best_configs = loaded if loaded is not None else {}
+        return _best_configs
 
 
 def _save_best_configs(best_configs):
@@ -194,18 +207,13 @@ def do_bench(fn, args, config, best_time=None):
 
 
 def get_best_config_by_key(key):
-    if key in BEST_CONFIGS:
-        return BEST_CONFIGS[key][0]
+    cache_dict = _get_best_configs()
+    if key in cache_dict:  # single-op dict read: FT-safe
+        return cache_dict[key][0]
 
 
 def get_best_config_fn(fn, args, configs):
-    global BEST_CONFIGS
-    if BEST_CONFIGS is None:
-        BEST_CONFIGS = _load_best_configs()
-
-    # This means no config file was loaded
-    if BEST_CONFIGS is None:
-        BEST_CONFIGS = {}
+    cache_dict = _get_best_configs()
 
     if len(configs) == 0:
         return None
@@ -217,7 +225,9 @@ def get_best_config_fn(fn, args, configs):
 
     logging.info(f"Starting autotune search. No config found for key {key}.")
 
-    # Search for the best config
+    # Two threads with the same key may both reach here and autotune in
+    # parallel — that wastes work but is correctness-preserving (last
+    # writer wins on the cache entry).
     best_config = configs[0]
     best_time = do_bench(fn, args, configs[0])
     logging.info(" ".join(map(str, [key, best_time, best_config])))
@@ -234,9 +244,12 @@ def get_best_config_fn(fn, args, configs):
             best_time = time
             best_config = config
         i += 1
-    # Also store time, so it can be proven that the config works
-    BEST_CONFIGS[key] = (best_config, best_time)
     logging.info("-- perfetto --")
     logging.info(" ".join(map(str, [best_time, best_config])))
-    _save_best_configs(BEST_CONFIGS)
+    # Snapshot under the lock so `_save_best_configs` (which iterates via
+    # pickle.dump) never sees a dict mid-mutation from another thread.
+    with _best_configs_lock:
+        cache_dict[key] = (best_config, best_time)
+        snapshot = dict(cache_dict)
+    _save_best_configs(snapshot)
     return best_config


### PR DESCRIPTION
`get_best_config_fn` in `torchao/kernel/autotuner.py` had a lazy-init-then-read-modify-write on the module-level `BEST_CONFIGS` dict, followed by `_save_best_configs(BEST_CONFIGS)` pickling it directly. Under free-threaded Python this is a check-then-act race on init, plus `pickle.dump` can iterate the dict while another thread is still inserting into it.

Guard lazy init and the miss-path write with a lock, and pickle a snapshot taken under that same lock rather than the live dict.