### PR TITLE
[CI] Speed up PT2E CPU tests with xdist

### DIFF
--- a/.github/workflows/regression_test_pt2e_cpu.yml
+++ b/.github/workflows/regression_test_pt2e_cpu.yml
@@ -66,6 +66,6 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        # Use a conservative worker count: these tests launch Inductor/C++
-        # compilers, so using every available CPU would oversubscribe the runner.
-        pytest test/quantization/pt2e --verbose -n 2 --dist=worksteal --durations=25
+        # Bound the worker count: these tests launch Inductor/C++ compilers,
+        # so using every available CPU could oversubscribe the runner.
+        pytest test/quantization/pt2e --verbose -n 4 --dist=worksteal --durations=25

--- a/.github/workflows/regression_test_pt2e_cpu.yml
+++ b/.github/workflows/regression_test_pt2e_cpu.yml
@@ -66,5 +66,6 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        # Run the full PT2E suite, including the slow x86 Inductor tests.
-        pytest test/quantization/pt2e --verbose -s
+        # Use a conservative worker count: these tests launch Inductor/C++
+        # compilers, so using every available CPU would oversubscribe the runner.
+        pytest test/quantization/pt2e --verbose -n 2 --dist=worksteal --durations=25

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 # Test utilities
 pytest==9.0.3
+pytest-xdist==3.8.0
 unittest-xml-reporting
 parameterized
 packaging

--- a/test/quantization/pt2e/test_graph_utils.py
+++ b/test/quantization/pt2e/test_graph_utils.py
@@ -121,14 +121,18 @@ class TestGraphUtils(TestCase):
             *copy.deepcopy(example_inputs),
             aten_graph=True,
         )
-        customized_equivalent_types = get_equivalent_types()
+        original_equivalent_types = copy.deepcopy(get_equivalent_types())
+        customized_equivalent_types = copy.deepcopy(original_equivalent_types)
         customized_equivalent_types.append({torch.nn.ReLU6, torch.nn.functional.relu6})
-        update_equivalent_types_dict(customized_equivalent_types)
-        fused_partitions = find_sequential_partitions(
-            m,
-            [torch.nn.Conv2d, torch.nn.ReLU6],
-        )
-        self.assertEqual(len(fused_partitions), 1)
+        try:
+            update_equivalent_types_dict(customized_equivalent_types)
+            fused_partitions = find_sequential_partitions(
+                m,
+                [torch.nn.Conv2d, torch.nn.ReLU6],
+            )
+            self.assertEqual(len(fused_partitions), 1)
+        finally:
+            update_equivalent_types_dict(original_equivalent_types)
 
     @unittest.skipIf(IS_WINDOWS, "torch.compile is not supported on Windows")
     def test_collect_producer_nodes_no_placeholder(self):

--- a/test/quantization/pt2e/test_learnable_fake_quantize.py
+++ b/test/quantization/pt2e/test_learnable_fake_quantize.py
@@ -754,7 +754,9 @@ class TestLearnableFakeQuantizeComparison(TestCase):
             torch_types, float_types, devices
         ):
             with self.subTest(
-                torch_type=torch_type, float_type=float_type, device=device
+                torch_type=str(torch_type),
+                float_type=str(float_type),
+                device=str(device),
             ):
                 X = torch.randn(3, 3, device=device).to(float_type)
                 scale = (10 * torch.randn(1, device=device)).abs().item()


### PR DESCRIPTION
## Summary

- run the dedicated PT2E CPU suite with four pytest-xdist workers and work-stealing scheduling
- include the 25 slowest test durations in each workflow log for follow-up optimization
- restore the graph-equivalence global state after the test that customizes it, preventing test-order leakage under xdist scheduling
- convert only the `subTest` labels to strings so xdist can serialize them; the dtype and device values used by the test are unchanged

Four workers are a bounded setting on the 16-vCPU runner. This avoids the unbounded compiler-process concurrency of `-n auto` while using the headroom confirmed by the four-worker CI run.

## CI speed confirmation

The worker count was measured at serial, two-worker, and four-worker settings:

- The [serial baseline](https://github.com/pytorch/ao/actions/runs/32376088163) ran commit `08f8d490ab566553dadb74de1e8430f156da42bc`.
- The [two-worker run](https://github.com/pytorch/ao/actions/runs/32410423588) tested PR head `e45866dee33d0a7761bc84905713c5f2253e0ed7` merged into that exact baseline commit.
- The [four-worker run](https://github.com/pytorch/ao/actions/runs/32520380355) tested PR head `93784ad350f99623303780c246036ec9920c12df`. Its merge base had advanced by two commits, but those commits modify only unrelated CUDA/MoE files (`mxfp8_quantize.cuh` and `cute_utils.py`), not PT2E CPU tests, this workflow, or its dependencies.
- All runs used the same `linux.4xlarge` runner class and CPU Nightly/CPU 2.13 matrix configurations. They used separate runner instances, so normal CI variance still applies.
- The workflow still targets the complete `test/quantization/pt2e` directory and adds no selection, ignore, or skip filters. Removing `-s` changes output capture only; xdist and duration flags change scheduling and reporting, not test selection.
- Pytest elapsed time comes from each job's final pytest summary line. Full-job elapsed time comes from the GitHub Actions job `startedAt` and `completedAt` timestamps.

| Environment | Metric | Serial | 2 workers | 4 workers | 4-worker reduction vs serial | 4-worker reduction vs 2 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| CPU Nightly | pytest | [1:18:59](https://github.com/pytorch/ao/actions/runs/32376088163/job/96447705469) | [0:41:22](https://github.com/pytorch/ao/actions/runs/32410423588/job/96559292858) | [0:20:19](https://github.com/pytorch/ao/actions/runs/32520380355/job/96891073406) | 74.3% | 50.9% |
| CPU Nightly | full job | 1:24:57 | 0:45:52 | 0:24:37 | 71.0% | 46.3% |
| CPU 2.13 | pytest | [1:12:50](https://github.com/pytorch/ao/actions/runs/32376088163/job/96447705710) | [0:38:13](https://github.com/pytorch/ao/actions/runs/32410423588/job/96559293033) | [0:19:55](https://github.com/pytorch/ao/actions/runs/32520380355/job/96891073495) | 72.7% | 47.9% |
| CPU 2.13 | full job | 1:18:34 | 0:42:55 | 0:24:14 | 69.2% | 43.5% |

All six measured jobs succeeded with the same test outcome counts: `538 passed, 74 skipped, 15 subtests passed`. The four-worker logs contain no OOM, worker-crash, compiler-resource, or timeout failures. This is one run per setting rather than a multi-run benchmark, but both matrix legs independently show that four workers approximately halve pytest time again relative to two workers.

## Validation

- [Four-worker PT2E CPU Nightly job](https://github.com/pytorch/ao/actions/runs/32520380355/job/96891073406): `538 passed, 74 skipped, 15 subtests passed` in `1219.53s (0:20:19)`
- [Four-worker PT2E CPU 2.13 job](https://github.com/pytorch/ao/actions/runs/32520380355/job/96891073495): `538 passed, 74 skipped, 15 subtests passed` in `1195.27s (0:19:55)`
- Four-worker full CI jobs completed successfully in `24:37` and `24:14`
- `python -m pip check`
- `git diff --check`