### PR TITLE
Restore fp32 matmul precision in TestQuantFlow (#4593)

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -158,6 +158,17 @@ class TestQuantFlow(TestCase):
         ["xpu"] if torch.xpu.is_available() else []
     )
 
+    def setUp(self):
+        super().setUp()
+        # quantize_() sets a global float32 matmul precision; snapshot fp32_precision
+        self._prev_cuda_matmul_fp32 = torch.backends.cuda.matmul.fp32_precision
+        self._prev_mkldnn_matmul_fp32 = torch.backends.mkldnn.matmul.fp32_precision
+
+    def tearDown(self):
+        torch.backends.cuda.matmul.fp32_precision = self._prev_cuda_matmul_fp32
+        torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
+        super().tearDown()
+
     def test_dynamic_quant_gpu_singleline(self):
         if is_ROCM():
             self.skipTest("Don't test CPU for ROCM version of torch")


### PR DESCRIPTION
Summary:

pytorch/pytorch #185236 breaks some tests due to detecting fp32 precision flag leaks, so some forward fixing is required for tests.

Differential Revision: D113332658


