### PR TITLE
Preserve custom batchnorm momentum and eps in train/eval switching

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2368,6 +2368,49 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         self.assertTrue(bn_node is not None)
         self.assertTrue(bn_node.args[5])
 
+    @parametrize("device", DEVICE_LIST)
+    def test_move_exported_model_bn_custom_eps_momentum(self, device):
+        """
+        Test that switching batch_norm between train and eval modes keeps the
+        momentum and eps the model was built with, instead of resetting them to
+        the defaults baked into the replacement pattern.
+        """
+        eps = 1e-3
+        momentum = 0.03
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(3, eps=eps, momentum=momentum)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        if TEST_CUDA or TEST_HPU or TEST_XPU:
+            m = M().train().to(device)
+            example_inputs = (torch.randn((1, 3, 3, 3), device=device),)
+        else:
+            m = M().train()
+            example_inputs = (torch.randn(1, 3, 3, 3),)
+        bn_train_op, bn_eval_op = self._get_bn_train_eval_ops()
+        m = torch.export.export(m, example_inputs, strict=True).module()
+
+        def assert_eps_and_momentum(node):
+            self.assertTrue(node is not None)
+            self.assertEqual(node.args[6], momentum)
+            self.assertEqual(node.args[7], eps)
+
+        # After export
+        assert_eps_and_momentum(self._get_node(m, bn_train_op))
+
+        # After moving to eval
+        torchao.quantization.pt2e.move_exported_model_to_eval(m)
+        assert_eps_and_momentum(self._get_node(m, bn_eval_op))
+
+        # After moving back to train
+        torchao.quantization.pt2e.move_exported_model_to_train(m)
+        assert_eps_and_momentum(self._get_node(m, bn_train_op))
+
     def test_disallow_eval_train(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)
         example_inputs = (torch.rand(3, 3, 5, 5),)

--- a/torchao/quantization/pt2e/export_utils.py
+++ b/torchao/quantization/pt2e/export_utils.py
@@ -18,6 +18,11 @@ __all__ = [
 
 _EXPORTED_TRAINING_ATTR = "_exported_training"
 
+# Positions of `momentum` and `eps` in the args of `aten.batch_norm.default`:
+# (input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled)
+_BN_MOMENTUM_ARG_INDEX = 6
+_BN_EPS_ARG_INDEX = 7
+
 
 class WrapperModule(torch.nn.Module):
     """Class to wrap a callable in an :class:`torch.nn.Module`. Use this if you
@@ -101,6 +106,46 @@ def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
         m.recompile()
 
 
+def _is_batchnorm_node(n) -> bool:
+    return (
+        isinstance(n, torch.fx.Node)
+        and n.op == "call_function"
+        and n.target == torch.ops.aten.batch_norm.default
+    )
+
+
+def _get_batchnorm_node(nodes):
+    """
+    Return the first batchnorm node in `nodes`, or None if there isn't one.
+    `nodes` may also contain literals and None, which are skipped.
+    """
+    for n in nodes:
+        if _is_batchnorm_node(n):
+            return n
+    return None
+
+
+def _copy_over_literal_bn_args(original_node, new_node):
+    """
+    Copy over literal args in batchnorm, namely momentum and eps, from the matched
+    node in the original graph to its replacement in the new graph.
+
+    This is needed because the replacement pattern is traced from a call to
+    `F.batch_norm` that uses the default momentum and eps, so without this the
+    rewrite would silently reset both to their defaults.
+
+    Note: Unlike tensor args like the running stats, literal args are preserved in
+    the original nodes after replacement, so we can access them here.
+    """
+    assert _is_batchnorm_node(original_node)
+    assert _is_batchnorm_node(new_node)
+    # x, weight, bias, running_mean, running_var, training, [momentum, eps], cudnn_enabled
+    new_args = list(new_node.args)
+    new_args[_BN_MOMENTUM_ARG_INDEX] = original_node.args[_BN_MOMENTUM_ARG_INDEX]
+    new_args[_BN_EPS_ARG_INDEX] = original_node.args[_BN_EPS_ARG_INDEX]
+    new_node.args = tuple(new_args)
+
+
 def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
     """
     Switch batchnorm patterns in the model between train and eval modes.
@@ -110,9 +155,6 @@ def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
     the batchnorm behavior between the two modes, so here we need to rewrite the aten
     batchnorm patterns manually to achieve the same effect.
     """
-    # TODO(Leslie): This function still fails to support custom momentum and eps value.
-    # Enable this support in future updates.
-
     # Avoid circular dependencies
     from .utils import _get_aten_graph_module_for_pattern
 
@@ -172,13 +214,22 @@ def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
 
     from torch.fx.subgraph_rewriter import replace_pattern_with_filters
 
-    replace_pattern_with_filters(
+    replaced_patterns = replace_pattern_with_filters(
         m,
         match_pattern,
         replacement_pattern,
         match_filters=[],
         ignore_literals=True,
     )
+
+    # Copy over literal args for batchnorm, so a custom momentum and eps survive
+    # the rewrite instead of being reset to the defaults of the replacement pattern.
+    for r in replaced_patterns:
+        original_node = _get_batchnorm_node(r.nodes_map.values())
+        new_node = _get_batchnorm_node(r.replacements)
+        if original_node is not None and new_node is not None:
+            _copy_over_literal_bn_args(original_node, new_node)
+
     m.recompile()
 
 


### PR DESCRIPTION
Fixes #4107.

`_replace_batchnorm` swaps the aten batchnorm node when an exported model moves between train and eval. The replacement pattern is traced from a call to `F.batch_norm` that uses the default momentum and eps, so the rewrite was quietly dropping whatever the model was built with. A `BatchNorm2d(3, eps=1e-3, momentum=0.03)` comes back as `0.1` and `1e-05` after the first `move_exported_model_to_eval` call and stays wrong on the way back to train, which is what the reporter hit on yolo11s.

The fix reads the return value of `replace_pattern_with_filters` and copies momentum and eps from the matched node onto the node that replaced it. `qat_utils.py` already does this for conv stride and padding in `_copy_over_literal_conv_args`, and the note there holds here too: literal args stay on the original nodes after replacement, so they can still be read. The training flag is left as the replacement pattern set it, since changing it is the point of the rewrite.

The new test sits next to the existing batchnorm test, which uses a plain `BatchNorm2d(3)` and so cannot catch this. It checks momentum and eps after export, after moving to eval, and after moving back to train. It fails on main and passes with this change. One caveat on my local verification: the whole `TestQuantizePT2E` class skips on my machine because the CPU build has no qnnpack, so I ran the two test bodies directly to confirm. The rest of `test_quantize_pt2e.py` is clean.

This covers the train/eval rewrite only. `qat_utils.py` still hardcodes `bn_eps = 1e-5` in four spots in the QAT conv-bn fusion patterns, which is the other half of the issue. I kept that out to hold the diff down and can send it separately if that sounds reasonable.

I used an AI assistant while writing this change, and I have read through it and understand it.