### PR TITLE
Add scale/zero_point dimension validation to quant_primitives

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -625,8 +625,66 @@ class TestQuantPrimitives(unittest.TestCase):
 
         # block_size and scale/zero_point shape mismatch
         block_size = (1, 1)
-        with self.assertRaisesRegex(RuntimeError, "is invalid for input of size 1"):
+        with self.assertRaisesRegex(RuntimeError, "Expected `scale` to have"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
+
+    def test_scale_zero_point_dimension_validation(self):
+        """Regression test for https://github.com/pytorch/ao/issues/4538.
+
+        `quantize_affine`/`dequantize_affine` should raise a clear error that
+        names `scale`/`zero_point` and the expected element count when they're
+        incompatible with `block_size`, instead of a generic RuntimeError from
+        an internal `.view()` call.
+        """
+        input = torch.randn(10, 10)
+        dtype = torch.int8
+        block_size = (1, 1)  # one scale/zero_point per element -> 100 expected
+
+        # scale has too few elements
+        bad_scale = torch.tensor([1.0])
+        good_zero_point = torch.zeros(10, 10, dtype=torch.int32)
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected `scale` to have 100 elements"
+        ):
+            quantize_affine(input, block_size, bad_scale, good_zero_point, dtype)
+
+        # zero_point has too few elements (scale is fine)
+        good_scale = torch.ones(10, 10)
+        bad_zero_point = torch.zeros(1, dtype=torch.int32)
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected `zero_point` to have 100 elements"
+        ):
+            quantize_affine(input, block_size, good_scale, bad_zero_point, dtype)
+
+        # same validation applies on the dequantize path
+        q = quantize_affine(input, block_size, good_scale, good_zero_point, dtype)
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected `scale` to have 100 elements"
+        ):
+            dequantize_affine(q, block_size, bad_scale, good_zero_point, dtype)
+
+        # correctly-shaped scale/zero_point still works (no false positive)
+        quantize_affine(input, block_size, good_scale, good_zero_point, dtype)
+        dequantize_affine(q, block_size, good_scale, good_zero_point, dtype)
+
+        # groupwise (non-degenerate) block_size also validated correctly
+        group_block_size = (1, 5)
+        good_group_scale = torch.randn(10, 2)
+        good_group_zero_point = torch.zeros(10, 2, dtype=torch.int32)
+        quantize_affine(
+            input, group_block_size, good_group_scale, good_group_zero_point, dtype
+        )
+        bad_group_scale = torch.randn(10, 3)  # wrong number of groups
+        with self.assertRaisesRegex(
+            RuntimeError, r"Expected `scale` to have 20 elements"
+        ):
+            quantize_affine(
+                input,
+                group_block_size,
+                bad_group_scale,
+                good_group_zero_point,
+                dtype,
+            )
 
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -328,6 +328,43 @@ def _get_reduction_params(block_size, input_size):
     return shape_for_reduction, reduction_dims
 
 
+def _validate_scale_zero_point(
+    scale: torch.Tensor,
+    zero_point: Optional[torch.Tensor],
+    block_size: Union[List[int], Tuple[int, ...]],
+    input_size: torch.Size,
+    shape_after_reduction: List[int],
+) -> None:
+    """Validate that `scale` (and `zero_point`, if present) have the number of
+    elements implied by `block_size` for a tensor of `input_size`, i.e. one
+    scale/zero_point per block. Without this, a shape mismatch instead surfaces
+    as a generic `RuntimeError` from the `.view(shape_after_reduction)` calls
+    that immediately follow, e.g. "shape '[10, 10]' is invalid for input of
+    size 1", which doesn't point at the actual cause.
+    """
+    expected_numel = math.prod(shape_after_reduction)
+    torch._check(
+        scale.numel() == expected_numel,
+        lambda: (
+            f"Expected `scale` to have {expected_numel} elements (one per "
+            f"block) for input of size {list(input_size)} and block_size "
+            f"{list(block_size)}, but got {scale.numel()} elements with shape "
+            f"{list(scale.shape)}"
+        ),
+    )
+    if zero_point is not None and zero_point.numel() > 0:
+        torch._check(
+            zero_point.numel() == expected_numel,
+            lambda: (
+                f"Expected `zero_point` to have {expected_numel} elements "
+                f"(one per block) for input of size {list(input_size)} and "
+                f"block_size {list(block_size)}, but got "
+                f"{zero_point.numel()} elements with shape "
+                f"{list(zero_point.shape)}"
+            ),
+        )
+
+
 @torch.no_grad()
 def quantize_affine(
     input: torch.Tensor,
@@ -450,8 +487,6 @@ def _quantize_affine_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale and zero_point with zero_point_domain = INT
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
     assert input.dtype in [
         torch.float32,
         torch.float16,
@@ -468,6 +503,9 @@ def _quantize_affine_no_dtype_cast(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     if zero_point is not None and zero_point.numel() > 0:
@@ -564,8 +602,6 @@ def _quantize_affine_tinygemm_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale and zero_point with zero_point_domain = FLOAT
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
     assert input.dtype in [
         torch.float32,
         torch.float16,
@@ -582,6 +618,9 @@ def _quantize_affine_tinygemm_no_dtype_cast(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     if zero_point is not None and zero_point.numel() > 0:
@@ -679,8 +718,6 @@ def _quantize_affine_no_zero_point_no_dtype_cast(
     2. Quantize the input based on the quantization parameters scale with zero_point_domain = NONE
     3. Reshape the quantized result to original shape
     """
-    # TODO: validations
-    # TODO: validate scale/zero_point dimensions are compatible with block_size
     assert input.dtype in [
         torch.float32,
         torch.float16,
@@ -697,6 +734,9 @@ def _quantize_affine_no_zero_point_no_dtype_cast(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     if zero_point is not None and zero_point.numel() > 0:
@@ -844,6 +884,9 @@ def _dequantize_affine_no_dtype_check(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     if zero_point is not None:
@@ -901,6 +944,9 @@ def _dequantize_affine_no_zero_point_no_dtype_check(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     assert zero_point is None, (
@@ -990,6 +1036,9 @@ def _dequantize_affine_tinygemm_no_dtype_check(
     shape_after_reduction = shape_for_reduction
     for i in reduction_dims:
         shape_after_reduction[i] = 1
+    _validate_scale_zero_point(
+        scale, zero_point, block_size, original_shape, shape_after_reduction
+    )
     scale = scale.view(shape_after_reduction)
 
     if zero_point is not None:


### PR DESCRIPTION
## Summary
The low-level affine quantization/dequantization primitives in `torchao/quantization/quant_primitives.py` didn't validate that `scale`/`zero_point`'s element count matches what `block_size` implies for the input shape, despite explicit `# TODO: validate scale/zero_point dimensions are compatible with block_size` comments at all six call sites. A mismatch instead surfaced as a generic `RuntimeError` from the internal `.view(shape_after_reduction)` call that immediately follows:

```python
import torch
from torchao.quantization.quant_primitives import quantize_affine

input_tensor = torch.randn(10, 10)
scale = torch.tensor([1.0])  # expects 100 elements for block_size=(1, 1)
zero_point = torch.tensor([0])
quantize_affine(input_tensor, (1, 1), scale, zero_point, torch.int8)
# RuntimeError: shape '[10, 10]' is invalid for input of size 1
```

which doesn't name `scale`/`zero_point` or say what was actually expected.

## Fix
Added a shared `_validate_scale_zero_point` helper and call it, right before the `.view()` calls, in all six functions the issue names: `_quantize_affine_no_dtype_cast`, `_quantize_affine_tinygemm_no_dtype_cast`, `_quantize_affine_no_zero_point_no_dtype_cast`, `_dequantize_affine_no_dtype_check`, `_dequantize_affine_no_zero_point_no_dtype_check`, and `_dequantize_affine_tinygemm_no_dtype_check`. It checks `scale` (and `zero_point`, when present) has exactly one element per block, and raises a message naming which of the two is wrong, the expected count, and the input shape/`block_size` that produced it:

```
RuntimeError: Expected `scale` to have 100 elements (one per block) for input of size [10, 10] and block_size [1, 1], but got 1 elements with shape [1]
```

## Test
Updated the existing `test_raises` (which asserted on the old generic message) and added `test_scale_zero_point_dimension_validation` in `test/quantization/test_quant_primitives.py`, covering:
- too-few `scale` elements
- too-few `zero_point` elements
- the same validation on the dequantize path
- correctly-shaped `scale`/`zero_point` still working (no false positive)
- a non-degenerate groupwise `block_size`

Ran the full existing `test/quantization/test_quant_primitives.py` suite plus `test/quantization/quantize_/workflows/int8/`, `test/quantization/test_observer.py`, and `test/quantization/pt2e/test_affine_fake_quantize.py` (all CPU-runnable callers of these primitives) — no regressions.

Fixes #4538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
