### PR TITLE
[xpu][test][integration] Enable test_export_float8 on XPU

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -796,7 +796,8 @@ class TestExport(unittest.TestCase):
         self.assertTrue(torch.equal(after_export, ref))
 
     @unittest.skipIf(
-        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_export_float8(self):
         class SimpleNetwork(torch.nn.Module):
@@ -809,8 +810,9 @@ class TestExport(unittest.TestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        model = SimpleNetwork().eval().to("cuda")
-        inp = torch.randn(2, 32).to("cuda")
+        device = get_current_accelerator_device()
+        model = SimpleNetwork().eval().to(device)
+        inp = torch.randn(2, 32).to(device)
         config = Float8DynamicActivationFloat8WeightConfig()
         quantize_(model, config)
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -769,7 +769,8 @@ class TestExport(unittest.TestCase):
         self.assertTrue(torch.equal(after_export, ref))
 
     @unittest.skipIf(
-        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_export_float8(self):
         class SimpleNetwork(torch.nn.Module):
@@ -782,8 +783,9 @@ class TestExport(unittest.TestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        model = SimpleNetwork().eval().to("cuda")
-        inp = torch.randn(2, 32).to("cuda")
+        device = get_current_accelerator_device()
+        model = SimpleNetwork().eval().to(device)
+        inp = torch.randn(2, 32).to(device)
         config = Float8DynamicActivationFloat8WeightConfig()
         quantize_(model, config)
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -783,7 +783,7 @@ class TestExport(unittest.TestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
         model = SimpleNetwork().eval().to(device)
         inp = torch.randn(2, 32).to(device)
         config = Float8DynamicActivationFloat8WeightConfig()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -810,7 +810,7 @@ class TestExport(unittest.TestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        device = get_current_accelerator_device()
+        device = torch.accelerator.current_accelerator()
         model = SimpleNetwork().eval().to(device)
         inp = torch.randn(2, 32).to(device)
         config = Float8DynamicActivationFloat8WeightConfig()


### PR DESCRIPTION

`TestExport::test_export_float8` is skipped on every non-CUDA accelerator, even though nothing in the test is NVIDIA-specific:

```python
    @unittest.skipIf(
        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
    )
    def test_export_float8(self):
        model = SimpleNetwork().eval().to("cuda")
        inp = torch.randn(2, 32).to("cuda")
```

`is_sm_at_least_89()` returns `False` whenever `torch.cuda.is_available()` is `False` — so on XPU it silently excludes the test, instead of expressing its real requirement ("CUDA needs sm89+ for native float8").

## Change

```diff
     @unittest.skipIf(
-        not is_sm_at_least_89(), "Requires GPU with compute capability >= 8.9"
+        torch.cuda.is_available() and not is_sm_at_least_89(),
+        "CUDA capability >= 8.9 required for native float8 support",
     )
     def test_export_float8(self):
         ...
-        model = SimpleNetwork().eval().to("cuda")
-        inp = torch.randn(2, 32).to("cuda")
+        device = get_current_accelerator_device()
+        model = SimpleNetwork().eval().to(device)
+        inp = torch.randn(2, 32).to(device)
```

On any CUDA box the new gate collapses to the old one (`torch.cuda.is_available()` is `True` there) — no behavior change on NVIDIA hardware.

No library change is needed: the float8 scale computation (`torchao/quantization/quant_primitives.py::_choose_scale_float8`) is pure-torch with no per-backend dispatch key. The only vendor gates on this path (`torchao/quantization/quantize_/workflows/float8/float8_tensor.py`) guard mslk kernel preference and fall back to `torch._scaled_mm` on XPU.

## Test plan

Validated on two independent Intel GPU machines (PVC and BMG) — identical results on both:

```
before: 55 passed, 51 skipped
  SKIPPED test_export_float8: Requires GPU with compute capability >= 8.9
after:  56 passed, 50 skipped
```

`test_export_float8` is the only test that moves skipped → passed; every other skip reason is unchanged.

CPU-only regression (accelerator hidden via `ZE_AFFINITY_MASK=99`, so `torch.accelerator.is_available()` is `False`) — identical before/after on both machines:

```
61 tests collected
8 passed, 52 skipped
```


> TODO:
> No NVIDIA hardware was available for testing; the CUDA non-regression claim above is analytical (the new gate reduces to the old one whenever `torch.cuda.is_available()`). CUDA validation information will be added after CI passes.
