### PR TITLE
fix(experimental/mps): raise ImportError so pkgutil.walk_packages can skip the module (#4577)

### DIFF
--- a/torchao/experimental/ops/mps/utils.py
+++ b/torchao/experimental/ops/mps/utils.py
@@ -47,7 +47,14 @@ def _get_torchao_mps_lib_path():
 
 
 def _load_torchao_mps_lib():
-    """Load the MPS ops library."""
+    """Load the MPS ops library.
+
+    Raises ImportError (not RuntimeError) when the library is unavailable:
+    this runs at import time of ``torchao.experimental.ops.mps``, and
+    ``pkgutil.walk_packages`` -- used by diffusers/transformers to enumerate
+    backends -- only suppresses ImportError. Any other exception type aborts
+    the caller's whole package walk.
+    """
     try:
         for nbit in range(1, 8):
             getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
@@ -55,14 +62,14 @@ def _load_torchao_mps_lib():
     except AttributeError:
         libpath = _get_torchao_mps_lib_path()
         if libpath is None:
-            raise RuntimeError(
+            raise ImportError(
                 "Could not find libtorchao_ops_mps_aten.dylib. "
                 "Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1"
             )
         try:
             torch.ops.load_library(libpath)
         except Exception as e:
-            raise RuntimeError(f"Failed to load library {libpath}: {e}")
+            raise ImportError(f"Failed to load library {libpath}: {e}") from e
 
         for nbit in range(1, 8):
             getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")


### PR DESCRIPTION
Fixes #4577.

### Problem

`torchao/experimental/ops/mps/__init__.py` calls `_load_torchao_mps_lib()` at import time. When the `torch.ops.torchao._linear_fp_act_*bit_weight` operators are not registered and `libtorchao_ops_mps_aten.dylib` is not present — which is the case for the XPU wheel on Windows, and for any non-macOS install that ships the MPS Python wrapper — the loader raises `RuntimeError`.

`pkgutil.walk_packages()` suppresses `ImportError` while enumerating a package, but lets every other exception propagate. Since diffusers and transformers use `walk_packages` for backend discovery, one unimportable optional submodule aborts the enumeration of all of `torchao`.

### Fix

Raise `ImportError` instead of `RuntimeError` when the MPS library cannot be found or loaded. `ImportError` is the semantically correct exception for an import-time native-library failure, and it lets `walk_packages` skip the module the same way it already skips other unavailable optional backends. Messages are unchanged; the load failure now chains the original exception with `from e`.

### Verification

Reduced repro of the `walk_packages` contract, independent of torchao:

```
sub/__init__.py raises RuntimeError -> walk ABORTED: RuntimeError boom
sub/__init__.py raises ImportError  -> walk completed: ['demo.sub']
```

Direct imports of `torchao.experimental.ops.mps` still surface the same message and are still fatal for callers that genuinely need MPS — only the exception type changes, so `except ImportError` at the discovery layer now behaves correctly. No test asserts `RuntimeError` from this path (`_load_torchao_mps_lib` has no other callers in the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
