### PR TITLE
Make the QAT tests to be device agnostic

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1871,7 +1871,7 @@ class TestQAT(TestCase):
     @unittest.skipIf(
         torch.cuda.is_available()
         and not (is_sm_at_least_89() or is_MI300() or is_MI350()),
-        "Need sm89+ or MI300/MI350",
+        "Need CUDA sm89+ or ROCm MI300/MI350",
     )
     def test_quantize_api_fp8_fp8(self, granularity: Granularity):
         """

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1867,9 +1867,10 @@ class TestQAT(TestCase):
         self.assertGreaterEqual(convert_sqnr, target_convert_sqnr)
 
     @parametrize("granularity", [PerTensor(), PerRow()])
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @unittest.skipIf(
-        not (is_sm_at_least_89() or is_MI300() or is_MI350()),
+        torch.cuda.is_available()
+        and not (is_sm_at_least_89() or is_MI300() or is_MI350()),
         "Need sm89+ or MI300/MI350",
     )
     def test_quantize_api_fp8_fp8(self, granularity: Granularity):
@@ -2360,7 +2361,6 @@ class TestQAT(TestCase):
         torch.testing.assert_close(m.linear2.weight.scale, scale2)
         torch.testing.assert_close(m.sub.linear.weight.scale, sub_scale)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
     def test_mx_fake_quantize_config(self):
         """Test MXFakeQuantizeConfig dataclass with various element dtypes."""
         from torchao.prototype.mx_formats.config import ScaleCalculationMode
@@ -2394,7 +2394,7 @@ class TestQAT(TestCase):
         )
         self.assertEqual(config_fp8_e5m2.dtype, torch.float8_e5m2)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("bias", [True, False])
     @parametrize("input_shape", [(128, 256), (1, 128, 256), (2, 4, 128, 256)])
     @parametrize(
@@ -2406,6 +2406,7 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         K, N = 256, 128
+        device = get_current_accelerator_device()
 
         activation_config = MXFakeQuantizeConfig(
             dtype=dtype,
@@ -2416,14 +2417,14 @@ class TestQAT(TestCase):
             block_size=32,
         )
 
-        linear = torch.nn.Linear(K, N, bias=bias, device="cuda", dtype=torch.bfloat16)
+        linear = torch.nn.Linear(K, N, bias=bias, device=device, dtype=torch.bfloat16)
         mx_linear = MXFakeQuantizedLinear.from_linear(
             linear,
             activation_config=activation_config,
             weight_config=weight_config,
         )
 
-        x = torch.randn(*input_shape, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(*input_shape, device=device, dtype=torch.bfloat16)
         y_ref = linear(x)
         y_mx = mx_linear(x)
 
@@ -2438,18 +2439,19 @@ class TestQAT(TestCase):
         else:
             self.assertGreaterEqual(sqnr, 10.0)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize("bias", [True, False])
     def test_mx_fake_quantized_linear_backward(self, bias):
         """Test MXFakeQuantizedLinear backward pass."""
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         M, K, N = 128, 256, 128
+        device = get_current_accelerator_device()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
 
-        linear = torch.nn.Linear(K, N, bias=bias, device="cuda", dtype=torch.bfloat16)
+        linear = torch.nn.Linear(K, N, bias=bias, device=device, dtype=torch.bfloat16)
         linear_ref = copy.deepcopy(linear)
         mx_linear = MXFakeQuantizedLinear.from_linear(
             linear,
@@ -2458,10 +2460,10 @@ class TestQAT(TestCase):
         )
 
         x_ref = torch.randn(
-            M, K, device="cuda", dtype=torch.bfloat16, requires_grad=True
+            M, K, device=device, dtype=torch.bfloat16, requires_grad=True
         )
         x = x_ref.clone().detach().requires_grad_(True)
-        grad_output = torch.randn(M, N, device="cuda", dtype=torch.bfloat16)
+        grad_output = torch.randn(M, N, device=device, dtype=torch.bfloat16)
 
         # Forward and backward for reference
         y_ref = linear_ref(x_ref)
@@ -2487,18 +2489,19 @@ class TestQAT(TestCase):
         self.assertGreaterEqual(x_grad_sqnr, 3.0)
         self.assertGreaterEqual(w_grad_sqnr, 3.0)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_mx_fake_quantized_linear_to_linear(self):
         """Test converting MXFakeQuantizedLinear back to nn.Linear."""
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         K, N = 256, 128
+        device = get_current_accelerator_device()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
 
         original_linear = torch.nn.Linear(
-            K, N, bias=True, device="cuda", dtype=torch.bfloat16
+            K, N, bias=True, device=device, dtype=torch.bfloat16
         )
         mx_linear = MXFakeQuantizedLinear.from_linear(
             original_linear,
@@ -2518,7 +2521,6 @@ class TestQAT(TestCase):
         torch.testing.assert_close(converted_linear.weight, mx_linear.weight)
         torch.testing.assert_close(converted_linear.bias, mx_linear.bias)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
     def test_mx_config_error_handling(self):
         """Test error handling for MX config."""
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
@@ -2541,7 +2543,7 @@ class TestQAT(TestCase):
                 weight_config=MXFakeQuantizeConfig(),
             )
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @parametrize(
         "shapes",
         [
@@ -2555,18 +2557,19 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         M, K, N = shapes
+        device = get_current_accelerator_device()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
 
-        linear = torch.nn.Linear(K, N, bias=False, device="cuda", dtype=torch.bfloat16)
+        linear = torch.nn.Linear(K, N, bias=False, device=device, dtype=torch.bfloat16)
         mx_linear = MXFakeQuantizedLinear.from_linear(
             linear,
             activation_config=activation_config,
             weight_config=weight_config,
         )
 
-        x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(M, K, device=device, dtype=torch.bfloat16)
         y_ref = linear(x)
         y_mx = mx_linear(x)
 
@@ -2575,19 +2578,20 @@ class TestQAT(TestCase):
 
         self.assertGreaterEqual(sqnr, SQNR_THRESHOLD)
 
-    @unittest.skipIf(not _CUDA_IS_AVAILABLE, "skipping when cuda is not available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     def test_mx_training_simulation(self):
         """Simulate a simple training loop with MX QAT."""
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         M, K, N = 128, 256, 128
         num_steps = 5
+        device = get_current_accelerator_device()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
 
         model = torch.nn.Sequential(
-            torch.nn.Linear(K, N, bias=True, device="cuda", dtype=torch.bfloat16),
+            torch.nn.Linear(K, N, bias=True, device=device, dtype=torch.bfloat16),
         )
 
         # Convert to MX QAT
@@ -2606,8 +2610,8 @@ class TestQAT(TestCase):
 
         # Training loop
         for _ in range(num_steps):
-            x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
-            target = torch.randn(M, N, device="cuda", dtype=torch.bfloat16)
+            x = torch.randn(M, K, device=device, dtype=torch.bfloat16)
+            target = torch.randn(M, N, device=device, dtype=torch.bfloat16)
 
             optimizer.zero_grad()
             output = mx_model(x)

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -2406,7 +2406,7 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         K, N = 256, 128
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
 
         activation_config = MXFakeQuantizeConfig(
             dtype=dtype,
@@ -2446,7 +2446,7 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         M, K, N = 128, 256, 128
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
@@ -2495,7 +2495,7 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         K, N = 256, 128
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
@@ -2557,7 +2557,7 @@ class TestQAT(TestCase):
         from torchao.prototype.qat import MXFakeQuantizeConfig, MXFakeQuantizedLinear
 
         M, K, N = shapes
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)
@@ -2585,7 +2585,7 @@ class TestQAT(TestCase):
 
         M, K, N = 128, 256, 128
         num_steps = 5
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
 
         activation_config = MXFakeQuantizeConfig(block_size=32)
         weight_config = MXFakeQuantizeConfig(block_size=32)


### PR DESCRIPTION
### Summary

Makes QAT (fp8, MX) and integration export tests device-agnostic so they run on non-CUDA accelerators (like Intel XPU) instead of being skipped by hardcoded CUDA checks:

1. **`test/quantization/test_qat.py`**:
   - Replaced CUDA-specific checks with accelerator-agnostic equivalents (`torch.accelerator.is_available()`, `get_current_accelerator_device()`).
   - Scoped SM89 / compute-capability checks to CUDA only, preventing spurious skips on non-NVIDIA accelerators with native fp8 support.
   - Removed unnecessary GPU gates from `test_mx_fake_quantize_config` and `test_mx_config_error_handling` (pure Python/dataclass checks that can safely run on CPU).

2. **`test/integration/test_export.py`**:
   - Made `test_export_float8` device-agnostic using the current accelerator device instead of hardcoded `"cuda"`.
   - Scoped the sm89 check to CUDA only.

CUDA-only tests (MSLK, NVFP4, SM100-specific kernels) remain untouched.

### Test Plan

- **XPU**: Verified on Intel GPU (PVC / BMG).
  - `test/quantization/test_qat.py`: 29 previously skipped tests now pass.
  - `test/integration/test_export.py`: `test_export_float8` passes.
  - No new failures or regressions.
- **CPU**: Verified tests collect and run cleanly when no accelerator is present.
- **CUDA**: Changes are non-breaking; CUDA paths retain existing capability checks.