### PR TITLE
float8: snapshot FSDP precomputed scale

### DIFF
--- a/torchao/float8/fsdp_utils.py
+++ b/torchao/float8/fsdp_utils.py
@@ -226,10 +226,15 @@ class WeightWithDynamicFloat8CastTensor(torch.Tensor):
         return f"WeightWithDynamicFloat8CastTensor(tensor={self._tensor}, linear_mm_config={self._linear_mm_config}, dtype={self._dtype})"
 
     def fsdp_pre_all_gather(self, mesh):
-        if self._precomputed_scale is not None:
+        # Snapshot once: `_precomputed_scale` may be re-assigned by
+        # `precompute_float8_dynamic_scale_for_fsdp` between iterations, and
+        # under free-threaded CPython we must not read the attribute twice in
+        # the if/use pair.
+        precomputed_scale = self._precomputed_scale
+        if precomputed_scale is not None:
             float8_training_tensor = hp_tensor_and_scale_to_float8(
                 self._tensor,
-                self._precomputed_scale,
+                precomputed_scale,
                 self._dtype,
                 self._linear_mm_config,
                 GemmInputRole.WEIGHT,


### PR DESCRIPTION
`fsdp_pre_all_gather` on `WeightWithDynamicFloat8CastTensor` checks `self._precomputed_scale is not None` and then reads `self._precomputed_scale` again to use it. `precompute_float8_dynamic_scale_for_fsdp` can reassign that attribute on the same shared instance between the check and the use, so under free-threaded Python the value used may differ from the one checked.

Read `self._precomputed_scale` into a local once and use that for both the check and the call.