### PR TITLE
Fix ZeroPointDomain.NONE branch in groupwise_affine_quantize_tensor_from_qparams

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -696,6 +696,47 @@ class TestQuantPrimitives(unittest.TestCase):
 
             self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
 
+    def test_groupwise_affine_quantize_tensor_from_qparams_zero_point_none(self):
+        # the local reference above only covers FLOAT and INT, so check
+        # ZeroPointDomain.NONE against a plain scale only quantize and a round
+        # trip through the dequantize helper. Both helpers need zeros=None here.
+        input = torch.randn(10, 256).bfloat16()
+        scales = torch.randn(10, 2).abs().clamp(min=1e-2).bfloat16()
+        n_bit = 4
+        groupsize = 128
+        quant_max = 2**n_bit - 1
+
+        w_int4x8 = groupwise_affine_quantize_tensor_from_qparams(
+            input, scales, None, n_bit, groupsize, ZeroPointDomain.NONE
+        )
+
+        grouped = input.reshape(input.shape[0], -1, groupsize)
+        grouped_scales = scales.reshape(scales.shape[0], -1, 1)
+        int_ref = (
+            torch.round(grouped * (1.0 / grouped_scales))
+            .clamp(0, quant_max)
+            .reshape_as(input)
+            .to(torch.int32)
+        )
+        w_int4x8_ref = int_ref
+        if (not (_is_device("cpu", input.device))) and (
+            not (_is_device("xpu", input.device))
+        ):
+            w_int4x8_ref = (int_ref[::, ::2] << 4 | int_ref[::, 1::2]).to(torch.uint8)
+        if _is_device("xpu", input.device):
+            w_int4x8_ref = (int_ref[::, 1::2] << 4 | int_ref[::, ::2]).to(torch.uint8)
+
+        self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
+
+        w_bf16 = groupwise_affine_dequantize_tensor_from_qparams(
+            w_int4x8, scales, None, n_bit, groupsize, ZeroPointDomain.NONE
+        )
+        w_bf16_ref = (
+            int_ref.reshape(input.shape[0], -1, groupsize).bfloat16() * grouped_scales
+        ).reshape_as(input)
+
+        self.assertTrue(torch.equal(w_bf16, w_bf16_ref))
+
     def test_groupwise_affine_dequantize_tensor_from_qparams(self):
         input = torch.randint(0, 15, (10, 256), dtype=torch.int32)
         scales = torch.randn(10, 2).bfloat16()

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -338,7 +338,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
         _quantize_affine = quantize_affine
     elif zero_point_domain == ZeroPointDomain.FLOAT:
         _quantize_affine = _quantize_affine_tinygemm
-    elif ZeroPointDomain == ZeroPointDomain.NONE:
+    elif zero_point_domain == ZeroPointDomain.NONE:
         _quantize_affine = _quantize_affine_no_zero_point
     else:
         raise ValueError(f"Unrecognized zero point domain: {zero_point_domain}")


### PR DESCRIPTION
The NONE branch of groupwise_affine_quantize_tensor_from_qparams compares the ZeroPointDomain class with ZeroPointDomain.NONE instead of the zero_point_domain argument. That is always false, so the branch never runs and passing ZeroPointDomain.NONE falls through to the else and raises ValueError: Unrecognized zero point domain. Fixes #4693.

The fix compares zero_point_domain, like the two branches above it, so NONE dispatches to _quantize_affine_no_zero_point.

The existing test only looped over FLOAT and INT, which is how the typo survived. I added a case for NONE. It cannot reuse the local reference helper in that file, since the helper only covers FLOAT and INT, and the no zero point path needs zeros=None, so the new test checks the quantized values against a scale only reference and round trips them back through groupwise_affine_dequantize_tensor_from_qparams. It fails before the fix and passes after. pytest test/quantization/test_quant_primitives.py passes on CPU, 26 passed and 1 skipped.

I used an AI assistant while writing the test and this description, and I reviewed and ran everything myself.