### PR TITLE
feat(optim): add COAT FP8 optimizer with dynamic range expansion

### DIFF
--- a/benchmarks/benchmark_low_bit_adam.py
+++ b/benchmarks/benchmark_low_bit_adam.py
@@ -60,6 +60,7 @@ OPTIM_MAP = dict(
     AdamW8bitBnb=bnb.optim.AdamW8bit,
     AdamW8bitAo=optim.AdamW8bit,
     AdamWFp8Ao=optim.AdamWFp8,
+    CoatAdamWAo=optim.CoatAdamW,
     AdamW4bitAo=optim.AdamW4bit,
 )
 

--- a/test/test_low_bit_optim.py
+++ b/test/test_low_bit_optim.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import copy
+import math
 import shutil
 import tempfile
 from pathlib import Path
@@ -39,6 +40,7 @@ from torchao.optim.quant_utils import (
 from torchao.optim.subclass_4bit import OptimState4bit
 from torchao.optim.subclass_8bit import OptimState8bit
 from torchao.optim.subclass_fp8 import OptimStateFp8
+from torchao.optim.subclass_fp8_coat import OptimStateFp8Coat
 from torchao.testing.utils import skip_if_rocm
 from torchao.utils import (
     get_available_devices,
@@ -59,9 +61,70 @@ if torch.version.hip is not None:
     pytest.skip("Skipping the test in ROCm", allow_module_level=True)
 
 _DEVICES = get_available_devices()
+_FP8_OPTIM_NAMES = {"AdamFp8", "AdamWFp8", "CoatAdam", "CoatAdamW"}
+_OPTIM_STATE_SUBCLASSES = (
+    OptimState4bit,
+    OptimState8bit,
+    OptimStateFp8,
+    OptimStateFp8Coat,
+)
+_FP8_OPTIM_STATE_SUBCLASSES = (OptimStateFp8, OptimStateFp8Coat)
 
 
 class TestQuantize(TestCase):
+    @parametrize("device", _DEVICES)
+    def test_quantize_fp8_coat_expansion_matches_reference(self, device):
+        block_size = 256
+        x = torch.linspace(1, 4, block_size, device=device)
+        coat = OptimStateFp8Coat.zeros(x.shape, block_size, device)
+        coat.copy_(x)
+
+        ratio_upper_bound = torch.finfo(torch.float8_e4m3fn).max**2 / 2
+        expected = (
+            math.floor(math.log2(ratio_upper_bound) / math.log2(4) * 16) / 16
+        )
+        torch.testing.assert_close(
+            coat.expansion, coat.expansion.new_tensor([expected])
+        )
+        torch.testing.assert_close(
+            coat.sqrt_minmax, coat.sqrt_minmax.new_tensor([2])
+        )
+
+    @parametrize("block_size", [128, 256])
+    @parametrize("device", _DEVICES)
+    def test_quantize_fp8_coat_roundtrip(self, block_size, device):
+        magnitudes = torch.linspace(0.75, 1.25, block_size, device=device)
+        signs = torch.where(
+            torch.arange(block_size, device=device) % 2 == 0, 1.0, -1.0
+        )
+        x = (magnitudes * signs).repeat(16)
+
+        plain = OptimStateFp8.zeros(x.shape, block_size, device)
+        plain.copy_(x)
+        coat = OptimStateFp8Coat.zeros(x.shape, block_size, device)
+        coat.copy_(x)
+
+        plain_mse = (plain.dequantize() - x).square().mean()
+        coat_mse = (coat.dequantize() - x).square().mean()
+        self.assertLess(coat_mse, plain_mse)
+
+    @parametrize("device", _DEVICES)
+    def test_quantize_fp8_coat_edge_cases(self, device):
+        x = torch.cat(
+            (
+                torch.zeros(256, device=device),
+                torch.ones(256, device=device),
+                torch.cat(
+                    (torch.zeros(255, device=device), torch.ones(1, device=device))
+                ),
+            )
+        )
+        coat = OptimStateFp8Coat.zeros(x.shape, 256, device)
+        coat.copy_(x)
+
+        self.assertTrue(torch.isfinite(coat.dequantize()).all())
+        torch.testing.assert_close(coat.dequantize(), x)
+
     @parametrize("device", _DEVICES)
     def test_quantize_8bit_with_qmap_correctness(self, device):
         x = torch.rand(32, 1024, device=device)
@@ -162,13 +225,22 @@ class TestQuantize(TestCase):
 class TestOptim(TestCase):
     @parametrize(
         "optim_name",
-        ["Adam8bit", "AdamW8bit", "Adam4bit", "AdamW4bit", "AdamFp8", "AdamWFp8"],
+        [
+            "Adam8bit",
+            "AdamW8bit",
+            "Adam4bit",
+            "AdamW4bit",
+            "AdamFp8",
+            "AdamWFp8",
+            "CoatAdam",
+            "CoatAdamW",
+        ],
     )
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize("device", _DEVICES)
     @skip_if_rocm("ROCm enablement in progress")
     def test_optim_smoke(self, optim_name, dtype, device):
-        if optim_name.endswith("Fp8") and device == "cuda":
+        if optim_name in _FP8_OPTIM_NAMES and device == "cuda":
             if torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -205,10 +277,10 @@ class TestOptim(TestCase):
         for p1, p2 in zip(model.parameters(), model2.parameters()):
             torch.testing.assert_close(p2, p1)
 
-    @parametrize("optim_name", ["Adam8bit", "Adam4bit", "AdamFp8"])
+    @parametrize("optim_name", ["Adam8bit", "Adam4bit", "AdamFp8", "CoatAdam"])
     @parametrize("device", _DEVICES)
     def test_optim_default_dtype_bf16(self, optim_name, device):
-        if optim_name.endswith("Fp8") and device == "cuda":
+        if optim_name in _FP8_OPTIM_NAMES and device == "cuda":
             if torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -229,10 +301,10 @@ class TestOptim(TestCase):
         finally:
             torch.set_default_dtype(old_dtype)
 
-    @parametrize("optim_name", ["Adam8bit", "Adam4bit", "AdamFp8"])
+    @parametrize("optim_name", ["Adam8bit", "Adam4bit", "AdamFp8", "CoatAdam"])
     @parametrize("device", _DEVICES)
     def test_param_groups(self, optim_name, device):
-        if optim_name.endswith("Fp8") and device == "cuda":
+        if optim_name in _FP8_OPTIM_NAMES and device == "cuda":
             if torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -255,11 +327,11 @@ class TestOptim(TestCase):
     # test 2 times with different world size, and persist checkpoint across the 2 runs.
     # thus, we only test for the required op. note that future implementations of dcp.load()
     # may use other ops.
-    @parametrize("subclass", [OptimState4bit, OptimState8bit, OptimStateFp8])
+    @parametrize("subclass", _OPTIM_STATE_SUBCLASSES)
     @parametrize("shape", [(4096,), (256, 256)])
     @parametrize("device", _DEVICES)
     def test_subclass_slice(self, subclass, shape, device):
-        if subclass == OptimStateFp8:
+        if subclass in _FP8_OPTIM_STATE_SUBCLASSES:
             if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
                 pytest.skip("FP8 CUDA requires compute capability >= 8.9")
 
@@ -274,7 +346,7 @@ class TestOptim(TestCase):
             tensor[offset : offset * 2].dequantize(),
         )
 
-    @parametrize("subclass", [OptimState4bit, OptimState8bit, OptimStateFp8])
+    @parametrize("subclass", _OPTIM_STATE_SUBCLASSES)
     @parametrize("device", _DEVICES)
     def test_subclass_appearance_dtype(self, subclass, device):
         shape = (1024,)
@@ -299,6 +371,26 @@ class TestOptim(TestCase):
         # direct BF16 creation
         tensor_bf16 = subclass.zeros(shape, device=device, dtype=torch.bfloat16)
         self.assertEqual(tensor_bf16.dtype, torch.bfloat16)
+
+    @parametrize("device", _DEVICES)
+    def test_coat_adamw_correctness(self, device):
+        if device == "cuda" and torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("FP8 CUDA requires compute capability >= 8.9")
+
+        torch.manual_seed(42)
+        p_ref = torch.randn(4096, device=device, requires_grad=True)
+        p_coat = p_ref.detach().clone().requires_grad_()
+        optim_ref = torch.optim.AdamW([p_ref], lr=1e-3)
+        optim_coat = optim.CoatAdamW([p_coat], lr=1e-3)
+
+        for _ in range(5):
+            grad = torch.randn_like(p_ref)
+            p_ref.grad = grad
+            p_coat.grad = grad.clone()
+            optim_ref.step()
+            optim_coat.step()
+
+        torch.testing.assert_close(p_coat, p_ref, rtol=2e-2, atol=2e-3)
 
     @pytest.mark.skipif(bnb is None, reason="bitsandbytes is not available")
     @pytest.mark.skipif(
@@ -543,6 +635,7 @@ class TestFSDP2(FSDPTest):
         ]
         if torch.cuda.get_device_capability() >= (8, 9):
             args_list.append((optim.AdamWFp8, OffloadPolicy))
+            args_list.append((optim.CoatAdamW, OffloadPolicy))
 
         self.run_subtests(
             {"args": args_list},
@@ -631,7 +724,7 @@ class TestFSDP2(FSDPTest):
         if dist.get_rank() == 0:
             shutil.rmtree(checkpoint_id)
 
-        subclasses = (OptimState4bit, OptimState8bit, OptimStateFp8)
+        subclasses = _OPTIM_STATE_SUBCLASSES
 
         for v1, v2 in zip(
             pytree.tree_iter(resumed_fsdp_optim.state_dict()),

--- a/torchao/optim/README.md
+++ b/torchao/optim/README.md
@@ -5,6 +5,7 @@ This module implements:
 - 8-bit optimizers as outlined in https://arxiv.org/abs/2110.02861
 - 4-bit optimizers as outlined in https://arxiv.org/abs/2309.01507
 - FP8 optimizers using the native `torch.float8_e4m3fn` dtype (experimental)
+- COAT FP8 optimizers with Dynamic Range Expansion (experimental)
 - Stochastic rounding for BF16 weight (https://arxiv.org/abs/2010.06192, experimental)
 - CPU offload optimizers for single GPU training
 
@@ -21,14 +22,22 @@ model = ...
 optim = Adam8bit(model.parameters())
 ```
 
-To use 4-bit Adam, replace the above with `Adam4bit`. Similarly for `AdamFp8`. You can also change quantization block size by passing `block_size=value` to the optimizer. By default, block size is 256 for 8-bit and FP8 optimizers, and 128 for 4-bit optimizers.
+To use 4-bit Adam, replace the above with `Adam4bit`. Similarly for `AdamFp8`.
+`CoatAdam` adds [COAT Dynamic Range Expansion](https://arxiv.org/abs/2410.19313)
+to make better use of FP8's representable range for optimizer states. You can also
+change quantization block size by passing `block_size=value` to the optimizer. By
+default, block size is 256 for 8-bit and FP8 optimizers, and 128 for 4-bit optimizers.
 
-**Other optimizers**: AdamW is also available as `AdamW8bit`, `AdamW4bit`, and `AdamWFp8`. Other optimizers can be added based on demand.
+**Other optimizers**: AdamW is also available as `AdamW8bit`, `AdamW4bit`,
+`AdamWFp8`, and `CoatAdamW`. Other optimizers can be added based on demand.
 
 NOTE:
 - The low-bit optimizers require PyTorch >= 2.3
 - For FP8 optimizers on CUDA, PyTorch >= 2.4 and CUDA compute capability >= 8.9 are required.
 - For 4-bit optimizers, we don't implement rank-1 normalization for quantizing 2nd moment as originally done in the paper.
+
+The benchmark script accepts `--optim CoatAdamWAo` to measure COAT accuracy,
+throughput, and peak memory alongside the other AdamW implementations.
 
 ## Benchmarks
 
@@ -153,4 +162,5 @@ Credits to
 
 - Tim Dettmers for creating the wonderful [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) library.
 - [lpmm](https://github.com/thu-ml/low-bit-optimizers) authors for their work on 4-bit optimizers.
+- [NVlabs/COAT](https://github.com/NVlabs/COAT) authors for Dynamic Range Expansion.
 - [DeepSpeed](https://github.com/microsoft/DeepSpeed) team for [ZeRO-Offload](https://arxiv.org/abs/2101.06840).

--- a/torchao/optim/__init__.py
+++ b/torchao/optim/__init__.py
@@ -1,4 +1,14 @@
-from .adam import Adam4bit, Adam8bit, AdamFp8, AdamW4bit, AdamW8bit, AdamWFp8, _AdamW
+from .adam import (
+    Adam4bit,
+    Adam8bit,
+    AdamFp8,
+    AdamW4bit,
+    AdamW8bit,
+    AdamWFp8,
+    CoatAdam,
+    CoatAdamW,
+    _AdamW,
+)
 from .cpu_offload import CPUOffloadOptimizer
 
 __all__ = [
@@ -8,6 +18,8 @@ __all__ = [
     "AdamW4bit",
     "AdamW8bit",
     "AdamWFp8",
+    "CoatAdam",
+    "CoatAdamW",
     "_AdamW",
     "CPUOffloadOptimizer",
 ]

--- a/torchao/optim/adam.py
+++ b/torchao/optim/adam.py
@@ -14,6 +14,7 @@ from .quant_utils import _fp32_to_bf16_sr
 from .subclass_4bit import OptimState4bit
 from .subclass_8bit import OptimState8bit
 from .subclass_fp8 import OptimStateFp8
+from .subclass_fp8_coat import OptimStateFp8Coat
 
 
 class _AdamBase(Optimizer):
@@ -306,6 +307,39 @@ class AdamFp8(_AdamBase):
         return OptimStateFp8.zeros(p.shape, block_size, p.device, dtype=p.dtype)
 
 
+class CoatAdam(_AdamBase):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=0,
+        amsgrad=False,
+        *,
+        block_size=256,
+        bf16_stochastic_round=False,
+    ) -> None:
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=False,
+        )
+        torch._C._log_api_usage_once("torchao.optim.CoatAdam")
+
+    @staticmethod
+    def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
+        return OptimStateFp8Coat.zeros(
+            p.shape, block_size, p.device, dtype=p.dtype
+        )
+
+
 class AdamW8bit(_AdamBase):
     def __init__(
         self,
@@ -401,6 +435,39 @@ class AdamWFp8(_AdamBase):
     @staticmethod
     def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
         return OptimStateFp8.zeros(p.shape, block_size, p.device, dtype=p.dtype)
+
+
+class CoatAdamW(_AdamBase):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        weight_decay=1e-2,
+        amsgrad=False,
+        *,
+        block_size=256,
+        bf16_stochastic_round=False,
+    ) -> None:
+        super().__init__(
+            params,
+            lr,
+            betas,
+            eps,
+            weight_decay,
+            amsgrad,
+            block_size=block_size,
+            bf16_stochastic_round=bf16_stochastic_round,
+            is_adamw=True,
+        )
+        torch._C._log_api_usage_once("torchao.optim.CoatAdamW")
+
+    @staticmethod
+    def _subclass_zeros(p: Tensor, signed: bool, block_size: int):
+        return OptimStateFp8Coat.zeros(
+            p.shape, block_size, p.device, dtype=p.dtype
+        )
 
 
 class _AdamW(_AdamBase):

--- a/torchao/optim/subclass_fp8_coat.py
+++ b/torchao/optim/subclass_fp8_coat.py
@@ -1,0 +1,261 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+import math
+
+import torch
+from torch import Tensor
+from torch.serialization import add_safe_globals
+from torch.utils._python_dispatch import return_and_correct_aliasing
+
+from torchao.utils import TorchAOBaseTensor, torch_version_at_least
+
+aten = torch.ops.aten
+c10d_functional = torch.ops.c10d_functional
+_c10d_functional = torch.ops._c10d_functional
+
+DTYPE = torch.float8_e4m3fn
+_EXPANSION_STEP = 16
+_QUANT_MIN_VAL = 1e-30
+
+
+def quantize_fp8_coat(input: Tensor, block_size: int):
+    """Quantize optimizer state with COAT Dynamic Range Expansion.
+
+    COAT applies a sign-preserving power transform to each block before FP8
+    quantization. ``sqrt_minmax`` recenters the block around one to avoid
+    overflow/underflow while applying the power. Zeros are excluded when
+    finding the minimum magnitude, as in the reference CUDA kernel.
+    """
+    shape = input.shape
+    input = input.float().view(-1, block_size)
+    abs_input = input.abs()
+
+    block_max = abs_input.amax(-1)
+    block_min = torch.where(abs_input > 0, abs_input, torch.inf).amin(-1)
+    block_min = torch.where(torch.isfinite(block_min), block_min, block_max)
+
+    block_max = block_max + _QUANT_MIN_VAL
+    block_min = block_min + _QUANT_MIN_VAL
+    sqrt_minmax = block_max.sqrt() * block_min.sqrt()
+    ratio = block_max / block_min
+
+    ratio_upper_bound = torch.finfo(DTYPE).max**2 / 2
+    expansion = torch.floor(
+        math.log2(ratio_upper_bound) / torch.log2(ratio) * _EXPANSION_STEP
+    ) / _EXPANSION_STEP
+    # A constant (including all-zero) block already round-trips exactly, and
+    # log2(1) would otherwise produce an infinite exponent.
+    expansion = torch.where(ratio > 1, expansion, torch.ones_like(expansion))
+    expansion = expansion.nan_to_num(
+        nan=1.0,
+        posinf=1.0,
+        neginf=1 / _EXPANSION_STEP,
+    ).clamp(min=1 / _EXPANSION_STEP)
+
+    expanded = input.sign() * (abs_input / sqrt_minmax.view(-1, 1)).pow(
+        expansion.view(-1, 1)
+    )
+    scale = expanded.abs().amax(-1).clip(1e-12) / torch.finfo(DTYPE).max
+    codes = (expanded / scale.view(-1, 1)).to(DTYPE).view(shape)
+    return codes, scale, expansion, sqrt_minmax
+
+
+class OptimStateFp8Coat(TorchAOBaseTensor):
+    """FP8 optimizer state using COAT Dynamic Range Expansion."""
+
+    tensor_attrs = ["codes", "scale", "expansion", "sqrt_minmax"]
+
+    @staticmethod
+    def __new__(
+        cls,
+        codes: Tensor,
+        scale: Tensor,
+        expansion: Tensor,
+        sqrt_minmax: Tensor,
+        dtype: torch.dtype | None = None,
+    ):
+        return Tensor._make_wrapper_subclass(
+            cls, codes.shape, device=codes.device, dtype=dtype
+        )
+
+    def __init__(
+        self,
+        codes: Tensor,
+        scale: Tensor,
+        expansion: Tensor,
+        sqrt_minmax: Tensor,
+        dtype: torch.dtype | None = None,
+    ):
+        assert codes.dtype is DTYPE
+        assert scale.ndim == expansion.ndim == sqrt_minmax.ndim == 1
+        assert scale.shape == expansion.shape == sqrt_minmax.shape
+        self.codes = codes
+        self.scale = scale
+        self.expansion = expansion
+        self.sqrt_minmax = sqrt_minmax
+        self.block_size = codes.numel() // scale.numel()
+
+    def __tensor_flatten__(self):
+        return self.tensor_attrs, [self.dtype]
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size=None, outer_stride=None
+    ):
+        return cls(
+            *[tensor_data_dict[name] for name in cls.tensor_attrs], *tensor_attributes
+        )
+
+    def dequantize(self, output_dtype=None):
+        float_data = self.codes.float().view(-1, self.block_size)
+        float_data = float_data * self.scale.view(-1, 1)
+        float_data = float_data.sign() * float_data.abs().pow(
+            self.expansion.reciprocal().view(-1, 1)
+        )
+        float_data = float_data * self.sqrt_minmax.view(-1, 1)
+
+        if output_dtype is not None:
+            float_data = float_data.to(output_dtype)
+        return float_data.view(self.codes.shape)
+
+    @classmethod
+    def zeros(
+        cls,
+        shape,
+        block_size: int = 256,
+        device: torch.types.Device = None,
+        dtype: torch.dtype | None = None,
+    ):
+        codes = torch.zeros(shape, dtype=DTYPE, device=device)
+        metadata_shape = (codes.numel() // block_size,)
+        scale = torch.zeros(metadata_shape, device=device)
+        expansion = torch.ones(metadata_shape, device=device)
+        sqrt_minmax = torch.ones(metadata_shape, device=device)
+        return cls(codes, scale, expansion, sqrt_minmax, dtype=dtype)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(block_size={self.block_size}, "
+            f"shape={tuple(self.shape)}, dtype={self.dtype}, device={self.device}, "
+            f"requires_grad={self.requires_grad})"
+        )
+
+
+@OptimStateFp8Coat.implements(aten.copy_.default)
+def _(func, types, args, kwargs):
+    dst = args[0]
+    src = args[1]
+
+    if isinstance(dst, OptimStateFp8Coat) and isinstance(src, OptimStateFp8Coat):
+        assert dst.block_size == src.block_size
+        for attr in OptimStateFp8Coat.tensor_attrs:
+            getattr(dst, attr).copy_(getattr(src, attr))
+    elif isinstance(dst, OptimStateFp8Coat):
+        values = quantize_fp8_coat(src, dst.block_size)
+        for attr, value in zip(OptimStateFp8Coat.tensor_attrs, values):
+            getattr(dst, attr).copy_(value)
+    else:
+        dst.copy_(src.dequantize())
+
+    return dst
+
+
+@OptimStateFp8Coat.implements(aten._to_copy.default)
+def _(func, types, args, kwargs):
+    dtype = kwargs.get("dtype", args[0].dtype)
+    device = kwargs.get("device", None)
+    out = OptimStateFp8Coat(
+        *[
+            getattr(args[0], attr).to(device=device)
+            for attr in OptimStateFp8Coat.tensor_attrs
+        ],
+        dtype=dtype,
+    )
+    return return_and_correct_aliasing(func, args, kwargs, out)
+
+
+@OptimStateFp8Coat.implements(aten.lerp.Scalar)
+def _(func, types, args, kwargs):
+    args = [x.dequantize() if isinstance(x, OptimStateFp8Coat) else x for x in args]
+    return func(*args, **kwargs)
+
+
+@OptimStateFp8Coat.implements(aten.view.default)
+def _(func, types, args, kwargs):
+    x, shape = args
+    return OptimStateFp8Coat(
+        x.codes.view(shape),
+        x.scale,
+        x.expansion,
+        x.sqrt_minmax,
+        dtype=x.dtype,
+    )
+
+
+_optim_state_fp8_coat_c10d_ops = [
+    c10d_functional.all_gather_into_tensor.default,
+    _c10d_functional.all_gather_into_tensor.default,
+    c10d_functional.wait_tensor.default,
+    _c10d_functional.wait_tensor.default,
+    aten.detach.default,
+]
+if torch_version_at_least("2.11.0.dev"):
+    _optim_state_fp8_coat_c10d_ops.append(
+        _c10d_functional._wrap_tensor_autograd.default
+    )
+
+
+@OptimStateFp8Coat.implements(_optim_state_fp8_coat_c10d_ops)
+def _(func, types, args, kwargs):
+    x = args[0]
+    if not isinstance(x, OptimStateFp8Coat):
+        raise ValueError(f"expecting a OptimStateFp8Coat but found {type(x)}")
+    return OptimStateFp8Coat(
+        *[
+            func(getattr(x, attr), *args[1:], **kwargs)
+            for attr in OptimStateFp8Coat.tensor_attrs
+        ],
+        dtype=x.dtype,
+    )
+
+
+@OptimStateFp8Coat.implements(aten.is_pinned.default)
+def _(func, types, args, kwargs):
+    return all(getattr(args[0], attr).is_pinned() for attr in args[0].tensor_attrs)
+
+
+@OptimStateFp8Coat.implements(aten.slice.Tensor)
+def _(func, types, args, kwargs):
+    x, dim, start, end = args[:4]
+    step = args[4] if len(args) > 4 else 1
+
+    if dim != 0:
+        raise ValueError("Only support aten.slice along the first dim")
+    if step != 1:
+        raise ValueError("Only support aten.slice with step=1")
+
+    block_size = x.block_size
+    stride = math.prod(x.shape[1:])
+    if (start * stride) % block_size != 0 or (end * stride) % block_size != 0:
+        raise ValueError(
+            f"Invalid start or end for shape={x.shape} and block_size={block_size}. "
+            "Make sure start and end align with block boundary. "
+            f"Received start={start}, end={end}."
+        )
+
+    metadata_slice = slice(
+        start * stride // block_size, end * stride // block_size
+    )
+    return OptimStateFp8Coat(
+        x.codes[start:end],
+        x.scale[metadata_slice],
+        x.expansion[metadata_slice],
+        x.sqrt_minmax[metadata_slice],
+        dtype=x.dtype,
+    )
+
+
+add_safe_globals([OptimStateFp8Coat])


### PR DESCRIPTION
## COAT FP8 Optimizer Implementation

Implemented COAT-style FP8 optimizer states for `torchao` using Dynamic Range Expansion (DRE), based on the official NVlabs COAT implementation and paper.

### Changes

- Added `OptimStateFp8Coat`, a tensor subclass that stores:
  - FP8 E4M3 codes
  - Per-block quantization scales
  - Dynamic expansion exponents
  - Geometric-center values used for stable expansion
- Implemented COAT quantization and dequantization:
  - Ignores zeros when calculating the minimum magnitude
  - Recenters each block using `sqrt(min * max)`
  - Calculates expansion exponents in 1/16 increments
  - Safely handles constant and all-zero blocks
- Added the public `CoatAdam` and `CoatAdamW` optimizers.
- Added serialization, device transfer, slicing, DTensor/FSDP, and distributed checkpoint support.
- Exported the new optimizers through `torchao.optim`.
- Added `CoatAdamW` to the low-bit optimizer benchmark.
- Updated the optimizer documentation with usage information and COAT references.

### Tests

Added coverage for:

- Agreement with the official COAT expansion formula
- FP8 round-trip quantization accuracy
- Improvement over ordinary FP8 on narrow-range tensors
- Constant and all-zero edge cases
- Optimizer correctness compared with `torch.optim.AdamW`
- Save/load serialization
- Appearance dtype and device transfers
- Tensor slicing and distributed checkpoint compatibility
- FSDP optimizer-state handling

Local validation confirmed full-graph tracing, serialization, numerical edge cases, and close agreement with AdamW over multiple optimizer steps.

### Environment limitation

Full CUDA FP8 benchmarking was not run locally because the available GTX 1660 has compute capability 7.5, while CUDA FP8 requires compute capability 8.9 or newer.