### PR TITLE
Add FSDP2 support for Int8Tensor inference weights

### DIFF
--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -6,7 +6,6 @@
 
 import copy
 import unittest
-from unittest import mock
 
 import torch
 from torch._inductor.utils import run_and_get_code
@@ -25,7 +24,6 @@ from torchao.quantization.quantize_.common import (
     _choose_quant_func_and_quantize_tensor,
 )
 from torchao.quantization.quantize_.workflows.int8.int8_tensor import (
-    Int8Tensor,
     QuantizeTensorToInt8Kwargs,
 )
 from torchao.quantization.utils import compute_error, get_block_size
@@ -202,67 +200,6 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
             self.assertEqual(weight2.scale, dummy.weight.scale)
         with self.assertRaises(NotImplementedError):
             _ = dummy.weight[::2]
-
-    @common_utils.parametrize("device", get_available_devices())
-    def test_fsdp_shard_ops(self, device):
-        """Test the local sharding and all-gather protocol used by FSDP2."""
-        linear = torch.nn.Linear(
-            128, 256, bias=False, dtype=torch.bfloat16, device=device
-        )
-        quantize_(linear, Int8DynamicActivationInt8WeightConfig())
-        weight = linear.weight
-
-        shards = torch.chunk(weight, 2, dim=0)
-        self.assertEqual(len(shards), 2)
-        self.assertEqual(shards[0].qdata, weight.qdata[:128])
-        self.assertEqual(shards[0].scale, weight.scale[:128])
-        self.assertEqual(shards[0].zero_point, weight.zero_point[:128])
-
-        padded_shard = weight.new_zeros(shards[0].shape)
-        padded_shard.copy_(shards[0])
-        self.assertEqual(padded_shard.qdata, shards[0].qdata)
-        self.assertEqual(padded_shard.scale, shards[0].scale)
-        self.assertEqual(padded_shard.zero_point, shards[0].zero_point)
-        self.assertEqual(padded_shard.view(-1).numel(), padded_shard.numel())
-
-        shard_inputs = []
-        metadata = None
-        mesh = mock.Mock()
-        mesh.size.return_value = 2
-        with self.assertRaisesRegex(NotImplementedError, "evenly divisible"):
-            shards[0].fsdp_pre_all_gather(mesh=mesh, outer_size=torch.Size((255, 128)))
-        for shard in shards:
-            inputs, shard_metadata = shard.fsdp_pre_all_gather(
-                mesh=mesh, outer_size=weight.size()
-            )
-            shard_inputs.append(inputs)
-            self.assertEqual(inputs[0].shape, (128, 128))
-            self.assertEqual(inputs[1].shape, (128, 1))
-            self.assertEqual(inputs[2].shape, (128, 1))
-            if metadata is None:
-                metadata = shard_metadata
-            else:
-                self.assertEqual(shard_metadata, metadata)
-
-        all_gather_outputs = tuple(
-            torch.cat([inputs[i] for inputs in shard_inputs], dim=0)
-            for i in range(len(shard_inputs[0]))
-        )
-        gathered, gathered_inputs = shards[0].fsdp_post_all_gather(
-            all_gather_outputs, metadata, weight.dtype
-        )
-        self.assertIsInstance(gathered, Int8Tensor)
-        self.assertEqual(gathered.qdata, weight.qdata)
-        self.assertEqual(gathered.scale, weight.scale)
-        self.assertEqual(gathered.zero_point, weight.zero_point)
-        self.assertEqual(gathered_inputs, all_gather_outputs)
-
-        unsharded = torch.as_strided(
-            gathered, weight.size(), weight.stride(), weight.storage_offset()
-        )
-        self.assertEqual(unsharded.qdata, weight.qdata)
-        self.assertEqual(unsharded.scale, weight.scale)
-        self.assertEqual(unsharded.zero_point, weight.zero_point)
 
     @common_utils.parametrize("config", INT8_TEST_CONFIGS)
     @common_utils.parametrize("device", get_available_devices())

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor.py
@@ -6,6 +6,7 @@
 
 import copy
 import unittest
+from unittest import mock
 
 import torch
 from torch._inductor.utils import run_and_get_code
@@ -24,6 +25,7 @@ from torchao.quantization.quantize_.common import (
     _choose_quant_func_and_quantize_tensor,
 )
 from torchao.quantization.quantize_.workflows.int8.int8_tensor import (
+    Int8Tensor,
     QuantizeTensorToInt8Kwargs,
 )
 from torchao.quantization.utils import compute_error, get_block_size
@@ -200,6 +202,67 @@ class TestInt8Tensor(TorchAOIntegrationTestCase):
             self.assertEqual(weight2.scale, dummy.weight.scale)
         with self.assertRaises(NotImplementedError):
             _ = dummy.weight[::2]
+
+    @common_utils.parametrize("device", get_available_devices())
+    def test_fsdp_shard_ops(self, device):
+        """Test the local sharding and all-gather protocol used by FSDP2."""
+        linear = torch.nn.Linear(
+            128, 256, bias=False, dtype=torch.bfloat16, device=device
+        )
+        quantize_(linear, Int8DynamicActivationInt8WeightConfig())
+        weight = linear.weight
+
+        shards = torch.chunk(weight, 2, dim=0)
+        self.assertEqual(len(shards), 2)
+        self.assertEqual(shards[0].qdata, weight.qdata[:128])
+        self.assertEqual(shards[0].scale, weight.scale[:128])
+        self.assertEqual(shards[0].zero_point, weight.zero_point[:128])
+
+        padded_shard = weight.new_zeros(shards[0].shape)
+        padded_shard.copy_(shards[0])
+        self.assertEqual(padded_shard.qdata, shards[0].qdata)
+        self.assertEqual(padded_shard.scale, shards[0].scale)
+        self.assertEqual(padded_shard.zero_point, shards[0].zero_point)
+        self.assertEqual(padded_shard.view(-1).numel(), padded_shard.numel())
+
+        shard_inputs = []
+        metadata = None
+        mesh = mock.Mock()
+        mesh.size.return_value = 2
+        with self.assertRaisesRegex(NotImplementedError, "evenly divisible"):
+            shards[0].fsdp_pre_all_gather(mesh=mesh, outer_size=torch.Size((255, 128)))
+        for shard in shards:
+            inputs, shard_metadata = shard.fsdp_pre_all_gather(
+                mesh=mesh, outer_size=weight.size()
+            )
+            shard_inputs.append(inputs)
+            self.assertEqual(inputs[0].shape, (128, 128))
+            self.assertEqual(inputs[1].shape, (128, 1))
+            self.assertEqual(inputs[2].shape, (128, 1))
+            if metadata is None:
+                metadata = shard_metadata
+            else:
+                self.assertEqual(shard_metadata, metadata)
+
+        all_gather_outputs = tuple(
+            torch.cat([inputs[i] for inputs in shard_inputs], dim=0)
+            for i in range(len(shard_inputs[0]))
+        )
+        gathered, gathered_inputs = shards[0].fsdp_post_all_gather(
+            all_gather_outputs, metadata, weight.dtype
+        )
+        self.assertIsInstance(gathered, Int8Tensor)
+        self.assertEqual(gathered.qdata, weight.qdata)
+        self.assertEqual(gathered.scale, weight.scale)
+        self.assertEqual(gathered.zero_point, weight.zero_point)
+        self.assertEqual(gathered_inputs, all_gather_outputs)
+
+        unsharded = torch.as_strided(
+            gathered, weight.size(), weight.stride(), weight.storage_offset()
+        )
+        self.assertEqual(unsharded.qdata, weight.qdata)
+        self.assertEqual(unsharded.scale, weight.scale)
+        self.assertEqual(unsharded.zero_point, weight.zero_point)
 
     @common_utils.parametrize("config", INT8_TEST_CONFIGS)
     @common_utils.parametrize("device", get_available_devices())

--- a/test/quantization/quantize_/workflows/int8/test_int8_tensor_cpu.py
+++ b/test/quantization/quantize_/workflows/int8/test_int8_tensor_cpu.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+from unittest import mock
 
 import torch
 from torch.testing._internal import common_utils
@@ -114,6 +115,64 @@ class TestInt8TensorCPU(TorchAOIntegrationTestCase):
         assert compute_error(output_fp, output_quantized) > 20, (
             f"Quantization error is too high got a SQNR of {compute_error(output_fp, output_quantized)}"
         )
+
+    def test_fsdp_shard_ops(self):
+        """Test the local sharding and all-gather protocol used by FSDP2."""
+        linear = torch.nn.Linear(128, 256, bias=False, dtype=torch.bfloat16)
+        quantize_(linear, Int8DynamicActivationInt8WeightConfig())
+        weight = linear.weight
+
+        shards = torch.chunk(weight, 2, dim=0)
+        self.assertEqual(len(shards), 2)
+        self.assertEqual(shards[0].qdata, weight.qdata[:128])
+        self.assertEqual(shards[0].scale, weight.scale[:128])
+        self.assertEqual(shards[0].zero_point, weight.zero_point[:128])
+
+        padded_shard = weight.new_zeros(shards[0].shape)
+        padded_shard.copy_(shards[0])
+        self.assertEqual(padded_shard.qdata, shards[0].qdata)
+        self.assertEqual(padded_shard.scale, shards[0].scale)
+        self.assertEqual(padded_shard.zero_point, shards[0].zero_point)
+        self.assertEqual(padded_shard.view(-1).numel(), padded_shard.numel())
+
+        shard_inputs = []
+        metadata = None
+        mesh = mock.Mock()
+        mesh.size.return_value = 2
+        with self.assertRaisesRegex(NotImplementedError, "evenly divisible"):
+            shards[0].fsdp_pre_all_gather(mesh=mesh, outer_size=torch.Size((255, 128)))
+        for shard in shards:
+            inputs, shard_metadata = shard.fsdp_pre_all_gather(
+                mesh=mesh, outer_size=weight.size()
+            )
+            shard_inputs.append(inputs)
+            self.assertEqual(inputs[0].shape, (128, 128))
+            self.assertEqual(inputs[1].shape, (128, 1))
+            self.assertEqual(inputs[2].shape, (128, 1))
+            if metadata is None:
+                metadata = shard_metadata
+            else:
+                self.assertEqual(shard_metadata, metadata)
+
+        all_gather_outputs = tuple(
+            torch.cat([inputs[i] for inputs in shard_inputs], dim=0)
+            for i in range(len(shard_inputs[0]))
+        )
+        gathered, gathered_inputs = shards[0].fsdp_post_all_gather(
+            all_gather_outputs, metadata, weight.dtype
+        )
+        self.assertIsInstance(gathered, Int8Tensor)
+        self.assertEqual(gathered.qdata, weight.qdata)
+        self.assertEqual(gathered.scale, weight.scale)
+        self.assertEqual(gathered.zero_point, weight.zero_point)
+        self.assertEqual(gathered_inputs, all_gather_outputs)
+
+        unsharded = torch.as_strided(
+            gathered, weight.size(), weight.stride(), weight.storage_offset()
+        )
+        self.assertEqual(unsharded.qdata, weight.qdata)
+        self.assertEqual(unsharded.scale, weight.scale)
+        self.assertEqual(unsharded.zero_point, weight.zero_point)
 
 
 if __name__ == "__main__":

--- a/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
+++ b/torchao/quantization/quantize_/workflows/int8/int8_tensor.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch.utils._python_dispatch import return_and_correct_aliasing
@@ -258,6 +258,90 @@ class Int8Tensor(TorchAOBaseTensor):
             output_dtype=output_dtype if output_dtype is not None else self.dtype,
         )
 
+    def fsdp_pre_all_gather(
+        self,
+        mesh,
+        outer_size=None,
+        outer_stride=None,
+        module=None,
+        mp_policy=None,
+    ):
+        """Return the row-sharded representation for FSDP2 all-gather."""
+        if self.ndim != 2 or self.block_size[0] != 1:
+            raise NotImplementedError(
+                "Int8Tensor FSDP2 only supports 2D weights with per-row "
+                f"quantization, got shape={self.shape}, block_size={self.block_size}"
+            )
+
+        if outer_size is not None and outer_size[0] % mesh.size() != 0:
+            raise NotImplementedError(
+                "Int8Tensor FSDP2 requires the number of rows to be evenly "
+                f"divisible by the FSDP world size, got rows={outer_size[0]}, "
+                f"world_size={mesh.size()}"
+            )
+
+        all_gather_inputs = [self.qdata, self.scale]
+        has_zero_point = self.zero_point is not None
+        if has_zero_point:
+            all_gather_inputs.append(self.zero_point)
+        metadata = (
+            self.block_size,
+            self.act_quant_scale,
+            self.act_quant_zero_point,
+            self.act_pre_scale,
+            self.act_quant_kwargs,
+            self.reduce_range,
+            has_zero_point,
+        )
+        return tuple(all_gather_inputs), metadata
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs: Tuple[torch.Tensor, ...],
+        metadata: Any,
+        param_dtype: torch.dtype,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ):
+        """Rebuild an Int8Tensor after FSDP2 gathers its inner tensors."""
+        (
+            block_size,
+            act_quant_scale,
+            act_quant_zero_point,
+            act_pre_scale,
+            act_quant_kwargs,
+            reduce_range,
+            has_zero_point,
+        ) = metadata
+        qdata, scale, *optional_outputs = all_gather_outputs
+        zero_point = optional_outputs[0] if has_zero_point else None
+        gathered = Int8Tensor(
+            qdata,
+            scale,
+            block_size,
+            param_dtype,
+            zero_point=zero_point,
+            act_quant_scale=act_quant_scale,
+            act_quant_zero_point=act_quant_zero_point,
+            act_pre_scale=act_pre_scale,
+            act_quant_kwargs=act_quant_kwargs,
+            reduce_range=reduce_range,
+        )
+
+        if out is not None:
+            from torch.distributed.tensor import DTensor
+
+            local_out = out.to_local() if isinstance(out, DTensor) else out
+            if not isinstance(local_out, Int8Tensor):
+                raise RuntimeError(
+                    "out must be an Int8Tensor or DTensor with an Int8Tensor "
+                    f"local tensor, got {type(out)}"
+                )
+            local_out.copy_(gathered)
+            return None
+
+        return gathered, all_gather_outputs
+
 
 implements = Int8Tensor.implements
 implements_torch_function = Int8Tensor.implements_torch_function
@@ -420,6 +504,89 @@ def _(func, types, args, kwargs):
             reduce_range=self.reduce_range,
         ),
     )
+
+
+@implements(aten.split.Tensor)
+def _(func, types, args, kwargs):
+    """Split a per-row Int8Tensor along rows for FSDP2 sharding."""
+    self, split_size, dim = fill_defaults(args, 3, [0])
+    dim = dim % self.ndim
+    if self.ndim != 2 or dim != 0 or self.block_size[0] != 1:
+        raise NotImplementedError(
+            "Int8Tensor split only supports dim=0 for 2D per-row weights, "
+            f"got shape={self.shape}, block_size={self.block_size}, dim={dim}"
+        )
+    if split_size <= 0:
+        raise ValueError(f"split_size must be greater than 0, got {split_size}")
+
+    return [
+        aten.slice.Tensor(self, dim, start, min(start + split_size, self.shape[dim]))
+        for start in range(0, self.shape[dim], split_size)
+    ]
+
+
+@implements(aten.new_zeros.default)
+def _(func, types, args, kwargs):
+    """Allocate a zeroed per-row shard with matching Int8Tensor metadata."""
+    self, size = args[:2]
+    size = tuple(size)
+    if (
+        self.ndim != 2
+        or len(size) != 2
+        or size[1] != self.shape[1]
+        or self.block_size[0] != 1
+    ):
+        raise NotImplementedError(
+            "Int8Tensor new_zeros only supports row-resized 2D per-row weights, "
+            f"got old_size={tuple(self.shape)}, new_size={size}, "
+            f"block_size={self.block_size}"
+        )
+
+    device = kwargs.get("device", self.device)
+    pin_memory = kwargs.get("pin_memory", False)
+
+    def resize_rows(tensor):
+        tensor_size = tensor.shape
+        if tensor.ndim > 0 and tensor.shape[0] == self.shape[0]:
+            tensor_size = (size[0], *tensor.shape[1:])
+        return torch.zeros(
+            tensor_size,
+            dtype=tensor.dtype,
+            device=device,
+            pin_memory=pin_memory,
+        )
+
+    return self._apply_fn_to_data(resize_rows)
+
+
+@implements(aten.view.default)
+def _(func, types, args, kwargs):
+    """Flatten an Int8Tensor shard for FSDP2 storage management."""
+    self, size = args[:2]
+    if tuple(size) not in [(-1,), (self.numel(),)]:
+        raise NotImplementedError(
+            f"Int8Tensor view only supports flattening, got size={tuple(size)}"
+        )
+    viewed = self._apply_fn_to_data(lambda tensor: tensor.reshape(-1))
+    return return_and_correct_aliasing(func, args, kwargs, viewed)
+
+
+@implements(aten.as_strided.default)
+def _(func, types, args, kwargs):
+    """Restore the original contiguous view after an FSDP2 all-gather."""
+    self, size, stride, storage_offset = args[:4]
+    if (
+        tuple(size) != tuple(self.shape)
+        or tuple(stride) != tuple(self.stride())
+        or storage_offset != self.storage_offset()
+    ):
+        raise NotImplementedError(
+            "Int8Tensor as_strided only supports its existing contiguous view, "
+            f"got size={tuple(size)}, stride={tuple(stride)}, "
+            f"storage_offset={storage_offset}"
+        )
+    viewed = self._apply_fn_to_data(lambda tensor: tensor)
+    return return_and_correct_aliasing(func, args, kwargs, viewed)
 
 
 @implements(aten.index.Tensor)


### PR DESCRIPTION
I reviewed the final diff line by line, understand the implementation and its limitations, and take responsibility for this contribution. The quoted description below was prepared with AI assistance and matches the code and validation I reviewed.

> ## Summary
>
> - add the FSDP2 all-gather extension for per-row `Int8Tensor` weights
> - implement the tensor operations FSDP2 uses to shard, allocate, flatten, and restore those weights
> - reject uneven row sharding early, since the current scale and zero-point representation cannot satisfy FSDP2's padded all-gather contract
> - add focused regression coverage for sharding, metadata preservation, reconstruction, and boundary handling
>
> Fixes #2127.
>
> ## Motivation
>
> `Int8DynamicActivationInt8WeightConfig` produces `Int8Tensor` weights, but FSDP2 currently fails while chunking them because `aten.split.Tensor` and the subclass all-gather protocol are not implemented. This change preserves the quantized inner tensors through sharding and reconstruction so inference can run with FSDP2 when the row count is evenly divisible by the FSDP world size.
>
> ## Test plan
>
> - targeted CPU regression: 1 passed
> - related Int8Tensor CPU tests: 46 passed, 218 deselected
> - two-process CPU/Gloo FSDP2 parity: three forwards, max difference 0
> - RTX 3090 GPU0 targeted test: 1 passed
> - RTX 3090 GPU1 targeted test: 1 passed
> - dual RTX 3090/NCCL FSDP2 parity: both ranks finite, max difference 0
> - `ruff check`
> - `ruff format --check`
> - `py_compile`
> - `git diff --check`
>
> ## Limitations
>
> Uneven dim-0 sharding is rejected because FSDP2 requires each all-gather input to use the padded outer tensor shape, while per-row scales and zero points have a different inner shape.