### PR TITLE
fix(autocast): resolve autocast state from the input's device type (#4601)

### DIFF
--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -255,10 +255,11 @@ class Float8Linear(torch.nn.Linear):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         # Duplicate the autocast logic for F.linear, so that the output
         # of our module has the right original precision
-        if torch.is_autocast_enabled():
-            # For now, hardcode to GPU's autocast dtype
-            # if we need CPU support in the future, we can add it
-            autocast_dtype = torch.get_autocast_gpu_dtype()
+        device_type = input.device.type
+        if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+            device_type
+        ):
+            autocast_dtype = torch.get_autocast_dtype(device_type)
             input = input.to(autocast_dtype)
 
         output = matmul_with_hp_or_float8_args.apply(

--- a/torchao/prototype/quantized_training/bitnet.py
+++ b/torchao/prototype/quantized_training/bitnet.py
@@ -142,8 +142,11 @@ class BitNetTrainingLinearWeight(TorchAOBaseTensor):
 
 @BitNetTrainingLinearWeight.implements_torch_function(F.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+        device_type
+    ):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _BitNetTrainingLinear.apply(*args, **kwargs)
 

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -167,8 +167,11 @@ class Int8MixedPrecisionTrainingLinearWeight(TorchAOBaseTensor):
 
 @Int8MixedPrecisionTrainingLinearWeight.implements(torch.nn.functional.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+        device_type
+    ):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _Int8MixedPrecisionTrainingLinearFunction.apply(*args, **kwargs)
 


### PR DESCRIPTION
Fixes #4601.

## Problem

Three call sites query CUDA's autocast state regardless of where the tensor actually lives:

| file | line | code |
|---|---|---|
| `torchao/float8/float8_linear.py` | 258 | `torch.is_autocast_enabled()` — the no-arg form defaults to `"cuda"` |
| `torchao/prototype/quantized_training/int8_mixed_precision.py` | 170 | `torch.is_autocast_enabled("cuda")` |
| `torchao/prototype/quantized_training/bitnet.py` | 145 | `torch.is_autocast_enabled("cuda")` |

On a non-CUDA accelerator with autocast active this returns `False`, so the input is never cast to the autocast dtype and quantization silently runs in fp32 — numerically fine, but slower and divergent from the CUDA path, with no warning. All three also call the deprecated `torch.get_autocast_gpu_dtype()`.

The `float8_linear.py` site already carried a `# For now, hardcode to GPU's autocast dtype / if we need CPU support in the future, we can add it` note, so this is the follow-up that comment anticipated.

## Fix

Resolve the device type from the input tensor:

```python
device_type = input.device.type
if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(device_type):
    autocast_dtype = torch.get_autocast_dtype(device_type)
    input = input.to(autocast_dtype)
```

## Why the `is_autocast_available` guard

The issue proposes calling `torch.is_autocast_enabled(device_type)` directly. That is not safe on its own — it raises for device types that have no autocast dispatch key:

```python
>>> torch.is_autocast_enabled("meta")
RuntimeError: unknown device type for autocast in get_autocast_dispatch_key_from_device_type
>>> torch.amp.is_autocast_available("meta")
False
```

Meta tensors show up in ordinary flows (`with torch.device("meta")` model init, FakeTensor tracing), so an unguarded lookup would turn a working path into a hard error. The `is_autocast_available()` short-circuit keeps those paths on the existing "autocast off" branch.

## Behavior

- **CUDA**: unchanged — `input.device.type == "cuda"`, so the same autocast state and dtype are read.
- **CPU / XPU / PrivateUse1 accelerators**: autocast is now detected on the device that is actually in use.
- **meta and other non-autocast device types**: treated as autocast-disabled, as today.

Verified against the pinned `ruff` 0.11.6 from `.pre-commit-config.yaml` (`check` and `format --check` both clean).

I did not add a regression test: reproducing the original miss needs a backend with autocast support other than CUDA, and I don't have one in CI reach to validate the test against. Happy to add one if you can point me at a suitable target (CPU autocast plus `Float8LinearConfig(emulate=True)` looks like it could work, but I couldn't verify it here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
