### PR TITLE
[pat] Fix SVD class leakage into `nn.Linear` from #4587

### DIFF
--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -498,6 +498,10 @@ class PruneOptimizer(Optimizer):
         for group in self.regularized_param_groups():
             if not self._prox_through_heal(group):
                 continue
+            # Global prox types build per-batch (see step()); the per-param path
+            # below can't build them and would raise a confusing TypeError.
+            if group["prox_type"] == "GlobalMinSparsityConstraint":
+                continue
             if not self.should_prune(group, self.num_steps):
                 continue
             prox_map, grouper_cls, grouper_kwargs, prox_kwargs = (

--- a/torchao/prototype/pat/utils.py
+++ b/torchao/prototype/pat/utils.py
@@ -133,6 +133,21 @@ def latent_svd(self, name=""):
     return ((U * S) @ Vh).view(orig_shape)
 
 
+def _isolate_module_class(module: nn.Module) -> type:
+    """Return a per-instance subclass so descriptor patches don't leak.
+
+    Patching the SVD descriptor onto ``module.__class__`` would mutate the
+    shared class (e.g. ``nn.Linear``) for every module in the process; a
+    private subclass isolates it to this instance.
+    """
+    cls = module.__class__
+    if cls.__dict__.get("_pat_svd_isolated", False):
+        return cls
+    private_cls = type(cls.__name__, (cls,), {"_pat_svd_isolated": True})
+    module.__class__ = private_cls
+    return private_cls
+
+
 def insert_svd_modules_(model: nn.Module, optimizer: torch.optim.Optimizer):
     """Replaces dense parameters with their SVD decompositions.
 
@@ -184,7 +199,7 @@ def insert_svd_modules_(model: nn.Module, optimizer: torch.optim.Optimizer):
 
                 module.__dict__.pop(pn, None)  # delete the original parameter
                 setattr(
-                    module.__class__,
+                    _isolate_module_class(module),
                     pn,
                     FuncDescriptor(partial(latent_svd, name=pn)),
                 )


### PR DESCRIPTION
From #4587: `insert_svd_modules_` patched the SVD descriptor onto `module.__class__`, mutating the shared class process-wide. Downstream `.weight` accesses then hit `latent_svd` and raised:

```python
AttributeError("'Linear' object has no attribute 'weight_U'")
```
breaking `torch.compile` tests across the int4/int8/float8 workflows.

**Fix**: patch a private per-instance subclass instead. Also skips global prox types in through-heal to avoid a `TypeError`.