### PR TITLE
extract FP8 inference compute kernels into torch.library ops (#4599)

### DIFF
--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -83,6 +83,47 @@ def preprocess_scale(input_scale: torch.Tensor, input_shape: Tuple[int, ...]):
     return input_scale
 
 
+def _float8_scaled_mm_decomposition(
+    a: Tensor,
+    a_scale: Tensor,
+    b: Tensor,
+    b_scale: Tensor,
+    bias: Optional[Tensor],
+    output_dtype: torch.dtype,
+    use_fast_accum: bool,
+    output_scale: Optional[Tensor] = None,
+) -> Tensor:
+    if output_dtype == torch.float32 and bias is not None:
+        # Bias is not supported by _scaled_mm when output is fp32
+        output = torch._scaled_mm(
+            a,
+            b,
+            scale_a=a_scale,
+            scale_b=b_scale,
+            scale_result=output_scale,
+            out_dtype=output_dtype,
+            use_fast_accum=use_fast_accum,
+        )
+        return output + bias
+    return torch._scaled_mm(
+        a,
+        b,
+        scale_a=a_scale,
+        scale_b=b_scale,
+        bias=bias,
+        scale_result=output_scale,
+        out_dtype=output_dtype,
+        use_fast_accum=use_fast_accum,
+    )
+
+
+import torchao.ops  # noqa: E402, F401
+
+torch.library.impl("torchao::float8_scaled_mm", "CompositeImplicitAutograd")(
+    _float8_scaled_mm_decomposition
+)
+
+
 def addmm_float8_unwrapped_inference(
     a_data: Tensor,
     a_scale: Tensor,
@@ -97,29 +138,14 @@ def addmm_float8_unwrapped_inference(
     This is the unwrapped version of addmm_float8, which does not take in Float8TrainingTensors
     as inputs. This is used to standardize the logic between subclassed and non subclassed
     versions of the linear module.
-    """
 
-    if output_dtype == torch.float32 and bias is not None:
-        # Bias is not supported by _scaled_mm when output is fp32
-        output = torch._scaled_mm(
-            a_data,
-            b_data,
-            scale_a=a_scale,
-            scale_b=b_scale,
-            scale_result=output_scale,
-            out_dtype=output_dtype,
-            use_fast_accum=use_fast_accum,
-        )
-        return output + bias
-    return torch._scaled_mm(
-        a_data,
-        b_data,
-        scale_a=a_scale,
-        scale_b=b_scale,
-        bias=bias,
-        scale_result=output_scale,
-        out_dtype=output_dtype,
-        use_fast_accum=use_fast_accum,
+    Routes through torch.ops.torchao.float8_scaled_mm so that third-party
+    backends can register a PrivateUse1 impl instead of monkey-patching
+    this function or the entire Float8Tensor dispatch handler.
+    """
+    return torch.ops.torchao.float8_scaled_mm(
+        a_data, a_scale, b_data, b_scale,
+        bias, output_dtype, use_fast_accum, output_scale,
     )
 
 

--- a/torchao/ops.py
+++ b/torchao/ops.py
@@ -46,6 +46,16 @@ lib.define(
 lib.define(
     "float8_linear_cpu(Tensor input, Tensor input_scales, Tensor weight, Tensor weight_scales, Tensor? bias, ScalarType output_dtype) -> Tensor"
 )
+# FP8 scaled matmul op for third-party backend extensibility.
+# CUDA gets the CompositeImplicitAutograd decomposition (registered in
+# torchao/float8/inference.py) which calls torch._scaled_mm — behavior
+# is unchanged.  Third-party backends register a PrivateUse1 impl.
+lib.define(
+    "float8_scaled_mm(Tensor a, Tensor a_scale, Tensor b, Tensor b_scale, "
+    "Tensor? bias, ScalarType output_dtype, bool use_fast_accum, "
+    "Tensor? output_scale=None) -> Tensor",
+    tags=[torch._C.Tag.needs_fixed_stride_order],
+)
 
 
 def register_custom_op(name):
@@ -315,6 +325,21 @@ def _check_scale_dtypes(A_scale, B_scale):
 def meta_mx_fp8_bf16(A: Tensor, B: Tensor, A_scale: Tensor, B_scale: Tensor):
     """Meta impl for mx_fp8_bf16"""
     return torch.empty((A.size(0), B.size(1)), dtype=torch.bfloat16, device=A.device)
+
+
+@register_custom_op("torchao::float8_scaled_mm")
+def meta_float8_scaled_mm(
+    a: Tensor,
+    a_scale: Tensor,
+    b: Tensor,
+    b_scale: Tensor,
+    bias: Optional[Tensor],
+    output_dtype: torch.dtype,
+    use_fast_accum: bool,
+    output_scale: Optional[Tensor] = None,
+):
+    """Meta impl for float8_scaled_mm"""
+    return torch.empty((a.size(0), b.size(1)), dtype=output_dtype, device=a.device)
 
 
 def da8w4_linear_prepack_cpu(


### PR DESCRIPTION
The FP8 inference paths in torchao couple routing logic (scale type checks, transpose, padding, reshape) with compute kernels (torch._scaled_mm, int_scaled_matmul) inside Python functions. Non-CUDA backends (e.g. MLU) cannot substitute only the kernel — we must monkey-patch the entire @implements dispatch handler, duplicating all routing logic and breaking on every torchao upgrade.

This proposes extracting the compute kernels into torch.library ops (torchao::float8_scaled_mm) with CompositeImplicitAutograd decompositions, so that:

    CUDA behavior is unchanged — no CUDA-specific registration; CUDA gets the decomposition automatically.
    Third-party backends register a single PrivateUse1 impl instead of patching dispatch handlers.
    Routing logic stays in torchao and evolves independently of backend kernels.
