### PR TITLE
Fix stale-index pop in _fqn_to_config_handler when multiple FqnToConfig parameters map to None

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -1155,6 +1155,9 @@ class TestFqnToConfigNoneParams(TestCase):
         )
         quantize_(model, quant_config, filter_fn=None)
 
+        # w1/w2 are deliberately bare, unrelated params configured with None (skip);
+        # only the regex-targeted w3 should be quantized. This asserts the None entries
+        # don't shift which sibling entry is removed.
         assert not isinstance(model.w1, Int8Tensor)
         assert not isinstance(model.w2, Int8Tensor)
         assert isinstance(model.w3, Int8Tensor)

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -1102,5 +1102,63 @@ class TestFqnToConfig(TestCase):
             )
 
 
+class TestFqnToConfigNoneParams(TestCase):
+    """Regression tests for FqnToConfig entries mapped to None (param exclusion).
+
+    Excluding a parameter used to remove entries from ``top_level_params`` by a
+    stale enumeration index, so excluding more than one parameter of the same
+    module either raised an IndexError or silently dropped the wrong entry
+    before the regex-matching pass. These tests are device-independent, so they
+    run on CPU as well.
+    """
+
+    def test_multiple_none_params_with_regex(self):
+        """Two None-configured params on one module + a regex default used to
+        raise `IndexError: pop index out of range`."""
+        model = torch.nn.Sequential(
+            torch.nn.Linear(16, 16), torch.nn.Linear(16, 16)
+        ).eval()
+        quant_config = FqnToConfig(
+            {
+                "0.weight": None,
+                "0.bias": None,
+                "re:1\\.weight": Int8WeightOnlyConfig(),
+            }
+        )
+        quantize_(model, quant_config, filter_fn=None)
+
+        assert not isinstance(model[0].weight, Int8Tensor)
+        assert not isinstance(model[0].bias, Int8Tensor)
+        assert isinstance(model[1].weight, Int8Tensor)
+
+    def test_none_params_do_not_shift_regex_match(self):
+        """None-configured params must not shift which sibling entry is removed,
+        otherwise a regex-targeted param is silently left unquantized."""
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w1 = torch.nn.Parameter(torch.randn(16, 16))
+                self.w2 = torch.nn.Parameter(torch.randn(16, 16))
+                self.w3 = torch.nn.Parameter(torch.randn(16, 16))
+
+            def forward(self, x):
+                return x @ self.w3.t()
+
+        model = TestModule().eval()
+        quant_config = FqnToConfig(
+            {
+                "w1": None,
+                "w2": None,
+                "re:w3": Int8WeightOnlyConfig(),
+            }
+        )
+        quantize_(model, quant_config, filter_fn=None)
+
+        assert not isinstance(model.w1, Int8Tensor)
+        assert not isinstance(model.w2, Int8Tensor)
+        assert isinstance(model.w3, Int8Tensor)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1613,21 +1613,22 @@ def _fqn_to_config_handler(
     """
     parameter_config_found = False
     top_level_params = []
-    for i, (parameter_name, param) in enumerate(list(module.named_parameters())):
+    for parameter_name, param in module.named_parameters():
         if parameter_name in dir(module):
             parameter_fqn = (
                 f"{fqn}.{parameter_name}" if len(fqn) > 0 else parameter_name
             )
-            top_level_params.append((i, parameter_name, param, parameter_fqn))
+            top_level_params.append((parameter_name, param, parameter_fqn))
 
     # First we see if any parameter fqn matches with FqnToConfig, if so, we apply the appropriate transform
-    for i, parameter_name, param, parameter_fqn in list(top_level_params):
+    for entry in list(top_level_params):
+        parameter_name, param, parameter_fqn = entry
         if parameter_fqn in config.fqn_to_config:
             parameter_config_found = True
             c = config.fqn_to_config[parameter_fqn]
             # if None, remove from subsequent regex check
             if c is None:
-                top_level_params.pop(i)
+                top_level_params.remove(entry)
             else:
                 handler = _QUANTIZE_CONFIG_HANDLER[type(c)]
                 if _handler_supports_fqn_quantization(handler):
@@ -1648,7 +1649,7 @@ def _fqn_to_config_handler(
             return module
 
     # Next try to match parameters on regex patterns
-    for i, parameter_name, param, parameter_fqn in top_level_params:
+    for parameter_name, param, parameter_fqn in top_level_params:
         for pattern in config.fqn_to_config:
             if pattern.startswith("re:") and re.fullmatch(pattern[3:], parameter_fqn):
                 parameter_config_found = True


### PR DESCRIPTION
## Summary

`_fqn_to_config_handler` stores each top-level parameter as `(i, parameter_name, param, parameter_fqn)`, where `i` is the enumeration index from `module.named_parameters()`, and removes excluded (config `None`) parameters with `top_level_params.pop(i)`. That index is a position in the original `named_parameters()` enumeration, not in the current `top_level_params` list, so it goes stale as soon as one entry is popped (or whenever a non-top-level parameter was filtered out during list construction). With more than one `None`-configured parameter on the same module this either:

1. **Raises `IndexError: pop index out of range`**

```python
m = nn.Sequential(nn.Linear(16, 16), nn.Linear(16, 16))
quantize_(m, FqnToConfig({
    "0.weight": None,
    "0.bias": None,
    "re:1\\.weight": Int8WeightOnlyConfig(),
}), filter_fn=None)
# IndexError: pop index out of range
```

2. **Silently pops the wrong entry**, removing a different parameter from the subsequent regex-matching pass, so a regex-targeted parameter is never quantized:

```python
# module with parameters w1, w2, w3
quantize_(m, FqnToConfig({
    "w1": None,
    "w2": None,
    "re:w3": Int8WeightOnlyConfig(),
}), filter_fn=None)
# no error, but w3 stays a plain Parameter: the stale pop(1) removed the w3 entry instead of w2
```

## Fix

Remove entries by identity (`top_level_params.remove(entry)`) instead of by stored index, and drop the now-unused enumeration index from the stored tuples. `list.remove` matches the exact entry object by identity before any equality comparison, and sibling entries always differ in their leading `parameter_name` string, so tuple comparison short-circuits without ever invoking tensor `__eq__`.

## Test plan

Added `TestFqnToConfigNoneParams` to `test/quantization/test_quant_api.py` covering both failure modes (device-independent, runs on CPU). Both tests fail on main and pass with this change:

```
$ pytest test/quantization/test_quant_api.py -k NoneParams -v
test_multiple_none_params_with_regex PASSED
test_none_params_do_not_shift_regex_match PASSED
2 passed, 46 deselected
```

Full `test/quantization/test_quant_api.py`: `2 failed, 14 passed, 32 skipped` — the same 2 failures (`test_quantized_model_streaming`, `test_workflow_e2e_numerics_config0`) occur identically on unpatched `main` in this environment (CPU-only macOS), so they are pre-existing and unrelated. `ruff check` / `ruff format --check` (ruff 0.11.6, including the pre-commit `F,I` and isolated selects) pass on both changed files.
