### PR TITLE
cpu: lock ukernel registration tables

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
@@ -8,6 +8,7 @@
 #include <cpuinfo.h>
 #include <torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_config.h>
 #include <torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/packed_weights_format.h>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -19,10 +20,12 @@
 namespace torchao::ops::groupwise_lowbit_weight_lut {
 
 /**
- * @brief A thread-unsafe registration table for kernel configurations.
+ * @brief A thread-safe registration table for kernel configurations.
  *
  * This table maps a combination of a weight format (header) and a CPU
- * microarchitecture to a specific UKernelConfig.
+ * microarchitecture to a specific UKernelConfig. Concurrent access is
+ * guarded by an internal mutex so callers under free-threaded CPython do
+ * not race on insert/lookup.
  */
 struct UKernelConfigRegistrationTable {
  private:
@@ -34,6 +37,7 @@ struct UKernelConfigRegistrationTable {
     }
   };
   std::unordered_map<Key, UKernelConfig, KeyHasher> registration_table_;
+  mutable std::mutex mu_;
   inline Key make_key(
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
@@ -48,6 +52,7 @@ struct UKernelConfigRegistrationTable {
       UKernelConfig config) {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     if (registration_table_.find(key) != registration_table_.end()) {
       throw std::runtime_error(
           "UKernelConfig is already registered for this format");
@@ -60,6 +65,7 @@ struct UKernelConfigRegistrationTable {
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     auto it = registration_table_.find(key);
     if (it == registration_table_.end()) {
       return std::nullopt;

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -8,6 +8,7 @@
 #include <cpuinfo.h>
 #include <torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_config.h>
 #include <torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/packed_weights_format.h>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -37,6 +38,10 @@ struct UKernelConfigRegistrationTable {
     }
   };
   std::unordered_map<Key, UKernelConfig, KeyHasher> registration_table_;
+  // Guards `registration_table_` against concurrent insert / lookup on the
+  // hot path. Required under free-threaded CPython, where the GIL no longer
+  // implicitly serializes callers.
+  mutable std::mutex mu_;
   inline Key make_key(
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
@@ -50,6 +55,7 @@ struct UKernelConfigRegistrationTable {
       UKernelConfig config) {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     if (registration_table_.find(key) != registration_table_.end()) {
       throw std::runtime_error(
           "UKernelConfig is already registered for this format");
@@ -61,6 +67,7 @@ struct UKernelConfigRegistrationTable {
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     auto it = registration_table_.find(key);
     if (it == registration_table_.end()) {
       return std::nullopt;
@@ -408,7 +415,6 @@ void register_ukernel_config(
   }
 }
 
-// Not thread safe
 template <int weight_nbit>
 UKernelConfig select_ukernel_config(torchao::ops::PackedWeightsHeader header) {
   static UKernelConfigRegistrationTable table;


### PR DESCRIPTION
Both `linear_8bit_act_xbit_weight/kernel_selector.h` and `groupwise_lowbit_weight_lut/kernel_selector.h` define a `UKernelConfigRegistrationTable` whose backing `std::unordered_map` is mutated on cache miss (`register_ukernel_config`) and read (`get_ukernel_config`) with no synchronization; the structs are used as function-local statics and the code was annotated "Not thread safe". Under free-threaded CPython the GIL no longer serializes callers, so two threads hitting a cold cache concurrently can race the map insertion (rehash during lookup, duplicate-key throw).

Add a `mutable std::mutex` to each struct and take a `std::lock_guard` in `register_ukernel_config` and `get_ukernel_config`. Contention is low since cache fills are rare, so a plain `std::mutex` is used rather than `std::shared_mutex`. The stale "Not thread safe" annotations are updated.

With the lock in place, two threads that both miss the cache can still hit the "already registered" throw in `register_ukernel_config`; a follow-up PR makes registration idempotent.

Assisted-by: Claude