### PR TITLE
clear cuBLAS workspaces at pytest teardown to fix nightly shutdown abort

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Workaround for https://github.com/pytorch/pytorch/pull/180283, which made
+    # the cuBLAS/cuBLASLt workspace maps thread_local (previously an intentionally
+    # leaked static whose destructor never ran). As a result, the maps now get a
+    # real destructor that frees CUDA workspace memory at process exit -- after the
+    # CUDA context may already be torn down -- which aborts the interpreter with
+    # SIGABRT (exit 134) once all tests have already passed. This first shipped in
+    # the torch nightly dev20260722 and is what makes the CUDA regression legs die
+    # at shutdown.
+    #
+    # torch.cuda._clear_cublas_workspaces() empties those maps. Calling it here, in
+    # pytest's session-finish hook, runs while the CUDA context is still alive, so
+    # the maps are empty by the time their thread_local destructors run and those
+    # destructors become no-ops.
+    #
+    # This is scoped to test/ (rather than the repo root) because every pytest
+    # invocation in CI targets a path under test/, so pytest loads this conftest for
+    # all of them; the only pytest run outside test/ is the MPS metal job, which has
+    # no CUDA and does not need this.
+    import torch
+
+    if torch.cuda.is_available() and hasattr(torch.cuda, "_clear_cublas_workspaces"):
+        torch.cuda._clear_cublas_workspaces()


### PR DESCRIPTION
Summary:
The CUDA regression legs on torch nightly started dying with SIGABRT
(exit 134, "core dumped") at process shutdown, after all tests had
already passed. Bisected to the nightly boundary dev20260721 (good) ->
dev20260722 (bad).

Root cause is upstream pytorch/pytorch#180283, which changed the
cuBLAS/cuBLASLt workspace maps from an intentionally-leaked static
(`static auto& instance = *new WorkspaceMapWithMutex`, whose destructor
never runs) to `thread_local WorkspaceMap instance`. The maps hold CUDA
device memory allocated via the caching allocator, so they now get a
real destructor that frees that memory at process/thread exit. When that
destructor runs after the CUDA context has already been torn down, the
free fails inside a destructor and aborts the interpreter. This is the
same destruction-order hazard the cuBLAS handle pool already documents
and dodges by deliberately not destroying its handle.

Any process that ran a GPU matmul (which populates the maps) and then
exits normally is exposed; our CUDA pytest legs reliably hit both
conditions, so the abort is deterministic.

Fix: clear the workspace maps in pytest's session-finish hook, while the
CUDA context is still alive, via torch.cuda._clear_cublas_workspaces()
(added in that same PR, so the hasattr guard is an exact version gate).
The maps are then empty when their thread_local destructors run, making
those destructors no-ops.

Scoped to test/ rather than the repo root because every pytest
invocation in CI targets a path under test/, so pytest loads this
conftest for all of them; the only pytest run outside test/ is the MPS
metal job, which has no CUDA and does not need this. Note this covers
the pytest legs only -- the direct `python test_*.py` GPU invocations go
through torch's run_tests() and would need the upstream fix if they ever
exhibit the same abort.

Test Plan:
- CI

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>