### PR TITLE
Fix CI test failures: fp32 precision leak and ROCm rowwise-fp8 warning

### DIFF
--- a/test/dtypes/test_affine_quantized_float.py
+++ b/test/dtypes/test_affine_quantized_float.py
@@ -46,6 +46,17 @@ class ToyLinearModel(torch.nn.Module):
 
 
 class TestAffineQuantizedFloat8Compile(InductorTestCase):
+    def setUp(self):
+        super().setUp()
+        # quantize_() sets a global float32 matmul precision; snapshot fp32_precision
+        self._prev_cuda_matmul_fp32 = torch.backends.cuda.matmul.fp32_precision
+        self._prev_mkldnn_matmul_fp32 = torch.backends.mkldnn.matmul.fp32_precision
+
+    def tearDown(self):
+        torch.backends.cuda.matmul.fp32_precision = self._prev_cuda_matmul_fp32
+        torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
+        super().tearDown()
+
     @unittest.skipIf(
         torch.cuda.is_available() and not is_sm_at_least_89(),
         "Requires GPU with compute capability >= 8.9",

--- a/test/prototype/test_awq.py
+++ b/test/prototype/test_awq.py
@@ -86,6 +86,17 @@ device_config_pairs = [
 
 
 class TestAWQ(TestCase):
+    def setUp(self):
+        super().setUp()
+        # quantize_() sets a global float32 matmul precision; snapshot fp32_precision
+        self._prev_cuda_matmul_fp32 = torch.backends.cuda.matmul.fp32_precision
+        self._prev_mkldnn_matmul_fp32 = torch.backends.mkldnn.matmul.fp32_precision
+
+    def tearDown(self):
+        torch.backends.cuda.matmul.fp32_precision = self._prev_cuda_matmul_fp32
+        torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
+        super().tearDown()
+
     def test_awq_config(self):
         base_config = Int4WeightOnlyConfig()
         AWQConfig(base_config, step=QuantizationStep.PREPARE)

--- a/test/prototype/test_int4_opaque_tensor.py
+++ b/test/prototype/test_int4_opaque_tensor.py
@@ -28,6 +28,17 @@ def get_config(group_size, use_hqq):
 
 
 class TestInt4OpaqueTensor(TestCase):
+    def setUp(self):
+        super().setUp()
+        # quantize_() sets a global float32 matmul precision; snapshot fp32_precision
+        self._prev_cuda_matmul_fp32 = torch.backends.cuda.matmul.fp32_precision
+        self._prev_mkldnn_matmul_fp32 = torch.backends.mkldnn.matmul.fp32_precision
+
+    def tearDown(self):
+        torch.backends.cuda.matmul.fp32_precision = self._prev_cuda_matmul_fp32
+        torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
+        super().tearDown()
+
     @parametrize(
         "sizes",
         [

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1287,7 +1287,9 @@ def _maybe_warn_rowwise_fp8_cuda_12_9(
 ) -> None:
     if not torch.cuda.is_available():
         return
-    if not torch.version.cuda.startswith("12.9"):
+    # torch.version.cuda is None on ROCm/HIP builds (where torch.cuda.is_available()
+    # is still True); the CUDA 12.9 regression does not apply there.
+    if torch.version.cuda is None or not torch.version.cuda.startswith("12.9"):
         return
     # config.granularity is normalized to [activation, weight] in __post_init__.
     if not any(isinstance(g, PerRow) for g in config.granularity):


### PR DESCRIPTION
Fixes two independent failures surfaced by recent CI runs.

1. fp32 precision flag leak (1xL4, 1xH100, CPU/CUDA nightly)

   PyTorch's new test harness fails any test that mutates a global fp32
   matmul precision flag without restoring it. quantize_() sets tf32 on
   torch.backends.{cuda,mkldnn}.matmul.fp32_precision, so tests that call
   it leak that state and trip the checker. Following the same fix as
   #4593 (which patched TestQuantFlow), add setUp/tearDown that snapshot
   and restore the two flags to the remaining affected classes:
     - TestAffineQuantizedFloat8Compile (test/dtypes/test_affine_quantized_float.py)
     - TestInt4OpaqueTensor (test/prototype/test_int4_opaque_tensor.py)
     - TestAWQ (test/prototype/test_awq.py)

2. ROCm rowwise-fp8 warning crash

   test_quantize_api_fp8_fp8_granularity1 (PerRow) failed on ROCm with
   "AttributeError: 'NoneType' object has no attribute 'startswith'" in
   _maybe_warn_rowwise_fp8_cuda_12_9 (added in #4588). On ROCm/HIP builds
   torch.cuda.is_available() is True but torch.version.cuda is None, so
   torch.version.cuda.startswith("12.9") raised. Guard for None so ROCm
   short-circuits out of the CUDA-12.9-specific warning.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>