### PR TITLE
fix(autocast):fix the bug when backward scaling is ScalingType.DISABLED

### DIFF
--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -126,7 +126,12 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
             # TODO(future PR): var name is axiswise specific, fix it
             weight_t_maybe_fp8_dim0 = weight_hp_t
         elif c.cast_config_weight_for_grad_input.scaling_type is ScalingType.DISABLED:
-            weight_t_maybe_fp8_dim0 = weight_hp_t
+            # Align dtype with grad_output for the torch.mm below.
+            # Under autocast, input_hp is bf16 but weight_hp_t may be
+            # float32 (master weight).  torch.mm requires matching dtypes.
+            weight_t_maybe_fp8_dim0 = weight_hp_t.to(
+                grad_output_reshaped_maybe_fp8_dim0.dtype
+            )
         else:
             weight_t_maybe_fp8_dim0 = hp_tensor_to_float8_dynamic(
                 weight_hp_t,


### PR DESCRIPTION
torchao/float8/float8_linear.py backward crashes with RuntimeError: expected scalar type BFloat16 but found Float when backward scaling is ScalingType.DISABLED and the model runs under torch.autocast(dtype=bfloat16).

Line 128-129 — DISABLED branch uses saved weight_hp_t directly:

elif c.cast_config_weight_for_grad_input.scaling_type is ScalingType.DISABLED:
    weight_t_maybe_fp8_dim0 = weight_hp_t  # float32 (master weight)

Line 143-145 — torch.mm with mismatched dtypes:

grad_input = torch.mm(
    grad_output_reshaped_maybe_fp8_dim0,  # bf16 (from autograd under autocast)
    weight_t_maybe_fp8_dim0.t(),          # float32 ← mismatch
)

Under autocast, Float8Linear.forward receives input as bf16 and self.weight.t() as float32 (master weight). Both are saved via ctx.save_for_backward(input_hp, weight_hp_t) — a (bf16, float32) pair. When backward scaling is active, hp_tensor_to_float8_dynamic casts both to float8, so the mismatch is masked. When DISABLED, the raw saved tensors go directly to torch.mm, which does not perform automatic dtype promotion.
