### PR TITLE
Fix _choose_qparams_affine collapsing to a scalar when block_size is all 1s

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -628,6 +628,52 @@ class TestQuantPrimitives(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "is invalid for input of size 1"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
 
+    def test_choose_qparams_affine_block_size_all_ones(self):
+        """Regression test for https://github.com/pytorch/ao/issues/3458.
+
+        `block_size` with every entry equal to 1 (e.g. `PerGroup(1)`) means
+        each element is its own block, so there's nothing to reduce over.
+        `_choose_qparams_affine` used to pass `dim=[]` (the resulting empty
+        `reduction_dims`) to `torch.amin`/`amax`, which -- like `dim=None` --
+        reduces over *all* dims instead of none, collapsing the per-element
+        min/max to a single scalar shared by the whole tensor and producing
+        a scale with 1 element instead of one per input element.
+        """
+        input = torch.randn(4, 8)
+        block_size = (1, 1)
+
+        scale, zero_point = choose_qparams_affine(
+            input,
+            MappingType.ASYMMETRIC,
+            block_size,
+            target_dtype=torch.int8,
+        )
+        # one scale/zero_point per input element, not a single shared scalar
+        self.assertEqual(scale.numel(), input.numel())
+        self.assertEqual(zero_point.numel(), input.numel())
+
+        # end to end: quantizing with these qparams should actually work,
+        # instead of raising the shape-mismatch RuntimeError from before
+        q = quantize_affine(
+            input, block_size, scale, zero_point, torch.int8
+        )
+        dq = dequantize_affine(
+            q, block_size, scale, zero_point, torch.int8
+        )
+        # per-element quantization (no grouping) should be near-lossless
+        self.assertTrue(torch.allclose(input, dq, atol=1e-1))
+
+        # keepdim=True path (used by IntxUnpackedToInt8Tensor.from_hp)
+        scale_kd, zero_point_kd = choose_qparams_affine(
+            input,
+            MappingType.ASYMMETRIC,
+            block_size,
+            target_dtype=torch.int8,
+            keepdim=True,
+        )
+        self.assertEqual(scale_kd.shape, input.shape)
+        self.assertEqual(zero_point_kd.shape, input.shape)
+
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)
         n_bit = 4

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -1531,8 +1531,20 @@ def _choose_qparams_affine(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=keepdim)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=keepdim)
+    if len(reduction_dims) == 0:
+        # `block_size` is 1 in every dim (e.g. `PerGroup(1)`), meaning every
+        # element is its own block, so there is nothing to reduce over: each
+        # output min/max is just that element. `torch.amin`/`amax` don't
+        # support expressing "reduce over zero dims" via `dim=[]` -- per
+        # their documented behavior (matching `dim=None`), an empty `dim`
+        # reduces over *all* dims instead, which would collapse this to a
+        # single scalar min/max shared by the whole tensor instead of one
+        # per element (see https://github.com/pytorch/ao/issues/3458).
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=keepdim)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=keepdim)
 
     min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
     max_val_pos = torch.max(max_val, torch.zeros_like(max_val))


### PR DESCRIPTION
## Summary
`PerGroup(1)` (and any `block_size` with every entry equal to 1) raises a `RuntimeError` instead of quantizing:

```python
config = IntxWeightOnlyConfig(torch.int4, PerGroup(1), mapping_type=MappingType.ASYMMETRIC)
quantize_(model, config)
...
RuntimeError: shape '[32, 32]' is invalid for input of size 1
```

**Root cause:** `block_size` all 1s means every element is its own block, so `_get_reduction_params` correctly returns an empty `reduction_dims` (there's nothing to reduce — each output min/max should just be that element). But `_choose_qparams_affine` then passes that empty list straight to `torch.amin(input, dim=reduction_dims, ...)`:

```python
>>> torch.amin(torch.randn(32, 32), dim=[], keepdim=True).shape
torch.Size([1, 1])
```

`torch.amin`/`amax` treat an empty `dim` the same as `dim=None` and reduce over *all* dims, not zero of them. That collapses the per-element min/max to a single scalar shared by the whole tensor, so `scale` ends up with 1 element instead of one per input element, and the later `scale.reshape(output_shape)`/`scale.view(shape_after_reduction)` calls raise.

## Fix
When `reduction_dims` is empty, skip the `amin`/`amax` call entirely and use the (already appropriately-shaped) input tensor directly as both `min_val` and `max_val` — there's nothing to reduce, so each element's min/max is itself.

## Test
Added `test_choose_qparams_affine_block_size_all_ones` to `test/quantization/test_quant_primitives.py`, verifying:
- `scale`/`zero_point` end up with one element per input element (not 1)
- `quantize_affine`/`dequantize_affine` actually work end to end with a `block_size` of all 1s and round-trip near-losslessly
- the `keepdim=True` path (used by `IntxUnpackedToInt8Tensor.from_hp`, which is what `PerGroup(1)` quantization actually goes through) produces correctly-shaped output

Verified this reproduces the issue's `RuntimeError` on the unpatched code and resolves it with the fix — the issue's own repro (`IntxWeightOnlyConfig(torch.int4, PerGroup(1), ...)` on a `ToyLinearModel`, run on CPU) now runs cleanly end to end. Also ran the full `test/quantization/quantize_/workflows/intx/test_intx_unpacked_to_int8_tensor.py` suite (229 tests) — no regressions.

Fixes #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
