### PR TITLE
cpu: make ukernel registration idempotent

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
@@ -53,11 +53,13 @@ struct UKernelConfigRegistrationTable {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
     std::lock_guard<std::mutex> guard(mu_);
-    if (registration_table_.find(key) != registration_table_.end()) {
-      throw std::runtime_error(
-          "UKernelConfig is already registered for this format");
-    }
+    // Idempotent: first registration wins. Concurrent callers may both
+    // observe a missing entry and attempt to register the same deterministic
+    // config.
     config.validate();
+    if (registration_table_.find(key) != registration_table_.end()) {
+      return;
+    }
     registration_table_[key] = config;
   }
   // get the kernel config for a given format and uarch.

--- a/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_selector.h
@@ -8,6 +8,7 @@
 #include <cpuinfo.h>
 #include <torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/kernel_config.h>
 #include <torchao/csrc/cpu/shared_kernels/groupwise_lowbit_weight_lut/packed_weights_format.h>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -19,10 +20,12 @@
 namespace torchao::ops::groupwise_lowbit_weight_lut {
 
 /**
- * @brief A thread-unsafe registration table for kernel configurations.
+ * @brief A thread-safe registration table for kernel configurations.
  *
  * This table maps a combination of a weight format (header) and a CPU
- * microarchitecture to a specific UKernelConfig.
+ * microarchitecture to a specific UKernelConfig. Concurrent access is
+ * guarded by an internal mutex so callers under free-threaded CPython do
+ * not race on insert/lookup.
  */
 struct UKernelConfigRegistrationTable {
  private:
@@ -34,6 +37,7 @@ struct UKernelConfigRegistrationTable {
     }
   };
   std::unordered_map<Key, UKernelConfig, KeyHasher> registration_table_;
+  mutable std::mutex mu_;
   inline Key make_key(
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
@@ -48,6 +52,7 @@ struct UKernelConfigRegistrationTable {
       UKernelConfig config) {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     if (registration_table_.find(key) != registration_table_.end()) {
       throw std::runtime_error(
           "UKernelConfig is already registered for this format");
@@ -60,6 +65,7 @@ struct UKernelConfigRegistrationTable {
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     auto it = registration_table_.find(key);
     if (it == registration_table_.end()) {
       return std::nullopt;

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -8,6 +8,7 @@
 #include <cpuinfo.h>
 #include <torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_config.h>
 #include <torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/packed_weights_format.h>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -37,6 +38,10 @@ struct UKernelConfigRegistrationTable {
     }
   };
   std::unordered_map<Key, UKernelConfig, KeyHasher> registration_table_;
+  // Guards `registration_table_` against concurrent insert / lookup on the
+  // hot path. Required under free-threaded CPython, where the GIL no longer
+  // implicitly serializes callers.
+  mutable std::mutex mu_;
   inline Key make_key(
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
@@ -50,6 +55,7 @@ struct UKernelConfigRegistrationTable {
       UKernelConfig config) {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     if (registration_table_.find(key) != registration_table_.end()) {
       throw std::runtime_error(
           "UKernelConfig is already registered for this format");
@@ -61,6 +67,7 @@ struct UKernelConfigRegistrationTable {
       torchao::ops::PackedWeightsHeader header,
       cpuinfo_uarch uarch) const {
     auto key = make_key(header, uarch);
+    std::lock_guard<std::mutex> guard(mu_);
     auto it = registration_table_.find(key);
     if (it == registration_table_.end()) {
       return std::nullopt;
@@ -408,7 +415,6 @@ void register_ukernel_config(
   }
 }
 
-// Not thread safe
 template <int weight_nbit>
 UKernelConfig select_ukernel_config(torchao::ops::PackedWeightsHeader header) {
   static UKernelConfigRegistrationTable table;

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -56,11 +56,13 @@ struct UKernelConfigRegistrationTable {
     auto header = format.to_packed_weights_header();
     auto key = make_key(header, uarch);
     std::lock_guard<std::mutex> guard(mu_);
-    if (registration_table_.find(key) != registration_table_.end()) {
-      throw std::runtime_error(
-          "UKernelConfig is already registered for this format");
-    }
+    // Idempotent: first registration wins. Concurrent callers of
+    // `select_ukernel_config` may both observe a missing entry and attempt
+    // to register the same deterministic config.
     config.validate();
+    if (registration_table_.find(key) != registration_table_.end()) {
+      return;
+    }
     registration_table_[key] = config;
   }
   std::optional<UKernelConfig> get_ukernel_config(


### PR DESCRIPTION
Stacked on #4561 (the first commit here); only the second commit is new.

With the table mutex from #4561 in place, the call site in `select_ukernel_config` is still racy:

```cpp
auto ukernel = table.get_ukernel_config(header, uarch);  // lock A
if (ukernel.has_value()) return ukernel.value();
register_ukernel_config<weight_nbit>(table, format, uarch);  // lock B
```

Lock A and lock B are independent critical sections. Two threads can both observe the missing entry, both call `register_ukernel_config`, and the second thread's "already registered" throw fires as a TOCTOU false positive under free-threaded Python.

Make registration idempotent: first registration wins, duplicates are silent no-ops (`try_emplace` semantics). The registered config is deterministic for a given (header, uarch) key, so dropping the duplicate loses nothing. Single-threaded behavior is unchanged. Applies to both `linear_8bit_act_xbit_weight` and `groupwise_lowbit_weight_lut`, which have structurally identical tables.

Reproduced on x86 with a free-threaded interpreter: concurrent cold-cache calls to the 8-bit-act linear op raised "UKernelConfig is already registered for this format" before this change, pass after.

Assisted-by: Claude