### PR TITLE
Remove unused multi-input helper

### DIFF
--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -111,28 +111,6 @@ class LoggingTensorMode(TorchDispatchMode):
         return rs
 
 
-class _MultiInput:
-    def __init__(self, inputs):
-        self.values = list(inputs)
-
-    def add_input(self, input):
-        self.values.append(input)
-        return self
-
-    def __getitem__(self, slice):
-        return _MultiInput(self.values[slice])
-
-    def cuda(self):
-        self.values = [
-            val.cuda() if isinstance(val, torch.Tensor) else val for val in self.values
-        ]
-
-    def xpu(self):
-        self.values = [
-            val.xpu() if isinstance(val, torch.Tensor) else val for val in self.values
-        ]
-
-
 def _guard_dtype_size(tensor_arg, arg_name, dtype=None, size=None):
     if dtype is not None and tensor_arg.dtype != dtype:
         raise ValueError(


### PR DESCRIPTION
## Summary

Remove the private `_MultiInput` class from `quantization/utils.py`.

This is a remnant of the old GPTQ/model-evaluation input flow. Nothing imports or constructs it; its only other repository occurrence is its self-reference when slicing. It is not in `utils.__all__`.

This removes 22 lines and no exported API.

Split from #4742.

## Test plan

- `CUDA_VISIBLE_DEVICES='' pytest -q test/quantization/test_quant_api.py`

Result: 6 passed, 41 skipped.