### PR TITLE
Fix speedup column name for FP4 recipes in bench_matmul

### DIFF
--- a/benchmarks/float8/bench_matmul.py
+++ b/benchmarks/float8/bench_matmul.py
@@ -53,6 +53,7 @@ def run(
     print(
         f"peak tops: bf16 {bf16_peak_tops:.2e}, fp8 {fp8_peak_tops:.2e}, fp4 {fp4_peak_tops:.2e}"
     )
+    speedup_col = "fp4_speedup" if use_fp4 else "fp8_speedup"
     headers = (
         "fast_accum",
         "name",
@@ -63,7 +64,7 @@ def run(
         "pct_top_peak",
         "ref_time_s",
         "time_s",
-        "fp8_speedup",
+        speedup_col,
     )
     results = []
 


### PR DESCRIPTION
Use fp4_speedup for mxfp4_cutlass and nvfp4; keep fp8_speedup for FP8 recipes.