### PR TITLE
[CI] Reuse pytorch setup-xpu/teardown-xpu actions in XPU workflow

### DIFF
--- a/.github/scripts/ci_test_xpu.sh
+++ b/.github/scripts/ci_test_xpu.sh
@@ -17,6 +17,7 @@ python -c "import torch; import torchao; print(f'Torch version: {torch.__version
 python -m pip install pytest expecttest parameterized accelerate hf_transfer 'modelscope!=1.15.0' transformers tabulate fire
 
 pytest -v -s --ignore=torchao/test/quantization/pt2e/test_x86inductor_fusion.py \
+        --ignore=torchao/test/prototype/moe_training/nvfp4_training/test_group_weight_amax.py \
         torchao/test/quantization/pt2e/ \
         torchao/test/quantization/*.py \
         torchao/test/dtypes/ \

--- a/.github/workflows/xpu_test.yml
+++ b/.github/workflows/xpu_test.yml
@@ -51,77 +51,10 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Clean all stopped docker containers
-        if: always()
-        shell: bash
-        run: |
-          # Prune all stopped containers.
-          # If other runner is pruning on this node, will skip.
-          nprune=$(ps -ef | grep -c "docker container prune")
-          if [[ $nprune -eq 1 ]]; then
-            docker container prune -f
-          fi
-
-      - name: Runner health check system info
-        if: always()
-        shell: bash
-        run: |
-          cat /etc/os-release || true
-          cat /etc/apt/sources.list.d/oneAPI.list || true
-          cat /etc/apt/sources.list.d/intel-gpu-jammy.list || true
-          whoami
-
-      - name: Runner health check xpu-smi
-        if: always()
-        shell: bash
-        run: |
-          timeout 30 xpu-smi discovery || true
-
-      - name: Runner health check GPU count
-        if: always()
-        shell: bash
-        run: |
-          ngpu=$(timeout 30 xpu-smi discovery | grep -c -E 'Device Name' || true)
-          msg="Please file an issue on pytorch/pytorch reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
-          if [[ $ngpu -eq 0 ]]; then
-            echo "Error: Failed to detect any GPUs on the runner"
-            echo "$msg"
-            exit 1
-          fi
-
-      - name: Runner diskspace health check
-        uses: pytorch/pytorch/.github/actions/diskspace-cleanup@main
-        if: always()
-
-      - name: Runner health check disconnect on failure
-        if: ${{ failure() }}
-        shell: bash
-        run: |
-          killall runsvc.sh
-
-      - name: Preserve github env variables for use in docker
-        shell: bash
-        run: |
-          env | grep '^GITHUB' >> "/tmp/github_env_${GITHUB_RUN_ID}"
-          env | grep '^CI' >> "/tmp/github_env_${GITHUB_RUN_ID}"
-
-      - name: XPU set GPU_FLAG
-        shell: bash
-        run: |
-          # Add render group for container creation.
-          render_gid=`cat /etc/group | grep render | cut -d: -f3`
-          echo "GPU_FLAG=--device=/dev/mem --device=/dev/dri --group-add video --group-add $render_gid" >> "${GITHUB_ENV}"
-
-      - name: configure aws credentials
-        id: aws_creds
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      # Runner health checks, GPU_FLAG, env preservation and ECR login are all
+      # handled by the shared setup-xpu action from pytorch/pytorch.
+      - name: Setup XPU
+        uses: pytorch/pytorch/.github/actions/setup-xpu@main
 
       - name: Calculate docker image
         id: calculate-docker-image
@@ -144,18 +77,6 @@ jobs:
         uses: pytorch/test-infra/.github/actions/pull-docker-image@main
         with:
           docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-
-      - name: Runner health check GPU count
-        if: always()
-        shell: bash
-        run: |
-          ngpu=$(timeout 30 clinfo -l | grep -c -E 'Device' || true)
-          msg="Please file an issue on pytorch/ao reporting the faulty runner. Include a link to the runner logs so the runner can be identified"
-          if [[ $ngpu -eq 0 ]]; then
-            echo "Error: Failed to detect any GPUs on the runner"
-            echo "$msg"
-            exit 1
-          fi
 
       - name: Test
         id: test
@@ -232,16 +153,5 @@ jobs:
           path: ./**/core.[1-9]*
 
       - name: Teardown XPU
-        if: always()
-        shell: bash
-        run: |
-          # Prune all stopped containers.
-          # If other runner is pruning on this node, will skip.
-          nprune=$(ps -ef | grep -c "docker container prune")
-          if [[ $nprune -eq 1 ]]; then
-            docker container prune -f
-          fi
-      
-      - name: Runner diskspace health check
-        uses: pytorch/pytorch/.github/actions/diskspace-cleanup@main
+        uses: pytorch/pytorch/.github/actions/teardown-xpu@main
         if: always()


### PR DESCRIPTION
Replace ~100 lines of runner health checks, `GPU_FLAG` setup, ECR login and container pruning copy-pasted from pytorch/pytorch with the shared `setup-xpu` / `teardown-xpu` composite actions. Also drops the redundant `clinfo -l` GPU count check, since `setup-xpu` already fails the job when no GPUs are detected.

Two minor deltas from our old version: the preserved github env now lands in `${RUNNER_TEMP}/` instead of `/tmp/` (nothing reads it), and `GPU_FLAG` gains `-e ZE_AFFINITY_MASK` for multi-runner-per-node GPU partitioning on XPU node.

Test plan: push a `ciflow/xpu/*` tag and confirm the job passes.