### PR TITLE
Expose FP8 blockwise grouped MM function

### DIFF
--- a/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
@@ -19,9 +19,9 @@ if not (
 
 pytest.importorskip("triton", reason="Triton required to run this test")
 
+from torchao.prototype.moe_training import fp8_blockwise_grouped_mm
 from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
     _to_fp8_blockwise_then_emulated_scaled_grouped_mm,
-    _to_fp8_blockwise_then_scaled_grouped_mm,
 )
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
@@ -77,7 +77,7 @@ def test_fp8_blockwise_emulated_grouped_mm_fwd_bwd(
 
 
 @skip_if_rocm("ROCm not supported")
-def test_fp8_blockwise_grouped_mm_emulated_backend():
+def test_fp8_blockwise_grouped_mm_public_function_emulated_backend():
     torch.manual_seed(0)
     E, tokens_per_expert, K, N = 2, 256, 256, 256
     M = E * tokens_per_expert
@@ -94,7 +94,7 @@ def test_fp8_blockwise_grouped_mm_emulated_backend():
     A_ref = A.detach().clone().requires_grad_(True)
     B_t_ref = B_t.detach().clone().requires_grad_(True)
 
-    out = _to_fp8_blockwise_then_scaled_grouped_mm(
+    out = fp8_blockwise_grouped_mm(
         A,
         B_t,
         offs,

--- a/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
@@ -21,7 +21,9 @@ pytest.importorskip("triton", reason="Triton required to run this test")
 
 from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
     _to_fp8_blockwise_then_emulated_scaled_grouped_mm,
+    _to_fp8_blockwise_then_scaled_grouped_mm,
 )
+from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import skip_if_rocm
 
@@ -60,6 +62,44 @@ def test_fp8_blockwise_emulated_grouped_mm_fwd_bwd(
         B_t,
         offs,
         pad_token_groups_for_grouped_mm=pad_token_groups_for_grouped_mm,
+    )
+    ref = torch._grouped_mm(A_ref, B_t_ref, offs=offs, out_dtype=torch.bfloat16)
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    assert compute_error(ref, out) >= 27.0
+
+    out.float().square().mean().backward()
+    ref.float().square().mean().backward()
+
+    assert compute_error(A_ref.grad, A.grad) >= 26.0
+    assert compute_error(B_t_ref.grad, B_t.grad) >= 26.0
+
+
+@skip_if_rocm("ROCm not supported")
+def test_fp8_blockwise_grouped_mm_emulated_backend():
+    torch.manual_seed(0)
+    E, tokens_per_expert, K, N = 2, 256, 256, 256
+    M = E * tokens_per_expert
+    offs = torch.arange(
+        tokens_per_expert,
+        M + 1,
+        tokens_per_expert,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    A = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    B_t = _make_column_major_weight_t(E, N, K).requires_grad_(True)
+
+    A_ref = A.detach().clone().requires_grad_(True)
+    B_t_ref = B_t.detach().clone().requires_grad_(True)
+
+    out = _to_fp8_blockwise_then_scaled_grouped_mm(
+        A,
+        B_t,
+        offs,
+        pad_token_groups_for_grouped_mm=False,
+        kernel_preference=KernelPreference.EMULATED,
     )
     ref = torch._grouped_mm(A_ref, B_t_ref, offs=offs, out_dtype=torch.bfloat16)
 

--- a/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py
@@ -19,7 +19,9 @@ if not (
 
 pytest.importorskip("triton", reason="Triton required to run this test")
 
-from torchao.prototype.moe_training import fp8_blockwise_grouped_mm
+from torchao.prototype.moe_training import (
+    _to_fp8_blockwise_then_scaled_grouped_mm,
+)
 from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
     _to_fp8_blockwise_then_emulated_scaled_grouped_mm,
 )
@@ -77,7 +79,7 @@ def test_fp8_blockwise_emulated_grouped_mm_fwd_bwd(
 
 
 @skip_if_rocm("ROCm not supported")
-def test_fp8_blockwise_grouped_mm_public_function_emulated_backend():
+def test_fp8_blockwise_grouped_mm_emulated_backend():
     torch.manual_seed(0)
     E, tokens_per_expert, K, N = 2, 256, 256, 256
     M = E * tokens_per_expert
@@ -94,7 +96,7 @@ def test_fp8_blockwise_grouped_mm_public_function_emulated_backend():
     A_ref = A.detach().clone().requires_grad_(True)
     B_t_ref = B_t.detach().clone().requires_grad_(True)
 
-    out = fp8_blockwise_grouped_mm(
+    out = _to_fp8_blockwise_then_scaled_grouped_mm(
         A,
         B_t,
         offs,

--- a/torchao/prototype/moe_training/__init__.py
+++ b/torchao/prototype/moe_training/__init__.py
@@ -6,6 +6,17 @@ from torchao.prototype.moe_training.mxfp8_grouped_mm import (
 )
 
 __all__ = [
+    "fp8_blockwise_grouped_mm",
     "_to_mxfp8_then_scaled_grouped_mm",
     "_to_fp8_rowwise_then_scaled_grouped_mm",
 ]
+
+
+def __getattr__(name: str):
+    if name == "fp8_blockwise_grouped_mm":
+        from torchao.prototype.moe_training.blockwise_fp8 import (
+            fp8_blockwise_grouped_mm,
+        )
+
+        return fp8_blockwise_grouped_mm
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchao/prototype/moe_training/__init__.py
+++ b/torchao/prototype/moe_training/__init__.py
@@ -6,17 +6,17 @@ from torchao.prototype.moe_training.mxfp8_grouped_mm import (
 )
 
 __all__ = [
-    "fp8_blockwise_grouped_mm",
+    "_to_fp8_blockwise_then_scaled_grouped_mm",
     "_to_mxfp8_then_scaled_grouped_mm",
     "_to_fp8_rowwise_then_scaled_grouped_mm",
 ]
 
 
 def __getattr__(name: str):
-    if name == "fp8_blockwise_grouped_mm":
+    if name == "_to_fp8_blockwise_then_scaled_grouped_mm":
         from torchao.prototype.moe_training.blockwise_fp8 import (
-            fp8_blockwise_grouped_mm,
+            _to_fp8_blockwise_then_scaled_grouped_mm,
         )
 
-        return fp8_blockwise_grouped_mm
+        return _to_fp8_blockwise_then_scaled_grouped_mm
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchao/prototype/moe_training/blockwise_fp8/__init__.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/__init__.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
-    fp8_blockwise_grouped_mm,
+    _to_fp8_blockwise_then_scaled_grouped_mm,
 )
 
 __all__ = [
-    "fp8_blockwise_grouped_mm",
+    "_to_fp8_blockwise_then_scaled_grouped_mm",
 ]

--- a/torchao/prototype/moe_training/blockwise_fp8/__init__.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/__init__.py
@@ -3,3 +3,11 @@
 #
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
+
+from torchao.prototype.moe_training.blockwise_fp8.grouped_mm import (
+    fp8_blockwise_grouped_mm,
+)
+
+__all__ = [
+    "fp8_blockwise_grouped_mm",
+]

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
@@ -29,7 +29,7 @@ from torchao.quantization.quantize_.common import KernelPreference
 
 
 @conditional_nostrict_trace
-def _to_fp8_blockwise_then_scaled_grouped_mm(
+def fp8_blockwise_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,
     offs: Optional[torch.Tensor] = None,
@@ -66,6 +66,9 @@ def _to_fp8_blockwise_then_scaled_grouped_mm(
         pad_token_groups_for_grouped_mm,
         kernel_preference,
     )
+
+
+_to_fp8_blockwise_then_scaled_grouped_mm = fp8_blockwise_grouped_mm
 
 
 @conditional_nostrict_trace

--- a/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
+++ b/torchao/prototype/moe_training/blockwise_fp8/grouped_mm.py
@@ -29,7 +29,7 @@ from torchao.quantization.quantize_.common import KernelPreference
 
 
 @conditional_nostrict_trace
-def fp8_blockwise_grouped_mm(
+def _to_fp8_blockwise_then_scaled_grouped_mm(
     A: torch.Tensor,
     B_t: torch.Tensor,
     offs: Optional[torch.Tensor] = None,
@@ -66,9 +66,6 @@ def fp8_blockwise_grouped_mm(
         pad_token_groups_for_grouped_mm,
         kernel_preference,
     )
-
-
-_to_fp8_blockwise_then_scaled_grouped_mm = fp8_blockwise_grouped_mm
 
 
 @conditional_nostrict_trace


### PR DESCRIPTION
## Summary
- Expose `_to_fp8_blockwise_then_scaled_grouped_mm` from the prototype MoE namespaces for direct TorchTitan integration without a tensor subclass or `quantize_`.
- Keep the established `_to_*` naming used by the existing grouped-MM entry points.

## Test Plan
`pytest -q test/prototype/moe_training/test_fp8_blockwise_grouped_mm.py::test_fp8_blockwise_grouped_mm_emulated_backend`