### PR TITLE
Add config equivalence helper

### DIFF
--- a/docs/source/api_reference/api_ref_utils.rst
+++ b/docs/source/api_reference/api_ref_utils.rst
@@ -11,6 +11,7 @@ torchao.core
     :nosignatures:
 
     AOBaseConfig
+    are_configs_equivalent
 
 =============
 torchao.utils

--- a/test/core/test_config.py
+++ b/test/core/test_config.py
@@ -17,6 +17,7 @@ import torch
 
 from torchao.core.config import (
     AOBaseConfig,
+    are_configs_equivalent,
     config_from_dict,
     config_to_dict,
 )
@@ -91,6 +92,34 @@ def get_config_ids(configs):
     if not isinstance(configs, list):
         configs = [configs]
     return [config.__class__.__name__ for config in configs]
+
+
+def test_are_configs_equivalent():
+    int4_config = Int4WeightOnlyConfig(group_size=32)
+    equivalent_int4_config = Int4WeightOnlyConfig(group_size=32)
+    different_int4_config = Int4WeightOnlyConfig(group_size=64)
+
+    assert are_configs_equivalent([])
+    assert are_configs_equivalent([int4_config])
+    assert are_configs_equivalent([int4_config, equivalent_int4_config])
+    assert are_configs_equivalent(iter([int4_config, equivalent_int4_config]))
+    assert not are_configs_equivalent([int4_config, different_int4_config])
+    assert not are_configs_equivalent(
+        [
+            int4_config,
+            Int8WeightOnlyConfig(granularity=PerGroup(32)),
+        ]
+    )
+
+    nested_config = ModuleFqnToConfig({"linear": Int4WeightOnlyConfig(group_size=32)})
+    equivalent_nested_config = ModuleFqnToConfig(
+        {"linear": Int4WeightOnlyConfig(group_size=32)}
+    )
+    different_nested_config = ModuleFqnToConfig(
+        {"linear": Int4WeightOnlyConfig(group_size=64)}
+    )
+    assert are_configs_equivalent([nested_config, equivalent_nested_config])
+    assert not are_configs_equivalent([nested_config, different_nested_config])
 
 
 @pytest.mark.parametrize("config", configs, ids=get_config_ids)

--- a/torchao/core/config.py
+++ b/torchao/core/config.py
@@ -9,12 +9,13 @@ import enum
 import importlib
 import json
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import torch
 
 __all__ = [
     "AOBaseConfig",
+    "are_configs_equivalent",
     "config_from_dict",
     "config_to_dict",
     "ALLOWED_AO_MODULES",
@@ -65,6 +66,27 @@ class AOBaseConfig(abc.ABC):
     default Version of a config, should never change
     """
     version: int = _DEFAULT_VERSION
+
+
+def are_configs_equivalent(configs: Iterable[AOBaseConfig]) -> bool:
+    """Return whether all configs in an iterable compare equal.
+
+    This is useful when a workflow requires multiple modules to use the same
+    quantization recipe. Empty and single-item iterables return ``True``.
+
+    Args:
+        configs: Configs to compare.
+
+    Returns:
+        ``True`` if every config compares equal to the first config, or if the
+        iterable contains fewer than two configs. Otherwise, ``False``.
+    """
+    config_iterator = iter(configs)
+    try:
+        first_config = next(config_iterator)
+    except StopIteration:
+        return True
+    return all(config == first_config for config in config_iterator)
 
 
 class ConfigJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
## Summary

- add `are_configs_equivalent` for checking whether every config in an iterable compares equal
- support empty, singleton, generator, and nested config inputs using existing config equality semantics
- add focused tests and include the helper in the API reference

## Motivation

Callers currently need to implement their own loop when checking that several TorchAO configs are equivalent. This adds a small shared helper without making mutable config objects hashable or introducing a new equivalence definition.

Fixes #3062.

## Test plan

- `python -m pytest -q test/core/test_config.py` (`21 passed, 3 skipped`)
- `python -m py_compile torchao/core/config.py test/core/test_config.py`
- `ruff check torchao/core/config.py test/core/test_config.py`
- `ruff format --check torchao/core/config.py test/core/test_config.py`
- `git diff --check HEAD^ HEAD`
- Sphinx dummy build for the documentation tree
- RTX 3090 smoke test with `Int8DynamicActivationInt8WeightConfig`, including eager and compiled output checks

## AI assistance disclosure

> AI tools assisted with issue and overlap screening, drafting the implementation and tests, and preparing validation commands.

I reviewed the final diff line by line, understand the implementation and tests, and take responsibility for this contribution. The implementation intentionally uses the existing equality semantics of TorchAO config classes and does not add hashing or mutate the supplied iterable.
