### PR TITLE
Guard torch.distributed imports so torchao imports with USE_DISTRIBUTED=0

### DIFF
--- a/test/test_lean_import.py
+++ b/test/test_lean_import.py
@@ -1,6 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import subprocess
+import sys
 import unittest
 
 import torch
+
+# Pretend torch was built with USE_DISTRIBUTED=0: the top-level
+# torch.distributed package still exists, but it reports itself as unavailable
+# and none of its submodules can be imported.
+_IMPORT_WITHOUT_DISTRIBUTED = """
+import sys
+
+import torch
+
+torch.distributed.is_available = lambda: False
+
+for name in [n for n in sys.modules if n.startswith("torch.distributed.")]:
+    del sys.modules[name]
+
+
+class BlockDistributedSubmodules:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.startswith("torch.distributed."):
+            raise ModuleNotFoundError(f"No module named {fullname!r}", name=fullname)
+        return None
+
+
+sys.meta_path.insert(0, BlockDistributedSubmodules())
+
+import torchao  # noqa: F401
+"""
+
+
+class TestImportWithoutDistributed(unittest.TestCase):
+    def test_torchao_import_without_torch_distributed(self):
+        # https://github.com/pytorch/ao/issues/3452 - torchao must import on a
+        # torch built with USE_DISTRIBUTED=0. Run this out of process so the
+        # parent interpreter's module cache is left alone.
+        result = subprocess.run(
+            [sys.executable, "-c", _IMPORT_WITHOUT_DISTRIBUTED],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"importing torchao without torch.distributed failed:\n{result.stderr}",
+        )
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")

--- a/torchao/float8/distributed_utils.py
+++ b/torchao/float8/distributed_utils.py
@@ -5,10 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-import torch.distributed._functional_collectives as funcol
-from torch.distributed._tensor import DTensor
 
 from torchao.float8.float8_training_tensor import Float8TrainingTensor
+
+if torch.distributed.is_available():
+    from torch.distributed._functional_collectives import AsyncCollectiveTensor
+    from torch.distributed.tensor import DTensor
+else:
+    # torch built with USE_DISTRIBUTED=0 has neither type, so the isinstance()
+    # checks below are always False.
+    AsyncCollectiveTensor = ()
+    DTensor = ()
 
 
 def tensor_already_casted_to_fp8(tensor: torch.Tensor) -> bool:
@@ -21,7 +28,7 @@ def tensor_already_casted_to_fp8(tensor: torch.Tensor) -> bool:
     elif isinstance(tensor, DTensor):
         # TODO: shall we stick to public API and directly use tensor.to_local() here?
         return tensor_already_casted_to_fp8(tensor._local_tensor)
-    elif isinstance(tensor, funcol.AsyncCollectiveTensor):
+    elif isinstance(tensor, AsyncCollectiveTensor):
         return tensor_already_casted_to_fp8(tensor.elem)
 
     return False

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -463,12 +463,24 @@ def autocast_to_copy(aten_op, args, kwargs=None):
     )
 
 
-@implements(
-    [
+# The c10d collectives below do not exist when torch is built with
+# USE_DISTRIBUTED=0. Registering no ops leaves the handlers unreachable, which
+# is correct because nothing can call a collective on such a build.
+if torch.distributed.is_available():
+    _all_gather_ops = [
         c10d_functional.all_gather_into_tensor.default,
         _c10d_functional.all_gather_into_tensor.default,
     ]
-)
+    _wait_tensor_ops = [
+        c10d_functional.wait_tensor.default,
+        _c10d_functional.wait_tensor.default,
+    ]
+else:
+    _all_gather_ops = []
+    _wait_tensor_ops = []
+
+
+@implements(_all_gather_ops)
 def allgather_fp8(aten_op, args, kwargs=None):
     """
     override funcol with FP8 handling
@@ -491,7 +503,7 @@ def allgather_fp8(aten_op, args, kwargs=None):
     )
 
 
-@implements([c10d_functional.wait_tensor.default, _c10d_functional.wait_tensor.default])
+@implements(_wait_tensor_ops)
 def wait_tensor_fp8(aten_op, args, kwargs=None):
     _assert_tensorwise_scale(aten_op, args[0]._scale)
     fp8_input = args[0]
@@ -509,7 +521,7 @@ def wait_tensor_fp8(aten_op, args, kwargs=None):
 
 
 # _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
-if torch_version_at_least("2.11.0.dev"):
+if torch.distributed.is_available() and torch_version_at_least("2.11.0.dev"):
 
     @implements([_c10d_functional._wrap_tensor_autograd.default])
     def wrap_tensor_autograd_fp8(aten_op, args, kwargs=None):

--- a/torchao/float8/float8_training_tensor.py
+++ b/torchao/float8/float8_training_tensor.py
@@ -7,11 +7,17 @@ import enum
 from typing import Dict, NamedTuple, Optional
 
 import torch
-from torch.distributed._tensor import DTensor
 
 from torchao.float8.float8_utils import (
     to_fp8_saturated,
 )
+
+if torch.distributed.is_available():
+    from torch.distributed.tensor import DTensor
+else:
+    # torch built with USE_DISTRIBUTED=0 has no DTensor, so the isinstance()
+    # checks below are always False.
+    DTensor = ()
 
 aten = torch.ops.aten
 

--- a/torchao/float8/float8_utils.py
+++ b/torchao/float8/float8_utils.py
@@ -8,9 +8,14 @@ from typing import Iterable, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
-from torch.distributed._functional_collectives import AsyncCollectiveTensor, all_reduce
 
 from torchao.float8.config import ScalingGranularity
+
+if torch.distributed.is_available():
+    from torch.distributed._functional_collectives import (
+        AsyncCollectiveTensor,
+        all_reduce,
+    )
 
 # Helpful visualizer for debugging (only supports fp32):
 # https://www.h-schmidt.net/FloatConverter/IEEE754.html

--- a/torchao/optim/adam.py
+++ b/torchao/optim/adam.py
@@ -7,13 +7,19 @@ from typing import Optional
 
 import torch
 from torch import Tensor
-from torch.distributed._tensor import DTensor
 from torch.optim import Optimizer
 
 from .quant_utils import _fp32_to_bf16_sr
 from .subclass_4bit import OptimState4bit
 from .subclass_8bit import OptimState8bit
 from .subclass_fp8 import OptimStateFp8
+
+if torch.distributed.is_available():
+    from torch.distributed.tensor import DTensor
+else:
+    # torch built with USE_DISTRIBUTED=0 has no DTensor, so the isinstance()
+    # checks below are always False.
+    DTensor = ()
 
 
 class _AdamBase(Optimizer):

--- a/torchao/optim/quant_utils.py
+++ b/torchao/optim/quant_utils.py
@@ -5,7 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 import torch
 from torch import Tensor
-from torch.distributed.tensor import DTensor
+
+if torch.distributed.is_available():
+    from torch.distributed.tensor import DTensor
+else:
+    # torch built with USE_DISTRIBUTED=0 has no DTensor, so the isinstance()
+    # checks below are always False.
+    DTensor = ()
 
 
 # https://github.com/TimDettmers/bitsandbytes/blob/dada530149212d64d4b69534716202659ef37ec8/bitsandbytes/functional.py#L339-L391

--- a/torchao/optim/subclass_4bit.py
+++ b/torchao/optim/subclass_4bit.py
@@ -204,17 +204,24 @@ def _(func, types, args, kwargs):
 
 # Build the list of c10d operations to implement
 _optim_state_4bit_c10d_ops = [
-    # required by DTensor.full_tensor()
-    c10d_functional.all_gather_into_tensor.default,
-    _c10d_functional.all_gather_into_tensor.default,
-    c10d_functional.wait_tensor.default,
-    _c10d_functional.wait_tensor.default,
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
-if torch_version_at_least("2.11.0.dev"):
-    _optim_state_4bit_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
+# the c10d collectives below do not exist when torch is built with
+# USE_DISTRIBUTED=0, and nothing can call them in that case
+if torch.distributed.is_available():
+    _optim_state_4bit_c10d_ops += [
+        # required by DTensor.full_tensor()
+        c10d_functional.all_gather_into_tensor.default,
+        _c10d_functional.all_gather_into_tensor.default,
+        c10d_functional.wait_tensor.default,
+        _c10d_functional.wait_tensor.default,
+    ]
+    # _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+    if torch_version_at_least("2.11.0.dev"):
+        _optim_state_4bit_c10d_ops.append(
+            _c10d_functional._wrap_tensor_autograd.default
+        )
 
 
 @OptimState4bit.implements(_optim_state_4bit_c10d_ops)

--- a/torchao/optim/subclass_8bit.py
+++ b/torchao/optim/subclass_8bit.py
@@ -176,17 +176,24 @@ def _(func, types, args, kwargs):
 
 # Build the list of c10d operations to implement
 _optim_state_8bit_c10d_ops = [
-    # required by DTensor.full_tensor()
-    c10d_functional.all_gather_into_tensor.default,
-    _c10d_functional.all_gather_into_tensor.default,
-    c10d_functional.wait_tensor.default,
-    _c10d_functional.wait_tensor.default,
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
-if torch_version_at_least("2.11.0.dev"):
-    _optim_state_8bit_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
+# the c10d collectives below do not exist when torch is built with
+# USE_DISTRIBUTED=0, and nothing can call them in that case
+if torch.distributed.is_available():
+    _optim_state_8bit_c10d_ops += [
+        # required by DTensor.full_tensor()
+        c10d_functional.all_gather_into_tensor.default,
+        _c10d_functional.all_gather_into_tensor.default,
+        c10d_functional.wait_tensor.default,
+        _c10d_functional.wait_tensor.default,
+    ]
+    # _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+    if torch_version_at_least("2.11.0.dev"):
+        _optim_state_8bit_c10d_ops.append(
+            _c10d_functional._wrap_tensor_autograd.default
+        )
 
 
 @OptimState8bit.implements(_optim_state_8bit_c10d_ops)

--- a/torchao/optim/subclass_fp8.py
+++ b/torchao/optim/subclass_fp8.py
@@ -151,17 +151,22 @@ def _(func, types, args, kwargs):
 
 # Build the list of c10d operations to implement
 _optim_state_fp8_c10d_ops = [
-    # required by DTensor.full_tensor()
-    c10d_functional.all_gather_into_tensor.default,
-    _c10d_functional.all_gather_into_tensor.default,
-    c10d_functional.wait_tensor.default,
-    _c10d_functional.wait_tensor.default,
     # required by torch.distributed.checkpoint.save
     aten.detach.default,
 ]
-# _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
-if torch_version_at_least("2.11.0.dev"):
-    _optim_state_fp8_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
+# the c10d collectives below do not exist when torch is built with
+# USE_DISTRIBUTED=0, and nothing can call them in that case
+if torch.distributed.is_available():
+    _optim_state_fp8_c10d_ops += [
+        # required by DTensor.full_tensor()
+        c10d_functional.all_gather_into_tensor.default,
+        _c10d_functional.all_gather_into_tensor.default,
+        c10d_functional.wait_tensor.default,
+        _c10d_functional.wait_tensor.default,
+    ]
+    # _wrap_tensor_autograd was added in PyTorch 2.11.0.dev
+    if torch_version_at_least("2.11.0.dev"):
+        _optim_state_fp8_c10d_ops.append(_c10d_functional._wrap_tensor_autograd.default)
 
 
 @OptimStateFp8.implements(_optim_state_fp8_c10d_ops)

--- a/torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py
+++ b/torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py
@@ -8,14 +8,18 @@ import math
 import sys
 from dataclasses import dataclass, replace
 from enum import Enum, auto
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
 from torch._prims_common import make_contiguous_strides_for
-from torch.distributed.device_mesh import DeviceMesh
 
 from torchao.utils import torch_version_at_least
+
+if TYPE_CHECKING:
+    # torch built with USE_DISTRIBUTED=0 has no DeviceMesh, and it is only
+    # needed here as a type annotation.
+    from torch.distributed.device_mesh import DeviceMesh
 
 aten = torch.ops.aten
 
@@ -63,10 +67,15 @@ def scatter_nf4tensor(func, *args, **kwargs):
     return new_attr, update_work
 
 
-NF4_OPS_TABLE: Dict[Any, Any] = {
-    torch.ops._c10d_functional.all_gather_into_tensor.default: nf4_all_gather_into_tensor,
-    torch.ops.c10d.scatter_.default: scatter_nf4tensor,
-}
+NF4_OPS_TABLE: Dict[Any, Any] = {}
+
+# The c10d ops below do not exist when torch is built with USE_DISTRIBUTED=0,
+# and nothing can call them on such a build.
+if torch.distributed.is_available():
+    NF4_OPS_TABLE[torch.ops._c10d_functional.all_gather_into_tensor.default] = (
+        nf4_all_gather_into_tensor
+    )
+    NF4_OPS_TABLE[torch.ops.c10d.scatter_.default] = scatter_nf4tensor
 
 
 _INNER_TENSOR_NAMES_FOR_SHARDING = [
@@ -508,11 +517,16 @@ def nf4_cat(aten_op: torch._ops.OpOverload, args, kwargs=None):
     return tensors
 
 
-@implements(
-    [
-        torch.ops._c10d_functional.wait_tensor.default,
-    ]
+# this op does not exist when torch is built with USE_DISTRIBUTED=0, and
+# nothing can call it on such a build
+_wait_tensor_ops = (
+    [torch.ops._c10d_functional.wait_tensor.default]
+    if torch.distributed.is_available()
+    else []
 )
+
+
+@implements(_wait_tensor_ops)
 def wait_tensor(func, *args, **kwargs):
     nf4tensor = args[0][0]
     updated_attrs = {}
@@ -974,7 +988,7 @@ class NF4Tensor(torch.Tensor):
             return func(*args, **kwargs)
 
     def fsdp_pre_all_gather(
-        self, mesh: DeviceMesh
+        self, mesh: "DeviceMesh"
     ) -> Tuple[Tuple[torch.Tensor, ...], Any]:
         return (
             self.quantized_scalers,


### PR DESCRIPTION
On a torch built with USE_DISTRIBUTED=0, `import torchao` fails immediately with `ModuleNotFoundError: No module named 'torch._C._distributed_c10d'`. Six modules import DTensor, DeviceMesh or the functional collectives at module scope, and five more read `torch.ops.c10d_functional` and `torch.ops._c10d_functional` while building their dispatch tables at import time. None of that exists on such a build, so the import dies before any user code runs.

Every one of those places is now guarded on `torch.distributed.is_available()`. Where a name is only used in `isinstance()` checks, the fallback binds an empty tuple, so the checks stay valid and always return False. NF4Tensor needs DeviceMesh only for a type annotation, so that import moved under `TYPE_CHECKING`. The c10d op registrations become no-ops, which is correct because nothing can call a collective on a build without distributed.

Behaviour is unchanged when distributed is available. I dumped FLOAT8_OPS_TABLE, NF4_OPS_TABLE and the three OptimState dispatch tables before and after the change, and all 82 entries match. The new test in `test/test_lean_import.py` runs a subprocess where `torch.distributed` reports itself unavailable and its submodules cannot be imported, then imports torchao; it fails on main and passes here. I ran `test/test_lean_import.py`, `test/float8` and the NF4 tests on CPU. I could not run the multi-GPU float8 scripts, and the `test_low_bit_optim.py` cases that need `torch.compile` fail on my machine for lack of a C++ compiler both before and after this change.

Fixes #3452

Disclosure: I used an AI coding assistant while writing this change and its test.