### PR TITLE
[Bug Fix] Inverted bias flag in swap_conv2d_1x1_to_linear

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -576,16 +576,18 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
-
     @common_utils.parametrize("bias", [True, False])
     def test_swap_conv2d_1x1_to_linear(self, bias):
         from torchao.quantization.quant_api import swap_conv2d_1x1_to_linear
+
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.conv = torch.nn.Conv2d(8, 16, kernel_size=1, bias=bias)
+
             def forward(self, x):
                 return self.conv(x)
+
         m = M().eval()
         x = torch.randn(2, 8, 4, 4)
         ref = m(x)

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -580,29 +580,22 @@ class TestQuantFlow(TestCase):
     @common_utils.parametrize("bias", [True, False])
     def test_swap_conv2d_1x1_to_linear(self, bias):
         from torchao.quantization.quant_api import swap_conv2d_1x1_to_linear
-
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
                 self.conv = torch.nn.Conv2d(8, 16, kernel_size=1, bias=bias)
-
             def forward(self, x):
                 return self.conv(x)
-
         m = M().eval()
         x = torch.randn(2, 8, 4, 4)
         ref = m(x)
-
         swap_conv2d_1x1_to_linear(m)
-
         lin = m.conv.mod
         self.assertIsInstance(lin, torch.nn.Linear)
-
         if bias:
             self.assertIsNotNone(lin.bias)
         else:
             self.assertIsNone(lin.bias)
-
         torch.testing.assert_close(m(x), ref, atol=1e-5, rtol=1e-5)
 
 

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -577,6 +577,35 @@ class TestQuantFlow(TestCase):
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
 
+    @common_utils.parametrize("bias", [True, False])
+    def test_swap_conv2d_1x1_to_linear(self, bias):
+        from torchao.quantization.quant_api import swap_conv2d_1x1_to_linear
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(8, 16, kernel_size=1, bias=bias)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        m = M().eval()
+        x = torch.randn(2, 8, 4, 4)
+        ref = m(x)
+
+        swap_conv2d_1x1_to_linear(m)
+
+        lin = m.conv.mod
+        self.assertIsInstance(lin, torch.nn.Linear)
+
+        if bias:
+            self.assertIsNotNone(lin.bias)
+        else:
+            self.assertIsNone(lin.bias)
+
+        torch.testing.assert_close(m(x), ref, atol=1e-5, rtol=1e-5)
+
+
 common_utils.instantiate_parametrized_tests(TestQuantFlow)
 
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -227,12 +227,12 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
             self.mod = mod
 
         def forward(self, *args):
-            return self.mod(args[0].permute(0, 2, 3, 1)).permute(-0, 3, 1, 2)
+            return self.mod(args[0].permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
 
     def replace_conv2d_1x1(conv):
         assert conv.kernel_size == (1, 1)
         lin = torch.nn.Linear(
-            conv.in_channels, conv.out_channels, bias=(conv.bias is None)
+            conv.in_channels, conv.out_channels, bias=(conv.bias is not None)
         )
         lin.weight = torch.nn.Parameter(conv.weight.squeeze(-1, -2))
         lin.bias = conv.bias


### PR DESCRIPTION
## Summary
###  https://github.com/pytorch/ao/issues/4615

- Fixed inverted `bias` flag in `replace_conv2d_1x1` inside `swap_conv2d_1x1_to_linear`. `bias=(conv.bias is None)` was creating a bias when the original conv had none. Changed to `bias=(conv.bias is not None)`.
- Fixed harmless `-0` typo to `0` in `PermuteSandwich.forward`.

## Impact

Low — the bug is self-healing because `lin.bias = conv.bias` on the next line overwrites the constructor value. The fix eliminates unnecessary Parameter allocation and reset_parameters() compute when converting bias-free convolutions.

## Test plan

- [x] Verified both buggy and fixed paths produce identical model state
- [x] Existing tests pass