### PR TITLE
Fixes `cutlass.base_dsl._mlir_helpers` import failure with nvidia-cutlass-dsl 4.6.1

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
@@ -50,7 +50,6 @@ if _cutedsl_runtime_available():
     import cutlass
     import cutlass.cute as cute
     from cutlass._mlir.dialects import llvm
-    from cutlass.base_dsl._mlir_helpers import arith as _dsl_arith
     from cutlass.cutlass_dsl import T, dsl_user_op
 
     # FP8 constants
@@ -135,7 +134,7 @@ if _cutedsl_runtime_available():
             Tuple of (scale_biased, inv_scale)
         """
         # reference: https://github.com/pytorch/ao/blob/ac0b820899b0a5d415310f798c9c96b5a5973f53/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh#L520
-        bits = _dsl_arith.bitcast(amax.ir_value(), _dsl_arith.T.i32())
+        bits = amax.bitcast(cutlass.Int32)
         exp_i = ((bits >> cutlass.Int32(23)) & cutlass.Int32(0xFF)) - cutlass.Int32(127)
         scale_exp_unbiased = exp_i - cutlass.Int32(8)
         if scale_exp_unbiased < -127:


### PR DESCRIPTION
In nvidia-cutlass-dsl 4.6.1, `cutlass.base_dsl._mlir_helpers` was moved to `cutlass._mlir_helpers`, breaking the import in torchao's `cute_utils.py`. This surfaces as a misleading `ImportError: torchao is not installed` when running MXFP8 configs in TorchTitan.

### Equivalence

`Numeric.bitcast()` (in `cutlass/base_dsl/typing.py`) calls `arith.bitcast(dtype.mlir_type, self.ir_value())`. The old `_dsl_arith.bitcast(src, res_elem_type)` calls `arith.bitcast(recast_type(src.type, res_elem_type), src)` -- `recast_type` only differs from a pass-through for vector/tensor types. Here `amax` is always a scalar `cutlass.Float32` (enforced by the `@cute.jit` type annotation), so both paths emit identical MLIR: `arith.bitcast(i32, <f32_value>)`.

### Backward compatibility

`Numeric.bitcast()` exists with the same signature in nvidia-cutlass-dsl 4.5.3 (verified by extracting the `nvidia-cutlass-dsl-libs-base==4.5.3` wheel and confirming the method in `cutlass/base_dsl/typing.py`).