### PR TITLE
Add MoE versions of the Cutedsl nvfp4 kernels

### DIFF
--- a/benchmarks/prototype/nvfp4_training/README.md
+++ b/benchmarks/prototype/nvfp4_training/README.md
@@ -153,8 +153,7 @@ Run environment: NVIDIA GB200, PyTorch 2.13.0a0+git1f19af4, Triton 3.7.0.
 
 Each `bench_*` script above runs **both backends** (Triton and CuteDSL) on the same shapes and
 reports the speedup. The CuteDSL (`nvidia-cutlass-dsl`) kernels do the Randomized Hadamard Transform
-on Blackwell tensor cores; they require SM100 and the same shape constraints as the Triton kernels,
-with the addition that **M must be divisible by 256**.
+on Blackwell tensor cores; they require SM100 and the same shape constraints as the Triton kernels.
 
 ```bash
 python -m benchmarks.prototype.nvfp4_training.bench_hadamard_amax --shape-set representative-models
@@ -192,7 +191,7 @@ Run environment: NVIDIA GB200, PyTorch 2.12.0a0, Triton 3.7.0, nvidia-cutlass-ds
 ### 2D Weight Quantize (`cutedsl_weight_quantize_2d` vs `triton_weight_quantize_2d`, no RHT)
 
 Both kernels emit 2D 16x16 weight block scaling.
-Requires `out_features % 256 == 0`.
+Requires `out_features % 128 == 0`.
 
 | Model | Weight | M (out) | N (in) | cutedsl_kernel_us | triton_kernel_us | speedup | cutedsl_gbps |
 |---|---|---:|---:|---:|---:|---:|---:|

--- a/benchmarks/prototype/nvfp4_training/bench_hadamard_amax.py
+++ b/benchmarks/prototype/nvfp4_training/bench_hadamard_amax.py
@@ -35,8 +35,8 @@ device = torch.device("cuda")
 
 BACKENDS = ("triton", "cutedsl")
 
-# Shared shape set (satisfies both backends: M % 256 == 0, N % 128 == 0).
-M_SHAPES = [256, 512, 1024, 8192]
+# Shared shape set (satisfies both backends: M % 128 == 0, N % 128 == 0).
+M_SHAPES = [256, 384, 512, 1024, 8192]
 N_SHAPES = [256, 512, 1024, 2048, 4096, 8192, 16384]
 
 LLAMA_BATCH_SIZE = 1

--- a/benchmarks/prototype/nvfp4_training/bench_hadamard_quantize_row_col.py
+++ b/benchmarks/prototype/nvfp4_training/bench_hadamard_quantize_row_col.py
@@ -32,8 +32,8 @@ device = torch.device("cuda")
 
 BACKENDS = ("triton", "cutedsl")
 
-# Shared shape set (satisfies both backends: M % 256 == 0, N % 128 == 0).
-M_SHAPES = [256, 512, 1024, 8192]
+# Shared shape set (satisfies both backends: M % 128 == 0, N % 128 == 0).
+M_SHAPES = [256, 384, 512, 1024, 8192]
 N_SHAPES = [256, 512, 1024, 2048, 4096, 8192, 16384]
 
 LLAMA_BATCH_SIZE = 1

--- a/benchmarks/prototype/nvfp4_training/bench_quantize_2d.py
+++ b/benchmarks/prototype/nvfp4_training/bench_quantize_2d.py
@@ -32,8 +32,8 @@ device = torch.device("cuda")
 
 BACKENDS = ("triton", "cutedsl")
 
-# Weight A = (out_features, in_features): out (M) % 256 == 0, in (N) % 128 == 0.
-M_SHAPES = [256, 512, 1024, 4096]
+# Weight A = (out_features, in_features): out (M) % 128 == 0, in (N) % 128 == 0.
+M_SHAPES = [256, 384, 512, 1024, 4096]
 N_SHAPES = [256, 512, 1024, 4096]
 
 

--- a/test/prototype/moe_training/nvfp4_training/test_group_hadamard_amax.py
+++ b/test/prototype/moe_training/nvfp4_training/test_group_hadamard_amax.py
@@ -1,0 +1,149 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the CuteDSL per-group RHT amax over a row-packed ragged tensor (SM100+).
+
+The grouped kernel processes each group's 128-aligned row range with the same
+supertiles the dense amax kernel uses on that slice, so per-group results are
+bitwise equal to ``cutedsl_rht_amax`` on ``A[start:end]``.
+"""
+
+import pytest
+import torch
+
+from torchao.prototype.moe_training.nvfp4_training.group_hadamard_amax_cutedsl import (
+    cutedsl_group_rht_amax,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_amax_cutedsl import (
+    cutedsl_rht_amax,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_cutedsl_utils import (
+    cutedsl_nvfp4_kernels_available,
+)
+
+_skip_no_cutedsl = pytest.mark.skipif(
+    not cutedsl_nvfp4_kernels_available(),
+    reason="requires SM100 (Blackwell) + CuteDSL runtime (cuda-python, nvidia-cutlass-dsl)",
+)
+
+_SIGN = [1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, 1, -1, -1]
+VARYING_FIRST_DIM = 1
+
+# (group row counts, hidden size): ragged 128-aligned groups, both supertile-relevant K.
+_CONFIGS = [
+    pytest.param([128, 384, 256], 256, id="g3_K256"),
+    pytest.param([256, 128, 512, 128, 384], 512, id="g5_K512"),
+    pytest.param([128], 128, id="g1_K128"),
+    pytest.param([1024], 384, id="g1_large_K384"),
+]
+
+
+def _packed(groups, K, scale_per_group=True):
+    torch.manual_seed(0)
+    parts = []
+    for i, rows in enumerate(groups):
+        scale = float(i + 1) if scale_per_group else 1.0
+        parts.append(
+            scale * torch.randn(rows, K, dtype=torch.bfloat16, device="cuda")
+        )
+    A = torch.cat(parts, dim=0).contiguous()
+    offsets = torch.tensor(
+        [sum(groups[: i + 1]) for i in range(len(groups))],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    return A, offsets
+
+
+@_skip_no_cutedsl
+@pytest.mark.parametrize("groups,K", _CONFIGS)
+@torch.no_grad()
+def test_group_rht_amax_matches_dense_per_group(groups, K):
+    A, offsets = _packed(groups, K)
+    T = A.shape[0]
+    col, row = cutedsl_group_rht_amax(
+        A, _SIGN, offsets, len(groups), T, K, VARYING_FIRST_DIM
+    )
+    assert col.shape == (len(groups),) and row.shape == (len(groups),)
+    start = 0
+    for g, rows in enumerate(groups):
+        d_col, d_row = cutedsl_rht_amax(A[start : start + rows].contiguous(), _SIGN)
+        torch.testing.assert_close(col[g], d_col.reshape(()), atol=0, rtol=0)
+        torch.testing.assert_close(row[g], d_row.reshape(()), atol=0, rtol=0)
+        start += rows
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_rht_amax_skips_capacity_rows():
+    """Rows in [logical, capacity) are storage only; poison them and expect no effect."""
+    groups, K = [256, 384], 256
+    A, offsets = _packed(groups, K)
+    logical = A.shape[0]
+    capacity = logical + 512
+    A_cap = torch.full(
+        (capacity, K), 3.0e38, dtype=torch.bfloat16, device="cuda"
+    )
+    A_cap[:logical] = A
+    logical_t = torch.tensor([logical], dtype=torch.int32, device="cuda")
+    col, row = cutedsl_group_rht_amax(
+        A_cap, _SIGN, offsets, len(groups), capacity, K, VARYING_FIRST_DIM,
+        logical_packed_length=logical_t,
+    )
+    ref_col, ref_row = cutedsl_group_rht_amax(
+        A, _SIGN, offsets, len(groups), logical, K, VARYING_FIRST_DIM
+    )
+    torch.testing.assert_close(col, ref_col, atol=0, rtol=0)
+    torch.testing.assert_close(row, ref_row, atol=0, rtol=0)
+    assert torch.isfinite(col).all() and torch.isfinite(row).all()
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_rht_amax_zero_group():
+    """An all-zero (fully padded) group reports zero amaxes."""
+    groups, K = [128, 128, 256], 256
+    A, offsets = _packed(groups, K)
+    A[128:256] = 0.0  # zero out group 1
+    col, row = cutedsl_group_rht_amax(
+        A, _SIGN, offsets, len(groups), A.shape[0], K, VARYING_FIRST_DIM
+    )
+    assert col[1].item() == 0.0 and row[1].item() == 0.0
+    assert col[0].item() > 0.0 and col[2].item() > 0.0
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_rht_amax_invalid_inputs_raise():
+    A, offsets = _packed([128, 128], 256)
+    T = A.shape[0]
+    with pytest.raises(ValueError, match="VARYING_FIRST_DIM"):
+        cutedsl_group_rht_amax(A, _SIGN, offsets, 2, T, 256, 0)
+    with pytest.raises(ValueError, match="TensorWise"):
+        cutedsl_group_rht_amax(
+            A, _SIGN, offsets, 2, T, 256, VARYING_FIRST_DIM, scaling_type=1
+        )
+    with pytest.raises(ValueError, match="entries"):
+        cutedsl_group_rht_amax(A, _SIGN, offsets, 3, T, 256, VARYING_FIRST_DIM)
+    with pytest.raises(ValueError, match="int32"):
+        cutedsl_group_rht_amax(
+            A, _SIGN, offsets.to(torch.int64), 2, T, 256, VARYING_FIRST_DIM
+        )
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_rht_amax_fake_shapes():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        A = torch.empty(512, 256, dtype=torch.bfloat16, device="cuda")
+        offsets = torch.empty(4, dtype=torch.int32, device="cuda")
+        col, row = cutedsl_group_rht_amax(
+            A, _SIGN, offsets, 4, 512, 256, VARYING_FIRST_DIM
+        )
+    assert col.shape == (4,) and row.shape == (4,)
+    assert col.dtype == torch.float32 and row.dtype == torch.float32

--- a/test/prototype/moe_training/nvfp4_training/test_group_quantize_2d.py
+++ b/test/prototype/moe_training/nvfp4_training/test_group_quantize_2d.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the CuteDSL per-expert (grouped) 2D NVFP4 weight quantize (SM100+).
+
+The grouped op invokes the dense no-RHT kernel per expert, so the primary contract
+is bitwise equality with ``cutedsl_weight_quantize_2d`` on each ``A[e]`` slice.
+Quantization quality of the dense kernel itself is covered by test_quantize_2d.py.
+"""
+
+import pytest
+import torch
+
+from torchao.float8.float8_utils import compute_error
+from torchao.prototype.moe_training.nvfp4_training.group_quantize_2d_cutedsl import (
+    cutedsl_group_weight_quantize_2d,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_cutedsl_utils import (
+    cutedsl_nvfp4_kernels_available,
+)
+from torchao.prototype.moe_training.nvfp4_training.quantize_2d_cutedsl import (
+    cutedsl_weight_quantize_2d,
+)
+from torchao.prototype.mx_formats.nvfp4_tensor import (
+    NVFP4Tensor,
+    per_tensor_amax_to_scale,
+)
+
+_skip_no_cutedsl = pytest.mark.skipif(
+    not cutedsl_nvfp4_kernels_available(),
+    reason="requires SM100 (Blackwell) + CuteDSL runtime (cuda-python, nvidia-cutlass-dsl)",
+)
+
+# (E, M, N): 256-row and 128-row supertile shapes.
+_SHAPES = [
+    pytest.param(3, 256, 256, id="E3_M256_N256"),
+    pytest.param(2, 1408, 512, id="E2_M1408_N512"),
+    pytest.param(4, 128, 128, id="E4_M128_N128"),
+    pytest.param(1, 512, 384, id="E1_M512_N384"),
+]
+
+
+def _dequantize(codes, sf, amax):
+    return (
+        NVFP4Tensor(
+            codes,
+            sf,
+            16,
+            torch.bfloat16,
+            per_tensor_scale=per_tensor_amax_to_scale(amax.reshape(())),
+            is_swizzled_scales=True,
+        )
+        .dequantize()
+        .float()
+    )
+
+
+@_skip_no_cutedsl
+@pytest.mark.parametrize("E,M,N", _SHAPES)
+@torch.no_grad()
+def test_group_weight_quantize_matches_dense_per_expert(E, M, N):
+    """Every expert slice of the grouped op is bitwise equal to the dense op on A[e]."""
+    torch.manual_seed(0)
+    A = torch.randn(E, M, N, dtype=torch.bfloat16, device="cuda") * (
+        torch.arange(1, E + 1, device="cuda").view(E, 1, 1)
+    )
+    amax = A.float().abs().amax(dim=(1, 2)).contiguous()
+
+    g_codes, g_sf, g_t_codes, g_t_sf = cutedsl_group_weight_quantize_2d(A, amax, E)
+
+    assert g_codes.shape == (E, M, N // 2) and g_codes.dtype == torch.uint8
+    assert g_sf.shape == (E, M // 128, N // 64, 32, 16)
+    assert g_t_codes.shape == (E, N, M // 2) and g_t_codes.dtype == torch.uint8
+    assert g_t_sf.shape == (E, N // 128, M // 64, 32, 16)
+
+    for e in range(E):
+        d_codes, d_sf, d_t_codes, d_t_sf = cutedsl_weight_quantize_2d(
+            A[e].contiguous(), amax[e].reshape(1)
+        )
+        torch.testing.assert_close(g_codes[e], d_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            g_sf[e].view(torch.uint8), d_sf.view(torch.uint8), atol=0, rtol=0
+        )
+        torch.testing.assert_close(g_t_codes[e], d_t_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            g_t_sf[e].view(torch.uint8), d_t_sf.view(torch.uint8), atol=0, rtol=0
+        )
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_weight_quantize_sqnr():
+    """Dequantized W and W.T reconstruct each expert with SQNR >= 18 dB (the dense
+    suite's cutedsl threshold for 2D 16x16 block scaling of gaussian data)."""
+    torch.manual_seed(1)
+    E, M, N = 2, 256, 512
+    A = torch.randn(E, M, N, dtype=torch.bfloat16, device="cuda")
+    amax = A.float().abs().amax(dim=(1, 2)).contiguous()
+    codes, sf, t_codes, t_sf = cutedsl_group_weight_quantize_2d(A, amax, E)
+    for e in range(E):
+        w = _dequantize(codes[e], sf[e], amax[e])
+        wt = _dequantize(t_codes[e], t_sf[e], amax[e])
+        assert compute_error(A[e].float(), w) >= 18.0
+        assert compute_error(A[e].t().float().contiguous(), wt) >= 18.0
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_weight_quantize_invalid_inputs_raise():
+    A = torch.randn(2, 256, 256, dtype=torch.bfloat16, device="cuda")
+    amax = A.float().abs().amax(dim=(1, 2)).contiguous()
+    with pytest.raises(ValueError, match="experts"):
+        cutedsl_group_weight_quantize_2d(A, amax, 3)
+    with pytest.raises(ValueError, match="3-D"):
+        cutedsl_group_weight_quantize_2d(A[0], amax[:1], 1)
+    with pytest.raises(ValueError):
+        cutedsl_group_weight_quantize_2d(
+            torch.randn(2, 192, 256, dtype=torch.bfloat16, device="cuda"), amax, 2
+        )
+    with pytest.raises(ValueError):
+        cutedsl_group_weight_quantize_2d(A, amax.to(torch.float64), 2)
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_weight_quantize_fake_shapes():
+    """register_fake propagates the E-batched output shapes (torch.compile support)."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        A = torch.empty(3, 384, 256, dtype=torch.bfloat16, device="cuda")
+        amax = torch.empty(3, dtype=torch.float32, device="cuda")
+        codes, sf, t_codes, t_sf = cutedsl_group_weight_quantize_2d(A, amax, 3)
+    assert codes.shape == (3, 384, 128)
+    assert sf.shape == (3, 3, 4, 32, 16)
+    assert t_codes.shape == (3, 256, 192)
+    assert t_sf.shape == (3, 2, 6, 32, 16)

--- a/test/prototype/moe_training/nvfp4_training/test_group_rht_quantize_row_col.py
+++ b/test/prototype/moe_training/nvfp4_training/test_group_rht_quantize_row_col.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the CuteDSL grouped fused RHT row+col quantize (SM100+).
+
+128-aligned group boundaries never split a 16-token RHT segment or scale vector,
+so group g's outputs equal the dense op's outputs on its row range when fed the
+same per-group amaxes -- the primary contract here is bitwise equality with
+``cutedsl_rht_quantize_row_col`` per group slice.
+"""
+
+import pytest
+import torch
+
+from torchao.prototype.moe_training.nvfp4_training.group_hadamard_amax_cutedsl import (
+    cutedsl_group_rht_amax,
+)
+from torchao.prototype.moe_training.nvfp4_training.group_rht_quantize_row_col_cutedsl import (
+    cutedsl_group_rht_quantize_row_col,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_cutedsl_utils import (
+    cutedsl_nvfp4_kernels_available,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_quantize_row_col_cutedsl import (
+    cutedsl_rht_quantize_row_col,
+)
+
+_skip_no_cutedsl = pytest.mark.skipif(
+    not cutedsl_nvfp4_kernels_available(),
+    reason="requires SM100 (Blackwell) + CuteDSL runtime (cuda-python, nvidia-cutlass-dsl)",
+)
+
+_SIGN = [1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, 1, -1, -1]
+VARYING_FIRST_DIM = 1
+
+_CONFIGS = [
+    pytest.param([128, 384, 256], 256, id="g3_K256"),
+    pytest.param([256, 128, 512, 128, 384], 512, id="g5_K512"),
+    pytest.param([1024], 384, id="g1_K384"),
+]
+
+
+def _packed(groups, K):
+    torch.manual_seed(0)
+    parts = [
+        float(i + 1) * torch.randn(rows, K, dtype=torch.bfloat16, device="cuda")
+        for i, rows in enumerate(groups)
+    ]
+    A = torch.cat(parts, dim=0).contiguous()
+    offsets = torch.tensor(
+        [sum(groups[: i + 1]) for i in range(len(groups))],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    return A, offsets
+
+
+def _grouped(A, offsets, E, row_amax, col_amax, sr=False, rng=None, T=None, logical=None):
+    T = A.shape[0] if T is None else T
+    return cutedsl_group_rht_quantize_row_col(
+        A, _SIGN, offsets, E, T, A.shape[1], VARYING_FIRST_DIM,
+        row_amax, col_amax, rng, sr, logical_packed_length=logical,
+    )
+
+
+@_skip_no_cutedsl
+@pytest.mark.parametrize("groups,K", _CONFIGS)
+@torch.no_grad()
+def test_group_quantize_matches_dense_per_group(groups, K):
+    A, offsets = _packed(groups, K)
+    E, T = len(groups), A.shape[0]
+    col_amax, row_amax = cutedsl_group_rht_amax(
+        A, _SIGN, offsets, E, T, K, VARYING_FIRST_DIM
+    )
+    qa, sfa, qd, sfd = _grouped(A, offsets, E, row_amax, col_amax)
+    assert qa.shape == (T, K // 2) and sfa.shape == (T, K // 16)
+    assert qd.shape == (K, T // 2) and sfd.shape == (K, T // 16)
+
+    sfa4 = sfa.reshape(T // 128, K // 64, 32, 16)
+    sfd4 = sfd.reshape(K // 128, T // 64, 32, 16)
+    start = 0
+    for g, rows in enumerate(groups):
+        end = start + rows
+        d_col, d_col_sf, d_row, d_row_sf = cutedsl_rht_quantize_row_col(
+            A[start:end].contiguous(),
+            col_amax[g].reshape(1),
+            row_amax[g].reshape(1),
+            _SIGN,
+        )
+        # Row grain: rows [start, end) of the packed outputs.
+        torch.testing.assert_close(qa[start:end], d_row, atol=0, rtol=0)
+        torch.testing.assert_close(
+            sfa4[start // 128 : end // 128].view(torch.uint8),
+            d_row_sf.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+        # Col grain: byte-columns [start//2, end//2) / SF blocks [start//64, end//64).
+        torch.testing.assert_close(qd[:, start // 2 : end // 2], d_col, atol=0, rtol=0)
+        torch.testing.assert_close(
+            sfd4[:, start // 64 : end // 64].contiguous().view(torch.uint8),
+            d_col_sf.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+        start = end
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_quantize_skips_capacity_rows():
+    groups, K = [256, 384], 256
+    A, offsets = _packed(groups, K)
+    E, logical = len(groups), A.shape[0]
+    capacity = logical + 384
+    A_cap = torch.full((capacity, K), 3.0e38, dtype=torch.bfloat16, device="cuda")
+    A_cap[:logical] = A
+    logical_t = torch.tensor([logical], dtype=torch.int32, device="cuda")
+    col_amax, row_amax = cutedsl_group_rht_amax(
+        A_cap, _SIGN, offsets, E, capacity, K, VARYING_FIRST_DIM,
+        logical_packed_length=logical_t,
+    )
+    qa_c, sfa_c, qd_c, sfd_c = _grouped(
+        A_cap, offsets, E, row_amax, col_amax, T=capacity, logical=logical_t
+    )
+    qa, sfa, qd, sfd = _grouped(A, offsets, E, row_amax, col_amax)
+    torch.testing.assert_close(qa_c[:logical], qa, atol=0, rtol=0)
+    torch.testing.assert_close(
+        sfa_c.reshape(capacity // 128, -1)[: logical // 128],
+        sfa.reshape(logical // 128, -1),
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(qd_c[:, : logical // 2], qd, atol=0, rtol=0)
+    torch.testing.assert_close(
+        sfd_c.reshape(K // 128, capacity // 64, 32, 16)[:, : logical // 64]
+        .contiguous()
+        .view(torch.uint8),
+        sfd.reshape(K // 128, logical // 64, 32, 16).view(torch.uint8),
+        atol=0,
+        rtol=0,
+    )
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_quantize_stochastic_rounding():
+    """SR is deterministic for a fixed rng_state, differs across states, and leaves
+    the scale factors identical to RTNE (rounding affects codes only)."""
+    groups, K = [256, 256], 256
+    A, offsets = _packed(groups, K)
+    E, T = len(groups), A.shape[0]
+    col_amax, row_amax = cutedsl_group_rht_amax(
+        A, _SIGN, offsets, E, T, K, VARYING_FIRST_DIM
+    )
+    rng1 = torch.tensor([7, 1234, 8, 999], dtype=torch.int64, device="cuda")
+    rng2 = torch.tensor([7, 5678, 8, 111], dtype=torch.int64, device="cuda")
+    out_a = _grouped(A, offsets, E, row_amax, col_amax, sr=True, rng=rng1)
+    out_b = _grouped(A, offsets, E, row_amax, col_amax, sr=True, rng=rng1.clone())
+    out_c = _grouped(A, offsets, E, row_amax, col_amax, sr=True, rng=rng2)
+    rtne = _grouped(A, offsets, E, row_amax, col_amax)
+    for a, b in zip(out_a, out_b):
+        torch.testing.assert_close(a, b, atol=0, rtol=0)
+    assert not torch.equal(out_a[0], out_c[0])
+    torch.testing.assert_close(
+        out_a[1].view(torch.uint8), rtne[1].view(torch.uint8), atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        out_a[3].view(torch.uint8), rtne[3].view(torch.uint8), atol=0, rtol=0
+    )
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_quantize_invalid_inputs_raise():
+    A, offsets = _packed([128, 128], 256)
+    E, T = 2, A.shape[0]
+    amax = torch.ones(E, dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="VARYING_FIRST_DIM"):
+        cutedsl_group_rht_quantize_row_col(
+            A, _SIGN, offsets, E, T, 256, 0, amax, amax, None, False
+        )
+    with pytest.raises(ValueError, match="rng_state"):
+        cutedsl_group_rht_quantize_row_col(
+            A, _SIGN, offsets, E, T, 256, VARYING_FIRST_DIM, amax, amax, None, True
+        )
+    with pytest.raises(ValueError, match="float32"):
+        cutedsl_group_rht_quantize_row_col(
+            A, _SIGN, offsets, E, T, 256, VARYING_FIRST_DIM,
+            amax.to(torch.float64), amax, None, False,
+        )
+
+
+@_skip_no_cutedsl
+@torch.no_grad()
+def test_group_quantize_fake_shapes():
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        A = torch.empty(512, 256, dtype=torch.bfloat16, device="cuda")
+        offsets = torch.empty(4, dtype=torch.int32, device="cuda")
+        amax = torch.empty(4, dtype=torch.float32, device="cuda")
+        qa, sfa, qd, sfd = cutedsl_group_rht_quantize_row_col(
+            A, _SIGN, offsets, 4, 512, 256, VARYING_FIRST_DIM, amax, amax, None, False
+        )
+    assert qa.shape == (512, 128) and sfa.shape == (512, 16)
+    assert qd.shape == (256, 256) and sfd.shape == (256, 32)

--- a/test/prototype/moe_training/nvfp4_training/test_hadamard_amax.py
+++ b/test/prototype/moe_training/nvfp4_training/test_hadamard_amax.py
@@ -57,17 +57,17 @@ _KERNELS = [
 ]
 
 # Both kernels require N % 128 == 0 (triton_rht_amax feeds triton_rht_quantize_row_col,
-# whose swizzled scales require it). triton additionally handles M % 256 != 0, so the
-# sweep is the union and _skip_if_unsupported_shape drops the sub-256 M for cutedsl.
+# whose swizzled scales require it). triton additionally handles M % 128 != 0 (M=64/96/160),
+# so the sweep is the union and _skip_if_unsupported_shape drops those for cutedsl.
 # M=32 excluded: all BLOCK_M configs (64, 128) exceed M=32 → all autotune configs fail.
-_M_VALUES = [64, 96, 128, 160, 256, 512, 1024]
+_M_VALUES = [64, 96, 128, 160, 256, 384, 512, 1024]
 _N_VALUES = [128, 256, 384, 512, 1024]
 
 
 def _skip_if_unsupported_shape(kernel: str, M: int, N: int) -> None:
     """Skip shapes the selected backend cannot handle."""
-    if kernel == "cutedsl" and M % 256 != 0:
-        pytest.skip("cutedsl amax kernel requires M % 256 == 0")
+    if kernel == "cutedsl" and M % 128 != 0:
+        pytest.skip("cutedsl amax kernel requires M % 128 == 0")
 
 
 def _rht_amax(kernel, A, sign_vector):
@@ -151,14 +151,14 @@ def test_cutedsl_rht_amax_returns_scalars():
 @_skip_no_cutedsl
 @pytest.mark.parametrize(
     "M,N",
-    [(128, 256), (256, 200), (384, 256)],
-    ids=["M_not_mult_256", "N_not_mult_128", "M_not_mult_256_b"],
+    [(64, 256), (256, 200), (192, 256)],
+    ids=["M_not_mult_128", "N_not_mult_128", "M_not_mult_128_b"],
 )
 @torch.no_grad()
 def test_cutedsl_rht_amax_invalid_shape_raises(M, N):
-    """M % 256 / N % 128 violations must raise. M=128 is the subtle one: it passes an
-    M % 128 check but is invalid here, and without the M % 256 check it silently returns
-    zero amaxes (empty grid, no-op launch)."""
+    """M % 128 / N % 128 violations must raise. M=64 is the subtle one: without the
+    M % 128 check a sub-supertile M silently returns zero amaxes (empty grid,
+    no-op launch)."""
     A = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
     with pytest.raises(ValueError):
         cutedsl_rht_amax(A, list(_HARDCODED_SIGN_VECTOR))
@@ -188,7 +188,7 @@ def test_rht_amax_propagates_nan():
 @_skip_no_triton
 @_skip_no_cutedsl
 @pytest.mark.parametrize("N", [256, 512], ids=lambda n: f"N{n}")
-@pytest.mark.parametrize("M", [256, 512], ids=lambda m: f"M{m}")
+@pytest.mark.parametrize("M", [256, 384, 512], ids=lambda m: f"M{m}")
 @torch.no_grad()
 def test_cutedsl_rht_amax_matches_triton(M, N):
     """CuteDSL and Triton amaxes agree closely (row is exact; col differs only by RHT

--- a/test/prototype/moe_training/nvfp4_training/test_hadamard_quantize_row_col.py
+++ b/test/prototype/moe_training/nvfp4_training/test_hadamard_quantize_row_col.py
@@ -13,7 +13,7 @@ parametrization (see ``_KERNELS``):
 
   RTNE (stochastic_rounding=False), both backends:
     - test_rht_quantize_rtne_scales_vs_reference: FP8 scale factors match the PyTorch
-      reference bitwise in swizzled layout.
+      reference within 1 fp8 ULP in swizzled layout
     - test_rht_quantize_rtne_sqnr: Dequantized output reconstructs post-RHT / raw-A
       values with SQNR >= 20 dB for both col and row paths.
     - test_rht_quantize_row_col_zero_and_near_zero_no_nan_or_saturation: zero and
@@ -74,9 +74,9 @@ if has_triton() and is_sm_at_least_100() and torch_version_at_least("2.10.0"):
     )
 
 # Shapes swept by the kernel-parametrized tests. Both kernels need M % 128 == 0 and
-# N % 128 == 0 for the swizzled scale layout; the CuteDSL kernel additionally needs
-# M % 256 == 0, so M=128 runs triton-only (see _skip_if_unsupported_shape).
-_M_VALUES = [128, 256, 512, 1024]
+# N % 128 == 0 for the swizzled scale layout. M=128/384 exercise the CuteDSL 128-row
+# supertile (M % 128 but not % 256); the other M run its tuned 256-row supertile.
+_M_VALUES = [128, 256, 384, 512, 1024]
 _N_VALUES = [128, 256, 384, 512, 1024]
 # Shape both kernels accept, for the tests that do not sweep shapes.
 _M_BOTH, _N_BOTH = 256, 256
@@ -215,8 +215,8 @@ def _skip_if_unsupported_shape(kernel: str, M: int, N: int) -> None:
     """Skip shapes the selected backend cannot handle."""
     if M % 128 != 0 or N % 128 != 0:
         pytest.skip("swizzled scales require M % 128 == 0 and N % 128 == 0")
-    if kernel == "cutedsl" and M % 256 != 0:
-        pytest.skip("cutedsl kernel requires M % 256 == 0")
+    if kernel == "cutedsl" and M % 128 != 0:
+        pytest.skip("cutedsl kernel requires M % 128 == 0")
 
 
 def _rht_amax(
@@ -304,6 +304,20 @@ def _unpack_fp4_magnitudes(codes: torch.Tensor) -> torch.Tensor:
     return _unpack_fp4_nibbles(codes) & 0x7
 
 
+def _assert_scales_adjacent(got: torch.Tensor, ref: torch.Tensor, label: str) -> None:
+    """fp8 scale bytes must be equal or on the adjacent representable value
+    (|Δ raw uint8| <= 1; positive e4m3 bytes are magnitude-monotonic). See the
+    scales_vs_reference docstring for why 1 ULP of slack exists."""
+    got_b = got.flatten().contiguous().view(torch.uint8).to(torch.int16)
+    ref_b = ref.flatten().contiguous().view(torch.uint8).to(torch.int16)
+    assert got_b.shape == ref_b.shape, f"{label}: shape mismatch"
+    diff = (got_b - ref_b).abs()
+    assert (diff <= 1).all(), (
+        f"{label}: {(diff > 1).sum().item()}/{diff.numel()} fp8 scale bytes "
+        f"differ by >1 ULP (max {diff.max().item()})"
+    )
+
+
 def _assert_scales_finite_and_nonzero(scales: torch.Tensor) -> None:
     scales_f32 = scales.to(torch.float32)
     assert torch.isfinite(scales_f32).all(), "scale factors must be finite"
@@ -351,9 +365,16 @@ def _assert_near_zero_values_do_not_saturate(
 @pytest.mark.parametrize("M", _M_VALUES, ids=lambda m: f"M{m}")
 @torch.no_grad()
 def test_rht_quantize_rtne_scales_vs_reference(kernel, M, N):
-    """FP8 scale factors must match the PyTorch reference bitwise.
+    """FP8 scale factors must match the PyTorch reference within 1 fp8 ULP.
 
     Columnwise: RHT + quantize of A.T. Rowwise: quantize raw A.
+
+    The kernels and the reference compute the same per-vector scale through
+    mathematically-equal but differently-associated f32 chains (the reference:
+    ``(vec_max/6) / (amax/2688)``; cutedsl: ``vec_max * ((2688/amax) * (1/6))``),
+    which can land 1 f32 ULP apart and flip an fp8 byte at rounding boundaries
+    for some (amax, data) draws. Scale bytes are therefore compared as equal or
+    adjacent (positive e4m3 bytes are magnitude-monotonic).
 
     Note: packed FP4 codes are NOT checked bitwise — the kernels use an approximate
     reciprocal (rcp.approx.f32, ≤2 ULP) while the reference uses correctly-rounded
@@ -374,15 +395,13 @@ def test_rht_quantize_rtne_scales_vs_reference(kernel, M, N):
         sign_vector=_HARDCODED_SIGN_VECTOR,
     )
 
-    # Rowwise scale check (plain NVFP4 quantize of A) — bitwise for both backends.
+    # Rowwise scale check (plain NVFP4 quantize of A).
     _, ref_row_sf, _ = _rht_quantize_rowwise_reference(A)
-    torch.testing.assert_close(row_sf.flatten(), to_blocked(ref_row_sf), atol=0, rtol=0)
+    _assert_scales_adjacent(row_sf, to_blocked(ref_row_sf), "row scale")
 
     if kernel == "triton":
         _, ref_col_sf, _ = _rht_quantize_reference(A)
-        torch.testing.assert_close(
-            col_sf.flatten(), to_blocked(ref_col_sf), atol=0, rtol=0
-        )
+        _assert_scales_adjacent(col_sf, to_blocked(ref_col_sf), "col scale")
 
 
 @pytest.mark.parametrize("kernel", _KERNELS)
@@ -514,7 +533,7 @@ def test_rht_quantize_row_col_zero_and_near_zero_no_nan_or_saturation(
 @_skip_no_triton
 @_skip_no_cutedsl
 @pytest.mark.parametrize("N", [256, 512], ids=lambda n: f"N{n}")
-@pytest.mark.parametrize("M", [256, 512], ids=lambda m: f"M{m}")
+@pytest.mark.parametrize("M", [256, 384, 512], ids=lambda m: f"M{m}")
 @torch.no_grad()
 def test_cutedsl_vs_triton_interchangeable(M, N):
     """Fed the SAME global amaxes, CuteDSL and Triton outputs reconstruct each other to
@@ -932,8 +951,8 @@ def test_cutedsl_rht_quantize_sr_unbiased():
 @_skip_no_cutedsl
 @pytest.mark.parametrize(
     "M,N",
-    [(128, 256), (256, 200), (384, 256)],
-    ids=["M_not_mult_256", "N_not_mult_128", "M_not_mult_256_b"],
+    [(64, 256), (256, 200), (192, 256)],
+    ids=["M_not_mult_128", "N_not_mult_128", "M_not_mult_128_b"],
 )
 @torch.no_grad()
 def test_cutedsl_rht_quantize_invalid_shape_raises(M, N):

--- a/test/prototype/moe_training/nvfp4_training/test_nvfp4_fsdp2_tp.py
+++ b/test/prototype/moe_training/nvfp4_training/test_nvfp4_fsdp2_tp.py
@@ -181,7 +181,7 @@ def _test_nvfp4_mlp_fsdp2_tp_smoke(
         512,
         256,
         512,
-    )  # per-TP shards (M//2=256, K=256, out//2=256) satisfy CuteDSL's %256/%128
+    )  # per-TP shards (M//2=256, K=256, out//2=256) satisfy CuteDSL's %128/%128
 
     model = NVFP4MLP(
         K, H, device=device, dtype=torch.bfloat16, kernel_preference=kernel_preference
@@ -260,7 +260,7 @@ def test_nvfp4_mlp_fsdp2_tp_cuda_graph_compile_smoke(distributed_env: DeviceMesh
 )
 def test_nvfp4_mlp_fsdp2_tp_cutedsl_smoke(distributed_env: DeviceMesh):
     """FSDP2 + TP (eager) with the CuteDSL backend. The per-TP weight/activation shards satisfy
-    CuteDSL's out_features % 256 / M % 256 / K % 128."""
+    CuteDSL's out_features % 128 / M % 128 / K % 128."""
     _test_nvfp4_mlp_fsdp2_tp_smoke(
         distributed_env, compile_model=False, kernel_preference=KernelPreference.CUTEDSL
     )

--- a/test/prototype/moe_training/nvfp4_training/test_nvfp4_linear.py
+++ b/test/prototype/moe_training/nvfp4_training/test_nvfp4_linear.py
@@ -27,8 +27,9 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 
 _HARDCODED_SIGN_VECTOR = (1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, -1, 1, -1, -1)
 
-# The CuteDSL path needs M % 256 == 0, K % 128 == 0 and out_features % 256 == 0; the Triton
-# path needs % 128. 512 satisfies both, so the parametrized tests share one shape.
+# Both paths need M, K, out_features % 128 == 0. 512 exercises the CuteDSL 256-row
+# supertile; the 128-row supertile (M % 128 but not % 256) is covered by the
+# kernel-level tests.
 _M = _K = _N = 512
 
 _TRITON_MARKS = [

--- a/test/prototype/moe_training/nvfp4_training/test_nvfp4_parallel.py
+++ b/test/prototype/moe_training/nvfp4_training/test_nvfp4_parallel.py
@@ -1036,13 +1036,37 @@ def test_mlp_colwise_rowwise_parallelize_module_cuda_graph_compile(
 # ---------------------------------------------------------------------------
 # CuteDSL tensor-parallel tests (kernel_preference=CUTEDSL). The CuteDSL amax +
 # quantize replace Triton's for both forward (RTNE) and backward (cvt.rs SR). The
-# per-rank M shard must be divisible by 256.
+# per-rank M shard must be divisible by 128 (128 * world_size for row-parallel).
 # ---------------------------------------------------------------------------
 
 _skip_no_cutedsl = pytest.mark.skipif(
     not cutedsl_nvfp4_kernels_available(),
     reason="requires SM100 + CuteDSL runtime (cuda-python, nvidia-cutlass-dsl, apache-tvm-ffi)",
 )
+
+
+def test_check_cutedsl_shard_bounds():
+    """Shape-only unit test of the TP shard validator (no process group needed).
+
+    Row-parallel (scatter_m) requires M % (128 * world_size) so the backward's
+    reduce-scattered M // world_size grad shard stays quantizable; everything else
+    requires plain % 128.
+    """
+    from torchao.prototype.moe_training.nvfp4_training.nvfp4_tensor_parallel import (
+        _check_cutedsl_shard,
+    )
+
+    x_ok = torch.empty(384, 256)
+    w_ok = torch.empty(384, 128)
+    _check_cutedsl_shard(x_ok, 2, w_ok)  # col-parallel: M % 128 suffices
+    _check_cutedsl_shard(torch.empty(512, 256), 2, scatter_m=True)  # 512 % (128*2) == 0
+
+    with pytest.raises(ValueError, match=r"M % 256 == 0"):
+        _check_cutedsl_shard(x_ok, 2, scatter_m=True)  # 384 % (128*2) != 0
+    with pytest.raises(ValueError, match="activation shard"):
+        _check_cutedsl_shard(torch.empty(192, 256), 1)
+    with pytest.raises(ValueError, match="weight shard"):
+        _check_cutedsl_shard(x_ok, 1, torch.empty(192, 128))
 
 
 def _cutedsl_tp_forward_equiv(tp_fn, seed, device, pg):

--- a/test/prototype/moe_training/nvfp4_training/test_quantize_2d.py
+++ b/test/prototype/moe_training/nvfp4_training/test_quantize_2d.py
@@ -39,18 +39,18 @@ _KERNELS = [
     pytest.param("cutedsl", marks=_skip_no_cutedsl, id="cutedsl"),
 ]
 
-# The CuteDSL kernel requires out_features (dim 0) % 256 == 0 and in_features (dim 1)
+# The CuteDSL kernel requires out_features (dim 0) % 128 == 0 and in_features (dim 1)
 # % 128 == 0; the triton kernel's BLOCK_M minimum is 128 and its swizzled scales require
-# both dims % 128. The sweep is the union, with _skip_if_unsupported_shape dropping
-# M=128 for cutedsl so triton keeps its BLOCK_M-minimum coverage.
-_M_VALUES = [128, 256, 512, 1024]
+# both dims % 128 — the same bound, so the sweep runs on both backends. M=128/384
+# exercise the CuteDSL 128-row supertile; the other M run its tuned 256-row supertile.
+_M_VALUES = [128, 256, 384, 512, 1024]
 _N_VALUES = [128, 256, 512, 1024, 2048]
 
 
 def _skip_if_unsupported_shape(kernel: str, M: int, N: int) -> None:
     """Skip shapes the selected backend cannot handle."""
-    if kernel == "cutedsl" and M % 256 != 0:
-        pytest.skip("cutedsl weight quantize requires out_features % 256 == 0")
+    if kernel == "cutedsl" and M % 128 != 0:
+        pytest.skip("cutedsl weight quantize requires out_features % 128 == 0")
 
 
 # Minimum reconstruction SQNR (dB) per backend; both land around 19 dB on the grid above.
@@ -393,9 +393,9 @@ def test_weight_quantize_2d_zero_and_near_zero_no_nan_or_saturation(kernel, inpu
 
 @_skip_no_cutedsl
 @torch.no_grad()
-def test_cutedsl_weight_quantize_2d_requires_out_features_256():
-    """out_features (dim 0) must be divisible by 256 (stricter than the Triton kernel's 128)."""
-    W = torch.randn(384, 256, dtype=torch.bfloat16, device="cuda")  # 384 % 256 == 128
+def test_cutedsl_weight_quantize_2d_requires_out_features_128():
+    """out_features (dim 0) must be divisible by 128 (matching the Triton kernel)."""
+    W = torch.randn(192, 256, dtype=torch.bfloat16, device="cuda")  # 192 % 128 == 64
     amax = W.float().abs().max()
     with pytest.raises(ValueError, match="out_features"):
         cutedsl_weight_quantize_2d(W, amax)

--- a/torchao/prototype/moe_training/nvfp4_training/_cutedsl_kernels_impl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/_cutedsl_kernels_impl.py
@@ -433,6 +433,8 @@ class _Tcgen05RowColFused:
         sr: bool = False,
         apply_rht: bool = True,
         col_groups_per_supertile: int = 16,
+        grouped: bool = False,
+        search_iters: int = 0,
     ):
         # swizzle_sf=True: cutlass NVFP4 swizzled SF (GEMM-ready, TMA-coalesced store).
         # False: plain (N,M//16)/(M,N//16) SF (row SF falls back to a strided SIMT store); its
@@ -448,9 +450,19 @@ class _Tcgen05RowColFused:
         assert not (col_groups_per_supertile < 16 and not swizzle_sf), (
             "swizzle_sf=False requires col_groups_per_supertile=16"
         )
+        # grouped=True: ragged per-expert activation quantize -- per-group scales from
+        # (E,) amax vectors selected by bisection over 128-aligned row-end offsets, and
+        # rows at or beyond logical_len_t[0] skipped (storage capacity, CUDA-graph-safe).
+        # Orthogonal to the L (expert) mode, which batches uniform stacked weights.
+        assert not (grouped and not apply_rht), "grouped requires apply_rht"
+        assert not (grouped and col_groups_per_supertile != 8), (
+            "grouped requires the 128-row supertile"
+        )
         self.swizzle_sf = swizzle_sf
         self.sr = sr
         self.apply_rht = apply_rht
+        self.grouped = grouped
+        self.search_iters = search_iters
         _set_supertile_geometry(self, col_groups_per_supertile)
 
     @cute.jit
@@ -465,6 +477,9 @@ class _Tcgen05RowColFused:
         row_amax_t: cute.Tensor,
         global_amax_t: cute.Tensor,
         sr_rng_t: cute.Tensor,
+        offsets_t: cute.Tensor,
+        logical_len_t: cute.Tensor,
+        num_experts: cutlass.Int32,
         M: cutlass.Int32,
         N: cutlass.Int32,
         GRID: cutlass.Int32,
@@ -599,7 +614,8 @@ class _Tcgen05RowColFused:
         num_tiles_ns = M // cutlass.Int32(
             N_TILE * self.col_groups_per_supertile
         )  # M contraction block-groups (K=16U)
-        num_super = num_tiles_m * num_tiles_ns
+        num_tiles_per_expert = num_tiles_m * num_tiles_ns
+        num_super = num_tiles_per_expert * cutlass.Int32(cute.size(mA, mode=[2]))
 
         self.kernel(
             tiled_mma,
@@ -618,6 +634,9 @@ class _Tcgen05RowColFused:
             mRowFP4,
             mRowSF,
             row_amax_t,
+            offsets_t,
+            logical_len_t,
+            num_experts,
             tma_atom_row_fp4,
             tma_tensor_row_fp4,
             row_fp4_smem_layout,
@@ -633,6 +652,7 @@ class _Tcgen05RowColFused:
             num_tmem_alloc_cols,
             num_tma_load_bytes,
             num_tiles_ns,
+            num_tiles_per_expert,
             num_super,
             GRID,
         ).launch(
@@ -664,6 +684,9 @@ class _Tcgen05RowColFused:
         mRowFP4: cute.Tensor,
         mRowSF: cute.Tensor,
         row_amax_t: cute.Tensor,
+        offsets_t: cute.Tensor,
+        logical_len_t: cute.Tensor,
+        num_experts: cutlass.Int32,
         tma_atom_row_fp4: cute.CopyAtom,
         mRowFP4_tma: cute.Tensor,
         row_fp4_smem_layout: cute.Layout,
@@ -679,6 +702,7 @@ class _Tcgen05RowColFused:
         num_tmem_alloc_cols: cutlass.Constexpr,
         num_tma_load_bytes: cutlass.Constexpr,
         num_tiles_ns: cutlass.Int32,
+        num_tiles_per_expert: cutlass.Int32,
         num_super: cutlass.Int32,
         GRID: cutlass.Int32,
     ):
@@ -898,13 +922,10 @@ class _Tcgen05RowColFused:
             dec = cutlass.Float32(1.0) / enc
             return enc, dec, enc * cutlass.Float32(1.0 / FP4_E2M1_MAX)
 
-        g_enc, g_dec, enc_over_fp4max = _global_scale(global_amax_t[0])  # col (RHT)
-        r_enc, r_dec, r_enc_over_fp4max = _global_scale(row_amax_t[0])  # row (plain)
         sr_rng = cutlass.Uint32(0)
         if cutlass.const_expr(self.sr):
-            sr_rng = cutlass.Uint32(
-                sr_rng_t[0]
-            )  # per-call stochastic-rounding RNG base
+            # Per-call stochastic-rounding RNG base.
+            sr_rng = cutlass.Uint32(sr_rng_t[0])
 
         pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
@@ -914,29 +935,41 @@ class _Tcgen05RowColFused:
             (rem + GRID - cutlass.Int32(1)) // GRID,
             cutlass.Int32(0),
         )
+        # Grouped: rows at or beyond the logical count are capacity only; every warp
+        # role skips their supertiles with the same predicate (pipelines stay in step).
+        logical_rows = cutlass.Int32(0)
+        if cutlass.const_expr(self.grouped):
+            logical_rows = cutlass.Int32(logical_len_t[0])
 
         # ==================== TMA warp (AB producer) ====================
         if warp_idx == _TMA_W:
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
-                pid_m = super_id // num_tiles_ns
-                pid_ns = super_id % num_tiles_ns
-                handle = ab_producer.acquire_and_advance()
-                cute.copy(
-                    tma_atom_a,
-                    tAgA[(None, pid_m, pid_ns, 0)],
-                    tAsA[(None, handle.index)],
-                    tma_bar_ptr=handle.barrier,
-                )
-                if cutlass.const_expr(
-                    self.apply_rht
-                ):  # B (Hadamard) only needed for the MMA
+                expert = super_id // num_tiles_per_expert
+                local_id = super_id % num_tiles_per_expert
+                pid_m = local_id // num_tiles_ns
+                pid_ns = local_id % num_tiles_ns
+                if cutlass.const_expr(self.grouped):
+                    do_tile = (pid_ns * cutlass.Int32(self.kw)) < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    handle = ab_producer.acquire_and_advance()
                     cute.copy(
-                        tma_atom_b,
-                        tBgB[(None, 0)],
-                        tBsB[(None, handle.index)],
+                        tma_atom_a,
+                        tAgA[(None, pid_m, pid_ns, expert)],
+                        tAsA[(None, handle.index)],
                         tma_bar_ptr=handle.barrier,
                     )
+                    if cutlass.const_expr(
+                        self.apply_rht
+                    ):  # B (Hadamard) only needed for the MMA
+                        cute.copy(
+                            tma_atom_b,
+                            tBgB[(None, 0)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                        )
             ab_producer.tail()
 
         # ==================== MMA warp (AB consumer, acc producer) ====================
@@ -949,20 +982,29 @@ class _Tcgen05RowColFused:
                 pipeline.PipelineUserType.Producer, NUM_ACC_STAGE
             )
             for local_iter in cutlass.range(num_iters):
-                ab_handle = ab_consumer.wait_and_advance()
-                acc_pipeline.producer_acquire(acc_producer_state)
-                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
-                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                    cute.gemm(
-                        tiled_mma,
-                        tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
-                        tCrA[(None, None, u, ab_handle.index)],
-                        tCrB[(None, None, 0, ab_handle.index)],
-                        tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
-                    )
-                acc_pipeline.producer_commit(acc_producer_state)
-                acc_producer_state.advance()
-                ab_handle.release()  # 1 UMMA arrive on AB empty barrier
+                if cutlass.const_expr(self.grouped):
+                    super_id = start_pid + local_iter * GRID
+                    do_tile = (
+                        ((super_id % num_tiles_per_expert) % num_tiles_ns)
+                        * cutlass.Int32(self.kw)
+                    ) < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    ab_handle = ab_consumer.wait_and_advance()
+                    acc_pipeline.producer_acquire(acc_producer_state)
+                    for u in cutlass.range_constexpr(self.col_groups_per_supertile):
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
+                            tCrA[(None, None, u, ab_handle.index)],
+                            tCrB[(None, None, 0, ab_handle.index)],
+                            tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
+                        )
+                    acc_pipeline.producer_commit(acc_producer_state)
+                    acc_producer_state.advance()
+                    ab_handle.release()  # 1 UMMA arrive on AB empty barrier
             acc_pipeline.producer_tail(acc_producer_state)
 
         # ==================== ROW warps (AB consumer, read raw sA) ====================
@@ -976,110 +1018,132 @@ class _Tcgen05RowColFused:
             row_ab_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, NUM_AB_STAGE
             )
+            exec_iter = cutlass.Int32(0)
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
-                pid_m = super_id // num_tiles_ns
-                pid_ns = super_id % num_tiles_ns
+                expert = super_id // num_tiles_per_expert
+                local_id = super_id % num_tiles_per_expert
+                pid_m = local_id // num_tiles_ns
+                pid_ns = local_id % num_tiles_ns
+                if cutlass.const_expr(self.grouped):
+                    scale_group = _group_of_row(
+                        offsets_t,
+                        pid_ns * cutlass.Int32(self.kw),
+                        num_experts,
+                        self.search_iters,
+                    )
+                    do_tile = (pid_ns * cutlass.Int32(self.kw)) < logical_rows
+                else:
+                    scale_group = expert
+                    do_tile = True
                 m0 = pid_ns * cutlass.Int32(self.kw)  # global M-row base
-                buf = local_iter % ROW_FP4_STAGES  # double-buffer index
+                buf = exec_iter % ROW_FP4_STAGES  # double-buffer index
+                if do_tile:
 
-                ab_pipeline.consumer_wait(row_ab_state)  # wait sA full
-                stage = row_ab_state.index
+                    _, r_dec, r_enc_over_fp4max = _global_scale(
+                        row_amax_t[scale_group]
+                    )
+                    exec_iter = exec_iter + cutlass.Int32(1)
+                    ab_pipeline.consumer_wait(row_ab_state)  # wait sA full
+                    stage = row_ab_state.index
 
-                # read this thread's M-row (128 N values across the m_mma grain), 8 SF-blocks
-                kc = k_row % cutlass.Int32(8)
-                kd = k_row // cutlass.Int32(8)
-                for b in cutlass.range_constexpr(M_TILE // 16):  # 8 blocks of 16 N
-                    blk = cute.make_rmem_tensor((16,), cutlass.Float32)
-                    for j in cutlass.range_constexpr(16):
-                        m_mma = b * 16 + j  # N position (0..127), python int
-                        blk[j] = sA_clean[
-                            ((m_mma % 64, m_mma // 64), (kc, kd), (0, stage))
-                        ].to(cutlass.Float32)
-                    row_rng = None
-                    if cutlass.const_expr(self.sr):
-                        # row-stream RNG seed for this (global M-row, SF-col block); 0x00B0.. tags row.
-                        # The two fields are mixed multiplicatively rather than bit-packed: the SF-col
-                        # block index runs to N/16, so a (row << 8) ^ blk packing aliases as soon as
-                        # N > 4096 -- seed(r, 256+j) == seed(r^1, j) -- handing whole block pairs the
-                        # same SR stream on real shapes (N=14336/28672). Distinct odd multipliers
-                        # scatter each field across all 32 bits instead.
-                        row_rng = (
-                            sr_rng
-                            ^ (cutlass.Uint32(m0 + k_row) * cutlass.Uint32(0x9E3779B1))
-                            ^ (
-                                cutlass.Uint32(
-                                    pid_m * cutlass.Int32(M_TILE // 16)
-                                    + cutlass.Int32(b)
+                    # read this thread's M-row (128 N values across the m_mma grain), 8 SF-blocks
+                    kc = k_row % cutlass.Int32(8)
+                    kd = k_row // cutlass.Int32(8)
+                    for b in cutlass.range_constexpr(M_TILE // 16):  # 8 blocks of 16 N
+                        blk = cute.make_rmem_tensor((16,), cutlass.Float32)
+                        for j in cutlass.range_constexpr(16):
+                            m_mma = b * 16 + j  # N position (0..127), python int
+                            blk[j] = sA_clean[
+                                ((m_mma % 64, m_mma // 64), (kc, kd), (0, stage))
+                            ].to(cutlass.Float32)
+                        row_rng = None
+                        if cutlass.const_expr(self.sr):
+                            # row-stream RNG seed for this (global M-row, SF-col block); 0x00B0.. tags row.
+                            # The two fields are mixed multiplicatively rather than bit-packed: the SF-col
+                            # block index runs to N/16, so a (row << 8) ^ blk packing aliases as soon as
+                            # N > 4096 -- seed(r, 256+j) == seed(r^1, j) -- handing whole block pairs the
+                            # same SR stream on real shapes (N=14336/28672). Distinct odd multipliers
+                            # scatter each field across all 32 bits instead.
+                            row_rng = (
+                                sr_rng
+                                ^ (cutlass.Uint32(m0 + k_row) * cutlass.Uint32(0x9E3779B1))
+                                ^ (
+                                    cutlass.Uint32(
+                                        pid_m * cutlass.Int32(M_TILE // 16)
+                                        + cutlass.Int32(b)
+                                    )
+                                    * cutlass.Uint32(0x85EBCA77)
                                 )
-                                * cutlass.Uint32(0x85EBCA77)
+                                ^ cutlass.Uint32(0x00B00200)
                             )
-                            ^ cutlass.Uint32(0x00B00200)
+                        amax = _abs_amax16(blk)
+                        if cutlass.const_expr(not self.apply_rht):
+                            amax = _group16_amax(amax)
+                        w0, w1, sf = _quant16_from_amax(
+                            blk, amax, r_enc_over_fp4max, r_dec, self.sr, row_rng
                         )
-                    amax = _abs_amax16(blk)
-                    if cutlass.const_expr(not self.apply_rht):
-                        amax = _group16_amax(amax)
-                    w0, w1, sf = _quant16_from_amax(
-                        blk, amax, r_enc_over_fp4max, r_dec, self.sr, row_rng
-                    )
-                    sRowFP4[k_row, b * 2, buf] = w0
-                    sRowFP4[k_row, b * 2 + 1, buf] = w1
-                    if cutlass.const_expr(self.swizzle_sf):
-                        # swizzled SF[r=m0+k_row, c=pid_m*8+b] -> [r//128, c//4, r%32, (r%128//32)*4 + c%4]
-                        sRowSF_w[
-                            k_row // cutlass.Int32(128),
-                            b // 4,
-                            k_row % cutlass.Int32(32),
-                            ((k_row // cutlass.Int32(32)) % cutlass.Int32(4))
-                            * cutlass.Int32(4)
-                            + (b % 4),
-                            buf,
-                        ] = sf
-                    else:
-                        mRowSF[
-                            m0 + k_row,
-                            pid_m * cutlass.Int32(M_TILE // 16) + cutlass.Int32(b),
-                        ] = sf
+                        sRowFP4[k_row, b * 2, buf] = w0
+                        sRowFP4[k_row, b * 2 + 1, buf] = w1
+                        if cutlass.const_expr(self.swizzle_sf):
+                            # swizzled SF[r=m0+k_row, c=pid_m*8+b] -> [r//128, c//4, r%32, (r%128//32)*4 + c%4]
+                            sRowSF_w[
+                                k_row // cutlass.Int32(128),
+                                b // 4,
+                                k_row % cutlass.Int32(32),
+                                ((k_row // cutlass.Int32(32)) % cutlass.Int32(4))
+                                * cutlass.Int32(4)
+                                + (b % 4),
+                                buf,
+                            ] = sf
+                        else:
+                            mRowSF[
+                                m0 + k_row,
+                                pid_m * cutlass.Int32(M_TILE // 16) + cutlass.Int32(b),
+                                expert,
+                            ] = sf
 
-                # all M-rows read -> release AB buffer (1 thread arrive each)
-                cute.arch.mbarrier_arrive(
-                    ab_pipeline.sync_object_empty.get_barrier(stage)
-                )
-                row_ab_state.advance()
+                    # all M-rows read -> release AB buffer (1 thread arrive each)
+                    cute.arch.mbarrier_arrive(
+                        ab_pipeline.sync_object_empty.get_barrier(stage)
+                    )
+                    row_ab_state.advance()
 
-                # TMA-store the (KW, M_TILE//8) row FP4 tile from buffer `buf`.
-                # wait_group(1) keeps <=1 store in flight -> this store overlaps the next
-                # iter's read/quant; the 2nd barrier makes its completion (via the *next*
-                # iter's wait_group) visible before buf is reused two iters later.
-                cute.arch.fence_proxy("async.shared", space="cta")
-                row_store_barrier.arrive_and_wait()
-                if warp_idx == cutlass.Int32(_ROW_BEG):
-                    gRowFP4 = cute.local_tile(
-                        mRowFP4_tma, (self.kw, M_TILE // 8), (pid_ns, pid_m)
-                    )
-                    tRs, tRg = cpasync.tma_partition(
-                        tma_atom_row_fp4,
-                        0,
-                        cta_layout,
-                        cute.group_modes(sRowFP4[(None, None, buf)], 0, 2),
-                        cute.group_modes(gRowFP4, 0, 2),
-                    )
-                    cute.copy(tma_atom_row_fp4, tRs, tRg)
-                    if cutlass.const_expr(self.swizzle_sf):
-                        gRowSF = cute.local_tile(
-                            mRowSF_tma, (self.sf_rblk, SF_RGRP * SF_BLK), (pid_ns, pid_m)
+                    # TMA-store the (KW, M_TILE//8) row FP4 tile from buffer `buf`.
+                    # wait_group(1) keeps <=1 store in flight -> this store overlaps the next
+                    # iter's read/quant; the 2nd barrier makes its completion (via the *next*
+                    # iter's wait_group) visible before buf is reused two iters later.
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    row_store_barrier.arrive_and_wait()
+                    if warp_idx == cutlass.Int32(_ROW_BEG):
+                        gRowFP4 = cute.local_tile(
+                            mRowFP4_tma, (self.kw, M_TILE // 8), (pid_ns, pid_m, expert)
                         )
-                        tRSs, tRSg = cpasync.tma_partition(
-                            tma_atom_row_sf,
+                        tRs, tRg = cpasync.tma_partition(
+                            tma_atom_row_fp4,
                             0,
                             cta_layout,
-                            cute.group_modes(sRowSF[(None, None, buf)], 0, 2),
-                            cute.group_modes(gRowSF, 0, 2),
+                            cute.group_modes(sRowFP4[(None, None, buf)], 0, 2),
+                            cute.group_modes(gRowFP4, 0, 2),
                         )
-                        cute.copy(tma_atom_row_sf, tRSs, tRSg)
-                    cute.arch.cp_async_bulk_commit_group()
-                    cute.arch.cp_async_bulk_wait_group(1, read=True)
-                row_store_barrier.arrive_and_wait()
+                        cute.copy(tma_atom_row_fp4, tRs, tRg)
+                        if cutlass.const_expr(self.swizzle_sf):
+                            gRowSF = cute.local_tile(
+                                mRowSF_tma,
+                                (self.sf_rblk, SF_RGRP * SF_BLK),
+                                (pid_ns, pid_m, expert),
+                            )
+                            tRSs, tRSg = cpasync.tma_partition(
+                                tma_atom_row_sf,
+                                0,
+                                cta_layout,
+                                cute.group_modes(sRowSF[(None, None, buf)], 0, 2),
+                                cute.group_modes(gRowSF, 0, 2),
+                            )
+                            cute.copy(tma_atom_row_sf, tRSs, tRSg)
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(1, read=True)
+                    row_store_barrier.arrive_and_wait()
             if warp_idx == cutlass.Int32(_ROW_BEG):
                 cute.arch.cp_async_bulk_wait_group(0, read=True)  # drain last store
 
@@ -1115,80 +1179,105 @@ class _Tcgen05RowColFused:
             )
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
-                pid_m = super_id // num_tiles_ns
-                pid_ns = super_id % num_tiles_ns
-                acc_idx = acc_consumer_state.index
-
-                acc_pipeline.consumer_wait(acc_consumer_state)
-                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
-                    cute.copy(
-                        tiled_copy_t2r,
-                        tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
-                        tTR_rAcc,
+                expert = super_id // num_tiles_per_expert
+                local_id = super_id % num_tiles_per_expert
+                pid_m = local_id // num_tiles_ns
+                pid_ns = local_id % num_tiles_ns
+                if cutlass.const_expr(self.grouped):
+                    scale_group = _group_of_row(
+                        offsets_t,
+                        pid_ns * cutlass.Int32(self.kw),
+                        num_experts,
+                        self.search_iters,
                     )
-                    vals = tTR_rAcc.load().reshape((16,))
-                    col_rng = None
-                    if cutlass.const_expr(self.sr):
-                        col_rng = (
-                            sr_rng
-                            ^ (
-                                cutlass.Uint32(pid_m * cutlass.Int32(M_TILE) + tidx)
-                                << cutlass.Uint32(8)
+                    do_tile = (pid_ns * cutlass.Int32(self.kw)) < logical_rows
+                else:
+                    scale_group = expert
+                    do_tile = True
+                if do_tile:
+                    _, g_dec, enc_over_fp4max = _global_scale(
+                        global_amax_t[scale_group]
+                    )
+                    acc_idx = acc_consumer_state.index
+
+                    acc_pipeline.consumer_wait(acc_consumer_state)
+                    for u in cutlass.range_constexpr(self.col_groups_per_supertile):
+                        cute.copy(
+                            tiled_copy_t2r,
+                            tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
+                            tTR_rAcc,
+                        )
+                        vals = tTR_rAcc.load().reshape((16,))
+                        col_rng = None
+                        if cutlass.const_expr(self.sr):
+                            col_rng = (
+                                sr_rng
+                                ^ (
+                                    cutlass.Uint32(pid_m * cutlass.Int32(M_TILE) + tidx)
+                                    << cutlass.Uint32(8)
+                                )
+                                ^ cutlass.Uint32(u)
+                                ^ cutlass.Uint32(0x00C01000)
                             )
-                            ^ cutlass.Uint32(u)
-                            ^ cutlass.Uint32(0x00C01000)
+                        w0, w1, pvscale_fp8 = _quant16(
+                            vals, enc_over_fp4max, g_dec, self.sr, col_rng
                         )
-                    w0, w1, pvscale_fp8 = _quant16(
-                        vals, enc_over_fp4max, g_dec, self.sr, col_rng
-                    )
 
-                    sFP4[tidx, u * 2] = w0
-                    sFP4[tidx, u * 2 + 1] = w1
-                    if cutlass.const_expr(self.swizzle_sf):
-                        # swizzled SF[r=pid_m*128+tidx, c=pid_ns*16+u] -> [r//128, c//4, r%32, (r%128//32)*4 + c%4]
-                        sSF_w[
+                        sFP4[tidx, u * 2] = w0
+                        sFP4[tidx, u * 2 + 1] = w1
+                        if cutlass.const_expr(self.swizzle_sf):
+                            # swizzled SF[r=pid_m*128+tidx, c=pid_ns*16+u] -> [r//128, c//4, r%32, (r%128//32)*4 + c%4]
+                            sSF_w[
+                                0,
+                                u // 4,
+                                tidx % cutlass.Int32(32),
+                                (tidx // cutlass.Int32(32)) * cutlass.Int32(4) + (u % 4),
+                            ] = pvscale_fp8
+                        else:
+                            sSF_w[tidx, u] = pvscale_fp8
+
+                    cute.arch.fence_view_async_tmem_load()
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    epi_store_barrier.arrive_and_wait()
+                    if warp_idx == cutlass.Int32(0):
+                        gFP4 = cute.local_tile(
+                            mFP4_tma,
+                            (M_TILE, 2 * self.col_groups_per_supertile),
+                            (pid_m, pid_ns, expert),
+                        )
+                        tSs, tSg = cpasync.tma_partition(
+                            tma_atom_fp4,
                             0,
-                            u // 4,
-                            tidx % cutlass.Int32(32),
-                            (tidx // cutlass.Int32(32)) * cutlass.Int32(4) + (u % 4),
-                        ] = pvscale_fp8
-                    else:
-                        sSF_w[tidx, u] = pvscale_fp8
-
-                cute.arch.fence_view_async_tmem_load()
-                with cute.arch.elect_one():
-                    acc_pipeline.consumer_release(acc_consumer_state)
-                acc_consumer_state.advance()
-
-                cute.arch.fence_proxy("async.shared", space="cta")
-                epi_store_barrier.arrive_and_wait()
-                if warp_idx == cutlass.Int32(0):
-                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * self.col_groups_per_supertile), (pid_m, pid_ns))
-                    tSs, tSg = cpasync.tma_partition(
-                        tma_atom_fp4,
-                        0,
-                        cta_layout,
-                        cute.group_modes(sFP4, 0, 2),
-                        cute.group_modes(gFP4, 0, 2),
-                    )
-                    cute.copy(tma_atom_fp4, tSs, tSg)
-                    if cutlass.const_expr(self.swizzle_sf):
-                        gSF = cute.local_tile(
-                            mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns)
+                            cta_layout,
+                            cute.group_modes(sFP4, 0, 2),
+                            cute.group_modes(gFP4, 0, 2),
                         )
-                    else:
-                        gSF = cute.local_tile(mSF_tma, (M_TILE, self.col_groups_per_supertile), (pid_m, pid_ns))
-                    tSFs, tSFg = cpasync.tma_partition(
-                        tma_atom_sf,
-                        0,
-                        cta_layout,
-                        cute.group_modes(sSF, 0, 2),
-                        cute.group_modes(gSF, 0, 2),
-                    )
-                    cute.copy(tma_atom_sf, tSFs, tSFg)
-                    cute.arch.cp_async_bulk_commit_group()
-                    cute.arch.cp_async_bulk_wait_group(0, read=True)
-                epi_store_barrier.arrive_and_wait()
+                        cute.copy(tma_atom_fp4, tSs, tSg)
+                        if cutlass.const_expr(self.swizzle_sf):
+                            gSF = cute.local_tile(
+                                mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns, expert)
+                            )
+                        else:
+                            gSF = cute.local_tile(
+                                mSF_tma,
+                                (M_TILE, self.col_groups_per_supertile),
+                                (pid_m, pid_ns, expert),
+                            )
+                        tSFs, tSFg = cpasync.tma_partition(
+                            tma_atom_sf,
+                            0,
+                            cta_layout,
+                            cute.group_modes(sSF, 0, 2),
+                            cute.group_modes(gSF, 0, 2),
+                        )
+                        cute.copy(tma_atom_sf, tSFs, tSFg)
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                    epi_store_barrier.arrive_and_wait()
 
             tmem_dealloc_barrier.arrive_and_wait()
             tmem.relinquish_alloc_permit()
@@ -1210,8 +1299,11 @@ class _Tcgen05RowColFused:
             u_half = tidx // cutlass.Int32(M_TILE)
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
-                pid_m = super_id // num_tiles_ns
-                pid_ns = super_id % num_tiles_ns
+                expert = super_id // num_tiles_per_expert
+                local_id = super_id % num_tiles_per_expert
+                pid_m = local_id // num_tiles_ns
+                pid_ns = local_id % num_tiles_ns
+                _, g_dec, enc_over_fp4max = _global_scale(global_amax_t[expert])
 
                 ab_pipeline.consumer_wait(col_ab_state)  # wait sA full
                 stage = col_ab_state.index
@@ -1262,7 +1354,11 @@ class _Tcgen05RowColFused:
                 cute.arch.fence_proxy("async.shared", space="cta")
                 col_store_barrier.arrive_and_wait()
                 if warp_idx == cutlass.Int32(0):
-                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * self.col_groups_per_supertile), (pid_m, pid_ns))
+                    gFP4 = cute.local_tile(
+                        mFP4_tma,
+                        (M_TILE, 2 * self.col_groups_per_supertile),
+                        (pid_m, pid_ns, expert),
+                    )
                     tSs, tSg = cpasync.tma_partition(
                         tma_atom_fp4,
                         0,
@@ -1273,10 +1369,14 @@ class _Tcgen05RowColFused:
                     cute.copy(tma_atom_fp4, tSs, tSg)
                     if cutlass.const_expr(self.swizzle_sf):
                         gSF = cute.local_tile(
-                            mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns)
+                            mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns, expert)
                         )
                     else:
-                        gSF = cute.local_tile(mSF_tma, (M_TILE, self.col_groups_per_supertile), (pid_m, pid_ns))
+                        gSF = cute.local_tile(
+                            mSF_tma,
+                            (M_TILE, self.col_groups_per_supertile),
+                            (pid_m, pid_ns, expert),
+                        )
                     tSFs, tSFg = cpasync.tma_partition(
                         tma_atom_sf,
                         0,
@@ -1290,6 +1390,17 @@ class _Tcgen05RowColFused:
                 col_store_barrier.arrive_and_wait()
 
 
+def _group_of_row(offsets_t, row, num_experts, search_iters: int):
+    lo = cutlass.Int32(0)
+    hi = num_experts - cutlass.Int32(1)
+    for _ in range(search_iters):
+        mid = (lo + hi) // cutlass.Int32(2)
+        below = cutlass.Int32(offsets_t[mid]) <= row
+        lo = cutlass.Int32(cutlass.select_(below, mid + cutlass.Int32(1), lo))
+        hi = cutlass.Int32(cutlass.select_(below, hi, mid))
+    return lo
+
+
 class _Tcgen05RhtAmax:
     """One-pass tensor-core RHT amax over the dual-consumer A load.
 
@@ -1299,8 +1410,18 @@ class _Tcgen05RhtAmax:
     M % (16 * col_groups_per_supertile) == 0 (16 -> M % 256, 8 -> M % 128), N % 128 == 0.
     """
 
-    def __init__(self, col_groups_per_supertile: int = 16):
+    def __init__(
+        self,
+        col_groups_per_supertile: int = 16,
+        grouped: bool = False,
+        search_iters: int = 0,
+    ):
+        # grouped=True: per-expert amax over a row-packed ragged tensor. offsets_t holds
+        # cumulative 128-aligned row ends, amax outputs are (E,), rows at or beyond
+        # logical_len_t[0] are storage capacity and are skipped (CUDA-graph-safe).
         _set_supertile_geometry(self, col_groups_per_supertile)
+        self.grouped = grouped
+        self.search_iters = search_iters
 
     @cute.jit
     def __call__(
@@ -1309,6 +1430,9 @@ class _Tcgen05RhtAmax:
         mB: cute.Tensor,
         col_amax_t: cute.Tensor,
         row_amax_t: cute.Tensor,
+        offsets_t: cute.Tensor,
+        logical_len_t: cute.Tensor,
+        num_experts: cutlass.Int32,
         M: cutlass.Int32,
         N: cutlass.Int32,
         GRID: cutlass.Int32,
@@ -1389,6 +1513,9 @@ class _Tcgen05RhtAmax:
             tma_tensor_b,
             col_amax_t,
             row_amax_t,
+            offsets_t,
+            logical_len_t,
+            num_experts,
             cluster_layout_vmnk,
             a_smem_layout_staged,
             a_clean_layout,
@@ -1411,6 +1538,9 @@ class _Tcgen05RhtAmax:
         mB_nkl: cute.Tensor,
         col_amax_t: cute.Tensor,
         row_amax_t: cute.Tensor,
+        offsets_t: cute.Tensor,
+        logical_len_t: cute.Tensor,
+        num_experts: cutlass.Int32,
         cluster_layout_vmnk: cute.Layout,
         a_smem_layout_staged: cute.ComposedLayout,
         a_clean_layout: cute.ComposedLayout,
@@ -1541,25 +1671,34 @@ class _Tcgen05RhtAmax:
             cutlass.Int32(0),
         )
 
+        logical_rows = cutlass.Int32(0)
+        if cutlass.const_expr(self.grouped):
+            logical_rows = cutlass.Int32(logical_len_t[0])
+
         # ==================== TMA warp (AB producer) ====================
         if warp_idx == self.tma_warp:
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
                 pid_m = super_id // num_tiles_ns
                 pid_ns = super_id % num_tiles_ns
-                handle = ab_producer.acquire_and_advance()
-                cute.copy(
-                    tma_atom_a,
-                    tAgA[(None, pid_m, pid_ns, 0)],
-                    tAsA[(None, handle.index)],
-                    tma_bar_ptr=handle.barrier,
-                )
-                cute.copy(
-                    tma_atom_b,
-                    tBgB[(None, 0)],
-                    tBsB[(None, handle.index)],
-                    tma_bar_ptr=handle.barrier,
-                )
+                if cutlass.const_expr(self.grouped):
+                    do_tile = (pid_ns * cutlass.Int32(self.kw)) < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    handle = ab_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA[(None, pid_m, pid_ns, 0)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB[(None, 0)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                    )
             ab_producer.tail()
 
         # ==================== MMA warp (AB consumer, acc producer) ====================
@@ -1571,20 +1710,28 @@ class _Tcgen05RhtAmax:
                 pipeline.PipelineUserType.Producer, NUM_ACC_STAGE
             )
             for local_iter in cutlass.range(num_iters):
-                ab_handle = ab_consumer.wait_and_advance()
-                acc_pipeline.producer_acquire(acc_producer_state)
-                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
-                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                    cute.gemm(
-                        tiled_mma,
-                        tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
-                        tCrA[(None, None, u, ab_handle.index)],
-                        tCrB[(None, None, 0, ab_handle.index)],
-                        tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
-                    )
-                acc_pipeline.producer_commit(acc_producer_state)
-                acc_producer_state.advance()
-                ab_handle.release()
+                if cutlass.const_expr(self.grouped):
+                    super_id = start_pid + local_iter * GRID
+                    do_tile = (
+                        (super_id % num_tiles_ns) * cutlass.Int32(self.kw)
+                    ) < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    ab_handle = ab_consumer.wait_and_advance()
+                    acc_pipeline.producer_acquire(acc_producer_state)
+                    for u in cutlass.range_constexpr(self.col_groups_per_supertile):
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
+                            tCrA[(None, None, u, ab_handle.index)],
+                            tCrB[(None, None, 0, ab_handle.index)],
+                            tCtAcc_base[(None, None, None, u, acc_producer_state.index)],
+                        )
+                    acc_pipeline.producer_commit(acc_producer_state)
+                    acc_producer_state.advance()
+                    ab_handle.release()
             acc_pipeline.producer_tail(acc_producer_state)
 
         # ==================== ROW warps (AB consumer, read raw sA) -> row amax ====================
@@ -1599,25 +1746,49 @@ class _Tcgen05RhtAmax:
             kc = k_row % cutlass.Int32(8)
             kd = k_row // cutlass.Int32(8)
             for local_iter in cutlass.range(num_iters):
-                ab_pipeline.consumer_wait(row_ab_state)
-                stage = row_ab_state.index
-                for b in cutlass.range_constexpr(M_TILE // 16):  # 8 blocks of 16 N
-                    for j in cutlass.range_constexpr(16):
-                        m_mma = b * 16 + j  # N position (0..127)
-                        v = sA_clean[
-                            ((m_mma % 64, m_mma // 64), (kc, kd), (0, stage))
-                        ].to(cutlass.Float32)
-                        thread_row_max = _max_f32(thread_row_max, _abs_f32(v))
-                cute.arch.mbarrier_arrive(
-                    ab_pipeline.sync_object_empty.get_barrier(stage)
-                )
-                row_ab_state.advance()
-            for offset in [16, 8, 4, 2, 1]:
-                thread_row_max = _max_f32(
-                    thread_row_max, cute.arch.shuffle_sync_bfly(thread_row_max, offset)
-                )
-            if lane == cutlass.Int32(0):
-                _atom_max_f32_nonneg(row_amax_t.iterator, thread_row_max)
+                super_id = start_pid + local_iter * GRID
+                pid_ns = super_id % num_tiles_ns
+                row_base = pid_ns * cutlass.Int32(self.kw)
+                if cutlass.const_expr(self.grouped):
+                    do_tile = row_base < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    ab_pipeline.consumer_wait(row_ab_state)
+                    stage = row_ab_state.index
+                    tile_max = cutlass.Float32(0.0)
+                    for b in cutlass.range_constexpr(M_TILE // 16):  # 8 blocks of 16 N
+                        for j in cutlass.range_constexpr(16):
+                            m_mma = b * 16 + j  # N position (0..127)
+                            v = sA_clean[
+                                ((m_mma % 64, m_mma // 64), (kc, kd), (0, stage))
+                            ].to(cutlass.Float32)
+                            tile_max = _max_f32(tile_max, _abs_f32(v))
+                    cute.arch.mbarrier_arrive(
+                        ab_pipeline.sync_object_empty.get_barrier(stage)
+                    )
+                    row_ab_state.advance()
+                    if cutlass.const_expr(self.grouped):
+                        # This supertile is one group's rows; commit its max now.
+                        for offset in [16, 8, 4, 2, 1]:
+                            tile_max = _max_f32(
+                                tile_max, cute.arch.shuffle_sync_bfly(tile_max, offset)
+                            )
+                        if lane == cutlass.Int32(0):
+                            g = _group_of_row(
+                                offsets_t, row_base, num_experts, self.search_iters
+                            )
+                            _atom_max_f32_nonneg(row_amax_t.iterator + g, tile_max)
+                    else:
+                        thread_row_max = _max_f32(thread_row_max, tile_max)
+            if cutlass.const_expr(not self.grouped):
+                for offset in [16, 8, 4, 2, 1]:
+                    thread_row_max = _max_f32(
+                        thread_row_max,
+                        cute.arch.shuffle_sync_bfly(thread_row_max, offset),
+                    )
+                if lane == cutlass.Int32(0):
+                    _atom_max_f32_nonneg(row_amax_t.iterator, thread_row_max)
 
         # ==================== COL epilogue warps (acc consumer, TMEM) -> col amax ====================
         if warp_idx < COL_WARP_END:
@@ -1648,28 +1819,51 @@ class _Tcgen05RhtAmax:
             )
             thread_col_max = cutlass.Float32(0.0)
             for local_iter in cutlass.range(num_iters):
-                acc_idx = acc_consumer_state.index
-                acc_pipeline.consumer_wait(acc_consumer_state)
-                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
-                    cute.copy(
-                        tiled_copy_t2r,
-                        tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
-                        tTR_rAcc,
-                    )
-                    vals = tTR_rAcc.load().reshape((16,))
-                    for i in cutlass.range_constexpr(16):
-                        thread_col_max = _max_f32(thread_col_max, _abs_f32(vals[i]))
-                cute.arch.fence_view_async_tmem_load()
-                with cute.arch.elect_one():
-                    acc_pipeline.consumer_release(acc_consumer_state)
-                acc_consumer_state.advance()
+                super_id = start_pid + local_iter * GRID
+                pid_ns = super_id % num_tiles_ns
+                row_base = pid_ns * cutlass.Int32(self.kw)
+                if cutlass.const_expr(self.grouped):
+                    do_tile = row_base < logical_rows
+                else:
+                    do_tile = True
+                if do_tile:
+                    acc_idx = acc_consumer_state.index
+                    acc_pipeline.consumer_wait(acc_consumer_state)
+                    tile_max = cutlass.Float32(0.0)
+                    for u in cutlass.range_constexpr(self.col_groups_per_supertile):
+                        cute.copy(
+                            tiled_copy_t2r,
+                            tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
+                            tTR_rAcc,
+                        )
+                        vals = tTR_rAcc.load().reshape((16,))
+                        for i in cutlass.range_constexpr(16):
+                            tile_max = _max_f32(tile_max, _abs_f32(vals[i]))
+                    cute.arch.fence_view_async_tmem_load()
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+                    if cutlass.const_expr(self.grouped):
+                        for offset in [16, 8, 4, 2, 1]:
+                            tile_max = _max_f32(
+                                tile_max, cute.arch.shuffle_sync_bfly(tile_max, offset)
+                            )
+                        if lane == cutlass.Int32(0):
+                            g = _group_of_row(
+                                offsets_t, row_base, num_experts, self.search_iters
+                            )
+                            _atom_max_f32_nonneg(col_amax_t.iterator + g, tile_max)
+                    else:
+                        thread_col_max = _max_f32(thread_col_max, tile_max)
 
-            for offset in [16, 8, 4, 2, 1]:
-                thread_col_max = _max_f32(
-                    thread_col_max, cute.arch.shuffle_sync_bfly(thread_col_max, offset)
-                )
-            if lane == cutlass.Int32(0):
-                _atom_max_f32_nonneg(col_amax_t.iterator, thread_col_max)
+            if cutlass.const_expr(not self.grouped):
+                for offset in [16, 8, 4, 2, 1]:
+                    thread_col_max = _max_f32(
+                        thread_col_max,
+                        cute.arch.shuffle_sync_bfly(thread_col_max, offset),
+                    )
+                if lane == cutlass.Int32(0):
+                    _atom_max_f32_nonneg(col_amax_t.iterator, thread_col_max)
 
             tmem_dealloc_barrier.arrive_and_wait()
             tmem.relinquish_alloc_permit()
@@ -1723,7 +1917,9 @@ def _get_sr_rng_buffer(device_idx):
 
 
 @functools.lru_cache(maxsize=None)
-def _compile_amax_tc_kernel(device_idx, col_groups_per_supertile=16):
+def _compile_amax_tc_kernel(
+    device_idx, col_groups_per_supertile=16, grouped=False, search_iters=0
+):
     """Compile the tensor-core RHT amax with symbolic shapes (cached per device+u).
 
     The symbolic (sym_int) shapes make the compiled kernel serve any (M % (16*u), N % 128);
@@ -1740,9 +1936,15 @@ def _compile_amax_tc_kernel(device_idx, col_groups_per_supertile=16):
     fake_bT = make_fake_tensor(
         cutlass.BFloat16, (HADAMARD_DIM, HADAMARD_DIM, 1), stride=(HADAMARD_DIM, 1, 1)
     )
-    fake_col = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
-    fake_row = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
-    k = _Tcgen05RhtAmax(col_groups_per_supertile=col_groups_per_supertile)
+    fake_col = make_fake_tensor(cutlass.Float32, (cute.sym_int(),), stride=(1,))
+    fake_row = make_fake_tensor(cutlass.Float32, (cute.sym_int(),), stride=(1,))
+    fake_offsets = make_fake_tensor(cutlass.Int32, (cute.sym_int(),), stride=(1,))
+    fake_logical = make_fake_tensor(cutlass.Int32, (1,), stride=(1,))
+    k = _Tcgen05RhtAmax(
+        col_groups_per_supertile=col_groups_per_supertile,
+        grouped=grouped,
+        search_iters=search_iters,
+    )
     # c_layout for the TMEM->reg read = layout of the col FP4 output (row-major 2D); the enum
     # depends only on row/col-majorness, so a dummy contiguous tensor suffices.
     dummy = torch.empty((M_TILE, 16), dtype=torch.int32, device=device)
@@ -1753,6 +1955,9 @@ def _compile_amax_tc_kernel(device_idx, col_groups_per_supertile=16):
         fake_bT,
         fake_col,
         fake_row,
+        fake_offsets,
+        fake_logical,
+        cutlass.Int32(0),
         cutlass.Int32(0),
         cutlass.Int32(0),
         cutlass.Int32(0),
@@ -1800,11 +2005,15 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
     stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
 
     amax_compiled = _compile_amax_tc_kernel(dev.index, col_groups_per_supertile)
+    dummy_i32 = _get_sr_rng_buffer(dev.index)  # grouped-only args; never read when grouped=False
     amax_compiled(
         A.t().unsqueeze(-1),
         rht_nk,
         col_amax,
         row_amax,
+        dummy_i32,
+        dummy_i32,
+        1,
         int(M),
         int(N),
         int(GRID),
@@ -1813,8 +2022,214 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
     return col_amax, row_amax
 
 
+# Grouped shape representation supported by the grouped kernels
+VARYING_FIRST_DIM = 1
+
+
+def _cutedsl_group_rht_amax_impl(
+    A: torch.Tensor,
+    sign_vector,
+    offsets: torch.Tensor,
+    num_tensors: int,
+    packed_sequence_length: int,
+    hidden_size: int,
+    shape_rep: int,
+    logical_packed_length: Optional[torch.Tensor] = None,
+):
+    """Per-group (col_amax, row_amax) over a row-packed ragged tensor.
+
+    col_amax[g] = max|RHT(A_g.t())|, row_amax[g] = max|A_g| for rows
+    [offsets[g-1], offsets[g]). Group boundaries must be 128-aligned.
+    """
+    if A.dtype != torch.bfloat16:
+        raise ValueError(f"Expected bfloat16, got {A.dtype}")
+    if A.ndim != 2:
+        raise ValueError("A must be 2-D")
+    if not A.is_contiguous():
+        raise ValueError("A must be row-major (contiguous)")
+    M, N = A.shape
+    if (M, N) != (packed_sequence_length, hidden_size):
+        raise ValueError(
+            f"A shape {tuple(A.shape)} != (packed_sequence_length, hidden_size) "
+            f"({packed_sequence_length}, {hidden_size})"
+        )
+    if shape_rep != VARYING_FIRST_DIM:
+        raise ValueError("cutedsl_group_rht_amax supports only VARYING_FIRST_DIM")
+    if M % 128 != 0:
+        raise ValueError(f"packed row capacity must be divisible by 128, got {M}")
+    if N % 128 != 0:
+        raise ValueError(f"hidden_size must be divisible by 128, got {N}")
+    if offsets.dtype != torch.int32 or offsets.ndim != 1:
+        raise ValueError("offsets must be a 1-D int32 tensor")
+    if offsets.numel() != num_tensors:
+        raise ValueError(f"offsets must have {num_tensors} entries, got {offsets.numel()}")
+    if not offsets.is_contiguous() or not offsets.is_cuda:
+        raise ValueError("offsets must be a contiguous CUDA tensor")
+    if logical_packed_length is None:
+        logical_packed_length = offsets[num_tensors - 1 : num_tensors]
+    if (
+        logical_packed_length.dtype != torch.int32
+        or logical_packed_length.numel() != 1
+    ):
+        raise ValueError("logical_packed_length must be a one-element int32 tensor")
+    A = A.detach()
+    dev = A.device
+    col_amax = torch.zeros(num_tensors, dtype=torch.float32, device=dev)
+    row_amax = torch.zeros(num_tensors, dtype=torch.float32, device=dev)
+
+    rht_nk = _get_rht_buffer(tuple(sign_vector), dev.index)
+    # 128-row supertile: group boundaries are 128-aligned, so no supertile straddles one.
+    col_groups = 8
+    search_iters = max(0, (num_tensors - 1).bit_length())
+    NUM_SMS = _get_num_sms(dev.index)
+    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * col_groups)))
+    stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
+
+    amax_compiled = _compile_amax_tc_kernel(
+        dev.index, col_groups, grouped=True, search_iters=search_iters
+    )
+    amax_compiled(
+        A.t().unsqueeze(-1),
+        rht_nk,
+        col_amax,
+        row_amax,
+        offsets,
+        logical_packed_length,
+        int(num_tensors),
+        int(M),
+        int(N),
+        int(GRID),
+        stream,
+    )
+    return col_amax, row_amax
+
+
+def _cutedsl_group_rht_quantize_row_col_impl(
+    A: torch.Tensor,
+    sign_vector,
+    offsets: torch.Tensor,
+    num_tensors: int,
+    packed_sequence_length: int,
+    hidden_size: int,
+    shape_rep: int,
+    row_global_amax: torch.Tensor,
+    col_global_amax: torch.Tensor,
+    rng_state: Optional[torch.Tensor],
+    enable_stochastic_rounding: bool,
+    logical_packed_length: Optional[torch.Tensor] = None,
+):
+    """Grouped fused RHT columnwise + rowwise NVFP4 quantize over a row-packed
+    ragged tensor.
+    """
+    if A.dtype != torch.bfloat16:
+        raise ValueError(f"Expected bfloat16, got {A.dtype}")
+    if A.ndim != 2:
+        raise ValueError("A must be 2-D")
+    if not A.is_contiguous():
+        raise ValueError("A must be row-major (contiguous)")
+    M, N = A.shape
+    if (M, N) != (packed_sequence_length, hidden_size):
+        raise ValueError(
+            f"A shape {tuple(A.shape)} != (packed_sequence_length, hidden_size) "
+            f"({packed_sequence_length}, {hidden_size})"
+        )
+    if shape_rep != VARYING_FIRST_DIM:
+        raise ValueError(
+            "cutedsl_group_rht_quantize_row_col supports only VARYING_FIRST_DIM"
+        )
+    if M % 128 != 0:
+        raise ValueError(f"packed row capacity must be divisible by 128, got {M}")
+    if N % 128 != 0:
+        raise ValueError(f"hidden_size must be divisible by 128, got {N}")
+    if offsets.dtype != torch.int32 or offsets.ndim != 1:
+        raise ValueError("offsets must be a 1-D int32 tensor")
+    if offsets.numel() != num_tensors:
+        raise ValueError(f"offsets must have {num_tensors} entries, got {offsets.numel()}")
+    if not offsets.is_contiguous() or not offsets.is_cuda:
+        raise ValueError("offsets must be a contiguous CUDA tensor")
+    for name, t in (("row_global_amax", row_global_amax), ("col_global_amax", col_global_amax)):
+        if t.shape != (num_tensors,) or t.dtype != torch.float32:
+            raise ValueError(f"{name} must be a ({num_tensors},) float32 tensor")
+    if logical_packed_length is None:
+        logical_packed_length = offsets[num_tensors - 1 : num_tensors]
+    if (
+        logical_packed_length.dtype != torch.int32
+        or logical_packed_length.numel() != 1
+    ):
+        raise ValueError("logical_packed_length must be a one-element int32 tensor")
+    A = A.detach()
+    dev = A.device
+    sr = bool(enable_stochastic_rounding)
+    sr_rng_t = _get_sr_rng_buffer(dev.index)
+    if sr:
+        if rng_state is None or rng_state.numel() != 4 or rng_state.dtype != torch.int64:
+            raise ValueError(
+                "enable_stochastic_rounding=True requires rng_state, an int64 tensor "
+                "[col_seed, col_offset, row_seed, row_offset]"
+            )
+        # Single int32 base; the kernel decorrelates col/row and per-block internally.
+        sr_rng_t.copy_(((rng_state[0] ^ rng_state[1]) & 0x7FFFFFFF).to(torch.int32).reshape(1))
+
+    col_fp4 = torch.empty((N, M // 8), dtype=torch.uint32, device=dev)
+    row_fp4 = torch.empty((M, N // 8), dtype=torch.uint32, device=dev)
+    col_sf = torch.empty((N // 128, M // 64, 32, 16), dtype=torch.float8_e4m3fn, device=dev)
+    row_sf = torch.empty((M // 128, N // 64, 32, 16), dtype=torch.float8_e4m3fn, device=dev)
+    csf_g = col_sf.reshape(N // 128, (M // 64) * SF_BLK)
+    rsf_g = row_sf.reshape(M // 128, (N // 64) * SF_BLK)
+
+    rht_nk = _get_rht_buffer(tuple(sign_vector), dev.index)
+    col_groups = 8  # 128-row supertile: group boundaries are 128-aligned
+    search_iters = max(0, (num_tensors - 1).bit_length())
+    NUM_SMS = _get_num_sms(dev.index)
+    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * col_groups)))
+    stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
+
+    fused = _compile_fused_kernel(
+        dev.index,
+        True,
+        sr,
+        apply_rht=True,
+        col_groups_per_supertile=col_groups,
+        grouped=True,
+        search_iters=search_iters,
+    )
+    fused(
+        A.t().unsqueeze(-1),
+        rht_nk,
+        col_fp4.unsqueeze(-1),
+        csf_g.unsqueeze(-1),
+        row_fp4.unsqueeze(-1),
+        rsf_g.unsqueeze(-1),
+        row_global_amax,
+        col_global_amax,
+        sr_rng_t,
+        offsets,
+        logical_packed_length,
+        int(num_tensors),
+        int(M),
+        int(N),
+        int(GRID),
+        stream,
+    )
+    # Ryan's return order and shapes: row first, scale bytes viewed as logical 2D.
+    return (
+        row_fp4.view(torch.uint8),
+        row_sf.view(M, N // 16),
+        col_fp4.view(torch.uint8),
+        col_sf.view(N, M // 16),
+    )
+
+
 @functools.lru_cache(maxsize=None)
-def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_per_supertile=16):
+def _compile_fused_kernel(
+    device_idx,
+    swizzle,
+    sr,
+    apply_rht=True,
+    col_groups_per_supertile=16,
+    grouped=False,
+    search_iters=0,
+):
     """Compile the fused kernel with symbolic shapes (cached per device+swizzle+sr+apply_rht+u).
 
     The symbolic (sym_int) shapes make the compiled kernel serve any (M % (16*u), N % 128); the
@@ -1828,9 +2243,10 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_pe
     n_sym = cute.sym_int(divisibility=M_TILE)  # N % 128
     free = cute.sym_int  # a fresh dynamic stride per call
 
-    # aT = A.t().unsqueeze(-1): (N, M, 1), dim0 contiguous; output FP4 tensors row-major.
+    # aT: (N, M, L), dim0 contiguous; L = expert count (1 for the dense op). Output FP4
+    # tensors are row-major per expert with L as the outermost (last-mode) coordinate.
     fake_aT = make_fake_tensor(
-        cutlass.BFloat16, (n_sym, m_sym, 1), stride=(1, free(), 1)
+        cutlass.BFloat16, (n_sym, m_sym, cute.sym_int()), stride=(1, free(), free())
     )
     fake_bT = make_fake_tensor(
         cutlass.BFloat16, (HADAMARD_DIM, HADAMARD_DIM, 1), stride=(HADAMARD_DIM, 1, 1)
@@ -1838,13 +2254,13 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_pe
     # col_fp4 (N, M//8) u32, store box inner = 2*col_groups; row_fp4 (M, N//8) u32, inner = 16.
     fake_cfp4 = make_fake_tensor(
         cutlass.Uint32,
-        (n_sym, cute.sym_int(divisibility=2 * col_groups_per_supertile)),
-        stride=(free(), 1),
+        (n_sym, cute.sym_int(divisibility=2 * col_groups_per_supertile), cute.sym_int()),
+        stride=(free(), 1, free()),
     )
     fake_rfp4 = make_fake_tensor(
         cutlass.Uint32,
-        (m_sym, cute.sym_int(divisibility=M_TILE // 8)),
-        stride=(free(), 1),
+        (m_sym, cute.sym_int(divisibility=M_TILE // 8), cute.sym_int()),
+        stride=(free(), 1, free()),
     )
     if swizzle:
         # SF flattened to 2D for the TMA atom: col_sf.reshape(N//128, (M//64)*512) has inner
@@ -1853,34 +2269,45 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_pe
         # inner by 1024 (from N%128).
         fake_csf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (cute.sym_int(divisibility=1), cute.sym_int(divisibility=(col_groups_per_supertile // 4) * SF_BLK)),
-            stride=(free(), 1),
+            (
+                cute.sym_int(divisibility=1),
+                cute.sym_int(divisibility=(col_groups_per_supertile // 4) * SF_BLK),
+                cute.sym_int(),
+            ),
+            stride=(free(), 1, free()),
         )
         fake_rsf = make_fake_tensor(
             cutlass.Float8E4M3FN,
             (
                 cute.sym_int(divisibility=(K * col_groups_per_supertile) // 128),
                 cute.sym_int(divisibility=1024),
+                cute.sym_int(),
             ),
-            stride=(free(), 1),
+            stride=(free(), 1, free()),
         )
     else:
         # plain SF: col (N, M//16), row (M, N//16). Requires col_groups=16 (col box is that many bytes wide).
         fake_csf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (n_sym, cute.sym_int(divisibility=col_groups_per_supertile)),
-            stride=(free(), 1),
+            (n_sym, cute.sym_int(divisibility=col_groups_per_supertile), cute.sym_int()),
+            stride=(free(), 1, free()),
         )
         fake_rsf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (m_sym, cute.sym_int(divisibility=M_TILE // 16)),
-            stride=(free(), 1),
+            (m_sym, cute.sym_int(divisibility=M_TILE // 16), cute.sym_int()),
+            stride=(free(), 1, free()),
         )
-    fake_amax = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
+    fake_amax = make_fake_tensor(cutlass.Float32, (cute.sym_int(),), stride=(1,))
     fake_sr_rng = make_fake_tensor(cutlass.Int32, (1,), stride=(1,))
+    fake_offsets = make_fake_tensor(cutlass.Int32, (cute.sym_int(),), stride=(1,))
+    fake_logical = make_fake_tensor(cutlass.Int32, (1,), stride=(1,))
     k = _Tcgen05RowColFused(
-        swizzle_sf=swizzle, sr=sr, apply_rht=apply_rht,
+        swizzle_sf=swizzle,
+        sr=sr,
+        apply_rht=apply_rht,
         col_groups_per_supertile=col_groups_per_supertile,
+        grouped=grouped,
+        search_iters=search_iters,
     )
     return cute.compile(
         k,
@@ -1893,6 +2320,9 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_pe
         fake_amax,
         fake_amax,
         fake_sr_rng,
+        fake_offsets,
+        fake_logical,
+        cutlass.Int32(0),
         cutlass.Int32(0),
         cutlass.Int32(0),
         cutlass.Int32(0),
@@ -2032,13 +2462,16 @@ def _cutedsl_rht_quantize_row_col_impl(
     fused(
         A.t().unsqueeze(-1),
         rht_nk,
-        col_fp4,
-        csf_g,
-        row_fp4,
-        rsf_g,
+        col_fp4.unsqueeze(-1),
+        csf_g.unsqueeze(-1),
+        row_fp4.unsqueeze(-1),
+        rsf_g.unsqueeze(-1),
         row_amax_t,
         col_amax_t,
         sr_rng_t,
+        sr_rng_t,  # grouped-only args; never read when grouped=False
+        sr_rng_t,
+        1,
         int(M),
         int(N),
         int(GRID),
@@ -2049,3 +2482,80 @@ def _cutedsl_rht_quantize_row_col_impl(
     if compute_rowwise:
         return col_fp4_u8, col_sf, row_fp4.view(torch.uint8), row_sf
     return col_fp4_u8, col_sf, None, None
+
+
+def _cutedsl_group_weight_quantize_2d_impl(
+    A: torch.Tensor,
+    global_amax: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-expert 2D (16x16) NVFP4 weight quantization over stacked (E, M, N) weights.
+
+    Returns (row codes, row sf, col codes = W.T, col sf) in the shapes:
+    (E, M, N//2) u8, (E, M//128, N//64, 32, 16) fp8,
+    (E, N, M//2) u8, (E, N//128, M//64, 32, 16) fp8.
+    """
+    if A.dtype != torch.bfloat16:
+        raise ValueError(f"Expected bfloat16, got {A.dtype}")
+    if A.ndim != 3:
+        raise ValueError("A must be 3-D (E, M, N)")
+    if not A.is_contiguous():
+        raise ValueError("A must be contiguous")
+    E, M, N = A.shape
+    if M % 128 != 0:
+        raise ValueError(f"M must be divisible by 128, got M={M}")
+    if N % 128 != 0:
+        raise ValueError(f"N must be divisible by 128, got N={N}")
+    if global_amax.shape != (E,):
+        raise ValueError(f"global_amax must have shape ({E},), got {tuple(global_amax.shape)}")
+    if global_amax.dtype != torch.float32:
+        raise ValueError(f"global_amax must be float32, got {global_amax.dtype}")
+    if not global_amax.is_contiguous():
+        raise ValueError("global_amax must be contiguous")
+    col_groups_per_supertile = 16 if M % 256 == 0 else 8
+    A = A.detach()
+    dev = A.device
+
+    row_fp4 = torch.empty((E, M, N // 8), dtype=torch.uint32, device=dev)
+    row_sf = torch.empty(
+        (E, M // 128, N // 64, 32, 16), dtype=torch.float8_e4m3fn, device=dev
+    )
+    col_fp4 = torch.empty((E, N, M // 8), dtype=torch.uint32, device=dev)
+    col_sf = torch.empty(
+        (E, N // 128, M // 64, 32, 16), dtype=torch.float8_e4m3fn, device=dev
+    )
+
+    identity_nk = _get_identity_buffer(dev.index)
+    sr_rng_t = _get_sr_rng_buffer(dev.index)
+    NUM_SMS = _get_num_sms(dev.index)
+
+    supers_per_expert = (N // M_TILE) * (M // (N_TILE * col_groups_per_supertile))
+    GRID = min(NUM_SMS, E * supers_per_expert)
+    stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
+    fused = _compile_fused_kernel(
+        dev.index, True, False, apply_rht=False,
+        col_groups_per_supertile=col_groups_per_supertile,
+    )
+    fused(
+        A.permute(2, 1, 0),
+        identity_nk,
+        col_fp4.permute(1, 2, 0),
+        col_sf.reshape(E, N // 128, (M // 64) * SF_BLK).permute(1, 2, 0),
+        row_fp4.permute(1, 2, 0),
+        row_sf.reshape(E, M // 128, (N // 64) * SF_BLK).permute(1, 2, 0),
+        global_amax,
+        global_amax,
+        sr_rng_t,
+        sr_rng_t,
+        sr_rng_t,
+        1,
+        int(M),
+        int(N),
+        int(GRID),
+        stream,
+    )
+    return (
+        row_fp4.view(torch.uint8),
+        row_sf,
+        col_fp4.view(torch.uint8),
+        col_sf,
+    )

--- a/torchao/prototype/moe_training/nvfp4_training/_cutedsl_kernels_impl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/_cutedsl_kernels_impl.py
@@ -291,36 +291,24 @@ def _get_num_sms(device_idx: int) -> int:
 M_TILE = 128
 N_TILE = 16
 K = 16
-U = 16  # adjacent col-groups per super-tile
-KW = K * U  # wide A load K (= M-positions per super-tile)
 MMA_TILER = (M_TILE, N_TILE, K)  # instruction atom stays 128x16x16
 
 NUM_AB_STAGE = 2
 NUM_ACC_STAGE = 1
 
-# --- warp specialization (RHT mode, 14 warps): col is a cheap TMEM epilogue (MMA does the work) ---
+# --- warp specialization, supertile-independent part (RHT mode): col is a cheap TMEM epilogue ---
 N_COL_WARPS = 4
-N_ROW_WARPS = 8
 COL_WARP_END = N_COL_WARPS  # warps 0..3 = col
 ROW_WARP_BEGIN = N_COL_WARPS  # 4
-ROW_WARP_END = N_COL_WARPS + N_ROW_WARPS  # 12
-MMA_WARP = ROW_WARP_END  # 12
-TMA_WARP = MMA_WARP + 1  # 13
-N_WARPS = TMA_WARP + 1  # 14
-FUSED_TPB = 32 * N_WARPS  # 448
 COL_THREADS = 32 * N_COL_WARPS  # 128
-ROW_THREADS = 32 * N_ROW_WARPS  # 256  (== KW rows for U=16: 1 row/thread)
 
-# --- warp specialization (weight mode, apply_rht=False, no MMA): col now does the heavy transposed
-# SMEM read itself, so col and row get EQUAL warps (their per-tile outputs are equal-sized). Col's 8
-# warps cover the 128 N-rows with 2 threads/row (each does half the U u-blocks). ---
+# --- weight mode (apply_rht=False, no MMA): col now does the heavy transposed SMEM read itself,
+# so col and row get EQUAL warps for the 256-row supertile (their per-tile outputs are
+# equal-sized; at 128-row col keeps 8 warps while row drops to 4). Col's 8 warps cover the
+# 128 N-rows with 2 threads/row (each owns half the col-group blocks). ---
 COL_WARP_END_W = 8  # warps 0..7 = col (2 threads / N-row)
 ROW_WARP_BEGIN_W = 8
-ROW_WARP_END_W = 16  # warps 8..15 = row (1 thread / M-row, KW=256)
-TMA_WARP_W = 16
-FUSED_TPB_W = 32 * (TMA_WARP_W + 1)  # 544
 COL_THREADS_W = 32 * COL_WARP_END_W  # 256
-ROW_THREADS_W = 32 * (ROW_WARP_END_W - ROW_WARP_BEGIN_W)  # 256
 
 TMEM_ALLOC_BAR = 1
 TMEM_DEALLOC_BAR = 2
@@ -331,9 +319,36 @@ ROW_FP4_STAGES = 2
 # Swizzled scale-factor layout (cutlass NVFP4): SF[r,c] -> [r//128, c//4, r%32, (r%128//32)*4 + c%4].
 # Per super-tile, the SF tile has a 32x16 (=16B-wide) inner -> TMA-storable. Block inner = 32*16.
 SF_BLK = 32 * 16  # 512 fp8 per (128-row x 4-col) swizzle block
-SF_GCOL = U // 4  # 4  : M-groups (c//4) per col super-tile (16 SF cols)
-SF_RBLK = KW // 128  # 2  : M-blocks (r//128) per row super-tile (256 M rows)
 SF_RGRP = (M_TILE // 16) // 4  # 2  : N-groups (c//4) per row super-tile (8 SF cols)
+
+
+def _set_supertile_geometry(kernel_obj, col_groups_per_supertile: int):
+    """Derive the supertile/warp geometry onto a kernel instance.
+
+    col_groups_per_supertile = the number of 16-column blocks each main-loop iteration
+    processes; a supertile spans kw = 16 * col_groups_per_supertile M-positions. 16 (a
+    256-row supertile) serves M % 256 and is the tuned config; 8 (128-row) serves M % 128
+    and is the floor (sf_rblk = kw//128 must stay >= 1; the plain col-SF box is
+    col_groups_per_supertile bytes wide, so swizzle_sf=False needs 16). Row warps own one
+    M-row per thread (row_threads == kw), so they scale with the supertile height.
+    """
+    assert col_groups_per_supertile in (8, 16), (
+        f"col_groups_per_supertile must be 8 or 16, got {col_groups_per_supertile}"
+    )
+    kernel_obj.col_groups_per_supertile = col_groups_per_supertile
+    kernel_obj.kw = K * col_groups_per_supertile
+    kernel_obj.sf_gcol = col_groups_per_supertile // 4  # M-groups (c//4) per col super-tile
+    kernel_obj.sf_rblk = kernel_obj.kw // 128  # M-blocks (r//128) per row super-tile
+    n_row_warps = kernel_obj.kw // 32  # 8 for the 256-row supertile, 4 for 128-row
+    kernel_obj.row_warp_end = ROW_WARP_BEGIN + n_row_warps
+    kernel_obj.mma_warp = kernel_obj.row_warp_end
+    kernel_obj.tma_warp = kernel_obj.mma_warp + 1
+    kernel_obj.fused_tpb = 32 * (kernel_obj.tma_warp + 1)  # 448 / 320 threads
+    kernel_obj.row_threads = 32 * n_row_warps  # == kw: 1 M-row per thread
+    kernel_obj.row_warp_end_w = ROW_WARP_BEGIN_W + n_row_warps
+    kernel_obj.tma_warp_w = kernel_obj.row_warp_end_w
+    kernel_obj.fused_tpb_w = 32 * (kernel_obj.tma_warp_w + 1)  # 544 / 416 threads
+    kernel_obj.row_threads_w = 32 * n_row_warps
 
 
 def _pack16(q, sr: cutlass.Constexpr, rng_base):
@@ -413,10 +428,15 @@ def _quant16(vals, enc_over_fp4max, dec, sr: cutlass.Constexpr = False, rng_base
 
 class _Tcgen05RowColFused:
     def __init__(
-        self, swizzle_sf: bool = True, sr: bool = False, apply_rht: bool = True
+        self,
+        swizzle_sf: bool = True,
+        sr: bool = False,
+        apply_rht: bool = True,
+        col_groups_per_supertile: int = 16,
     ):
         # swizzle_sf=True: cutlass NVFP4 swizzled SF (GEMM-ready, TMA-coalesced store).
-        # False: plain (N,M//16)/(M,N//16) SF (row SF falls back to a strided SIMT store).
+        # False: plain (N,M//16)/(M,N//16) SF (row SF falls back to a strided SIMT store); its
+        # col-SF box is col_groups_per_supertile bytes wide, so it requires 16 (TMA 16B min).
         # sr=True: stochastic rounding (cvt.rs) in the FP4 cast; False: round-to-nearest.
         # apply_rht=True: columnwise path = NVFP4(RHT(A.t())) via the tcgen05 UMMA (the B operand is
         # the Hadamard matrix). False (weight quantize): plain NVFP4(A.t()) — the col warps read the
@@ -424,9 +444,14 @@ class _Tcgen05RowColFused:
         # emits 2D 16x16 block scaling.
         # Activations (apply_rht=True) keep the standard 1x16 scaling. The RHT path is compiled
         # separately, so its codegen is unchanged.
+        # col_groups_per_supertile=16 (256-row supertile) serves M % 256; 8 serves M % 128.
+        assert not (col_groups_per_supertile < 16 and not swizzle_sf), (
+            "swizzle_sf=False requires col_groups_per_supertile=16"
+        )
         self.swizzle_sf = swizzle_sf
         self.sr = sr
         self.apply_rht = apply_rht
+        _set_supertile_geometry(self, col_groups_per_supertile)
 
     @cute.jit
     def __call__(
@@ -458,20 +483,20 @@ class _Tcgen05RowColFused:
         )
         tiled_mma = cute.make_tiled_mma(cute.make_mma_atom(mma_op))
 
-        # --- wide A: K = 16*U -> U k-blocks (M-blocks); MN_SW128 swizzle ---
+        # --- wide A: K = 16*col_groups -> col_groups k-blocks (M-blocks); MN_SW128 swizzle ---
         a_atom = tcgen05.make_smem_layout_atom(
             tcgen05.SmemLayoutAtomKind.MN_SW128, cutlass.BFloat16
         )
         a_shape = tiled_mma.partition_shape_A(
-            cute.dice((M_TILE, N_TILE, KW), (1, None, 1))
+            cute.dice((M_TILE, N_TILE, self.kw), (1, None, 1))
         )
         a_smem_layout_staged = tcgen05.tile_to_mma_shape(
             a_atom, cute.append(a_shape, NUM_AB_STAGE), order=(1, 2, 3)
         )
-        # clean (M_mma=128, KW=256, STAGE) view of the SAME bytes for the row read
+        # clean (M_mma=128, KW, STAGE) view of the SAME bytes for the row read
         # (same atom + swizzle -> identical physical mapping to a_smem_layout_staged).
         a_clean_layout = cute.tile_to_shape(
-            a_atom, (M_TILE, KW, NUM_AB_STAGE), order=(0, 1, 2)
+            a_atom, (M_TILE, self.kw, NUM_AB_STAGE), order=(0, 1, 2)
         )
 
         # --- narrow B: one 16x16 RHT, 1 k-block ---
@@ -489,7 +514,7 @@ class _Tcgen05RowColFused:
             g2s,
             mA,
             a_smem_layout,
-            (M_TILE, N_TILE, KW),
+            (M_TILE, N_TILE, self.kw),
             tiled_mma,
             (1, 1, 1, 1),
         )
@@ -510,30 +535,30 @@ class _Tcgen05RowColFused:
 
         acc_shape = tiled_mma.partition_shape_C(MMA_TILER[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(
-            cute.append(cute.append(acc_shape, U), NUM_ACC_STAGE)
+            cute.append(cute.append(acc_shape, self.col_groups_per_supertile), NUM_ACC_STAGE)
         )
         num_tmem_alloc_cols = sm100_utils.get_num_tmem_alloc_cols(tCtAcc_fake)
 
         # Weight mode (apply_rht=False) skips the B (Hadamard) load — no MMA — so don't count it
         # in the TMA tx_count, or the AB-full barrier would wait on bytes that never arrive.
         num_tma_load_bytes = (
-            M_TILE * KW + (N_TILE * K if cutlass.const_expr(self.apply_rht) else 0)
+            M_TILE * self.kw + (N_TILE * K if cutlass.const_expr(self.apply_rht) else 0)
         ) * 2
 
         # COL FP4 store: super-tile = 2U u32 wide
-        fp4_smem_layout = cute.make_layout((M_TILE, 2 * U), stride=(2 * U, 1))
+        fp4_smem_layout = cute.make_layout((M_TILE, 2 * self.col_groups_per_supertile), stride=(2 * self.col_groups_per_supertile, 1))
         tma_atom_fp4, tma_tensor_fp4 = cpasync.make_tiled_tma_atom(
             cpasync.CopyBulkTensorTileS2GOp(),
             mFP4,
             fp4_smem_layout,
-            (M_TILE, 2 * U),
+            (M_TILE, 2 * self.col_groups_per_supertile),
         )
         # COL SF store (TMA). swizzled: (1, SF_GCOL*SF_BLK) box over flat (N//128, (M//64)*SF_BLK);
-        # plain: (M_TILE, U) box over (N, M//16).
+        # plain: (M_TILE, col_groups) box over (N, M//16).
         if cutlass.const_expr(self.swizzle_sf):
-            col_sf_box = (1, SF_GCOL * SF_BLK)
+            col_sf_box = (1, self.sf_gcol * SF_BLK)
         else:
-            col_sf_box = (M_TILE, U)
+            col_sf_box = (M_TILE, self.col_groups_per_supertile)
         sf_smem_layout = cute.make_layout(col_sf_box, stride=(col_sf_box[1], 1))
         tma_atom_sf, tma_tensor_sf = cpasync.make_tiled_tma_atom(
             cpasync.CopyBulkTensorTileS2GOp(),
@@ -542,21 +567,21 @@ class _Tcgen05RowColFused:
             col_sf_box,
         )
 
-        # ROW FP4 store: super-tile = (KW M-rows, M_TILE//8 u32) = (256,16) = 64B wide -> TMA-ok
+        # ROW FP4 store: super-tile = (KW M-rows, M_TILE//8 u32), inner = 64B wide -> TMA-ok
         row_fp4_smem_layout = cute.make_layout(
-            (KW, M_TILE // 8), stride=(M_TILE // 8, 1)
+            (self.kw, M_TILE // 8), stride=(M_TILE // 8, 1)
         )
         tma_atom_row_fp4, tma_tensor_row_fp4 = cpasync.make_tiled_tma_atom(
             cpasync.CopyBulkTensorTileS2GOp(),
             mRowFP4,
             row_fp4_smem_layout,
-            (KW, M_TILE // 8),
+            (self.kw, M_TILE // 8),
         )
 
         # ROW SF store. swizzled: TMA, (SF_RBLK, SF_RGRP*SF_BLK) box over flat (M//128, (N//64)*SF_BLK).
         # plain: strided SIMT, so this atom is unused (alias the FP4 atom).
         if cutlass.const_expr(self.swizzle_sf):
-            row_sf_box = (SF_RBLK, SF_RGRP * SF_BLK)
+            row_sf_box = (self.sf_rblk, SF_RGRP * SF_BLK)
             row_sf_smem_layout = cute.make_layout(row_sf_box, stride=(row_sf_box[1], 1))
             tma_atom_row_sf, tma_tensor_row_sf = cpasync.make_tiled_tma_atom(
                 cpasync.CopyBulkTensorTileS2GOp(),
@@ -572,7 +597,7 @@ class _Tcgen05RowColFused:
 
         num_tiles_m = N // cutlass.Int32(M_TILE)  # N output-row tiles (M_mma=128)
         num_tiles_ns = M // cutlass.Int32(
-            N_TILE * U
+            N_TILE * self.col_groups_per_supertile
         )  # M contraction block-groups (K=16U)
         num_super = num_tiles_m * num_tiles_ns
 
@@ -613,7 +638,7 @@ class _Tcgen05RowColFused:
         ).launch(
             grid=(GRID, 1, 1),
             block=(
-                FUSED_TPB if cutlass.const_expr(self.apply_rht) else FUSED_TPB_W,
+                self.fused_tpb if cutlass.const_expr(self.apply_rht) else self.fused_tpb_w,
                 1,
                 1,
             ),
@@ -667,18 +692,18 @@ class _Tcgen05RowColFused:
             _COL_END, _ROW_BEG, _ROW_END, _TMA_W = (
                 COL_WARP_END,
                 ROW_WARP_BEGIN,
-                ROW_WARP_END,
-                TMA_WARP,
+                self.row_warp_end,
+                self.tma_warp,
             )
-            _COL_THR, _ROW_THR = COL_THREADS, ROW_THREADS
+            _COL_THR, _ROW_THR = COL_THREADS, self.row_threads
         else:
             _COL_END, _ROW_BEG, _ROW_END, _TMA_W = (
                 COL_WARP_END_W,
                 ROW_WARP_BEGIN_W,
-                ROW_WARP_END_W,
-                TMA_WARP_W,
+                self.row_warp_end_w,
+                self.tma_warp_w,
             )
-            _COL_THR, _ROW_THR = COL_THREADS_W, ROW_THREADS_W
+            _COL_THR, _ROW_THR = COL_THREADS_W, self.row_threads_w
 
         if warp_idx == _TMA_W:
             cpasync.prefetch_descriptor(tma_atom_a)
@@ -702,9 +727,9 @@ class _Tcgen05RowColFused:
         # AB pipeline: TMA producer. RHT mode consumers = MMA (1 umma arrive) + ROW_THREADS;
         # weight mode (no MMA) consumers = COL_THREADS_W + ROW_THREADS_W (both warp groups read sA).
         if cutlass.const_expr(self.apply_rht):
-            ab_cons_count = 1 + ROW_THREADS
+            ab_cons_count = 1 + self.row_threads
         else:
-            ab_cons_count = COL_THREADS_W + ROW_THREADS_W
+            ab_cons_count = COL_THREADS_W + self.row_threads_w
         ab_prod_grp = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         ab_cons_grp = pipeline.CooperativeGroup(pipeline.Agent.Thread, ab_cons_count)
         ab_pipeline = pipeline.PipelineTmaUmma.create(
@@ -754,7 +779,7 @@ class _Tcgen05RowColFused:
             raw_a, a_smem_layout_staged.inner, dtype=cutlass.BFloat16
         )
         sA = cute.make_tensor(swz_ptr, a_smem_layout_staged.outer)
-        # row view: SAME swizzled pointer, clean (M_mma=128, KW=256, STAGE) *outer* layout
+        # row view: SAME swizzled pointer, clean (M_mma=128, KW, STAGE) *outer* layout
         # -> swizzle applied identically to sA (both PDSL), just a different logical grouping.
         sA_clean = cute.make_tensor(swz_ptr, a_clean_layout.outer)
 
@@ -770,15 +795,15 @@ class _Tcgen05RowColFused:
             byte_alignment=128,
         )
         # COL SF SMEM. swizzled: raw bytes with a 4D write-view (group, 32, 16) + a 2D TMA-view
-        # over the same memory; plain: a single (M_TILE, U) tile (write == TMA view).
+        # over the same memory; plain: a single (M_TILE, col_groups) tile (write == TMA view).
         if cutlass.const_expr(self.swizzle_sf):
             raw_csf = smem.allocate_array(
-                cutlass.Float8E4M3FN, SF_GCOL * SF_BLK, byte_alignment=128
+                cutlass.Float8E4M3FN, self.sf_gcol * SF_BLK, byte_alignment=128
             )
             sSF_w = cute.make_tensor(
                 raw_csf,
                 cute.make_layout(
-                    (1, SF_GCOL, 32, 16), stride=(SF_GCOL * SF_BLK, SF_BLK, 16, 1)
+                    (1, self.sf_gcol, 32, 16), stride=(self.sf_gcol * SF_BLK, SF_BLK, 16, 1)
                 ),
             )
             sSF = cute.make_tensor(
@@ -790,12 +815,12 @@ class _Tcgen05RowColFused:
                 layout=sf_smem_layout,
                 byte_alignment=128,
             )
-            sSF_w = sSF  # (M_TILE, U) write == TMA
+            sSF_w = sSF  # (M_TILE, col_groups) write == TMA
 
         # double-buffered row FP4 staging: overlap TMA store with next iter's compute
         row_fp4_staged = cute.make_layout(
-            (KW, M_TILE // 8, ROW_FP4_STAGES),
-            stride=(M_TILE // 8, 1, KW * (M_TILE // 8)),
+            (self.kw, M_TILE // 8, ROW_FP4_STAGES),
+            stride=(M_TILE // 8, 1, self.kw * (M_TILE // 8)),
         )
         sRowFP4 = smem.allocate_tensor(
             element_type=cutlass.Int32,
@@ -807,21 +832,21 @@ class _Tcgen05RowColFused:
         sRowSF_w = None
         sRowSF = None
         if cutlass.const_expr(self.swizzle_sf):
-            _rsf_stage = SF_RBLK * SF_RGRP * SF_BLK
+            _rsf_stage = self.sf_rblk * SF_RGRP * SF_BLK
             raw_rsf = smem.allocate_array(
                 cutlass.Float8E4M3FN, _rsf_stage * ROW_FP4_STAGES, byte_alignment=128
             )
             sRowSF_w = cute.make_tensor(
                 raw_rsf,
                 cute.make_layout(
-                    (SF_RBLK, SF_RGRP, 32, 16, ROW_FP4_STAGES),
+                    (self.sf_rblk, SF_RGRP, 32, 16, ROW_FP4_STAGES),
                     stride=(SF_RGRP * SF_BLK, SF_BLK, 16, 1, _rsf_stage),
                 ),
             )
             sRowSF = cute.make_tensor(
                 raw_rsf,
                 cute.make_layout(
-                    (SF_RBLK, SF_RGRP * SF_BLK, ROW_FP4_STAGES),
+                    (self.sf_rblk, SF_RGRP * SF_BLK, ROW_FP4_STAGES),
                     stride=(SF_RGRP * SF_BLK, 1, _rsf_stage),
                 ),
             )
@@ -830,7 +855,7 @@ class _Tcgen05RowColFused:
         thr_mma = tiled_mma.get_slice(0)
         gA_mkl = cute.local_tile(
             mA_mkl,
-            cute.slice_((M_TILE, N_TILE, KW), (None, 0, None)),
+            cute.slice_((M_TILE, N_TILE, self.kw), (None, 0, None)),
             (None, None, None),
         )
         gB_nkl = cute.local_tile(
@@ -856,7 +881,7 @@ class _Tcgen05RowColFused:
         )
         tBgB = tBgB[(None, 0, None, 0)]
 
-        tCrA = tiled_mma.make_fragment_A(sA)  # (MMA, M, U, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)  # (MMA, M, col_groups, STAGE)
         tCrB = tiled_mma.make_fragment_B(sB)
 
         def _global_scale(amax):
@@ -915,7 +940,7 @@ class _Tcgen05RowColFused:
             ab_producer.tail()
 
         # ==================== MMA warp (AB consumer, acc producer) ====================
-        if warp_idx == MMA_WARP and cutlass.const_expr(self.apply_rht):
+        if warp_idx == self.mma_warp and cutlass.const_expr(self.apply_rht):
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(cutlass.Float32)
             tCtAcc_base = cute.make_tensor(tmem_ptr, acc_fake_layout)
@@ -926,7 +951,7 @@ class _Tcgen05RowColFused:
             for local_iter in cutlass.range(num_iters):
                 ab_handle = ab_consumer.wait_and_advance()
                 acc_pipeline.producer_acquire(acc_producer_state)
-                for u in cutlass.range_constexpr(U):
+                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
                     tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                     cute.gemm(
                         tiled_mma,
@@ -955,7 +980,7 @@ class _Tcgen05RowColFused:
                 super_id = start_pid + local_iter * GRID
                 pid_m = super_id // num_tiles_ns
                 pid_ns = super_id % num_tiles_ns
-                m0 = pid_ns * cutlass.Int32(KW)  # global M-row base
+                m0 = pid_ns * cutlass.Int32(self.kw)  # global M-row base
                 buf = local_iter % ROW_FP4_STAGES  # double-buffer index
 
                 ab_pipeline.consumer_wait(row_ab_state)  # wait sA full
@@ -1030,7 +1055,7 @@ class _Tcgen05RowColFused:
                 row_store_barrier.arrive_and_wait()
                 if warp_idx == cutlass.Int32(_ROW_BEG):
                     gRowFP4 = cute.local_tile(
-                        mRowFP4_tma, (KW, M_TILE // 8), (pid_ns, pid_m)
+                        mRowFP4_tma, (self.kw, M_TILE // 8), (pid_ns, pid_m)
                     )
                     tRs, tRg = cpasync.tma_partition(
                         tma_atom_row_fp4,
@@ -1042,7 +1067,7 @@ class _Tcgen05RowColFused:
                     cute.copy(tma_atom_row_fp4, tRs, tRg)
                     if cutlass.const_expr(self.swizzle_sf):
                         gRowSF = cute.local_tile(
-                            mRowSF_tma, (SF_RBLK, SF_RGRP * SF_BLK), (pid_ns, pid_m)
+                            mRowSF_tma, (self.sf_rblk, SF_RGRP * SF_BLK), (pid_ns, pid_m)
                         )
                         tRSs, tRSg = cpasync.tma_partition(
                             tma_atom_row_sf,
@@ -1095,7 +1120,7 @@ class _Tcgen05RowColFused:
                 acc_idx = acc_consumer_state.index
 
                 acc_pipeline.consumer_wait(acc_consumer_state)
-                for u in cutlass.range_constexpr(U):
+                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
                     cute.copy(
                         tiled_copy_t2r,
                         tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
@@ -1138,7 +1163,7 @@ class _Tcgen05RowColFused:
                 cute.arch.fence_proxy("async.shared", space="cta")
                 epi_store_barrier.arrive_and_wait()
                 if warp_idx == cutlass.Int32(0):
-                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * U), (pid_m, pid_ns))
+                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * self.col_groups_per_supertile), (pid_m, pid_ns))
                     tSs, tSg = cpasync.tma_partition(
                         tma_atom_fp4,
                         0,
@@ -1149,10 +1174,10 @@ class _Tcgen05RowColFused:
                     cute.copy(tma_atom_fp4, tSs, tSg)
                     if cutlass.const_expr(self.swizzle_sf):
                         gSF = cute.local_tile(
-                            mSF_tma, (1, SF_GCOL * SF_BLK), (pid_m, pid_ns)
+                            mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns)
                         )
                     else:
-                        gSF = cute.local_tile(mSF_tma, (M_TILE, U), (pid_m, pid_ns))
+                        gSF = cute.local_tile(mSF_tma, (M_TILE, self.col_groups_per_supertile), (pid_m, pid_ns))
                     tSFs, tSFg = cpasync.tma_partition(
                         tma_atom_sf,
                         0,
@@ -1180,7 +1205,7 @@ class _Tcgen05RowColFused:
                 pipeline.PipelineUserType.Consumer, NUM_AB_STAGE
             )
             # 8 col warps (256 threads) cover the 128 N-rows with 2 threads/row: nrow = the N-row,
-            # u_half selects which half of the U u-blocks this thread owns (each does U//2 blocks).
+            # u_half selects which half of the col-group blocks this thread owns.
             nrow = tidx % cutlass.Int32(M_TILE)
             u_half = tidx // cutlass.Int32(M_TILE)
             for local_iter in cutlass.range(num_iters):
@@ -1190,8 +1215,8 @@ class _Tcgen05RowColFused:
 
                 ab_pipeline.consumer_wait(col_ab_state)  # wait sA full
                 stage = col_ab_state.index
-                for u_local in cutlass.range_constexpr(U // 2):
-                    u = cutlass.Int32(u_local) + u_half * cutlass.Int32(U // 2)
+                for u_local in cutlass.range_constexpr(self.col_groups_per_supertile // 2):
+                    u = cutlass.Int32(u_local) + u_half * cutlass.Int32(self.col_groups_per_supertile // 2)
                     blk = cute.make_rmem_tensor((16,), cutlass.Float32)
                     for i in cutlass.range_constexpr(16):
                         mpos = u * cutlass.Int32(16) + cutlass.Int32(
@@ -1237,7 +1262,7 @@ class _Tcgen05RowColFused:
                 cute.arch.fence_proxy("async.shared", space="cta")
                 col_store_barrier.arrive_and_wait()
                 if warp_idx == cutlass.Int32(0):
-                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * U), (pid_m, pid_ns))
+                    gFP4 = cute.local_tile(mFP4_tma, (M_TILE, 2 * self.col_groups_per_supertile), (pid_m, pid_ns))
                     tSs, tSg = cpasync.tma_partition(
                         tma_atom_fp4,
                         0,
@@ -1248,10 +1273,10 @@ class _Tcgen05RowColFused:
                     cute.copy(tma_atom_fp4, tSs, tSg)
                     if cutlass.const_expr(self.swizzle_sf):
                         gSF = cute.local_tile(
-                            mSF_tma, (1, SF_GCOL * SF_BLK), (pid_m, pid_ns)
+                            mSF_tma, (1, self.sf_gcol * SF_BLK), (pid_m, pid_ns)
                         )
                     else:
-                        gSF = cute.local_tile(mSF_tma, (M_TILE, U), (pid_m, pid_ns))
+                        gSF = cute.local_tile(mSF_tma, (M_TILE, self.col_groups_per_supertile), (pid_m, pid_ns))
                     tSFs, tSFg = cpasync.tma_partition(
                         tma_atom_sf,
                         0,
@@ -1271,8 +1296,11 @@ class _Tcgen05RhtAmax:
     Each epilogue reduces to a global max-abs instead of quantizing:
       col_amax = max|RHT(A.t())|  (TMEM accumulator),  row_amax = max|A|  (raw sA).
     The 16x16 RHT runs on tensor cores, so the pass is HBM-bound. Requires
-    M % 256 == 0, N % 128 == 0.
+    M % (16 * col_groups_per_supertile) == 0 (16 -> M % 256, 8 -> M % 128), N % 128 == 0.
     """
+
+    def __init__(self, col_groups_per_supertile: int = 16):
+        _set_supertile_geometry(self, col_groups_per_supertile)
 
     @cute.jit
     def __call__(
@@ -1301,13 +1329,13 @@ class _Tcgen05RhtAmax:
             tcgen05.SmemLayoutAtomKind.MN_SW128, cutlass.BFloat16
         )
         a_shape = tiled_mma.partition_shape_A(
-            cute.dice((M_TILE, N_TILE, KW), (1, None, 1))
+            cute.dice((M_TILE, N_TILE, self.kw), (1, None, 1))
         )
         a_smem_layout_staged = tcgen05.tile_to_mma_shape(
             a_atom, cute.append(a_shape, NUM_AB_STAGE), order=(1, 2, 3)
         )
         a_clean_layout = cute.tile_to_shape(
-            a_atom, (M_TILE, KW, NUM_AB_STAGE), order=(0, 1, 2)
+            a_atom, (M_TILE, self.kw, NUM_AB_STAGE), order=(0, 1, 2)
         )
 
         b_atom = tcgen05.make_smem_layout_atom(
@@ -1324,7 +1352,7 @@ class _Tcgen05RhtAmax:
             g2s,
             mA,
             a_smem_layout,
-            (M_TILE, N_TILE, KW),
+            (M_TILE, N_TILE, self.kw),
             tiled_mma,
             (1, 1, 1, 1),
         )
@@ -1345,12 +1373,12 @@ class _Tcgen05RhtAmax:
 
         acc_shape = tiled_mma.partition_shape_C(MMA_TILER[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(
-            cute.append(cute.append(acc_shape, U), NUM_ACC_STAGE)
+            cute.append(cute.append(acc_shape, self.col_groups_per_supertile), NUM_ACC_STAGE)
         )
         num_tmem_alloc_cols = sm100_utils.get_num_tmem_alloc_cols(tCtAcc_fake)
 
-        num_tma_load_bytes = (M_TILE * KW + N_TILE * K) * 2
-        num_tiles_ns = M // cutlass.Int32(N_TILE * U)
+        num_tma_load_bytes = (M_TILE * self.kw + N_TILE * K) * 2
+        num_tiles_ns = M // cutlass.Int32(N_TILE * self.col_groups_per_supertile)
         num_super = (N // cutlass.Int32(M_TILE)) * num_tiles_ns
 
         self.kernel(
@@ -1371,7 +1399,7 @@ class _Tcgen05RhtAmax:
             num_tiles_ns,
             num_super,
             GRID,
-        ).launch(grid=(GRID, 1, 1), block=(FUSED_TPB, 1, 1), stream=stream)
+        ).launch(grid=(GRID, 1, 1), block=(self.fused_tpb, 1, 1), stream=stream)
 
     @cute.kernel
     def kernel(
@@ -1399,7 +1427,7 @@ class _Tcgen05RhtAmax:
         start_pid, _, _ = cute.arch.block_idx()
         lane = tidx % cutlass.Int32(32)
 
-        if warp_idx == TMA_WARP:
+        if warp_idx == self.tma_warp:
             cpasync.prefetch_descriptor(tma_atom_a)
             cpasync.prefetch_descriptor(tma_atom_b)
 
@@ -1414,7 +1442,7 @@ class _Tcgen05RhtAmax:
         storage = smem.allocate(SharedStorage)
 
         # AB pipeline: TMA producer; consumers = MMA (1 umma arrive) + ROW_THREADS (thread arrives)
-        ab_cons_count = 1 + ROW_THREADS
+        ab_cons_count = 1 + self.row_threads
         ab_prod_grp = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         ab_cons_grp = pipeline.CooperativeGroup(pipeline.Agent.Thread, ab_cons_count)
         ab_pipeline = pipeline.PipelineTmaUmma.create(
@@ -1475,7 +1503,7 @@ class _Tcgen05RhtAmax:
         thr_mma = tiled_mma.get_slice(0)
         gA_mkl = cute.local_tile(
             mA_mkl,
-            cute.slice_((M_TILE, N_TILE, KW), (None, 0, None)),
+            cute.slice_((M_TILE, N_TILE, self.kw), (None, 0, None)),
             (None, None, None),
         )
         gB_nkl = cute.local_tile(
@@ -1514,7 +1542,7 @@ class _Tcgen05RhtAmax:
         )
 
         # ==================== TMA warp (AB producer) ====================
-        if warp_idx == TMA_WARP:
+        if warp_idx == self.tma_warp:
             for local_iter in cutlass.range(num_iters):
                 super_id = start_pid + local_iter * GRID
                 pid_m = super_id // num_tiles_ns
@@ -1535,7 +1563,7 @@ class _Tcgen05RhtAmax:
             ab_producer.tail()
 
         # ==================== MMA warp (AB consumer, acc producer) ====================
-        if warp_idx == MMA_WARP:
+        if warp_idx == self.mma_warp:
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(cutlass.Float32)
             tCtAcc_base = cute.make_tensor(tmem_ptr, acc_fake_layout)
@@ -1545,7 +1573,7 @@ class _Tcgen05RhtAmax:
             for local_iter in cutlass.range(num_iters):
                 ab_handle = ab_consumer.wait_and_advance()
                 acc_pipeline.producer_acquire(acc_producer_state)
-                for u in cutlass.range_constexpr(U):
+                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
                     tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                     cute.gemm(
                         tiled_mma,
@@ -1560,7 +1588,7 @@ class _Tcgen05RhtAmax:
             acc_pipeline.producer_tail(acc_producer_state)
 
         # ==================== ROW warps (AB consumer, read raw sA) -> row amax ====================
-        if warp_idx >= ROW_WARP_BEGIN and warp_idx < ROW_WARP_END:
+        if warp_idx >= ROW_WARP_BEGIN and warp_idx < self.row_warp_end:
             k_row = tidx - cutlass.Int32(
                 ROW_WARP_BEGIN * 32
             )  # 0..KW-1 = M-position within super-tile
@@ -1622,7 +1650,7 @@ class _Tcgen05RhtAmax:
             for local_iter in cutlass.range(num_iters):
                 acc_idx = acc_consumer_state.index
                 acc_pipeline.consumer_wait(acc_consumer_state)
-                for u in cutlass.range_constexpr(U):
+                for u in cutlass.range_constexpr(self.col_groups_per_supertile):
                     cute.copy(
                         tiled_copy_t2r,
                         tTR_tAcc_base[(None, None, None, 0, 0, u, acc_idx)],
@@ -1694,17 +1722,17 @@ def _get_sr_rng_buffer(device_idx):
     return torch.zeros(1, dtype=torch.int32, device=torch.device("cuda", device_idx))
 
 
-@functools.lru_cache(maxsize=8)
-def _compile_amax_tc_kernel(device_idx):
-    """Compile the tensor-core RHT amax with symbolic shapes (cached per device).
+@functools.lru_cache(maxsize=None)
+def _compile_amax_tc_kernel(device_idx, col_groups_per_supertile=16):
+    """Compile the tensor-core RHT amax with symbolic shapes (cached per device+u).
 
-    The symbolic (sym_int) shapes make the compiled kernel serve any (M % 256, N % 128); M/N/GRID
-    are runtime Int32 args. Not keyed on the sign vector, which is a runtime launch buffer (the
-    compile uses a fake), so the compiled kernel is identical for every sign vector.
+    The symbolic (sym_int) shapes make the compiled kernel serve any (M % (16*u), N % 128);
+    M/N/GRID are runtime Int32 args. Not keyed on the sign vector, which is a runtime launch
+    buffer (the compile uses a fake), so the compiled kernel is identical for every sign vector.
     """
     device = torch.device("cuda", device_idx)
     # aT = A.t().unsqueeze(-1): (N, M, 1), dim0 (N) contiguous -> stride (1, N, 1).
-    m_sym = cute.sym_int(divisibility=N_TILE * U)  # M % 256
+    m_sym = cute.sym_int(divisibility=N_TILE * col_groups_per_supertile)  # M % 256 or M % 128
     n_sym = cute.sym_int(divisibility=M_TILE)  # N % 128
     fake_aT = make_fake_tensor(
         cutlass.BFloat16, (n_sym, m_sym, 1), stride=(1, cute.sym_int(), 1)
@@ -1714,7 +1742,7 @@ def _compile_amax_tc_kernel(device_idx):
     )
     fake_col = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
     fake_row = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
-    k = _Tcgen05RhtAmax()
+    k = _Tcgen05RhtAmax(col_groups_per_supertile=col_groups_per_supertile)
     # c_layout for the TMEM->reg read = layout of the col FP4 output (row-major 2D); the enum
     # depends only on row/col-majorness, so a dummy contiguous tensor suffices.
     dummy = torch.empty((M_TILE, 16), dtype=torch.int32, device=device)
@@ -1742,7 +1770,7 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
 
     The column amax is taken over the post-RHT data (not the plain amax) for correctness: RHT
     can raise the per-block max, and a too-small global scale saturates the E4M3 block scales.
-    Requires M % 256 == 0, N % 128 == 0.
+    Requires M % 128 == 0, N % 128 == 0.
     """
     if A.dtype != torch.bfloat16:
         raise ValueError(f"Expected bfloat16, got {A.dtype}")
@@ -1751,12 +1779,13 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
     if not A.is_contiguous():
         raise ValueError("A must be row-major (contiguous)")
     M, N = A.shape
-    # The tile is N_TILE*U=256 wide in M. Without M%256, M=128 gives GRID=0
+    # The tile is N_TILE*col_groups wide in M. Below that divisibility, GRID=0
     # -> a no-op launch that silently returns amax=0.
-    if M % 256 != 0:
-        raise ValueError(f"M must be divisible by 256, got M={M}")
+    if M % 128 != 0:
+        raise ValueError(f"M must be divisible by 128, got M={M}")
     if N % 128 != 0:
         raise ValueError(f"N must be divisible by 128, got N={N}")
+    col_groups_per_supertile = 16 if M % 256 == 0 else 8
     # This is a non-differentiable op (autograd is owned by the outer linear Function);
     # detach so the input passed to the kernel never carries autograd state.
     A = A.detach()
@@ -1767,10 +1796,10 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
     rht_nk = _get_rht_buffer(tuple(sign_vector), dev.index)  # torch buffer (kept alive)
 
     NUM_SMS = _get_num_sms(dev.index)
-    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * U)))
+    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * col_groups_per_supertile)))
     stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
 
-    amax_compiled = _compile_amax_tc_kernel(dev.index)
+    amax_compiled = _compile_amax_tc_kernel(dev.index, col_groups_per_supertile)
     amax_compiled(
         A.t().unsqueeze(-1),
         rht_nk,
@@ -1784,18 +1813,18 @@ def _cutedsl_rht_amax_impl(A: torch.Tensor, sign_vector=DEFAULT_SIGN_VECTOR):
     return col_amax, row_amax
 
 
-@functools.lru_cache(maxsize=16)
-def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True):
-    """Compile the fused kernel with symbolic shapes (cached per device+swizzle+sr+apply_rht).
+@functools.lru_cache(maxsize=None)
+def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True, col_groups_per_supertile=16):
+    """Compile the fused kernel with symbolic shapes (cached per device+swizzle+sr+apply_rht+u).
 
-    The symbolic (sym_int) shapes make the compiled kernel serve any (M % 256, N % 128); the
+    The symbolic (sym_int) shapes make the compiled kernel serve any (M % (16*u), N % 128); the
     divisibilities below match each output's TMA store box so the atoms tile cleanly. ``swizzle``
     selects the cutlass-swizzled SF layout (op default) vs the plain (N, M//16)/(M, N//16) layout.
     ``sr`` compiles the stochastic-rounding (cvt.rs) variant as a separate kernel, leaving the RTNE
     forward path untouched. ``apply_rht=False`` compiles the no-MMA weight-quantize variant (the col
     path reads transposed A from SMEM). Not keyed on the sign vector / RNG (runtime launch buffers).
     """
-    m_sym = cute.sym_int(divisibility=N_TILE * U)  # M % 256
+    m_sym = cute.sym_int(divisibility=N_TILE * col_groups_per_supertile)  # M % 256 or M % 128
     n_sym = cute.sym_int(divisibility=M_TILE)  # N % 128
     free = cute.sym_int  # a fresh dynamic stride per call
 
@@ -1806,9 +1835,11 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True):
     fake_bT = make_fake_tensor(
         cutlass.BFloat16, (HADAMARD_DIM, HADAMARD_DIM, 1), stride=(HADAMARD_DIM, 1, 1)
     )
-    # col_fp4 (N, M//8) u32, store box inner = 2*U = 32; row_fp4 (M, N//8) u32, inner = 16.
+    # col_fp4 (N, M//8) u32, store box inner = 2*col_groups; row_fp4 (M, N//8) u32, inner = 16.
     fake_cfp4 = make_fake_tensor(
-        cutlass.Uint32, (n_sym, cute.sym_int(divisibility=2 * U)), stride=(free(), 1)
+        cutlass.Uint32,
+        (n_sym, cute.sym_int(divisibility=2 * col_groups_per_supertile)),
+        stride=(free(), 1),
     )
     fake_rfp4 = make_fake_tensor(
         cutlass.Uint32,
@@ -1817,22 +1848,27 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True):
     )
     if swizzle:
         # SF flattened to 2D for the TMA atom: col_sf.reshape(N//128, (M//64)*512) has inner
-        # divisible by 2048 (from M%256); row_sf.reshape(M//128, (N//64)*512) inner by 1024.
+        # inner divisible by (col_groups//4)*512 (from the M bound);
+        # row_sf.reshape(M//128, (N//64)*512) outer divisible by supertile M-blocks,
+        # inner by 1024 (from N%128).
         fake_csf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (cute.sym_int(divisibility=1), cute.sym_int(divisibility=2048)),
+            (cute.sym_int(divisibility=1), cute.sym_int(divisibility=(col_groups_per_supertile // 4) * SF_BLK)),
             stride=(free(), 1),
         )
         fake_rsf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (cute.sym_int(divisibility=2), cute.sym_int(divisibility=1024)),
+            (
+                cute.sym_int(divisibility=(K * col_groups_per_supertile) // 128),
+                cute.sym_int(divisibility=1024),
+            ),
             stride=(free(), 1),
         )
     else:
-        # plain SF: col (N, M//16), row (M, N//16).
+        # plain SF: col (N, M//16), row (M, N//16). Requires col_groups=16 (col box is that many bytes wide).
         fake_csf = make_fake_tensor(
             cutlass.Float8E4M3FN,
-            (n_sym, cute.sym_int(divisibility=U)),
+            (n_sym, cute.sym_int(divisibility=col_groups_per_supertile)),
             stride=(free(), 1),
         )
         fake_rsf = make_fake_tensor(
@@ -1842,7 +1878,10 @@ def _compile_fused_kernel(device_idx, swizzle, sr, apply_rht=True):
         )
     fake_amax = make_fake_tensor(cutlass.Float32, (1,), stride=(1,))
     fake_sr_rng = make_fake_tensor(cutlass.Int32, (1,), stride=(1,))
-    k = _Tcgen05RowColFused(swizzle_sf=swizzle, sr=sr, apply_rht=apply_rht)
+    k = _Tcgen05RowColFused(
+        swizzle_sf=swizzle, sr=sr, apply_rht=apply_rht,
+        col_groups_per_supertile=col_groups_per_supertile,
+    )
     return cute.compile(
         k,
         fake_aT,
@@ -1888,7 +1927,9 @@ def _cutedsl_rht_quantize_row_col_impl(
     since ``max|A.t()| == max|A|``.
 
     Args:
-        A: (M, N) bfloat16, row-major. M % 256 == 0, N % 128 == 0.
+        A: (M, N) bfloat16, row-major. M % 128 == 0 (M % 256 selects the faster
+            256-row supertile; other M % 128 shapes compile a 128-row variant),
+            N % 128 == 0.
         col_global_amax: scalar float32 = max|RHT(A.t())| (columnwise decode scale).
         row_global_amax: scalar float32 = max|A| (rowwise decode scale).
         sign_vector: RHT sign vector as a list of ints.
@@ -1917,10 +1958,17 @@ def _cutedsl_rht_quantize_row_col_impl(
     if not A.is_contiguous():
         raise ValueError("A must be row-major (contiguous)")
     M, N = A.shape
-    if M % 256 != 0:
-        raise ValueError(f"M must be divisible by 256, got M={M}")
+    if M % 128 != 0:
+        raise ValueError(f"M must be divisible by 128, got M={M}")
     if N % 128 != 0:
         raise ValueError(f"N must be divisible by 128, got N={N}")
+    col_groups_per_supertile = 16 if M % 256 == 0 else 8
+    if col_groups_per_supertile < 16 and not swizzle_scale_factors:
+        raise ValueError(
+            "swizzle_scale_factors=False requires M % 256 == 0 (the plain col-SF "
+            "TMA box is col_groups_per_supertile bytes wide, below TMA's 16B "
+            "minimum for the 128-row supertile)"
+        )
     # Non-differentiable op (autograd owned by the outer linear Function); detach so the
     # input passed to the kernel never carries autograd state.
     A = A.detach()
@@ -1975,10 +2023,12 @@ def _cutedsl_rht_quantize_row_col_impl(
     row_amax_t = row_global_amax.reshape(1)
 
     NUM_SMS = _get_num_sms(dev.index)
-    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * U)))
+    GRID = min(NUM_SMS, (N // M_TILE) * (M // (N_TILE * col_groups_per_supertile)))
     stream = cuda.CUstream(int(torch.cuda.current_stream(dev).cuda_stream))
 
-    fused = _compile_fused_kernel(dev.index, swizzle, sr, bool(apply_rht))
+    fused = _compile_fused_kernel(
+        dev.index, swizzle, sr, bool(apply_rht), col_groups_per_supertile
+    )
     fused(
         A.t().unsqueeze(-1),
         rht_nk,

--- a/torchao/prototype/moe_training/nvfp4_training/group_hadamard_amax_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/group_hadamard_amax_cutedsl.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CuteDSL per-group RHT amax over a row-packed ragged tensor (SM100+).
+
+Drop-in for ``triton_group_rht_amax``: per expert group of a row-concatenated packed
+tensor, the post-RHT columnwise amax and the raw rowwise amax, without materializing
+the transformed output. Graph-safe: the launch depends only on the allocated row
+capacity; rows at or beyond ``logical_packed_length`` are skipped on device.
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+
+from .hadamard_cutedsl_utils import raise_if_cutedsl_nvfp4_unavailable
+
+_TENSORWISE_SCALING = 0  # int(torch.nn.functional.ScalingType.TensorWise)
+
+
+@torch.library.custom_op("torchao::cutedsl_group_rht_amax", mutates_args=())
+def cutedsl_group_rht_amax(
+    A: torch.Tensor,
+    sign_vector: List[int],
+    offsets: torch.Tensor,
+    num_tensors: int,
+    packed_sequence_length: int,
+    hidden_size: int,
+    shape_rep: int,
+    scaling_type: int = _TENSORWISE_SCALING,
+    logical_packed_length: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-group RHT columnwise amax and raw rowwise amax (grouped, graph-safe).
+
+    Args:
+        A: packed (packed_sequence_length, hidden_size) bfloat16 tensor, row-major.
+            Groups are concatenated along the row dimension with 128-aligned
+            boundaries; hidden_size must be divisible by 128.
+        sign_vector: sign vector for the cached 16x16 RHT matrix.
+        offsets: (num_tensors,) int32 cumulative row-end offsets, one per group.
+        num_tensors: number of expert groups.
+        packed_sequence_length: allocated row capacity of A (divisible by 128).
+        hidden_size: number of columns of A.
+        shape_rep: grouped shape representation; only VARYING_FIRST_DIM (1).
+        scaling_type: int encoding of F.ScalingType; only TensorWise is supported.
+        logical_packed_length: one-element int32 CUDA tensor with the valid padded
+            row count. Rows beyond it are storage capacity only. Defaults to
+            ``offsets[-1:]``.
+
+    Returns:
+        (col_amax, row_amax), each (num_tensors,) float32:
+          - col_amax[g] = max|RHT(A_g.t())|
+          - row_amax[g] = max|A_g|
+    """
+    raise_if_cutedsl_nvfp4_unavailable("cutedsl_group_rht_amax")
+    if scaling_type != _TENSORWISE_SCALING:
+        raise ValueError("cutedsl_group_rht_amax supports only TensorWise scaling")
+
+    from ._cutedsl_kernels_impl import _cutedsl_group_rht_amax_impl
+
+    return _cutedsl_group_rht_amax_impl(
+        A,
+        sign_vector,
+        offsets,
+        num_tensors,
+        packed_sequence_length,
+        hidden_size,
+        shape_rep,
+        logical_packed_length,
+    )
+
+
+@cutedsl_group_rht_amax.register_fake
+def _(
+    A,
+    sign_vector,
+    offsets,
+    num_tensors,
+    packed_sequence_length,
+    hidden_size,
+    shape_rep,
+    scaling_type=_TENSORWISE_SCALING,
+    logical_packed_length=None,
+):
+    col = A.new_empty((num_tensors,), dtype=torch.float32)
+    row = A.new_empty((num_tensors,), dtype=torch.float32)
+    return col, row

--- a/torchao/prototype/moe_training/nvfp4_training/group_quantize_2d_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/group_quantize_2d_cutedsl.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CuteDSL per-expert 2D NVFP4 E2M1 weight quantization (no RHT), SM100+.
+
+Quantizes stacked ``(E, M, N)`` expert weights, producing rowwise (W) and
+colwise (W.T) FP4 codes and swizzled scale factors per expert.
+"""
+
+from typing import Tuple
+
+import torch
+
+from .hadamard_cutedsl_utils import raise_if_cutedsl_nvfp4_unavailable
+
+
+@torch.library.custom_op("torchao::cutedsl_group_weight_quantize_2d", mutates_args=())
+def cutedsl_group_weight_quantize_2d(
+    A: torch.Tensor,
+    global_amax: torch.Tensor,
+    num_tensors: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-expert 2D NVFP4 E2M1 weight quantization without RHT (CuteDSL, SM100+).
+
+    Args:
+        A:           (E, M, N) bfloat16, contiguous. M == out_features and
+                     N == in_features must both be divisible by 128 (M % 256 shapes
+                     use the faster 256-row supertile).
+        global_amax: (E,) float32 per-expert ``A[e].float().abs().max()`` (caller may
+                     all-reduce for tensor parallelism).
+        num_tensors: Number of experts; must equal E.
+
+    Returns:
+        4-tuple:
+          - (E, M, N//2) uint8: rowwise FP4 codes (W).
+          - (E, M//128, N//64, 32, 16) float8_e4m3fn: rowwise swizzled scale factors.
+          - (E, N, M//2) uint8: colwise FP4 codes (W.T).
+          - (E, N//128, M//64, 32, 16) float8_e4m3fn: colwise swizzled scale factors.
+
+    Raises:
+        NotImplementedError: pre-SM100 / missing CuteDSL runtime.
+        ValueError: bad dtype/shape/expert count.
+    """
+    raise_if_cutedsl_nvfp4_unavailable("cutedsl_group_weight_quantize_2d")
+    if A.ndim != 3:
+        raise ValueError("A must be 3-D (E, M, N)")
+    if A.shape[0] != num_tensors:
+        raise ValueError(f"Expected {num_tensors} experts, got {A.shape[0]}")
+
+    from ._cutedsl_kernels_impl import _cutedsl_group_weight_quantize_2d_impl
+
+    return _cutedsl_group_weight_quantize_2d_impl(A, global_amax)
+
+
+@cutedsl_group_weight_quantize_2d.register_fake
+def _(A, global_amax, num_tensors):
+    E, M, N = A.shape
+    codes = A.new_empty((E, M, N // 2), dtype=torch.uint8)
+    sf = A.new_empty((E, M // 128, N // 64, 32, 16), dtype=torch.float8_e4m3fn)
+    t_codes = A.new_empty((E, N, M // 2), dtype=torch.uint8)
+    t_sf = A.new_empty((E, N // 128, M // 64, 32, 16), dtype=torch.float8_e4m3fn)
+    return codes, sf, t_codes, t_sf

--- a/torchao/prototype/moe_training/nvfp4_training/group_rht_quantize_row_col_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/group_rht_quantize_row_col_cutedsl.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CuteDSL grouped fused RHT columnwise + rowwise NVFP4 quantize (SM100+).
+
+Quantizes a row-packed ragged activation tensor per expert group, with
+per-group scales from the (E,) global amax vectors.
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+
+from .hadamard_cutedsl_utils import raise_if_cutedsl_nvfp4_unavailable
+
+
+@torch.library.custom_op(
+    "torchao::cutedsl_group_rht_quantize_row_col", mutates_args=()
+)
+def cutedsl_group_rht_quantize_row_col(
+    A: torch.Tensor,
+    sign_vector: List[int],
+    offsets: torch.Tensor,
+    num_tensors: int,
+    packed_sequence_length: int,
+    hidden_size: int,
+    shape_rep: int,
+    a_global_amax: torch.Tensor,
+    d_global_amax: torch.Tensor,
+    rng_state: Optional[torch.Tensor],
+    enable_stochastic_rounding: bool,
+    logical_packed_length: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Grouped fused RHT columnwise + direct rowwise NVFP4 E2M1 quantization.
+
+    Args:
+        A: packed (packed_sequence_length, hidden_size) bfloat16 capacity buffer,
+            row-major, groups concatenated along dim 0 with 128-aligned boundaries.
+        sign_vector: sign vector for the cached 16x16 RHT matrix.
+        offsets: (num_tensors,) int32 cumulative row-end offsets, one per group.
+        num_tensors: number of expert groups.
+        packed_sequence_length: allocated row capacity of A (divisible by 128).
+        hidden_size: number of columns of A (divisible by 128).
+        shape_rep: grouped shape representation; only VARYING_FIRST_DIM (1).
+        a_global_amax: (num_tensors,) float32 per-group rowwise amax (max|A_g|).
+        d_global_amax: (num_tensors,) float32 per-group columnwise amax
+            (max|RHT(A_g.t())|).
+        rng_state: int64 CUDA tensor [col_seed, col_offset, row_seed, row_offset];
+            required when enable_stochastic_rounding, else may be None. The caller
+            owns its advancement; the op performs no host RNG.
+        enable_stochastic_rounding: hardware cvt.rs rounding for both grains.
+        logical_packed_length: one-element int32 CUDA tensor with the valid padded
+            row count; rows beyond it are storage capacity only. Defaults to
+            ``offsets[-1:]``.
+
+    Returns:
+        (qa_base, sfa, qd, sfd) matching ``triton_group_rht_quantize_row_col``:
+          - qa_base: (packed_sequence_length, hidden_size//2) uint8 rowwise codes.
+          - sfa: (packed_sequence_length, hidden_size//16) float8_e4m3fn -- swizzled
+            scale bytes viewed in the logical 2D shape.
+          - qd: (hidden_size, packed_sequence_length//2) uint8 columnwise codes.
+          - sfd: (hidden_size, packed_sequence_length//16) float8_e4m3fn, swizzled
+            bytes in the logical 2D shape.
+    """
+    raise_if_cutedsl_nvfp4_unavailable("cutedsl_group_rht_quantize_row_col")
+
+    from ._cutedsl_kernels_impl import _cutedsl_group_rht_quantize_row_col_impl
+
+    return _cutedsl_group_rht_quantize_row_col_impl(
+        A,
+        sign_vector,
+        offsets,
+        num_tensors,
+        packed_sequence_length,
+        hidden_size,
+        shape_rep,
+        a_global_amax,
+        d_global_amax,
+        rng_state,
+        enable_stochastic_rounding,
+        logical_packed_length,
+    )
+
+
+@cutedsl_group_rht_quantize_row_col.register_fake
+def _(
+    A,
+    sign_vector,
+    offsets,
+    num_tensors,
+    packed_sequence_length,
+    hidden_size,
+    shape_rep,
+    a_global_amax,
+    d_global_amax,
+    rng_state,
+    enable_stochastic_rounding,
+    logical_packed_length=None,
+):
+    T, K = packed_sequence_length, hidden_size
+    qa = A.new_empty((T, K // 2), dtype=torch.uint8)
+    sfa = A.new_empty((T, K // 16), dtype=torch.float8_e4m3fn)
+    qd = A.new_empty((K, T // 2), dtype=torch.uint8)
+    sfd = A.new_empty((K, T // 16), dtype=torch.float8_e4m3fn)
+    return qa, sfa, qd, sfd

--- a/torchao/prototype/moe_training/nvfp4_training/hadamard_amax_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/hadamard_amax_cutedsl.py
@@ -29,7 +29,7 @@ def cutedsl_rht_amax(
     """Compute the post-RHT columnwise amax and the plain rowwise amax of ``A``.
 
     Args:
-        A: (M, N) bfloat16 tensor, row-major. M must be divisible by 256, N by 128.
+        A: (M, N) bfloat16 tensor, row-major. M must be divisible by 128, N by 128.
         sign_vector: Sign vector for the RHT as a list of ints.
         hadamard_dimension: Dimension of the Hadamard matrix (only 16 supported).
 

--- a/torchao/prototype/moe_training/nvfp4_training/hadamard_cutedsl_utils.py
+++ b/torchao/prototype/moe_training/nvfp4_training/hadamard_cutedsl_utils.py
@@ -87,7 +87,7 @@ def raise_if_cutedsl_nvfp4_unavailable(op_name: str) -> None:
         )
 
 
-def cutedsl_prepare_for_cuda_graph(device, *, sign_vectors=None) -> None:
+def cutedsl_prepare_for_cuda_graph(device, *, sign_vectors=None, moe_num_experts=None) -> None:
     """Pre-allocate per-device CuteDSL state before ``torch.compile(mode="reduce-overhead")``.
 
     The CuteDSL ops cache small per-device buffers (the RHT / identity Hadamard operands and the
@@ -125,3 +125,18 @@ def cutedsl_prepare_for_cuda_graph(device, *, sign_vectors=None) -> None:
         _compile_fused_kernel(
             idx, True, False, apply_rht=False, col_groups_per_supertile=col_groups
         )
+    # Grouped amax: 128-row supertile, group-search depth keyed on the expert
+    # count -- pass moe_num_experts when graphing the grouped MoE ops.
+    if moe_num_experts is not None:
+        search_iters = max(0, (int(moe_num_experts) - 1).bit_length())
+        _compile_amax_tc_kernel(idx, 8, grouped=True, search_iters=search_iters)
+        for sr in (False, True):
+            _compile_fused_kernel(
+                idx,
+                True,
+                sr,
+                apply_rht=True,
+                col_groups_per_supertile=8,
+                grouped=True,
+                search_iters=search_iters,
+            )

--- a/torchao/prototype/moe_training/nvfp4_training/hadamard_cutedsl_utils.py
+++ b/torchao/prototype/moe_training/nvfp4_training/hadamard_cutedsl_utils.py
@@ -115,7 +115,13 @@ def cutedsl_prepare_for_cuda_graph(device, *, sign_vectors=None) -> None:
         _get_rht_buffer(tuple(int(v) for v in sign_vector), idx)
     # Pre-compile the kernels so no lazy compile fires mid-capture: amax; the RHT fused RTNE +
     # SR variants (apply_rht=True); and the no-MMA weight-quantize variant (apply_rht=False).
-    _compile_amax_tc_kernel(idx)
-    for sr in (False, True):
-        _compile_fused_kernel(idx, True, sr, apply_rht=True)
-    _compile_fused_kernel(idx, True, False, apply_rht=False)
+    # Both supertile heights: 256-row (M % 256 shapes) and 128-row (other M % 128).
+    for col_groups in (16, 8):
+        _compile_amax_tc_kernel(idx, col_groups)
+        for sr in (False, True):
+            _compile_fused_kernel(
+                idx, True, sr, apply_rht=True, col_groups_per_supertile=col_groups
+            )
+        _compile_fused_kernel(
+            idx, True, False, apply_rht=False, col_groups_per_supertile=col_groups
+        )

--- a/torchao/prototype/moe_training/nvfp4_training/hadamard_quantize_row_col_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/hadamard_quantize_row_col_cutedsl.py
@@ -44,7 +44,7 @@ def cutedsl_rht_quantize_row_col(
         FP4 + (M//128, N//64, 32, 16) swizzled scales.
 
     Args:
-        A: (M, N) bfloat16, row-major. M must be divisible by 256, N by 128.
+        A: (M, N) bfloat16, row-major. M must be divisible by 128, N by 128.
         col_global_amax: scalar float32 ``max(abs(RHT(A.t())))``. Compute via
             ``cutedsl_rht_amax`` (and optionally all-reduce for TP) before passing in.
         row_global_amax: scalar float32 ``max(abs(A))``. Same source.

--- a/torchao/prototype/moe_training/nvfp4_training/nvfp4_linear.py
+++ b/torchao/prototype/moe_training/nvfp4_training/nvfp4_linear.py
@@ -172,18 +172,6 @@ class nvfp4_mm_triton(torch.autograd.Function):
                 f"nvfp4_mm_triton requires M, K, N all divisible by 128; "
                 f"got M={M}, K={K}, N={N}"
             )
-        if use_cutedsl and M % 256 != 0:
-            # The outer M % 128 gate is too coarse for CuteDSL: M=128 reaches the amax
-            # kernel and silently returns zero amaxes.
-            raise ValueError(
-                f"kernel_preference=CUTEDSL requires M divisible by 256, got M={M}"
-            )
-        if use_cutedsl and N % 256 != 0:
-            # The CuteDSL weight quantize maps the weight as (out=N, in=K) into the fused kernel,
-            # whose M tiler needs out_features % 256 (stricter than the Triton weight kernel's %128).
-            raise ValueError(
-                f"kernel_preference=CUTEDSL requires N (out_features) divisible by 256, got N={N}"
-            )
         input_2d = input_hp.reshape(-1, K).contiguous()
 
         # Amaxes are separate ops so TP callers can all-reduce them before quantizing.
@@ -328,7 +316,7 @@ def nvfp4_linear(
         sign_vector: RHT sign vector used for amax and quantization.
         kernel_preference: Backend for quantization, TRITON (default) or CUTEDSL.
             CUTEDSL runs the full path on CuteDSL — the amax, the forward RTNE quantize, the
-            backward SR (cvt.rs) quantize, and the 2D weight quantize (requires out_features % 256).
+            backward SR (cvt.rs) quantize, and the 2D weight quantize (requires out_features % 128).
         sr_seed: Fixed int64 seed tensor (size=(1,)) for SR Philox key. Allocated
             fresh if None. For reproducibility, pass a pre-allocated module buffer.
     """

--- a/torchao/prototype/moe_training/nvfp4_training/nvfp4_tensor_parallel.py
+++ b/torchao/prototype/moe_training/nvfp4_training/nvfp4_tensor_parallel.py
@@ -50,32 +50,32 @@ def _check_cutedsl_shard(
     *,
     scatter_m: bool = False,
 ) -> None:
-    """The CuteDSL kernels need the per-rank activation shard to have M % 256 == 0 and
-    K % 128 == 0 (Triton allows M % 128). The weight quantize additionally needs the per-rank
-    weight shard to have out_features % 256 == 0 and in_features % 128 == 0. Fail early with a
+    """The CuteDSL kernels need the per-rank activation shard to have M % 128 == 0 and
+    K % 128 == 0. The weight quantize additionally needs the per-rank
+    weight shard to have out_features % 128 == 0 and in_features % 128 == 0. Fail early with a
     TP-aware message.
 
     ``scatter_m=True`` (row parallel): the forward reduce-scatters the output along M, so the
-    backward quantizes a grad shard of M // world_size rows. Requiring M % (256 * world_size)
+    backward quantizes a grad shard of M // world_size rows. Requiring M % (128 * world_size)
     here keeps that backward quantize legal — otherwise a shape that passes this check dies
-    mid-backward with a bare "M must be divisible by 256" and no TP context."""
+    mid-backward with a bare "M must be divisible by 128" and no TP context."""
     M, K = x.shape[0], x.shape[1]
-    m_multiple = 256 * world_size if scatter_m else 256
+    m_multiple = 128 * world_size if scatter_m else 128
     if M % m_multiple != 0 or K % 128 != 0:
         detail = (
-            f"M % {m_multiple} == 0 (256 x world_size, since the backward quantizes the "
+            f"M % {m_multiple} == 0 (128 x world_size, since the backward quantizes the "
             f"reduce-scattered M // {world_size} grad shard) and K % 128 == 0"
             if scatter_m
-            else "M % 256 == 0 and K % 128 == 0"
+            else "M % 128 == 0 and K % 128 == 0"
         )
         raise ValueError(
             "kernel_preference=CUTEDSL requires the per-rank activation shard to have "
             f"{detail}; got shard shape {tuple(x.shape)} (world_size={world_size})"
         )
-    if w is not None and (w.shape[0] % 256 != 0 or w.shape[1] % 128 != 0):
+    if w is not None and (w.shape[0] % 128 != 0 or w.shape[1] % 128 != 0):
         raise ValueError(
             "kernel_preference=CUTEDSL requires the per-rank weight shard to have "
-            f"out_features % 256 == 0 and in_features % 128 == 0; got shard shape {tuple(w.shape)} "
+            f"out_features % 128 == 0 and in_features % 128 == 0; got shard shape {tuple(w.shape)} "
             f"(world_size={world_size})"
         )
 
@@ -410,7 +410,7 @@ def nvfp4_col_parallel_linear(
         sign_vector: RHT sign vector used for amax and quantization. Must
             match across TP ranks.
         use_cutedsl: Use the CuteDSL amax + quantize for both forward (RTNE) and the
-            backward SR (cvt.rs) paths. Requires the per-rank M shard % 256 == 0.
+            backward SR (cvt.rs) paths. Requires the per-rank M shard % 128 == 0.
     """
     if tp_group is None:
         raise ValueError("tp_group is required for nvfp4_col_parallel_linear")
@@ -661,7 +661,7 @@ def nvfp4_row_parallel_linear(
         sign_vector: RHT sign vector used for amax and quantization. Must
             match across TP ranks.
         use_cutedsl: Use the CuteDSL amax + quantize for both forward (RTNE) and the
-            backward SR (cvt.rs) paths. Requires the per-rank M shard % 256 == 0.
+            backward SR (cvt.rs) paths. Requires the per-rank M shard % 128 == 0.
     """
     if tp_group is None:
         raise ValueError("tp_group is required for nvfp4_row_parallel_linear")

--- a/torchao/prototype/moe_training/nvfp4_training/nvfp4_training.py
+++ b/torchao/prototype/moe_training/nvfp4_training/nvfp4_training.py
@@ -81,8 +81,8 @@ class NVFP4TrainingConfig(AOBaseConfig):
             CUTEDSL: CuteDSL kernels for the full quantize path (amax, forward
                 RTNE quantize, SR backward quantize, and 2D weight quantize).
                 Requires SM100; in_features divisible by 128 and out_features
-                by 256. Under tensor parallel the same constraints apply to each
-                per-rank shard, and the per-rank M shard must be divisible by 256.
+                by 128. Under tensor parallel the same constraints apply to each
+                per-rank shard, and the per-rank M shard must be divisible by 128.
             Default: TRITON.
         process_group: Optional ProcessGroup for tensor-parallel TP.
             When set, forward dispatches to the selected NVFP4 tensor-parallel

--- a/torchao/prototype/moe_training/nvfp4_training/quantize_2d_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/quantize_2d_cutedsl.py
@@ -30,9 +30,8 @@ def cutedsl_weight_quantize_2d(
     """2D NVFP4 E2M1 weight quantization without RHT (CuteDSL, SM100+).
 
     Args:
-        A:           (M, N) bfloat16, row-major. M == out_features must be divisible by 256,
-                     N == in_features by 128 (the fused kernel's tiling constraints, stricter
-                     than the Triton kernel's M % 128).
+        A:           (M, N) bfloat16, row-major. M == out_features must be divisible by,
+                     N == in_features by 128.
         global_amax: scalar float32 ``A.float().abs().max()`` (caller may all-reduce for TP).
 
     Returns:
@@ -44,15 +43,15 @@ def cutedsl_weight_quantize_2d(
 
     Raises:
         NotImplementedError: pre-SM100 / missing CuteDSL runtime.
-        ValueError: bad dtype/shape, or out_features not divisible by 256.
+        ValueError: bad dtype/shape, or out_features not divisible by 128.
     """
     raise_if_cutedsl_nvfp4_unavailable("cutedsl_weight_quantize_2d")
     if A.ndim != 2:
         raise ValueError("A must be 2-D")
     M, N = A.shape
-    if M % 256 != 0:
+    if M % 128 != 0:
         raise ValueError(
-            f"cutedsl_weight_quantize_2d requires out_features (dim 0) divisible by 256, got {M}"
+            f"cutedsl_weight_quantize_2d requires out_features (dim 0) divisible by 128, got {M}"
         )
 
     from ._cutedsl_kernels_impl import (


### PR DESCRIPTION
Followup adding MoE support to the [CuteDSL kernels](https://github.com/pytorch/ao/pull/4487)

This PR also relaxes the 256-divisible requirement for the kernels to a 128-divisible requirement. This was done so that the CuteDSL and Triton kernels have matching interfaces and capabilities.