### PR TITLE
[mxfp8] fix dim1 scale store for tiles which do not divide the shape

### DIFF
--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -466,6 +466,49 @@ def test_triton_mxfp8_dim1_randn(M, K, scaling_mode):
     not is_sm_at_least_100() and not is_MI350(),
     reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
 )
+@pytest.mark.parametrize("M", (128, 384))
+@pytest.mark.parametrize("K", (128, 384))
+@pytest.mark.parametrize("row_tile_size", (128, 256, 512))
+@pytest.mark.parametrize("col_tile_size", (128, 256))
+def test_triton_mxfp8_dim1_partial_tile(M, K, row_tile_size, col_tile_size):
+    """
+    ROW_TILE_SIZE and COL_TILE_SIZE are autotuned over, and are not guaranteed to
+    divide the shape being quantized (the autotune key does not even include
+    n_rows, so a config chosen for one shape is reused for others). Pin each
+    config from the sweep in turn and check that a tile which overhangs the end
+    of the tensor does not corrupt the scales of the neighboring columns.
+    """
+    import triton
+
+    from torchao.prototype.mx_formats.kernels import to_mxfp8_dim1_kernel
+
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    x_mx_ref, x_s_ref = triton_to_mxfp8_dim1_reference(x, block_size=32)
+
+    orig_configs, orig_cache = to_mxfp8_dim1_kernel.configs, to_mxfp8_dim1_kernel.cache
+    to_mxfp8_dim1_kernel.configs = [
+        triton.Config(
+            {"ROW_TILE_SIZE": row_tile_size, "COL_TILE_SIZE": col_tile_size},
+            num_warps=4,
+            num_stages=2,
+        )
+    ]
+    to_mxfp8_dim1_kernel.cache = {}
+    try:
+        x_mx_t, x_s_t = triton_to_mxfp8_dim1(x, inner_block_size=32)
+    finally:
+        to_mxfp8_dim1_kernel.configs = orig_configs
+        to_mxfp8_dim1_kernel.cache = orig_cache
+
+    torch.testing.assert_close(x_mx_t, x_mx_ref, rtol=0, atol=0)
+    torch.testing.assert_close(x_s_t, x_s_ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not has_triton(), reason="unsupported without triton")
+@pytest.mark.skipif(
+    not is_sm_at_least_100() and not is_MI350(),
+    reason="mxfp8 requires CUDA capability 10.0 or greater or ROCm gfx950 or greater.",
+)
 @pytest.mark.parametrize("M", (128, 256))
 @pytest.mark.parametrize("K", (128, 256))
 @pytest.mark.parametrize(

--- a/torchao/prototype/mx_formats/kernels.py
+++ b/torchao/prototype/mx_formats/kernels.py
@@ -721,9 +721,16 @@ if _triton_kernels_available:
         # shape: (COL_TILE_SIZE * BLOCKS_PER_ROW_TILE,) -> (COL_TILE_SIZE, BLOCKS_PER_ROW_TILE,)
         col_scale_e8m0 = col_scale_e8m0_r.reshape(COL_TILE_SIZE * BLOCKS_PER_ROW_TILE)
 
+        # Number of scale blocks in one column of the scale tensor, i.e. the
+        # stride between adjacent columns. Note that this has to be derived from
+        # INNER_BLOCK_SIZE rather than from ROW_TILE_SIZE: ROW_TILE_SIZE is
+        # autotuned and is not guaranteed to divide n_rows, and
+        # `(n_rows // ROW_TILE_SIZE) * BLOCKS_PER_ROW_TILE` silently truncates
+        # (down to zero, if ROW_TILE_SIZE > n_rows) when it does not.
+        blocks_per_col = n_rows // INNER_BLOCK_SIZE
+
         col_scale_start_offsets = (
-            (pid_col * COL_TILE_SIZE * (n_rows // ROW_TILE_SIZE))
-            * BLOCKS_PER_ROW_TILE  # number of blocks seen so far
+            pid_col * COL_TILE_SIZE * blocks_per_col  # number of blocks seen so far
             + pid_row * BLOCKS_PER_ROW_TILE  # increment BLOCKS_PER_ROW_TILE
         )
 
@@ -732,18 +739,33 @@ if _triton_kernels_available:
         # calculate col_scale_indices
         col_scale_indices = tl.arange(0, COL_TILE_SIZE * BLOCKS_PER_ROW_TILE)
 
+        # position of each scale within this tile: which column it belongs to, and
+        # which block of that column
+        tile_col_idx = col_scale_indices // BLOCKS_PER_ROW_TILE
+        tile_block_idx = col_scale_indices % BLOCKS_PER_ROW_TILE
+
         # How many values are in all the other columns for this row_pid, need to jump
         # over them for every BLOCKS_PER_ROW_TILE values
-        jump_vals_per_col = (n_rows - ROW_TILE_SIZE) // INNER_BLOCK_SIZE
+        jump_vals_per_col = blocks_per_col - BLOCKS_PER_ROW_TILE
 
         # example transformation (specifics depend on tile sizes):
         # [0, 1, 2, 3, 4, 5, 6, 7] -> [0, 1, 4, 5, 8, 9, 12, 13]
-        col_scale_indices = col_scale_indices + (
-            (col_scale_indices // BLOCKS_PER_ROW_TILE) * jump_vals_per_col
+        col_scale_indices = col_scale_indices + (tile_col_idx * jump_vals_per_col)
+
+        # Mask out the part of a tile which overhangs the end of the tensor.
+        # Without this, the scales computed for the zero-padded region are still
+        # stored, and (since the jump above is relative to the real column
+        # stride) they land on the scales of the following columns, or past the
+        # end of the scale tensor entirely.
+        col_scale_mask = (start_col + tile_col_idx < n_cols) & (
+            pid_row * BLOCKS_PER_ROW_TILE + tile_block_idx < blocks_per_col
         )
 
-        # TODO(future): mask this store
-        tl.store(col_scale_start_ptr + col_scale_indices, col_scale_e8m0)
+        tl.store(
+            col_scale_start_ptr + col_scale_indices,
+            col_scale_e8m0,
+            mask=col_scale_mask,
+        )
 
     @triton.autotune(
         configs=_get_mxfp8_quant_autotune_configs(),
@@ -931,14 +953,18 @@ if _triton_kernels_available:
         # Get tensor shape
         n_rows, n_cols = x.shape
 
-        # Masking of loads and stores is not well tested yet, so for now enforce
-        # shapes which do not need masking. Note that this condition depends on max values of
-        # ROW_TILE_SIZE and COL_TILE_SIZE, which are autotuned above.
-        # TODO(future): implement and test masking and remove this restriction
-        max_row_tile_size = 128
-        max_col_tile_size = 128
-        assert n_rows % max_row_tile_size == 0, "unsupported"
-        assert n_cols % max_col_tile_size == 0, "unsupported"
+        # Shapes which do not divide evenly into tiles are handled by masking in
+        # the kernel, but are not well tested yet, so for now enforce shapes
+        # which are a multiple of the smallest autotuned tile size. Note that
+        # this deliberately does not depend on the *max* autotuned
+        # ROW_TILE_SIZE/COL_TILE_SIZE: the kernel masks the overhang of a partial
+        # tile, so a shape which the selected tile size does not divide is still
+        # handled correctly.
+        # TODO(future): test the remaining shapes and remove this restriction
+        row_size_multiple = 128
+        col_size_multiple = 128
+        assert n_rows % row_size_multiple == 0, "unsupported"
+        assert n_cols % col_size_multiple == 0, "unsupported"
 
         # Create output tensors
         output_col_major = torch.empty(


### PR DESCRIPTION
## Summary

The per-block e8m0 scale store in `to_mxfp8_dim1_kernel` computes the stride between adjacent columns of the scale tensor as `(n_rows // ROW_TILE_SIZE) * BLOCKS_PER_ROW_TILE`, and stores unmasked (there is an existing `# TODO(future): mask this store`). Both assume `ROW_TILE_SIZE` divides `n_rows`.

That isn't guaranteed. `ROW_TILE_SIZE` is autotuned over `(128, 256, 512)` and `COL_TILE_SIZE` over `(128, 256)`, but `triton_to_mxfp8_dim1` only asserts the shape is a multiple of 128:

```python
max_row_tile_size = 128
max_col_tile_size = 128
assert n_rows % max_row_tile_size == 0, "unsupported"
assert n_cols % max_col_tile_size == 0, "unsupported"
```

so the guard under-guards by 4x on rows and 2x on cols. The comment above it already notes the condition "depends on max values of ROW_TILE_SIZE and COL_TILE_SIZE". The autotune key is `["n_cols", "INNER_BLOCK_SIZE"]` and omits `n_rows`, so a config benchmarked at one `n_rows` is reused for every other `n_rows` sharing the same `n_cols`.

When the selected tile doesn't divide the shape, the scales computed for the zero-padded overhang of a partial tile are still stored, and — since the jump between columns is relative to the real column stride — they land on the scales of the following columns, or past the end of the scale tensor. When `ROW_TILE_SIZE > n_rows` the divisor collapses to zero outright.

## Repro

Measured against `triton_to_mxfp8_dim1_reference` on B200-class hardware (sm_120, torch 2.13, triton 3.7.1). Every shape below satisfies the existing asserts, i.e. these are valid inputs today:

| shape | tile config | result on main |
|---|---|---|
| `n_rows=384, n_cols=128` | `ROW_TILE_SIZE=512` | 256/1536 scale entries corrupted, deterministic |
| `n_rows=384, n_cols=128` | `ROW_TILE_SIZE=256` | corrupted in 1/20 runs (cross-CTA write-write race) |
| `n_rows=512, n_cols=384` | `COL_TILE_SIZE=256` | 2048 bytes written past the end of the scale allocation |
| controls (`ROW_TILE_SIZE`/`COL_TILE_SIZE`=128) | — | clean |

The corrupted entries are exactly blocks 0..3 of each column, all written as `0` — the e8m0 of the zero-masked padding rows aliasing onto the next column's real scales.

Note this is config-dependent: it only bites when the autotuner selects a 256/512 tile for a shape that tile doesn't divide. On the machine above the autotuner picked 128/128 for every shape I swept (`n_cols` 256 through 8192), so the defect is latent there rather than actively firing. The tests below pin each config from the sweep so the behavior doesn't depend on which one wins the benchmark.

## Fix

- Derive the column stride from `INNER_BLOCK_SIZE`, which does divide `n_rows`, instead of from the autotuned `ROW_TILE_SIZE`.
- Mask the store on both axes, as the sibling `to_mxfp8_dim0_kernel` already does.

The wrapper's asserts are deliberately left alone, so the supported set of shapes is unchanged. (Raising them to the autotuner's max instead would be the other way to close this, but it would start rejecting shapes such as `n_rows=384` that work today.) Only the now-inaccurate comment claiming the guard depends on the *max* autotuned tile size is updated.

## Test plan

```
pytest test/prototype/mx_formats/test_kernels.py -k dim1
```

Adds `test_triton_mxfp8_dim1_partial_tile`, which pins each config from the autotune sweep in turn rather than relying on which one the autotuner happens to pick. **16 of its 24 cases fail before this change; all 24 pass after.**

The full `test/prototype/mx_formats/` suite produces an identical failure set before and after the change (the failures present are unrelated to this path — they need the CUDA extension built, which this environment does not have).