### PR TITLE
Support GPTQ synchronization on accelerator devices

### DIFF
--- a/test/prototype/gptq/test_gptqv2.py
+++ b/test/prototype/gptq/test_gptqv2.py
@@ -22,6 +22,7 @@ from torchao.prototype.gptq import (
     gptq_quantize,
     gptq_quantize_3d,
 )
+from torchao.prototype.gptq.api import _synchronize_gptq_device
 from torchao.prototype.gptq.observer import GPTQObserverTensor
 from torchao.prototype.mx_formats.inference_workflow import (
     NVFP4DynamicActivationNVFP4WeightConfig,
@@ -32,6 +33,38 @@ from torchao.utils import (
     _is_mslk_available,
     is_sm_at_least_100,
 )
+
+
+class TestGPTQDeviceSynchronization:
+    def test_synchronize_skips_cpu(self, monkeypatch):
+        def get_device_module(device):
+            raise AssertionError("CPU GPTQ should not request a device module")
+
+        monkeypatch.setattr(torch, "get_device_module", get_device_module)
+
+        _synchronize_gptq_device(torch.device("cpu"))
+
+    def test_synchronize_uses_weight_device_module(self, monkeypatch):
+        calls = []
+
+        class FakeDevice:
+            type = "xpu"
+
+        class FakeDeviceModule:
+            def synchronize(self):
+                calls.append("synchronize")
+
+        device = FakeDevice()
+
+        def get_device_module(requested_device):
+            assert requested_device is device
+            return FakeDeviceModule()
+
+        monkeypatch.setattr(torch, "get_device_module", get_device_module)
+
+        _synchronize_gptq_device(device)
+
+        assert calls == ["synchronize"]
 
 
 def _calculate_hessian(inputs, device=None):

--- a/torchao/prototype/gptq/api.py
+++ b/torchao/prototype/gptq/api.py
@@ -108,6 +108,16 @@ class GPTQConfig(AOBaseConfig):
 gptq_convert_layer_counter = 0
 
 
+def _synchronize_gptq_device(device: torch.device) -> None:
+    if device.type == "cpu":
+        return
+
+    device_module = torch.get_device_module(device)
+    synchronize = getattr(device_module, "synchronize", None)
+    if synchronize is not None:
+        synchronize()
+
+
 @register_quantize_module_handler(GPTQConfig)
 def _gptq_config_transform(
     module: torch.nn.Module, config: GPTQConfig, *, parameter_name="weight"
@@ -387,8 +397,6 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
     columns = W_t.shape[1]
     device = W_t.device
 
-    assert device.type == "cuda", "GPTQ only supports CUDA currently"
-
     dead = torch.diag(H) == 0
     H[dead, dead] = 1
     W_t[:, dead] = 0
@@ -531,7 +539,7 @@ def gptq_quantize(H: torch.Tensor, W_t: torch.Tensor, config: GPTQConfig):
             Hinv[B_cur_k_start:B_cur_k_end, B_cur_k_end:]
         )
 
-    torch.cuda.synchronize()
+    _synchronize_gptq_device(device)
 
     # Create the final quantized tensor, which has the same qparams (scale, zero_point), but different qdata
     if isinstance(base_config, Int4WeightOnlyConfig):


### PR DESCRIPTION
Summary:
- remove the CUDA-only GPTQ device assertion so accelerator backends can run the device-generic quantization path
- synchronize through the weight tensor's device module instead of calling torch.cuda.synchronize()
- add focused tests for the GPTQ synchronization helper

Fixes #4600

Testing:
- PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile torchao/prototype/gptq/api.py test/prototype/gptq/test_gptqv2.py
- git diff --check
- rg -n "GPTQ only supports CUDA|torch\\.cuda\\.synchronize\\(\\)" torchao/prototype/gptq/api.py test/prototype/gptq/test_gptqv2.py

Note: I could not run the pytest module locally because this workspace does not have torch installed.
