### PR TITLE
Expose compile_backend for low-bit Adam optimizers

### DIFF
--- a/test/test_low_bit_optim.py
+++ b/test/test_low_bit_optim.py
@@ -7,6 +7,7 @@ import copy
 import shutil
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -249,6 +250,49 @@ class TestOptim(TestCase):
         loss.backward()
         optimizer.step()
         optimizer.zero_grad()
+
+    # issue #955: low-bit Adam optimizers should let users choose the
+    # torch.compile backend (e.g. aot_eager on MPS) instead of being locked
+    # to the default. these tests run on CPU and do not require MPS/CUDA.
+    @parametrize(
+        "optim_name",
+        ["Adam8bit", "AdamW8bit", "Adam4bit", "AdamW4bit", "AdamFp8", "AdamWFp8"],
+    )
+    def test_optim_accepts_compile_backend(self, optim_name):
+        # constructing with compile_backend must not raise (regression guard
+        # against the TypeError before compile_backend was exposed).
+        model = nn.Linear(4, 4)
+        getattr(optim, optim_name)(model.parameters(), compile_backend="aot_eager")
+
+    def _run_step_capturing_compile(self, **optim_kwargs):
+        # patch torch.compile with a fake that records the kwargs it receives
+        # and runs the function eagerly, so we can assert on forwarding without
+        # relying on a real compile backend.
+        model = nn.Linear(256, 32)  # weight (8192 elems) exercises the 8-bit path
+        optimizer = optim.Adam8bit(model.parameters(), **optim_kwargs)
+        model(torch.randn(8, 256)).sum().backward()
+
+        with patch("torch.compile", side_effect=lambda fn=None, **kw: fn) as mock:
+            optimizer.step()
+
+        assert mock.call_count > 0
+        return [call.kwargs for call in mock.call_args_list]
+
+    def test_optim_compile_backend_forwarded(self):
+        all_kwargs = self._run_step_capturing_compile(compile_backend="aot_eager")
+        for kwargs in all_kwargs:
+            assert kwargs.get("backend") == "aot_eager"
+            assert kwargs.get("fullgraph") is True
+            assert kwargs.get("dynamic") is False
+
+    def test_optim_compile_backend_default(self):
+        # when compile_backend is not provided, no backend kwarg is passed,
+        # preserving the original torch.compile behavior.
+        all_kwargs = self._run_step_capturing_compile()
+        for kwargs in all_kwargs:
+            assert "backend" not in kwargs
+            assert kwargs.get("fullgraph") is True
+            assert kwargs.get("dynamic") is False
 
     # aten.slice is required for dcp.load() when world size changes i.e. re-sharding
     # however, it's cumbersome to test it directly, since we would need to run distributed

--- a/torchao/optim/README.md
+++ b/torchao/optim/README.md
@@ -25,6 +25,14 @@ To use 4-bit Adam, replace the above with `Adam4bit`. Similarly for `AdamFp8`. Y
 
 **Other optimizers**: AdamW is also available as `AdamW8bit`, `AdamW4bit`, and `AdamWFp8`. Other optimizers can be added based on demand.
 
+**Choosing a `torch.compile` backend**: the low-bit Adam optimizers accept an optional `compile_backend` argument, which is forwarded to `torch.compile()` as its `backend`. This is useful when the default backend (`inductor`) is not available on your platform, e.g. on MPS:
+
+```python
+optim = Adam8bit(model.parameters(), compile_backend="aot_eager")
+```
+
+If `compile_backend` is not provided, the default `torch.compile()` behavior is unchanged.
+
 NOTE:
 - The low-bit optimizers require PyTorch >= 2.3
 - For FP8 optimizers on CUDA, PyTorch >= 2.4 and CUDA compute capability >= 8.9 are required.

--- a/torchao/optim/adam.py
+++ b/torchao/optim/adam.py
@@ -29,6 +29,7 @@ class _AdamBase(Optimizer):
         block_size,
         bf16_stochastic_round,
         is_adamw,
+        compile_backend=None,
     ) -> None:
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
@@ -49,6 +50,7 @@ class _AdamBase(Optimizer):
         self.block_size = block_size
         self.bf16_stochastic_round = bf16_stochastic_round
         self.is_adamw = is_adamw
+        self.compile_backend = compile_backend
 
     def add_param_group(self, param_group: dict) -> None:
         super().add_param_group(param_group)
@@ -139,7 +141,19 @@ class _AdamBase(Optimizer):
                     # https://github.com/pytorch/ao/issues/652#issuecomment-2285040894
                     # thus, by calling p.detach(), DTensor won't have .grad anymore, which is ok since we
                     # are passing grad separately anyway.
-                    torch.compile(single_param_adam, fullgraph=True, dynamic=False)(
+                    # only pass `backend` when explicitly set so the default
+                    # behavior (inductor) is preserved unchanged.
+                    compile_kwargs = (
+                        {}
+                        if self.compile_backend is None
+                        else {"backend": self.compile_backend}
+                    )
+                    torch.compile(
+                        single_param_adam,
+                        fullgraph=True,
+                        dynamic=False,
+                        **compile_kwargs,
+                    )(
                         p.detach(),
                         grad,
                         state["step"],
@@ -221,6 +235,7 @@ class Adam8bit(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -231,6 +246,7 @@ class Adam8bit(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=False,
         )
         torch._C._log_api_usage_once("torchao.optim.Adam8bit")
@@ -254,6 +270,7 @@ class Adam4bit(_AdamBase):
         *,
         block_size=128,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -264,6 +281,7 @@ class Adam4bit(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=False,
         )
         torch._C._log_api_usage_once("torchao.optim.Adam4bit")
@@ -287,6 +305,7 @@ class AdamFp8(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -297,6 +316,7 @@ class AdamFp8(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=False,
         )
         torch._C._log_api_usage_once("torchao.optim.AdamFp8")
@@ -318,6 +338,7 @@ class AdamW8bit(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -328,6 +349,7 @@ class AdamW8bit(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=True,
         )
         torch._C._log_api_usage_once("torchao.optim.AdamW8bit")
@@ -351,6 +373,7 @@ class AdamW4bit(_AdamBase):
         *,
         block_size=128,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -361,6 +384,7 @@ class AdamW4bit(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=True,
         )
         torch._C._log_api_usage_once("torchao.optim.AdamW4bit")
@@ -384,6 +408,7 @@ class AdamWFp8(_AdamBase):
         *,
         block_size=256,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         super().__init__(
             params,
@@ -394,6 +419,7 @@ class AdamWFp8(_AdamBase):
             amsgrad,
             block_size=block_size,
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=True,
         )
         torch._C._log_api_usage_once("torchao.optim.AdamWFp8")
@@ -414,6 +440,7 @@ class _AdamW(_AdamBase):
         amsgrad=False,
         *,
         bf16_stochastic_round=False,
+        compile_backend=None,
     ) -> None:
         """AdamW optimizer that supports quantized training (parameter is quantized). This optimizer should
         only be used with torchao's quantized training."""
@@ -426,5 +453,6 @@ class _AdamW(_AdamBase):
             amsgrad,
             block_size=float("inf"),
             bf16_stochastic_round=bf16_stochastic_round,
+            compile_backend=compile_backend,
             is_adamw=True,
         )


### PR DESCRIPTION
## What does this PR do?

This PR adds an optional `compile_backend` argument to torchao’s low-bit Adam optimizers. When provided, the value is forwarded to the internal `torch.compile` call as the `backend` argument. When it is not provided, the existing default behavior is preserved and no `backend` argument is passed.

## Why was this PR needed?

Issue #955 requests a way for torchao low-bit optimizers to expose the `backend` argument used by `torch.compile`. During investigation, I found that the shared `_AdamBase.step()` path calls `torch.compile(single_param_adam, fullgraph=True, dynamic=False)` directly, while the public optimizer constructors do not accept a backend option. This means users are locked into the default compile backend, which can be a problem on platforms such as MPS where an alternative backend like `aot_eager` may be needed.

## What changed?

- Added `compile_backend=None` to the low-bit Adam optimizer path in `torchao/optim/adam.py`
- Forwarded `compile_backend` through the public optimizer constructors:
  - `Adam8bit`
  - `AdamW8bit`
  - `Adam4bit`
  - `AdamW4bit`
  - `AdamFp8`
  - `AdamWFp8`
- Passed `backend=self.compile_backend` to `torch.compile` only when `compile_backend` is provided
- Added tests for constructor support, backend forwarding, and preserved default behavior
- Updated `torchao/optim/README.md` with a short usage note

## What are the relevant issue numbers?

Closes #955

## Testing

I ran the following checks locally:

```bash
ruff check --isolated --select F821,F823,W191
ruff check torchao/optim/adam.py test/test_low_bit_optim.py
ruff format --check torchao/optim/adam.py test/test_low_bit_optim.py
python -m pytest test/test_low_bit_optim.py -k "compile_backend or smoke" -q
python -m pytest test/test_low_bit_optim.py -q