### PR TITLE
[xpu][test][dtypes] Finish XPU enablement of test_affine_quantized_float

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -80,16 +80,18 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
                 granularity=(UnsupportedGranularity(), UnsupportedGranularity()),
             )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @unittest.skipIf(
-        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "Requires GPU with compute capability >= 8.9",
     )
     def test_per_row_with_float32(self):
+        device = get_current_accelerator_device()
         with pytest.raises(
             AssertionError,
             match="PerRow quantization only works for bfloat16 precision",
         ):
-            model = ToyLinearModel(64, 64).eval().to(torch.float32).to("cuda")
+            model = ToyLinearModel(64, 64).eval().to(torch.float32).to(device)
             quantize_(
                 model,
                 Float8DynamicActivationFloat8WeightConfig(granularity=PerRow()),
@@ -141,7 +143,7 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
 
     @unittest.skipIf(not torch.accelerator.is_available(), "Need GPU available")
     @unittest.skipIf(
-        torch.cuda.is_available() == "cuda" and not is_sm_at_least_89(),
+        torch.cuda.is_available() and not is_sm_at_least_89(),
         "Requires GPU with compute capability >= 8.9",
     )
     @common_utils.parametrize("float8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])

--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -86,7 +86,7 @@ class TestAffineQuantizedFloat8Compile(InductorTestCase):
         "Requires GPU with compute capability >= 8.9",
     )
     def test_per_row_with_float32(self):
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
         with pytest.raises(
             AssertionError,
             match="PerRow quantization only works for bfloat16 precision",


### PR DESCRIPTION
## Summary

Two targeted fixes to complete XPU enablement of `test/dtypes/test_affine_quantized_float.py`:

1. `test_per_row_with_float32` — last CUDA-hardcoded test

Replaces the `torch.cuda.is_available()` skip and hardcoded `"cuda"` device with the device-agnostic pattern. 

2. Fix broken gate on `test_dequantize_affine_float8` (line 144)

The previous gate was:
```python
torch.cuda.is_available() == "cuda" and not is_sm_at_least_89()
```

`torch.cuda.is_available()` returns `bool`, not a string, so this comparison is always `False`. The sm89 requirement was **never enforced on pre-sm89 CUDA hardware**. This is a leftover from the earlier partial device-agnostic conversion (the sibling test `test_choose_scale_float8_bounds` already carries the correct `torch.cuda.is_available() and not is_sm_at_least_89()` form). Fixed to the correct form. 

### Validation

All checks performed on an XPU machine (torch 2.14.0.dev20260714+xpu):

- Before/after run:**
  - Before (main): 28 passed, 1 skipped
  - After (this PR): 29 passed, 0 skipped
- Static check — `ruff check` and `ruff format --check` both clean. Grep sweep for `.cuda()`/`device="cuda"`/hardcoded skip strings returns nothing. Remaining `torch.cuda.is_available()` occurrences are all properly paired with `and not is_sm_at_least_89()`.

