### PR TITLE
fix(float8nocompile): correct swapped bounds-mask axes in _to_fp8_row_major_t (#4584)

### DIFF
--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
@@ -148,8 +148,14 @@ def _to_fp8_row_major_t(
         block_col_offs[:, None] * output_stride_row
         + block_row_offs[None, :] * output_stride_col
     )
-    out_mask = (block_row_offs[:, None] < output_num_rows) & (
-        block_col_offs[None, :] < output_num_cols
+    # The transposed store indexes the output row by block_col_offs and the
+    # output column by block_row_offs, so the bounds mask must be checked
+    # against the same axes. Using block_row_offs against output_num_rows here
+    # swaps the axes relative to out_offs, which for rectangular / non-tile
+    # aligned shapes masks off whole valid tiles (leaving uninitialized garbage)
+    # or lets out-of-bounds tiles through.
+    out_mask = (block_col_offs[:, None] < output_num_rows) & (
+        block_row_offs[None, :] < output_num_cols
     )
     tl.store(out_ptr + out_offs, fp8_vals.trans(1, 0), mask=out_mask)
 

--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
@@ -93,9 +93,11 @@ def test_fp8_hp_to_fp8_row_major(input_shape: tuple[int, int], algo: KernelAlgor
 def test_fp8_hp_to_fp8_row_major_t(input_shape: tuple[int, int], algo: KernelAlgorithm):
     assert torch.cuda.is_available()
     device = "cuda"
-    input_bf16 = torch.tensor(
-        [[1, 2, 3], [4, 5, 6]], dtype=torch.bfloat16, device=device
-    )
+    # Use the parametrized shape (matching test_fp8_hp_to_fp8_row_major) so the
+    # rectangular / non-tile-aligned cases actually exercise the transposed
+    # store's bounds mask. A fixed tiny tensor fit in a single tile and never
+    # hit the boundary, hiding the swapped-axis mask bug.
+    input_bf16 = torch.randn(input_shape, dtype=torch.bfloat16, device=device)
     x_bf16 = input_bf16.clone().detach().to(device)
     y_bf16 = input_bf16.clone().detach().to(device)
 

--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise_test.py
@@ -88,7 +88,11 @@ def test_fp8_hp_to_fp8_row_major(input_shape: tuple[int, int], algo: KernelAlgor
 )
 @pytest.mark.parametrize(
     "input_shape",
-    [(2, 4), (32, 16), (512, 512)],
+    # (129, 16) is deliberately not a multiple of the 128-wide block: it makes the
+    # row and column block starts differ, which is exactly what the swapped-axis
+    # bounds mask got wrong. The other shapes are single-block or square and pass
+    # under both the old and the new mask.
+    [(2, 4), (32, 16), (129, 16), (512, 512)],
 )
 def test_fp8_hp_to_fp8_row_major_t(input_shape: tuple[int, int], algo: KernelAlgorithm):
     assert torch.cuda.is_available()


### PR DESCRIPTION
## Summary

`_to_fp8_row_major_t` in `torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py` builds the transposed store address so that the output **row** is indexed by `block_col_offs` and the output **column** by `block_row_offs`:

```python
out_offs = (
    block_col_offs[:, None] * output_stride_row
    + block_row_offs[None, :] * output_stride_col
)
```

but the bounds mask checks the opposite axes:

```python
out_mask = (block_row_offs[:, None] < output_num_rows) & (
    block_col_offs[None, :] < output_num_cols
)
```

so the mask axes are swapped relative to `out_offs`. For square, tile-aligned inputs the two coincide, but for **rectangular / non-tile-aligned** shapes whole valid output tiles get masked off (leaving the `torch.empty` garbage in the result) or are written out of bounds.

## Fix

- Swap the mask axes so `block_col_offs` is bounded by `output_num_rows` and `block_row_offs` by `output_num_cols`, matching `out_offs`.
- Make `test_fp8_hp_to_fp8_row_major_t` actually use its parametrized `input_shape` (as the sibling `test_fp8_hp_to_fp8_row_major` already does) instead of a fixed `2x3` tensor. The fixed tensor fit inside a single tile and never hit the boundary, which is why the parametrized `(32, 16)` / `(512, 512)` cases were not exercising the transposed store and the bug slipped through.

Fixes #4584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
