### PR TITLE
Gate int8 channelwise neondot qmatmul behind runtime FEAT_DotProd check

### DIFF
--- a/torchao/csrc/cpu/torch_free_kernels/interface/quantized_matmul.h
+++ b/torchao/csrc/cpu/torch_free_kernels/interface/quantized_matmul.h
@@ -12,6 +12,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/fallback/matmul/fp32_a_channelwise_8bit_b_fp32_c.h>
 
 #if defined(__aarch64__) && defined(__ARM_NEON)
+#include <cpuinfo.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/matmul/matmul.h>
 #endif // defined(__aarch64__) && defined(__ARM_NEON)
 
@@ -66,7 +67,12 @@ get_int8_a_int8_b_channelwise_qmatmul(
     int& a_stride_m,
     int& b_stride_n) {
 #if defined(__aarch64__) && defined(__ARM_NEON)
-  if (!a_transposed && b_transposed && n >= 8) {
+  // This kernel uses dot-product (UDOT/SDOT, FEAT_DotProd) instructions, which
+  // are absent on ARMv8.3 and earlier (e.g. Apple A12). Dispatching it on such
+  // hardware traps with SIGILL, so gate it behind a runtime cpuinfo check and
+  // fall through to the scalar kernel when FEAT_DotProd is unavailable.
+  if (cpuinfo_initialize() && cpuinfo_has_arm_neon_dot() && !a_transposed &&
+      b_transposed && n >= 8) {
     a_stride_m = k;
     b_stride_n = k;
     return aarch64::quantized_matmul::


### PR DESCRIPTION
Summary:
The channelwise int8 quantized-matmul dispatcher
(get_int8_a_int8_b_channelwise_qmatmul) selected the aarch64 neondot
microkernel based only on compile-time guards (__aarch64__ && __ARM_NEON) plus
a geometry check (n >= 8), with no runtime CPU-feature detection. That kernel
uses ARM dot-product instructions (UDOT/SDOT, FEAT_DotProd), which are only
available on ARMv8.4+. On ARMv8.3 and earlier CPUs the dispatched kernel
executes an unsupported instruction and traps with SIGILL.

Gate the neondot branch behind a runtime cpuinfo_has_arm_neon_dot() check
(guarded by cpuinfo_initialize()) and fall through to the existing scalar
fallback kernel when FEAT_DotProd is unavailable. This mirrors the runtime
guard already used in the linear kernel selector (kernel_selector.h).

- Add the runtime dotprod check in interface/quantized_matmul.h (fbcode + xplat)
- Add the cpuinfo dependency to the interface BUCK targets

Only the int8 channelwise_8bit_a_channelwise_8bit_b branch uses dotprod
intrinsics; the sibling fp32_a_input_channelwise_8bit_b branch does not and is
left unchanged.

Differential Revision: D111949649


