### PR TITLE
[test][xpu]Skip test_comm as XPU CI does not support distributed test currently

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -16,9 +16,6 @@ python -c "import torch; import torchao; print(f'Torch version: {torch.__version
 
 python -m pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire
 
-export CCL_ROOT=$(dirname $(which python))/../
-export PATH="${CCL_ROOT}/bin/libfabric:${PATH}"
-export LD_LIBRARY_PATH="${CCL_ROOT}/lib:${LD_LIBRARY_PATH}"
 pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py \
         torchao/test/quantization/pt2e/ \
         torchao/test/quantization/*.py \

--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -16,6 +16,9 @@ python -c "import torch; import torchao; print(f'Torch version: {torch.__version
 
 python -m pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire
 
+export CCL_ROOT=$(dirname $(which python))/../
+export PATH="${CCL_ROOT}/bin/libfabric:${PATH}"
+export LD_LIBRARY_PATH="${CCL_ROOT}/lib:${LD_LIBRARY_PATH}"
 pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py \
         torchao/test/quantization/pt2e/ \
         torchao/test/quantization/*.py \

--- a/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
+++ b/test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py
@@ -30,6 +30,8 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 
+from torchao.testing.utils import skip_if_xpu
+
 if common_utils.SEED is None:
     common_utils.SEED = 1234
 
@@ -766,6 +768,7 @@ class TestQLoRA(FSDPTest):
             self.assertEqual(fsdp_loss, base_loss)
 
 
+@skip_if_xpu("Distributed test is not supported on XPU currently")
 class TestComm(FSDPTest):
     @property
     def world_size(self) -> int:


### PR DESCRIPTION
Fix https://github.com/pytorch/ao/actions/runs/29694233643/job/88212101392#step:18:46555 oneCCL could not be initialized! Could not load any plugin.

Skip it as XPU CI does not support distributed test currently.