### PR TITLE
[ROCm] Switch ROCm CI runner label from gfx950 to ecosystem.mi350

### DIFF
--- a/.github/workflows/regression_test_rocm.yml
+++ b/.github/workflows/regression_test_rocm.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - name: ROCM Nightly
-            runs-on: linux.rocm.gpu.ecosystem.gfx950.1
+            runs-on: linux.rocm.gpu.ecosystem.mi350.1
             torch-spec: '--pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm7.2'
             gpu-arch-type: "rocm"
             gpu-arch-version: "7.2"


### PR DESCRIPTION
## Summary
- Switch ROCm CI runner label from `linux.rocm.gpu.ecosystem.gfx950.1` to `linux.rocm.gpu.ecosystem.mi350.1` in `.github/workflows/regression_test_rocm.yml`