### PR TITLE
Fix ROCm rowwise-fp8 warning crash

### DIFF
--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1287,7 +1287,9 @@ def _maybe_warn_rowwise_fp8_cuda_12_9(
 ) -> None:
     if not torch.cuda.is_available():
         return
-    if not torch.version.cuda.startswith("12.9"):
+    # torch.version.cuda is None on ROCm/HIP builds (where torch.cuda.is_available()
+    # is still True); the CUDA 12.9 regression does not apply there.
+    if torch.version.cuda is None or not torch.version.cuda.startswith("12.9"):
         return
     # config.granularity is normalized to [activation, weight] in __post_init__.
     if not any(isinstance(g, PerRow) for g in config.granularity):


### PR DESCRIPTION
test_quantize_api_fp8_fp8_granularity1 (PerRow) failed on ROCm with
"AttributeError: 'NoneType' object has no attribute 'startswith'" in
_maybe_warn_rowwise_fp8_cuda_12_9 (added in #4588). On ROCm/HIP builds
torch.cuda.is_available() is True but torch.version.cuda is None, so
torch.version.cuda.startswith("12.9") raised. Guard for None so ROCm
short-circuits out of the CUDA-12.9-specific warning.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>