### PR TITLE
Restore straight-through estimator at the fake-quant clamp boundary (#4806)

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -17,6 +17,7 @@ from torchao.quantization.quant_primitives import (
     _choose_qparams_affine_tinygemm,
     _choose_qparams_and_quantize_scale_only_sinq,
     _choose_scale_float8,
+    _ClampSTE,
     _fake_quantize_affine,
     _fake_quantize_affine_cachemask,
     _maybe_expand_scale_to_tensor_shape,
@@ -795,6 +796,37 @@ class TestQuantPrimitives(unittest.TestCase):
         expected_mask = torch.full(input.shape, True)
         torch.testing.assert_close(dequantized, fake_quantized)
         torch.testing.assert_close(expected_mask, mask)
+
+    def test_clamp_ste(self):
+        # Fake quantization clamps rounded values against integer bounds, so
+        # every saturated element sits exactly on quant_min/quant_max. The STE
+        # must keep passing the gradient through there.
+        lo, hi = -8.0, 7.0
+        values = [-9.0, -8.0, 0.0, 7.0, 8.0]
+
+        x = torch.tensor(values)
+        torch.testing.assert_close(_ClampSTE.apply(x, lo, hi), torch.clamp(x, lo, hi))
+
+        x = torch.tensor(values, requires_grad=True)
+        _ClampSTE.apply(x, lo, hi).sum().backward()
+        torch.testing.assert_close(x.grad, torch.tensor([0.0, 1.0, 1.0, 1.0, 0.0]))
+
+    def test_clamp_ste_nonfinite(self):
+        # Backward selects with `torch.where`, so an out-of-range position is
+        # replaced by exactly 0 even when the incoming gradient is NaN/Inf
+        # there. A multiplicative mask would leak NaN (0 * nan == nan). This
+        # matches aten::clamp, which selects with `where` as well.
+        lo, hi = -8.0, 7.0
+        x = torch.tensor([-9.0, -8.0, 0.0, 7.0, 8.0], requires_grad=True)
+        gy = torch.tensor([float("nan"), 1.0, 1.0, 1.0, float("inf")])
+        _ClampSTE.apply(x, lo, hi).backward(gy)
+        torch.testing.assert_close(x.grad, torch.tensor([0.0, 1.0, 1.0, 1.0, 0.0]))
+
+        # A NaN input compares false against both bounds, so it gets no
+        # gradient -- also matching aten::clamp.
+        x = torch.tensor([float("nan"), 0.0], requires_grad=True)
+        _ClampSTE.apply(x, lo, hi).sum().backward()
+        torch.testing.assert_close(x.grad, torch.tensor([0.0, 1.0]))
 
     def test_maybe_expand_scale_to_tensor_shape(self):
         # rowwise quantization: if all dimensions match except for the last one,

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -226,6 +226,38 @@ class _Round(torch.autograd.Function):
         return gy
 
 
+class _ClampSTE(torch.autograd.Function):
+    """
+    Clamp that preserves the straight-through estimator at the boundary.
+
+    https://github.com/pytorch/pytorch/pull/191142 changed the boundary
+    subgradient of scalar-bound `clamp` from pass-through to zero
+    (`self >= min` became `self > min`). That is measure-zero for ordinary
+    floats, but fake quantization clamps *rounded* values against *integer*
+    bounds, so every saturated element sits exactly on quant_min/quant_max and
+    loses its gradient.
+
+    Backward selects with `torch.where` rather than multiplying by a 0/1 mask so
+    that a NaN or Inf incoming gradient at an out-of-range position is replaced
+    by exactly 0 instead of contaminating the result (`0 * nan == nan`). That
+    matches `aten::clamp`, which selects with `where` both before and after the
+    PR above.
+    """
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, lo: float, hi: float) -> torch.Tensor:
+        ctx.save_for_backward(x)
+        ctx.lo, ctx.hi = lo, hi
+        return torch.clamp(x, lo, hi)
+
+    @staticmethod
+    def backward(ctx, gy: torch.Tensor):
+        (x,) = ctx.saved_tensors
+        in_range = (x >= ctx.lo) & (x <= ctx.hi)
+        zero = torch.zeros((), dtype=gy.dtype, device=gy.device)
+        return torch.where(in_range, gy, zero), None, None
+
+
 class _RoundToFloat8(torch.autograd.Function):
     """
     Implementation of `tensor.to(float8_dtype)` with backward STE.
@@ -477,7 +509,7 @@ def _quantize_affine_no_dtype_cast(
         # with numel=0 which we handle by unifying the two
         zero_point = None
 
-    quant = torch.clamp(
+    quant = _ClampSTE.apply(
         _Round.apply(input * (1.0 / scale)) + zero_point, quant_min, quant_max
     )
     quant = quant.view(original_shape)
@@ -593,7 +625,9 @@ def _quantize_affine_tinygemm_no_dtype_cast(
 
     mid_point = (quant_max + quant_min + 1) / 2
     min_val = zero_point - scale * mid_point
-    quant = torch.clamp(_Round.apply((input - min_val) / scale), quant_min, quant_max)
+    quant = _ClampSTE.apply(
+        _Round.apply((input - min_val) / scale), quant_min, quant_max
+    )
     quant = quant.view(original_shape)
 
     return quant
@@ -706,7 +740,7 @@ def _quantize_affine_no_zero_point_no_dtype_cast(
         # with numel=0 which we handle by unifying the two
         zero_point = None
 
-    quant = torch.clamp(_Round.apply(input * (1.0 / scale)), quant_min, quant_max)
+    quant = _ClampSTE.apply(_Round.apply(input * (1.0 / scale)), quant_min, quant_max)
     quant = quant.view(original_shape)
 
     return quant


### PR DESCRIPTION
Summary:

D114609849 ("[autograd] Align clamp and min/max subgradients with dispatcher
schemas", PR #191142) changed clamp's boundary subgradient from pass-through to
zero -- `where(self >= min, grad, 0)` became `where(self > min, grad, 0)`.

For ordinary float tensors, landing exactly on the bound is measure-zero, so the
change is harmless. Fake quantization breaks that assumption: it clamps ROUNDED
values against INTEGER bounds,

    quant = torch.clamp(_Round.apply(input * (1.0 / scale)), quant_min, quant_max)

so every saturated element is exactly equal to quant_min or quant_max. The change
therefore zeroes the gradient across the whole saturated tail, silently disabling
the straight-through estimator that QAT depends on. There is no error -- training
simply diverges thousands of steps later.

This adds _ClampSTE, a clamp whose backward restores the previous >= / <=
semantics, and uses it at the three fake-quant quantize sites. Forward values are
bit-identical; only the boundary gradient differs.

Scope note: this fixes the torchao fake-quant call sites so QAT users are
unblocked. It does not change clamp itself -- the broader question of whether the
new subgradient should stand, and what QAT should rely on long term, is tracked in
T285341027 with the PyTorch autograd owners.

Root-caused by a 9-run bisect (see T285341027). Discriminator is the number of
logged steps with gnorm > 1.0 over steps 1400-1700, n=31, on a 1B llama4_mini comms
QAT LoRA SFT job, single variable = base revision:

  7/31 (x2)                     0 excursions, max 0.026 / 0.027   GOOD
  8/02                          0 excursions, max 0.028           GOOD
  8/03                          5 excursions, max 7.695           BAD
  8/03 w/ rlformers reverted    7 excursions, max 29.262          BAD  (not app code)
  8/02 w/ caffe2/torch @ 8/03   1 excursion,  max 2.917           BAD  (torch owns it)
  8/03 w/ ONLY D114609849 rev.  0 excursions, max 0.030           GOOD (confirms)

Differential Revision: D116512011


