### PR TITLE
Remove unused NF4 helper

### DIFF
--- a/torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py
+++ b/torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py
@@ -137,16 +137,6 @@ def apply_to_inner_tensors(nf4tensor: "NF4Tensor", aten_op, args, kwargs):
     return attr_to_tensor
 
 
-# __torch_function__ utils: call tensor ops from inner tensors
-def call_from_inner_tensors(nf4tensor: "NF4Tensor", method_name: str, args, kwargs):
-    attr_to_tensor = {}
-    for attr in _INNER_TENSOR_NAMES_FOR_SHARDING:
-        inner_tensor = getattr(nf4tensor, attr)
-        func = getattr(inner_tensor, method_name)
-        attr_to_tensor[attr] = func(*args, **kwargs)
-    return attr_to_tensor
-
-
 class CompareOp(Enum):
     EQ = auto()
     LT = auto()


### PR DESCRIPTION
## Summary

Remove `call_from_inner_tensors` from the NF4 tensor implementation.

Repository-wide search finds only its definition. It is not registered in the NF4 `__torch_dispatch__` or `__torch_function__` tables. The active `apply_to_inner_tensors` helper and all NF4 dispatch behavior remain unchanged.

This removes 10 internal lines and no exported API.

Split from #4742.

## Test plan

- `pytest -q test/quantization/quantize_/workflows/nf4/test_nf4_tensor.py`

Result: 87 passed, 7 skipped.