### PR TITLE
Preserve dropout p / batch_norm eps,momentum across QAT train<->eval switches

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -2317,6 +2317,41 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
     def test_move_exported_model_dropout_inplace(self):
         self._test_move_exported_model_dropout(inplace=True)
 
+    def test_move_exported_model_dropout_preserves_custom_p(self):
+        """
+        Regression test for https://github.com/pytorch/ao/issues/2980.
+
+        move_exported_model_to_eval/train used to always rewrite dropout's
+        `p` to a hardcoded 0.5, silently discarding any custom dropout rate.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.dropout = torch.nn.Dropout(0.7)
+
+            def forward(self, x):
+                return self.dropout(x)
+
+        example_inputs = (torch.randn(1),)
+        m = M().train()
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        target = torch.ops.aten.dropout.default
+
+        dropout_node = self._get_node(m, target)
+        self.assertEqual(dropout_node.args[1], 0.7)
+        self.assertTrue(dropout_node.args[2])
+
+        torchao.quantization.pt2e.move_exported_model_to_eval(m)
+        dropout_node = self._get_node(m, target)
+        self.assertEqual(dropout_node.args[1], 0.7)
+        self.assertFalse(dropout_node.args[2])
+
+        torchao.quantization.pt2e.move_exported_model_to_train(m)
+        dropout_node = self._get_node(m, target)
+        self.assertEqual(dropout_node.args[1], 0.7)
+        self.assertTrue(dropout_node.args[2])
+
     def _get_bn_train_eval_ops(self):
         return (
             torch.ops.aten.batch_norm.default,
@@ -2367,6 +2402,40 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
         bn_node = self._get_node(m, bn_train_op)
         self.assertTrue(bn_node is not None)
         self.assertTrue(bn_node.args[5])
+
+    def test_move_exported_model_bn_preserves_custom_momentum_and_eps(self):
+        """
+        Regression test for https://github.com/pytorch/ao/issues/2980.
+
+        move_exported_model_to_eval/train used to always rewrite batch_norm's
+        momentum/eps to torch's defaults (0.1/1e-5), silently discarding any
+        custom values, which can noticeably affect accuracy (e.g. YOLO-style
+        configs commonly use eps=1e-3).
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(3, eps=1e-3, momentum=0.3)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        m = M().train()
+        example_inputs = (torch.randn(1, 3, 3, 3),)
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        bn_op = torch.ops.aten.batch_norm.default
+
+        def _assert_momentum_and_eps(m):
+            bn_node = self._get_node(m, bn_op)
+            self.assertEqual(bn_node.args[6], 0.3)
+            self.assertEqual(bn_node.args[7], 1e-3)
+
+        _assert_momentum_and_eps(m)
+        torchao.quantization.pt2e.move_exported_model_to_eval(m)
+        _assert_momentum_and_eps(m)
+        torchao.quantization.pt2e.move_exported_model_to_train(m)
+        _assert_momentum_and_eps(m)
 
     def test_disallow_eval_train(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)

--- a/torchao/quantization/pt2e/export_utils.py
+++ b/torchao/quantization/pt2e/export_utils.py
@@ -43,6 +43,12 @@ def model_is_exported(m: torch.nn.Module) -> bool:
     )
 
 
+_DROPOUT_OPS = (
+    torch.ops.aten.dropout.default,
+    torch.ops.aten.dropout_.default,
+)
+
+
 def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
     """
     Switch dropout patterns in the model between train and eval modes.
@@ -61,6 +67,8 @@ def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
     m.graph.eliminate_dead_code()
     m.recompile()
 
+    from torch.fx.subgraph_rewriter import replace_pattern_with_filters
+
     for inplace in [False, True]:
 
         def dropout_train(x):
@@ -75,30 +83,48 @@ def _replace_dropout(m: torch.fx.GraphModule, train_to_eval: bool):
                 WrapperModule(dropout_train),
                 example_inputs,
             )
-            replacement_pattern = _get_aten_graph_module_for_pattern(
-                WrapperModule(dropout_eval),
-                example_inputs,
-            )
         else:
             match_pattern = _get_aten_graph_module_for_pattern(
                 WrapperModule(dropout_eval),
                 example_inputs,
             )
-            replacement_pattern = _get_aten_graph_module_for_pattern(
-                WrapperModule(dropout_train),
-                example_inputs,
-            )
 
-        from torch.fx.subgraph_rewriter import replace_pattern_with_filters
+        def replacement_callback(match, original_graph, pattern_graph):
+            # `ignore_literals=True` lets this pattern match dropout calls with
+            # any `p`, not just the literal 0.5 used to build the pattern above.
+            # Build the replacement using the *matched* node's actual `p` so we
+            # don't silently overwrite the user's configured dropout rate with
+            # 0.5. See https://github.com/pytorch/ao/issues/2980.
+            (dropout_pattern_node,) = [
+                n
+                for n in pattern_graph.nodes
+                if n.op == "call_function" and n.target in _DROPOUT_OPS
+            ]
+            matched_dropout_node = match.nodes_map[dropout_pattern_node]
+            p = matched_dropout_node.args[1]
+            target_training = not train_to_eval
+
+            def dropout_replacement(x):
+                return F.dropout(
+                    x, p=p, training=target_training, inplace=inplace
+                )
+
+            return _get_aten_graph_module_for_pattern(
+                WrapperModule(dropout_replacement),
+                example_inputs,
+            ).graph
 
         replace_pattern_with_filters(
             m,
             match_pattern,
-            replacement_pattern,
             match_filters=[],
             ignore_literals=True,
+            replacement_callback=replacement_callback,
         )
         m.recompile()
+
+
+_BATCHNORM_OPS = (torch.ops.aten.batch_norm.default,)
 
 
 def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
@@ -110,9 +136,6 @@ def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
     the batchnorm behavior between the two modes, so here we need to rewrite the aten
     batchnorm patterns manually to achieve the same effect.
     """
-    # TODO(Leslie): This function still fails to support custom momentum and eps value.
-    # Enable this support in future updates.
-
     # Avoid circular dependencies
     from .utils import _get_aten_graph_module_for_pattern
 
@@ -165,19 +188,61 @@ def _replace_batchnorm(m: torch.fx.GraphModule, train_to_eval: bool):
 
     if train_to_eval:
         match_pattern = bn_train_aten
-        replacement_pattern = bn_eval_aten
     else:
         match_pattern = bn_eval_aten
-        replacement_pattern = bn_train_aten
+
+    def replacement_callback(match, original_graph, pattern_graph):
+        # `ignore_literals=True` lets this pattern match batch_norm calls with
+        # any momentum/eps, not just the (unset, i.e. torch defaults of 0.1 and
+        # 1e-5) values used to build the pattern above. Build the replacement
+        # using the *matched* node's actual momentum/eps/cudnn_enabled so we
+        # don't silently overwrite the user's configured values.
+        # See https://github.com/pytorch/ao/issues/2980.
+        (bn_pattern_node,) = [
+            n
+            for n in pattern_graph.nodes
+            if n.op == "call_function" and n.target in _BATCHNORM_OPS
+        ]
+        matched_bn_node = match.nodes_map[bn_pattern_node]
+        # torch.ops.aten.batch_norm.default args:
+        # (input, weight, bias, running_mean, running_var, training, momentum,
+        #  eps, cudnn_enabled)
+        _, _, _, _, _, _, momentum, eps, cudnn_enabled = matched_bn_node.args
+        target_training = not train_to_eval
+
+        def bn_replacement(
+            x: torch.Tensor,
+            bn_weight: torch.Tensor,
+            bn_bias: torch.Tensor,
+            bn_running_mean: torch.Tensor,
+            bn_running_var: torch.Tensor,
+        ):
+            return torch.ops.aten.batch_norm.default(
+                x,
+                bn_weight,
+                bn_bias,
+                bn_running_mean,
+                bn_running_var,
+                target_training,
+                momentum,
+                eps,
+                cudnn_enabled,
+            )
+
+        return _get_aten_graph_module_for_pattern(
+            WrapperModule(bn_replacement),
+            example_inputs,
+            is_cuda,
+        ).graph
 
     from torch.fx.subgraph_rewriter import replace_pattern_with_filters
 
     replace_pattern_with_filters(
         m,
         match_pattern,
-        replacement_pattern,
         match_filters=[],
         ignore_literals=True,
+        replacement_callback=replacement_callback,
     )
     m.recompile()
 


### PR DESCRIPTION
## Summary
`_replace_dropout`/`_replace_batchnorm` in `torchao/quantization/pt2e/export_utils.py` (used by `move_exported_model_to_eval`/`move_exported_model_to_train`, which QAT users call via `allow_exported_model_train_eval` + `model.train()`/`model.eval()`) rewrote the model's dropout/batch_norm aten nodes on every train↔eval switch.

The match patterns use `ignore_literals=True` so they match dropout/batch_norm calls with **any** `p`/`momentum`/`eps` — but the *replacement* patterns baked in hardcoded literals (dropout `p=0.5`, batch_norm's default `momentum=0.1`/`eps=1e-5`). So every train↔eval switch silently overwrote the model's actual configured values with those defaults. There was even a maintainer TODO acknowledging the batch_norm half of this:
```python
# TODO(Leslie): This function still fails to support custom momentum and eps value.
```
Reported to cause a real accuracy drop on a YOLOv5 model configured with `eps=1e-3`.

## Fix
Use `torch.fx.subgraph_rewriter`'s `replacement_callback` hook instead of a static replacement pattern. For each match, look up the actual matched node via `match.nodes_map`, read its real `p` (dropout) or `momentum`/`eps`/`cudnn_enabled` (batch_norm), and build the replacement graph with those values instead of the hardcoded ones — only the `training` flag is toggled.

## Test
Added two regression tests in `test/quantization/pt2e/test_quantize_pt2e.py`:
- `test_move_exported_model_dropout_preserves_custom_p` — `nn.Dropout(0.7)`, checked through export → eval → train.
- `test_move_exported_model_bn_preserves_custom_momentum_and_eps` — `nn.BatchNorm2d(eps=1e-3, momentum=0.3)`, same cycle.

- Verified both fail on the unpatched code (values silently reset to `0.5`/`0.1`/`1e-5`).
- Pass with the fix, across train→eval→train.
- The full `test/quantization/pt2e/test_quantize_pt2e.py` suite (72 tests, including the pre-existing `test_allow_exported_model_train_eval`/`test_move_exported_model_bn`/`test_move_exported_model_dropout*`) still passes.

Fixes #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)