### PR TITLE
float8: work around Triton fp8 store miscompile in compiled training

### DIFF
--- a/torchao/float8/_inductor_patch.py
+++ b/torchao/float8/_inductor_patch.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Workaround for a Triton miscompile that produces spurious NaN/Inf in compiled
+float8 backward kernels (e.g. FSDP2 float8 training with torch.compile).
+
+Root cause: PyTorch inductor PR pytorch/pytorch#186933 changed the Triton codegen
+for ``minimum``/``maximum`` from the ``tl.where``-based ``triton_helpers.{minimum,
+maximum}`` to ``tl.{minimum,maximum}(a, b, tl.PropagateNan.ALL)``. The two forms
+are numerically identical (both propagate NaN), but the ``PropagateNan.ALL`` form
+lowers to PTX ``min.NaN``/``max.NaN`` instructions that make Triton mis-lower a
+neighboring transposed, vectorized 1-byte (fp8) store. The stored value is
+correct, but the transposed store writes garbage bytes that decode as NaN/Inf in
+fp8. See https://github.com/triton-lang/triton/issues/11111.
+
+This monkeypatch reverts the inductor min/max codegen to the numerically-identical
+``triton_helpers`` (``tl.where``) form, which does not emit the ``min.NaN``/
+``max.NaN`` instructions and so avoids tripping the Triton store bug. It is applied
+from ``convert_to_float8_training`` so it only affects callers who actually use the
+float8 training product, not every ``import torchao``. The reverted form is always
+correct, so this is a no-op on numerics even once Triton fixes the underlying bug.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+def _patch_inductor_min_max_codegen() -> None:
+    """Revert inductor's Triton min/max codegen to the ``tl.where`` form.
+
+    Idempotent and defensive: if inductor internals have moved, this logs and
+    returns rather than breaking ``import torchao.float8``.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        from torch._inductor.codegen.triton import TritonOverrides
+    except Exception as e:  # pragma: no cover - inductor internals moved
+        logger.debug("float8: could not import TritonOverrides to patch: %s", e)
+        return
+
+    # Numerically-identical replacements for the post-pytorch/pytorch#186933
+    # `tl.{minimum,maximum}(a, b, tl.PropagateNan.ALL)` codegen. `triton_helpers`
+    # is always imported into inductor-generated Triton kernels.
+    @staticmethod
+    def minimum(a, b):
+        return f"triton_helpers.minimum({a}, {b})"
+
+    @staticmethod
+    def maximum(a, b):
+        return f"triton_helpers.maximum({a}, {b})"
+
+    TritonOverrides.minimum = minimum
+    TritonOverrides.maximum = maximum
+    _PATCHED = True
+    logger.debug(
+        "float8: patched inductor Triton min/max codegen to work around "
+        "https://github.com/triton-lang/triton/issues/11111"
+    )

--- a/torchao/float8/float8_linear_utils.py
+++ b/torchao/float8/float8_linear_utils.py
@@ -108,6 +108,16 @@ def convert_to_float8_training(
        :language: python
     """
     torch._C._log_api_usage_once("torchao.float8.convert_to_float8_training")
+
+    # Work around a Triton fp8 store miscompile triggered by inductor's
+    # PropagateNan.ALL min/max codegen (triton-lang/triton#11111). Scoped to the
+    # float8 training entry point (rather than at import) so it only affects users
+    # who actually convert a model to float8 training, and is applied here before
+    # any float8 kernel is compiled.
+    from torchao.float8._inductor_patch import _patch_inductor_min_max_codegen
+
+    _patch_inductor_min_max_codegen()
+
     if config is None:
         config = Float8LinearConfig()
 


### PR DESCRIPTION
Summary:
Compiled float8 training (e.g. FSDP2 + torch.compile) could intermittently
produce NaN/Inf losses. Root cause is a Triton miscompile: when a kernel
contains `min.NaN`/`max.NaN` PTX instructions, Triton mis-lowers a neighboring
transposed, vectorized 1-byte (fp8) store, writing garbage bytes that decode as
NaN/Inf. The computed value is correct (the contiguous store of the same value
is clean); only the transposed store is corrupted. Filed upstream as
https://github.com/triton-lang/triton/issues/11111.

The bug became visible after PyTorch inductor PR
https://github.com/pytorch/pytorch/pull/186933, which changed the Triton codegen
for min/max from the `tl.where`-based `triton_helpers.{minimum,maximum}` to
`tl.{minimum,maximum}(a, b, tl.PropagateNan.ALL)`. The two forms are numerically
identical, but only the `PropagateNan.ALL` form lowers to the `min.NaN`/`max.NaN`
instructions that trip the store bug.

Timeline: nightlies were GOOD through 2026-06-13 and BAD starting 2026-06-14,
bracketing #186933. The failure is flaky (~25%/run) because inductor autotunes
the fused kernel's launch config and only a subset of configs trip the store
miscompile; the miscompile itself is deterministic per config.

This change reverts the inductor min/max codegen back to the numerically-identical
`triton_helpers` (`tl.where`) form, which avoids emitting `min.NaN`/`max.NaN`.
It is applied from `convert_to_float8_training` so it only affects users of the
float8 training product, not every `import torchao`. The reverted form is always
correct, so this is a numeric no-op even after Triton fixes the underlying bug.

Test Plan:
Repro'd the FSDP2 float8 + torch.compile NaN in a standalone script; verified the
config that deterministically NaN'd now produces finite losses with the workaround
applied, and confirmed `convert_to_float8_training` (but not bare `import torchao`)
flips the codegen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>