### PR TITLE
mxfp8: make RCEIL NaN handling CSE-friendly

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -9,7 +9,9 @@ import math
 
 import pytest
 import torch
+from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 from torchao.prototype.mx_formats.constants import (
@@ -21,6 +23,7 @@ from torchao.prototype.mx_formats.kernels import pack_uint4
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     ScaleCalculationMode,
+    _to_mx_rceil,
     to_dtype,
 )
 from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
@@ -311,6 +314,34 @@ def test_to_mx_rceil():
     )
     torch.testing.assert_close(data_mx.scale, ground_truth_scale)
     torch.testing.assert_close(data_mx.qdata, ground_truth_fp8)
+
+
+def test_to_mx_rceil_nan_branch_is_cse_compatible():
+    def repeated_rceil(data_hp, max_abs):
+        first = _to_mx_rceil(data_hp, max_abs, 448.0)
+        second = _to_mx_rceil(data_hp, max_abs, 448.0)
+        return *first, *second
+
+    data_hp = torch.randn(4, 32)
+    max_abs = data_hp.abs().amax(dim=-1, keepdim=True)
+    gm = make_fx(repeated_rceil)(data_hp, max_abs)
+    gm.graph = fx_graph_cse(gm.graph)
+
+    nan_branches = []
+    for node in gm.graph.nodes:
+        if node.target != torch.ops.aten.where.self:
+            continue
+        condition = node.args[0]
+        if (
+            isinstance(condition, torch.fx.Node)
+            and condition.target == torch.ops.aten.eq.Scalar
+            and condition.args[1] == 255
+        ):
+            nan_branches.append(node.args[1])
+
+    assert len(nan_branches) == 2
+    assert nan_branches[0] is nan_branches[1]
+    assert nan_branches[0].target == torch.ops.aten.div.Tensor
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -188,6 +188,7 @@ def _to_mx_rceil(
         # exponent is 255 exactly when descale is NaN. Reusing descale avoids
         # materializing distinct NaN constants that prevent graph CSE when the
         # same activation is quantized for multiple linear projections.
+        # See https://github.com/pytorch/pytorch/issues/191013.
         descale,
         torch.where(
             exponent == 254,  # Inf case -> return 2^-127

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -185,7 +185,10 @@ def _to_mx_rceil(
     # Ref: https://github.com/NVIDIA/TransformerEngine/blob/b7598aa887eb7d619d64c90692980009669379bf/transformer_engine/common/util/ptx.cuh#L332-L341
     rcp_fp32 = torch.where(
         exponent == 255,  # NaN case -> stays NaN
-        float("nan"),
+        # exponent is 255 exactly when descale is NaN. Reusing descale avoids
+        # materializing distinct NaN constants that prevent graph CSE when the
+        # same activation is quantized for multiple linear projections.
+        descale,
         torch.where(
             exponent == 254,  # Inf case -> return 2^-127
             2**-127,


### PR DESCRIPTION
RCEIL conversion currently creates a fresh float('nan') for each quantizer. NaN is non-reflexive, so AOTAutograd's FX CSE cannot treat otherwise identical projection casts as the same expression.

When the encoded E8M0 exponent is 255, descale is already NaN. Reuse that computed value for the reciprocal branch instead of creating a new scalar constant. This preserves the existing NaN propagation while making repeated quantizers structurally commonable.

Add an FX regression that runs the same CSE pass used by AOTAutograd and verifies repeated RCEIL branches share the computed NaN operand. The existing RCEIL numerical test continues to cover NaN and special-value output bytes.