### PR TITLE
Remove unused quantization API helpers

### DIFF
--- a/torchao/prototype/awq/api.py
+++ b/torchao/prototype/awq/api.py
@@ -10,15 +10,13 @@ from dataclasses import dataclass
 import torch
 
 from torchao.core.config import AOBaseConfig
-from torchao.quantization.quant_api import (
-    _linear_extra_repr,
-)
 from torchao.quantization.quantize_.common import SupportsActivationPreScaling
 from torchao.quantization.quantize_.common.quantization_step import QuantizationStep
 from torchao.quantization.transform_module import (
     _QUANTIZE_CONFIG_HANDLER,
     register_quantize_module_handler,
 )
+from torchao.quantization.utils import _linear_extra_repr
 from torchao.utils import DummyModule
 
 from .core import (

--- a/torchao/prototype/parq/quant/config_torchao.py
+++ b/torchao/prototype/parq/quant/config_torchao.py
@@ -19,10 +19,10 @@ from torchao.quantization.quant_api import (
     Int8DynamicActivationIntxWeightConfig,
     IntxWeightOnlyConfig,
     ModuleFqnToConfig,
-    _linear_extra_repr,
 )
 from torchao.quantization.quantize_.workflows import IntxUnpackedToInt8Tensor
 from torchao.quantization.transform_module import register_quantize_module_handler
+from torchao.quantization.utils import _linear_extra_repr
 
 from .quant_api import choose_qparams_stretched_affine, quantize_stretched_affine
 from .uniform_torchao import (

--- a/torchao/prototype/quantization/int4/inference_workflow.py
+++ b/torchao/prototype/quantization/int4/inference_workflow.py
@@ -15,7 +15,6 @@ from torchao.core.config import AOBaseConfig
 
 logger = logging.getLogger(__name__)
 
-from torchao.quantization.quant_api import _linear_extra_repr
 from torchao.quantization.quant_primitives import MappingType
 from torchao.quantization.quantize_.workflows import (
     Int4ChooseQParamsAlgorithm,
@@ -23,6 +22,7 @@ from torchao.quantization.quantize_.workflows import (
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
+from torchao.quantization.utils import _linear_extra_repr
 
 from .int4_opaque_tensor import Int4OpaqueTensor
 

--- a/torchao/prototype/smoothquant/api.py
+++ b/torchao/prototype/smoothquant/api.py
@@ -10,10 +10,7 @@ from typing import Optional
 import torch
 
 from torchao.core.config import AOBaseConfig
-from torchao.quantization.quant_api import (
-    _QUANTIZE_CONFIG_HANDLER,
-    _linear_extra_repr,
-)
+from torchao.quantization.quant_api import _QUANTIZE_CONFIG_HANDLER
 from torchao.quantization.quantize_.common import (
     IsStaticQuantizationConfig,
     SupportsActivationPreScaling,
@@ -22,6 +19,7 @@ from torchao.quantization.quantize_.common.quantization_step import Quantization
 from torchao.quantization.transform_module import (
     register_quantize_module_handler,
 )
+from torchao.quantization.utils import _linear_extra_repr
 from torchao.utils import DummyModule
 
 from .core import (

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -75,9 +75,7 @@ from torchao.quantization.transform_module import (
 )
 from torchao.quantization.utils import (
     _fp8_mm_compat,
-    _linear_extra_repr,
     _module_extra_repr,
-    _quantization_type,
 )
 from torchao.utils import (
     is_MI300,
@@ -246,30 +244,6 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
     _replace_with_custom_fn_if_matches_filter(
         model, replace_conv2d_1x1, filter_fn=filter_fn
     )
-
-
-def _embedding_extra_repr(self):
-    return f"num_embeddings={self.weight.shape[0]}, embedding_dim={self.weight.shape[1]}, weight={_quantization_type(self.weight)}"
-
-
-def _get_linear_subclass_inserter(
-    constructor, *, allow_requires_grad=False, propagate_bias=False, **kwargs
-):
-    """Helper function to apply the constructor that quantizes the weight Tensor (with additional kwargs)
-    to the weight of linear module
-    """
-
-    def insert_subclass(lin):
-        requires_grad = allow_requires_grad and lin.weight.requires_grad
-        if propagate_bias == True:
-            kwargs["bias"] = lin.bias
-        lin.weight = torch.nn.Parameter(
-            constructor(lin.weight, **kwargs), requires_grad=requires_grad
-        )
-        lin.extra_repr = types.MethodType(_linear_extra_repr, lin)
-        return lin
-
-    return insert_subclass
 
 
 def quantize_(


### PR DESCRIPTION
## Summary

Remove `_embedding_extra_repr` and `_get_linear_subclass_inserter` from `quant_api.py`, along with their now-unused imports.

Repository-wide exact-symbol searches find only the two definitions: neither helper is called, imported, registered, tested, documented, or listed in `quant_api.__all__`. `_get_linear_subclass_inserter` is distinct from the live `_get_subclass_inserter`, which remains exported and used by `benchmark_aq.py` and `test_quant_api.py`. The shared `_linear_extra_repr` and `_quantization_type` definitions also remain; only their dead imports into this module are removed.

Public GitHub code search found no source consumers of `_get_linear_subclass_inserter`; results were generated package metadata. Internal fbcode usage should be confirmed through the normal internal review process.

This removes 26 lines and no declared API.

Split from #4742.

## Test plan

- `CUDA_VISIBLE_DEVICES='' pytest -q test/quantization/test_quant_api.py`

Result: 6 passed, 41 skipped.