### PR TITLE
Allow fixed-qparam observers to accept multi-element qparams

### DIFF
--- a/test/quantization/test_observer.py
+++ b/test/quantization/test_observer.py
@@ -179,6 +179,27 @@ class TestQuantFlow(TestCase):
         scale, _ = obs.calculate_qparams()  # ignore zero_point for symmetric quant
         self.assertTrue(torch.allclose(scale, torch.ones(2048)))
 
+        obs = AffineQuantizedFixedQParamObserver(
+            MappingType.ASYMMETRIC,
+            torch.uint8,
+            granularity=PerAxis(0),
+            scale_dtype=torch.float32,
+            zero_point_dtype=torch.int64,
+            scale=torch.tensor([0.5, 0.25], dtype=torch.float64),
+            zero_point=torch.tensor([0, 1], dtype=torch.int32),
+        )
+        scale, zero_point = obs.calculate_qparams()
+        self.assertEqual(scale, torch.tensor([0.5, 0.25], dtype=torch.float32))
+        self.assertEqual(zero_point, torch.tensor([0, 1], dtype=torch.int64))
+
+        obs.set_qparams(
+            torch.tensor([0.125, 0.0625], dtype=torch.float64),
+            torch.tensor([2, 3], dtype=torch.int32),
+        )
+        scale, zero_point = obs.calculate_qparams()
+        self.assertEqual(scale, torch.tensor([0.125, 0.0625], dtype=torch.float32))
+        self.assertEqual(zero_point, torch.tensor([2, 3], dtype=torch.int64))
+
     def test_keepdim_per_axis(self):
         """Test keepdim option for per-axis quantization."""
         # Test with keepdim=False (default)

--- a/torchao/quantization/observer.py
+++ b/torchao/quantization/observer.py
@@ -224,15 +224,15 @@ class AffineQuantizedFixedQParamObserver(AffineQuantizedObserverBase):
             preserve_zero,
             zero_point_domain,
         )
-        if not scale:
+        if scale is None:
             scale = torch.Tensor([1])
-        if not zero_point:
+        if zero_point is None:
             zero_point = torch.zeros_like(scale)
         self.register_buffer("scale", scale.to(dtype=scale_dtype))
         self.register_buffer("zero_point", zero_point.to(dtype=zero_point_dtype))
 
     def set_qparams(self, scale, zero_point=None):
-        if not zero_point:
+        if zero_point is None:
             zero_point = torch.zeros_like(scale)
         self.scale = scale.to(dtype=self.scale_dtype)
         self.zero_point = zero_point.to(dtype=self.zero_point_dtype)


### PR DESCRIPTION
`AffineQuantizedFixedQParamObserver` evaluated optional `scale` and `zero_point` tensors with Python truthiness. Multi-element per-axis qparams therefore raised `RuntimeError: Boolean value of Tensor with more than one value is ambiguous` during construction, and explicit multi-element zero points failed in `set_qparams`.

Use explicit `is None` checks so default qparams are created only when arguments are omitted. Extend the fixed-observer test to cover constructor-supplied multi-element qparams, dtype conversion, explicit updates, and the existing omitted-zero-point behavior.

Tests:
- `pytest test/quantization/test_observer.py::TestQuantFlow::test_fixed_qparams_observer -q` (1 passed)
- `pytest test/quantization/test_observer.py -q` (9 passed)
- `ruff check torchao/quantization/observer.py test/quantization/test_observer.py` (passed)
- `ruff format --check torchao/quantization/observer.py test/quantization/test_observer.py` (2 files already formatted)
- `ruff check --isolated --select F821,F823,W191 && ruff check && ruff format --check` (passed; 739 files already formatted)
