### PR TITLE
Drop the zero-row copy in permute_and_pad

### DIFF
--- a/test/prototype/moe_training/ep/test_permute.py
+++ b/test/prototype/moe_training/ep/test_permute.py
@@ -71,3 +71,58 @@ def test_mxfp8_permute_forward():
     assert sqnr >= 30.0, f"SQNR too low: {sqnr} dB"
 
     # Note: backward is tested in an e2e integration test with other mxfp8 EP pipeline components
+
+
+def _free_gib() -> float:
+    free, _ = torch.cuda.mem_get_info()
+    return free / 1024**3
+
+
+def test_permute_kernels_address_past_int32():
+    """Row offsets must be widened to int64 before scaling by the column count.
+
+    The permute kernels index with ``row_offsets * cols``, and ``row_offsets`` is
+    ``program_id * BLOCK + tl.arange(...)``, i.e. int32. Once ``rows * cols``
+    reaches 2**31 that product wraps and the access lands at a negative/aliased
+    address. The backward's is a *scatter*, so it corrupts memory silently rather
+    than faulting.
+
+    This is reachable in practice: a DeepSeek-V3-16B EP=8 step with imbalanced
+    routing put 1,141,504 rows x 2048 cols = 2,337,800,192 elements through these
+    kernels, which manifested as NaN gradients across the whole model a dozen
+    steps into training.
+
+    Identity permutation, so every output row must equal its input row -- a
+    wrapped address sends the write somewhere else. Only the first column is
+    fingerprinted, so the check itself stays cheap.
+    """
+    cols = 1024
+    rows = 2**31 // cols + 1024  # 2,098,176 rows -> 2,148,532,224 elements
+    need_gib = rows * cols * 2 * 2 / 1024**3  # bf16 in + bf16 out
+    if _free_gib() < need_gib + 4:
+        pytest.skip(f"needs ~{need_gib + 4:.0f} GiB free, have {_free_gib():.0f}")
+
+    from torchao.prototype.moe_training.ep.permute import (
+        _triton_permute_bwd,
+        _triton_permute_fwd,
+    )
+
+    device = "cuda"
+    marks = (torch.arange(rows, device=device, dtype=torch.float32) % 1000 + 1).to(
+        torch.bfloat16
+    )
+    idx = torch.arange(rows, device=device, dtype=torch.int32)
+
+    x = torch.zeros(rows, cols, device=device, dtype=torch.bfloat16)
+    x[:, 0] = marks
+    out = _triton_permute_fwd(x, idx)
+    assert torch.equal(out[:, 0], marks), "forward store wrapped past int32"
+    assert out[:, 1:].abs().sum() == 0, "forward wrote outside its rows"
+    del x, out
+    torch.cuda.empty_cache()
+
+    grad = torch.zeros(rows, cols, device=device, dtype=torch.bfloat16)
+    grad[:, 0] = marks
+    back = _triton_permute_bwd(grad, idx, rows, cols)
+    assert torch.equal(back[:, 0], marks), "backward gather/scatter wrapped past int32"
+    assert back[:, 1:].abs().sum() == 0, "backward wrote outside its rows"

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -201,11 +201,107 @@ def permute_and_pad(
             alignment,
         )
 
-    x = torch.vstack((x, x.new_zeros((1, x.shape[-1]))))
-    input_shape = x.shape
-    x = x[permuted_indices, :]
+    # `permuted_indices` holds -1 in padding slots. Rather than appending a zero
+    # row to x so those land on it, which copies the whole activation, have the
+    # gather emit zeros for -1 directly. `input_shape` still reports the padded
+    # (rows + 1, cols) that the caller's unpermute allocates.
+    input_rows, input_cols = x.shape
+    input_shape = torch.Size((input_rows + 1, input_cols))
+    x = _PermutePadGather.apply(x, permuted_indices)
 
     return input_shape, x, permuted_indices, num_tokens_per_expert_padded, group_offsets
+
+
+class _PermutePadGather(torch.autograd.Function):
+    """x[permuted_indices], with -1 gathering a zero row instead of a real one.
+
+    Backward is `_triton_permute_bwd`, the exact transpose of this gather: it
+    skips -1 rows and scatters into the unpadded row count.
+    """
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, permuted_indices: torch.Tensor):
+        ctx.save_for_backward(permuted_indices)
+        ctx.input_shape = x.shape
+        return _triton_permute_fwd(x, permuted_indices)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (permuted_indices,) = ctx.saved_tensors
+        input_rows, input_cols = ctx.input_shape
+        grad_input = _triton_permute_bwd(
+            grad_output.contiguous(), permuted_indices, input_rows, input_cols
+        )
+        return grad_input, None
+
+
+@triton_op("torchao::_triton_permute_fwd", mutates_args={})
+def _triton_permute_fwd(
+    x: torch.Tensor,
+    permuted_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Gather rows of x per permuted_indices, writing zeros where the index is -1."""
+    src_rows, cols = x.shape
+    out_rows = permuted_indices.shape[0]
+    out = x.new_empty((out_rows, cols))
+    grid = lambda meta: (  # noqa: E731
+        triton.cdiv(out_rows, meta["BLOCK_ROWS"]),
+        triton.cdiv(cols, meta["BLOCK_COLS"]),
+    )
+    wrap_triton(_triton_permute_fwd_kernel)[grid](
+        x,
+        permuted_indices,
+        out,
+        src_rows,
+        cols,
+        out_rows,
+        BLOCK_ROWS=8,
+        BLOCK_COLS=512,
+        PADDING_VALUE=-1,
+    )
+    return out
+
+
+@triton.jit
+def _triton_permute_fwd_kernel(
+    x_ptr,
+    permuted_indices_ptr,
+    out_ptr,
+    src_rows,
+    cols,
+    out_rows,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+    PADDING_VALUE: tl.constexpr = -1,
+):
+    row_pid = tl.program_id(0)
+    col_pid = tl.program_id(1)
+    row_offsets = row_pid * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    col_offsets = col_pid * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+
+    src = tl.load(
+        permuted_indices_ptr + row_offsets,
+        mask=row_offsets < out_rows,
+        other=PADDING_VALUE,
+    ).to(tl.int64)
+
+    # Padding slots read nothing and land as 0.0 via `other`, which is exactly what
+    # the appended zero row used to supply.
+    read_mask = (
+        (src[:, None] != PADDING_VALUE)
+        & (src[:, None] < src_rows)
+        & (col_offsets[None, :] < cols)
+    )
+    vals = tl.load(
+        x_ptr + src[:, None] * cols + col_offsets[None, :], mask=read_mask, other=0.0
+    )
+
+    write_mask = (row_offsets[:, None] < out_rows) & (col_offsets[None, :] < cols)
+    tl.store(
+        out_ptr + row_offsets[:, None] * cols + col_offsets[None, :],
+        vals,
+        mask=write_mask,
+    )
 
 
 @conditional_nostrict_trace

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -297,8 +297,13 @@ def _triton_permute_fwd_kernel(
     )
 
     write_mask = (row_offsets[:, None] < out_rows) & (col_offsets[None, :] < cols)
+    # int64: `row_offsets` is int32 (program_id * BLOCK + arange), so
+    # `row_offsets * cols` wraps once out_rows*cols >= 2**31 and the store lands
+    # at a negative/aliased address. The READ path above was already widened via
+    # `.to(tl.int64)` on `src`; the write was not. At DSV3-16B under ragged
+    # routing this is reachable: 1,141,504 rows x 2048 cols = 2,337,800,192.
     tl.store(
-        out_ptr + row_offsets[:, None] * cols + col_offsets[None, :],
+        out_ptr + row_offsets[:, None].to(tl.int64) * cols + col_offsets[None, :],
         vals,
         mask=write_mask,
     )
@@ -399,15 +404,20 @@ def _triton_permute_bwd_kernel(
     row_offsets = row_pid * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
     col_offsets = col_pid * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
 
+    # int64 on every address term. The backward had NO widening at all -- neither
+    # the gather of `grad` nor the scatter into `output_buffer` -- so both wrap
+    # once rows*cols >= 2**31, and the scatter writes to aliased addresses, which
+    # is silent memory corruption rather than a fault. See the forward's store
+    # for the reachable magnitude.
     dest_rows = tl.load(
         permuted_indices_ptr + row_offsets,
         mask=row_offsets < grad_rows,
         other=PADDING_VALUE,
-    )
+    ).to(tl.int64)
 
     read_mask = (row_offsets[:, None] < grad_rows) & (col_offsets[None, :] < grad_cols)
     grad_values = tl.load(
-        grad_ptr + row_offsets[:, None] * grad_cols + col_offsets[None, :],
+        grad_ptr + row_offsets[:, None].to(tl.int64) * grad_cols + col_offsets[None, :],
         mask=read_mask,
         other=PADDING_VALUE,
     )


### PR DESCRIPTION
`permute_and_pad` appends a zero row to the activation so that padding slots
(`-1` in `permuted_indices`) gather from it:

```python
x = torch.vstack((x, x.new_zeros((1, x.shape[-1]))))
x = x[permuted_indices, :]
```

Two costs follow from that:

- the `vstack` copies the whole activation to carry one row — 805 MB for a
  DSV3-16B MoE layer (196608x2048 bf16), 52 times per step over 26 layers
- every padding slot points at that one sentinel index, so the gather's backward
  hands `indexing_backward_kernel` a single index whose multiplicity is the
  padding count, and it serializes that run of equal sorted indices

This gathers with a Triton kernel that writes `0` where the index is `-1`, and
takes the backward through `_triton_permute_bwd`, which this file already has.

### Numbers

Gather only, both arms consuming the same index vector. DSV3-16B EP=8, 8 local
experts, 24576 tokens/expert, 196608 rows, 2048 cols, median of 11.

| | forward | backward | sum | per step |
| --- | --- | --- | --- | --- |
| MI350 series, before | 0.860 ms | 1.804 ms | 2.664 ms | |
| MI350 series, after | 0.427 ms | 0.510 ms | 0.937 ms | **56.2 ms** |
| B200, before | 0.593 ms | 1.848 ms | 2.441 ms | |
| B200, after | 0.340 ms | 0.526 ms | 0.867 ms | **47.5 ms** |

Per step is 26 MoE layers x (2 forwards, for activation-checkpoint recompute,
plus 1 backward).

### The win does not depend on group balance

`padded_max_len = _round_up(rows + num_local_experts * alignment, alignment)`,
so the `-1` count sits near `num_local_experts * alignment` no matter how the
tokens are distributed. Raggedness moves where the padding slots are, not how
many. Saved ms/step:

| routing | skew | pad slots | MI350 series | B200 |
| --- | --- | --- | --- | --- |
| balanced, aligned | 1.00x | 256 | 56.3 | 48.1 |
| mildly ragged | 1.01x | 260 | 54.9 | 48.4 |
| heavily ragged | 1.16x | 282 | 56.1 | 48.5 |
| collapsed, one hot expert | 41.00x | 256 | 56.7 | 48.5 |
| every total at align+1 | 1.00x | 256 | 57.3 | 48.4 |

Under balanced routing every expert is already a multiple of `alignment`, so the
padding pads nothing — and the old path still paid the full copy and the
serialized scatter for it.

### What the backward was paying

Gather backward at the same shape, collapsing N padding slots onto one sentinel
index:

| pad slots | MI350 series | B200 |
| --- | --- | --- |
| 64 | +0.087 ms | +0.095 ms |
| 256 | +0.560 ms | +0.399 ms |
| 1024 | +2.454 ms | +1.611 ms |
| 2048 | +4.969 ms | +3.210 ms |

Linear, ~2.45 us/slot on MI350 series and ~1.57 us/slot on B200. The same number
of duplicate entries **spread over distinct indices costs nothing** (+0.024 ms at
2048 on MI350 series, +0.014 ms on B200), so it is the length of the equal-index
run in the sort, not the presence of duplicates.

This also means the cost scales with `num_local_experts`: at 8 local experts it
is ~256 slots, but 64 local experts would be ~2048.

### End to end

torchtitan DSV3-16B, 8x MI350 series, mean tps over steps 40-49, 2 runs per arm:

| | tps | step |
| --- | --- | --- |
| before | 17,203 | 1904.8 ms |
| after | 17,751 | 1845.9 ms |

+3.2%, 58.9 ms/step. A bf16 control over the same window drifted 0.03%. There is
no end-to-end run on NVIDIA — the B200 numbers above are isolated.

### Correctness

Forward output, padding zeros, and gradients are bitwise equal (`torch.equal`) to
the previous implementation on **both** MI350 series and B200, with both
implementations consuming the same index vector: balanced, ragged, heavily
ragged, tiny, empty-expert, already-aligned, and single-token-per-entry groups.

Environments: MI350 series on torch 2.14.0.dev+rocm7.2; B200 on torch
2.10.0+cu130 with triton 3.6.0.