### PR TITLE
Fix RoundingModeKind incompatible with nvidia-cutlass-dsl 4.6.0+

### DIFF
--- a/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
+++ b/torchao/prototype/moe_training/kernels/mxfp8/cute_utils.py
@@ -201,7 +201,7 @@ if _cutedsl_runtime_available():
             cutlass.Int32(0).ir_value(loc=loc, ip=ip),
             nvvm.CVTPackFloatKind.UE8M0x2,
             nvvm.CVTPackFloatKind.BF16x2,
-            rnd=nvvm.RoundingModeKind.RN,
+            rnd=nvvm.FPRoundingMode.RN,
             sat=nvvm.SaturationModeKind.NONE,
             loc=loc,
             ip=ip,
@@ -243,7 +243,7 @@ if _cutedsl_runtime_available():
             Tuple of (scale_biased, inv_scale)
         """
         descale = amax * INV_F8_MAX
-        scale_e8m0 = _cvt_f32_to_ue8m0(descale, rounding_mode=nvvm.RoundingModeKind.RP)
+        scale_e8m0 = _cvt_f32_to_ue8m0(descale, rounding_mode=nvvm.FPRoundingMode.RP)
         return view_as(scale_e8m0, cutlass.Uint8), _reciprocal_scale(scale_e8m0)
 
     @cute.jit
@@ -257,7 +257,7 @@ if _cutedsl_runtime_available():
             Tuple of (scale_biased, inv_scale)
         """
         descale = amax * cutlass.Float32(1.0 / 256.0)
-        scale_e8m0 = _cvt_f32_to_ue8m0(descale, rounding_mode=nvvm.RoundingModeKind.RZ)
+        scale_e8m0 = _cvt_f32_to_ue8m0(descale, rounding_mode=nvvm.FPRoundingMode.RZ)
         return view_as(scale_e8m0, cutlass.Uint8), _reciprocal_scale(scale_e8m0)
 
     @cute.jit


### PR DESCRIPTION
**Summary:** `nvidia-cutlass-dsl 4.6.0` renamed `RoundingModeKind` -> `FPRoundingMode`, while both existed in 4.5.0. #4725 recently added references to the old name, resulting in the following error. This breaks compatibility with vllm nightly, which currently depends on 4.6.2:

```
AttributeError: module 'cutlass._mlir.dialects.nvvm' has no attribute
'RoundingModeKind'
  at cute_utils.py:246, in compute_scale_rceil
```

**Claude summary:**
```
Rename the three uses to `FPRoundingMode`, which is correct on every released
version:

  - Values are identical for the members used here:
      RoundingModeKind: NONE=0 RN=1 RM=2 RP=3 RZ=4
      FPRoundingMode:   NONE=0 RN=1 RM=2 RP=3 RZ=4 RNA=5   (strict superset)
  - Both register attribute builders with the same body, emitting a signless
    i32 IntegerAttr from int(x), so the enum class does not affect the attribute.
  - From 4.6.0 the generated op requests 'FPRoundingModeAttr' (22 uses, 0 of
    'RoundingModeKindAttr'), so this is the expected API there, not a shim.
  - FPRoundingMode is present in 4.4.2, 4.5.0, 4.6.0, 4.6.2 and 4.7.0, so the
    unconditional rename keeps older versions working.
```