### PR TITLE
Make autocast dtype detection device-agnostic (not CUDA-only)

### DIFF
--- a/test/quantization/test_device_agnostic_autocast.py
+++ b/test/quantization/test_device_agnostic_autocast.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for https://github.com/pytorch/ao/issues/4601.
+
+Three call sites hardcoded CUDA autocast queries
+(`torch.is_autocast_enabled()` with no argument, or explicitly
+`torch.is_autocast_enabled("cuda")`, plus `torch.get_autocast_gpu_dtype()`),
+so on a non-CUDA device with device autocast active they always saw
+autocast as disabled and left the input in its original (usually fp32)
+dtype instead of casting it to the active autocast dtype:
+
+  - torchao/float8/float8_linear.py: Float8Linear.forward
+  - torchao/prototype/quantized_training/int8_mixed_precision.py:
+    the F.linear override for Int8MixedPrecisionTrainingLinearWeight
+  - torchao/prototype/quantized_training/bitnet.py: the F.linear override
+    for BitNetTrainingLinearWeight
+
+Each test below runs entirely on CPU under `torch.autocast(device_type="cpu")`
+and checks the dtype actually seen by the wrapped compute op, bypassing the
+op itself (fp8/int8 matmul kernels are GPU-only) via a lightweight monkeypatch
+so only the autocast-detection logic under test executes.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+class TestDeviceAgnosticAutocast(TestCase):
+    def test_float8_linear_respects_cpu_autocast(self):
+        from torchao.float8 import float8_linear as m
+        from torchao.float8.config import Float8LinearConfig
+
+        captured = {}
+
+        class FakeMatmul:
+            @staticmethod
+            def apply(input, weight_t, linear_mm_config, config):
+                captured["dtype"] = input.dtype
+                return input @ weight_t
+
+        orig = m.matmul_with_hp_or_float8_args
+        m.matmul_with_hp_or_float8_args = FakeMatmul
+        try:
+            lin = m.Float8Linear(
+                8, 8, bias=False, config=Float8LinearConfig(emulate=True)
+            )
+            x = torch.randn(4, 8)
+            with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+                lin(x)
+        finally:
+            m.matmul_with_hp_or_float8_args = orig
+
+        self.assertEqual(captured["dtype"], torch.bfloat16)
+
+    def test_int8_mixed_precision_training_respects_cpu_autocast(self):
+        from torchao.prototype.quantized_training import int8_mixed_precision as m
+
+        W = m.Int8MixedPrecisionTrainingLinearWeight
+        fn = W._ATEN_OP_TABLE[W][F.linear]
+
+        captured = {}
+
+        class FakeFunction:
+            @staticmethod
+            def apply(input, weight, bias, config=None):
+                captured["dtype"] = input.dtype
+                return input
+
+        orig = m._Int8MixedPrecisionTrainingLinearFunction
+        m._Int8MixedPrecisionTrainingLinearFunction = FakeFunction
+        try:
+            weight = W(torch.randn(8, 8), m.Int8MixedPrecisionTrainingConfig())
+            x = torch.randn(4, 8)
+            with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+                fn(F.linear, (W,), (x, weight, None), {})
+        finally:
+            m._Int8MixedPrecisionTrainingLinearFunction = orig
+
+        self.assertEqual(captured["dtype"], torch.bfloat16)
+
+    def test_bitnet_training_respects_cpu_autocast(self):
+        from torchao.prototype.quantized_training import bitnet as m
+
+        W = m.BitNetTrainingLinearWeight
+        fn = W._TORCH_FN_TABLE[W][F.linear]
+
+        captured = {}
+
+        class FakeFunction:
+            @staticmethod
+            def apply(input, weight, bias):
+                captured["dtype"] = input.dtype
+                return input
+
+        orig = m._BitNetTrainingLinear
+        m._BitNetTrainingLinear = FakeFunction
+        try:
+            weight = W(torch.randn(8, 8))
+            x = torch.randn(4, 8)
+            with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+                fn(F.linear, (W,), (x, weight, None), {})
+        finally:
+            m._BitNetTrainingLinear = orig
+
+        self.assertEqual(captured["dtype"], torch.bfloat16)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -255,10 +255,9 @@ class Float8Linear(torch.nn.Linear):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         # Duplicate the autocast logic for F.linear, so that the output
         # of our module has the right original precision
-        if torch.is_autocast_enabled():
-            # For now, hardcode to GPU's autocast dtype
-            # if we need CPU support in the future, we can add it
-            autocast_dtype = torch.get_autocast_gpu_dtype()
+        device_type = input.device.type
+        if torch.is_autocast_enabled(device_type):
+            autocast_dtype = torch.get_autocast_dtype(device_type)
             input = input.to(autocast_dtype)
 
         output = matmul_with_hp_or_float8_args.apply(

--- a/torchao/prototype/quantized_training/bitnet.py
+++ b/torchao/prototype/quantized_training/bitnet.py
@@ -142,8 +142,9 @@ class BitNetTrainingLinearWeight(TorchAOBaseTensor):
 
 @BitNetTrainingLinearWeight.implements_torch_function(F.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.is_autocast_enabled(device_type):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _BitNetTrainingLinear.apply(*args, **kwargs)
 

--- a/torchao/prototype/quantized_training/int8_mixed_precision.py
+++ b/torchao/prototype/quantized_training/int8_mixed_precision.py
@@ -167,8 +167,9 @@ class Int8MixedPrecisionTrainingLinearWeight(TorchAOBaseTensor):
 
 @Int8MixedPrecisionTrainingLinearWeight.implements(torch.nn.functional.linear)
 def _(func, types, args, kwargs):
-    if torch.is_autocast_enabled("cuda"):
-        dtype = torch.get_autocast_gpu_dtype()
+    device_type = args[0].device.type
+    if torch.is_autocast_enabled(device_type):
+        dtype = torch.get_autocast_dtype(device_type)
         args = tuple(x.to(dtype) if x is not None else x for x in args)
     return _Int8MixedPrecisionTrainingLinearFunction.apply(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
Three call sites hardcoded CUDA autocast queries, so on non-CUDA devices with device autocast active they always saw autocast as disabled and silently left the input in its original (usually fp32) dtype instead of casting it to the active autocast dtype:

1. `torchao/float8/float8_linear.py:258` — `Float8Linear.forward` used bare `torch.is_autocast_enabled()` (implicitly `device_type="cuda"`) and `torch.get_autocast_gpu_dtype()`.
2. `torchao/prototype/quantized_training/int8_mixed_precision.py:170` and `torchao/prototype/quantized_training/bitnet.py:145` — both explicitly hardcoded `torch.is_autocast_enabled("cuda")` and `torch.get_autocast_gpu_dtype()`.

## Fix
As suggested in the issue: use the input tensor's own device type instead of hardcoding `"cuda"`:
```python
device_type = input.device.type
if torch.is_autocast_enabled(device_type):
    dtype = torch.get_autocast_dtype(device_type)
```
On CUDA this is behaviorally identical (`input.device.type == "cuda"`); on any other autocast-supporting device (XPU, MLU, NPU, ...) it now works correctly.

## Test
Added `test/quantization/test_device_agnostic_autocast.py`, covering all three call sites entirely **on CPU** under `torch.autocast(device_type="cpu")`. Since the underlying fp8/int8 matmul kernels are GPU-only, each test monkeypatches the wrapped compute op (`matmul_with_hp_or_float8_args`, `_Int8MixedPrecisionTrainingLinearFunction`, `_BitNetTrainingLinear`) to capture the dtype it actually receives, so only the autocast-detection logic under test runs — no GPU kernel is exercised.

- Verified all three tests fail with `dtype == torch.float32` (autocast silently skipped) on the unpatched code — reproducing the exact bug described in the issue.
- Pass with `dtype == torch.bfloat16` after the fix.
- Existing `test/float8/test_base.py` (125 tests) and `test/prototype/test_quantized_training.py` (36 tests) still collect cleanly.

Fixes #4601

🤖 Generated with [Claude Code](https://claude.com/claude-code)