### PR TITLE
ci: lint on Python 3.11 so setup-python hits the tool cache

### DIFF
--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
     steps:
     - name: Extract PR info
       if: github.event_name == 'workflow_dispatch'

--- a/test/test_ruff_linter_workflow.py
+++ b/test/test_ruff_linter_workflow.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "ruff_linter.yml"
+
+# Python versions preinstalled in the ubuntu-latest (24.04) runner tool cache, see
+# https://github.com/actions/runner-images/blob/main/images/ubuntu/toolsets/toolset-2404.json
+# Asking setup-python for any other version makes the job download an interpreter
+# through the GitHub API before it can lint, which is a network dependency the
+# lint job does not need.
+UBUNTU_LATEST_TOOLCACHE_PYTHONS = {"3.10", "3.11", "3.12", "3.13", "3.14"}
+
+
+class TestRuffLinterWorkflow(unittest.TestCase):
+    def test_python_version_is_preinstalled_on_runner(self):
+        job = yaml.safe_load(WORKFLOW.read_text())["jobs"]["build"]
+        self.assertEqual(job["runs-on"], "ubuntu-latest")
+        for version in job["strategy"]["matrix"]["python-version"]:
+            self.assertIn(version, UBUNTU_LATEST_TOOLCACHE_PYTHONS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #4656

`ruff_linter.yml` runs on `ubuntu-latest`, which is now Ubuntu 24.04. That image's tool cache ships Python 3.10 through 3.14 only, so `python-version: ["3.9"]` misses the cache on every run and `setup-python` falls through to `tc.getManifestFromRepo(...)`, which fetches `https://api.github.com/repos/actions/python-versions/git/trees/main` and downloads an interpreter. A lint job that needs no network is gated on a GitHub API round trip, and when that request stalls the job dies in `Set up Python 3.9` before Ruff runs.

Switched the matrix to 3.11, which is in the tool cache and is what `doc_build.yml` already uses for its `ubuntu-latest` job. The step now resolves from disk and makes no network calls.

Added `test/test_ruff_linter_workflow.py` asserting the matrix version is one the runner preinstalls.

Verified:

- Ran `actions/setup-python@v3`'s `dist/setup/index.js` locally under node 20, against a tool cache mirroring ubuntu-24.04, with `https_proxy` pointed at a socket that accepts and never replies. With `3.9` it logs `Version 3.9 was not found in the local cache` (the line from the issue) and then hangs on api.github.com. With `3.11`, same blocked network, it logs `Found tool in cache Python 3.11.15 x64` and exits 0 in under a second.
- `ruff==0.11.6` under 3.9.25 and 3.11.15 gives byte-identical output for all three commands in `Regular lint check`. Expected, since `ruff.toml` sets no `target-version` and Ruff never inspects the running interpreter.
- New test fails on the old workflow, passes on the new one. Full `ruff check` / `ruff format --check` / copyright header check pass on the changed tree.

Not verified: I could not read the real job log (`/actions/runs/.../logs` is admin-only), so the exact error string comes from the issue report, not from anything I read. The step failed in 5 seconds, which does not match the http client's 3-minute default socket timeout, so the proximate error may have been a connect or API error rather than a timeout. Either way it is a network failure that only occurs because 3.9 forces a download. I also have no way to run the patched workflow on a real GitHub runner; the tool cache contents come from `actions/runner-images`' `toolset-2404.json`.

Worth knowing: this is rare. Of the last ~500 runs of this workflow, exactly one failed in `Set up Python`; every other failure was a real lint failure. This removes an unnecessary network dependency rather than fixing constant breakage.

Two adjacent things left alone: `trymerge.yml` requests 3.8 on `ubuntu-latest` and has the same problem, and `ruff_linter.yml` still pins `setup-python@v3` (a Node 16 action). Bumping the action does not help here, since v5 also downloads on a cache miss.

Thanks to @github-actions[bot] for the report, which pinpointed the failing step.