### PR TITLE
[torchao] Add torch-free linear kernel target for ExecuTorch consumers

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.cpp
@@ -16,7 +16,13 @@
 
 namespace torchao::ops::linear_8bit_act_xbit_weight {
 
-void pack_weights_operator(
+#if defined(TORCHAO_WEAK_LINEAR_OPERATOR_SYMBOLS)
+#define TORCHAO_LINEAR_OPERATOR_SYMBOL __attribute__((weak))
+#else
+#define TORCHAO_LINEAR_OPERATOR_SYMBOL
+#endif
+
+TORCHAO_LINEAR_OPERATOR_SYMBOL void pack_weights_operator(
     const UKernelConfig& uk,
     // Outputs
     void* packed_weights,
@@ -75,7 +81,7 @@ void pack_weights_operator(
   });
 }
 
-void pack_weights_with_lut_operator(
+TORCHAO_LINEAR_OPERATOR_SYMBOL void pack_weights_with_lut_operator(
     const UKernelConfig& uk,
     // Outputs
     void* packed_weights,
@@ -130,7 +136,8 @@ void pack_weights_with_lut_operator(
   });
 }
 
-LinearTilingParams LinearTilingParams::from_target_tiles_per_thread(
+TORCHAO_LINEAR_OPERATOR_SYMBOL LinearTilingParams
+LinearTilingParams::from_target_tiles_per_thread(
     int m,
     int m_step,
     int n,
@@ -172,7 +179,7 @@ LinearTilingParams LinearTilingParams::from_target_tiles_per_thread(
   return tiling_params;
 }
 
-void linear_operator(
+TORCHAO_LINEAR_OPERATOR_SYMBOL void linear_operator(
     const UKernelConfig& uk,
     const std::optional<LinearTilingParams>& tiling_params,
     // Outputs
@@ -279,5 +286,14 @@ void linear_operator(
     });
   }
 }
+
+// Out-of-line accessor so consumers in other translation units can link against
+// the linked kernel's thread count (get_num_threads() itself is inline-only).
+// Weak/strong like the operators above, so it co-resolves with linear_operator.
+TORCHAO_LINEAR_OPERATOR_SYMBOL int linear_operator_num_threads() {
+  return get_num_threads();
+}
+
+#undef TORCHAO_LINEAR_OPERATOR_SYMBOL
 
 } // namespace torchao::ops::linear_8bit_act_xbit_weight

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/linear_8bit_act_xbit_weight.h
@@ -74,5 +74,10 @@ void linear_operator(
     float clamp_min,
     float clamp_max);
 
+// Number of threads the linked linear kernel uses internally (1 for the
+// single-threaded / thread-pool-free build). Lets a caller that adds its own
+// parallelism avoid nesting it on top of the kernel's.
+int linear_operator_num_threads();
+
 } // namespace
   // torchao::ops::linear_8bit_act_xbit_weight

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/compute_sum.cpp
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/compute_sum.cpp
@@ -20,7 +20,17 @@ int32_t torchao::kernels::cpu::aarch64::reduction::compute_sum(
 #pragma unroll(4)
   for (; i + 15 < size; i += 16) {
     int8x16_t vec_vals = vld1q_s8(vals + i);
+#if defined(__aarch64__)
     res += (int)(vaddlvq_s8(vec_vals));
+#else
+    // vaddlvq_s8 (widening across-vector add) is AArch64-only. On AArch32 NEON,
+    // widen pairwise (s8->s16->s32) then fold the 4 lanes to a scalar.
+    int16x8_t w16 = vpaddlq_s8(vec_vals);
+    int32x4_t w32 = vpaddlq_s16(w16);
+    int32x2_t w2 = vadd_s32(vget_low_s32(w32), vget_high_s32(w32));
+    w2 = vpadd_s32(w2, w2);
+    res += vget_lane_s32(w2, 0);
+#endif
   }
   for (; i < size; i += 1) {
     res += vals[i];

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/find_min_and_max.cpp
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/find_min_and_max.cpp
@@ -31,8 +31,19 @@ void torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
       mins = vminq_f32(mins, v);
       maxes = vmaxq_f32(maxes, v);
     }
+#if defined(__aarch64__)
     min = vminvq_f32(mins);
     max = vmaxvq_f32(maxes);
+#else
+    // vminvq_f32/vmaxvq_f32 (across-vector reductions) are AArch64-only. On
+    // AArch32 NEON, fold the 128-bit vector to a scalar with pairwise reductions.
+    float32x2_t min_pair = vpmin_f32(vget_low_f32(mins), vget_high_f32(mins));
+    min_pair = vpmin_f32(min_pair, min_pair);
+    min = vget_lane_f32(min_pair, 0);
+    float32x2_t max_pair = vpmax_f32(vget_low_f32(maxes), vget_high_f32(maxes));
+    max_pair = vpmax_f32(max_pair, max_pair);
+    max = vget_lane_f32(max_pair, 0);
+#endif
   }
 
   // Remainder

--- a/torchao/csrc/cpu/torch_free_kernels/fallback/weight_packing_internals.h
+++ b/torchao/csrc/cpu/torch_free_kernels/fallback/weight_packing_internals.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#if !defined(__aarch64__) && !defined(__ARM_NEON)
+#if !defined(__aarch64__)
 
 #include <torchao/csrc/cpu/torch_free_kernels/fallback/bitpacking/bitpack.h>
 #include <torchao/csrc/cpu/torch_free_kernels/macro.h>
@@ -77,4 +77,4 @@ inline int32_t compute_sum(const int8_t* vals, int count) {
 
 } // namespace torchao::weight_packing::fallback
 
-#endif // !defined(__aarch64__) && !defined(__ARM_NEON)
+#endif // !defined(__aarch64__)

--- a/torchao/csrc/cpu/torch_free_kernels/weight_packing/weight_packing.h
+++ b/torchao/csrc/cpu/torch_free_kernels/weight_packing/weight_packing.h
@@ -12,7 +12,7 @@
 
 #include <torchao/csrc/cpu/torch_free_kernels/macro.h>
 
-#if defined(__aarch64__) || defined(__ARM_NEON)
+#if defined(__aarch64__)
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/weight_packing_internals.h>
 #else
 #include <torchao/csrc/cpu/torch_free_kernels/fallback/weight_packing_internals.h>
@@ -26,7 +26,7 @@
 
 namespace torchao::weight_packing {
 
-#if defined(__aarch64__) || defined(__ARM_NEON)
+#if defined(__aarch64__)
 namespace impl = torchao::weight_packing::aarch64;
 #else
 namespace impl = torchao::weight_packing::fallback;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4645

Add a statically linked, torch-free and ExecuTorch-free `linear_8bit_act_xbit_weight` target for consumers inside `libexecutorch.so`. This avoids the `kernel_util` dependency and the Android native-library merge cycle.

Prefer static linkage for the aarch64 subkernels. Support AArch32 NEON by selecting the scalar weight-packing fallback and implementing reductions without AArch64-only intrinsics. Mark the standalone implementation symbols weak so binaries that also link the registered ExecuTorch operator use its strong threaded implementation without duplicate-symbol failures.

Differential Revision: [D112958457](https://our.internmc.facebook.com/intern/diff/D112958457/)