### PR TITLE
Remove shadowed GGUF tensor method

### DIFF
--- a/torchao/prototype/quantization/gguf/gguf_quantized_tensor.py
+++ b/torchao/prototype/quantization/gguf/gguf_quantized_tensor.py
@@ -66,18 +66,6 @@ class GGUFQuantizedTensor(TorchAOBaseTensor):
         self.quantized_block_min = quantized_block_min
         self.int_data = int_data
 
-    def _apply_fn_to_data(self, fn):
-        return self.__class__(
-            self.n_blocks_per_superblock,
-            fn(self.super_block_scale_scale),
-            fn(self.super_block_min_sclae),
-            fn(self.quantized_block_scale),
-            fn(self.quantized_block_min),
-            fn(self.int_data),
-            self.shape,
-            dtype=self.dtype,
-        )
-
     def __tensor_flatten__(self):
         return [
             "super_block_scale_scale",


### PR DESCRIPTION
## Summary

Remove the first `GGUFQuantizedTensor._apply_fn_to_data` definition.

The class defines the same method again later in its body, so Python always overwrites the first implementation during class construction. The unreachable definition also contains the typo `super_block_min_sclae`. The live second implementation remains unchanged.

This removes 12 unreachable lines.

Split from #4742.

## Test plan

- `pytest -q test/prototype/test_gguf_quant.py`

Result: 3 passed.