### PR TITLE
Floor the float8 scale so all-zero blocks do not quantize to NaN

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -10,13 +10,14 @@ import unittest
 
 import torch
 
-from torchao.quantization.granularity import PerRow
+from torchao.quantization.granularity import PerRow, PerTensor
 from torchao.quantization.quant_primitives import (
     MappingType,
     ZeroPointDomain,
     _choose_qparams_affine_tinygemm,
     _choose_qparams_and_quantize_scale_only_sinq,
     _choose_scale_float8,
+    _dequantize_affine_float8,
     _fake_quantize_affine,
     _fake_quantize_affine_cachemask,
     _maybe_expand_scale_to_tensor_shape,
@@ -910,6 +911,50 @@ class TestQuantPrimitives(unittest.TestCase):
 
         assert scale.shape == (B, 1, N)
         assert data.shape == (B, K, N)
+
+    def test_float8_scaling_all_zeros(self):
+        """
+        An all-zero tensor has an amax of zero, which used to give a zero scale
+        and turn every value into NaN. See https://github.com/pytorch/ao/issues/4713
+        """
+        hp_tensor = torch.zeros(64, 128, dtype=torch.float)
+        block_sizes = [
+            get_block_size(hp_tensor.shape, PerRow()),
+            get_block_size(hp_tensor.shape, PerTensor()),
+            (32, 32),
+        ]
+
+        for block_size in block_sizes:
+            scale = _choose_scale_float8(
+                hp_tensor,
+                float8_dtype=torch.float8_e4m3fn,
+                block_size=block_size,
+            )
+            data = _quantize_affine_float8(hp_tensor, scale, torch.float8_e4m3fn)
+            dequantized = _dequantize_affine_float8(data, scale, torch.float)
+
+            self.assertTrue(torch.isfinite(scale).all())
+            self.assertTrue((scale > 0).all())
+            self.assertEqual(dequantized.abs().max().item(), 0.0)
+
+    def test_float8_scaling_single_zero_row(self):
+        """
+        A zeroed row inside an otherwise normal tensor should stay finite.
+        """
+        hp_tensor = torch.randn(16, 32, dtype=torch.float)
+        hp_tensor[7] = 0.0
+
+        block_size = get_block_size(hp_tensor.shape, PerRow())
+        scale = _choose_scale_float8(
+            hp_tensor,
+            float8_dtype=torch.float8_e4m3fn,
+            block_size=block_size,
+        )
+        data = _quantize_affine_float8(hp_tensor, scale, torch.float8_e4m3fn)
+        dequantized = _dequantize_affine_float8(data, scale, torch.float)
+
+        self.assertTrue(torch.isfinite(dequantized).all())
+        self.assertEqual(dequantized[7].abs().max().item(), 0.0)
 
 
 if __name__ == "__main__":

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -2205,11 +2205,20 @@ def _choose_scale_float8(
     ]
     scale = scale.reshape(output_shape)
 
+    # A block of all zeros has max_abs == 0 and so gets a zero scale, and
+    # dividing the data by that scale gives NaN. Floor the scale at the
+    # smallest positive normal float32 value, like the eps clamp the affine
+    # qparams helpers above use. This runs before the e8m0 conversion because
+    # log2(0) is -inf.
+    scale = scale.to(dtype=torch.float32).clamp(
+        min=torch.finfo(torch.float32).smallest_normal
+    )
+
     if scale_dtype is not torch.float32:
         # Shielding for Version > 2.8
         assert scale_dtype is torch.float8_e8m0fnu, "Only float8_e8m0fnuz is supported"
         scale = torch.exp2(_Round.apply(torch.log2(scale)))
-    return scale.to(dtype=torch.float32)
+    return scale
 
 
 def _maybe_expand_scale_to_tensor_shape(


### PR DESCRIPTION
`_choose_scale_float8` returns `amax / quant_max` with no lower bound. When a block is all zeros the amax is zero, so the scale is zero, and `_quantize_affine_float8` then divides the data by it. Every value in the block comes out NaN. A single zeroed row in an otherwise normal tensor is enough to trigger it.

The fix clamps the scale to the smallest normal float32 value before returning. I followed the eps convention already in that file, where the affine qparams helpers default eps to `torch.finfo(...).smallest_normal` and clamp the scale with it, rather than the `EPS = 1e-12` amax clamp in `torchao/float8/float8_utils.py`. Flooring the scale leaves nonzero blocks untouched. The clamp sits before the e8m0 branch because `log2(0)` is `-inf`.

New CPU tests cover all-zero per-row, per-tensor and blockwise scaling, plus one zeroed row inside a normal tensor. They fail before the change and pass after. The whole of `test/quantization/test_quant_primitives.py` passes.

I used an AI assistant while working on this. I read the change, ran the tests myself, and take responsibility for it.

Fixes #4713