### PR TITLE
Fix float8 zero scale quantization

### DIFF
--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -193,6 +193,19 @@ class ToyLoRAModel(torch.nn.Module):
 
 
 # TODO: move tests in test_affine_quantized_float.py here after we migrated all implementations
+class TestFloat8TensorCPU(common_utils.TestCase):
+    @common_utils.parametrize("granularity", [PerTensor(), PerRow()])
+    def test_zero_tensor_quantizes_to_finite_zero(self, granularity):
+        x = torch.zeros(2, 4, dtype=torch.float32)
+
+        x_fp8 = Float8Tensor.from_hp(x, torch.float8_e4m3fn, granularity)
+        x_dequantized = x_fp8.dequantize()
+
+        self.assertTrue(torch.isfinite(x_fp8.qdata.float()).all())
+        self.assertTrue(torch.isfinite(x_dequantized).all())
+        torch.testing.assert_close(x_dequantized, x, atol=0, rtol=0)
+
+
 @unittest.skipIf(
     not torch.accelerator.is_available(), "skipping when gpu is not available"
 )
@@ -1645,6 +1658,7 @@ class TestFloat8Tensor(TorchAOIntegrationTestCase):
             model(x, offs)
 
 
+common_utils.instantiate_parametrized_tests(TestFloat8TensorCPU)
 common_utils.instantiate_parametrized_tests(TestFloat8Tensor)
 
 

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -2267,6 +2267,7 @@ def _choose_scale_float8(
     max_abs = tensor_reshaped.abs().amax(dim=reduction_dims, keepdim=True)
     if hp_value_lb is not None or hp_value_ub is not None:
         max_abs = torch.clamp(max_abs, min=hp_value_lb, max=hp_value_ub)
+    max_abs = torch.clamp(max_abs, min=1e-12)
     scale = max_abs / quant_max
     # Reshape scale back to match the expected output shape
     # The scale tensor should have the same shape as the input divided by block_size


### PR DESCRIPTION
## Summary

Fixes #4713.

Float8Tensor.from_hp currently produces NaN qdata and NaN dequantized output for all-zero tensors because _choose_scale_float8 returns a zero scale for zero blocks. The later affine float8 quantization path divides 0 by 0.

This clamps the amax value to a small positive floor before dividing by the float8 max, matching the nearby floatx scale helper pattern.

## Test Plan

- CUDA_VISIBLE_DEVICES="" python -m pytest -q test/quantization/quantize_/workflows/float8/test_float8_tensor.py::TestFloat8TensorCPU -q
- CUDA_VISIBLE_DEVICES="" python -m pytest -q test/quantization/test_quant_primitives.py -q
- ruff check torchao/quantization/quant_primitives.py test/quantization/quantize_/workflows/float8/test_float8_tensor.py
- ruff format --check torchao/quantization/quant_primitives.py test/quantization/quantize_/workflows/float8/test_float8_tensor.py
