### PR TITLE
Fix Int8WeightOnlyConfig crash when in_features=1

### DIFF
--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -510,6 +510,19 @@ class TestInt8StaticQuant(TorchAOIntegrationTestCase):
         sqnr = compute_error(output_baseline, output)
         self.assertGreater(sqnr, 40, f"SQNR too low: {sqnr}")
 
+    def test_int8_weight_only_in_features_one(self):
+        """Per-row int8 weight-only must work when in_features=1.
+
+        Regression for https://github.com/pytorch/ao/issues/761
+        """
+        torch.manual_seed(0)
+        model = torch.nn.Linear(1, 4)
+        ref = model(torch.randn(8, 1)).detach().clone()
+        quantize_(model, Int8WeightOnlyConfig(version=2, granularity=PerRow()))
+        self.assertEqual(model.weight.scale.shape, torch.Size([4, 1]))
+        out = model(torch.randn(8, 1))
+        self.assertEqual(out.shape, ref.shape)
+
 
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -628,6 +628,44 @@ class TestQuantPrimitives(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "is invalid for input of size 1"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
 
+    def test_choose_qparams_affine_all_ones_block_size(self):
+        """block_size of all ones (e.g. PerRow on in_features=1) must not collapse scales.
+
+        See https://github.com/pytorch/ao/issues/761
+        """
+        input = torch.randn(4, 1)
+        block_size = (1, 1)
+        for mapping_type in (MappingType.SYMMETRIC, MappingType.ASYMMETRIC):
+            scale, zero_point = choose_qparams_affine(
+                input,
+                mapping_type,
+                block_size,
+                torch.int8,
+                keepdim=True,
+                eps=torch.finfo(torch.float32).eps,
+            )
+            self.assertEqual(scale.shape, torch.Size([4, 1]))
+            self.assertEqual(zero_point.shape, torch.Size([4, 1]))
+            quantized = quantize_affine(
+                input, block_size, scale, zero_point, torch.int8
+            )
+            self.assertEqual(quantized.shape, input.shape)
+
+        # Same empty-reduction edge case for float8 scale selection
+        float8_scale = _choose_scale_float8(input, block_size=[1, 1])
+        self.assertEqual(float8_scale.shape, torch.Size([4, 1]))
+
+    def test_int8_weight_only_linear_in_features_one(self):
+        """End-to-end Int8WeightOnlyConfig with in_features=1 (issue #761)."""
+        from torchao.quantization import Int8WeightOnlyConfig, quantize_
+
+        torch.manual_seed(0)
+        model = torch.nn.Linear(1, 4)
+        quantize_(model, Int8WeightOnlyConfig(version=2, granularity=PerRow()))
+        self.assertEqual(model.weight.scale.shape, torch.Size([4, 1]))
+        out = model(torch.randn(8, 1))
+        self.assertEqual(out.shape, torch.Size([8, 4]))
+
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)
         n_bit = 4

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -1323,8 +1323,12 @@ def _choose_qparams_affine_tinygemm(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
+    if len(reduction_dims) == 0:
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
 
     # For preserve_zero=False, we don't ensure zero is exactly representable
     min_val_neg = min_val
@@ -1394,8 +1398,12 @@ def _choose_qparams_affine_dont_preserve_zero(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
+    if len(reduction_dims) == 0:
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
 
     # For no preserve zero, we don't ensure zero is exactly representable
     min_val_neg = min_val
@@ -1541,8 +1549,15 @@ def _choose_qparams_affine(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=keepdim)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=keepdim)
+    # When every block_size entry is 1 (e.g. PerRow on in_features=1), there are
+    # no dims to reduce over. torch.amin/amax with dim=[] reduce over *all* dims,
+    # which collapses the tensor to a single value and breaks the later reshape.
+    if len(reduction_dims) == 0:
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=keepdim)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=keepdim)
 
     min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
     max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
@@ -1617,8 +1632,12 @@ def _choose_qparams_gguf(
         block_size, input.size()
     )
     input = input.view(shape_for_reduction)
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
+    if len(reduction_dims) == 0:
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
     quant_max = 15
     quant_min = 0
     # asymmetric quant to fully utilize the range
@@ -2264,7 +2283,12 @@ def _choose_scale_float8(
         block_size, tensor.shape
     )
     tensor_reshaped = tensor.view(shape_for_reduction)
-    max_abs = tensor_reshaped.abs().amax(dim=reduction_dims, keepdim=True)
+    # Same empty-reduction edge case as _choose_qparams_affine: dim=[] would
+    # incorrectly reduce over all dims (e.g. PerRow on in_features=1).
+    if len(reduction_dims) == 0:
+        max_abs = tensor_reshaped.abs()
+    else:
+        max_abs = tensor_reshaped.abs().amax(dim=reduction_dims, keepdim=True)
     if hp_value_lb is not None or hp_value_ub is not None:
         max_abs = torch.clamp(max_abs, min=hp_value_lb, max=hp_value_ub)
     scale = max_abs / quant_max


### PR DESCRIPTION
## Summary
`Int8WeightOnlyConfig` with per-row granularity crashes on `nn.Linear(1, N)` because `block_size` becomes `(1, 1)`, `reduction_dims` is empty, and `torch.amin`/`amax` with `dim=[]` incorrectly reduce over all dims. That collapses the scale tensor and breaks the later reshape.

This PR guards the empty-`reduction_dims` case in `choose_qparams` helpers (and the matching float8 scale path) so each element keeps its own qparam when there is nothing to reduce over.

Fixes #761

## Test plan
- [x] `pytest test/quantization/test_quant_primitives.py::TestQuantPrimitives::test_choose_qparams_affine_all_ones_block_size`
- [x] `pytest test/quantization/test_quant_primitives.py::TestQuantPrimitives::test_int8_weight_only_linear_in_features_one`
- [x] `pytest test/quantization/test_quant_primitives.py::TestQuantPrimitives::test_raises` (existing mismatch case still fails as expected)
- [x] Manual repro: `quantize_(nn.Linear(1, 4), Int8WeightOnlyConfig())` now succeeds for PerRow and PerTensor
- [x] `ruff check` / `ruff format` on touched files


Made with [Cursor](https://cursor.com)