### PR TITLE
Fold quantization into mutable buffer storage (#4665)

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -3435,6 +3435,372 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             ViewM(), example_inputs, {"select_scatter": "buf"}
         )
 
+    def _prepare_mutable_buffer_quantization(
+        self,
+        module: torch.nn.Module,
+        example_inputs: tuple[torch.Tensor, torch.Tensor],
+        share_observer: bool = True,
+    ) -> torch.fx.GraphModule:
+        class MutableBufferQuantizer(Quantizer):
+            def __init__(self) -> None:
+                super().__init__()
+                self.qspec = QuantizationSpec(
+                    dtype=torch.int8,
+                    observer_or_fake_quant_ctr=observer.default_observer,
+                    quant_min=-128,
+                    quant_max=127,
+                    qscheme=torch.per_tensor_symmetric,
+                )
+
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                for node in model.graph.nodes:
+                    if node.op != "call_function" or node.target not in (
+                        torch.ops.aten.index_put.default,
+                        torch.ops.aten.index_put_.default,
+                    ):
+                        continue
+                    buffer = node.args[0]
+                    value = node.args[2]
+                    assert isinstance(buffer, Node) and isinstance(value, Node)
+                    node.meta["quantization_annotation"] = QuantizationAnnotation(
+                        input_qspec_map={buffer: self.qspec, value: None},
+                        output_qspec=(
+                            SharedQuantizationSpec((buffer, node))
+                            if share_observer
+                            else self.qspec
+                        ),
+                        _annotated=True,
+                    )
+                return model
+
+            def transform_for_annotation(
+                self, model: torch.fx.GraphModule
+            ) -> torch.fx.GraphModule:
+                return model
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                return None
+
+        exported = torch.export.export(
+            module.eval(), example_inputs, strict=True
+        ).module()
+        prepared = prepare_pt2e(exported, MutableBufferQuantizer())
+        prepared(*example_inputs)
+        return prepared
+
+    def test_fold_quantize_into_mutable_buffer_storage(self):
+        initial = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", initial.clone())
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put((idx,), x)
+                self.buf.copy_(updated)
+                return updated.clone()
+
+        inputs = (torch.tensor([5.0, 6.0]), torch.tensor([1, 3]))
+        prepared = self._prepare_mutable_buffer_quantization(M(), inputs)
+        dict(prepared.named_buffers())["buf"].copy_(initial)
+        converted = convert_pt2e(
+            prepared,
+            fold_quantize_into_mutable_buffers=True,
+        )
+
+        buffer = dict(converted.named_buffers())["buf"]
+        self.assertEqual(torch.int8, buffer.dtype, msg=str(converted.graph))
+        self.assertIn("buf", converted.state_dict())
+        index_put = next(
+            node
+            for node in converted.graph.nodes
+            if node.target
+            in (torch.ops.aten.index_put.default, torch.ops.aten.index_put_.default)
+        )
+        buffer_dequant = index_put.args[0]
+        self.assertIsInstance(buffer_dequant, Node)
+        assert isinstance(buffer_dequant, Node)
+        self.assertEqual(
+            torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+            buffer_dequant.target,
+        )
+        buffer_node = buffer_dequant.args[0]
+        self.assertIsInstance(buffer_node, Node)
+        assert isinstance(buffer_node, Node)
+        self.assertEqual("get_attr", buffer_node.op)
+        self.assertEqual("buf", buffer_node.target)
+        self.assertEqual(torch.int8, buffer_node.meta["val"].dtype)
+        output_quant = next(
+            user
+            for user in index_put.users
+            if user.target == torch.ops.quantized_decomposed.quantize_per_tensor.default
+        )
+        copy = next(
+            node
+            for node in converted.graph.nodes
+            if node.target == torch.ops.aten.copy_.default
+        )
+        self.assertIs(copy.args[1], output_quant)
+        output_dequants = [
+            user
+            for user in output_quant.users
+            if user.target
+            == torch.ops.quantized_decomposed.dequantize_per_tensor.default
+        ]
+        self.assertEqual(1, len(output_dequants))
+        self.assertEqual(
+            {copy, output_dequants[0]},
+            set(output_quant.users),
+        )
+
+        expected = initial.clone()
+        expected.index_put_((inputs[1],), inputs[0])
+        torch.testing.assert_close(converted(*inputs), expected, atol=0.03, rtol=0)
+
+        second_inputs = (torch.tensor([2.5, 4.5]), torch.tensor([0, 2]))
+        expected.index_put_((second_inputs[1],), second_inputs[0])
+        torch.testing.assert_close(
+            converted(*second_inputs), expected, atol=0.03, rtol=0
+        )
+
+        reexported = torch.export.export(
+            converted, inputs, strict=True
+        ).run_decompositions({})
+        self.assertEqual(
+            set(reexported.graph_signature.buffers_to_mutate.values()),
+            {"buf"},
+            msg=str(reexported),
+        )
+
+    def test_fold_quantize_into_mutable_buffer_storage_with_fanout(self):
+        initial = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", initial.clone())
+
+            def forward(self, x: torch.Tensor, factor: torch.Tensor) -> torch.Tensor:
+                value = self.buf.clone()
+                updated = value + x + value * factor
+                self.buf.copy_(updated)
+                return updated.clone()
+
+        class FanoutMutableBufferQuantizer(Quantizer):
+            def __init__(self) -> None:
+                super().__init__()
+                self.qspec = QuantizationSpec(
+                    dtype=torch.int8,
+                    observer_or_fake_quant_ctr=observer.default_observer,
+                    quant_min=-128,
+                    quant_max=127,
+                    qscheme=torch.per_tensor_symmetric,
+                )
+
+            def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                buffer = next(
+                    node
+                    for node in model.graph.nodes
+                    if node.op == "get_attr" and node.target == "buf"
+                )
+                copy = next(
+                    node
+                    for node in buffer.users
+                    if node.op == "call_function"
+                    and node.target == torch.ops.aten.copy_.default
+                )
+                read_users = set(buffer.users) - {copy}
+                assert len(read_users) == 1
+                read = next(iter(read_users))
+                read.meta["quantization_annotation"] = QuantizationAnnotation(
+                    input_qspec_map={buffer: self.qspec},
+                    _annotated=True,
+                )
+
+                write = copy.args[1]
+                assert isinstance(write, Node)
+                write.meta["quantization_annotation"] = QuantizationAnnotation(
+                    output_qspec=self.qspec,
+                    _annotated=True,
+                )
+                return model
+
+            def transform_for_annotation(
+                self, model: torch.fx.GraphModule
+            ) -> torch.fx.GraphModule:
+                return model
+
+            def validate(self, model: torch.fx.GraphModule) -> None:
+                return None
+
+        inputs = (torch.full((4,), 0.25), torch.full((4,), 0.1))
+        exported = torch.export.export(M().eval(), inputs, strict=True).module()
+        prepared = prepare_pt2e(exported, FanoutMutableBufferQuantizer())
+        prepared(*inputs)
+        dict(prepared.named_buffers())["buf"].copy_(initial)
+        converted = convert_pt2e(
+            prepared,
+            fold_quantize_into_mutable_buffers=True,
+        )
+
+        buffer = dict(converted.named_buffers())["buf"]
+        self.assertEqual(torch.int8, buffer.dtype, msg=str(converted.graph))
+        buffer_dequant = next(
+            user
+            for node in converted.graph.nodes
+            if node.op == "get_attr" and node.target == "buf"
+            for user in node.users
+            if user.target
+            == torch.ops.quantized_decomposed.dequantize_per_tensor.default
+        )
+        read = next(iter(buffer_dequant.users))
+        self.assertGreaterEqual(len(read.users), 2, msg=str(converted.graph))
+        copy = next(
+            node
+            for node in converted.graph.nodes
+            if node.target == torch.ops.aten.copy_.default
+        )
+        output_quant = copy.args[1]
+        self.assertIsInstance(output_quant, Node)
+        assert isinstance(output_quant, Node)
+        self.assertEqual(
+            torch.ops.quantized_decomposed.quantize_per_tensor.default,
+            output_quant.target,
+        )
+
+        expected = initial + inputs[0] + initial * inputs[1]
+        torch.testing.assert_close(converted(*inputs), expected, atol=0.05, rtol=0)
+
+    def test_fold_independently_observed_mutable_buffer_storage(self):
+        initial = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", initial.clone())
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put((idx,), x)
+                self.buf.copy_(updated)
+                return updated.clone()
+
+        inputs = (torch.tensor([5.0, 6.0]), torch.tensor([1, 3]))
+        prepared = self._prepare_mutable_buffer_quantization(
+            M(), inputs, share_observer=False
+        )
+        index_put = next(
+            node
+            for node in prepared.graph.nodes
+            if node.target
+            in (torch.ops.aten.index_put.default, torch.ops.aten.index_put_.default)
+        )
+        input_observer = index_put.args[0]
+        self.assertIsInstance(input_observer, Node)
+        assert isinstance(input_observer, Node)
+        input_observer_module = prepared.get_submodule(str(input_observer.target))
+        self.assertIsInstance(input_observer_module, ObserverBase)
+        assert isinstance(input_observer_module, ObserverBase)
+        output_observer = next(
+            user
+            for user in index_put.users
+            if user.op == "call_module"
+            and isinstance(prepared.get_submodule(str(user.target)), ObserverBase)
+        )
+        output_observer_module = prepared.get_submodule(str(output_observer.target))
+        self.assertIsInstance(output_observer_module, ObserverBase)
+        assert isinstance(output_observer_module, ObserverBase)
+        input_scale = input_observer_module.calculate_qparams()[0].item()
+        output_scale = output_observer_module.calculate_qparams()[0].item()
+        self.assertNotEqual(input_scale, output_scale)
+
+        dict(prepared.named_buffers())["buf"].copy_(initial)
+        converted = convert_pt2e(
+            prepared,
+            fold_quantize_into_mutable_buffers=True,
+        )
+
+        converted_index_put = next(
+            node
+            for node in converted.graph.nodes
+            if node.target
+            in (torch.ops.aten.index_put.default, torch.ops.aten.index_put_.default)
+        )
+        buffer_dequant = converted_index_put.args[0]
+        self.assertIsInstance(buffer_dequant, Node)
+        assert isinstance(buffer_dequant, Node)
+        output_quant = next(
+            user
+            for user in converted_index_put.users
+            if user.target == torch.ops.quantized_decomposed.quantize_per_tensor.default
+        )
+        self.assertEqual(buffer_dequant.args[1:6], output_quant.args[1:6])
+        self.assertAlmostEqual(buffer_dequant.args[1], output_scale)
+        self.assertEqual(torch.int8, dict(converted.named_buffers())["buf"].dtype)
+
+        expected = initial.clone()
+        expected.index_put_((inputs[1],), inputs[0])
+        torch.testing.assert_close(converted(*inputs), expected, atol=0.05, rtol=0)
+
+    def test_mutable_buffer_storage_folding_disabled_by_default(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(4))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put((idx,), x)
+                self.buf.copy_(updated)
+                return updated.clone()
+
+        inputs = (torch.tensor([1.0, 2.0]), torch.tensor([1, 3]))
+        prepared = self._prepare_mutable_buffer_quantization(M(), inputs)
+        converted = convert_pt2e(prepared)
+
+        self.assertEqual(torch.float32, dict(converted.named_buffers())["buf"].dtype)
+
+    def test_mutable_buffer_without_explicit_copy_is_not_folded(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(4))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                return self.buf.index_put_((idx,), x).clone()
+
+        inputs = (torch.tensor([1.0, 2.0]), torch.tensor([1, 3]))
+        prepared = self._prepare_mutable_buffer_quantization(M(), inputs)
+        converted = convert_pt2e(
+            prepared,
+            fold_quantize_into_mutable_buffers=True,
+        )
+
+        self.assertEqual(torch.float32, dict(converted.named_buffers())["buf"].dtype)
+
+    def test_mutable_buffer_storage_folding_requires_fold_quantize(self):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("buf", torch.zeros(4))
+
+            def forward(self, x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+                updated = self.buf.index_put((idx,), x)
+                self.buf.copy_(updated)
+                return updated.clone()
+
+        inputs = (torch.tensor([1.0, 2.0]), torch.tensor([1, 3]))
+        prepared = self._prepare_mutable_buffer_quantization(M(), inputs)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "fold_quantize_into_mutable_buffers=True requires fold_quantize=True",
+        ):
+            convert_pt2e(
+                prepared,
+                fold_quantize=False,
+                fold_quantize_into_mutable_buffers=True,
+            )
+
     def test_scan_op_quantization(self):
         """Test that prepare_pt2e and convert_pt2e correctly quantize ops
         inside the combine_fn subgraph of torch._higher_order_ops.scan.

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -5,8 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx import GraphModule, Node
 from torch.fx.passes.infra.pass_manager import PassManager
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from torch.multiprocessing.reductions import StorageWeakRef
 
 from torchao.quantization.pt2e.qat_utils import _fold_conv_bn_qat, _fuse_conv_bn_qat
 from torchao.quantization.pt2e.quantizer import (  # noqa: F401
@@ -19,6 +22,7 @@ from torchao.quantization.pt2e.utils import (
     _fuse_conv_bn_,
     _fuse_linear_bn_,
     _get_node_name_to_scope,
+    get_arg,
 )
 
 from .constant_fold import constant_fold
@@ -223,6 +227,141 @@ _QUANT_OPS = [
     torch.ops.torchao.quantize_affine,
 ]
 
+_QUANTIZE_PER_TENSOR = torch.ops.quantized_decomposed.quantize_per_tensor.default
+_DEQUANTIZE_PER_TENSOR = torch.ops.quantized_decomposed.dequantize_per_tensor.default
+_QParams = tuple[float, int, int, int, torch.dtype]
+
+
+def _static_qparams(node: Node, target: torch._ops.OpOverload) -> _QParams | None:
+    if node.target != target:
+        return None
+    return (
+        get_arg(node, "scale", float),
+        get_arg(node, "zero_point", int),
+        get_arg(node, "quant_min", int),
+        get_arg(node, "quant_max", int),
+        get_arg(node, "dtype", torch.dtype),
+    )
+
+
+def _tensor_signature(tensor: torch.Tensor) -> tuple[object, ...]:
+    signature = (tuple(tensor.shape), tensor.device, tensor.layout)
+    if tensor.layout == torch.strided:
+        return (*signature, tuple(tensor.stride()))
+    return signature
+
+
+def _fold_quantize_into_mutable_buffers(model: GraphModule) -> None:
+    """Fold Q/DQ buffer boundaries with an explicit copy writeback."""
+    named_buffers = dict(model.named_buffers(remove_duplicate=False))
+    changed = False
+
+    for target, buffer_value in named_buffers.items():
+        buffers = model.graph.find_nodes(op="get_attr", target=target)
+        if len(buffers) != 1:
+            continue
+        buffer = buffers[0]
+
+        input_quants = [
+            user for user in buffer.users if user.target == _QUANTIZE_PER_TENSOR
+        ]
+        if len(input_quants) != 1:
+            continue
+        input_quant = input_quants[0]
+        input_qparams = _static_qparams(input_quant, _QUANTIZE_PER_TENSOR)
+        assert input_qparams is not None
+        input_dequants = [
+            user
+            for user in input_quant.users
+            if _static_qparams(user, _DEQUANTIZE_PER_TENSOR) == input_qparams
+        ]
+        if len(input_dequants) != 1 or set(input_quant.users) != {input_dequants[0]}:
+            continue
+        input_dequant = input_dequants[0]
+
+        copies = tuple(
+            user
+            for user in buffer.users
+            if user.target == torch.ops.aten.copy_.default
+            and user.args[0] is buffer
+            and not user.users
+        )
+        if len(copies) != 1 or set(buffer.users) != {input_quant, copies[0]}:
+            continue
+        copy = copies[0]
+        output_dequant = get_arg(copy, "src", Node)
+        output_dequant_qparams = _static_qparams(output_dequant, _DEQUANTIZE_PER_TENSOR)
+        if output_dequant_qparams is None:
+            continue
+        output_quant = get_arg(output_dequant, "input", Node)
+        output_qparams = _static_qparams(output_quant, _QUANTIZE_PER_TENSOR)
+        if output_qparams is None or output_dequant_qparams != output_qparams:
+            continue
+        output_dequants = tuple(
+            user
+            for user in output_quant.users
+            if _static_qparams(user, _DEQUANTIZE_PER_TENSOR) == output_qparams
+        )
+        if not output_dequants or set(output_quant.users) != set(output_dequants):
+            continue
+
+        if not buffer_value.is_floating_point():
+            continue
+        storage_ref = StorageWeakRef(buffer_value.untyped_storage())
+        aliases = [
+            name
+            for name, value in named_buffers.items()
+            if name != target and StorageWeakRef(value.untyped_storage()) == storage_ref
+        ]
+        if aliases:
+            raise ValueError(
+                f"Cannot fold quantization into mutable buffer {target!r}; "
+                f"it aliases registered buffers {sorted(aliases)}"
+            )
+
+        current_value = buffer.meta.get("val")
+        if not isinstance(current_value, FakeTensor):
+            raise ValueError(
+                f"Cannot fold quantization into mutable buffer {target!r}; "
+                "the buffer is missing FakeTensor metadata"
+            )
+        scale, zero_point, quant_min, quant_max, dtype = output_qparams
+        with torch.utils._python_dispatch._disable_current_modes():
+            quantized_buffer = _QUANTIZE_PER_TENSOR(
+                buffer_value,
+                scale,
+                zero_point,
+                quant_min,
+                quant_max,
+                dtype,
+            )
+        if _tensor_signature(quantized_buffer) != _tensor_signature(buffer_value):
+            raise ValueError(
+                f"Cannot fold quantization into mutable buffer {target!r}; "
+                "quantization changed its shape, device, layout, or stride"
+            )
+
+        *prefix, attr = target.split(".")
+        owner = model.get_submodule(".".join(prefix)) if prefix else model
+        setattr(owner, attr, quantized_buffer)
+        input_dequant.update_arg(0, buffer)
+        for index, value in enumerate(output_qparams, 1):
+            input_dequant.update_arg(index, value)
+        copy.update_arg(1, output_quant)
+        metadata_value = current_value.fake_mode.from_tensor(
+            quantized_buffer, static_shapes=True
+        )
+        tensor_meta = _extract_tensor_metadata(metadata_value)
+        for node in (buffer, copy):
+            node.meta["val"] = metadata_value
+            node.meta["tensor_meta"] = tensor_meta
+        changed = True
+
+    if changed:
+        model.graph.eliminate_dead_code()
+        model.graph.lint()
+        model.recompile()
+
 
 def _quant_node_constraint(n: Node) -> bool:
     """If there is any pure ops between get_attr and quantize op they will be const propagated
@@ -276,6 +415,7 @@ def convert_pt2e(
     model: GraphModule,
     use_reference_representation: bool = False,
     fold_quantize: bool = True,
+    fold_quantize_into_mutable_buffers: bool = False,
 ) -> GraphModule:
     """Convert a calibrated/trained model to a quantized model
 
@@ -283,6 +423,8 @@ def convert_pt2e(
       * `model` (torch.fx.GraphModule): calibrated/trained model
       * `use_reference_representation` (bool): boolean flag to indicate whether to produce referece representation or not
       * `fold_quantize` (bool): boolean flag for whether fold the quantize op or not
+      * `fold_quantize_into_mutable_buffers` (bool): boolean flag for whether to fold
+        quantize ops into mutable registered buffer storage. Requires `fold_quantize=True`.
 
     Returns:
         quantized model, either in q/dq representation or reference representation
@@ -304,6 +446,10 @@ def convert_pt2e(
             "Unexpected argument type for `use_reference_representation`, "
             f"please make sure you intend to pass argument {use_reference_representation} to convert_pt2e"
         )
+    if fold_quantize_into_mutable_buffers and not fold_quantize:
+        raise ValueError(
+            "fold_quantize_into_mutable_buffers=True requires fold_quantize=True"
+        )
     original_graph_meta = model.meta
     # Recursively convert combine_fn subgraphs of scan ops before the
     # top-level conversion, so that passes like DuplicateDQPass that
@@ -319,6 +465,7 @@ def convert_pt2e(
                 scan_combine_fn,
                 use_reference_representation=use_reference_representation,
                 fold_quantize=fold_quantize,
+                fold_quantize_into_mutable_buffers=fold_quantize_into_mutable_buffers,
             )
             setattr(model, scan_combine_fn_node.target, converted_scan_combine_fn)
     # Recursively convert body_fn subgraphs of while_loop ops.
@@ -336,6 +483,7 @@ def convert_pt2e(
                 while_loop_body_fn,
                 use_reference_representation=use_reference_representation,
                 fold_quantize=fold_quantize,
+                fold_quantize_into_mutable_buffers=fold_quantize_into_mutable_buffers,
             )
             setattr(model, while_loop_body_fn_node.target, converted_while_loop_body_fn)
     model = _convert_to_reference_decomposed_fx(model)
@@ -348,6 +496,8 @@ def convert_pt2e(
     model = pm(model).graph_module
 
     if fold_quantize:
+        if fold_quantize_into_mutable_buffers:
+            _fold_quantize_into_mutable_buffers(model)
         constant_fold(model, _quant_node_constraint)
 
     if use_reference_representation:

--- a/torchao/quantization/pt2e/utils.py
+++ b/torchao/quantization/pt2e/utils.py
@@ -17,7 +17,7 @@ import types
 import warnings
 from collections import OrderedDict
 from inspect import getfullargspec, signature
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 import torch
 import torch.nn.functional as F
@@ -46,6 +46,7 @@ from torchao.utils import _assert_and_get_unique_device
 __all__ = [
     "is_per_tensor",
     "is_per_channel",
+    "get_arg",
     "getattr_from_fqn",
     "get_qparam_dict",
     "check_min_max_valid",
@@ -63,6 +64,8 @@ __all__ = [
     "_is_sym_size_node",
     "_filter_sym_size_users",
 ]
+
+_T = TypeVar("_T")
 
 
 # TODO: remove unused
@@ -83,6 +86,22 @@ def getattr_from_fqn(obj: Any, fqn: str) -> Any:
     Given an obj and a fqn such as "foo.bar.baz", returns gm.foo.bar.baz.
     """
     return functools.reduce(getattr, fqn.split("."), obj)
+
+
+def get_arg(node: Node, name: str, expected_type: type[_T]) -> _T:
+    """Get a normalized FX node argument and validate its type."""
+    normalized_args = node.normalized_arguments(
+        node.graph.owning_module,
+        normalize_to_only_use_kwargs=True,
+    )
+    if normalized_args is None:
+        raise RuntimeError(f"Cannot normalize arguments for {node}")
+    value = normalized_args.kwargs[name]
+    if not isinstance(value, expected_type):
+        raise TypeError(
+            f"Expected {name!r} to have type {expected_type}, got {type(value)}"
+        )
+    return cast(_T, value)
 
 
 def to_underlying_dtype(qdtype):


### PR DESCRIPTION
Summary:

Add an opt-in `fold_quantize_into_mutable_buffers=False` argument to `convert_pt2e`. When enabled with `fold_quantize`, it recognizes registered floating-point state with an explicit buffer Q/DQ read boundary and exactly one terminal `copy_` sourced from a matching static Q/DQ write boundary. The write no longer has to be reached through a single-user read-to-write path, so the dequantized buffer read may fan out through arbitrary floating-point computation. The matcher does not infer mutation from operator schemas or synthesize a writeback.

Use the terminal write qparams as the canonical storage domain. Quantize the backing buffer in that domain, retarget the input DQ to the integer buffer, and preserve the output Q as the value written by `copy_`. Reject aliased buffers and incompatible tensor metadata, update FX metadata, and propagate the option into supported control-flow subgraphs. The option remains disabled by default and requires `fold_quantize=True`.

Reviewed By: DrJessop

Differential Revision: D113826710


