### PR TITLE
Stop quantize_ from leaking global fp32 matmul precision

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -116,7 +116,6 @@ def undo_recommended_configs():
     torch._inductor.config.force_fuse_int_mm_with_mul = False
     torch._inductor.config.fx_graph_cache = False
     torch._inductor.config.triton.unique_kernel_names = False
-    torch.set_float32_matmul_precision("highest")
 
 
 def combine_parameters(a, b):

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -169,6 +169,22 @@ class TestQuantFlow(TestCase):
         torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
         super().tearDown()
 
+    def test_quantize_does_not_leak_fp32_precision(self):
+        # quantize_() must not mutate the process wide fp32 precision flags, torch's
+        # TestCase.tearDown reports any change as "fp32 precision flag leak detected"
+        backends = (
+            torch.backends.cuda.matmul,
+            torch.backends.cudnn.conv,
+            torch.backends.cudnn.rnn,
+            torch.backends.mkldnn.matmul,
+            torch.backends.mkldnn.conv,
+            torch.backends.mkldnn.rnn,
+        )
+        before = [b.fp32_precision for b in backends]
+        m = ToyLinearModel().eval()
+        quantize_(m, Int8WeightOnlyConfig())
+        self.assertEqual([b.fp32_precision for b in backends], before)
+
     def test_dynamic_quant_gpu_singleline(self):
         if is_ROCM():
             self.skipTest("Don't test CPU for ROCM version of torch")

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -680,14 +680,16 @@ def recommended_inductor_config_setter():
         force_fuse_int_mm_with_mul = True
         fx_graph_cache = True
         triton.unique_kernel_names = True
-        torch.set_float32_matmul_precision("high")
+
+    This used to also call `torch.set_float32_matmul_precision("high")`. That is not an
+    inductor config, it is process wide state that changes the numerics of every fp32
+    matmul in the process and is never restored, so it is left to the caller.
     """
     torch._inductor.config.coordinate_descent_tuning = True
     torch._inductor.config.coordinate_descent_check_all_directions = True
     torch._inductor.config.force_fuse_int_mm_with_mul = True
     torch._inductor.config.fx_graph_cache = True
     torch._inductor.config.triton.unique_kernel_names = True
-    torch.set_float32_matmul_precision("high")
 
 
 def get_block_size(


### PR DESCRIPTION
Fixes #4625

`recommended_inductor_config_setter()` called `torch.set_float32_matmul_precision("high")`. That is not an inductor config, it is process-global state: it moves `torch.backends.{cuda,mkldnn}.matmul.fp32_precision` from `'none'` to `'tf32'` and never puts them back. Every `quantize_()` call runs that setter by default, so any test that quantizes a model leaks the flags and trips PyTorch's new `TestCase.tearDown` invariant check with `AssertionError: fp32 precision flag leak detected`.

Changes:

- Drop the `set_float32_matmul_precision` call from `recommended_inductor_config_setter()`. The other five inductor knobs are unchanged. Callers that want tf32 should set it themselves, the way `examples/` already does.
- Drop the mirror line from `undo_recommended_configs()` in `test/integration/test_integration.py`, which only existed to undo the setter. It also leaked, `'none' -> 'ieee'`.
- Add `TestQuantFlow::test_quantize_does_not_leak_fp32_precision`, which asserts `quantize_()` leaves all six fp32 precision flags untouched.

Verified on 8x A40 (sm_86), CUDA 12.6, torch 2.13.0+cu126. That torch predates the leak check, so I re-implemented the check from pytorch main as a pytest plugin to reproduce it. `pytest test/quantization/quantize_/` with the check on: 324 failed / 317 passed before, 68 failed / 573 passed after, and 68/573 is exactly what the same suite gives with the check off both before and after. The residual 68 are a pre-existing sandbox issue (g++ too old for `-std=c++20`), unrelated to this change. `test/quantization/*.py` and `test/dtypes/` are clean post-fix: 307 passed, 0 leak assertions.

Not verified:

- No sm_89+ here, so `test_per_row_with_float32` (the specific test in #4595) is skipped and nothing fp8 ran.
- No XPU hardware. The leak is device-independent and I did observe the mkldnn flag flip on CPU, but I did not run an XPU job.
- Performance impact of no longer enabling tf32. For a bf16 model it should be a no-op since the quantized matmuls are not fp32. For an fp32 model under torch.compile it is a real behavior change.
- `test/prototype/test_quantized_training.py` still leaks and this PR does not touch it. Its `_reset()` helper calls `torch.set_float32_matmul_precision("highest")` directly, which is a separate root cause with its own correctness comment, and those configs never called `recommended_inductor_config_setter` anyway. Worth a follow-up.

Thanks to @zxd1997066 for reporting.