### PR TITLE
[Bug Fix] Fix typo: ZeroPointDomain class compared instead of variable in utils.py

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -696,6 +696,19 @@ class TestQuantPrimitives(unittest.TestCase):
 
             self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
 
+    def test_groupwise_affine_quantize_tensor_from_qparams_none_domain(self):
+        """Regression test: ZeroPointDomain.NONE was unreachable due to typo (uppercase Z)."""
+        input = torch.randn(10, 256)
+        scales = torch.randn(10, 2)
+        zeros = torch.zeros(10, 2)
+        n_bit = 4
+        groupsize = 128
+
+        w_int4x8 = groupwise_affine_quantize_tensor_from_qparams(
+            input, scales, zeros, n_bit, groupsize, ZeroPointDomain.NONE,
+        )
+        self.assertEqual(w_int4x8.shape[-1], input.shape[-1])
+
     def test_groupwise_affine_dequantize_tensor_from_qparams(self):
         input = torch.randint(0, 15, (10, 256), dtype=torch.int32)
         scales = torch.randn(10, 2).bfloat16()

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -444,7 +444,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
         _quantize_affine = quantize_affine
     elif zero_point_domain == ZeroPointDomain.FLOAT:
         _quantize_affine = _quantize_affine_tinygemm
-    elif ZeroPointDomain == ZeroPointDomain.NONE:
+    elif zero_point_domain == ZeroPointDomain.NONE:
         _quantize_affine = _quantize_affine_no_zero_point
     else:
         raise ValueError(f"Unrecognized zero point domain: {zero_point_domain}")


### PR DESCRIPTION
## Summary

Fixes #4693
Found a one-character typo in `torchao/quantization/utils.py` at line 447.

In `groupwise_affine_quantize_tensor_from_qparams`, the `ZeroPointDomain.NONE` case is broken because the code compares the **class** (`ZeroPointDomain`, uppercase Z) instead of the **variable** (`zero_point_domain`, lowercase z).

```python
if zero_point_domain == ZeroPointDomain.INT:       # correct (variable)
elif zero_point_domain == ZeroPointDomain.FLOAT:   # correct (variable)
elif ZeroPointDomain == ZeroPointDomain.NONE:      # BUG (class, not variable)
```

Since an enum class is never equal to one of its members, this is always False. Passing `zero_point_domain=ZeroPointDomain.NONE` raises `ValueError` instead of using `_quantize_affine_no_zero_point`.

## Fix

```diff
- elif ZeroPointDomain == ZeroPointDomain.NONE:
+ elif zero_point_domain == ZeroPointDomain.NONE:
```

## Test plan

- [x] Added regression test for `ZeroPointDomain.NONE` — passes
- [x] Existing tests still pass
- [x] Verified the comparison behavior

Fixes #4693