### PR TITLE
[ROCm][CI] Switch ROCm CI runner label from gfx942 to ecosystem.mi350

### DIFF
--- a/.github/workflows/regression_test_pt2e_gpu.yml
+++ b/.github/workflows/regression_test_pt2e_gpu.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         include:
           - name: ROCM Nightly
-            runs-on: linux.rocm.gpu.gfx942.1
+            runs-on: linux.rocm.gpu.ecosystem.mi350.1
             torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2'
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.2"


### PR DESCRIPTION
This PR replaces gfx942 label with ecosystem.mi350 label as the linux.rocm.gpu.gfx942.1 label is a retired runner label.