### PR TITLE
Fix inverted bias flag in swap_conv2d_1x1_to_linear

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -48,6 +48,7 @@ from torchao.quantization.quant_api import (
     PerRow,
     PerTensor,
     _replace_with_custom_fn_if_matches_filter,
+    swap_conv2d_1x1_to_linear,
 )
 from torchao.quantization.quant_primitives import MappingType
 from torchao.quantization.utils import compute_error
@@ -168,6 +169,39 @@ class TestQuantFlow(TestCase):
         torch.backends.cuda.matmul.fp32_precision = self._prev_cuda_matmul_fp32
         torch.backends.mkldnn.matmul.fp32_precision = self._prev_mkldnn_matmul_fp32
         super().tearDown()
+
+    def test_swap_conv2d_1x1_to_linear_bias(self):
+        # Regression test for https://github.com/pytorch/ao/issues/4615
+        # `replace_conv2d_1x1` passed `bias=(conv.bias is None)` to `nn.Linear`,
+        # which is inverted relative to the intent (create a bias iff the
+        # source conv has one). The very next line unconditionally does
+        # `lin.bias = conv.bias`, which today happens to paper over the
+        # inverted flag and leaves the final module correct either way. This
+        # test locks in that end-to-end correctness and guards against the
+        # inverted flag becoming an actual bug if that line is ever touched.
+        model_with_bias = torch.nn.Sequential(
+            torch.nn.Conv2d(4, 8, kernel_size=1, bias=True)
+        )
+        model_without_bias = torch.nn.Sequential(
+            torch.nn.Conv2d(4, 8, kernel_size=1, bias=False)
+        )
+
+        swap_conv2d_1x1_to_linear(model_with_bias)
+        swap_conv2d_1x1_to_linear(model_without_bias)
+
+        self.assertIsNotNone(model_with_bias[0].mod.bias)
+        self.assertIsNone(model_without_bias[0].mod.bias)
+
+        # the converted module should also be numerically equivalent to the
+        # original conv (bias correctly carried over, weight correctly reshaped)
+        conv = torch.nn.Conv2d(4, 8, kernel_size=1, bias=True)
+        x = torch.randn(2, 4, 5, 5)
+        expected = conv(x)
+
+        converted = torch.nn.Sequential(conv)
+        swap_conv2d_1x1_to_linear(converted)
+        actual = converted(x)
+        torch.testing.assert_close(actual, expected)
 
     def test_quantize_does_not_leak_fp32_precision(self):
         # quantize_() must not mutate the process wide fp32 precision flags, torch's

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -232,7 +232,7 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
     def replace_conv2d_1x1(conv):
         assert conv.kernel_size == (1, 1)
         lin = torch.nn.Linear(
-            conv.in_channels, conv.out_channels, bias=(conv.bias is None)
+            conv.in_channels, conv.out_channels, bias=(conv.bias is not None)
         )
         lin.weight = torch.nn.Parameter(conv.weight.squeeze(-1, -2))
         lin.bias = conv.bias


### PR DESCRIPTION
## Summary
In `replace_conv2d_1x1` (used by `swap_conv2d_1x1_to_linear`), the `bias=` argument passed to the `nn.Linear` constructor is inverted relative to intent:

```python
lin = torch.nn.Linear(
    conv.in_channels, conv.out_channels, bias=(conv.bias is None)  # should be 'is not None'
)
lin.weight = torch.nn.Parameter(conv.weight.squeeze(-1, -2))
lin.bias = conv.bias
```

**Important note found during verification:** this does **not** currently cause a user-observable bug. The very next line, `lin.bias = conv.bias`, unconditionally overwrites whatever the constructor allocated — `nn.Module.__setattr__` re-registers the `bias` parameter regardless of the module's initial `bias=` flag, as long as the target attribute name already exists in `_parameters` (which it always does after `nn.Linear.__init__`). So the final module ends up with the correct bias either way today.

It's still worth fixing because:
1. The flag is backwards relative to its obvious intent and is misleading to future readers.
2. It's technically wasteful in the `bias=True`-when-unnecessary case (allocates and discards a placeholder bias Parameter).
3. It's a latent foot-gun — if the explicit `lin.bias = conv.bias` override is ever refactored away, the inverted flag would become a real, silent bug.

## Fix
`bias=(conv.bias is not None)`, matching intent.

## Test
Added `test_swap_conv2d_1x1_to_linear_bias` in `test/quantization/test_quant_api.py`, covering both the bias and no-bias case, checking both the resulting module's `bias` attribute and full numerical equivalence to the original conv's output.

Fixes #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)