### PR TITLE
[test] Fix dead device comparison that disabled the SM80 bfloat16 skip in test/integration/test_integration.py

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -691,7 +691,7 @@ class TestAOTI(unittest.TestCase):
     )
     def test_aoti(self, api, test_device, test_dtype):
         if (
-            test_device == get_current_accelerator_device()
+            test_device == torch.accelerator.current_accelerator()
             and torch.cuda.is_available()
             and test_dtype == torch.bfloat16
             and torch.cuda.get_device_capability() < (8, 0)
@@ -748,7 +748,7 @@ class TestExport(unittest.TestCase):
     )
     def test_export(self, api, test_device, test_dtype):
         if (
-            test_device == get_current_accelerator_device()
+            test_device == torch.accelerator.current_accelerator()
             and torch.cuda.is_available()
             and test_dtype == torch.bfloat16
             and torch.cuda.get_device_capability() < (8, 0)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -691,7 +691,7 @@ class TestAOTI(unittest.TestCase):
     )
     def test_aoti(self, api, test_device, test_dtype):
         if (
-            test_device == "cuda"
+            test_device == get_current_accelerator_device()
             and torch.cuda.is_available()
             and test_dtype == torch.bfloat16
             and torch.cuda.get_device_capability() < (8, 0)
@@ -748,7 +748,7 @@ class TestExport(unittest.TestCase):
     )
     def test_export(self, api, test_device, test_dtype):
         if (
-            test_device == "cuda"
+            test_device == get_current_accelerator_device()
             and torch.cuda.is_available()
             and test_dtype == torch.bfloat16
             and torch.cuda.get_device_capability() < (8, 0)


### PR DESCRIPTION
`TestAOTI::test_aoti` and `TestExport::test_export` both skip their bfloat16 case on pre-SM80 CUDA via:

```python
        if (
            test_device == "cuda"
            and torch.cuda.is_available()
            and test_dtype == torch.bfloat16
            and torch.cuda.get_device_capability() < (8, 0)
        ):
            self.skipTest("Need CUDA and SM80+ available.")
```

Since [#3634](https://github.com/pytorch/ao/pull/3634), `COMMON_DEVICES`'s GPU entry is a `torch.device` object, not the string `"cuda"`. `torch.device.__eq__` doesn't coerce strings:

```pycon
>>> torch.device("cuda") == "cuda"
False
```

So `test_device == "cuda"` is permanently `False` and the whole SM80 check is dead. **Effect:** on pre-SM80 NVIDIA hardware, the bfloat16 cases of both tests now run instead of skipping.

## Fix

```diff
-            test_device == "cuda"
+            test_device == get_current_accelerator_device()
```

in both `test_aoti` and `test_export`. `torch.cuda.is_available()` stays in the conjunction, so the branch remains CUDA-only — this matches the idiom already used elsewhere in the same file (`test_weight_only_quant_force_mixed_mm`, `test_get_model_size_aqt`, ...).

`TestAOTI` is currently disabled wholesale (`AOTI tests are failing right now`), so that half of the fix is a no-op today; included so the two identical sites don't drift apart later.

## Test plan

```pycon
>>> torch.device("cuda") == "cuda"
False   # confirms the bug
```

XPU and CPU-only (`ZE_AFFINITY_MASK=99`) runs are unchanged before/after this diff:
`55 passed, 51 skipped` and `8 passed, 52 skipped` respectively.

No NVIDIA hardware was available to reproduce the pre-SM80 behavior directly; verified analytically instead — the new gate is only reachable when `torch.cuda.is_available()` is `True` *and* the parametrized device equals the current accelerator, i.e. exactly the pre-#3634 intent.
Worst case if this analysis is wrong: extra skips on old CUDA hardware, never a false pass.
