### PR TITLE
Allow DCP to load Float8 MoE training weights

### DIFF
--- a/test/prototype/moe_training/test_serialization.py
+++ b/test/prototype/moe_training/test_serialization.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import io
+import tempfile
+import unittest
+
+import torch
+import torch.distributed.checkpoint as dcp
+
+from torchao.prototype.moe_training.config import Float8TrainingOpConfig
+from torchao.prototype.moe_training.tensor import (
+    Float8TrainingWeightWrapperTensor,
+)
+
+
+def _make_wrapper(value: float) -> Float8TrainingWeightWrapperTensor:
+    return Float8TrainingWeightWrapperTensor(
+        torch.full((2, 2), value, dtype=torch.bfloat16),
+        Float8TrainingOpConfig(),
+    )
+
+
+class Float8TrainingWeightWrapperSerializationTest(unittest.TestCase):
+    def test_weights_only_round_trip(self) -> None:
+        expected = _make_wrapper(1.0)
+        serialized = io.BytesIO()
+        torch.save(expected, serialized)
+
+        serialized.seek(0)
+        actual = torch.load(serialized, weights_only=True)
+
+        self.assertIsInstance(actual, Float8TrainingWeightWrapperTensor)
+        torch.testing.assert_close(actual._data, expected._data)
+        self.assertEqual(expected.config, actual.config)
+
+    def test_dcp_round_trip(self) -> None:
+        expected = _make_wrapper(1.0)
+        actual = _make_wrapper(0.0)
+
+        with tempfile.TemporaryDirectory() as checkpoint_id:
+            dcp.save({"weight": expected}, checkpoint_id=checkpoint_id)
+            dcp.load({"weight": actual}, checkpoint_id=checkpoint_id)
+
+        torch.testing.assert_close(actual._data, expected._data)
+        self.assertEqual(expected.config, actual.config)

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -16,8 +16,15 @@ from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import MixedPrecisionPolicy
 
 from torchao.prototype.moe_training.config import (
+    Float8TrainingOpConfig,
     MXFP8TrainingOpConfig,
     TrainingOpBaseConfig,
+)
+from torchao.float8.config import (
+    CastConfig,
+    Float8GemmConfig,
+    Float8LinearConfig,
+    ScalingType,
 )
 from torchao.prototype.moe_training.mxfp8_linear import _to_mxfp8_then_scaled_mm
 from torchao.prototype.moe_training.utils import (
@@ -335,3 +342,16 @@ class MXFP8TrainingWeightWrapperTensor(TrainingWeightWrapperBaseTensor):
             # the wrapping behavior of the super() impl, go directly to dispatch
             with torch._C.DisableTorchFunctionSubclass():
                 return func(*args, **kwargs)
+
+
+# These types comprise the serialized Float8 training-weight wrapper state.
+torch.serialization.add_safe_globals(
+    [
+        Float8TrainingWeightWrapperTensor,
+        Float8TrainingOpConfig,
+        Float8LinearConfig,
+        CastConfig,
+        Float8GemmConfig,
+        ScalingType,
+    ]
+)


### PR DESCRIPTION
Summary:
Register `Float8TrainingWeightWrapperTensor` and its serialized configuration types as safe globals so the DCP `weights_only=True` reader can restore Float8 MoE training weights. Add direct and DCP round-trip coverage.

This fixes a general DCP deserialization compatibility gap exposed by TorchTitan, not a TorchTitan-specific reader bug. The quantized DeepSeek-V3.1 671B MoE configuration wraps expert weights in `Float8TrainingWeightWrapperTensor`. Both native DCP resume and DCP-to-`torch_checkpointing` compatibility loading ultimately use the DCP `FileSystemReader`, which restores payloads with `torch.load(..., weights_only=True)`. Without this registration, loading fails before state-dict adaptation with `Unsupported global`.

Differential Revision: D113730611


