### PR TITLE
Fix dtype mismatch in Float8Linear backward when weight scaling is DISABLED

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -320,6 +320,53 @@ class TestFloat8Linear:
         if m_ref.bias is not None:
             torch.testing.assert_close(m_ref.bias.grad, m_fp8.bias.grad)
 
+    def test_backward_disabled_grad_input_dtype_mismatch(self):
+        """
+        Regression test for https://github.com/pytorch/ao/issues/4616.
+
+        matmul_with_hp_or_float8_args.backward's grad_input calculation, when
+        cast_config_weight_for_grad_input.scaling_type is DISABLED, used the
+        saved high precision weight (weight_hp_t) as-is in torch.mm against
+        grad_output. Under autocast, Float8Linear.forward casts its input
+        (and therefore the output, and therefore grad_output during
+        backward) to the autocast dtype (e.g. bf16), while weight_hp_t - the
+        fp32 master weight - is saved untouched. torch.mm does not promote
+        dtypes, so this crashed with:
+            RuntimeError: expected m1 and m2 to have the same dtype, ...
+
+        This reproduces the dtype mismatch directly via
+        matmul_with_hp_or_float8_args, without needing autocast or CUDA:
+        constructing input_hp as bf16 (mirroring what an autocast region
+        would produce) and weight_hp_t as fp32 (the master weight) is
+        sufficient to trigger the same mismatch on any device.
+        """
+        from torchao.float8.float8_linear import matmul_with_hp_or_float8_args
+
+        disabled = CastConfig(scaling_type=ScalingType.DISABLED)
+        config = Float8LinearConfig(
+            emulate=True,
+            cast_config_grad_output=disabled,
+            cast_config_weight_for_grad_input=disabled,
+            cast_config_input_for_grad_weight=disabled,
+            cast_config_grad_output_for_grad_weight=disabled,
+        )
+
+        input_hp = torch.randn(8, 64, dtype=torch.bfloat16, requires_grad=True)
+        weight_hp_t = torch.randn(64, 64, dtype=torch.float32, requires_grad=True)
+
+        y = matmul_with_hp_or_float8_args.apply(
+            input_hp, weight_hp_t, LinearMMConfig(), config
+        )
+        assert y.dtype == torch.bfloat16
+        # Used to raise:
+        #   RuntimeError: expected m1 and m2 to have the same dtype, but
+        #   got: c10::BFloat16 != float
+        y.sum().backward()
+        assert input_hp.grad is not None
+        assert input_hp.grad.dtype == torch.bfloat16
+        assert weight_hp_t.grad is not None
+        assert weight_hp_t.grad.dtype == torch.float32
+
     @pytest.mark.parametrize(
         "emulate",
         [True, False] if is_sm_at_least_89() or torch.xpu.is_available() else [True],

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -126,7 +126,14 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
             # TODO(future PR): var name is axiswise specific, fix it
             weight_t_maybe_fp8_dim0 = weight_hp_t
         elif c.cast_config_weight_for_grad_input.scaling_type is ScalingType.DISABLED:
-            weight_t_maybe_fp8_dim0 = weight_hp_t
+            # `weight_hp_t` is the saved high precision (master) weight, which
+            # under autocast can be float32 while `grad_output_reshaped` (from
+            # autograd) is the autocast dtype (e.g. bf16). `torch.mm` below
+            # does not promote dtypes, so align them here. This is a no-op
+            # outside autocast, where both are already the same dtype.
+            weight_t_maybe_fp8_dim0 = weight_hp_t.to(
+                grad_output_reshaped_maybe_fp8_dim0.dtype
+            )
         else:
             weight_t_maybe_fp8_dim0 = hp_tensor_to_float8_dynamic(
                 weight_hp_t,


### PR DESCRIPTION
## Summary
`matmul_with_hp_or_float8_args.backward`'s `grad_input` calculation, when `cast_config_weight_for_grad_input.scaling_type` is `ScalingType.DISABLED`, used the saved high precision weight (`weight_hp_t`) as-is in `torch.mm` against `grad_output`. Under autocast, `Float8Linear.forward` casts its input (and therefore the output, and therefore `grad_output` during backward) to the autocast dtype (e.g. bf16), while `weight_hp_t` — the fp32 master weight — is saved untouched. `torch.mm` does not promote dtypes, so this crashes with:
```
RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float
```

## Fix
As proposed in the issue: cast `weight_hp_t` to `grad_output`'s dtype in the DISABLED branch. `.to(dtype)` is a no-op outside autocast (both already the same dtype), so this has zero cost outside the autocast + DISABLED scenario. The `grad_weight` path needs no change — both its operands are already the autocast dtype in that scenario.

## Test
Added `test_backward_disabled_grad_input_dtype_mismatch` in `test/float8/test_base.py`. It reproduces the exact dtype mismatch directly via `matmul_with_hp_or_float8_args` — constructing `input_hp` as bf16 (mirroring what an autocast region produces) and `weight_hp_t` as fp32 (the master weight) is sufficient to trigger the same mismatch on **any device**, no autocast context or CUDA required.

- Verified it fails with the issue's exact `RuntimeError` on the unpatched code.
- Passes with the fix, and both `input_hp.grad`/`weight_hp_t.grad` come back with the correct dtypes.
- The full `test/float8/test_base.py` suite still passes (28 tests runnable without CUDA, 98 CUDA-gated and cleanly skipped).

Fixes #4616

🤖 Generated with [Claude Code](https://claude.com/claude-code)