### PR TITLE
Forward weight dtype to gemlite helper in UIntxBitPackedTensor

### DIFF
--- a/test/prototype/test_uintx_bit_packed_tensor.py
+++ b/test/prototype/test_uintx_bit_packed_tensor.py
@@ -24,7 +24,12 @@ except ModuleNotFoundError:
 @unittest.skipIf(not has_gemlite, "gemlite not available")
 class TestUIntxBitPackedTensor(TestCase):
     def _test_quantize_and_linear(
-        self, bit_width, group_size, packing_bitwidth, sqnr_threshold=24
+        self,
+        bit_width,
+        group_size,
+        packing_bitwidth,
+        sqnr_threshold=22,
+        dtype=torch.float16,
     ):
         """Helper: quantize a linear layer and verify forward pass produces valid output."""
         from torchao.prototype.quantization.quant_api import UIntxWeightOnlyConfig
@@ -32,11 +37,11 @@ class TestUIntxBitPackedTensor(TestCase):
         in_features = 512
         out_features = 256
         model = torch.nn.Linear(in_features, out_features, bias=False).to(
-            device="cuda", dtype=torch.float16
+            device="cuda", dtype=dtype
         )
 
         # Compute reference output before quantization
-        x = torch.randn(2, in_features, device="cuda", dtype=torch.float16)
+        x = torch.randn(2, in_features, device="cuda", dtype=dtype)
         ref_out = model(x)
 
         config = UIntxWeightOnlyConfig(
@@ -82,6 +87,34 @@ class TestUIntxBitPackedTensor(TestCase):
 
     def test_8bit_perchannel_pack8(self):
         self._test_quantize_and_linear(bit_width=8, group_size=None, packing_bitwidth=8)
+
+    # bfloat16 variants: the 4-bit path used to bake gemlite's float16 default into
+    # meta_args regardless of the weight dtype, so the forward pass died in Triton
+    # with "Both operands must be same dtype. Got bf16 and fp16" (issue #4614).
+    def test_4bit_group64_pack32_bf16(self):
+        self._test_quantize_and_linear(
+            bit_width=4, group_size=64, packing_bitwidth=32, dtype=torch.bfloat16
+        )
+
+    def test_4bit_group128_pack32_bf16(self):
+        self._test_quantize_and_linear(
+            bit_width=4, group_size=128, packing_bitwidth=32, dtype=torch.bfloat16
+        )
+
+    def test_4bit_group64_pack8_bf16(self):
+        self._test_quantize_and_linear(
+            bit_width=4, group_size=64, packing_bitwidth=8, dtype=torch.bfloat16
+        )
+
+    def test_8bit_perchannel_pack32_bf16(self):
+        self._test_quantize_and_linear(
+            bit_width=8, group_size=None, packing_bitwidth=32, dtype=torch.bfloat16
+        )
+
+    def test_8bit_perchannel_pack8_bf16(self):
+        self._test_quantize_and_linear(
+            bit_width=8, group_size=None, packing_bitwidth=8, dtype=torch.bfloat16
+        )
 
     def _test_dynamic_quantize_and_linear(
         self, bit_width, group_size, packing_bitwidth, sqnr_threshold=22

--- a/torchao/prototype/quantization/uintx/uintx_bit_packed_tensor.py
+++ b/torchao/prototype/quantization/uintx/uintx_bit_packed_tensor.py
@@ -141,10 +141,16 @@ class UIntxBitPackedTensor(TorchAOBaseTensor):
                 int_data, scales=scale, bias=None
             )
         else:
+            # gemlite infers its compute dtype from the scale dtype, but the 4-bit
+            # HQQ path above always produces float16 scales. Pass the original
+            # weight dtype explicitly so bfloat16 weights don't get a float16
+            # kernel baked into meta_args.
             if mode == "dynamic":
                 if hasattr(gemlite.helper, "A8Wn_dynamic"):
                     gemlite_linear = gemlite.helper.A8Wn_dynamic(
-                        device=int_data.device, packing_bitwidth=packing_bitwidth
+                        device=int_data.device,
+                        dtype=hp_tensor.dtype,
+                        packing_bitwidth=packing_bitwidth,
                     ).from_weights(
                         int_data,
                         scale,
@@ -156,6 +162,7 @@ class UIntxBitPackedTensor(TorchAOBaseTensor):
                 elif hasattr(gemlite.helper, "A8Wn_HQQ_INT_dynamic"):
                     gemlite_linear = gemlite.helper.A8Wn_HQQ_INT_dynamic(
                         device=int_data.device,
+                        dtype=hp_tensor.dtype,
                         packing_bitwidth=packing_bitwidth,
                         W_nbits=bit_width,
                     ).from_weights(int_data, scale, zero_point, bias=None)
@@ -165,7 +172,9 @@ class UIntxBitPackedTensor(TorchAOBaseTensor):
                     )
             else:
                 gemlite_linear = gemlite.helper.A16Wn(
-                    device=int_data.device, packing_bitwidth=packing_bitwidth
+                    device=int_data.device,
+                    dtype=hp_tensor.dtype,
+                    packing_bitwidth=packing_bitwidth,
                 ).from_weights(
                     int_data,
                     scale,


### PR DESCRIPTION
Fixes #4614

## Summary

`UIntxWeightOnlyConfig(bit_width=4)` quantizes a `bfloat16` model fine but dies in the
forward pass with:

```
triton.compiler.errors.CompilationError: at 140:14:
    acc = tl.dot(a, b.to(input_dtype), acc=acc, out_dtype=acc_dtype)
          ^
Both operands must be same dtype. Got bf16 and fp16
```

**Root cause:** `UIntxBitPackedTensor.from_hp` never forwards the weight dtype to the
gemlite helper. gemlite's `A16Wn` infers its compute dtype from `scales.dtype`, and the
4-bit path gets its scales from `_choose_qparams_and_quantize_affine_hqq`, whose
`compute_dtype` defaults to `torch.float16` -- so the scales are float16 even for a
bfloat16 weight. gemlite therefore bakes a float16 kernel into `meta_args`, and at
runtime the bf16 activation meets an fp16-cast weight in `tl.dot`.

torchao already has the correct dtype -- it asserts on it and stores it a few lines
later -- it just wasn't passing it. The fix is to pass `dtype=hp_tensor.dtype` when
constructing the helper.

**Why 8-bit was unaffected:** the 8-bit path goes through `A16W8`, and its scales come
from `choose_qparams_affine`, which preserves the input dtype -- so gemlite's inference
already lands on bfloat16 there. Verified: 8-bit bf16 passes both before and after this
change. I left the 8-bit call site alone for that reason; `A16W8` does not cast scales
to `self.dtype`, so passing a dtype there would set the kernel dtype without moving the
scales and could introduce the very mismatch this PR removes.

**Why it escaped:** `_test_quantize_and_linear` hardcoded `dtype=torch.float16` for both
the model and the input, so no bfloat16 case was exercised anywhere in the file.

## Verification

Confirmed the dtype actually baked into `meta_args` changes as intended, and only for bf16:

| weight dtype | `meta_args` before | `meta_args` after |
|---|---|---|
| float16  | `[0, 4, 128, 15, 8, 1, 1, 0, 1, 0, 4, 1]` | `[0, 4, 128, 15, 8, 1, 1, 0, 1, 0, 4, 1]` (identical) |
| bfloat16 | `[0, 4, 128, 15, 8, 1, 1, 0, 1, 0, 4, 1]` | `[0, 4, 128, 15, 8, 2, 2, 0, 2, 0, 4, 1]` |

The dtype enum fields go `1 -> 2` (fp16 -> bf16) for bfloat16 and are byte-identical for
float16, so the existing fp16 path is untouched. The stored `scale`/`zero_point` also
become bfloat16 instead of float16.

The reporter's reproducer runs clean after the change, for both dtypes.

**Hardware / versions:** NVIDIA A40 (GA102, sm_86 -- same compute capability as the
reporter's RTX 3060), driver 560.35.03, torch 2.13.0+cu126, triton 3.7.1, Python 3.13,
gemlite 0.5.1.post1.

`test/prototype/test_uintx_bit_packed_tensor.py`, gemlite 0.5.1.post1:

- before: `3 failed, 15 passed` (the 3 are pre-existing, see below)
- after: `3 failed, 20 passed` -- the 5 new bf16 tests pass, the same 3 pre-existing
  failures remain
- with the source fix reverted but the new tests present, the 3 new 4-bit bf16 tests fail
  with the exact error from the issue, confirming they are a real regression test

## Test changes

Per the issue, `_test_quantize_and_linear` gains a `dtype` parameter (default
`torch.float16`, so existing cases are unchanged) threaded through both the `.to(...)`
call and the `torch.randn(...)` input, plus bf16 variants of all five weight-only cases --
including the `group_size=128, bit_width=4, packing_bitwidth=32` configuration from the
reproducer.

### One judgement call: `sqnr_threshold` default 24 -> 22

I measured SQNR over 20 seeds per config, both dtypes:

| bits | group_size | pack | dtype | min | mean | max |
|---|---|---|---|---|---|---|
| 4 | 64  | 32 | fp16 | 23.69 | 24.16 | 24.70 |
| 4 | 64  | 32 | bf16 | 23.62 | 24.10 | 24.50 |
| 4 | 128 | 32 | fp16 | 23.14 | 23.84 | 24.30 |
| 4 | 128 | 32 | bf16 | 23.25 | 23.85 | 24.38 |
| 4 | 64  | 8  | fp16 | 23.69 | 24.16 | 24.70 |
| 4 | 64  | 8  | bf16 | 23.62 | 24.10 | 24.50 |
| 8 | None| 32 | fp16 | 47.19 | 48.09 | 48.62 |
| 8 | None| 32 | bf16 | 44.75 | 45.01 | 45.50 |

Two things fall out:

1. **bfloat16 costs essentially nothing at 4 bits** -- within 0.06 dB of float16 on every
   config. The 4-bit quantization error dominates, not the accumulation dtype. So I did
   *not* loosen the threshold for bf16 specifically; both dtypes use the same number.
2. The existing `24` was already too tight on float16: `group_size=128` has a mean of
   23.84 and never exceeded 24.38 across 20 seeds, so `test_4bit_group128_pack32` was
   passing on luck and is latently flaky today, independent of this issue.

`22` sits ~1.1 dB below the lowest value observed anywhere in that sweep, and it matches
the threshold `_test_dynamic_quantize_and_linear` already uses in this same file for the
same 4-bit configurations. It also costs nothing in detection power for this bug: #4614
manifests as a hard Triton compilation error, not as a quality regression, so it is the
forward pass completing at all that catches it, not the SQNR value.

Happy to revert this to 24 and leave the flakiness for a separate PR if you'd prefer to
keep the diff strictly scoped.

## Two things noted but deliberately not fixed here

**gemlite 0.6.0 is incompatible with this module, independent of this issue.** The
reporter mentioned downgrading 0.6.0 -> 0.5.1.post1 over "unrelated errors"; those are
reproducible and have a specific cause. In 0.6.0 `GemLiteLinearTriton.get_tensor_args()`
returns four values (a `meta_scale` was added) rather than three, so
`uintx_bit_packed_tensor.py:198` raises `ValueError: too many values to unpack
(expected 3)`. On gemlite 0.6.0 the **unmodified** tree already fails 19 of 20 float16
tests, so this is pre-existing and orthogonal. Happy to file it separately. Note also
that gemlite is not pinned or installed anywhere in this repo's requirements or CI
config, so this whole test file is skipped in CI via the `has_gemlite` gate.

**The `mode == "dynamic"` call sites have the same omission**, so I fixed them
consistently -- but I could not verify them on this hardware. gemlite's dynamic path uses
fp8 (`fp8e4nv`), which requires sm_89+; on sm_86 all three `test_dynamic_4bit_*` tests
already fail with `ValueError: type fp8e4nv not supported in this architecture` on
**both** float16 and bfloat16, before and after this change. Those are the 3 pre-existing
failures in the counts above. `A8Wn_HQQ_INT_dynamic` accepts `dtype=` and infers it the
same way `A16Wn` does in both 0.5.1.post1 and 0.6.0, so the change is signature-safe.
`A8Wn_dynamic` does not exist in either version -- that branch is currently unreachable --
so its `dtype=` is by symmetry with its sibling and is untested.

## Credit

Thanks to @gabriel-marinkovic for the report -- the reproducer was minimal and immediately
runnable, and the diagnosis that "some dtypes aren't fully propagated in the int4 path"
was exactly right.
