### PR TITLE
Guard three-input PTX max by CUDA and architecture

### DIFF
--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -131,13 +131,20 @@ __device__ __forceinline__ float max_nan_f32(float a, float b) {
   return result;
 }
 
-// max(|current|, |a|, |b|), with NaN propagation, in one instruction.
+// max(|current|, |a|, |b|), with NaN propagation. The three-input max form
+// requires PTX ISA 8.8 and SM100+. CUDA_VERSION guards assembler syntax, while
+// __CUDA_ARCH__ guards target support.
 __device__ __forceinline__ float abs_max_nan_f32(float current, float a,
                                                  float b) {
+#if CUDA_VERSION >= 12090 && defined(__CUDA_ARCH__) &&                     \
+    __CUDA_ARCH__ >= MIN_CUDA_SM
   asm("max.NaN.abs.f32 %0, %1, %2, %3;"
       : "=f"(current)
       : "f"(current), "f"(a), "f"(b));
   return current;
+#else
+  return max_nan_f32(max_nan_f32(fabsf(current), fabsf(a)), fabsf(b));
+#endif
 }
 
 // Constants for MXFP8 kernel


### PR DESCRIPTION
Original changes by @lw (Luca Wehrstedt), from D116784835.

**Summary:**
The three-input `max.NaN.abs.f32` form needs PTX ISA 8.8 and an SM100+ target. `CUDA_VERSION >= 12090` checks that the compiler can emit the ISA syntax, while `__CUDA_ARCH__ >= 1000` checks the selected GPU architecture. Older toolchains or targets use a NaN-propagating two-input max fallback.

**Test Plan:**
- Generated code for CUDA 12.8/SM100, CUDA 12.9/SM90, and CUDA 12.9/SM100; the first two selected the fallback and the last selected `max.NaN.abs.f32`.
- Assembled the fallback output as PTX ISA 8.7.