### PR TITLE
[pat] Low-rank pruning support

### DIFF
--- a/test/prototype/pat/test_pat_min_rank.py
+++ b/test/prototype/pat/test_pat_min_rank.py
@@ -1,0 +1,319 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import random
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.testing._internal import common_utils
+
+from test.prototype.pat.test_common import TwoLayerMLP, make_prox_kwargs, optim_step
+from torchao.prototype.pat.group import PackedSVDGrouper, SVDGrouper
+from torchao.prototype.pat.optim import MinRankConstraint, PruneOptimizer
+from torchao.prototype.pat.utils import get_param_groups
+
+
+class TestMinRankConstraintApply(common_utils.TestCase):
+    """Direct tests for MinRankConstraint on singular-value tensors."""
+
+    @common_utils.parametrize(
+        "k,min_sparsity,n_killed",
+        [(5, 0.0, 0), (5, 0.4, 2), (5, 0.5, 3), (5, 1.0, 5)],
+    )
+    def test_zeros_smallest_singular_values(self, k, min_sparsity, n_killed):
+        p = torch.arange(1, k + 1, dtype=torch.float32)
+        prox = MinRankConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        zeros_count, group_norm = prox.apply_(p, gamma=1.0)
+
+        self.assertEqual(zeros_count.item(), n_killed)
+        self.assertTrue(p[:n_killed].eq(0).all())
+        expected_survivors = torch.arange(n_killed + 1, k + 1, dtype=torch.float32)
+        self.assertEqual(p[n_killed:], expected_survivors)
+        if min_sparsity == 1.0:
+            self.assertEqual(group_norm.item(), 0.0)
+
+    def test_packed_singular_values_are_pruned_per_matrix(self):
+        npack, k, min_sparsity = 3, 6, 0.5
+        p = torch.arange(1, k + 1, dtype=torch.float32).repeat(npack, 1)
+        prox = MinRankConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        zeros_count, _ = prox.apply_(p, gamma=1.0)
+
+        n_killed = math.ceil(min_sparsity * k)
+        self.assertEqual(zeros_count.item(), npack * n_killed)
+        self.assertTrue(p[:, :n_killed].eq(0).all())
+        expected_survivors = torch.arange(
+            n_killed + 1, k + 1, dtype=torch.float32
+        ).expand(npack, -1)
+        self.assertEqual(p[:, n_killed:], expected_survivors)
+
+    @common_utils.parametrize("min_sparsity", [-0.1, 1.1])
+    def test_invalid_min_sparsity(self, min_sparsity):
+        with self.assertRaises(AssertionError):
+            MinRankConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+
+
+class TestMinRankWithSVDGrouper(common_utils.TestCase):
+    """Integration tests for MinRankConstraint with SVD groupers."""
+
+    @staticmethod
+    def _effective_rank(weight):
+        singular_values = torch.linalg.svdvals(weight.to(torch.float32))
+        return int((singular_values > 1e-5).sum().item())
+
+    @common_utils.parametrize("min_sparsity", [0.25, 0.5, 0.75])
+    def test_svd_grouper(self, min_sparsity):
+        torch.manual_seed(0)
+        in_dim, out_dim = 64, 32
+        k = min(in_dim, out_dim)
+        model = torch.nn.Linear(in_dim, out_dim)
+        prox = MinRankConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        grouper = SVDGrouper(model.weight)
+        prox_kwargs = make_prox_kwargs(
+            gamma=1.0, zero_elts_are_counts=True, is_svd_grouper=True
+        )
+        zero_elts, _, zeros_are_summed = PruneOptimizer._apply_prox(
+            grouper,
+            prox,
+            model.weight,
+            sv_count=torch.zeros(1, dtype=torch.int),
+            **prox_kwargs,
+        )
+
+        n_killed = math.ceil(min_sparsity * k)
+        self.assertTrue(zeros_are_summed)
+        self.assertEqual(zero_elts, n_killed)
+        self.assertEqual(self._effective_rank(model.weight), k - n_killed)
+
+    def test_packed_svd_grouper(self):
+        torch.manual_seed(0)
+        embed_dim, npack, min_sparsity = 16, 3, 0.5
+        model = torch.nn.Linear(embed_dim, embed_dim * npack)
+        prox = MinRankConstraint(reg_lambda=0.0, min_sparsity=min_sparsity)
+        grouper = PackedSVDGrouper(model.weight, npack, pack_dim=0)
+        prox_kwargs = make_prox_kwargs(
+            gamma=1.0, zero_elts_are_counts=True, is_svd_grouper=True
+        )
+        sv_count = torch.zeros(npack, dtype=torch.int)
+        zero_elts, _, _ = PruneOptimizer._apply_prox(
+            grouper,
+            prox,
+            model.weight,
+            sv_count=sv_count,
+            **prox_kwargs,
+        )
+
+        n_killed_per_pack = math.ceil(min_sparsity * embed_dim)
+        retained_per_pack = embed_dim - n_killed_per_pack
+        self.assertEqual(zero_elts, npack * n_killed_per_pack)
+        self.assertEqual(sv_count, torch.full_like(sv_count, retained_per_pack))
+        for packed_weight in model.weight.chunk(npack, dim=0):
+            self.assertEqual(
+                self._effective_rank(packed_weight), embed_dim - n_killed_per_pack
+            )
+
+
+class TestProxFreqGate(common_utils.TestCase):
+    def test_prox_freq_gates_svd(self):
+        torch.manual_seed(0)
+        n_steps, prox_freq = 16, 4
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        prune_config = {
+            (torch.nn.Linear, "weight"): {
+                "group_type": "SVDGrouper",
+                "prox_type": "MinRankConstraint",
+                "min_sparsity": 0.5,
+                "prox_freq": prox_freq,
+            }
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            warmup_steps=0,
+            reg_lambda=0.0,
+        )
+        dummy_input = torch.randn(n_steps, 8)
+        label = torch.randint(0, 2, (n_steps,))
+
+        enter_count = 0
+        real_enter = SVDGrouper.__enter__
+
+        def counting_enter(grouper):
+            nonlocal enter_count
+            enter_count += 1
+            return real_enter(grouper)
+
+        with patch.object(SVDGrouper, "__enter__", counting_enter):
+            for step in range(n_steps):
+                optim_step(model, optimizer, dummy_input, label, step)
+
+        n_params = sum(
+            len(group["params"]) for group in optimizer.regularized_param_groups()
+        )
+        expected_per_param = n_steps // prox_freq
+        self.assertEqual(enter_count, expected_per_param * n_params)
+
+    def test_mixed_frequencies_keep_complete_metrics(self):
+        torch.manual_seed(0)
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        prune_config = {
+            "fc1.weight": {
+                "group_type": "SVDGrouper",
+                "prox_type": "MinRankConstraint",
+                "min_sparsity": 0.5,
+                "prox_freq": 2,
+            },
+            "fc2.weight": {
+                "group_type": "SVDGrouper",
+                "prox_type": "MinRankConstraint",
+                "min_sparsity": 0.5,
+                "prox_freq": 3,
+            },
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            warmup_steps=0,
+            reg_lambda=0.0,
+        )
+        dummy_input = torch.randn(3, 8)
+        label = torch.randint(0, 2, (3,))
+
+        optim_step(model, optimizer, dummy_input, label, 0)
+        relative_sparsity = optimizer.relative_sparsity
+        relative_factored_frac = optimizer.relative_factored_frac
+
+        # At step 2 only fc1 runs. The global metrics must retain the last
+        # complete aggregate instead of reporting the running subset alone.
+        optim_step(model, optimizer, dummy_input, label, 1)
+        optim_step(model, optimizer, dummy_input, label, 2)
+        self.assertEqual(optimizer.relative_sparsity, relative_sparsity)
+        self.assertEqual(optimizer.relative_factored_frac, relative_factored_frac)
+
+
+class TestProxThroughHeal(common_utils.TestCase):
+    @staticmethod
+    def _make_optimizer(group_type, prox_type, prox_through_heal=None):
+        param = torch.nn.Parameter(torch.randn(4, 4))
+        group = {
+            "params": [param],
+            "group_type": group_type,
+            "prox_type": prox_type,
+        }
+        if prox_type == "MinRankConstraint":
+            group["min_sparsity"] = 0.5
+        if prox_through_heal is not None:
+            group["prox_through_heal"] = prox_through_heal
+        return PruneOptimizer(torch.optim.SGD([group], lr=0.1))
+
+    def test_non_svd_opt_in_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, "prox_through_heal=True requires an SVD grouper"
+        ):
+            self._make_optimizer("Dim0Grouper", "ProxGroupLasso", True)
+
+    def test_non_svd_opt_in_mutation_is_rejected(self):
+        optimizer = self._make_optimizer("Dim0Grouper", "ProxGroupLasso")
+        group = next(optimizer.regularized_param_groups())
+        group["prox_through_heal"] = True
+        with self.assertRaisesRegex(
+            ValueError, "prox_through_heal=True requires an SVD grouper"
+        ):
+            optimizer._prox_through_heal(group)
+
+    @common_utils.parametrize(
+        "prox_type,override,expected",
+        [
+            ("MinRankConstraint", None, True),
+            ("ProxNuclearNorm", None, False),
+            ("ProxNuclearNorm", True, True),
+            ("MinRankConstraint", False, False),
+        ],
+    )
+    def test_svd_policy_defaults_and_overrides(self, prox_type, override, expected):
+        optimizer = self._make_optimizer("SVDGrouper", prox_type, override)
+        group = next(optimizer.regularized_param_groups())
+        self.assertEqual(optimizer._prox_through_heal(group), expected)
+
+    def test_singular_values_stay_zero_during_healing(self):
+        torch.manual_seed(0)
+        warmup, healing_start, n_steps = 2, 6, 12
+        min_sparsity = 0.5
+        model = TwoLayerMLP(input_size=8, output_size=2)
+        prune_config = {
+            (torch.nn.Linear, "weight"): {
+                "group_type": "SVDGrouper",
+                "prox_type": "MinRankConstraint",
+                "min_sparsity": min_sparsity,
+            }
+        }
+        param_groups = get_param_groups(model, prune_config, verbose=False)
+        optimizer = PruneOptimizer(
+            torch.optim.SGD(param_groups, lr=0.1),
+            warmup_steps=warmup,
+            healing_start_step=healing_start,
+            reg_lambda=0.0,
+        )
+        dummy_input = torch.randn(n_steps, 8)
+        label = torch.randint(0, 2, (n_steps,))
+
+        for step in range(n_steps):
+            optim_step(model, optimizer, dummy_input, label, step)
+
+        for layer in (model.fc1, model.fc2):
+            k = min(layer.weight.shape)
+            singular_values = torch.linalg.svdvals(
+                layer.weight.detach().to(torch.float32)
+            )
+            n_killed = math.ceil(min_sparsity * k)
+            effective_rank = int((singular_values > 1e-5).sum().item())
+            self.assertLessEqual(effective_rank, k - n_killed)
+
+
+class TestPackedFactorizationMetrics(common_utils.TestCase):
+    @common_utils.parametrize("pack_dim", [0, 1])
+    def test_full_step_uses_total_packed_storage(self, pack_dim):
+        torch.manual_seed(0)
+        embed_dim, npack, min_sparsity = 8, 3, 0.75
+        shape = (
+            (embed_dim * npack, embed_dim)
+            if pack_dim == 0
+            else (embed_dim, embed_dim * npack)
+        )
+        param = torch.nn.Parameter(torch.randn(shape))
+        group = {
+            "params": [param],
+            "group_type": "PackedSVDGrouper",
+            "prox_type": "MinRankConstraint",
+            "min_sparsity": min_sparsity,
+            "npack": npack,
+            "pack_dim": pack_dim,
+        }
+        optimizer = PruneOptimizer(torch.optim.SGD([group], lr=0.1))
+
+        param.grad = torch.zeros_like(param)
+        optimizer.step()
+
+        retained_per_pack = embed_dim - math.ceil(min_sparsity * embed_dim)
+        retained_total = npack * retained_per_pack
+        factored_size = (embed_dim + embed_dim) * retained_total
+        expected_frac = factored_size / param.numel()
+        self.assertEqual(optimizer.param_groups[0]["factored_frac"], expected_frac)
+        self.assertEqual(optimizer.relative_factored_frac, expected_frac)
+
+
+common_utils.instantiate_parametrized_tests(TestMinRankConstraintApply)
+common_utils.instantiate_parametrized_tests(TestMinRankWithSVDGrouper)
+common_utils.instantiate_parametrized_tests(TestProxFreqGate)
+common_utils.instantiate_parametrized_tests(TestProxThroughHeal)
+common_utils.instantiate_parametrized_tests(TestPackedFactorizationMetrics)
+
+
+if __name__ == "__main__":
+    random.seed(0)
+    torch.manual_seed(0)
+    unittest.main()

--- a/torchao/prototype/pat/README.md
+++ b/torchao/prototype/pat/README.md
@@ -1,65 +1,96 @@
 # PAT: Pruning-Aware Training
 
-PAT is a library based on group Lasso regularization. It directly induces structured sparsity during training, removing the need for custom pruning metrics and/or multiple rounds of training.
+PAT is a library based on proximal gradient methods. It directly induces structured sparsity or low-rank structure during training, removing the need for custom pruning metrics and multiple rounds of training.
 
-PAT's simple optimizer-only interface supports easy integration into existing training pipelines. The code is organized into two main components:
-* grouper: defines the granularity of pruning (e.g., filter, channel, layer)
-* proximal mapping: projects groups of weights onto sparse values
+PAT's optimizer-only interface supports integration into existing training pipelines. The code is organized around two components:
+
+* grouper: defines how a parameter is viewed as groups of weights or singular values
+* proximal map: projects those groups toward sparse or low-rank values
 
 ## Optimizer-only interface
 
-This package provides a `PruneOptimizer` that simply wraps around a base optimizer inheriting from `torch.optim.Optimizer`. The following code snippet illustrates how to set up PAT:
+This package provides a `PruneOptimizer` that wraps a base optimizer inheriting from `torch.optim.Optimizer`. The following code illustrates how to set up PAT:
 
 ```python
-from pat.optim import PruneOptimizer
+from torchao.prototype.pat.optim import PruneOptimizer
 
 model = torchvision.models.resnet18().cuda()
 
-# split params into prunable and non-prunable groups
+# Split parameters into prunable and non-prunable groups.
 weights = [p for name, p in model.named_parameters() if name.endswith("weight")]
 others = [p for name, p in model.named_parameters() if not name.endswith("weight")]
 
-# apply row-wise group Lasso regularization to the weights
+# Apply row-wise group Lasso regularization to the weights.
 param_groups = [
     {
-        "params": weights",
+        "params": weights,
         "group_type": "Dim0Grouper",
         "prox_type": "ProxGroupLasso",
+        "reg_lambda": 2e-4,
     },
     {"params": others},
 ]
 
-# create base optimizer (SGD, Adam or AdamW)
 base_optimizer = torch.optim.SGD(
     param_groups, lr=0.1, momentum=0.9, weight_decay=1e-4
 )
-
-# create PruneOptimizer
-optimizer = PruneOptimizer(base_optimizer, warmup_steps=10, reg_lambda=2e-4)
+optimizer = PruneOptimizer(base_optimizer)
 ```
 
-After creating `PruneOptimizer`, one can use it as a regular PyTorch optimizer.
-
-## Grouper and proximal mapping combinations
-
-PAT supports various combinations of groupers and proximal mappings. The following table summarizes the available options:
-| grouper | proximal mapping | description |
-|---|---|---|
-| `AttentionHeadGrouperDim{0,1}` | `ProxGroupLasso` | Structured pruning of attention heads. |
-| `ConvFilterGrouper` | `ProxGroupLasso` | Structured pruning of convolutional filters. |
-| `Dim0Grouper` | `ProxGroupLasso` | Row-wise group Lasso regularization. |
-| `Dim1Grouper` | `ProxGroupLasso` | Column-wise group Lasso regularization. |
-| `ElemGrouper` | ProxLasso | Unstructured pruning that induces elementwise sparsity. |
-| `LayerGrouper` | `ProxGroupLasso` | Structured pruning that induces layer-wise sparsity. |
-| `SVDGrouper` | `ProxNuclearNorm` | Induces low-rank structure in weight matrices with an SVD-based proximal mapping. |
+After creating `PruneOptimizer`, use it as a regular PyTorch optimizer.
 
 ## Pruning configuration
 
-Pruning configs are dictionaries that define which parameter groups to prune and how to prune them. Each key-value pair in the config maps to a prunable parameter group of `PruneOptimizer`. The keys are used to match model parameters, while the values specify the pruning granularity and proximal map. The key can be one of the following types:
+Pruning configs are dictionaries that define which parameter groups to prune and how to prune them. Each key-value pair maps to a prunable parameter group of `PruneOptimizer`. The keys match model parameters, while the values specify the pruning granularity and proximal map. A key can be one of the following types:
 
-- parameter name (string): e.g., `blocks.0.attn.qkv.weight`
-- regex pattern (string): e.g., `:.*attn\.qkv\.weight`
-- module type and parameter name suffix ((class, string) tuple): e.g., `(torch.nn.Linear, 'weight')`
+- parameter name (string): for example, `blocks.0.attn.qkv.weight`
+- regex pattern (string): for example, `:.*attn\.qkv\.weight`
+- module type and parameter name suffix (`(class, string)` tuple): for example, `(torch.nn.Linear, "weight")`
+
+## Groupers and proximal maps
+
+A pruning entry pairs a **grouper** with a **proximal map**. The grouper reshapes a tensor into `(n_groups, group_size)`, or exposes singular values for an SVD grouper, and the proximal map is then applied to that view.
+
+### Groupers (`torchao.prototype.pat.group`)
+
+| Grouper | Group structure |
+| --- | --- |
+| `Dim0Grouper` / `Dim1Grouper` | One group per row or column of a 2-D weight |
+| `ElemGrouper` | Whole tensor as one group with per-element pruning |
+| `LayerGrouper` | Whole tensor as one group for layer-level pruning |
+| `KElementGrouper(k)` | `(numel / k, k)` blocks of `k` consecutive elements |
+| `ConvFilterGrouper` | One group per `(c_out, c_in)` filter slice of a Conv2d kernel |
+| `AttentionHeadGrouperDim0(num_heads)` | One group per attention head along dimension 0 |
+| `AttentionHeadGrouperDim1(num_heads)` | One group per attention head along dimension 1 |
+| `SVDGrouper` | Decompose `W = U diag(s) Vh` and expose its singular values |
+| `PackedSVDGrouper(npack)` | Apply SVD independently to each of `npack` sub-tensors |
+
+### Proximal maps (`torchao.prototype.pat.optim`)
+
+| Proximal map | Behavior |
+| --- | --- |
+| `ProxLasso` | Soft-threshold each element for magnitude-based sparsity |
+| `ProxGroupLasso` | Soft-threshold each group's L2 norm to zero whole groups |
+| `ProxNuclearNorm` | Soft-threshold singular values to shrink rank smoothly |
+| `MinSparsityConstraint(min_sparsity)` | Hard-zero the smallest-L2 `ceil(min_sparsity * n_groups)` groups |
+| `MinRankConstraint(min_sparsity)` | Hard-zero the smallest `ceil(min_sparsity * k)` singular values in each matrix |
+| `NMSparseConstraint(n_nonzero)` | Keep the largest-magnitude `n_nonzero` elements per group |
+
+### Recipes
+
+| Goal | Grouper | Proximal map | Notes |
+| --- | --- | --- | --- |
+| **2:4 sparsity** | `KElementGrouper(k=4)` | `NMSparseConstraint(n_nonzero=2)` | Keeps two nonzero elements in each four-element block |
+| **Row sparsity** | `Dim0Grouper` | `MinSparsityConstraint` or `ProxGroupLasso` | Use the hard constraint for an exact target or group Lasso for a smooth regularization knob |
+| **Column sparsity** | `Dim1Grouper` | `MinSparsityConstraint` or `ProxGroupLasso` | Drops input channels of a Linear layer |
+| **Conv filter sparsity** | `ConvFilterGrouper` | `MinSparsityConstraint` or `ProxGroupLasso` | Drops complete `(c_out, c_in)` filter slices |
+| **Attention head sparsity** | `AttentionHeadGrouperDim0` and/or `AttentionHeadGrouperDim1` | `MinSparsityConstraint` | Configure matching `num_heads` for the selected projections |
+| **Low-rank approximation, smooth** | `SVDGrouper` or `PackedSVDGrouper` | `ProxNuclearNorm` | Uses regularization-controlled rank decay |
+| **Low-rank approximation, exact target** | `SVDGrouper` or `PackedSVDGrouper` | `MinRankConstraint(min_sparsity)` | Zeros `ceil(min_sparsity * k)` and retains `k - ceil(min_sparsity * k)` singular values per matrix |
+
+`MinSparsityConstraint`, `MinRankConstraint`, and `NMSparseConstraint` are hard-zero maps: they ignore `reg_lambda` and `gamma` and are driven by their target argument. Set `min_sparsity_schedule: true` to ramp a minimum-sparsity or minimum-rank target cubically from the end of warmup to `healing_start_step`.
+
+SVD decompositions can dominate optimizer cost on wide tensors. Set `prox_freq: N` on a parameter group to run its grouper and proximal map every `N` optimizer steps. SVD groups using the hard `MinRankConstraint` reapply the proximal map during healing by default so the base optimizer cannot refill removed singular values. Soft SVD maps such as `ProxNuclearNorm` retain their existing behavior unless `prox_through_heal: true` is set explicitly, while `MinRankConstraint` can opt out with `prox_through_heal: false`. Setting `prox_through_heal: true` on a non-SVD grouper is invalid and rejected during optimizer construction.
 
 ## Unstructured pruning on 1.3B OLMo models
 
@@ -71,4 +102,3 @@ We borrowed the setup from AllenAI's OLMo models. The table below is Table 1 of 
 The two plots show that the PAT pruned 1.3B models (blue curve) reach much better training loss and mean test accuracy on 8 reasoning benchmarks (ARC-Challenge, ARC-Easy, BoolQ, HellaSwag, OpenBookQA, PIQA, Social IQa, WinoGrande) across different sparsity levels.
 ![](https://github.com/user-attachments/assets/b04347bd-6f16-44ca-85b9-8591349a9b31)
 ![](https://github.com/user-attachments/assets/91820a7f-519b-4415-ba68-f510df1e18e9)
-

--- a/torchao/prototype/pat/group/__init__.py
+++ b/torchao/prototype/pat/group/__init__.py
@@ -4,17 +4,9 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .attention import (  # noqa: F401
-    AttentionHeadGrouperDim0,
-    AttentionHeadGrouperDim1,
-    QKGrouper,
-)
+from .attention import AttentionHeadGrouperDim0, AttentionHeadGrouperDim1  # noqa: F401
 from .conv import ConvFilterGrouper  # noqa: F401
 from .dim import Dim0Grouper, Dim1Grouper  # noqa: F401
-from .grouper import (  # noqa: F401
-    ElemGrouper,
-    Grouper,
-    LayerGrouper,
-)
+from .grouper import ElemGrouper, Grouper, LayerGrouper  # noqa: F401
 from .k_element import KElementGrouper  # noqa: F401
 from .low_rank import PackedSVDGrouper, SVDGrouper  # noqa: F401

--- a/torchao/prototype/pat/group/attention.py
+++ b/torchao/prototype/pat/group/attention.py
@@ -8,35 +8,6 @@
 from torch import Tensor
 
 from .dim import Dim0Grouper, Dim1Grouper
-from .packed import PackedGrouperMixin
-
-
-class QKGrouper(PackedGrouperMixin, Dim1Grouper):
-    """Grouper applied only to query and key weights. Assumes that query, key,
-    value weights are packed along `qk_pack_dim` dimension.
-
-    Args:
-        p (Tensor): The packed query, key, value weights.
-        qk_pack_dim (int): Dimension along which query and key are packed.
-        qk_reg_index (int, optional): 0 for query, 1 for key. Default: 0.
-    """
-
-    def __init__(
-        self,
-        p: Tensor,
-        qk_pack_dim: int = 0,
-        qk_reg_index: int = 0,
-    ):
-        super().__init__(p, 3, qk_pack_dim)
-
-        if qk_reg_index == 0:  # query
-            start, end = 0, self.embed_dim
-        else:  # key
-            start, end = self.embed_dim, self.embed_dim * 2
-
-        super(PackedGrouperMixin, self).__init__(
-            p[start:end] if qk_pack_dim == 0 else p[:, start:end]
-        )
 
 
 class AttentionHeadGrouperDim0(Dim0Grouper):

--- a/torchao/prototype/pat/optim/__init__.py
+++ b/torchao/prototype/pat/optim/__init__.py
@@ -10,7 +10,11 @@ from torch.optim import Optimizer
 
 from .group_lasso import ProxGroupLasso, ProxGroupLassoVectorized  # noqa: F401
 from .lasso import ProxLasso  # noqa: F401
-from .min_sparsity import MinSparsityConstraint, NMSparseConstraint  # noqa: F401
+from .min_sparsity import (  # noqa: F401
+    MinRankConstraint,
+    MinSparsityConstraint,
+    NMSparseConstraint,
+)
 from .nuclear_norm import ProxNuclearNorm  # noqa: F401
 from .proxmap import ProxMap  # noqa: F401
 from .pruneopt import PruneOptimizer

--- a/torchao/prototype/pat/optim/min_sparsity.py
+++ b/torchao/prototype/pat/optim/min_sparsity.py
@@ -78,6 +78,52 @@ class MinSparsityConstraint(ProxMap, _TopKZeroMixin):
         return self._topk_zero_(p, scores, n_zero)
 
 
+class MinRankConstraint(ProxMap, _TopKZeroMixin):
+    """Zeros the smallest ``ceil(min_sparsity * k)`` singular values of an
+    SVD-grouped tensor. Here the shared ``min_sparsity`` key is the fraction of
+    singular values zeroed, so each matrix retains
+    ``k - ceil(min_sparsity * k)`` singular values. Pair with ``SVDGrouper`` or
+    ``PackedSVDGrouper``. ``reg_lambda``, ``gamma``, and ``tau_reweight`` are
+    ignored; the count is optionally resolved on the cubic schedule by
+    ``PruneOptimizer._effective_min_sparsity``.
+
+    ``whole_tensor = True`` routes the optimizer around ``torch.vmap`` so
+    ``apply_`` sees the complete singular-value vector for each matrix.
+    """
+
+    whole_tensor = True
+
+    def __init__(self, reg_lambda: float, min_sparsity: float) -> None:
+        super().__init__(reg_lambda)
+        assert 0.0 <= min_sparsity <= 1.0, (
+            f"min_sparsity must be in [0, 1], but got {min_sparsity}"
+        )
+        self.min_sparsity = min_sparsity
+
+    def _get_norm(self, p: Tensor) -> Tensor:
+        return p
+
+    def tau(self, p: Tensor) -> float:
+        return 1.0
+
+    def apply_(
+        self,
+        p: Tensor,
+        gamma: Union[Tensor, float],
+        tau_reweight: Union[Tensor, float] = 1.0,
+    ) -> tuple[Tensor, Tensor]:
+        # SVDGrouper.p is (k,); PackedSVDGrouper.p is (npack, k).
+        n_zero = math.ceil(self.min_sparsity * p.shape[-1])
+        if p.dim() == 1:
+            return self._topk_zero_(p, self._get_norm(p), n_zero)
+
+        zeros_total = torch.zeros((), dtype=torch.long, device=p.device)
+        for i in range(p.size(0)):
+            zeros, _ = self._topk_zero_(p[i], self._get_norm(p[i]), n_zero)
+            zeros_total += zeros
+        return zeros_total, torch.linalg.vector_norm(p)
+
+
 class NMSparseConstraint(ProxMap, _TopKZeroMixin):
     """Keeps at most ``n_nonzero`` largest-magnitude elements per group.
     Vmapped per group, so ``apply_`` receives one 1-D group at a time.

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -73,6 +73,7 @@ class PruneOptimizer(Optimizer):
         for group in self.regularized_param_groups():
             group.setdefault("gamma", 0.0)
             group.setdefault("reg_lambda", reg_lambda)
+            self._validate_prox_through_heal(group)
             if group.get("min_sparsity_schedule", False):
                 assert self.healing_start_step != sys.maxsize, (
                     "min_sparsity_schedule requires a finite healing_start_step; "
@@ -162,9 +163,9 @@ class PruneOptimizer(Optimizer):
                 "NMSparseConstraint requires 'n_nonzero' in prune config"
             )
             prox_kwargs["n_nonzero"] = group["n_nonzero"]
-        elif group["prox_type"] == "MinSparsityConstraint":
+        elif group["prox_type"] in ("MinSparsityConstraint", "MinRankConstraint"):
             assert "min_sparsity" in group, (
-                "MinSparsityConstraint requires 'min_sparsity' in prune config"
+                f"{group['prox_type']} requires 'min_sparsity' in prune config"
             )
             prox_kwargs["min_sparsity"] = self._effective_min_sparsity(group)
         return prox_kwargs
@@ -194,11 +195,6 @@ class PruneOptimizer(Optimizer):
         grouper_kwargs = {}
         if group["group_type"].startswith("AttentionHeadGrouper"):
             grouper_kwargs["num_heads"] = group["num_heads"]
-        elif group["group_type"] == "QKGrouper":
-            if "qk_pack_dim" in group:
-                grouper_kwargs["qk_pack_dim"] = group["qk_pack_dim"]
-            if "qk_reg_index" in group:
-                grouper_kwargs["qk_reg_index"] = group["qk_reg_index"]
         elif group["group_type"] == "KElementGrouper":
             grouper_kwargs["k"] = group["k"]
         elif group["group_type"] == "PackedSVDGrouper":
@@ -377,7 +373,7 @@ class PruneOptimizer(Optimizer):
 
             # Record for reconstruction and logging
             if prox_kwargs["is_svd_grouper"]:
-                dim = 0 if sv_count.dim() > 1 else None
+                dim = -1 if grouper.p.dim() > 1 else None
                 sv_count.copy_(
                     (grouper.p != 0).to(torch.uint8).sum(dim=dim)
                     if _is_dtensor(p)
@@ -389,6 +385,103 @@ class PruneOptimizer(Optimizer):
     def _set_gamma(self, group):
         # AProx in practice: ensure shrinkage coefficient >= 1
         group["gamma"] += group["lr"]
+
+    def _build_prox_artifacts(self, group: dict[str, Any]):
+        """Build the prox and grouper objects shared by pruning and healing."""
+        prox_map = instantiate_module(
+            f"torchao.prototype.pat.optim.{group['prox_type']}"
+        )(group["reg_lambda"], **self._get_prox_kwargs(group))
+        grouper_cls = instantiate_module(
+            f"torchao.prototype.pat.group.{group['group_type']}"
+        )
+        grouper_kwargs = self._get_grouper_kwargs(group)
+        prox_kwargs = {
+            "gamma": group["gamma"],
+            "gamma_index_slope": group.get("gamma_index_slope", 0.0),
+            "disable_vmap": group["group_type"].endswith(
+                ("ElemGrouper", "LayerGrouper")
+            ),
+            "is_svd_grouper": group["group_type"].endswith("SVDGrouper"),
+            "zero_elts_are_counts": group["prox_type"]
+            in ("NMSparseConstraint", "MinSparsityConstraint", "MinRankConstraint"),
+        }
+        return prox_map, grouper_cls, grouper_kwargs, prox_kwargs
+
+    def _run_prox_on_param(
+        self, p, state, prox_map, grouper_cls, grouper_kwargs, prox_kwargs
+    ):
+        """Apply prox to one parameter, including SVD DTensor synchronization."""
+        if prox_kwargs["is_svd_grouper"]:
+            npack = grouper_kwargs.get("npack", 1)
+            state.setdefault(
+                "sv_count", torch.zeros(npack, dtype=torch.int, device=p.device)
+            )
+
+        sharded_p = None
+        if _is_dtensor(p) and prox_kwargs["is_svd_grouper"]:
+            sharded_p = p
+            p = p.full_tensor()
+
+        sv_count = state.get("sv_count")
+        result = None
+        if sharded_p is None or sharded_p.device_mesh.get_rank() == 0:
+            grouper = grouper_cls(p, **grouper_kwargs)
+            zero_elts, group_norm, zeros_are_summed = self._apply_prox(
+                grouper,
+                prox_map,
+                p,
+                tau_reweight=state.get("tau_reweight", 1.0),
+                sv_count=sv_count,
+                **prox_kwargs,
+            )
+            result = {
+                "zero_elts": zero_elts,
+                "group_norm": group_norm,
+                "zeros_are_summed": zeros_are_summed,
+                "numel": grouper.p.numel(),
+            }
+            if prox_kwargs["is_svd_grouper"]:
+                result["matrix_rows"] = grouper.U.size(-2)
+                result["matrix_cols"] = grouper.Vh.size(-1)
+                result["unfactored_size"] = p.numel()
+
+        if sharded_p is not None:
+            torch.distributed.barrier()
+            if isinstance(sv_count, Tensor):
+                torch.distributed.broadcast(sv_count, src=0)
+            sharded_p.copy_(
+                distribute_tensor(
+                    p,
+                    device_mesh=sharded_p.device_mesh,
+                    placements=sharded_p.placements,
+                )
+            )
+        return result
+
+    def should_prune(self, group: dict[str, Any], step: int) -> bool:
+        """Run the group's prox map every ``prox_freq`` steps after warmup."""
+        freq = group.get("prox_freq", 1)
+        if freq <= 1:
+            return True
+        offset = step - self.warmup_steps
+        return offset >= 0 and offset % freq == 0
+
+    @staticmethod
+    def _validate_prox_through_heal(group: dict[str, Any]) -> bool:
+        is_svd_grouper = str(group.get("group_type", "")).endswith("SVDGrouper")
+        if group.get("prox_through_heal", False) and not is_svd_grouper:
+            raise ValueError(
+                "prox_through_heal=True requires an SVD grouper, but got "
+                f"group_type={group.get('group_type')!r}."
+            )
+        return is_svd_grouper
+
+    def _prox_through_heal(self, group: dict[str, Any]) -> bool:
+        """Default to reapplying hard rank constraints during healing."""
+        is_svd_grouper = self._validate_prox_through_heal(group)
+        if "prox_through_heal" in group:
+            return bool(group["prox_through_heal"])
+        return is_svd_grouper and group.get("prox_type") == "MinRankConstraint"
 
     def _init_latent_state(self):
         for group in self.regularized_param_groups():
@@ -406,11 +499,16 @@ class PruneOptimizer(Optimizer):
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """
-        # during healing, zero grads of pruned params and save masks to re-zero
-        # them after the step (momentum may push them non-zero)
+        # During healing, literal zeros are frozen by gradient masking. Groups
+        # opted into through-heal instead reapply their prox map because dense
+        # low-rank weights have no literal zeros to mask. Soft SVD maps default
+        # to unconstrained healing unless they explicitly opt in.
         healing_masks = {}
-        if self.num_steps >= self.healing_start_step:
+        is_healing = self.num_steps >= self.healing_start_step
+        if is_healing:
             for group in self.regularized_param_groups():
+                if self._prox_through_heal(group):
+                    continue
                 for p in group["params"]:
                     if p.grad is None:
                         continue
@@ -421,10 +519,7 @@ class PruneOptimizer(Optimizer):
                     else:
                         p.grad.masked_fill_(~mask, 0)
 
-        if (
-            self.num_steps < self.warmup_steps
-            or self.num_steps >= self.healing_start_step
-        ):
+        if self.num_steps < self.warmup_steps or is_healing:
             # run base optimizer only during warmup and healing periods
             loss = self.base_optimizer.step(closure=closure)  # pyre-ignore[6]
             # re-zero pruned params after step
@@ -437,6 +532,8 @@ class PruneOptimizer(Optimizer):
                         else:
                             p.masked_fill_(~mask, 0)
             del healing_masks
+            if is_healing:
+                self._apply_prox_to_through_heal_groups()
             self._init_latent_state()
             self.num_steps += 1
             return loss
@@ -475,118 +572,81 @@ class PruneOptimizer(Optimizer):
 
         regularized_zeros = 0
         regularized_factored_size = 0
+        all_groups_ran = True
         for group in self.regularized_param_groups():
+            # Advance on every step so gamma tracks cumulative learning rate,
+            # including steps skipped by prox_freq.
             self._set_gamma(group)
 
-            # apply shrinkage to latent parameters in place
-            prox_map = instantiate_module(
-                f"torchao.prototype.pat.optim.{group['prox_type']}"
-            )(group["reg_lambda"], **self._get_prox_kwargs(group))
+            if not self.should_prune(group, self.num_steps):
+                all_groups_ran = False
+                # Keep latent parameters aligned with the base optimizer while
+                # retaining cached sparsity and factorization metrics.
+                for p in group["params"]:
+                    if not p.requires_grad:
+                        continue
+                    self.state[p]["latent"].copy_(p)
+                continue
 
-            # grouper is a context manager that reshapes p if needed
-            grouper_cls = instantiate_module(
-                f"torchao.prototype.pat.group.{group['group_type']}"
+            prox_map, grouper_cls, grouper_kwargs, prox_kwargs = (
+                self._build_prox_artifacts(group)
             )
-            grouper_kwargs = self._get_grouper_kwargs(group)
-            prox_kwargs = {
-                "gamma": group["gamma"],
-                "gamma_index_slope": group.get("gamma_index_slope", 0.0),
-                "disable_vmap": group["group_type"].endswith(
-                    ("ElemGrouper", "LayerGrouper")
-                ),
-                "is_svd_grouper": group["group_type"].endswith("SVDGrouper"),
-                "zero_elts_are_counts": group["prox_type"]
-                in ("NMSparseConstraint", "MinSparsityConstraint"),
-            }
             for p in group["params"]:
                 if not p.requires_grad:
                     continue
 
-                # save latent parameters
                 state = self.state[p]
                 state["latent"].copy_(p)
+                result = self._run_prox_on_param(
+                    p, state, prox_map, grouper_cls, grouper_kwargs, prox_kwargs
+                )
+                if result is None:
+                    continue
 
-                # store the number of non-zero singular values
-                if prox_kwargs["is_svd_grouper"]:
-                    npack = grouper_kwargs.get("npack", 1)
-                    state.setdefault(
-                        "sv_count", torch.zeros(npack, dtype=torch.int, device=p.device)
-                    )
+                zero_elts = result["zero_elts"]
+                group_norm = result["group_norm"]
+                zeros_are_summed = result["zeros_are_summed"]
+                numel = result["numel"]
 
-                # update the full tensor if sharded
-                sharded_p = None
-                if _is_dtensor(p) and prox_kwargs["is_svd_grouper"]:
-                    sharded_p = p
-                    p = p.full_tensor()
+                if zeros_are_summed:
+                    state["sparsity_frac"] = zero_elts / numel
+                elif dist_is_init:
+                    _maybe_async_aggregate(regularized_zeros_buf, zero_elts)
 
-                # only rank 0 of the device mesh should run the grouper
-                sv_count = state.get("sv_count")
-                if sharded_p is None or sharded_p.device_mesh.get_rank() == 0:
-                    grouper = grouper_cls(p, **grouper_kwargs)
-                    zero_elts, group_norm, zeros_are_summed = self._apply_prox(
-                        grouper,
-                        prox_map,
-                        p,
-                        tau_reweight=state.get("tau_reweight", 1.0),
-                        sv_count=sv_count,
-                        **prox_kwargs,
-                    )
+                if torch.is_tensor(zero_elts):
+                    zero_elts = zero_elts.item()
 
-                    if zeros_are_summed:
-                        state["sparsity_frac"] = zero_elts / grouper.p.numel()
-                    elif dist_is_init:
-                        _maybe_async_aggregate(regularized_zeros_buf, zero_elts)
-
-                    if torch.is_tensor(zero_elts):
-                        zero_elts = zero_elts.item()
-
-                    if self.iterative_reweight is not None:
-                        if init_sigma_reweight:
-                            state["sigma"] = group_norm
-                        if "sigma" in state and update_tau_reweight:
-                            state["tau_reweight"] = self.iterative_reweight(
-                                group_norm, state["sigma"]
-                            )
-
-                    if prox_kwargs["is_svd_grouper"]:
-                        unfactored_size = grouper.U.size(0) * grouper.Vh.size(1)
-                        n_singular_vals = grouper.p.numel() - zero_elts
-                        factored_size = (
-                            grouper.U.size(0) + grouper.Vh.size(1)
-                        ) * n_singular_vals
-                        group["factored_frac"] = factored_size / unfactored_size
-                        # Only aggregate if not already globally summed
-                        if zeros_are_summed:
-                            regularized_factored_size += factored_size
-                        else:
-                            _maybe_async_aggregate(
-                                regularized_factored_size_buf,
-                                torch.tensor(
-                                    factored_size, dtype=torch.int, device=p.device
-                                ),
-                            )
-
-                        regularized_unfactored_size += unfactored_size
-
-                        # Only factor matrices if it reduces params
-                        regularized_zeros += max(unfactored_size - factored_size, 0)
-                        regularized_params += unfactored_size
-                    else:
-                        regularized_zeros += zero_elts
-                        regularized_params += grouper.p.numel()
-
-                # copy the updated full tensor to the sharded tensor
-                if sharded_p is not None:
-                    torch.distributed.barrier()
-                    if isinstance(sv_count, Tensor):
-                        torch.distributed.broadcast(sv_count, src=0)
-                    sharded_p.copy_(
-                        distribute_tensor(
-                            p,
-                            device_mesh=sharded_p.device_mesh,
-                            placements=sharded_p.placements,
+                if self.iterative_reweight is not None:
+                    if init_sigma_reweight:
+                        state["sigma"] = group_norm
+                    if "sigma" in state and update_tau_reweight:
+                        state["tau_reweight"] = self.iterative_reweight(
+                            group_norm, state["sigma"]
                         )
-                    )
+
+                if prox_kwargs["is_svd_grouper"]:
+                    unfactored_size = result["unfactored_size"]
+                    n_singular_vals = numel - zero_elts
+                    factored_size = (
+                        result["matrix_rows"] + result["matrix_cols"]
+                    ) * n_singular_vals
+                    group["factored_frac"] = factored_size / unfactored_size
+                    if zeros_are_summed:
+                        regularized_factored_size += factored_size
+                    else:
+                        _maybe_async_aggregate(
+                            regularized_factored_size_buf,
+                            torch.tensor(
+                                factored_size, dtype=torch.int, device=p.device
+                            ),
+                        )
+
+                    regularized_unfactored_size += unfactored_size
+                    regularized_zeros += max(unfactored_size - factored_size, 0)
+                    regularized_params += unfactored_size
+                else:
+                    regularized_zeros += zero_elts
+                    regularized_params += numel
 
         self.num_steps += 1
 
@@ -596,7 +656,7 @@ class PruneOptimizer(Optimizer):
                 regularized_factored_size_buf
             )
 
-        if _is_main_process():
+        if _is_main_process() and all_groups_ran:
             self.relative_sparsity = (
                 regularized_zeros / regularized_params
                 if regularized_params > 0
@@ -609,6 +669,29 @@ class PruneOptimizer(Optimizer):
             )
 
         return loss
+
+    @torch.no_grad()
+    def _apply_prox_to_through_heal_groups(self) -> None:
+        """Reapply opted-in prox maps during healing without advancing gamma."""
+        for group in self.regularized_param_groups():
+            if not self._prox_through_heal(group):
+                continue
+            if not self.should_prune(group, self.num_steps):
+                continue
+            prox_map, grouper_cls, grouper_kwargs, prox_kwargs = (
+                self._build_prox_artifacts(group)
+            )
+            for p in group["params"]:
+                if not p.requires_grad:
+                    continue
+                self._run_prox_on_param(
+                    p,
+                    self.state[p],
+                    prox_map,
+                    grouper_cls,
+                    grouper_kwargs,
+                    prox_kwargs,
+                )
 
     @torch._disable_dynamo
     def restore_latent_params(self) -> None:

--- a/torchao/prototype/pat/utils.py
+++ b/torchao/prototype/pat/utils.py
@@ -151,7 +151,9 @@ def insert_svd_modules_(model: nn.Module, optimizer: torch.optim.Optimizer):
 
                 k = int(optimizer.state[p]["sv_count"].item())
                 assert k > 0, f"Invalid sv_count={k}"
-                with instantiate_module("pat.group.SVDGrouper")(p) as grouper:
+                with instantiate_module("torchao.prototype.pat.group.SVDGrouper")(
+                    p
+                ) as grouper:
                     # patch parameter with SVD
                     module.register_buffer(
                         f"{pn}_orig_shape", torch.tensor(grouper.orig_shape)


### PR DESCRIPTION
Update 7/21: closing this in favor of `ghstack` created [#4579](https://github.com/pytorch/ao/pull/4586)

- Refactors proximal map functionality to that pruning and healing share DTensor gather/scatter and rank-zero paths
- Adds low-rank pruning analogous to `MinSparsityConstraint` via `MinRankConstraint`
- Exposes a `prox_freq` lever to control how frequently the expensive SVD step runs in terms of steps
- Removed unused `QKGrouper` class