### PR TITLE
make tensor subclass copy_ error report exactly which metadata mismatched

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import torch
 import torch.nn.functional as F
 
+from torchao.quantization import Int8Tensor
 from torchao.testing.utils import skip_if_no_cuda
 from torchao.utils import TorchAOBaseTensor, torch_version_at_least
 
@@ -399,9 +400,8 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"type: MyTensor vs OtherTensor"):
             lp_tensor.copy_(other_tensor)
 
-    def test_copy__tensor_shape_mismatch_error_names_tensor(self):
-        """Inner tensor shape mismatch should be reported by name even when
-        the outer shapes match (e.g. packed formats)"""
+    def _get_packed_copy_test_tensor_class(self):
+        """Outer shape is decoupled from the inner tensor shape, as in packed formats"""
 
         class MyPackedTensor(TorchAOBaseTensor):
             tensor_data_names = ["qdata"]
@@ -418,10 +418,31 @@ class TestTorchAOBaseTensor(unittest.TestCase):
             def __init__(self, qdata, shape, device=None):
                 pass
 
+        return MyPackedTensor
+
+    def test_copy__tensor_shape_mismatch_error_names_tensor(self):
+        """Inner tensor shape mismatch should be reported by name even when
+        the outer shapes match (e.g. packed formats)"""
+        MyPackedTensor = self._get_packed_copy_test_tensor_class()
         lp_tensor = MyPackedTensor(torch.randn(2), torch.Size([4]))
         lp_tensor_for_copy = MyPackedTensor(torch.randn(4), torch.Size([4]))
         with self.assertRaisesRegex(
             ValueError, r"qdata\.shape: torch\.Size\(\[2\]\) vs torch\.Size\(\[4\]\)"
+        ):
+            lp_tensor.copy_(lp_tensor_for_copy)
+
+    def test_copy__outer_shape_mismatch_reported_on_its_own(self):
+        """An outer shape mismatch is reported by itself when the inner tensors agree.
+
+        Packed formats decouple the two, so `shape` and `qdata.shape` are independent
+        signals and the message must not conflate them.
+        """
+        MyPackedTensor = self._get_packed_copy_test_tensor_class()
+        lp_tensor = MyPackedTensor(torch.randn(4), torch.Size([4]))
+        lp_tensor_for_copy = MyPackedTensor(torch.randn(4), torch.Size([2, 2]))
+        with self.assertRaisesRegex(
+            ValueError,
+            r"metadata mismatch: shape: torch\.Size\(\[4\]\) vs torch\.Size\(\[2, 2\]\)$",
         ):
             lp_tensor.copy_(lp_tensor_for_copy)
 
@@ -456,6 +477,29 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         self.assertTrue(
             torch.equal(lp_tensor.zero_point, lp_tensor_for_copy.zero_point)
         )
+
+    def test_copy__real_tensor_subclass_names_the_single_field(self):
+        """End-to-end on a shipped subclass rather than a test-local one: the
+        message names the one field that differs instead of dumping both
+        tensors' full reprs (#3046)"""
+
+        def make_int8_tensor(block_size):
+            return Int8Tensor(
+                torch.randint(-8, 7, (4, 8), dtype=torch.int8),
+                torch.randn(4, 1),
+                block_size,
+                torch.bfloat16,
+            )
+
+        lp_tensor = make_int8_tensor([1, 8])
+        lp_tensor_for_copy = make_int8_tensor([1, 4])
+        with self.assertRaisesRegex(
+            ValueError, r"block_size: \[1, 8\] vs \[1, 4\]"
+        ) as context:
+            lp_tensor.copy_(lp_tensor_for_copy)
+        # the entire point of #3046: no tensor data, no wall of text
+        self.assertNotIn("tensor(", str(context.exception))
+        self.assertLess(len(str(context.exception)), 200)
 
     def test_implements_and_torch_function_together(self):
         """Ensure a function decorated with both @_implements and @_implements_torch_function works."""

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -328,6 +328,135 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         )
         self._test_default_impls_helper(lp_tensor, lp_tensor_for_copy)
 
+    def _get_copy_test_tensor_class(self):
+        class MyTensor(TorchAOBaseTensor):
+            tensor_data_names = ["qdata"]
+            tensor_attribute_names = ["attr", "device"]
+            optional_tensor_data_names = ["zero_point"]
+            optional_tensor_attribute_names = ["optional_attr"]
+
+            def __new__(
+                cls,
+                qdata,
+                attr="attr",
+                device=None,
+                zero_point=None,
+                optional_attr=None,
+            ):
+                if device is None:
+                    device = qdata.device
+                kwargs = {"device": device}
+                r = torch.Tensor._make_wrapper_subclass(cls, qdata.shape, **kwargs)  # type: ignore[attr-defined]
+                r.qdata = qdata
+                r.attr = attr
+                r.zero_point = zero_point
+                r.optional_attr = optional_attr
+                return r
+
+            def __init__(
+                self,
+                qdata,
+                attr="attr",
+                device=None,
+                zero_point=None,
+                optional_attr=None,
+            ):
+                pass
+
+        return MyTensor
+
+    def test_copy__attribute_mismatch_error_names_field(self):
+        """copy_ error should name the mismatched attribute and both values,
+        instead of dumping both tensors' full reprs (#3046)"""
+        MyTensor = self._get_copy_test_tensor_class()
+        lp_tensor = MyTensor(torch.randn(2, 3), "attr1")
+        lp_tensor_for_copy = MyTensor(torch.randn(2, 3), "attr2")
+        with self.assertRaisesRegex(ValueError, r"attr: 'attr1' vs 'attr2'") as context:
+            lp_tensor.copy_(lp_tensor_for_copy)
+        # the message should not contain tensor data dumps
+        self.assertNotIn("tensor(", str(context.exception))
+
+    def test_copy__type_mismatch_error_names_types(self):
+        MyTensor = self._get_copy_test_tensor_class()
+
+        class OtherTensor(TorchAOBaseTensor):
+            tensor_data_names = ["data"]
+            tensor_attribute_names = ["device"]
+
+            def __new__(cls, data, device=None):
+                if device is None:
+                    device = data.device
+                kwargs = {"device": device}
+                r = torch.Tensor._make_wrapper_subclass(cls, data.shape, **kwargs)  # type: ignore[attr-defined]
+                r.data = data
+                return r
+
+            def __init__(self, data, device=None):
+                pass
+
+        lp_tensor = MyTensor(torch.randn(2, 3))
+        other_tensor = OtherTensor(torch.randn(2, 3))
+        with self.assertRaisesRegex(ValueError, r"type: MyTensor vs OtherTensor"):
+            lp_tensor.copy_(other_tensor)
+
+    def test_copy__tensor_shape_mismatch_error_names_tensor(self):
+        """Inner tensor shape mismatch should be reported by name even when
+        the outer shapes match (e.g. packed formats)"""
+
+        class MyPackedTensor(TorchAOBaseTensor):
+            tensor_data_names = ["qdata"]
+            tensor_attribute_names = ["device"]
+
+            def __new__(cls, qdata, shape, device=None):
+                if device is None:
+                    device = qdata.device
+                kwargs = {"device": device}
+                r = torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+                r.qdata = qdata
+                return r
+
+            def __init__(self, qdata, shape, device=None):
+                pass
+
+        lp_tensor = MyPackedTensor(torch.randn(2), torch.Size([4]))
+        lp_tensor_for_copy = MyPackedTensor(torch.randn(4), torch.Size([4]))
+        with self.assertRaisesRegex(
+            ValueError, r"qdata\.shape: torch\.Size\(\[2\]\) vs torch\.Size\(\[4\]\)"
+        ):
+            lp_tensor.copy_(lp_tensor_for_copy)
+
+    def test_copy__optional_tensor_presence_mismatch(self):
+        """A None vs non-None optional tensor should be reported as a metadata
+        mismatch (in both directions) instead of crashing"""
+        MyTensor = self._get_copy_test_tensor_class()
+        lp_tensor = MyTensor(torch.randn(2, 3))
+        lp_tensor_for_copy = MyTensor(torch.randn(2, 3), zero_point=torch.zeros(3))
+        with self.assertRaisesRegex(ValueError, r"zero_point: None vs Tensor"):
+            lp_tensor.copy_(lp_tensor_for_copy)
+        with self.assertRaisesRegex(ValueError, r"zero_point: Tensor vs None"):
+            lp_tensor_for_copy.copy_(lp_tensor)
+
+    def test_copy__multiple_mismatches_all_reported(self):
+        MyTensor = self._get_copy_test_tensor_class()
+        lp_tensor = MyTensor(torch.randn(2, 3), "attr1", optional_attr="value1")
+        lp_tensor_for_copy = MyTensor(
+            torch.randn(2, 3), "attr2", optional_attr="value2"
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"attr: 'attr1' vs 'attr2'.*optional_attr: 'value1' vs 'value2'"
+        ):
+            lp_tensor.copy_(lp_tensor_for_copy)
+
+    def test_copy__with_matching_metadata_succeeds(self):
+        MyTensor = self._get_copy_test_tensor_class()
+        lp_tensor = MyTensor(torch.randn(2, 3), zero_point=torch.zeros(3))
+        lp_tensor_for_copy = MyTensor(torch.randn(2, 3), zero_point=torch.ones(3))
+        lp_tensor.copy_(lp_tensor_for_copy)
+        self.assertTrue(torch.equal(lp_tensor.qdata, lp_tensor_for_copy.qdata))
+        self.assertTrue(
+            torch.equal(lp_tensor.zero_point, lp_tensor_for_copy.zero_point)
+        )
+
     def test_implements_and_torch_function_together(self):
         """Ensure a function decorated with both @_implements and @_implements_torch_function works."""
         counter = {"calls": 0}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import torch
 import torch.nn.functional as F
 
+from torchao.quantization import Int8Tensor
 from torchao.utils import TorchAOBaseTensor, torch_version_at_least
 
 
@@ -399,9 +400,8 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"type: MyTensor vs OtherTensor"):
             lp_tensor.copy_(other_tensor)
 
-    def test_copy__tensor_shape_mismatch_error_names_tensor(self):
-        """Inner tensor shape mismatch should be reported by name even when
-        the outer shapes match (e.g. packed formats)"""
+    def _get_packed_copy_test_tensor_class(self):
+        """Outer shape is decoupled from the inner tensor shape, as in packed formats"""
 
         class MyPackedTensor(TorchAOBaseTensor):
             tensor_data_names = ["qdata"]
@@ -418,10 +418,31 @@ class TestTorchAOBaseTensor(unittest.TestCase):
             def __init__(self, qdata, shape, device=None):
                 pass
 
+        return MyPackedTensor
+
+    def test_copy__tensor_shape_mismatch_error_names_tensor(self):
+        """Inner tensor shape mismatch should be reported by name even when
+        the outer shapes match (e.g. packed formats)"""
+        MyPackedTensor = self._get_packed_copy_test_tensor_class()
         lp_tensor = MyPackedTensor(torch.randn(2), torch.Size([4]))
         lp_tensor_for_copy = MyPackedTensor(torch.randn(4), torch.Size([4]))
         with self.assertRaisesRegex(
             ValueError, r"qdata\.shape: torch\.Size\(\[2\]\) vs torch\.Size\(\[4\]\)"
+        ):
+            lp_tensor.copy_(lp_tensor_for_copy)
+
+    def test_copy__outer_shape_mismatch_reported_on_its_own(self):
+        """An outer shape mismatch is reported by itself when the inner tensors agree.
+
+        Packed formats decouple the two, so `shape` and `qdata.shape` are independent
+        signals and the message must not conflate them.
+        """
+        MyPackedTensor = self._get_packed_copy_test_tensor_class()
+        lp_tensor = MyPackedTensor(torch.randn(4), torch.Size([4]))
+        lp_tensor_for_copy = MyPackedTensor(torch.randn(4), torch.Size([2, 2]))
+        with self.assertRaisesRegex(
+            ValueError,
+            r"metadata mismatch: shape: torch\.Size\(\[4\]\) vs torch\.Size\(\[2, 2\]\)$",
         ):
             lp_tensor.copy_(lp_tensor_for_copy)
 
@@ -456,6 +477,29 @@ class TestTorchAOBaseTensor(unittest.TestCase):
         self.assertTrue(
             torch.equal(lp_tensor.zero_point, lp_tensor_for_copy.zero_point)
         )
+
+    def test_copy__real_tensor_subclass_names_the_single_field(self):
+        """End-to-end on a shipped subclass rather than a test-local one: the
+        message names the one field that differs instead of dumping both
+        tensors' full reprs (#3046)"""
+
+        def make_int8_tensor(block_size):
+            return Int8Tensor(
+                torch.randint(-8, 7, (4, 8), dtype=torch.int8),
+                torch.randn(4, 1),
+                block_size,
+                torch.bfloat16,
+            )
+
+        lp_tensor = make_int8_tensor([1, 8])
+        lp_tensor_for_copy = make_int8_tensor([1, 4])
+        with self.assertRaisesRegex(
+            ValueError, r"block_size: \[1, 8\] vs \[1, 4\]"
+        ) as context:
+            lp_tensor.copy_(lp_tensor_for_copy)
+        # the entire point of #3046: no tensor data, no wall of text
+        self.assertNotIn("tensor(", str(context.exception))
+        self.assertLess(len(str(context.exception)), 200)
 
     def test_implements_and_torch_function_together(self):
         """Ensure a function decorated with both @_implements and @_implements_torch_function works."""

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -11,7 +11,7 @@ import time
 from functools import reduce
 from importlib.metadata import version
 from math import gcd
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 import torch
 import torch.nn.utils.parametrize as parametrize
@@ -536,55 +536,72 @@ def _implements_common_tensor_ops(cls):
             args[0]._apply_fn_to_data(lambda x: func(x, *args[1:], **kwargs)),
         )
 
-    def _same_metadata(self: TorchAOBaseTensor, src: TorchAOBaseTensor) -> bool:
-        _tensor_shape_match = all(
-            getattr(self, t_name).shape == getattr(src, t_name).shape
-            for t_name in self.tensor_data_names
-        )
-        _optional_tensor_shape_match = True
+    def _metadata_mismatch_details(
+        self: TorchAOBaseTensor, src: TorchAOBaseTensor
+    ) -> List[str]:
+        """Returns human readable descriptions of the metadata differences
+        between `self` and `src` (an empty list means the metadata matches),
+        using the same comparisons as `_same_metadata`
+        """
+        if type(self) != type(src):
+            return [f"type: {type(self).__name__} vs {type(src).__name__}"]
+
+        details = []
+        if self.shape != src.shape:
+            details.append(f"shape: {self.shape} vs {src.shape}")
+
+        for t_name in self.tensor_data_names:
+            self_shape = getattr(self, t_name).shape
+            src_shape = getattr(src, t_name).shape
+            if self_shape != src_shape:
+                details.append(f"{t_name}.shape: {self_shape} vs {src_shape}")
+
         if hasattr(self, "optional_tensor_data_names"):
-            # either both are None or both are not Tensors and the shape match
-            _optional_tensor_shape_match = all(
-                (
-                    getattr(self, t_name).shape == getattr(src, t_name).shape
-                    if getattr(self, t_name) is not None
-                    else getattr(src, t_name) is None
-                )
-                for t_name in self.optional_tensor_data_names
-            )
+            for t_name in self.optional_tensor_data_names:
+                self_tensor = getattr(self, t_name)
+                src_tensor = getattr(src, t_name)
+                # either both should be None or both should be Tensors
+                # with the same shape
+                if (self_tensor is None) != (src_tensor is None):
+                    self_presence = "None" if self_tensor is None else "Tensor"
+                    src_presence = "None" if src_tensor is None else "Tensor"
+                    details.append(f"{t_name}: {self_presence} vs {src_presence}")
+                elif self_tensor is not None and self_tensor.shape != src_tensor.shape:
+                    details.append(
+                        f"{t_name}.shape: {self_tensor.shape} vs {src_tensor.shape}"
+                    )
 
-        _attr_match = all(
-            getattr(self, a_name) == getattr(src, a_name)
-            for a_name in self.tensor_attribute_names
-        )
+        for a_name in self.tensor_attribute_names:
+            self_attr = getattr(self, a_name)
+            src_attr = getattr(src, a_name)
+            if self_attr != src_attr:
+                details.append(f"{a_name}: {self_attr!r} vs {src_attr!r}")
 
-        _optional_attr_match = True
         if hasattr(self, "optional_tensor_attribute_names"):
-            _optional_attr_match = all(
-                getattr(self, a_name) == getattr(src, a_name)
-                for a_name in self.optional_tensor_attribute_names
-            )
+            for a_name in self.optional_tensor_attribute_names:
+                self_attr = getattr(self, a_name)
+                src_attr = getattr(src, a_name)
+                if self_attr != src_attr:
+                    details.append(f"{a_name}: {self_attr!r} vs {src_attr!r}")
 
-        return (
-            type(self) == type(src)
-            and self.shape == src.shape
-            and _tensor_shape_match
-            and _optional_tensor_shape_match
-            and _attr_match
-            and _optional_attr_match
-        )
+        return details
+
+    def _same_metadata(self: TorchAOBaseTensor, src: TorchAOBaseTensor) -> bool:
+        return not _metadata_mismatch_details(self, src)
 
     @implements(aten.copy_.default)
     def _(func, types, args, kwargs):
         self = args[0]
         src = args[1]
-        if _same_metadata(self, src):
+        mismatch_details = _metadata_mismatch_details(self, src)
+        if not mismatch_details:
             self_tensors = self.__tensor_flatten__()[0]
             for tensor_name in self_tensors:
                 getattr(self, tensor_name).copy_(getattr(src, tensor_name))
             return
         raise ValueError(
-            f"Not supported args for copy_ due to metadata mismatch: {args[0], args[1]}"
+            f"Not supported args for copy_ due to metadata mismatch: "
+            f"{'; '.join(mismatch_details)}"
         )
 
     @implements(aten._to_copy.default)


### PR DESCRIPTION
## Summary

`TorchAOBaseTensor`'s generic `aten.copy_.default` handler raised a `ValueError` that interpolated both tensors' full `repr`s — multi-KB walls of tensor data — without saying which metadata field actually mismatched. This PR makes the error name exactly the mismatched fields with concise values, e.g.:

```
ValueError: Not supported args for copy_ due to metadata mismatch: shape: torch.Size([256, 128]) vs torch.Size([256, 64]); qdata.shape: torch.Size([256, 128]) vs torch.Size([256, 64]); block_size: [1, 128] vs [1, 64]
```

Fixes #3046

## What changed

- `torchao/utils.py`: factored the comparisons of `_same_metadata` into `_metadata_mismatch_details(self, src) -> List[str]`, which returns a human-readable entry per mismatched field (type, outer shape, `tensor_data_names` shapes, `optional_tensor_data_names` presence/shapes, `tensor_attribute_names` / `optional_tensor_attribute_names` values). `_same_metadata` is now `not _metadata_mismatch_details(...)` (same name, same boolean semantics), and the `copy_` handler reports the joined details instead of dumping both tensors.
- The comparison semantics are unchanged, except two cases that previously crashed with `AttributeError` before reaching the `ValueError` at all:
  - `self`'s optional tensor set while `src`'s is `None` (`None.shape`) — now reported as `zero_point: Tensor vs None`;
  - type mismatch between structurally different subclasses (`getattr(src, ...)` on a missing field) — now reported as `type: A vs B` via an early return.
- `test/test_utils.py`: 8 new CPU tests (no CUDA gate): attribute mismatch names the field and both values (and the message contains no tensor dumps), type mismatch, inner-tensor shape mismatch with equal outer shapes (packed-format case), outer-shape mismatch with equal inner shapes (reported on its own, not conflated with `qdata.shape`), optional-tensor `None` vs set in both directions, multiple mismatches all reported, matching-metadata `copy_` still succeeds, and an end-to-end case on a shipped subclass rather than a test-local one.

## Test plan

```
pytest test/test_utils.py -q
# before: 9 passed, 3 skipped  |  after: 17 passed, 3 skipped
# TDD: the 7 new error-message tests were written first and verified failing on main
# (5 on the old wall-of-text message, 2 on the pre-existing AttributeError crashes)

ruff check --isolated --select F821,F823,W191 && ruff check && ruff format --check
# all pass
```

The end-to-end check on a real subclass is now a test rather than a manual step:
`test_copy__real_tensor_subclass_names_the_single_field` builds two `Int8Tensor`s on
CPU differing only in `block_size` and asserts the three properties #3046 asks for —
the differing field is named, the message contains no tensor data, and it stays short
(83 chars, against the multi-KB dump in the issue).

## Risk / BC notes

- The error message prefix `Not supported args for copy_ due to metadata mismatch:` is preserved; only the payload after it changed. This exact string appears nowhere else in the repo, so no other tests depend on it.
- `NVFP4Tensor` has its own separate `_same_metadata`/`copy_` implementation (`torchao/prototype/mx_formats/nvfp4_tensor.py`) and is intentionally not touched here; can follow up if wanted.

### A note on `device`

The trace in #3046 ends with `self.device=device(type='cuda', index=0)` against
`device(type='cpu')`, so it seems worth being explicit: **`device` is not part of the
metadata `_same_metadata` compares — neither before nor after this PR.** The comparison
is driven by `tensor_data_names` / `tensor_attribute_names`, and e.g.
`Float8Tensor.tensor_attribute_names` is `[]`. With only `.device` differing, the check
finds no mismatch and the `copy_` proceeds.

Making a device difference a reported mismatch would be a behaviour change, not a
message change — cross-device `copy_` is legal today and would start raising — so this
PR deliberately leaves the comparison set alone and only changes how an already-detected
mismatch is *reported*. Happy to add device as a separate PR if you'd prefer those
semantics.

---

*This PR was developed with AI assistance.*

