### PR TITLE
Fix constant_fold deleting attrs still referenced by live get_attr nodes

### DIFF
--- a/test/quantization/pt2e/test_constant_fold.py
+++ b/test/quantization/pt2e/test_constant_fold.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for https://github.com/pytorch/ao/issues/4420.
+
+constant_fold's cleanup pass deleted the underlying module attribute for a
+get_attr node as soon as it found one dead get_attr node for that target -
+even if another get_attr node with the same target was still live. That
+left the graph with a live get_attr pointing at an attribute that no
+longer existed, which graph.lint() rejects.
+"""
+
+import torch
+from torch.fx import Graph, GraphModule
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from torchao.quantization.pt2e.constant_fold import constant_fold
+
+
+class Root(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("shared", torch.arange(4.0))
+
+
+class TestConstantFold(TestCase):
+    def test_shared_get_attr_target_survives_constant_fold(self):
+        root = Root().eval()
+
+        g = Graph()
+        x = g.placeholder("x")
+
+        # First get_attr is used only by a foldable constant expression, so
+        # it becomes dead after constant folding.
+        shared0 = g.get_attr("shared")
+        folded = g.call_function(torch.ops.aten.neg.default, (shared0,))
+
+        # Second get_attr references the same target but remains live.
+        shared1 = g.get_attr("shared")
+        live = g.call_function(torch.ops.aten.add.Tensor, (x, shared1))
+
+        g.output((folded, live))
+        gm = GraphModule(root, g)
+
+        # Used to raise:
+        #   RuntimeError: Node shared_1 target shared references
+        #   nonexistent attribute shared of ...
+        constant_fold(gm)
+
+        # The live get_attr's target must still resolve.
+        get_attr_nodes = gm.graph.find_nodes(op="get_attr")
+        self.assertTrue(len(get_attr_nodes) >= 1)
+        for node in get_attr_nodes:
+            self.assertTrue(hasattr(gm, node.target))
+
+        x_val = torch.ones(4)
+        folded_out, live_out = gm(x_val)
+        torch.testing.assert_close(folded_out, -root.shared)
+        torch.testing.assert_close(live_out, x_val + root.shared)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/quantization/pt2e/constant_fold.py
+++ b/torchao/quantization/pt2e/constant_fold.py
@@ -351,10 +351,23 @@ def constant_fold(
                 continue
             replace_node_with_constant(gm, node, constant)
 
+        # Multiple get_attr nodes can share the same target (e.g. a buffer or
+        # parameter referenced more than once in the graph). Only delete the
+        # underlying module attribute once none of the get_attr nodes for
+        # that target are still live, otherwise the graph is left with a
+        # get_attr node pointing at an attribute that no longer exists.
+        live_get_attr_targets = {
+            node.target
+            for node in gm.graph.find_nodes(op="get_attr")
+            if len(node.users) > 0
+        }
+
         erased_params = []
         for node in gm.graph.find_nodes(op="get_attr"):
             if len(node.users) == 0:
-                if hasattr(gm, node.target):
+                if node.target not in live_get_attr_targets and hasattr(
+                    gm, node.target
+                ):
                     delattr(gm, node.target)
                 erased_params.append(node)
 


### PR DESCRIPTION
## Summary
`torchao.quantization.pt2e.constant_fold.constant_fold`'s cleanup pass deleted the underlying module attribute for a `get_attr` node as soon as it found one dead `get_attr` node for that target — even if another `get_attr` node with the same target was still live elsewhere in the graph. That leaves the graph with a live `get_attr` node pointing at an attribute that no longer exists, which `graph.lint()` (called from `eliminate_dead_code`) rejects:

```
RuntimeError: Node shared_1 target shared references nonexistent attribute shared of ...
```

This was hit in ExecuTorch on a model where the same buffer/parameter is referenced through multiple `get_attr` nodes.

## Fix
Compute the set of targets that still have at least one live `get_attr` node *before* deleting anything, and only `delattr` a target when it isn't in that set — i.e. only once every `get_attr` node for that target is dead.

## Test
Added `test/quantization/pt2e/test_constant_fold.py` using the exact repro from the issue: two `get_attr` nodes sharing one buffer target, one folded away (dead), one live.

- Verified it fails with the issue's exact `RuntimeError` on the unpatched code.
- Passes with the fix, and the resulting graph module still runs and produces correct values for both outputs.
- The pre-existing `test/quantization/pt2e/test_quantize_pt2e.py` suite (70 tests, which exercises `constant_fold` indirectly via lowering/quantize_pt2e) still passes.

Fixes #4420

🤖 Generated with [Claude Code](https://claude.com/claude-code)