### PR TITLE
[mxfp8] use explicit RCEIL scaling in on-device all-to-all-v

### DIFF
--- a/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
+++ b/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
@@ -26,6 +26,11 @@ from torchao.prototype.moe_training.kernels.mxfp8.comms import (
     mxfp8_on_device_all_to_all_v,
     to_mxfp8_a2a_dequant,
 )
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.kernels import (
+    triton_mxfp8_dequant_dim0,
+    triton_to_mxfp8_dim0,
+)
 
 from ..testing_utils import generate_split_sizes
 
@@ -141,6 +146,78 @@ class MXFP8OnDeviceAllToAllVTest(MultiProcessTestCase):
                 f"grad_sqnr={grad_sqnr} is less than min_grad_sqnr={min_grad_sqnr}"
             )
 
+        finally:
+            dist.destroy_process_group()
+
+    def test_scaling_mode_semantics(self):
+        self._init_process()
+        try:
+            self._init_device()
+            group_name = dist.group.WORLD.group_name
+            symm_mem.enable_symm_mem_for_group(group_name)
+
+            tokens = 4
+            dim = 64
+            input_splits = torch.zeros(
+                self.world_size, dtype=torch.int64, device=self.device
+            )
+            input_splits[self.rank] = tokens
+            x = torch.full(
+                (tokens, dim),
+                500.0,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+
+            def quantize_dequantize(mode):
+                qdata, scales = triton_to_mxfp8_dim0(
+                    x, inner_block_size=32, scaling_mode=mode.value
+                )
+                return triton_mxfp8_dequant_dim0(
+                    qdata, scales.view(torch.uint8), x.dtype, 32
+                )
+
+            expected = {
+                mode: quantize_dequantize(mode)
+                for mode in (ScaleCalculationMode.RCEIL, ScaleCalculationMode.FLOOR)
+            }
+            assert not torch.equal(
+                expected[ScaleCalculationMode.RCEIL],
+                expected[ScaleCalculationMode.FLOOR],
+            )
+
+            max_output_tokens_per_rank = tokens * self.world_size
+            x_default = x.clone().requires_grad_(True)
+            output_default, output_splits = mxfp8_on_device_all_to_all_v(
+                x_default,
+                input_splits,
+                max_output_tokens_per_rank,
+                group_name,
+            )
+            assert torch.equal(output_splits, input_splits)
+            assert torch.equal(
+                output_default, expected[ScaleCalculationMode.RCEIL]
+            )
+
+            for mode in (ScaleCalculationMode.RCEIL, ScaleCalculationMode.FLOOR):
+                output, output_splits = mxfp8_on_device_all_to_all_v(
+                    x,
+                    input_splits,
+                    max_output_tokens_per_rank,
+                    group_name,
+                    scaling_mode=mode,
+                )
+                assert torch.equal(output_splits, input_splits)
+                assert torch.equal(output, expected[mode])
+
+            grad = torch.full_like(output_default, 500.0)
+            actual_grad = torch.autograd.grad(
+                output_default, x_default, grad_outputs=grad
+            )[0]
+            assert torch.equal(
+                actual_grad,
+                expected[ScaleCalculationMode.RCEIL],
+            )
         finally:
             dist.destroy_process_group()
 

--- a/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
+++ b/test/prototype/moe_training/mxfp8/test_mxfp8_a2a.py
@@ -200,12 +200,14 @@ class MXFP8OnDeviceAllToAllVTest(MultiProcessTestCase):
             )
 
             for mode in (ScaleCalculationMode.RCEIL, ScaleCalculationMode.FLOOR):
+                # scaling_mode is positional: autograd.Function.apply does not
+                # bind keyword arguments for this forward.
                 output, output_splits = mxfp8_on_device_all_to_all_v(
                     x,
                     input_splits,
                     max_output_tokens_per_rank,
                     group_name,
-                    scaling_mode=mode,
+                    mode,
                 )
                 assert torch.equal(output_splits, input_splits)
                 assert torch.equal(output, expected[mode])

--- a/torchao/prototype/moe_training/kernels/mxfp8/comms.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/comms.py
@@ -11,6 +11,7 @@ from torchao.prototype.moe_training.kernels.triton_utils import (
     blockwise_barrier,
     sync_threads,
 )
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import (
     triton_mxfp8_dequant_dim0,
     triton_to_mxfp8_dim0,
@@ -54,7 +55,8 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         input: torch.Tensor,
         input_splits: torch.Tensor,
         max_output_rows_per_rank: int,
-        group: dist.ProcessGroup = dist.group.WORLD,
+        group: dist.ProcessGroup,
+        scaling_mode: ScaleCalculationMode,
     ):
         """
         Args:
@@ -63,6 +65,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
             input_splits: input splits of shape (group.world_size,)
             max_output_rows_per_rank: maximum output rows/tokens per rank.
             group: process group to scope the collective.
+            scaling_mode: mode used to calculate MXFP8 scales.
         """
         assert input.dtype in (torch.float32, torch.bfloat16)
 
@@ -79,6 +82,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
             input,
             elem_dtype=torch.float8_e4m3fn,
             block_size=block_size,
+            scaling_mode=scaling_mode,
         )
 
         # Triton doesn't support float8_e8m0fnu yet, view as uint8
@@ -161,6 +165,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         ctx.input_scales_shape = input_scales.shape
         ctx.hp_dtype = hp_dtype
         ctx.max_output_rows_per_rank = max_output_rows_per_rank
+        ctx.scaling_mode = scaling_mode
         ctx.save_for_backward(output_splits)
         tokens_on_device_after_a2a_fwd = output_splits.sum()
         hp_output_no_padding = hp_output[:tokens_on_device_after_a2a_fwd]
@@ -194,6 +199,7 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
             grad_output,
             elem_dtype=torch.float8_e4m3fn,
             block_size=block_size,
+            scaling_mode=ctx.scaling_mode,
         )
 
         # Triton doesn't support float8_e8m0fnu yet, view as uint8
@@ -255,11 +261,29 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         tokens_on_device_after_a2a_bwd = (
             MXFP8OnDeviceAllToAllV.grad_input_splits_buf.sum()
         )
-        return grad_input_hp[:tokens_on_device_after_a2a_bwd], None, None, None
+        return grad_input_hp[:tokens_on_device_after_a2a_bwd], None, None, None, None
 
 
-# Alias
-mxfp8_on_device_all_to_all_v = MXFP8OnDeviceAllToAllV.apply
+def mxfp8_on_device_all_to_all_v(
+    input: torch.Tensor,
+    input_splits: torch.Tensor,
+    max_output_rows_per_rank: int,
+    group: dist.ProcessGroup = dist.group.WORLD,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
+):
+    """
+    Quantize, exchange, and dequantize rows with an on-device all-to-all-v.
+
+    RCEIL is the training-safe default. Pass ``ScaleCalculationMode.FLOOR``
+    explicitly when OCP MX 1.0 floor scaling semantics are required.
+    """
+    return MXFP8OnDeviceAllToAllV.apply(
+        input,
+        input_splits,
+        max_output_rows_per_rank,
+        group,
+        scaling_mode,
+    )
 
 
 # Triton launcher function

--- a/torchao/prototype/moe_training/kernels/mxfp8/comms.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/comms.py
@@ -55,8 +55,8 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         input: torch.Tensor,
         input_splits: torch.Tensor,
         max_output_rows_per_rank: int,
-        group: dist.ProcessGroup,
-        scaling_mode: ScaleCalculationMode,
+        group: dist.ProcessGroup = dist.group.WORLD,
+        scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
     ):
         """
         Args:
@@ -65,7 +65,9 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
             input_splits: input splits of shape (group.world_size,)
             max_output_rows_per_rank: maximum output rows/tokens per rank.
             group: process group to scope the collective.
-            scaling_mode: mode used to calculate MXFP8 scales.
+            scaling_mode: mode used to calculate MXFP8 scales. RCEIL is the
+                training-safe default; pass ``ScaleCalculationMode.FLOOR`` when
+                OCP MX 1.0 floor scaling semantics are required.
         """
         assert input.dtype in (torch.float32, torch.bfloat16)
 
@@ -264,26 +266,8 @@ class MXFP8OnDeviceAllToAllV(torch.autograd.Function):
         return grad_input_hp[:tokens_on_device_after_a2a_bwd], None, None, None, None
 
 
-def mxfp8_on_device_all_to_all_v(
-    input: torch.Tensor,
-    input_splits: torch.Tensor,
-    max_output_rows_per_rank: int,
-    group: dist.ProcessGroup = dist.group.WORLD,
-    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL,
-):
-    """
-    Quantize, exchange, and dequantize rows with an on-device all-to-all-v.
-
-    RCEIL is the training-safe default. Pass ``ScaleCalculationMode.FLOOR``
-    explicitly when OCP MX 1.0 floor scaling semantics are required.
-    """
-    return MXFP8OnDeviceAllToAllV.apply(
-        input,
-        input_splits,
-        max_output_rows_per_rank,
-        group,
-        scaling_mode,
-    )
+# Alias
+mxfp8_on_device_all_to_all_v = MXFP8OnDeviceAllToAllV.apply
 
 
 # Triton launcher function


### PR DESCRIPTION
Default the public operation to training-safe RCEIL while retaining explicit FLOOR support and propagating the selected mode through backward.