### PR TITLE
mxfp8: use versioned TMA lookup with CUDA 13

### DIFF
--- a/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
+++ b/torchao/csrc/cuda/mx_kernels/mx_block_rearrange_2d_M_groups.cu
@@ -50,8 +50,14 @@ inline void* get_driver_ptr() {
     static void *driver_ptr = nullptr;
     if (!driver_ptr) {
         cudaDriverEntryPointQueryResult result;
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13000
+        CUDA_CHECK(cudaGetDriverEntryPointByVersion(
+            "cuTensorMapEncodeTiled", &driver_ptr, 12000, cudaEnableDefault,
+            &result));
+#else
         CUDA_CHECK(cudaGetDriverEntryPoint("cuTensorMapEncodeTiled", &driver_ptr,
                                 cudaEnableDefault, &result));
+#endif
     }
     return driver_ptr;
 }

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -364,8 +364,13 @@ void* get_driver_ptr() {
   static void *driver_ptr = nullptr;
   if (!driver_ptr) {
     cudaDriverEntryPointQueryResult result;
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 13000
+    CUDA_CHECK(cudaGetDriverEntryPointByVersion(
+        "cuTensorMapEncodeTiled", &driver_ptr, 12000, cudaEnableDefault, &result));
+#else
     CUDA_CHECK(cudaGetDriverEntryPoint("cuTensorMapEncodeTiled", &driver_ptr,
                             cudaEnableDefault, &result));
+#endif
   }
   return driver_ptr;
 }


### PR DESCRIPTION
The MXFP8 CUDA kernels cast cuTensorMapEncodeTiled to the v12.0 driver ABI, but cudaGetDriverEntryPoint chooses an ABI from the build-time runtime. On CUDA 13.2 that lookup returned cudaErrorInvalidValue before either quantization kernel could launch.

For CUDA 13 and newer, use cudaGetDriverEntryPointByVersion(..., 12000, ...) at both TMA lookup sites. This matches PFN_cuTensorMapEncodeTiled_v12000 and keeps the extension on the same stable ABI with newer toolkits. Retain cudaGetDriverEntryPoint for older toolkits, preserving the previous path where it already selects the expected ABI and avoiding a dependency on the newer versioned runtime API.