### PR TITLE
Fix: use 'is None' instead of 'not' for tensor checks in FixedQParamO…

### DIFF
--- a/test/quantization/test_observer.py
+++ b/test/quantization/test_observer.py
@@ -286,6 +286,51 @@ class TestQuantFlow(TestCase):
         )
 
 
+    def test_fixed_qparam_observer_multi_element_scale(self):
+        """Regression test: 'if not scale' crashes on multi-element tensors."""
+        scale = torch.tensor([1.0, 2.0, 3.0])
+        zero_point = torch.tensor([0.0, 0.0, 0.0])
+        obs = AffineQuantizedFixedQParamObserver(
+            MappingType.SYMMETRIC,
+            torch.int8,
+            PerTensor(),
+            scale=scale,
+            zero_point=zero_point,
+        )
+        s, zp = obs.calculate_qparams()
+        torch.testing.assert_close(s, scale)
+        torch.testing.assert_close(zp, zero_point)
+
+    def test_fixed_qparam_observer_zero_value_scale(self):
+        """Regression test: 'if not scale' overwrites valid scale=0.0."""
+        scale = torch.tensor([0.0])
+        zero_point = torch.tensor([0.0])
+        obs = AffineQuantizedFixedQParamObserver(
+            MappingType.SYMMETRIC,
+            torch.int8,
+            PerTensor(),
+            scale=scale,
+            zero_point=zero_point,
+        )
+        s, zp = obs.calculate_qparams()
+        self.assertEqual(s.item(), 0.0)
+        self.assertEqual(zp.item(), 0.0)
+
+    def test_fixed_qparam_observer_set_qparams_multi_element(self):
+        """Regression test: set_qparams 'if not zero_point' crashes on multi-element."""
+        obs = AffineQuantizedFixedQParamObserver(
+            MappingType.SYMMETRIC,
+            torch.int8,
+            PerTensor(),
+        )
+        scale = torch.tensor([1.0, 2.0])
+        zero_point = torch.tensor([0.0, 0.0])
+        obs.set_qparams(scale, zero_point)
+        s, zp = obs.calculate_qparams()
+        torch.testing.assert_close(s, scale)
+        torch.testing.assert_close(zp, zero_point)
+
+
 common_utils.instantiate_parametrized_tests(TestQuantFlow)
 
 if __name__ == "__main__":

--- a/torchao/quantization/observer.py
+++ b/torchao/quantization/observer.py
@@ -224,15 +224,15 @@ class AffineQuantizedFixedQParamObserver(AffineQuantizedObserverBase):
             preserve_zero,
             zero_point_domain,
         )
-        if not scale:
+        if scale is None:
             scale = torch.Tensor([1])
-        if not zero_point:
+        if zero_point is None:
             zero_point = torch.zeros_like(scale)
         self.register_buffer("scale", scale.to(dtype=scale_dtype))
         self.register_buffer("zero_point", zero_point.to(dtype=zero_point_dtype))
 
     def set_qparams(self, scale, zero_point=None):
-        if not zero_point:
+        if zero_point is None:
             zero_point = torch.zeros_like(scale)
         self.scale = scale.to(dtype=self.scale_dtype)
         self.zero_point = zero_point.to(dtype=self.zero_point_dtype)


### PR DESCRIPTION
## Summary

`AffineQuantizedFixedQParamObserver` in `torchao/quantization/observer.py` uses `if not scale` and `if not zero_point` to check for missing arguments. This is incorrect for tensors:

1. **Crash** — Multi-element tensors (e.g. per-channel scales) raise `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`
2. **Silent data corruption** — A valid single-element `scale=0.0` is treated as falsy and overwritten with `1.0`

### Buggy code (3 locations)

```python
# __init__ (lines 227-230)
if not scale:              # BUG: should be 'is None'
    scale = torch.Tensor([1])
if not zero_point:         # BUG: should be 'is None'
    zero_point = torch.zeros_like(scale)

# set_qparams (line 235)
if not zero_point:         # BUG: should be 'is None'
    zero_point = torch.zeros_like(scale)