### PR TITLE
Align weight dtype in DISABLED grad_input path under autocast

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -457,6 +457,37 @@ class TestFloat8Linear:
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
         )
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+    def test_autocast_backward_scaling_disabled(self):
+        # https://github.com/pytorch/ao/issues/4616 - under autocast the saved
+        # weight is still in the original high precision dtype while
+        # grad_output is in the autocast dtype, and the DISABLED backward path
+        # feeds both to the gemm without casting
+        device = torch.accelerator.current_accelerator()
+        disabled = CastConfig(scaling_type=ScalingType.DISABLED)
+        config = Float8LinearConfig(
+            cast_config_input=disabled,
+            cast_config_weight=disabled,
+            cast_config_grad_output=disabled,
+            cast_config_weight_for_grad_input=disabled,
+            cast_config_input_for_grad_weight=disabled,
+            cast_config_grad_output_for_grad_weight=disabled,
+        )
+        m_ref = nn.Linear(32, 32, bias=False, device=device)
+        m = Float8Linear.from_float(copy.deepcopy(m_ref), config=config)
+
+        x_ref = torch.randn(16, 32, device=device, requires_grad=True)
+        x = copy.deepcopy(x_ref)
+        with torch.autocast(str(device), dtype=torch.bfloat16):
+            y_ref = m_ref(x_ref)
+            y = m(x)
+        y_ref.sum().backward()
+        y.sum().backward()
+
+        # all casts are disabled, so this should match nn.Linear exactly
+        torch.testing.assert_close(x.grad, x_ref.grad, atol=0, rtol=0)
+        torch.testing.assert_close(m.weight.grad, m_ref.weight.grad, atol=0, rtol=0)
+
     def test_repr(self):
         m = nn.Linear(32, 16)
         config = Float8LinearConfig(

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -126,7 +126,12 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
             # TODO(future PR): var name is axiswise specific, fix it
             weight_t_maybe_fp8_dim0 = weight_hp_t
         elif c.cast_config_weight_for_grad_input.scaling_type is ScalingType.DISABLED:
-            weight_t_maybe_fp8_dim0 = weight_hp_t
+            # under autocast, `grad_output` is in the autocast dtype but the saved
+            # weight is still in the original high precision dtype, and `torch.mm`
+            # in backward does not autocast. Align the dtypes here.
+            weight_t_maybe_fp8_dim0 = weight_hp_t.to(
+                grad_output_reshaped_maybe_fp8_dim0.dtype
+            )
         else:
             weight_t_maybe_fp8_dim0 = hp_tensor_to_float8_dynamic(
                 weight_hp_t,


### PR DESCRIPTION
Fixes #4616

`Float8Linear.forward` casts only the input to the autocast dtype, so `ctx.save_for_backward` holds a (bf16 input, fp32 weight) pair. The forward gemm gets away with this because autocast is still active there and `torch.mm` is autocast-eligible, but backward runs with autocast off, so the `ScalingType.DISABLED` branch for `cast_config_weight_for_grad_input` hands the raw fp32 weight to `torch.mm` against a bf16 `grad_output` and raises `expected mat1 and mat2 to have the same dtype`.

Cast the saved weight to the dtype of the grad_output tensor it is multiplied against. No-op without autocast, since both are already fp32. The `grad_weight` gemm is unaffected, `input_hp` was already cast to the autocast dtype in forward.

Verified on 1x A40 (sm_86), torch 2.13.0+cu126:

- Reproduced the crash at `float8_linear.py:143`, both with the issue's config plus `emulate=True` and with all six cast configs set to `DISABLED`. Both pass after the change.
- New test `TestFloat8Linear::test_autocast_backward_scaling_disabled` fails before the change with the reported `RuntimeError` and passes after. It uses the all-DISABLED config so it needs no fp8 hardware, and asserts both gradients match a plain `nn.Linear` reference bitwise under the same autocast.
- `pytest test/float8/test_base.py` 66 passed, 60 skipped. `pytest test/float8/` minus the distributed modules, 95 passed, 76 skipped. Ruff lint and format clean.

Not verified: sm_86 cannot run `torch._scaled_mm`, so the real fp8 path (DYNAMIC forward with DISABLED `weight_for_grad_input`, `emulate=False`) was not executed, and neither were the FSDP/DTensor tests. `Float8TrainingTensor.dtype` is `_orig_dtype`, so the new `.to()` is well defined on that path, but it was not run on hardware. Only bf16 autocast was tested, not fp16.

Thanks to @TangSiLiYang for the report and the diagnosis, which pinned the exact line and the correct fix.