### PR TITLE
Raise ImportError (not RuntimeError) when the MPS lib can't load on non-macOS

### DIFF
--- a/test/prototype/test_mps_lib_import_error.py
+++ b/test/prototype/test_mps_lib_import_error.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for https://github.com/pytorch/ao/issues/4577.
+
+`torchao.experimental.ops.mps` eagerly calls `_load_torchao_mps_lib()` at
+import time. On any non-macOS platform where the `torch.ops.torchao`
+MPS operators aren't already registered (e.g. an XPU wheel on Windows),
+this used to raise a bare `RuntimeError`. `pkgutil.walk_packages` /
+`pkgutil.iter_modules` - used by libraries like diffusers and transformers
+for optional-backend discovery - only swallow `ImportError` while probing
+submodule importability; any other exception aborts the whole package walk.
+These tests run on any platform (they don't require macOS or MPS hardware)
+and lock in that:
+  1. failing to load the MPS lib raises ImportError, not RuntimeError.
+  2. pkgutil.walk_packages over torchao's tree no longer aborts because of
+     this module.
+"""
+
+import pkgutil
+import sys
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+class TestMpsLibImportError(TestCase):
+    def test_load_torchao_mps_lib_raises_import_error(self):
+        if sys.platform == "darwin":
+            self.skipTest(
+                "this test targets the non-macOS failure path; on macOS "
+                "the lib may load successfully"
+            )
+        # `torchao.experimental.ops.mps.utils` calls `_load_torchao_mps_lib()`
+        # eagerly in the parent package's `__init__.py`, so the failure
+        # surfaces as soon as anything under `mps` is imported for the
+        # first time in this process.
+        with self.assertRaises(ImportError):
+            import torchao.experimental.ops.mps  # noqa: F401
+
+    def test_pkgutil_walk_packages_survives_missing_mps_lib(self):
+        import torchao
+
+        # This must not raise: pkgutil only catches ImportError internally,
+        # so if `torchao.experimental.ops.mps` ever raises anything else on
+        # import, this walk aborts for every downstream caller (diffusers,
+        # transformers, etc.), not just torchao users who touch MPS.
+        modules = list(pkgutil.walk_packages(torchao.__path__, prefix="torchao."))
+        names = {m.name for m in modules}
+        self.assertIn("torchao.experimental.ops.mps", names)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/experimental/ops/mps/utils.py
+++ b/torchao/experimental/ops/mps/utils.py
@@ -6,6 +6,7 @@
 
 import glob
 import os
+import sys
 
 import torch
 
@@ -47,23 +48,46 @@ def _get_torchao_mps_lib_path():
 
 
 def _load_torchao_mps_lib():
-    """Load the MPS ops library."""
+    """Load the MPS ops library.
+
+    Raises:
+        ImportError: if the library isn't available, e.g. because we're not
+            on macOS, or the package wasn't built with MPS support. This is
+            deliberately ImportError (not RuntimeError): this function runs
+            eagerly at `torchao.experimental.ops.mps` import time, and tools
+            like `pkgutil.walk_packages` / `pkgutil.iter_modules` (used by
+            libraries such as diffusers and transformers for optional-backend
+            discovery) only catch ImportError when probing submodules for
+            importability, not arbitrary exceptions. See
+            https://github.com/pytorch/ao/issues/4577.
+    """
     try:
         for nbit in range(1, 8):
             getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
             getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+        return
     except AttributeError:
-        libpath = _get_torchao_mps_lib_path()
-        if libpath is None:
-            raise RuntimeError(
-                "Could not find libtorchao_ops_mps_aten.dylib. "
-                "Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1"
-            )
-        try:
-            torch.ops.load_library(libpath)
-        except Exception as e:
-            raise RuntimeError(f"Failed to load library {libpath}: {e}")
+        pass
 
-        for nbit in range(1, 8):
-            getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
-            getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+    # The MPS ops are backed by a macOS-only .dylib. On any other platform
+    # (e.g. an XPU wheel running on Windows/Linux) the library can never
+    # exist, so fail fast with ImportError instead of searching for it.
+    if sys.platform != "darwin":
+        raise ImportError(
+            f"torchao MPS ops are only available on macOS, not {sys.platform!r}."
+        )
+
+    libpath = _get_torchao_mps_lib_path()
+    if libpath is None:
+        raise ImportError(
+            "Could not find libtorchao_ops_mps_aten.dylib. "
+            "Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1"
+        )
+    try:
+        torch.ops.load_library(libpath)
+    except Exception as e:
+        raise ImportError(f"Failed to load library {libpath}: {e}") from e
+
+    for nbit in range(1, 8):
+        getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+        getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")


### PR DESCRIPTION
## Summary
`torchao.experimental.ops.mps.__init__` eagerly calls `_load_torchao_mps_lib()` at import time. When `torch.ops.torchao`'s MPS operators aren't already registered and the platform can't have the macOS-only `libtorchao_ops_mps_aten.dylib` (e.g. an XPU wheel running on Windows), this raised a bare `RuntimeError`.

`pkgutil.walk_packages()`/`iter_modules()` — used by diffusers, transformers, and other libraries for optional-backend discovery — only catch `ImportError` while probing submodule importability internally; any other exception aborts the *entire* package walk, for every caller, not just users who actually touch MPS.

Reproduced directly on Linux (no macOS/XPU hardware needed — the failure path only requires the ops not being registered, which is true on any non-macOS build):

```
>>> import pkgutil, torchao
>>> list(pkgutil.walk_packages(torchao.__path__, prefix="torchao."))
...
RuntimeError: Could not find libtorchao_ops_mps_aten.dylib. Please build with TORCHAO_BUILD_EXPERIMENTAL_MPS=1
```

## Fix
- Fail fast with `ImportError` when `sys.platform != "darwin"`, since the `.dylib` this code looks for can never exist on any other platform — addresses the XPU/Windows case directly rather than searching for a file that can't be there.
- Also switch the remaining "lib not found" / "failed to load" branches (which can still apply on macOS itself, e.g. an unbuilt dev checkout) from `RuntimeError` to `ImportError`, matching the standard Python convention for optional native extensions and keeping this well-behaved for any future all-platform discovery tooling.

## Test
Added `test/prototype/test_mps_lib_import_error.py`:
- `test_load_torchao_mps_lib_raises_import_error` — imports `torchao.experimental.ops.mps` on a non-macOS platform and asserts it raises `ImportError`.
- `test_pkgutil_walk_packages_survives_missing_mps_lib` — the exact repro from the issue: `pkgutil.walk_packages(torchao.__path__)` must complete and include `torchao.experimental.ops.mps` in the results, not abort.

Verified both fail on the unpatched code (reproducing the issue's exact `RuntimeError`) and pass with the fix.

Fixes #4577

🤖 Generated with [Claude Code](https://claude.com/claude-code)