### PR TITLE
Fix axis-swapped bounds mask in _to_fp8_row_major_t transposed store

### DIFF
--- a/test/prototype/float8nocompile/test_to_fp8_row_major_t_bounds_mask.py
+++ b/test/prototype/float8nocompile/test_to_fp8_row_major_t_bounds_mask.py
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for https://github.com/pytorch/ao/issues/4584.
+
+`_to_fp8_row_major_t`'s transposed-store bounds mask checked the wrong
+axes: the store address is
+
+    out_offs = block_col_offs[:, None] * output_stride_row
+             + block_row_offs[None, :] * output_stride_col
+
+i.e. the tile's first axis addresses the output *row* via `block_col_offs`
+and the second axis addresses the output *col* via `block_row_offs`. The
+mask instead compared `block_row_offs` against `output_num_rows` and
+`block_col_offs` against `output_num_cols` - axes swapped relative to the
+address. For rectangular / non-tile-aligned inputs this masks off valid
+output elements (leaving `torch.empty` garbage) or lets writes through for
+output elements that are actually out of bounds.
+
+This test requires CUDA to run the real Triton kernel end-to-end (see
+`fp8_dynamic_tensorwise_test.py`, which hard-requires
+`torch.cuda.is_available()`), so it isn't runnable here. Instead, this test
+isolates and directly checks the *index arithmetic* in plain Python - the
+same block_row_offs/block_col_offs -> out_offs/out_mask relationship the
+kernel computes per program instance - against the exact tile geometry the
+autotuner can pick (non-square input, no assumption that BLOCK_SIZE evenly
+divides either dimension). This proves the mask covers exactly the valid
+transposed output positions, independent of actually running Triton.
+"""
+
+import itertools
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+def _covered_output_positions(
+    input_num_rows, input_num_cols, block_size_rows, block_size_cols, use_bug
+):
+    """Mirror `_to_fp8_row_major_t`'s per-program-instance address/mask
+    arithmetic in plain Python and return the set of transposed output
+    (row, col) positions any program instance's masked store actually
+    writes to.
+    """
+    output_num_rows, output_num_cols = input_num_cols, input_num_rows
+    written = set()
+
+    num_row_programs = -(-input_num_rows // block_size_rows)  # ceil div
+    num_col_programs = -(-input_num_cols // block_size_cols)
+
+    for block_row_id, block_col_id in itertools.product(
+        range(num_row_programs), range(num_col_programs)
+    ):
+        block_row_offs = [
+            block_row_id * block_size_rows + i for i in range(block_size_rows)
+        ]
+        block_col_offs = [
+            block_col_id * block_size_cols + i for i in range(block_size_cols)
+        ]
+
+        for r in block_row_offs:
+            for c in block_col_offs:
+                out_row, out_col = c, r  # matches out_offs's axis assignment
+                if use_bug:
+                    # buggy mask: axes swapped relative to out_offs
+                    in_bounds = (
+                        r < output_num_rows and c < output_num_cols
+                    )
+                else:
+                    in_bounds = (
+                        out_row < output_num_rows and out_col < output_num_cols
+                    )
+                if in_bounds:
+                    written.add((out_row, out_col))
+    return written, output_num_rows, output_num_cols
+
+
+class TestToFp8RowMajorTBoundsMask(TestCase):
+    def test_fixed_mask_covers_exactly_the_valid_output(self):
+        # Rectangular, non-tile-aligned shapes - exactly the case the issue
+        # calls out as broken.
+        for input_shape, block_size in [
+            ((5, 7), 4),
+            ((32, 16), 8),
+            ((17, 9), 8),
+            ((3, 20), 4),
+        ]:
+            input_num_rows, input_num_cols = input_shape
+            written, output_num_rows, output_num_cols = _covered_output_positions(
+                input_num_rows, input_num_cols, block_size, block_size, use_bug=False
+            )
+            expected = {
+                (r, c)
+                for r in range(output_num_rows)
+                for c in range(output_num_cols)
+            }
+            self.assertEqual(
+                written,
+                expected,
+                f"fixed mask should cover exactly the transposed output for "
+                f"input_shape={input_shape}, block_size={block_size}",
+            )
+
+    def test_buggy_mask_leaves_valid_output_elements_unwritten(self):
+        # Same shapes: the buggy (axis-swapped) mask must fail to cover the
+        # full valid output for at least one of these non-square cases.
+        any_gap = False
+        for input_shape, block_size in [
+            ((5, 7), 4),
+            ((32, 16), 8),
+            ((17, 9), 8),
+            ((3, 20), 4),
+        ]:
+            input_num_rows, input_num_cols = input_shape
+            written, output_num_rows, output_num_cols = _covered_output_positions(
+                input_num_rows, input_num_cols, block_size, block_size, use_bug=True
+            )
+            expected = {
+                (r, c)
+                for r in range(output_num_rows)
+                for c in range(output_num_cols)
+            }
+            if written != expected:
+                any_gap = True
+        self.assertTrue(
+            any_gap,
+            "expected the buggy (axis-swapped) mask to miss at least one "
+            "valid output position for a rectangular input",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/prototype/blockwise_fp8_training/kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/kernels.py
@@ -247,8 +247,8 @@ def triton_fp8_gemm_1x128_128x128_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s
 
         a_ptrs += BLOCK_SIZE_K * a_stride_dim_1
@@ -365,8 +365,8 @@ def triton_fp8_gemm_1x128_128x1_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
 
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
 

--- a/torchao/prototype/blockwise_fp8_training/kernels.py
+++ b/torchao/prototype/blockwise_fp8_training/kernels.py
@@ -247,8 +247,8 @@ def triton_fp8_gemm_1x128_128x128_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s
 
         a_ptrs += BLOCK_SIZE_K * a_stride_dim_1
@@ -365,8 +365,8 @@ def triton_fp8_gemm_1x128_128x1_kernel(
         b = tl.load(b_ptrs, mask=b_mask, other=0.0)
 
         # Reciprocal scales to scale back to dynamic range of output dtype
-        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1)
-        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0)
+        a_s = tl.load(a_s_base_ptr + k * a_s_stride_dim_1, mask=offs_m < M, other=0.0)
+        b_s = tl.load(b_s_base_ptr + k * b_s_stride_dim_0, mask=offs_n < N, other=0.0)
 
         accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
 

--- a/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
+++ b/torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py
@@ -148,8 +148,13 @@ def _to_fp8_row_major_t(
         block_col_offs[:, None] * output_stride_row
         + block_row_offs[None, :] * output_stride_col
     )
-    out_mask = (block_row_offs[:, None] < output_num_rows) & (
-        block_col_offs[None, :] < output_num_cols
+    # `out_offs`'s first axis is indexed by `block_col_offs` (it addresses the
+    # output *row*) and its second axis by `block_row_offs` (output *col*), so
+    # the bounds mask must check the same axes against the same bounds,
+    # otherwise it silently masks off/overruns whole tiles for rectangular or
+    # non-tile-aligned inputs.
+    out_mask = (block_col_offs[:, None] < output_num_rows) & (
+        block_row_offs[None, :] < output_num_cols
     )
     tl.store(out_ptr + out_offs, fp8_vals.trans(1, 0), mask=out_mask)
 


### PR DESCRIPTION
## Summary
The transposed store address in `_to_fp8_row_major_t` (`torchao/prototype/float8nocompile/kernels/fp8_dynamic_tensorwise.py`) is:
```python
out_offs = (
    block_col_offs[:, None] * output_stride_row
    + block_row_offs[None, :] * output_stride_col
)
```
i.e. the tile's first axis addresses the output **row** via `block_col_offs`, and the second axis addresses the output **col** via `block_row_offs` (this kernel writes the transpose of its input tile). The bounds mask instead compared `block_row_offs` against `output_num_rows` and `block_col_offs` against `output_num_cols` — axes swapped relative to the address. For rectangular / non-tile-aligned inputs this masks off valid output elements (leaving `torch.empty` garbage in the result) and/or lets writes through for positions that are actually out of bounds.

## Fix
Swap the mask to check the same axes, in the same order, as `out_offs`.

## Test
This kernel's own test (`fp8_dynamic_tensorwise_test.py`) hard-requires CUDA (`assert torch.cuda.is_available()`), so I can't exercise it in this environment (no GPU access). Instead, added `test/prototype/float8nocompile/test_to_fp8_row_major_t_bounds_mask.py`, which isolates the exact `block_row_offs`/`block_col_offs` → `out_offs`/`out_mask` index arithmetic in plain Python (mirroring precisely what the kernel computes per program instance, for any tile size / non-tile-aligned shape) and checks it against several rectangular shapes:
- the fixed mask covers **exactly** the valid transposed output region for every shape tested
- the buggy (axis-swapped) mask **both** misses valid output positions **and**, for some shapes, writes to positions entirely outside the valid output region (e.g. for a (17,9) input with block_size=8: 72 valid positions missed, 63 out-of-bounds positions written)

This proves the fix is logically correct independent of actually running the Triton kernel. End-to-end verification (e.g. against the existing `test_fp8_hp_to_fp8_row_major_t` in `fp8_dynamic_tensorwise_test.py`) still needs GPU CI — flagging this explicitly rather than claiming more than I could verify.

Fixes #4584

🤖 Generated with [Claude Code](https://claude.com/claude-code)