### PR TITLE
Mask scale loads in blockwise fp8 training GEMMs

### DIFF
--- a/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
+++ b/test/prototype/blockwise_fp8_training/test_blockwise_kernels.py
@@ -4,6 +4,11 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+import shutil
+import subprocess
+import sys
+
 import pytest
 import torch
 
@@ -93,6 +98,46 @@ def test_triton_fp8_gemm_1x128_128x1(M, N, K, dtype):
     sqnr = compute_error(C, C_q)
     min_sqnr = 28.0
     assert sqnr >= min_sqnr, f"SQNR {sqnr:.2f} must be >= {min_sqnr}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    shutil.which("compute-sanitizer") is None,
+    reason="compute-sanitizer required to detect out of bounds reads",
+)
+def test_gemm_scale_loads_stay_in_bounds():
+    # Tiles that overhang M or N must not read past the end of a_s / b_s. The
+    # stray reads are dropped by the store mask, so they are only visible under
+    # memcheck, with the caching allocator disabled so allocator slack does not
+    # absorb them. See https://github.com/pytorch/ao/issues/4634.
+    # Operands are e5m2 so this also runs on GPUs that cannot compile e4m3; the
+    # scale pointer arithmetic is the same either way.
+    script = """\
+import torch
+from torchao.prototype.blockwise_fp8_training.kernels import (
+    triton_fp8_gemm_1x128_128x1,
+    triton_fp8_gemm_1x128_128x128,
+)
+
+M, N, K = 2, 128, 128
+a = torch.randn(M, K, device="cuda").to(torch.float8_e5m2)
+b = torch.randn(N, K, device="cuda").to(torch.float8_e5m2).t()
+a_s = torch.randn(K // 128, M, device="cuda").t()
+b_s_128x128 = torch.randn(N // 128, K // 128, device="cuda").t()
+b_s_128x1 = torch.randn(K // 128, N, device="cuda")
+triton_fp8_gemm_1x128_128x128(a, b, a_s, b_s_128x128, out_dtype=torch.bfloat16)
+triton_fp8_gemm_1x128_128x1(a, b, a_s, b_s_128x1, out_dtype=torch.bfloat16)
+torch.cuda.synchronize()
+"""
+    env = {**os.environ, "PYTORCH_NO_CUDA_MEMORY_CACHING": "1"}
+    result = subprocess.run(
+        ["compute-sanitizer", "--tool", "memcheck", sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    assert "ERROR SUMMARY: 0 errors" in result.stdout, result.stdout
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/torchao/prototype/blockwise_fp8_training/kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/kernels.py
@@ -247,8 +247,8 @@ def triton_fp8_gemm_1x128_128x128_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s
 
         a_ptrs += BLOCK_SIZE_K * a_stride_dim_1
@@ -365,8 +365,8 @@ def triton_fp8_gemm_1x128_128x1_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
 
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
 


### PR DESCRIPTION
Fixes #4634. Reported by @truong-v, with a clean sanitizer trace.

Both blockwise FP8 GEMM kernels build their scale base pointers from the full
tile offsets and then load `a_s` / `b_s` with no mask, so a tile that overhangs
`M` or `N` reads past the end of the scale tensors. The result is still correct
because those lanes are dropped by `c_mask` at the store, so this only shows up
as an intermittent `unspecified launch failure` when a scale tensor sits at the
tail of a mapped region.

This masks the four scale loads with the same bounds that already guard the
operand loads and the store in those loops.

Also adds `test_gemm_scale_loads_stay_in_bounds`, which runs both GEMMs in a
subprocess under `compute-sanitizer --tool memcheck` with
`PYTORCH_NO_CUDA_MEMORY_CACHING=1` and asserts zero errors. It skips when
`compute-sanitizer` is not on PATH. The test uses e5m2 operands so it also runs
on pre-sm89 GPUs; the scale pointer arithmetic under test is the same for either
fp8 dtype.

Verified on an A40 (sm_86), torch 2.13.0+cu126, triton 3.7.1, compute-sanitizer
from CUDA 12.6:

- Before: 228 invalid 4-byte global reads at `kernels.py:250`, ending in `CUDA
  error: unspecified launch failure`. After: `ERROR SUMMARY: 0 errors`.
- Each of the four loads was isolated with its own shape and confirmed out of
  bounds before the fix (lines 250, 251, 368, 369).
- Outputs are bitwise identical before and after the fix for (M,N,K) of
  (2,512,128), (3,2048,2048) and (67,6656,1408).

Not verified: sm_86 cannot compile `fp8e4nv`, so I could not run the issue's
repro script or any e4m3 path. I drove the same two kernels with e5m2 operands
and hand-built scale tensors matching the shapes and layouts the quantize
helpers produce. The existing tests in this directory are gated on sm90+/MI300
and skipped here. I did not benchmark the added masks.