### PR TITLE
Fix CUTLASS DSL 4.6 helper import

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
@@ -50,7 +50,7 @@ if _cutedsl_runtime_available():
     import cutlass
     import cutlass.cute as cute
     from cutlass._mlir.dialects import llvm
-    from cutlass.base_dsl._mlir_helpers import arith as _dsl_arith
+    from cutlass._mlir_helpers import arith as _dsl_arith
     from cutlass.cutlass_dsl import T, dsl_user_op
 
     # FP8 constants


### PR DESCRIPTION
The MLIR helpers moved out of `cutlass.base_dsl` in CUTLASS DSL 4.6. Update the import so the MXFP8 training config can be imported with the current package.

Tested with `nvidia-cutlass-dsl==4.6.0.dev0` and `apache-tvm-ffi==0.1.11`. Ruff check and format check pass.