### PR TITLE
Fix _is_128_128_scaled false-positive on PerTensor-scaled 128x128 tensors

### DIFF
--- a/test/float8/test_inference_granularity_helpers.py
+++ b/test/float8/test_inference_granularity_helpers.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression test for https://github.com/pytorch/ao/issues/4089.
+
+`_is_128_128_scaled` used to infer "128x128 blockwise scaling" purely from
+`block_size == (128, 128)`. That's ambiguous: a `PerTensor`-granularity
+weight whose shape happens to be exactly 128x128 also gets `block_size ==
+(128, 128)` (one block spanning the whole tensor, from `get_block_size`),
+even though it was never blockwise-scaled. Downstream dispatch code
+(`torchao/quantization/quantize_/workflows/float8/float8_tensor.py`) uses
+`_is_128_128_scaled` to decide whether the *activation* tensor must be 1x128
+scaled, which then fails for a plain PerTensor-quantized activation - this is
+exactly the crash the issue reports for `ToyLinearModel`'s 128x128 linear.
+
+These tests exercise `_is_128_128_scaled`/`_is_tensorwise_scaled` directly
+with plain CPU tensors carrying a `block_size` attribute (the only thing
+these helpers actually touch - no float8 dtype or GPU compute is involved),
+so they run happily in CPU-only CI.
+"""
+
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+from torchao.float8.inference import _is_128_128_scaled, _is_tensorwise_scaled
+
+
+def _with_block_size(shape, block_size):
+    t = torch.empty(shape)
+    t.block_size = block_size
+    return t
+
+
+class TestIs128128Scaled(TestCase):
+    def test_pertensor_128x128_is_not_128x128_scaled(self):
+        # PerTensor granularity on an exactly-128x128 tensor: get_block_size()
+        # returns the full tensor shape, i.e. (128, 128) - same numbers as
+        # genuine 128x128 blockwise scaling, but semantically PerTensor.
+        x = _with_block_size((128, 128), [128, 128])
+        self.assertTrue(_is_tensorwise_scaled(x))
+        self.assertFalse(_is_128_128_scaled(x))
+
+    def test_genuine_128x128_blockwise_on_larger_tensor_is_detected(self):
+        # A 256x256 tensor tiled into 128x128 blocks is unambiguous: block_size
+        # (128, 128) does *not* equal the full (256, 256) shape, so it can only
+        # mean blockwise scaling.
+        x = _with_block_size((256, 256), [128, 128])
+        self.assertFalse(_is_tensorwise_scaled(x))
+        self.assertTrue(_is_128_128_scaled(x))
+
+    def test_non_128_128_block_size_is_not_128x128_scaled(self):
+        x = _with_block_size((256, 256), [1, 256])  # rowwise
+        self.assertFalse(_is_128_128_scaled(x))
+
+    def test_pertensor_non_128_shape_is_not_128x128_scaled(self):
+        # Sanity check: PerTensor on a shape that isn't 128x128 was already
+        # correctly excluded before this fix (included for completeness).
+        x = _with_block_size((64, 64), [64, 64])
+        self.assertTrue(_is_tensorwise_scaled(x))
+        self.assertFalse(_is_128_128_scaled(x))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torchao/float8/inference.py
+++ b/torchao/float8/inference.py
@@ -210,6 +210,14 @@ def _is_128_128_scaled(x: torch.Tensor) -> bool:
         x: quantized tensor (should have `block_size` attribute)
     """
     assert hasattr(x, "block_size"), "Expecting input to have `block_size` attribute"
+    # `block_size == (128, 128)` alone is ambiguous: a `PerTensor`-granularity
+    # tensor whose shape happens to be exactly 128x128 also has block_size
+    # (128, 128) (one block spanning the whole tensor), even though it wasn't
+    # created with 128x128 blockwise scaling. Exclude that case explicitly so
+    # a 128x128 PerTensor-scaled tensor isn't misidentified as blockwise-scaled
+    # (see https://github.com/pytorch/ao/issues/4089).
+    if _is_tensorwise_scaled(x):
+        return False
     b = x.block_size
     return len(b) == 2 and b[0] == 128 and b[1] == 128
 


### PR DESCRIPTION
## Summary
`_is_128_128_scaled` (torchao/float8/inference.py) inferred "128x128 blockwise scaling" purely from `block_size == (128, 128)`. That's ambiguous: `get_block_size()` gives a `PerTensor`-granularity tensor a `block_size` equal to its full shape, so a weight whose shape happens to be exactly 128x128 also gets `block_size == (128, 128)`, even though it was never blockwise-scaled.

`Float8DynamicActivationFloat8WeightConfig()`'s dispatch (`quantize_/workflows/float8/float8_tensor.py`) uses `_is_128_128_scaled` to decide whether the activation tensor must be 1x128 scaled. For a 128x128 `PerTensor`-quantized linear this misfires and requires a plain per-tensor-quantized activation to be 1x128 scaled instead, breaking inference:

```python
from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_

model = ToyLinearModel()  # contains 128x128 linear
config = Float8DynamicActivationFloat8WeightConfig()  # default PerTensor granularity
quantize_(model, config)  # -> breaks test_workflow_e2e_numerics
```

One of the four call sites (the `KernelPreference.AUTO` mslk-selection check) already worked around this ambiguity with an extra `and not _is_tensorwise_scaled(weight_tensor)` check; the other three (including the one that actually causes the reported failure, at the `_is_128_128_scaled(weight_tensor)` branch that decides between the blockwise GEMM path and the normal `addmm_float8_unwrapped_inference` path) did not.

## Fix
Move that exclusion into `_is_128_128_scaled` itself, so every call site gets it consistently (the now-redundant explicit check at the one site that already had it was left as-is, to keep this diff minimal).

## Test
Added `test/float8/test_inference_granularity_helpers.py`, which exercises `_is_128_128_scaled`/`_is_tensorwise_scaled` directly against plain CPU tensors carrying a `block_size` attribute (the only thing these helpers actually touch — no float8 dtype or GPU compute is involved, so this runs on CPU-only CI):
- A 128x128 tensor with `block_size == (128, 128)` (matching its full shape, i.e. `PerTensor`) is no longer misidentified as 128x128-blockwise.
- A 256x256 tensor tiled into 128x128 blocks (`block_size == (128, 128)` but the tensor's full shape is `(256, 256)`) is still correctly identified as 128x128-blockwise.
- Verified the first assertion fails against the unpatched code (reproduces the reported bug) and passes with the fix.

Fixes #4089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
