### PR TITLE
Add QAT flow for CoreML codebook quantization

### DIFF
--- a/test/prototype/test_codebook_coreml_qat.py
+++ b/test/prototype/test_codebook_coreml_qat.py
@@ -1,0 +1,313 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import copy
+import unittest
+
+import torch
+
+from torchao.prototype.qat import (
+    CodebookFakeQuantizeConfig,
+    CodebookFakeQuantizer,
+)
+from torchao.prototype.quantization.codebook_coreml import (
+    CodebookQuantizedTensor,
+    CodebookWeightOnlyConfig,
+)
+from torchao.quantization import quantize_
+from torchao.quantization.qat import QATConfig
+from torchao.quantization.qat.fake_quantize_config import _infer_fake_quantize_configs
+from torchao.quantization.qat.linear import FakeQuantizedLinear
+from torchao.utils import is_package_at_least
+
+
+class TestCodebookQATConfig(unittest.TestCase):
+    """
+    Tests for the codebook QAT config: PTQ->QAT config inference, the prepare
+    module swap, config validation, and checkpoint save/load of the cached
+    codebook. These do not run k-means and so do not require coremltools.
+    """
+
+    def test_infer_codebook_config(self):
+        base_config = CodebookWeightOnlyConfig(dtype=torch.uint4, block_size=[-1, 16])
+        (act_config, weight_config) = _infer_fake_quantize_configs(base_config)
+        self.assertIsNone(act_config)
+        self.assertIsInstance(weight_config, CodebookFakeQuantizeConfig)
+        self.assertEqual(weight_config.dtype, torch.uint4)
+        self.assertEqual(weight_config.block_size, [-1, 16])
+
+    def test_prepare_swaps_to_fake_quantized_linear(self):
+        base_config = CodebookWeightOnlyConfig(dtype=torch.uint4, block_size=[-1, 16])
+        m = torch.nn.Sequential(torch.nn.Linear(64, 64))
+        quantize_(m, QATConfig(base_config, step="prepare"))
+        self.assertIsInstance(m[0], FakeQuantizedLinear)
+        self.assertIsNone(m[0].activation_fake_quantizer)
+        self.assertIsInstance(m[0].weight_fake_quantizer, CodebookFakeQuantizer)
+
+    def test_config_validation(self):
+        # unsupported dtype
+        with self.assertRaises(ValueError):
+            CodebookFakeQuantizeConfig(dtype=torch.int8)
+        # invalid refresh interval
+        with self.assertRaises(ValueError):
+            CodebookFakeQuantizeConfig(dtype=torch.uint4, refresh_interval=0)
+
+    def test_config_default_refresh_interval(self):
+        config = CodebookFakeQuantizeConfig(dtype=torch.uint4)
+        self.assertEqual(config.refresh_interval, 100)
+
+    def test_codebook_saved_and_loaded_from_checkpoint(self):
+        """
+        The cached codebook is a persistent buffer, so it is saved in the
+        state_dict and restored on load (into a fresh module whose codebook is
+        still the lazily-created None). No coremltools needed: we set the codebook
+        directly to exercise the save/load plumbing.
+        """
+        config = CodebookFakeQuantizeConfig(dtype=torch.uint4, block_size=[-1, 16])
+
+        fake_quantizer = CodebookFakeQuantizer(config)
+        # simulate a populated codebook: (g0, g1, 2**nbits, 1) = (1, 4, 16, 1)
+        codebook = torch.randn(1, 4, 16, 1)
+        fake_quantizer._codebook = codebook
+        state_dict = fake_quantizer.state_dict()
+        self.assertIn("_codebook", state_dict)
+
+        # load into a fresh module whose codebook is still None
+        loaded = CodebookFakeQuantizer(config)
+        self.assertIsNone(loaded._codebook)
+        loaded.load_state_dict(state_dict)
+        torch.testing.assert_close(loaded._codebook, codebook)
+
+    def test_deferred_convert_reuses_persisted_codebook(self):
+        """
+        Deferred lifecycle: prepare -> train -> save prepared checkpoint ->
+        load later -> convert -> inference. Convert must reuse the persisted
+        codebook (assignment only, no k-means), so this whole path needs no
+        coremltools. We set the codebook directly to stand in for the codebook a
+        training forward would have produced.
+        """
+        base_config = CodebookWeightOnlyConfig(dtype=torch.uint4, block_size=[-1, 16])
+
+        def build():
+            return torch.nn.Sequential(torch.nn.Linear(64, 16, bias=True))
+
+        # prepare, then persist a codebook (as a training forward would have)
+        m = build()
+        quantize_(m, QATConfig(base_config, step="prepare"))
+        persisted = torch.randn(1, 4, 16, 1)  # (g0=1, g1=4, 2**nbits=16, vec_dim=1)
+        m[0].weight_fake_quantizer._codebook = persisted
+        state_dict = copy.deepcopy(m.state_dict())
+
+        # later: load the prepared checkpoint into a fresh prepared model
+        m2 = build()
+        quantize_(m2, QATConfig(base_config, step="prepare"))
+        self.assertIsNone(m2[0].weight_fake_quantizer._codebook)
+        m2.load_state_dict(state_dict)
+        torch.testing.assert_close(m2[0].weight_fake_quantizer._codebook, persisted)
+
+        # convert reuses the persisted codebook (no k-means / coremltools) ...
+        quantize_(m2, QATConfig(base_config, step="convert"))
+        converted = m2[0].weight
+        self.assertIsInstance(converted, CodebookQuantizedTensor)
+        torch.testing.assert_close(converted.codebook, persisted)
+
+        # ... and inference runs
+        out = m2(torch.randn(2, 64, dtype=torch.float32))
+        self.assertEqual(out.shape, (2, 16))
+
+
+@unittest.skipIf(
+    not is_package_at_least("coremltools", "8.3.0"), "Requires coremltools >= 8.3.0"
+)
+class TestCodebookQAT(unittest.TestCase):
+    # Small shapes + mostly uint4 (k=16 centroids) keep real k-means fast: the
+    # weight below has few lookup tables per config, so each test runs in well
+    # under a second even with coremltools installed.
+    def setUp(self):
+        torch.manual_seed(123)
+        # (16, 64): rows divisible by row block (4), cols divisible by col block (16)
+        self.weight = torch.randn(16, 64, dtype=torch.float32)
+        self.in_features = 64
+        self.out_features = 16
+
+    def _fake_quant_configs(self):
+        return [
+            (torch.uint4, [-1, 16]),  # column grouping, k=16
+            (torch.uint4, [4, -1]),  # row grouping, k=16
+        ]
+
+    def test_fake_quantizer_matches_ptq(self):
+        """
+        The fake quantizer output must match the PTQ dequantized weight exactly.
+        """
+        for code_dtype, block_size in self._fake_quant_configs():
+            config = CodebookFakeQuantizeConfig(dtype=code_dtype, block_size=block_size)
+            fake_quantizer = CodebookFakeQuantizer(config)
+            fq_weight = fake_quantizer(self.weight)
+
+            ptq_tensor = CodebookQuantizedTensor.from_float(
+                self.weight, code_dtype, block_size
+            )
+            ptq_weight = ptq_tensor.dequantize()
+
+            self.assertEqual(fq_weight.shape, self.weight.shape)
+            # Matches PTQ (deterministic k-means, same underlying ops)
+            torch.testing.assert_close(
+                fq_weight.detach(),
+                ptq_weight,
+                msg=f"fake quant != PTQ for dtype={code_dtype}, block_size={block_size}",
+            )
+
+    def test_periodic_refresh(self):
+        """
+        The codebook should be recomputed via k-means only every
+        `refresh_interval` steps (including the first step).
+        """
+        config = CodebookFakeQuantizeConfig(
+            dtype=torch.uint4, block_size=[-1, 16], refresh_interval=3
+        )
+        fake_quantizer = CodebookFakeQuantizer(config)
+        for _ in range(7):
+            fake_quantizer(self.weight)
+        # refreshes happen at steps 0, 3, 6
+        self.assertEqual(fake_quantizer._step, 7)
+        self.assertEqual(fake_quantizer._num_refreshes, 3)
+
+    def test_refresh_interval_1_matches_ptq_every_step(self):
+        """
+        With refresh_interval=1 the codebook is recomputed every step, so every
+        forward matches PTQ exactly.
+        """
+        config = CodebookFakeQuantizeConfig(
+            dtype=torch.uint4, block_size=[-1, 16], refresh_interval=1
+        )
+        fake_quantizer = CodebookFakeQuantizer(config)
+        ptq_weight = CodebookQuantizedTensor.from_float(
+            self.weight, torch.uint4, [-1, 16]
+        ).dequantize()
+        for _ in range(3):
+            fq_weight = fake_quantizer(self.weight)
+            torch.testing.assert_close(fq_weight.detach(), ptq_weight)
+        self.assertEqual(fake_quantizer._num_refreshes, 3)
+
+    def test_loaded_codebook_used_without_reclustering(self):
+        """
+        A codebook restored from a checkpoint must be used as-is on the next
+        forward, without re-running k-means (which would defeat the point of
+        saving it and would require coremltools at inference time).
+        """
+        config = CodebookFakeQuantizeConfig(
+            dtype=torch.uint4, block_size=[-1, 16], refresh_interval=1000
+        )
+        trained = CodebookFakeQuantizer(config)
+        trained(self.weight)  # populate the codebook via k-means
+        self.assertEqual(trained._num_refreshes, 1)
+
+        loaded = CodebookFakeQuantizer(config)
+        loaded.load_state_dict(trained.state_dict())
+
+        out = loaded(self.weight)
+        # used the loaded codebook (assignment path), did not re-run k-means
+        self.assertEqual(loaded._num_refreshes, 0)
+        torch.testing.assert_close(loaded._codebook, trained._codebook)
+        # and the output matches the trained module's fake quant on the same weight
+        torch.testing.assert_close(out.detach(), trained(self.weight).detach())
+
+    def test_fake_quantizer_straight_through_gradient(self):
+        """
+        Gradients should flow to the original weight unchanged (straight-through).
+        """
+        config = CodebookFakeQuantizeConfig(dtype=torch.uint4, block_size=[-1, 16])
+        fake_quantizer = CodebookFakeQuantizer(config)
+        w = self.weight.clone().requires_grad_(True)
+        out = fake_quantizer(w)
+        out.sum().backward()
+        self.assertIsNotNone(w.grad)
+        # Straight-through estimator => gradient of sum() w.r.t. each element is 1
+        torch.testing.assert_close(w.grad, torch.ones_like(w))
+
+    def test_qat_prepare_and_convert_match_ptq(self):
+        """
+        End-to-end: without training, both the prepared (fake quantized) model
+        and the converted model must be identical to running PTQ directly, since
+        fake quant == PTQ dequant and convert (with no training) falls back to
+        the PTQ handler.
+        """
+        for code_dtype, block_size in self._fake_quant_configs():
+            base_config = CodebookWeightOnlyConfig(
+                dtype=code_dtype, block_size=block_size
+            )
+            m = torch.nn.Sequential(
+                torch.nn.Linear(self.in_features, self.out_features, bias=True)
+            )
+            m[0].weight = torch.nn.Parameter(self.weight.clone())
+            example_inputs = (torch.randn(8, self.in_features, dtype=torch.float32),)
+            msg = f"dtype={code_dtype}, block_size={block_size}"
+
+            # PTQ baseline
+            m_ptq = copy.deepcopy(m)
+            quantize_(m_ptq, base_config)
+            out_ptq = m_ptq(*example_inputs)
+
+            # Prepare: prepared output matches PTQ output
+            m_prepared = copy.deepcopy(m)
+            quantize_(m_prepared, QATConfig(base_config, step="prepare"))
+            torch.testing.assert_close(
+                m_prepared(*example_inputs), out_ptq, msg=f"prepare != PTQ for {msg}"
+            )
+
+            # Convert (no training forward -> falls back to PTQ): converted weight
+            # and output match PTQ
+            m_converted = copy.deepcopy(m)
+            quantize_(m_converted, QATConfig(base_config, step="prepare"))
+            quantize_(m_converted, QATConfig(base_config, step="convert"))
+            self.assertIsInstance(m_converted[0].weight, CodebookQuantizedTensor)
+            torch.testing.assert_close(
+                m_converted[0].weight.dequantize(),
+                m_ptq[0].weight.dequantize(),
+                msg=f"convert weight != PTQ for {msg}",
+            )
+            torch.testing.assert_close(
+                m_converted(*example_inputs), out_ptq, msg=f"convert != PTQ for {msg}"
+            )
+
+    def test_convert_reuses_training_codebook(self):
+        """
+        After a training forward populates the cached codebook, convert must
+        reuse that (frozen) codebook rather than re-clustering on the drifted
+        final weights, so the deployed grid matches what training optimized
+        against.
+        """
+        base_config = CodebookWeightOnlyConfig(dtype=torch.uint4, block_size=[-1, 16])
+        m = torch.nn.Sequential(
+            torch.nn.Linear(self.in_features, self.out_features, bias=True)
+        )
+        m[0].weight = torch.nn.Parameter(self.weight.clone())
+
+        quantize_(m, QATConfig(base_config, step="prepare"))
+
+        # Training forward populates the cached codebook (grid A from initial weights)
+        m(torch.randn(8, self.in_features, dtype=torch.float32))
+        cached_codebook = m[0].weight_fake_quantizer._codebook.clone()
+
+        # Weights drift during "training"
+        with torch.no_grad():
+            m[0].weight.add_(0.5 * torch.randn_like(m[0].weight))
+        final_weight = m[0].weight.detach().clone()
+
+        quantize_(m, QATConfig(base_config, step="convert"))
+        converted = m[0].weight
+        self.assertIsInstance(converted, CodebookQuantizedTensor)
+
+        # convert reused the training-time codebook, not a fresh re-cluster
+        torch.testing.assert_close(converted.codebook, cached_codebook)
+
+        # and it differs from re-clustering PTQ on the drifted final weights
+        fresh = CodebookQuantizedTensor.from_float(final_weight, torch.uint4, [-1, 16])
+        self.assertFalse(torch.equal(fresh.codebook, cached_codebook))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchao/prototype/qat/__init__.py
+++ b/torchao/prototype/qat/__init__.py
@@ -1,6 +1,10 @@
 # Temporary location for prototype QAT features that will
 # eventually live in torchao/quantization/qat
 
+from .codebook import (
+    CodebookFakeQuantizeConfig,
+    CodebookFakeQuantizer,
+)
 from .mx import (
     MXFakeQuantizeConfig,
     MXFakeQuantizedLinear,
@@ -11,6 +15,8 @@ from .nvfp4 import (
 )
 
 __all__ = [
+    "CodebookFakeQuantizeConfig",
+    "CodebookFakeQuantizer",
     "MXFakeQuantizeConfig",
     "MXFakeQuantizedLinear",
     "NVFP4FakeQuantizeConfig",

--- a/torchao/prototype/qat/codebook.py
+++ b/torchao/prototype/qat/codebook.py
@@ -1,0 +1,188 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Codebook (lookup table) Quantization-Aware Training (QAT) support.
+
+This module provides QAT support for CoreML-style codebook weight-only
+quantization. The fake quantization numerics mirror the post-training
+quantization (PTQ) flow in
+:class:`~torchao.prototype.quantization.codebook_coreml.CodebookWeightOnlyConfig`.
+
+The codebook (the k-means centroids / lookup table) is expensive to compute and
+non-differentiable, so it is not recomputed on every training step. Instead it
+is refreshed every ``refresh_interval`` steps; in between, only the cheap
+nearest-centroid assignment against the cached codebook is recomputed (this part
+is pure torch and runs on the weight's device). On a refresh step the fake
+quantization is bit-for-bit identical to PTQ.
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+import torch
+
+from torchao.quantization.qat import FakeQuantizeConfigBase, FakeQuantizerBase
+from torchao.quantization.quant_primitives import (
+    _DTYPE_TO_BIT_WIDTH,
+    _SUB_BYTE_UINT_BOUNDS,
+)
+
+
+@dataclass
+class CodebookFakeQuantizeConfig(FakeQuantizeConfigBase):
+    """
+    Config for fake quantizing weights using CoreML-style codebook (lookup table)
+    quantization, mirroring the numerics of
+    :class:`~torchao.prototype.quantization.codebook_coreml.CodebookWeightOnlyConfig`.
+
+    Args:
+        dtype (torch.dtype): the logical dtype for the codes, one of
+            [torch.uint1, ..., torch.uint8]. This determines the number of bits
+            per code and hence the number of codebook entries (``2 ** nbits``).
+        block_size (List[int]): granularity of quantization, specifying the
+            dimensions of the tensor blocks that share the same lookup table.
+            Must have length equal to the weight's rank (2). A value of ``-1``
+            in a dimension means the entire dimension is used. See
+            :func:`~torchao.prototype.quantization.codebook_coreml.choose_qparams_and_quantize_codebook_coreml`
+            for details.
+        refresh_interval (int): how often (in forward steps) to recompute the
+            codebook via k-means. On these steps the fake quantization matches
+            PTQ exactly. In between, the cached codebook is reused and only the
+            (cheap) nearest-centroid assignment is recomputed against the current
+            weight. ``refresh_interval=1`` recomputes the codebook every step
+            (exact PTQ numerics every step, but expensive). Default is 100.
+    """
+
+    dtype: torch.dtype
+    block_size: List[int] = field(default_factory=lambda: [-1, 1])
+    refresh_interval: int = 100
+
+    def __post_init__(self):
+        supported_dtypes = list(_SUB_BYTE_UINT_BOUNDS.keys()) + [torch.uint8]
+        if self.dtype not in supported_dtypes:
+            raise ValueError(
+                f"Unsupported dtype '{self.dtype}', must be one of "
+                f"torch.uint1 to torch.uint8"
+            )
+        if self.refresh_interval < 1:
+            raise ValueError(
+                f"refresh_interval must be >= 1, got {self.refresh_interval}"
+            )
+
+
+class CodebookFakeQuantizer(FakeQuantizerBase):
+    """
+    Generic module for applying codebook fake quantization to a weight tensor,
+    matching the numerics of
+    :class:`~torchao.prototype.quantization.codebook_coreml.CodebookQuantizedTensor`.
+
+    On a refresh step, we compute the codebook (lookup table) and codes using the
+    exact same op as the PTQ flow, so the output matches PTQ bit-for-bit. On other
+    steps, we reuse the cached codebook and recompute only the nearest-centroid
+    assignment against the current weight (pure torch, runs on the weight's
+    device). Because codebook selection is not differentiable, we use a
+    straight-through estimator so gradients flow to the original weight unchanged.
+    """
+
+    def __init__(self, config: CodebookFakeQuantizeConfig):
+        super().__init__()
+        self.config = config
+        # Number of forward steps taken so far, and the cached codebook. The
+        # cached codebook is registered as a (non-persistent) buffer so it moves
+        # with the module across devices.
+        # Number of forward steps taken and refreshes performed so far.
+        self._step = 0
+        self._num_refreshes = 0
+        # The cached codebook is a persistent buffer so it is saved as part of the
+        # checkpoint (state_dict) and restored on load. It is created lazily on
+        # the first forward, so it starts as None; see _load_from_state_dict for
+        # how it is materialized when loading a checkpoint into a fresh module.
+        self.register_buffer("_codebook", None, persistent=True)
+        torch._C._log_api_usage_once("torchao.quantization.qat.CodebookFakeQuantizer")
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        # The codebook buffer is created lazily (None until the first forward), so
+        # a freshly constructed module has it as None and the default loader would
+        # treat the checkpointed codebook as an unexpected key. Materialize it here
+        # so the standard load path can copy the checkpointed values in.
+        codebook_key = prefix + "_codebook"
+        if self._codebook is None and codebook_key in state_dict:
+            self._codebook = state_dict[codebook_key].clone()
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+    def forward(self, w: torch.Tensor) -> torch.Tensor:
+        # Imported here to avoid a hard dependency on coremltools at import time
+        from torchao.prototype.quantization.codebook_coreml.codebook_ops import (
+            choose_qparams_and_quantize_codebook_coreml,
+            dequantize_codebook,
+        )
+
+        nbits = _DTYPE_TO_BIT_WIDTH[self.config.dtype]
+        block_size = self.config.block_size
+
+        # Refresh (re-run k-means) on the very first forward (no codebook yet) and
+        # then every `refresh_interval` steps. The `_step > 0` guard means a
+        # codebook restored from a checkpoint is used as-is on the next forward
+        # rather than being immediately recomputed (or re-clustered at inference).
+        refresh = self._codebook is None or (
+            self._step > 0 and self._step % self.config.refresh_interval == 0
+        )
+        if refresh:
+            # Recompute the codebook (and codes) via k-means, exactly as PTQ does.
+            codebook, codes = choose_qparams_and_quantize_codebook_coreml(
+                w,
+                self.config.dtype,
+                block_size,
+            )
+            codebook = codebook.to(w.device)
+            codes = codes.to(w.device)
+            self._codebook = codebook
+            self._num_refreshes += 1
+        else:
+            # Reuse the cached codebook and only recompute the nearest-centroid
+            # assignment against the current weight.
+            from torchao.prototype.quantization.codebook_coreml.codebook_ops import (
+                assign_codebook_codes,
+            )
+
+            codebook = self._codebook.to(w.device)
+            codes = assign_codebook_codes(w, codebook, block_size)
+
+        self._step += 1
+
+        # dequantize_codebook indexes the codebook using int32 codes, matching
+        # CodebookQuantizedTensor.dequantize.
+        codes = codes.to(torch.int32)
+        dq = dequantize_codebook(
+            codes,
+            codebook,
+            nbits,
+            block_size,
+            output_dtype=w.dtype,
+        )
+
+        # Straight-through estimator. The parentheses matter: `w - w.detach()` is
+        # exactly zero elementwise, so the forward value equals `dq` bit-for-bit
+        # while gradients still flow to `w` unchanged.
+        return dq.detach() + (w - w.detach())

--- a/torchao/prototype/quantization/codebook_coreml/api.py
+++ b/torchao/prototype/quantization/codebook_coreml/api.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -29,25 +29,39 @@ class CodebookWeightOnlyConfig(AOBaseConfig):
 def _codebook_weight_only_transform(
     module: torch.nn.Module,
     config: CodebookWeightOnlyConfig,
+    custom_codebook: Optional[torch.Tensor] = None,
 ):
     """
     Applies codebook weight-only quantization to linear layers.
 
     Args:
         dtype: torch.uint1 to torch.uint8, torch.int32 supported.
+        custom_codebook: an optional pre-computed codebook (lookup table). When
+            provided, the weight is quantized by assigning each element to the
+            nearest entry of this codebook instead of running k-means. This is
+            used by codebook QAT convert so the deployed grid matches the one
+            training optimized against.
     Returns:
         Callable for quantization transformation.
     """
-    if not is_package_at_least("coremltools", "8.3.0"):
+    if custom_codebook is None and not is_package_at_least("coremltools", "8.3.0"):
         raise ImportError("Requires coremltools >= 8.3.0")
 
     dtype = config.dtype
     weight = module.weight
 
-    quantized_weight = CodebookQuantizedTensor.from_float(
-        weight,
-        dtype,
-        config.block_size,
-    )
+    if custom_codebook is not None:
+        quantized_weight = CodebookQuantizedTensor.from_float_and_codebook(
+            weight,
+            dtype,
+            config.block_size,
+            custom_codebook,
+        )
+    else:
+        quantized_weight = CodebookQuantizedTensor.from_float(
+            weight,
+            dtype,
+            config.block_size,
+        )
     module.weight = torch.nn.Parameter(quantized_weight, requires_grad=False)
     return module

--- a/torchao/prototype/quantization/codebook_coreml/codebook_ops.py
+++ b/torchao/prototype/quantization/codebook_coreml/codebook_ops.py
@@ -136,6 +136,62 @@ def choose_qparams_and_quantize_codebook_coreml(
     return final_luts, final_codes
 
 
+def assign_codebook_codes(
+    input_tensor: torch.Tensor,
+    codebook: torch.Tensor,
+    block_size: List[int],
+) -> torch.Tensor:
+    """
+    Assign each element of ``input_tensor`` to the index of the nearest entry in
+    its block's codebook (lookup table). This is exactly the k-means assignment
+    step against a fixed codebook, and mirrors the block-to-lookup-table mapping
+    used by :func:`dequantize_codebook`.
+
+    Args:
+        input_tensor (torch.Tensor): the (rank-2) tensor to quantize.
+        codebook (torch.Tensor): the codebook, shape
+            ``(g0, g1, 2 ** nbits, 1)`` where ``gi = input_tensor.shape[i] // block_size[i]``.
+        block_size (List[int]): block sizes (``-1`` means the entire dimension).
+
+    Returns:
+        torch.Tensor: the codes (nearest-entry indices), torch.uint8, same shape
+        as ``input_tensor``.
+    """
+    assert input_tensor.dim() == 2, "Currently only rank 2 tensors are supported"
+    N, K = input_tensor.shape
+
+    processed_block_size = list(block_size)
+    assert len(processed_block_size) == 2
+    if processed_block_size[0] == -1:
+        processed_block_size[0] = N
+    if processed_block_size[1] == -1:
+        processed_block_size[1] = K
+    row_block_size, col_block_size = processed_block_size
+    assert N % row_block_size == 0 and K % col_block_size == 0
+    g0, g1 = N // row_block_size, K // col_block_size
+
+    codebook = codebook.to(input_tensor.device)
+    # centroids per group, shape (g0, g1, num_levels); the last codebook dim
+    # (vec_dim) is 1 for scalar lookup values
+    num_levels = codebook.shape[-2]
+    centroids = codebook.reshape(g0, g1, num_levels)
+
+    row_group = torch.arange(N, device=input_tensor.device) // row_block_size
+    col_group = torch.arange(K, device=input_tensor.device) // col_block_size
+
+    codes = torch.empty(N, K, dtype=torch.uint8, device=input_tensor.device)
+    # Chunk over rows to bound the (rows, K, num_levels) distance tensor's memory
+    max_elems = 8 * 1024 * 1024
+    row_chunk = max(1, max_elems // max(1, K * num_levels))
+    for n0 in range(0, N, row_chunk):
+        n1 = min(n0 + row_chunk, N)
+        # centroids for this row chunk, expanded across columns: (r, K, num_levels)
+        c = centroids[row_group[n0:n1]][:, col_group, :]
+        dist = (input_tensor[n0:n1].unsqueeze(-1) - c).abs()
+        codes[n0:n1] = dist.argmin(dim=-1).to(torch.uint8)
+    return codes
+
+
 @register_custom_op
 def dequantize_codebook(
     codes: torch.Tensor,

--- a/torchao/prototype/quantization/codebook_coreml/codebook_quantized_tensor.py
+++ b/torchao/prototype/quantization/codebook_coreml/codebook_quantized_tensor.py
@@ -9,6 +9,7 @@ import torch
 from torch.utils._python_dispatch import return_and_correct_aliasing
 
 from torchao.prototype.quantization.codebook_coreml.codebook_ops import (
+    assign_codebook_codes,
     choose_qparams_and_quantize_codebook_coreml,
     dequantize_codebook,
 )
@@ -141,6 +142,44 @@ class CodebookQuantizedTensor(TorchAOBaseTensor):
         codebook, codes = choose_qparams_and_quantize_codebook_coreml(
             input_tensor, code_dtype, block_size
         )
+
+        assert codes.dtype == torch.uint8, "Only support using uint8 for codes for now"
+
+        return cls(
+            codes,
+            codebook,
+            code_dtype,
+            block_size,
+            input_tensor.shape,
+            dtype=input_tensor.dtype,
+        )
+
+    @classmethod
+    def from_float_and_codebook(
+        cls,
+        input_tensor: torch.Tensor,
+        code_dtype: torch.dtype,
+        block_size: List[int],
+        codebook: torch.Tensor,
+    ):
+        """
+        Creates a CodebookQuantizedTensor from a floating-point tensor and a
+        pre-computed codebook (lookup table), assigning each element to the
+        nearest codebook entry instead of running k-means.
+
+        This is used by codebook QAT convert, so the deployed quantization grid
+        matches the (frozen/last-refreshed) codebook that training optimized
+        against, rather than re-clustering on the final weights.
+
+        Args:
+            input_tensor (torch.Tensor): The input floating-point tensor to quantize.
+            code_dtype (torch.dtype): The dtype of the codes, Note the codes Tensor is stored in uint8
+            block_size (List[int]): block sizes for how many elements in each dimension share
+                the same lookup table.
+            codebook (torch.Tensor): The pre-computed codebook (lookup table).
+        """
+        codebook = codebook.to(input_tensor.device)
+        codes = assign_codebook_codes(input_tensor, codebook, block_size)
 
         assert codes.dtype == torch.uint8, "Only support using uint8 for codes for now"
 

--- a/torchao/quantization/qat/api.py
+++ b/torchao/quantization/qat/api.py
@@ -200,6 +200,7 @@ def _qat_config_transform(
     # TODO: rewrite this using a registration API so
     # specific quantization schemes do not leak here
     from torchao.prototype.qat import (
+        CodebookFakeQuantizer,
         MXFakeQuantizeConfig,
         MXFakeQuantizedLinear,
         NVFP4FakeQuantizeConfig,
@@ -268,14 +269,25 @@ def _qat_config_transform(
         # This is only for range learning and only applies to weights
         kwargs = {}
         has_custom_scale_and_zero_point = False
+        weight_fake_quantizer = getattr(module, "weight_fake_quantizer", None)
         if (
-            hasattr(module, "weight_fake_quantizer")
-            and isinstance(module.weight_fake_quantizer.config, IntxFakeQuantizeConfig)
-            and module.weight_fake_quantizer.config.range_learning
+            weight_fake_quantizer is not None
+            and isinstance(weight_fake_quantizer.config, IntxFakeQuantizeConfig)
+            and weight_fake_quantizer.config.range_learning
         ):
-            kwargs["custom_scale"] = module.weight_fake_quantizer.scale
-            kwargs["custom_zero_point"] = module.weight_fake_quantizer.zero_point
+            kwargs["custom_scale"] = weight_fake_quantizer.scale
+            kwargs["custom_zero_point"] = weight_fake_quantizer.zero_point
             has_custom_scale_and_zero_point = True
+
+        # For codebook QAT, reuse the codebook that training last computed so the
+        # deployed quantization grid matches what QAT optimized against, instead
+        # of re-clustering on the final weights. Only applies if at least one
+        # forward pass populated the cached codebook during training.
+        if (
+            isinstance(weight_fake_quantizer, CodebookFakeQuantizer)
+            and weight_fake_quantizer._codebook is not None
+        ):
+            kwargs["custom_codebook"] = weight_fake_quantizer._codebook
 
         # Swap FakeQuantizedLinear -> nn.Linear
         # Swap FakeQuantizedEmbedding -> nn.Embedding

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -359,8 +359,12 @@ def _infer_fake_quantize_configs(
         NVFP4DynamicActivationNVFP4WeightConfig,
     )
     from torchao.prototype.qat import (
+        CodebookFakeQuantizeConfig,
         MXFakeQuantizeConfig,
         NVFP4FakeQuantizeConfig,
+    )
+    from torchao.prototype.quantization.codebook_coreml import (
+        CodebookWeightOnlyConfig,
     )
     from torchao.quantization import (
         Float8DynamicActivationFloat8WeightConfig,
@@ -483,6 +487,12 @@ def _infer_fake_quantize_configs(
             granularity=base_config.granularity,
             mapping_type=base_config.mapping_type,
             scale_precision=base_config.scale_dtype,
+        )
+    elif isinstance(base_config, CodebookWeightOnlyConfig):
+        act_config = None
+        weight_config = CodebookFakeQuantizeConfig(
+            dtype=base_config.dtype,
+            block_size=base_config.block_size,
         )
     else:
         raise ValueError("Unexpected base config: %s" % base_config)

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -67,6 +67,15 @@ class FakeQuantizerBase(torch.nn.Module):
         elif isinstance(config, Float8FakeQuantizeConfig):
             return Float8FakeQuantizer(config)
         else:
+            # Prototype configs, imported lazily to avoid importing prototype
+            # code (and its optional dependencies) at module load time
+            from torchao.prototype.qat import (
+                CodebookFakeQuantizeConfig,
+                CodebookFakeQuantizer,
+            )
+
+            if isinstance(config, CodebookFakeQuantizeConfig):
+                return CodebookFakeQuantizer(config)
             raise ValueError(f"Unknown config type: {config}")
 
 


### PR DESCRIPTION
**Summary:** Adds a QAT flow for CoreML-style codebook (lookup-table) quantization that mirrors the numerics of the PTQ config CodebookWeightOnlyConfig and plugs into the standard QATConfig prepare/convert mechanism. On a refresh step the fake quantization matches PTQ.

- CodebookFakeQuantizeConfig / CodebookFakeQuantizer, wired into the QAT config-inference and from_config paths; a straight-through estimator lets gradients flow to the underlying weight.
- The codebook (k-means centroids) is expensive and non-differentiable, so it is refreshed every `refresh_interval` steps (default 100); between refreshes only the cheap nearest-centroid assignment is recomputed. `refresh_interval=1` gives exact PTQ numerics every step.
- The cached codebook is a persistent buffer, so it is saved in the prepared checkpoint. Convert reuses the persisted codebook via a new `custom_codebook` path and runs no new k-means, so a model can be trained, checkpointed, then loaded and converted later.

Example usage:

```python
import torch
from torchao.quantization import quantize_
from torchao.quantization.qat import QATConfig
from torchao.prototype.quantization.codebook_coreml import CodebookWeightOnlyConfig

base_config = CodebookWeightOnlyConfig(dtype=torch.uint4, block_size=[-1, 16])

# training session (needs coremltools)
quantize_(model, QATConfig(base_config, step="prepare"))
train_loop(model)                                  # populates the codebook
torch.save(model.state_dict(), "prepared.pt")      # codebook saved in state_dict

# later session
model = build_model()
quantize_(model, QATConfig(base_config, step="prepare"))    # codebook starts empty
model.load_state_dict(torch.load("prepared.pt"))            # restores the codebook
quantize_(model, QATConfig(base_config, step="convert"))    # reuses it, no k-means
output = model(example_input)
```

**Test Plan:**
```
pytest test/prototype/test_codebook_coreml_qat.py
```