### PR TITLE
Assign XPU code ownership to liangan1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,3 +34,12 @@ torchao/prototype/inductor/ @Xia-Weiwen @Valentine233 @jerryzh168 @vkuzo @andrew
 torchao/prototype/quantization/int4/ @Xia-Weiwen @jerryzh168 @vkuzo @andrewor14
 torchao/quantization/pt2e/inductor_passes/ @Xia-Weiwen @jerryzh168 @vkuzo @andrewor14
 torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py @Xia-Weiwen @jerryzh168 @vkuzo @andrewor14
+
+# XPU
+/docs/source/pt2e_quantization/pt2e_quant_xpu_inductor.rst  @liangan1 @vkuzo @jerryzh168 @andrewor14
+/torchao/quantization/pt2e/quantizer/xpu_inductor_quantizer.py @liangan1 @vkuzo @jerryzh168 @andrewor14
+/torchao/quantization/quantize_/workflows/int4/int4_plain_int32_tensor.py @liangan1 @vkuzo @jerryzh168 @andrewor14
+.github/scripts/ci_test_xpu.sh @liangan1 @vkuzo @jerryzh168 @andrewor14
+.github/workflows/xpu_test.yml @liangan1 @vkuzo @jerryzh168 @andrewor14
+
+


### PR DESCRIPTION
To reduce the effort of the community to maintain the Intel xpu related features and accelerate the fix process of these features, we request to add liangan1 who is from intel to be the code owner. 


- assign the XPU int4 plain tensor implementation to `@liangan1`
- assign XPU CI scripts and workflow ownership to `@liangan1`
- assign the XPU PT2E quantizer and documentation to `@liangan1`