### PR TITLE
docs/types(pt2e): annotate and document utils and qat_utils (#4541)

### DIFF
--- a/torchao/quantization/pt2e/__init__.py
+++ b/torchao/quantization/pt2e/__init__.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import sys
 from typing import Callable, Optional, Union
 
@@ -184,7 +182,7 @@ class DerivedObserverOrFakeQuantize(ObserverBase):
         quant_max: Optional[int] = None,
         qscheme: Optional[torch.qscheme] = None,
         ch_axis: Optional[int] = None,
-    ):
+    ) -> None:
         super().__init__(dtype)
         self.obs_or_fqs = obs_or_fqs
         self.derive_qparams_fn = derive_qparams_fn
@@ -203,5 +201,6 @@ class DerivedObserverOrFakeQuantize(ObserverBase):
     def forward(self, x: Tensor) -> Tensor:
         return x
 
-    def calculate_qparams(self):  # type:ignore[override]
+    def calculate_qparams(self) -> tuple[Tensor, Tensor]:  # type:ignore[override]
         return self.derive_qparams_fn(self.obs_or_fqs)
+

--- a/torchao/quantization/pt2e/qat_utils.py
+++ b/torchao/quantization/pt2e/qat_utils.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-# mypy: allow-untyped-defs
 import copy
 import dataclasses
 import itertools
@@ -44,8 +43,7 @@ def _get_quantized_conv_bn_example_inputs_kwargs(
     bias_is_quantized: bool,
     is_cuda: bool,
 ) -> dict[str, Any]:
-    """
-    Optional example inputs for quantized and folded conv-bn patterns
+    """Optional example inputs for quantized and folded conv-bn patterns
     used in convert, expressed as kwargs.
     """
     kwargs = {}
@@ -66,7 +64,8 @@ def _get_quantized_conv_bn_example_inputs_kwargs(
     return kwargs
 
 
-def _get_conv_bn_pattern(conv_fn: Callable) -> Callable:
+def _get_conv_bn_pattern(conv_fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Create a standard conv + batchnorm pattern callable wrapped in WrapperModule."""
     def _conv_bn_pattern(
         x: torch.Tensor,
         conv_weight: torch.Tensor,
@@ -86,7 +85,8 @@ def _get_conv_bn_pattern(conv_fn: Callable) -> Callable:
 
 
 # TODO: merge this with the `no_conv_bias` case
-def _get_qat_conv_bn_pattern(conv_fn: Callable) -> Callable:
+def _get_qat_conv_bn_pattern(conv_fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Create an approximated QAT conv + batchnorm pattern callable wrapped in WrapperModule."""
     def _qat_conv_bn_pattern(
         x: torch.Tensor,
         conv_weight: torch.Tensor,
@@ -96,8 +96,7 @@ def _get_qat_conv_bn_pattern(conv_fn: Callable) -> Callable:
         bn_running_mean: torch.Tensor,
         bn_running_var: torch.Tensor,
     ) -> torch.Tensor:
-        """
-        Approximated method to fuse conv and bn. It requires only one forward pass.
+        """Approximated method to fuse conv and bn. It requires only one forward pass.
         conv_orig = conv / scale_factor where scale_factor = bn.weight / running_std.
         This is based on `nniqat.ConvBn2d._forward_approximate`.
         """
@@ -129,7 +128,8 @@ def _get_qat_conv_bn_pattern(conv_fn: Callable) -> Callable:
     return WrapperModule(_qat_conv_bn_pattern)
 
 
-def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable) -> Callable:
+def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Create a QAT conv + batchnorm pattern callable without conv bias wrapped in WrapperModule."""
     def _qat_conv_bn_pattern_no_conv_bias(
         x: torch.Tensor,
         conv_weight: torch.Tensor,
@@ -140,9 +140,7 @@ def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable) -> Callable:
         bn_running_mean: torch.Tensor,
         bn_running_var: torch.Tensor,
     ) -> torch.Tensor:
-        """
-        Same as `_get_qat_conv_bn_pattern`, but handles the case with no conv bias.
-        """
+        """Same as `_get_qat_conv_bn_pattern`, but handles the case with no conv bias."""
         # TODO: allow setting eps
         bn_eps = 1e-5
         running_std = torch.sqrt(bn_running_var + bn_eps)
@@ -169,9 +167,13 @@ def _get_qat_conv_bn_pattern_no_conv_bias(conv_fn: Callable) -> Callable:
     return WrapperModule(_qat_conv_bn_pattern_no_conv_bias)
 
 
-def _append_qdq(x, is_per_channel, is_bias, kwargs):
-    """
-    Helper function to append q-dq ops after `x`, using dummy values for the qparams
+def _append_qdq(
+    x: torch.Tensor,
+    is_per_channel: bool,
+    is_bias: bool,
+    kwargs: dict[str, Any],
+) -> torch.Tensor:
+    """Helper function to append q-dq ops after `x`, using dummy values for the qparams
     and qmin/qmax. We use dummy values here because we match with `ignore_literals=True`
     and will manually replace these values after subgraph rewriting.
 
@@ -195,6 +197,7 @@ def _append_qdq(x, is_per_channel, is_bias, kwargs):
         x = qd.quantize_per_tensor(x, scale, zp, qmin, qmax, dtype)
         x = qd.dequantize_per_tensor(x, scale, zp, qmin, qmax, dtype)
     return x
+
 
 
 def _get_quantized_qat_conv_bn_pattern(

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -4,14 +4,11 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-# mypy: allow-untyped-defs
 """
 Utils shared by different modes of quantization (eager/graph)
 """
 
 import functools
-
-# mypy: allow-untyped-defs
 import operator
 import types
 import warnings
@@ -66,11 +63,13 @@ __all__ = [
 
 
 # TODO: remove unused
-def is_per_tensor(qscheme):
+def is_per_tensor(qscheme: Optional[torch.qscheme]) -> bool:
+    """Return True if the qscheme represents per-tensor quantization."""
     return qscheme == torch.per_tensor_affine or qscheme == torch.per_tensor_symmetric
 
 
-def is_per_channel(qscheme):
+def is_per_channel(qscheme: Optional[torch.qscheme]) -> bool:
+    """Return True if the qscheme represents per-channel quantization."""
     return qscheme in [
         torch.per_channel_affine,
         torch.per_channel_affine_float_qparams,
@@ -79,13 +78,12 @@ def is_per_channel(qscheme):
 
 
 def getattr_from_fqn(obj: Any, fqn: str) -> Any:
-    """
-    Given an obj and a fqn such as "foo.bar.baz", returns gm.foo.bar.baz.
-    """
+    """Given an obj and a fqn such as "foo.bar.baz", returns gm.foo.bar.baz."""
     return functools.reduce(getattr, fqn.split("."), obj)
 
 
-def to_underlying_dtype(qdtype):
+def to_underlying_dtype(qdtype: torch.dtype) -> torch.dtype:
+    """Map a quantized dtype or standard dtype to its underlying unquantized tensor representation dtype."""
     DTYPE_MAPPING = {
         torch.quint8: torch.uint8,
         torch.qint8: torch.int8,
@@ -104,12 +102,13 @@ def to_underlying_dtype(qdtype):
     return DTYPE_MAPPING[qdtype]
 
 
-def get_qparam_dict(observer_or_fake_quant):
+def get_qparam_dict(observer_or_fake_quant: Any) -> dict[str, Any]:
+    """Extract a dictionary of quantization parameters (qscheme, scale, zero_point, dtype, etc.) from an observer or fake quantize instance."""
     from torchao.quantization.pt2e.observer import PlaceholderObserver
 
     qscheme = getattr(observer_or_fake_quant, "qscheme", None)
     dtype = observer_or_fake_quant.dtype
-    qparams = {"qscheme": qscheme, "dtype": dtype}
+    qparams: dict[str, Any] = {"qscheme": qscheme, "dtype": dtype}
 
     if not qscheme or isinstance(observer_or_fake_quant, PlaceholderObserver):
         return {"qscheme": None, "dtype": dtype}
@@ -138,6 +137,7 @@ def get_qparam_dict(observer_or_fake_quant):
         qparams["quant_max"] = observer_or_fake_quant.quant_max
 
     return qparams
+
 
 
 def check_min_max_valid(min_val: torch.Tensor, max_val: torch.Tensor) -> bool:


### PR DESCRIPTION
## Summary

Part of the PT2E type-hinting & docstring audit proposed in #4541 (Batch 2A). This PR covers `torchao/quantization/pt2e/utils.py`, `torchao/quantization/pt2e/qat_utils.py`, and `torchao/quantization/pt2e/__init__.py`.

- Removed file-level `# mypy: allow-untyped-defs` pragmas.
- Added PEP-484 type annotations for untyped functions, methods, and helpers.
- Standardized Google-style docstrings across utility and QAT functions.

No runtime behavior changes — signatures and functionality remain 100% backward compatible.

## Test Plan

- `.venv/bin/python -m pytest test/quantization/pt2e/test_graph_utils.py test/quantization/pt2e/test_quantize_pt2e.py`: 68 PASSED
- `.venv/bin/python -m ruff check torchao/quantization/pt2e/utils.py torchao/quantization/pt2e/qat_utils.py torchao/quantization/pt2e/__init__.py`: All checks passed!

## Why this is safe

`allow-untyped-defs` only suppresses checking of untyped function bodies. Adding type annotations and docstrings does not alter runtime behavior or public API contracts.