### PR TITLE
fix(autocast): use input device type

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -449,13 +449,32 @@ class TestFloat8Linear:
         # autocast on
         with torch.autocast(str(device)):
             y = m(x)
-        assert y.dtype == torch.half, f"y.dtype is {y.dtype}, expected {torch.half}"
+        default_autocast_dtype = torch.get_autocast_dtype(device.type)
+        assert y.dtype == default_autocast_dtype, (
+            f"y.dtype is {y.dtype}, expected {default_autocast_dtype}"
+        )
 
         with torch.autocast(str(device), dtype=torch.bfloat16):
             y = m(x)
         assert y.dtype == torch.bfloat16, (
             f"y.dtype is {y.dtype}, expected {torch.bfloat16}"
         )
+
+    def test_meta_device_skips_autocast_query(self):
+        linear = nn.Linear(8, 16, device="meta")
+        config = Float8LinearConfig(emulate=True)
+        float8_linear = Float8Linear.from_float(linear, config=config)
+        input = torch.randn(4, 8, device="meta")
+        expected = torch.empty(4, 16, device="meta")
+
+        with unittest.mock.patch(
+            "torchao.float8.float8_linear.matmul_with_hp_or_float8_args.apply",
+            return_value=expected,
+        ) as apply:
+            output = float8_linear(input)
+
+        assert output is expected
+        assert apply.call_args.args[0] is input
 
     def test_repr(self):
         m = nn.Linear(32, 16)

--- a/test/prototype/test_quantized_training.py
+++ b/test/prototype/test_quantized_training.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import copy
+from unittest import mock
 
 import pytest
 import torch
@@ -33,6 +34,14 @@ from torchao.prototype.quantized_training import (
     int8_weight_only_quantized_training,
     quantize_int8_rowwise,
 )
+from torchao.prototype.quantized_training.bitnet import (
+    BitNetTrainingLinearWeight,
+    _BitNetTrainingLinear,
+)
+from torchao.prototype.quantized_training.int8_mixed_precision import (
+    Int8MixedPrecisionTrainingLinearWeight,
+    _Int8MixedPrecisionTrainingLinearFunction,
+)
 from torchao.quantization.quant_api import quantize_
 from torchao.utils import torch_version_at_least
 
@@ -40,6 +49,13 @@ if common_utils.SEED is None:
     common_utils.SEED = 1234
 
 _DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+_AUTOCAST_LINEAR_CASES = [
+    (
+        Int8MixedPrecisionTrainingLinearWeight,
+        _Int8MixedPrecisionTrainingLinearFunction,
+    ),
+    (BitNetTrainingLinearWeight, _BitNetTrainingLinear),
+]
 
 
 def _reset():
@@ -226,6 +242,50 @@ class TestQuantizedTraining(TestCase):
             loss_int8.backward()
             optim_int8.step()
             optim_int8.zero_grad()
+
+    @parametrize(
+        "weight_cls,linear_function",
+        _AUTOCAST_LINEAR_CASES,
+    )
+    def test_non_cuda_autocast(self, weight_cls, linear_function):
+        input = torch.randn(4, 8)
+        weight_data = torch.randn(16, 8)
+        bias = torch.randn(16)
+        if weight_cls is Int8MixedPrecisionTrainingLinearWeight:
+            weight = weight_cls(weight_data, Int8MixedPrecisionTrainingConfig())
+        else:
+            weight = weight_cls(weight_data)
+
+        expected = torch.empty(4, 16, dtype=torch.bfloat16)
+        with mock.patch.object(
+            linear_function, "apply", return_value=expected
+        ) as apply:
+            with torch.autocast("cpu", dtype=torch.bfloat16):
+                output = F.linear(input, weight, bias)
+
+        assert output is expected
+        forwarded_args = apply.call_args.args
+        assert all(arg.dtype == torch.bfloat16 for arg in forwarded_args)
+
+    @parametrize("weight_cls,linear_function", _AUTOCAST_LINEAR_CASES)
+    def test_unsupported_device_skips_autocast_query(self, weight_cls, linear_function):
+        input = torch.randn(4, 8, device="meta")
+        weight_data = torch.randn(16, 8, device="meta")
+        bias = torch.randn(16, device="meta")
+        if weight_cls is Int8MixedPrecisionTrainingLinearWeight:
+            weight = weight_cls(weight_data, Int8MixedPrecisionTrainingConfig())
+        else:
+            weight = weight_cls(weight_data)
+
+        expected = torch.empty(4, 16, device="meta")
+        with mock.patch.object(
+            linear_function, "apply", return_value=expected
+        ) as apply:
+            output = F.linear(input, weight, bias)
+
+        assert output is expected
+        forwarded_args = apply.call_args.args
+        assert all(arg.dtype == torch.float32 for arg in forwarded_args)
 
     @parametrize("compile", [False, True])
     @parametrize(

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -255,10 +255,11 @@ class Float8Linear(torch.nn.Linear):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         # Duplicate the autocast logic for F.linear, so that the output
         # of our module has the right original precision
-        if torch.is_autocast_enabled():
-            # For now, hardcode to GPU's autocast dtype
-            # if we need CPU support in the future, we can add it
-            autocast_dtype = torch.get_autocast_gpu_dtype()
+        device_type = input.device.type
+        if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+            device_type
+        ):
+            autocast_dtype = torch.get_autocast_dtype(device_type)
             input = input.to(autocast_dtype)
 
         output = matmul_with_hp_or_float8_args.apply(

--- a/torchao/prototype/quantized_training/bitnet.py
+++ b/torchao/prototype/quantized_training/bitnet.py
@@ -142,8 +142,11 @@ class BitNetTrainingLinearWeight(TorchAOBaseTensor):
 
 @BitNetTrainingLinearWeight.implements_torch_function(F.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+        device_type
+    ):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _BitNetTrainingLinear.apply(*args, **kwargs)
 

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -167,8 +167,11 @@ class Int8MixedPrecisionTrainingLinearWeight(TorchAOBaseTensor):
 
 @Int8MixedPrecisionTrainingLinearWeight.implements(torch.nn.functional.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.amp.is_autocast_available(device_type) and torch.is_autocast_enabled(
+        device_type
+    ):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _Int8MixedPrecisionTrainingLinearFunction.apply(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

Related to #4601 and #4603.

Several float8 and quantized-training paths query CUDA autocast state regardless of the input tensor's actual device. On non-CUDA backends, this silently skips the expected autocast conversion and allows quantization to run in fp32.

This change derives the autocast device type from the input tensor and uses the corresponding device-aware PyTorch AMP APIs.

## Changes

- Make autocast queries device-aware in `Float8Linear`.
- Apply the same fix to the Int8 mixed-precision and BitNet handlers.
- Guard unsupported devices with `torch.amp.is_autocast_available(device_type)`.
- Make the existing float8 autocast test device-generic.
- Add CPU autocast regression tests for both quantized-training handlers.
- Add `meta` device regression coverage for all affected paths.

## Difference from #4603

PR #4603 contains the same production fix. This PR additionally adds CPU and `meta` regression coverage. I am keeping this PR as a draft while coordinating with the existing author and maintainers to avoid duplicating active work.

## Validation

- `ruff check` — passed
- `ruff format --check` — passed
- `python -m compileall` — passed
- `git diff --check` — passed
- CPU and `meta` autocast API smoke test — passed

Focused pytest collection was blocked locally because the installed PyTorch 2.7.1 lacks newer APIs required by current TorchAO `main`, including `torch.nn.functional.ScalingType`; `expecttest` is also unavailable.
```