### PR TITLE
Split PT2E tests into dedicated CPU and GPU CI workflows

### DIFF
--- a/.github/workflows/nightly_smoke_test.yml
+++ b/.github/workflows/nightly_smoke_test.yml
@@ -39,4 +39,7 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r dev-requirements.txt
         pip install . --no-build-isolation
-        pytest test --verbose -s
+        # PT2E tests (test/quantization/pt2e) are excluded here and run in the
+        # dedicated regression_test_pt2e_cpu.yml / regression_test_pt2e_gpu.yml
+        # workflows instead.
+        pytest test --verbose -s --ignore=test/quantization/pt2e

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -80,7 +80,14 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        pytest test --verbose -s
+        # PT2E tests (test/quantization/pt2e) are intentionally excluded here.
+        # They are slow (~40+ min, dominated by torch.compile / Inductor codegen)
+        # and are CPU/x86-centric, so running them on every regression leg -- and
+        # especially on the expensive GPU runner -- is wasteful and largely
+        # redundant. They now run in dedicated workflows instead:
+        #   - regression_test_pt2e_cpu.yml (full PT2E suite on CPU)
+        #   - regression_test_pt2e_gpu.yml (GPU-relevant PT2E, slow x86 tests excluded)
+        pytest test --verbose -s --ignore=test/quantization/pt2e
   test:
     strategy:
       fail-fast: false
@@ -117,4 +124,11 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        pytest test --verbose -s
+        # PT2E tests (test/quantization/pt2e) are intentionally excluded here.
+        # They are slow (~40+ min, dominated by torch.compile / Inductor codegen)
+        # and are CPU/x86-centric, so running them on every regression leg -- and
+        # especially on the expensive GPU runner -- is wasteful and largely
+        # redundant. They now run in dedicated workflows instead:
+        #   - regression_test_pt2e_cpu.yml (full PT2E suite on CPU)
+        #   - regression_test_pt2e_gpu.yml (GPU-relevant PT2E, slow x86 tests excluded)
+        pytest test --verbose -s --ignore=test/quantization/pt2e

--- a/.github/workflows/regression_test_pt2e_cpu.yml
+++ b/.github/workflows/regression_test_pt2e_cpu.yml
@@ -1,0 +1,70 @@
+# Dedicated CI for PT2E (PyTorch 2 Export) quantization tests on CPU.
+#
+# Why this workflow exists:
+#   The PT2E test suite (test/quantization/pt2e) is slow -- ~40+ minutes, almost
+#   entirely torch.export / torch.compile / Inductor codegen time -- and it is
+#   CPU/x86-centric. To keep the main regression jobs fast, PT2E is excluded from
+#   regression_test.yml and run here instead.
+#
+# This is the CPU leg: it runs the FULL PT2E suite, including the x86 Inductor
+# fusion/quantizer tests. Those tests gate on CPU ISA features (AMX tile, AVX512
+# VNNI, mkldnn bf16/fp16), so an Intel CPU runner is where they actually get
+# exercised -- a GPU runner's CPU typically lacks these instructions and would
+# silently skip large portions of the suite.
+name: Run PT2E CPU Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'gh/**'
+  pull_request:
+    branches:
+      - main
+      - 'gh/**'
+
+concurrency:
+  group: regression_test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PyTorch nightly -- catches breakages from upstream PT2E/Inductor
+          # changes early.
+          - name: CPU Nightly
+            runs-on: linux.4xlarge
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu'
+          # Pinned release -- validates PT2E against the currently supported
+          # stable PyTorch.
+          - name: CPU 2.13
+            runs-on: linux.4xlarge
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 --index-url https://download.pytorch.org/whl/cpu'
+
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 120
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: "cpu"
+      gpu-arch-version: ""
+      submodules: recursive
+      script: |
+        conda create -n venv python=3.10 libgcc-ng=11.2.0 libstdcxx-ng=11.2.0 -y
+        conda activate venv
+        python -m pip install --upgrade pip
+        pip install ${{ matrix.torch-spec }}
+        pip install -r dev-requirements.txt
+        pip install . --no-build-isolation
+        export CONDA=$(dirname $(dirname $(which conda)))
+        export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
+        # Run the full PT2E suite, including the slow x86 Inductor tests.
+        pytest test/quantization/pt2e --verbose -s

--- a/.github/workflows/regression_test_pt2e_gpu.yml
+++ b/.github/workflows/regression_test_pt2e_gpu.yml
@@ -1,0 +1,120 @@
+# Dedicated CI for PT2E (PyTorch 2 Export) quantization tests on GPU.
+#
+# Why this workflow exists:
+#   PT2E is excluded from the main regression jobs (see regression_test.yml)
+#   because it is slow and CPU/x86-centric. This is the GPU leg, which exists to
+#   cover the small number of PT2E tests that actually exercise the accelerator
+#   (e.g. the *_cuda QAT conv-bn fusion variants). It has two jobs: `test` for
+#   CUDA (nightly + pinned) and `test-rocm` for ROCm (nightly).
+#
+# Slow x86 tests are excluded here:
+#   test_x86inductor_fusion.py and test_x86inductor_quantizer.py hardcode
+#   device="cpu" and gate on CPU ISA features -- they do not use the GPU at all,
+#   and a GPU runner's CPU typically lacks the AMX/VNNI instructions they need,
+#   so they would either be redundant with the CPU leg or silently skip. They add
+#   ~45 min of Inductor codegen with zero GPU coverage, so we skip them here and
+#   let regression_test_pt2e_cpu.yml own them.
+name: Run PT2E GPU Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'gh/**'
+  pull_request:
+    branches:
+      - main
+      - 'gh/**'
+
+concurrency:
+  group: regression_test-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PyTorch nightly -- catches breakages from upstream PT2E/Inductor
+          # changes early.
+          - name: CUDA Nightly
+            runs-on: linux.g5.12xlarge.nvidia.gpu
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu126'
+          # Pinned release -- validates PT2E against the currently supported
+          # stable PyTorch.
+          - name: CUDA 2.13
+            runs-on: linux.g5.12xlarge.nvidia.gpu
+            torch-spec: 'torch==2.13.0 torchvision==0.28.0 --index-url https://download.pytorch.org/whl/cu126'
+
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 120
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: "cuda"
+      gpu-arch-version: "12.6"
+      submodules: recursive
+      script: |
+        conda create -n venv python=3.10 libgcc-ng=11.2.0 libstdcxx-ng=11.2.0 -y
+        conda activate venv
+        python -m pip install --upgrade pip
+        pip install ${{ matrix.torch-spec }}
+        pip install -r dev-requirements.txt
+        pip install . --no-build-isolation
+        export CONDA=$(dirname $(dirname $(which conda)))
+        export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
+        # Run PT2E tests, excluding the slow CPU-only x86 Inductor tests (they
+        # are owned by regression_test_pt2e_cpu.yml). Everything else runs so the
+        # CUDA-specific PT2E paths get coverage.
+        pytest test/quantization/pt2e --verbose -s \
+          --ignore=test/quantization/pt2e/test_x86inductor_fusion.py \
+          --ignore=test/quantization/pt2e/test_x86inductor_quantizer.py
+
+  # ROCm leg. Kept as a separate job (rather than a matrix row on `test`) because
+  # ROCm needs a custom docker image and no-sudo, which the CUDA rows do not set.
+  # The x86 Inductor tests are excluded here too -- they self-skip on ROCm anyway
+  # (they are guarded with skipIf(torch.version.hip is not None)).
+  test-rocm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ROCM Nightly
+            runs-on: linux.rocm.gpu.gfx942.1
+            torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2'
+            gpu-arch-type: "rocm"
+            gpu-arch-version: "7.2"
+            docker-image: pytorch/manylinux2_28-builder:rocm7.2
+
+    permissions:
+      id-token: write
+      contents: read
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 120
+      no-sudo: ${{ matrix.gpu-arch-type == 'rocm' }}
+      runner: ${{ matrix.runs-on }}
+      gpu-arch-type: ${{ matrix.gpu-arch-type }}
+      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      docker-image: ${{ matrix.docker-image }}
+      submodules: recursive
+      script: |
+        conda create -n venv python=3.10 -y
+        conda activate venv
+        python -m pip install --upgrade pip
+        pip install ${{ matrix.torch-spec }}
+        pip install -r dev-requirements.txt
+        pip install . --no-build-isolation
+        export CONDA=$(dirname $(dirname $(which conda)))
+        export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
+        # Run PT2E tests, excluding the slow CPU-only x86 Inductor tests (they
+        # are owned by regression_test_pt2e_cpu.yml).
+        pytest test/quantization/pt2e --verbose -s \
+          --ignore=test/quantization/pt2e/test_x86inductor_fusion.py \
+          --ignore=test/quantization/pt2e/test_x86inductor_quantizer.py

--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -48,4 +48,8 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        pytest test --verbose -s
+        # PT2E tests (test/quantization/pt2e) are excluded here -- they are slow
+        # and CPU/x86-centric (the x86 Inductor tests self-skip on ROCm anyway).
+        # PT2E now runs in dedicated workflows: regression_test_pt2e_cpu.yml and
+        # regression_test_pt2e_gpu.yml.
+        pytest test --verbose -s --ignore=test/quantization/pt2e


### PR DESCRIPTION
Summary:

analysis: https://gist.github.com/vkuzo/1267ce1872eca8fbd583bdc48779a220 

The PT2E test suite (test/quantization/pt2e) is slow -- ~40+ min, almost
entirely torch.export / torch.compile / Inductor codegen -- and CPU/x86-centric.
Running it on every regression leg, and especially on the expensive GPU runner,
is wasteful and largely redundant.

This change:
- Excludes PT2E from the existing workflows that run the full suite
  (regression_test.yml, regression_test_rocm.yml, nightly_smoke_test.yml) via
  --ignore=test/quantization/pt2e.
- Adds regression_test_pt2e_cpu.yml: runs the FULL PT2E suite on an Intel CPU
  runner (nightly + torch 2.13.0 pinned). The x86 Inductor tests gate on CPU ISA
  features (AMX tile, AVX512 VNNI), so an Intel CPU runner is where they are
  actually exercised.
- Adds regression_test_pt2e_gpu.yml: runs the accelerator-relevant PT2E tests on
  CUDA (nightly + 2.13.0 pinned) and ROCm (nightly). The slow x86 Inductor tests
  (test_x86inductor_fusion.py, test_x86inductor_quantizer.py) are excluded here
  since they are CPU-only and add ~45 min with zero GPU coverage.

Each workflow has comments explaining what runs where and why.

Test Plan:
- Validated YAML for all changed/new workflows.
- CI will exercise the new PT2E CPU/GPU workflows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>