### PR TITLE
Route ROCm regression CI to MI350 ecosystem runners

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - name: ROCM Nightly
-            runs-on: linux.rocm.gpu.gfx942.1
+            runs-on: linux.rocm.gpu.ecosystem.gfx950.1
             torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2'
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.2"


### PR DESCRIPTION
## Summary

Switch the ROCm nightly regression test runner label in
`.github/workflows/regression_test_rocm.yml` to
`linux.rocm.gpu.ecosystem.gfx950.1`, the shared **MI350 (gfx950) ecosystem**
runner scale set used by downstream PyTorch ecosystem projects (e.g.
`pytorch/helion`, `pytorch/torchtitan`).

## Test plan

- Apply the `ciflow/rocm` label to trigger the "Run Regression Tests on ROCm"
  workflow on this PR.
- Verify the `ROCM Nightly` job schedules and runs on a
  `linux.rocm.gpu.ecosystem.gfx950.1` runner.

Made with Cursor