### PR TITLE
Fix ZeroPointDomain.NONE branch comparing class instead of variable

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -696,6 +696,24 @@ class TestQuantPrimitives(unittest.TestCase):
 
             self.assertTrue(torch.equal(w_int4x8, w_int4x8_ref))
 
+    def test_groupwise_affine_quantize_tensor_from_qparams_none_domain(self):
+        # Regression test for https://github.com/pytorch/ao/issues/4693
+        # `ZeroPointDomain.NONE` used to hit an always-false comparison
+        # (`ZeroPointDomain == ZeroPointDomain.NONE` instead of
+        # `zero_point_domain == ZeroPointDomain.NONE`) and fall through to
+        # the `raise ValueError` branch instead of dispatching to
+        # `_quantize_affine_no_zero_point`.
+        input = torch.randn(10, 256)
+        scales = torch.randn(10, 2)
+        zeros = torch.randn(10, 2)
+        n_bit = 4
+        groupsize = 128
+
+        w_int4x8 = groupwise_affine_quantize_tensor_from_qparams(
+            input, scales, zeros, n_bit, groupsize, ZeroPointDomain.NONE
+        )
+        self.assertEqual(w_int4x8.dtype, torch.int32)
+
     def test_groupwise_affine_dequantize_tensor_from_qparams(self):
         input = torch.randint(0, 15, (10, 256), dtype=torch.int32)
         scales = torch.randn(10, 2).bfloat16()

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -338,7 +338,7 @@ def groupwise_affine_quantize_tensor_from_qparams(
         _quantize_affine = quantize_affine
     elif zero_point_domain == ZeroPointDomain.FLOAT:
         _quantize_affine = _quantize_affine_tinygemm
-    elif ZeroPointDomain == ZeroPointDomain.NONE:
+    elif zero_point_domain == ZeroPointDomain.NONE:
         _quantize_affine = _quantize_affine_no_zero_point
     else:
         raise ValueError(f"Unrecognized zero point domain: {zero_point_domain}")


### PR DESCRIPTION
## Summary
`groupwise_affine_quantize_tensor_from_qparams` in `torchao/quantization/utils.py` had a typo on the `ZeroPointDomain.NONE` branch: it compared the `ZeroPointDomain` class object itself against `ZeroPointDomain.NONE` instead of comparing the `zero_point_domain` argument:

```python
elif ZeroPointDomain == ZeroPointDomain.NONE:   # always False
```

Since a class is never equal to one of its enum members, this branch was dead code — any caller passing `zero_point_domain=ZeroPointDomain.NONE` fell through to the `else` and hit:

```
ValueError: Unrecognized zero point domain: ZeroPointDomain.NONE
```

instead of correctly dispatching to `_quantize_affine_no_zero_point`.

## Fix
Compare the `zero_point_domain` variable, consistent with the two branches above it.

## Test
Added `test_groupwise_affine_quantize_tensor_from_qparams_none_domain` in `test/quantization/test_quant_primitives.py`, which calls `groupwise_affine_quantize_tensor_from_qparams` with `ZeroPointDomain.NONE` and asserts it returns an int32 tensor instead of raising. Verified this test fails on main (raises `ValueError`) and passes with the fix.

Fixes #4693

🤖 Generated with [Claude Code](https://claude.com/claude-code)