### PR TITLE
Raise ImportError when the MPS ops library is unavailable

### DIFF
--- a/test/test_lean_import.py
+++ b/test/test_lean_import.py
@@ -1,3 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import subprocess
+import sys
 import unittest
 
 import torch
@@ -18,6 +26,27 @@ class TestLeanImport(unittest.TestCase):
         import torchao  # noqa: F401
 
         torch.cuda.current_device = old_current_device
+
+
+class TestWalkPackages(unittest.TestCase):
+    def test_walk_packages_does_not_raise(self):
+        # Optional backends that are not built must signal their absence with
+        # ImportError, which pkgutil.walk_packages and other importlib-based
+        # discovery tolerate. Anything else escapes and breaks the walk for
+        # every caller. See https://github.com/pytorch/ao/issues/4577
+        # Run in a subprocess so the parent module cache is untouched.
+        code = (
+            "import pkgutil, torchao\n"
+            "[None for _ in pkgutil.walk_packages(torchao.__path__, prefix='torchao.')]\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"walking torchao raised a non-ImportError:\n{result.stderr}",
+        )
 
 
 if __name__ == "__main__":

--- a/torchao/experimental/ops/mps/utils.py
+++ b/torchao/experimental/ops/mps/utils.py
@@ -55,15 +55,21 @@ def _load_torchao_mps_lib():
     except AttributeError:
         libpath = _get_torchao_mps_lib_path()
         if libpath is None:
-            raise RuntimeError(
+            raise ImportError(
                 "Could not find libtorchao_ops_mps_aten.dylib. "
                 "Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1"
             )
         try:
             torch.ops.load_library(libpath)
         except Exception as e:
-            raise RuntimeError(f"Failed to load library {libpath}: {e}")
+            raise ImportError(f"Failed to load library {libpath}: {e}")
 
-        for nbit in range(1, 8):
-            getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
-            getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+        try:
+            for nbit in range(1, 8):
+                getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+                getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+        except AttributeError as e:
+            raise ImportError(
+                f"Loaded {libpath} but the MPS ops did not register. "
+                "Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1"
+            ) from e


### PR DESCRIPTION
torchao.experimental.ops.mps calls _load_torchao_mps_lib() at import time. When libtorchao_ops_mps_aten.dylib is missing, which is every non-macOS build, that function raised RuntimeError. pkgutil.walk_packages only catches ImportError, so the RuntimeError escaped and broke package discovery for anyone walking torchao, not just people using the MPS backend.

This switches the two raise sites to ImportError. It also wraps the getattr loop that runs after the library loads, which raised a bare AttributeError if the ops still did not register. That third path had the same problem, so fixing only the missing-file case would have left a hole. Message text is unchanged and still points at TORCHAO_BUILD_EXPERIMENTAL_MPS=1, so anyone actually building for MPS sees the same hint.

The test walks torchao with pkgutil in a subprocess and checks the exit code. It fails before this change and passes after, on any platform. Touching test_lean_import.py made the copyright pre-commit hook add the standard header to it.

> Written with AI assistance. I reproduced the bug and ran the tests myself.