### PR TITLE
Pin CI to PyTorch 2.13 for release; drop unused torchaudio

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -9,7 +9,7 @@ export SCCACHE_DISABLE=1
 
 python -m pip install --upgrade pip setuptools wheel
 
-python -m pip install torch torchvision torchaudio pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir 
+python -m pip install torch torchvision pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir
 cd torchao && python -m pip install . --no-build-isolation && cd ..
 
 python -c "import torch; import torchao; print(f'Torch version: {torch.__version__}')"

--- a/.github/workflows/1xH100_tests.yml
+++ b/.github/workflows/1xH100_tests.yml
@@ -25,7 +25,12 @@ jobs:
         include:
           - name: H100
             runs-on: mt-l-x86iamx-22-225-h100
-            torch-spec: '--pre torch torchvision torchaudio mslk --index-url https://download.pytorch.org/whl/nightly/cu130'
+            torch-spec: '--pre torch torchvision mslk --index-url https://download.pytorch.org/whl/nightly/cu130'
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "13.0"
+          - name: H100 2.13
+            runs-on: mt-l-x86iamx-22-225-h100
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 mslk==1.3.0 --index-url https://download.pytorch.org/whl/cu130'
             gpu-arch-type: "cuda"
             gpu-arch-version: "13.0"
     permissions:

--- a/.github/workflows/1xL4_tests.yml
+++ b/.github/workflows/1xL4_tests.yml
@@ -28,6 +28,11 @@ jobs:
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
+          - name: SM-89 2.13
+            runs-on: linux.g6.4xlarge.experimental.nvidia.gpu
+            torch-spec: 'torch==2.13.0 --index-url https://download.pytorch.org/whl/cu126'
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.6"
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/4xH100_tests.yml
+++ b/.github/workflows/4xH100_tests.yml
@@ -23,7 +23,12 @@ jobs:
         include:
           - name: H100
             runs-on: mt-l-x86iamx-88-900-h100-4
-            torch-spec: '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
+            gpu-arch-type: "cuda"
+            gpu-arch-version: "12.4"
+          - name: H100 2.13
+            runs-on: mt-l-x86iamx-88-900-h100-4
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 --index-url https://download.pytorch.org/whl/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
     permissions:

--- a/.github/workflows/dashboard_perf_test.yml
+++ b/.github/workflows/dashboard_perf_test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         torch-spec:
-          - '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
+          - '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -86,16 +86,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: CUDA 2.12
+          - name: CUDA 2.13
             runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: 'torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cu126'
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 --index-url https://download.pytorch.org/whl/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"
             dev-requirements-overrides: ""
 
-          - name: CPU 2.12
+          - name: CPU 2.13
             runs-on: linux.4xlarge
-            torch-spec: 'torch==2.12.0 torchvision==0.27.0 --index-url https://download.pytorch.org/whl/cpu'
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 --index-url https://download.pytorch.org/whl/cpu'
             gpu-arch-type: "cpu"
             gpu-arch-version: ""
             dev-requirements-overrides: ""

--- a/.github/workflows/regression_test_aarch64.yml
+++ b/.github/workflows/regression_test_aarch64.yml
@@ -37,7 +37,7 @@ jobs:
           # Install executorch first because it installs its own version
           # of torch and torchao, which we do not want to use
           pip install executorch
-          pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -r dev-requirements.txt
           USE_CPP=1 TORCHAO_BUILD_KLEIDIAI=1 pip install . --no-build-isolation
       - name: Install requirements linux
@@ -45,7 +45,7 @@ jobs:
         run: |
           conda activate venv
           pip install coremltools
-          pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -r dev-requirements.txt
           BUILD_TORCHAO_EXPERIMENTAL=1 TORCHAO_BUILD_CPU_AARCH64=1 TORCHAO_BUILD_KLEIDIAI=1 TORCHAO_ENABLE_ARM_NEON_DOT=1 TORCHAO_PARALLEL_BACKEND=OPENMP pip install . --no-build-isolation
       - name: Run python tests

--- a/.github/workflows/release_model.yml
+++ b/.github/workflows/release_model.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - name: H100
             runs-on: mt-l-x86iamx-22-225-h100
-            torch-spec: '--pre torch torchvision torchaudio mslk --index-url https://download.pytorch.org/whl/nightly/cu126'
+            torch-spec: '--pre torch torchvision mslk --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.4"
     permissions:

--- a/.github/workflows/run_microbenchmarks.yml
+++ b/.github/workflows/run_microbenchmarks.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         torch-spec:
-          - '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
+          - '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         torch-spec:
-          - '--pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126'
+          - '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Prepare the CI matrix for the torchao release corresponding to
PyTorch 2.13.

- Re-pin the version-pinned regression jobs from 2.12 to 2.13:
  - regression_test.yml: CUDA/CPU legs -> torch==2.13.0
    torchvision==0.28.0 (renamed from "2.12" to "2.13").
  - regression_test_aarch64.yml: torch==2.12.0 -> torch==2.13.0.

- Add a pinned-2.13 leg alongside the existing nightly leg in the
  GPU test jobs, each mirroring its own nightly CUDA index:
  - 1xL4_tests.yml:  torch==2.13.0 (cu126).
  - 1xH100_tests.yml: torch==2.13.0 torchvision==0.28.0 mslk==1.3.0
    (cu130 -- the only stable index carrying mslk 1.3.0, the stable
    mslk that pairs with torch 2.13).
  - 4xH100_tests.yml: torch==2.13.0 torchvision==0.28.0 (cu126).

- Drop torchaudio from every spec that installed it (both H100
  nightly specs, dashboard_perf_test, run_microbenchmarks,
  run_tutorials, release_model, and ci_test_xpu.sh). torchaudio is
  not imported anywhere in torchao and has no 2.13 build, so it was
  dead install weight and a source of resolution risk.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>