### PR TITLE
Remove stale codebook exports

### DIFF
--- a/torchao/prototype/quantization/codebook_groupwise/__init__.py
+++ b/torchao/prototype/quantization/codebook_groupwise/__init__.py
@@ -4,6 +4,4 @@ from .codebook_quantized_tensor import CodebookQuantizedPackedTensor
 __all__ = [
     "CodebookQuantizedPackedTensor",
     "GroupwiseLutWeightConfig",
-    "QuantizedLutEmbedding",
-    "EmbeddingLutQuantizer",
 ]


### PR DESCRIPTION
## Summary

Remove `QuantizedLutEmbedding` and `EmbeddingLutQuantizer` from `codebook_groupwise.__all__`.

Neither name is defined or imported by the package. Their only repository occurrences are these two strings, so wildcard imports currently request nonexistent attributes. The two real codebook exports remain unchanged.

This removes two invalid API entries.

Split from #4742.

## Test plan

- `python -c "from torchao.prototype.quantization.codebook_groupwise import *; assert CodebookQuantizedPackedTensor and GroupwiseLutWeightConfig"`
- `pytest -q test/prototype/test_codebook_quant.py`

Result: 4 passed.