### PR TITLE
Refactor MXTensor: Use  SwizzleType  enum for device-agnostic scale layout dispatch

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.utils import (
     is_MI300,
     is_MI350,
@@ -370,7 +370,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
     out = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -440,7 +440,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
     out_mx = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -494,7 +494,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
 
     with pytest.raises(AssertionError, match="wgrad_with_hp"):

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -8,8 +8,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
-from torchao.prototype.mx_formats.config import NoSwizzle
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.utils import (
     is_MI300,
     is_MI350,

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -9,7 +9,7 @@ import torch
 from torch.nn import functional as F
 
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
-from torchao.prototype.mx_formats.mx_tensor import SwizzleType
+from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.utils import (
     is_MI300,
     is_MI350,
@@ -371,7 +371,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=SwizzleType.NO_SWIZZLE,
+        swizzle_type=NoSwizzle(),
     )
     out = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -441,7 +441,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=SwizzleType.NO_SWIZZLE,
+        swizzle_type=NoSwizzle(),
     )
     out_mx = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -495,7 +495,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=SwizzleType.NO_SWIZZLE,
+        swizzle_type=NoSwizzle(),
     )
 
     with pytest.raises(AssertionError, match="wgrad_with_hp"):

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
 from torchao.utils import (
     is_MI300,
     is_MI350,
@@ -370,7 +370,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NoSwizzle(),
+        swizzle_type=NO_SWIZZLE(),
     )
     out = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -440,7 +440,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NoSwizzle(),
+        swizzle_type=NO_SWIZZLE(),
     )
     out_mx = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -494,7 +494,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        swizzle_type=NoSwizzle(),
+        swizzle_type=NO_SWIZZLE(),
     )
 
     with pytest.raises(AssertionError, match="wgrad_with_hp"):

--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -9,6 +9,7 @@ import torch
 from torch.nn import functional as F
 
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.mx_tensor import SwizzleType
 from torchao.utils import (
     is_MI300,
     is_MI350,
@@ -370,7 +371,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
     out = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -440,7 +441,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
     out_mx = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -494,7 +495,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
 
     with pytest.raises(AssertionError, match="wgrad_with_hp"):

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -10,9 +10,9 @@ from contextlib import contextmanager
 import pytest
 import torch
 import torch.nn as nn
-from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torch.profiler import ProfilerActivity, profile
 
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 from torch.profiler import ProfilerActivity, profile
 
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,
@@ -109,7 +109,7 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
-        swizzle_type=NO_SWIZZLE() if device == "xpu" else SWIZZLE_32_4_4(),
+        swizzle_type=NoSwizzle() if device == "xpu" else Swizzle_32_4_4(),
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 import pytest
 import torch
 import torch.nn as nn
-from torch.nn.functional import SwizzleType
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torch.profiler import ProfilerActivity, profile
 
 from torchao.prototype.mx_formats.inference_workflow import (
@@ -109,9 +109,7 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
-        swizzle_type=SwizzleType.NO_SWIZZLE
-        if device == "xpu"
-        else SwizzleType.SWIZZLE_32_4_4,
+        swizzle_type=NoSwizzle() if device == "xpu" else Swizzle_32_4_4(),
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 from torch.profiler import ProfilerActivity, profile
 
-from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,
@@ -109,7 +109,7 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
-        swizzle_type=NoSwizzle() if device == "xpu" else Swizzle_32_4_4(),
+        swizzle_type=NO_SWIZZLE() if device == "xpu" else SWIZZLE_32_4_4(),
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -453,8 +453,9 @@ def test_grouped_mm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, GroupedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, GroupedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"
@@ -513,8 +514,9 @@ def test_bmm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, BatchedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, BatchedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn.functional import SwizzleType
 from torch.profiler import ProfilerActivity, profile
 
 from torchao.prototype.mx_formats.inference_workflow import (
@@ -57,7 +58,10 @@ def cuda_kernel_profiler(kernel_pattern):
     result["found"] = any(kernel_pattern in name for name in kernel_names)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -79,21 +83,22 @@ def test_inference_workflow_mx(
     """
     Smoke test for inference compile
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
-    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2) and device == "cuda":
         if not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
         elif not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp8 gemm")
-    elif elem_dtype == torch.float4_e2m1fn_x2:
+    elif elem_dtype == torch.float4_e2m1fn_x2 and device == "cuda":
         if not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
 
-    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device=device)
     m_mx = copy.deepcopy(m)
 
     if emulate:
@@ -104,12 +109,15 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
+        swizzle_type=SwizzleType.NO_SWIZZLE
+        if device == "xpu"
+        else SwizzleType.SWIZZLE_32_4_4,
     )
     quantize_(m_mx, config=config)
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True)
 
-    x = torch.randn(128, 32, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(128, 32, device=device, dtype=torch.bfloat16)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -16,8 +16,19 @@ from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
 
-def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
+def _mxfp4_scaled_mm(
+    a_data, b_data, a_scale, b_scale, swizzle=SwizzleType.SWIZZLE_32_4_4
+):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
+    match swizzle:
+        case SwizzleType.NO_SWIZZLE:
+            a_scale_block = a_scale.contiguous()
+            b_scale_block = b_scale.contiguous()
+        case SwizzleType.SWIZZLE_32_4_4:
+            a_scale_block = to_blocked(a_scale)
+            b_scale_block = to_blocked(b_scale)
+        case _:
+            raise ValueError(f"Unsupported swizzle type: {swizzle}")
     return F.scaled_mm(
         a_data.view(torch.float4_e2m1fn_x2),
         b_data.view(torch.float4_e2m1fn_x2),
@@ -25,29 +36,48 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
         scale_recipe_a=ScalingType.BlockWise1x32,
         scale_b=b_scale_block,
         scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_a=swizzle,
+        swizzle_b=swizzle,
         output_dtype=torch.bfloat16,
+    )
+
+
+def _mxfp8_scaled_mm(
+    a_data, b_data, a_scale, b_scale, swizzle=SwizzleType.SWIZZLE_32_4_4
+):
+    """Wrapper for torch._scaled_mm with MXFP8 configuration."""
+    match swizzle:
+        case SwizzleType.NO_SWIZZLE:
+            a_scale_block = a_scale.contiguous()
+            b_scale_block = b_scale.t().contiguous()
+        case SwizzleType.SWIZZLE_32_4_4:
+            a_scale_block = to_blocked(a_scale)
+            b_scale_block = to_blocked(b_scale)
+        case _:
+            raise ValueError(f"Unsupported swizzle type: {swizzle}")
+    return torch._scaled_mm(
+        a_data,
+        b_data,
+        a_scale_block,
+        b_scale_block,
+        out_dtype=torch.bfloat16,
     )
 
 
 def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    is_xpu = device == "xpu"
+    swizzle = SwizzleType.NO_SWIZZLE if device == "xpu" else SwizzleType.SWIZZLE_32_4_4
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
 
-    if is_xpu:
-        mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-    else:
-        mx_func = (
-            partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-            if format == "fp8"
-            else _mxfp4_scaled_mm
-        )
+    mx_func = (
+        partial(_mxfp8_scaled_mm, swizzle=swizzle)
+        if format == "fp8"
+        else partial(_mxfp4_scaled_mm, swizzle=swizzle)
+    )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -60,26 +90,11 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    if is_xpu:
-        a_scale_block = a_scale.contiguous()
-        b_scale_block = b_scale.t().contiguous()
-    else:
-        a_scale_block = to_blocked(a_scale)
-        b_scale_block = to_blocked(b_scale)
-
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
 
-    if is_xpu and format == "fp4":
-        out = mx_func(
-            a_data.view(torch.float4_e2m1fn_x2),
-            b_data.view(torch.float4_e2m1fn_x2),
-            a_scale_block,
-            b_scale_block,
-        )
-    else:
-        out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+    out = mx_func(a_data, b_data, a_scale, b_scale)
 
     return compute_error(out_hp, out).item()
 

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -31,19 +31,23 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
     )
 
 
-def run_matrix_test(M: int, K: int, N: int, format) -> float:
+def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    device = torch.device("cuda")
+    is_xpu = device == "xpu"
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
-    mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
-        if format == "fp8"
-        else _mxfp4_scaled_mm
-    )
+
+    if is_xpu:
+        mx_func = partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+    else:
+        mx_func = (
+            partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+            if format == "fp8"
+            else _mxfp4_scaled_mm
+        )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
     b_mx = MXTensor.to_mx(b, fmt, 32)
@@ -56,20 +60,37 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
+    if is_xpu:
+        a_scale_block = a_scale.contiguous()
+        b_scale_block = b_scale.t().contiguous()
+    else:
+        a_scale_block = to_blocked(a_scale)
+        b_scale_block = to_blocked(b_scale)
 
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+
+    if is_xpu and format == "fp4":
+        out = mx_func(
+            a_data.view(torch.float4_e2m1fn_x2),
+            b_data.view(torch.float4_e2m1fn_x2),
+            a_scale_block,
+            b_scale_block,
+        )
+    else:
+        out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
 
     return compute_error(out_hp, out).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -90,8 +111,9 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):
+    device = torch.accelerator.current_accelerator().type
     M, K, N = size
-    sqnr = run_matrix_test(M, K, N, format)
+    sqnr = run_matrix_test(M, K, N, format, device=device)
     threshold = 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -21,16 +21,25 @@ from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_100(), reason="needs CUDA capability 10.0+")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):
     """
     Ensure that only `import torchao.prototype.mx_formats` is needed to load MX
     and NV checkpoints.
     """
+    device = torch.accelerator.current_accelerator().type
+    if recipe_name == "nvfp4" and device == "xpu":
+        pytest.skip("NVFP4 is not supported on XPU")
 
-    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device=device)
     fname = None
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
         if recipe_name == "mxfp8":

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,
@@ -83,7 +83,8 @@ _ = torch.load('{fname}', weights_only=True)
     torch.cuda.is_available() and not is_sm_at_least_100(),
     reason="needs CUDA capability 10.0+",
 )
-def test_load_old_format_is_swizzled_scales():
+@pytest.mark.parametrize("old_is_swizzled", [False, True])
+def test_load_old_format_is_swizzled_scales(old_is_swizzled):
     """
     Regression test: load a state_dict saved with the old bool-based
     `is_swizzled_scales` field (both top-level MXTensor attribute and nested
@@ -95,26 +96,22 @@ def test_load_old_format_is_swizzled_scales():
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,
         kernel_preference=KernelPreference.EMULATED,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
     quantize_(m, config=config)
 
     # Save state_dict and manually patch to old format
     sd = m.state_dict()
+    expected_type = "Swizzle_32_4_4" if old_is_swizzled else "NoSwizzle"
     with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as f:
-        # Patch the MXTensor to simulate old format:
-        # Replace swizzle_type with is_swizzled_scales in tensor_attributes
         for key, val in sd.items():
             if isinstance(val, MXTensor):
                 # Patch act_quant_kwargs to old format
                 if val.act_quant_kwargs is not None:
                     old_kwargs = copy.copy(val.act_quant_kwargs)
-                    old_kwargs.__dict__["is_swizzled_scales"] = isinstance(
-                        old_kwargs.swizzle_type, SWIZZLE_32_4_4
-                    )
+                    old_kwargs.__dict__["is_swizzled_scales"] = old_is_swizzled
                     del old_kwargs.__dict__["swizzle_type"]
                     val.act_quant_kwargs = old_kwargs
-        # Save with pickle (bypass weights_only for patching)
         torch.save(sd, f.name)
         fname = f.name
 
@@ -122,12 +119,16 @@ def test_load_old_format_is_swizzled_scales():
     code = f"""
 import torch
 import torchao.prototype.mx_formats
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 sd = torch.load('{fname}', weights_only=True)
-# Verify act_quant_kwargs has swizzle_type after loading
 for k, v in sd.items():
     if hasattr(v, 'act_quant_kwargs') and v.act_quant_kwargs is not None:
-        assert hasattr(v.act_quant_kwargs, 'swizzle_type'), (
-            f"act_quant_kwargs missing swizzle_type after load: {{v.act_quant_kwargs.__dict__}}"
+        kw = v.act_quant_kwargs
+        assert hasattr(kw, 'swizzle_type'), (
+            f"act_quant_kwargs missing swizzle_type after load: {{kw.__dict__}}"
+        )
+        assert type(kw.swizzle_type).__name__ == '{expected_type}', (
+            f"Expected {{'{expected_type}'}}, got {{type(kw.swizzle_type).__name__}}"
         )
 print("OK")
 """
@@ -155,7 +156,7 @@ def test_load_old_format_top_level_is_swizzled_scales():
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,
         kernel_preference=KernelPreference.EMULATED,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
     quantize_(m, config=config)
 
@@ -178,7 +179,7 @@ def test_load_old_format_top_level_is_swizzled_scales():
     restored = MXTensor.__tensor_unflatten__(
         tensor_data, dict(old_attrs), weight.shape, None
     )
-    assert isinstance(restored.swizzle_type, NO_SWIZZLE)
+    assert isinstance(restored.swizzle_type, NoSwizzle)
 
     # Also test with is_swizzled_scales=True
     old_attrs_swizzled = dict(old_attrs)
@@ -186,4 +187,4 @@ def test_load_old_format_top_level_is_swizzled_scales():
     restored2 = MXTensor.__tensor_unflatten__(
         tensor_data, old_attrs_swizzled, weight.shape, None
     )
-    assert isinstance(restored2.swizzle_type, SWIZZLE_32_4_4)
+    assert isinstance(restored2.swizzle_type, Swizzle_32_4_4)

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import os
 import subprocess
 import tempfile
@@ -12,10 +13,12 @@ import pytest
 import torch
 import torch.nn as nn
 
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,
 )
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
@@ -70,3 +73,101 @@ _ = torch.load('{fname}', weights_only=True)
     subprocess_out = subprocess.run(["python"], input=code, text=True)
     os.remove(fname)
     assert subprocess_out.returncode == 0, "failed weights-only load"
+
+
+def test_load_old_format_is_swizzled_scales():
+    """
+    Regression test: load a state_dict saved with the old bool-based
+    `is_swizzled_scales` field (both top-level MXTensor attribute and nested
+    QuantizeTensorToMXKwargs). Verifies backward compat shims work.
+    """
+    # Create a quantized model using emulated kernels (no accelerator needed)
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device="cpu")
+    config = MXDynamicActivationMXWeightConfig(
+        activation_dtype=torch.float8_e4m3fn,
+        weight_dtype=torch.float8_e4m3fn,
+        kernel_preference=KernelPreference.EMULATED,
+        swizzle_type=NO_SWIZZLE(),
+    )
+    quantize_(m, config=config)
+
+    # Save state_dict and manually patch to old format
+    sd = m.state_dict()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as f:
+        # Patch the MXTensor to simulate old format:
+        # Replace swizzle_type with is_swizzled_scales in tensor_attributes
+        for key, val in sd.items():
+            if isinstance(val, MXTensor):
+                # Patch act_quant_kwargs to old format
+                if val.act_quant_kwargs is not None:
+                    old_kwargs = copy.copy(val.act_quant_kwargs)
+                    old_kwargs.__dict__["is_swizzled_scales"] = isinstance(
+                        old_kwargs.swizzle_type, SWIZZLE_32_4_4
+                    )
+                    del old_kwargs.__dict__["swizzle_type"]
+                    val.act_quant_kwargs = old_kwargs
+        # Save with pickle (bypass weights_only for patching)
+        torch.save(sd, f.name)
+        fname = f.name
+
+    # Load in a subprocess to prove weights_only loading works
+    code = f"""
+import torch
+import torchao.prototype.mx_formats
+sd = torch.load('{fname}', weights_only=True)
+# Verify act_quant_kwargs has swizzle_type after loading
+for k, v in sd.items():
+    if hasattr(v, 'act_quant_kwargs') and v.act_quant_kwargs is not None:
+        assert hasattr(v.act_quant_kwargs, 'swizzle_type'), (
+            f"act_quant_kwargs missing swizzle_type after load: {{v.act_quant_kwargs.__dict__}}"
+        )
+print("OK")
+"""
+    result = subprocess.run(["python"], input=code, text=True, capture_output=True)
+    os.remove(fname)
+    assert result.returncode == 0, f"Failed: {result.stderr}"
+
+
+def test_load_old_format_top_level_is_swizzled_scales():
+    """
+    Regression test: MXTensor.__tensor_unflatten__ converts old
+    is_swizzled_scales metadata to swizzle_type.
+    """
+    # Create MXTensor with emulated kernel
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device="cpu")
+    config = MXDynamicActivationMXWeightConfig(
+        activation_dtype=torch.float8_e4m3fn,
+        weight_dtype=torch.float8_e4m3fn,
+        kernel_preference=KernelPreference.EMULATED,
+        swizzle_type=NO_SWIZZLE(),
+    )
+    quantize_(m, config=config)
+
+    # Extract the MXTensor and manually reconstruct it via __tensor_unflatten__
+    # using the old metadata format (is_swizzled_scales instead of swizzle_type)
+    weight = m.weight
+    assert isinstance(weight, MXTensor)
+
+    tensor_data = {"qdata": weight.qdata, "scale": weight.scale}
+    old_attrs = {
+        "elem_dtype": weight.elem_dtype,
+        "block_size": weight.block_size,
+        "orig_dtype": weight.orig_dtype,
+        "kernel_preference": weight.kernel_preference,
+        "act_quant_kwargs": weight.act_quant_kwargs,
+        "is_swizzled_scales": False,  # old bool format
+    }
+
+    # This exercises the __tensor_unflatten__ backward compat shim
+    restored = MXTensor.__tensor_unflatten__(
+        tensor_data, dict(old_attrs), weight.shape, None
+    )
+    assert isinstance(restored.swizzle_type, NO_SWIZZLE)
+
+    # Also test with is_swizzled_scales=True
+    old_attrs_swizzled = dict(old_attrs)
+    old_attrs_swizzled["is_swizzled_scales"] = True
+    restored2 = MXTensor.__tensor_unflatten__(
+        tensor_data, old_attrs_swizzled, weight.shape, None
+    )
+    assert isinstance(restored2.swizzle_type, SWIZZLE_32_4_4)

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 import os
 import subprocess
 import tempfile
@@ -84,13 +83,16 @@ _ = torch.load('{fname}', weights_only=True)
     reason="needs CUDA capability 10.0+",
 )
 @pytest.mark.parametrize("old_is_swizzled", [False, True])
-def test_load_old_format_is_swizzled_scales(old_is_swizzled):
+def test_setstate_migrates_old_is_swizzled_scales(old_is_swizzled):
     """
-    Regression test: load a state_dict saved with the old bool-based
-    `is_swizzled_scales` field (both top-level MXTensor attribute and nested
-    QuantizeTensorToMXKwargs). Verifies backward compat shims work.
+    Regression: old checkpoints stored ``is_swizzled_scales: bool`` instead of
+    ``swizzle_type``.  We can't produce old-format files from current code, so
+    we call ``__setstate__`` directly with simulated old-format data (this is
+    the exact code path ``torch.load``).
     """
     device = torch.accelerator.current_accelerator().type
+    # NoSwizzle() is used here only to create valid tensor data for the test;
+    # the actual backward-compat migration is driven by old_is_swizzled below.
     m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
@@ -100,41 +102,36 @@ def test_load_old_format_is_swizzled_scales(old_is_swizzled):
     )
     quantize_(m, config=config)
 
-    # Save state_dict and manually patch to old format
-    sd = m.state_dict()
-    expected_type = "Swizzle_32_4_4" if old_is_swizzled else "NoSwizzle"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as f:
-        for key, val in sd.items():
-            if isinstance(val, MXTensor):
-                # Patch act_quant_kwargs to old format
-                if val.act_quant_kwargs is not None:
-                    old_kwargs = copy.copy(val.act_quant_kwargs)
-                    old_kwargs.__dict__["is_swizzled_scales"] = old_is_swizzled
-                    del old_kwargs.__dict__["swizzle_type"]
-                    val.act_quant_kwargs = old_kwargs
-        torch.save(sd, f.name)
-        fname = f.name
+    weight = m.weight
+    assert isinstance(weight, MXTensor)
 
-    # Load in a subprocess to prove weights_only loading works
-    code = f"""
-import torch
-import torchao.prototype.mx_formats
-from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
-sd = torch.load('{fname}', weights_only=True)
-for k, v in sd.items():
-    if hasattr(v, 'act_quant_kwargs') and v.act_quant_kwargs is not None:
-        kw = v.act_quant_kwargs
-        assert hasattr(kw, 'swizzle_type'), (
-            f"act_quant_kwargs missing swizzle_type after load: {{kw.__dict__}}"
-        )
-        assert type(kw.swizzle_type).__name__ == '{expected_type}', (
-            f"Expected {{'{expected_type}'}}, got {{type(kw.swizzle_type).__name__}}"
-        )
-print("OK")
-"""
-    result = subprocess.run(["python"], input=code, text=True, capture_output=True)
-    os.remove(fname)
-    assert result.returncode == 0, f"Failed: {result.stderr}"
+    # Build an old-format state dict (as torch.load would pass to __setstate__)
+    old_state = {
+        "qdata": weight.qdata,
+        "scale": weight.scale,
+        "elem_dtype": weight.elem_dtype,
+        "block_size": weight.block_size,
+        "orig_dtype": weight.orig_dtype,
+        "kernel_preference": weight.kernel_preference,
+        "act_quant_kwargs": weight.act_quant_kwargs,
+        "is_swizzled_scales": old_is_swizzled,  # old bool field
+    }
+
+    # Create a shell MXTensor and apply __setstate__ (simulates torch.load path)
+    shell = torch.Tensor._make_wrapper_subclass(
+        MXTensor,
+        weight.shape,
+        strides=weight.stride(),
+        dtype=weight.orig_dtype,
+        device=weight.device,
+    )
+    shell.__setstate__(old_state)
+
+    # Verify top-level migration
+    expected = Swizzle_32_4_4 if old_is_swizzled else NoSwizzle
+    assert isinstance(shell.swizzle_type, expected), (
+        f"Top-level: expected {expected.__name__}, got {type(shell.swizzle_type).__name__}"
+    )
 
 
 @pytest.mark.skipif(
@@ -145,12 +142,17 @@ print("OK")
     torch.cuda.is_available() and not is_sm_at_least_100(),
     reason="needs CUDA capability 10.0+",
 )
-def test_load_old_format_top_level_is_swizzled_scales():
+@pytest.mark.parametrize("old_is_swizzled", [False, True])
+def test_tensor_unflatten_migrates_old_is_swizzled_scales(old_is_swizzled):
     """
-    Regression test: MXTensor.__tensor_unflatten__ converts old
-    is_swizzled_scales metadata to swizzle_type.
+    Regression: old checkpoints stored ``is_swizzled_scales: bool`` instead of
+    ``swizzle_type``.  We can't produce old-format files from current code, so
+    we call ``__tensor_unflatten__`` directly with simulated old-format metadata
+    (this is the exact code path Dynamo tracing takes).
     """
     device = torch.accelerator.current_accelerator().type
+    # NoSwizzle() is used here only to create valid tensor data for the test;
+    # the actual backward-compat migration is driven by old_is_swizzled below.
     m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
@@ -160,8 +162,6 @@ def test_load_old_format_top_level_is_swizzled_scales():
     )
     quantize_(m, config=config)
 
-    # Extract the MXTensor and manually reconstruct it via __tensor_unflatten__
-    # using the old metadata format (is_swizzled_scales instead of swizzle_type)
     weight = m.weight
     assert isinstance(weight, MXTensor)
 
@@ -172,19 +172,11 @@ def test_load_old_format_top_level_is_swizzled_scales():
         "orig_dtype": weight.orig_dtype,
         "kernel_preference": weight.kernel_preference,
         "act_quant_kwargs": weight.act_quant_kwargs,
-        "is_swizzled_scales": False,  # old bool format
+        "is_swizzled_scales": old_is_swizzled,
     }
 
-    # This exercises the __tensor_unflatten__ backward compat shim
+    expected = Swizzle_32_4_4 if old_is_swizzled else NoSwizzle
     restored = MXTensor.__tensor_unflatten__(
         tensor_data, dict(old_attrs), weight.shape, None
     )
-    assert isinstance(restored.swizzle_type, NoSwizzle)
-
-    # Also test with is_swizzled_scales=True
-    old_attrs_swizzled = dict(old_attrs)
-    old_attrs_swizzled["is_swizzled_scales"] = True
-    restored2 = MXTensor.__tensor_unflatten__(
-        tensor_data, old_attrs_swizzled, weight.shape, None
-    )
-    assert isinstance(restored2.swizzle_type, Swizzle_32_4_4)
+    assert isinstance(restored.swizzle_type, expected)

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -75,14 +75,22 @@ _ = torch.load('{fname}', weights_only=True)
     assert subprocess_out.returncode == 0, "failed weights-only load"
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 def test_load_old_format_is_swizzled_scales():
     """
     Regression test: load a state_dict saved with the old bool-based
     `is_swizzled_scales` field (both top-level MXTensor attribute and nested
     QuantizeTensorToMXKwargs). Verifies backward compat shims work.
     """
-    # Create a quantized model using emulated kernels (no accelerator needed)
-    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device="cpu")
+    device = torch.accelerator.current_accelerator().type
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,
@@ -128,13 +136,21 @@ print("OK")
     assert result.returncode == 0, f"Failed: {result.stderr}"
 
 
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 def test_load_old_format_top_level_is_swizzled_scales():
     """
     Regression test: MXTensor.__tensor_unflatten__ converts old
     is_swizzled_scales metadata to swizzle_type.
     """
-    # Create MXTensor with emulated kernel
-    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device="cpu")
+    device = torch.accelerator.current_accelerator().type
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -15,7 +15,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.constants import (
     DTYPE_FP6_E2M3,
     DTYPE_FP6_E3M2,
@@ -589,7 +589,7 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        NO_SWIZZLE(),
+        NoSwizzle(),
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
@@ -1052,7 +1052,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        swizzle_type=SWIZZLE_32_4_4(),
+        swizzle_type=Swizzle_32_4_4(),
     )
 
     if transpose:

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -15,7 +15,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
-from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, SWIZZLE_32_4_4
 from torchao.prototype.mx_formats.constants import (
     DTYPE_FP6_E2M3,
     DTYPE_FP6_E3M2,
@@ -589,7 +589,7 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        NoSwizzle(),
+        NO_SWIZZLE(),
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
@@ -1052,7 +1052,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        swizzle_type=Swizzle_32_4_4(),
+        swizzle_type=SWIZZLE_32_4_4(),
     )
 
     if transpose:

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -12,6 +12,7 @@ import torch
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.nn.functional import SwizzleType
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
@@ -65,11 +66,15 @@ def test_e8m0_scale_to_reciprocal_fp32(monkeypatch, use_direct_cast):
     assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
-def test_e8m0_scale_to_reciprocal_fp32_cuda_fallback(monkeypatch, use_compile):
+def test_e8m0_scale_to_reciprocal_fp32_gpu_fallback(monkeypatch, use_compile):
+    device = torch.accelerator.current_accelerator().type
     monkeypatch.setattr(mx_tensor_module, "_TORCH_VERSION_AT_LEAST_2_14", False)
-    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device="cuda")
+    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device=device)
     convert = (
         torch.compile(_e8m0_scale_to_reciprocal_fp32, fullgraph=True)
         if use_compile
@@ -134,55 +139,78 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_realistic_numerics(elem_dtype, scale_calculation_mode):
-    data = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
-    data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
-    data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
 def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile):
-    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device=device)
     quantize = torch.compile(to_mx, fullgraph=True) if use_compile else to_mx
     scales, qdata = quantize(cases.inputs, torch.float8_e4m3fn, 32, scaling_mode)
     assert_mxfp8_semantics(qdata, scales, cases)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -431,15 +459,19 @@ def test_to_mx_rceil_fallback_nan_branch_is_cse_compatible(monkeypatch):
     assert nan_branches[0].args[0] == 0x7F800001
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
     If high precision block values has a NaN, the exponent block
     value is set to is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.tensor(
-        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device="cuda", dtype=torch.bfloat16
+        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
     block_size = 4
     tensor_mx = MXTensor.to_mx(tensor_hp, elem_dtype, block_size)
@@ -447,7 +479,10 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
     """
@@ -455,12 +490,13 @@ def test_all_nan_blocks(elem_dtype):
     - Mixed real + NaN: scale = NaN
     - All NaN: scale = NaN
     """
+    device = torch.accelerator.current_accelerator().type
     block_size = 4
 
     # Test case 1: Mixed NaN + real values
     mixed_tensor = torch.tensor(
         [float("nan"), 2.0, float("nan"), 4.0, 1.0, 3.0, 5.0, 2.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     mixed_mx = MXTensor.to_mx(mixed_tensor, elem_dtype, block_size)
@@ -476,7 +512,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 2: All NaN blocks (should return NaN scale)
     all_nan_tensor = torch.tensor(
         [float("nan"), float("nan"), float("nan"), float("nan"), 1.0, 2.0, 3.0, 4.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     all_nan_mx = MXTensor.to_mx(all_nan_tensor, elem_dtype, block_size)
@@ -502,7 +538,7 @@ def test_all_nan_blocks(elem_dtype):
             float("nan"),
             float("nan"),
         ],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     completely_nan_mx = MXTensor.to_mx(completely_nan_tensor, elem_dtype, block_size)
@@ -513,29 +549,33 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     scale_e8m0 = torch.tensor(
-        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device="cuda"
+        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
 
     block_size = 4
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device=device
         )  # noqa: E501
     elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
     elif elem_dtype == torch.float4_e2m1fn_x2:
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
         data_bits = pack_uint4(data_bits)
     else:
@@ -549,44 +589,56 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        False,
+        SwizzleType.NO_SWIZZLE,
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
     """
+    device = torch.accelerator.current_accelerator().type
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
-        tensor_hp = torch.randn(*s, device="cuda", dtype=torch.bfloat16)
+        tensor_hp = torch.randn(*s, device=device, dtype=torch.bfloat16)
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
 def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
     """
+    device = torch.accelerator.current_accelerator().type
     if B == 1 and elem_dtype == torch.float4_e2m1fn_x2:
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
         pytest.skip("unsupported configuration")
-    tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(B, device=device, dtype=torch.bfloat16)
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_round_trip():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -608,9 +660,13 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -626,9 +682,13 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -644,15 +704,19 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
+    device = torch.accelerator.current_accelerator().type
     M, K = 128, 256
     block_size = 32
-    tensor_hp = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         elem_dtype,
@@ -667,18 +731,26 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
-    x = torch.randn(1, 2, 4, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 def test_clone():
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
     data_mx_c = data_mx.clone()
@@ -690,7 +762,10 @@ def test_clone():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
@@ -698,16 +773,17 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
+    device = torch.accelerator.current_accelerator().type
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if torch.cuda.is_available() and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:
-        x = torch.randn(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.randn(*shape, dtype=hp_dtype, device=device)
     else:
-        x = torch.zeros(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.zeros(*shape, dtype=hp_dtype, device=device)
     block_size = 4
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
 
@@ -740,9 +816,12 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     torch.testing.assert_close(x_mx_dq, x_mx_c_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 def test_to_mx_inductor_single_kernel():
@@ -750,17 +829,24 @@ def test_to_mx_inductor_single_kernel():
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
-    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
     block_size = 32
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
     out, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
     FileCheck().check("def call(").check_count(".run(", 1, exactly=True).run(code[0])
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Need sm90+")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    reason="Need sm90+",
+)
 def test_index_select():
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
@@ -768,9 +854,10 @@ def test_index_select():
     a single 3D parameter when converting between model definitions that
     use 2D and 3D parameters for their expert weights.
     """
+    device = torch.accelerator.current_accelerator().type
 
     E, K, N = 128, 256, 512
-    x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
 
     x_mx_1 = x_mx[1]
@@ -779,9 +866,12 @@ def test_index_select():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
@@ -790,6 +880,7 @@ def test_index_select():
 )
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
+    device = torch.accelerator.current_accelerator().type
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -799,7 +890,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * max_val,
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # create example data outside the representable range
@@ -809,7 +900,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * (max_val * 2),
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # PyTorch core saturates finite-overflow e4m3fn casts as of
@@ -852,7 +943,10 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.accelerator.is_available():
+        device = torch.accelerator.current_accelerator().type
+    else:
+        device = "cpu"
 
     original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 
@@ -868,7 +962,10 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -878,12 +975,13 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -921,7 +1019,10 @@ def test_scale_shape_matches_qdata(transpose, shape):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", (torch.float8_e4m3fn, torch.float4_e2m1fn_x2))
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
@@ -932,12 +1033,13 @@ def test_scale_shape_matches_qdata(transpose, shape):
     ),
 )
 def test_swizzle(elem_dtype, transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         elem_dtype,
@@ -950,7 +1052,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        is_swizzled_scales=True,
+        swizzle_type=SwizzleType.SWIZZLE_32_4_4,
     )
 
     if transpose:
@@ -985,10 +1087,14 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -12,10 +12,10 @@ import torch
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
-from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.constants import (
     DTYPE_FP6_E2M3,
     DTYPE_FP6_E3M2,

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -12,7 +12,7 @@ import torch
 from torch._functorch.compile_utils import fx_graph_cse
 from torch._inductor.utils import run_and_get_code
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.nn.functional import SwizzleType
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
@@ -589,7 +589,7 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        SwizzleType.NO_SWIZZLE,
+        NoSwizzle(),
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
@@ -1052,7 +1052,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        swizzle_type=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_type=Swizzle_32_4_4(),
     )
 
     if transpose:

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,7 +1,7 @@
 import torch
 import torch.distributed as dist
 
-from torchao.prototype.mx_formats.config import NoSwizzle
+from torchao.prototype.mx_formats.config import NO_SWIZZLE
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
 
@@ -38,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=NoSwizzle(),
+        swizzle_type=NO_SWIZZLE(),
     )
 
     local_rank = torch.distributed.get_rank()
@@ -58,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=NoSwizzle(),
+        swizzle_type=NO_SWIZZLE(),
     )
 
     # Perform all_gather

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,7 +1,7 @@
 import torch
 import torch.distributed as dist
-from torch.nn.functional import SwizzleType
 
+from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
 
@@ -38,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=SwizzleType.NO_SWIZZLE,
+        swizzle_type=NoSwizzle(),
     )
 
     local_rank = torch.distributed.get_rank()
@@ -58,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=SwizzleType.NO_SWIZZLE,
+        swizzle_type=NoSwizzle(),
     )
 
     # Perform all_gather

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,7 +1,7 @@
 import torch
 import torch.distributed as dist
 
-from torchao.prototype.mx_formats.config import NO_SWIZZLE
+from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
 
@@ -38,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
 
     local_rank = torch.distributed.get_rank()
@@ -58,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        swizzle_type=NO_SWIZZLE(),
+        swizzle_type=NoSwizzle(),
     )
 
     # Perform all_gather

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,5 +1,6 @@
 import torch
 import torch.distributed as dist
+from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
@@ -37,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
 
     local_rank = torch.distributed.get_rank()
@@ -57,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=SwizzleType.NO_SWIZZLE,
     )
 
     # Perform all_gather

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -10,9 +10,8 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
 

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -142,7 +142,7 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=ctx.hp_dtype,
                 kernel_preference=None,
                 act_quant_kwargs=None,
-                swizzle_type=NO_SWIZZLE(),
+                swizzle_type=NoSwizzle(),
             )
         else:
             # BF16 backward path: Just do inverse all-to-all in bf16

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -12,7 +12,8 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType
+from torchao.prototype.mx_formats.config import NoSwizzle
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
 
 class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
@@ -142,7 +143,7 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=ctx.hp_dtype,
                 kernel_preference=None,
                 act_quant_kwargs=None,
-                swizzle_type=SwizzleType.NO_SWIZZLE,
+                swizzle_type=NoSwizzle(),
             )
         else:
             # BF16 backward path: Just do inverse all-to-all in bf16

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -142,7 +142,7 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=ctx.hp_dtype,
                 kernel_preference=None,
                 act_quant_kwargs=None,
-                swizzle_type=NoSwizzle(),
+                swizzle_type=NO_SWIZZLE(),
             )
         else:
             # BF16 backward path: Just do inverse all-to-all in bf16

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -12,7 +12,7 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType
 
 
 class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
@@ -142,7 +142,7 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=ctx.hp_dtype,
                 kernel_preference=None,
                 act_quant_kwargs=None,
-                is_swizzled_scales=False,
+                swizzle_type=SwizzleType.NO_SWIZZLE,
             )
         else:
             # BF16 backward path: Just do inverse all-to-all in bf16

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -10,9 +10,8 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
 

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -12,7 +12,8 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType
+from torchao.prototype.mx_formats.config import NoSwizzle
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
 
 class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
@@ -102,7 +103,7 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=input.dtype,
             kernel_preference=None,
             act_quant_kwargs=None,
-            swizzle_type=SwizzleType.NO_SWIZZLE,
+            swizzle_type=NoSwizzle(),
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -102,7 +102,7 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=input.dtype,
             kernel_preference=None,
             act_quant_kwargs=None,
-            swizzle_type=NoSwizzle(),
+            swizzle_type=NO_SWIZZLE(),
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -12,7 +12,7 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType
 
 
 class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
@@ -102,7 +102,7 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=input.dtype,
             kernel_preference=None,
             act_quant_kwargs=None,
-            is_swizzled_scales=False,
+            swizzle_type=SwizzleType.NO_SWIZZLE,
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import NO_SWIZZLE, ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -102,7 +102,7 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=input.dtype,
             kernel_preference=None,
             act_quant_kwargs=None,
-            swizzle_type=NO_SWIZZLE(),
+            swizzle_type=NoSwizzle(),
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -105,7 +105,7 @@ class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=mx_tensor.orig_dtype,
             kernel_preference=mx_tensor.kernel_preference,
             act_quant_kwargs=mx_tensor.act_quant_kwargs,
-            is_swizzled_scales=mx_tensor.is_swizzled_scales,
+            swizzle_type=mx_tensor.swizzle_type,
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/unpermute.py
+++ b/torchao/prototype/moe_training/ep/unpermute.py
@@ -96,7 +96,7 @@ class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=grad_output.orig_dtype,
                 kernel_preference=grad_output.kernel_preference,
                 act_quant_kwargs=grad_output.act_quant_kwargs,
-                is_swizzled_scales=grad_output.is_swizzled_scales,
+                swizzle_type=grad_output.swizzle_type,
             )
         else:
             # BF16 tensor path: permute directly

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -36,7 +36,8 @@ from torchao.prototype.mx_formats.kernels import (
     triton_mxfp8_dequant_dim0,
     triton_to_mxfp8_dim0,
 )
-from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType, to_mx
+from torchao.prototype.mx_formats.config import NoSwizzle
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference
 
@@ -519,7 +520,7 @@ def _compute_fwd_sm100(
             padded_input_act.qdata,
             padded_input_act.scale,
         )
-        if SwizzleType(padded_input_act.swizzle_type) == SwizzleType.NO_SWIZZLE:
+        if isinstance(padded_input_act.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 padded_input_act.scales, padded_group_end_offsets
@@ -619,7 +620,7 @@ def _compute_dgrad_sm100(
     # Quantize grad_output along dim0
     if isinstance(grad_output, MXTensor):
         grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
-        if SwizzleType(grad_output.swizzle_type) == SwizzleType.NO_SWIZZLE:
+        if isinstance(grad_output.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 grad_output.scales, group_end_offsets
@@ -1074,7 +1075,7 @@ def _validate_grouped_mm_input_act(
     assert input_act.block_size == block_size, (
         f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
     )
-    assert SwizzleType(input_act.swizzle_type) == SwizzleType.NO_SWIZZLE, (
+    assert isinstance(input_act.swizzle_type, NoSwizzle), (
         "MXTensor input scales must be unswizzled for grouped GEMM"
     )
     assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -25,8 +25,8 @@ from torchao.prototype.moe_training.utils import (
     unpad_token_groups,
 )
 from torchao.prototype.mx_formats.config import (
-    NO_SWIZZLE,
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.kernels import (
@@ -520,7 +520,7 @@ def _compute_fwd_sm100(
             padded_input_act.qdata,
             padded_input_act.scale,
         )
-        if isinstance(padded_input_act.swizzle_type, NO_SWIZZLE):
+        if isinstance(padded_input_act.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 padded_input_act.scales, padded_group_end_offsets
@@ -620,7 +620,7 @@ def _compute_dgrad_sm100(
     # Quantize grad_output along dim0
     if isinstance(grad_output, MXTensor):
         grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
-        if isinstance(grad_output.swizzle_type, NO_SWIZZLE):
+        if isinstance(grad_output.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 grad_output.scales, group_end_offsets
@@ -1075,7 +1075,7 @@ def _validate_grouped_mm_input_act(
     assert input_act.block_size == block_size, (
         f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
     )
-    assert isinstance(input_act.swizzle_type, NO_SWIZZLE), (
+    assert isinstance(input_act.swizzle_type, NoSwizzle), (
         "MXTensor input scales must be unswizzled for grouped GEMM"
     )
     assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -25,8 +25,8 @@ from torchao.prototype.moe_training.utils import (
     unpad_token_groups,
 )
 from torchao.prototype.mx_formats.config import (
+    NO_SWIZZLE,
     MXFP8Dim1CastKernelChoice,
-    NoSwizzle,
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.kernels import (
@@ -520,7 +520,7 @@ def _compute_fwd_sm100(
             padded_input_act.qdata,
             padded_input_act.scale,
         )
-        if isinstance(padded_input_act.swizzle_type, NoSwizzle):
+        if isinstance(padded_input_act.swizzle_type, NO_SWIZZLE):
             # Convert scales to blocked layout for SM100 kernels
             input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 padded_input_act.scales, padded_group_end_offsets
@@ -620,7 +620,7 @@ def _compute_dgrad_sm100(
     # Quantize grad_output along dim0
     if isinstance(grad_output, MXTensor):
         grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
-        if isinstance(grad_output.swizzle_type, NoSwizzle):
+        if isinstance(grad_output.swizzle_type, NO_SWIZZLE):
             # Convert scales to blocked layout for SM100 kernels
             grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 grad_output.scales, group_end_offsets
@@ -1075,7 +1075,7 @@ def _validate_grouped_mm_input_act(
     assert input_act.block_size == block_size, (
         f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
     )
-    assert isinstance(input_act.swizzle_type, NoSwizzle), (
+    assert isinstance(input_act.swizzle_type, NO_SWIZZLE), (
         "MXTensor input scales must be unswizzled for grouped GEMM"
     )
     assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -26,6 +26,7 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.kernels import (
@@ -36,7 +37,6 @@ from torchao.prototype.mx_formats.kernels import (
     triton_mxfp8_dequant_dim0,
     triton_to_mxfp8_dim0,
 )
-from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -36,7 +36,7 @@ from torchao.prototype.mx_formats.kernels import (
     triton_mxfp8_dequant_dim0,
     triton_to_mxfp8_dim0,
 )
-from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, SwizzleType, to_mx
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common import KernelPreference
 
@@ -519,7 +519,7 @@ def _compute_fwd_sm100(
             padded_input_act.qdata,
             padded_input_act.scale,
         )
-        if not padded_input_act.is_swizzled_scales:
+        if SwizzleType(padded_input_act.swizzle_type) == SwizzleType.NO_SWIZZLE:
             # Convert scales to blocked layout for SM100 kernels
             input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 padded_input_act.scales, padded_group_end_offsets
@@ -619,7 +619,7 @@ def _compute_dgrad_sm100(
     # Quantize grad_output along dim0
     if isinstance(grad_output, MXTensor):
         grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
-        if not grad_output.is_swizzled_scales:
+        if SwizzleType(grad_output.swizzle_type) == SwizzleType.NO_SWIZZLE:
             # Convert scales to blocked layout for SM100 kernels
             grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 grad_output.scales, group_end_offsets
@@ -1074,7 +1074,7 @@ def _validate_grouped_mm_input_act(
     assert input_act.block_size == block_size, (
         f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
     )
-    assert not input_act.is_swizzled_scales, (
+    assert SwizzleType(input_act.swizzle_type) == SwizzleType.NO_SWIZZLE, (
         "MXTensor input scales must be unswizzled for grouped GEMM"
     )
     assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
 from enum import Enum
 
 import torch
@@ -11,6 +12,30 @@ import torch
 from torchao.prototype.mx_formats.constants import SUPPORTED_ELEM_DTYPES
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
 from torchao.utils import register_as_pytree_constant
+
+
+@dataclass(frozen=True)
+class SwizzleGranularity:
+    """Base class for MX scale swizzle layout."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class NoSwizzle(SwizzleGranularity):
+    """Row-major scale layout (no swizzling)."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class Swizzle_32_4_4(SwizzleGranularity):
+    """32x4x4 blocked scale layout for NVIDIA Blackwell."""
+
+    pass
+
+
+torch.serialization.add_safe_globals([NoSwizzle, Swizzle_32_4_4])
 
 
 class MXFP8Dim0CastKernelChoice(Enum):

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -15,27 +15,27 @@ from torchao.utils import register_as_pytree_constant
 
 
 @dataclass(frozen=True)
-class SwizzleGranularity:
+class SwizzleType:
     """Base class for scale swizzle layout."""
 
     pass
 
 
 @dataclass(frozen=True)
-class NoSwizzle(SwizzleGranularity):
+class NO_SWIZZLE(SwizzleType):
     """No swizzling."""
 
     pass
 
 
 @dataclass(frozen=True)
-class Swizzle_32_4_4(SwizzleGranularity):
+class SWIZZLE_32_4_4(SwizzleType):
     """32x4x4 blocked scale layout for NVIDIA."""
 
     pass
 
 
-torch.serialization.add_safe_globals([NoSwizzle, Swizzle_32_4_4])
+torch.serialization.add_safe_globals([NO_SWIZZLE, SWIZZLE_32_4_4])
 
 
 class MXFP8Dim0CastKernelChoice(Enum):

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -16,21 +16,21 @@ from torchao.utils import register_as_pytree_constant
 
 @dataclass(frozen=True)
 class SwizzleGranularity:
-    """Base class for MX scale swizzle layout."""
+    """Base class for scale swizzle layout."""
 
     pass
 
 
 @dataclass(frozen=True)
 class NoSwizzle(SwizzleGranularity):
-    """Row-major scale layout (no swizzling)."""
+    """No swizzling."""
 
     pass
 
 
 @dataclass(frozen=True)
 class Swizzle_32_4_4(SwizzleGranularity):
-    """32x4x4 blocked scale layout for NVIDIA Blackwell."""
+    """32x4x4 blocked scale layout for NVIDIA."""
 
     pass
 

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -22,20 +22,20 @@ class SwizzleType:
 
 
 @dataclass(frozen=True)
-class NO_SWIZZLE(SwizzleType):
+class NoSwizzle(SwizzleType):
     """No swizzling."""
 
     pass
 
 
 @dataclass(frozen=True)
-class SWIZZLE_32_4_4(SwizzleType):
+class Swizzle_32_4_4(SwizzleType):
     """32x4x4 blocked scale layout for NVIDIA."""
 
     pass
 
 
-torch.serialization.add_safe_globals([NO_SWIZZLE, SWIZZLE_32_4_4])
+torch.serialization.add_safe_globals([NoSwizzle, Swizzle_32_4_4])
 
 
 class MXFP8Dim0CastKernelChoice(Enum):

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -15,7 +15,7 @@ from torch import Tensor
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import (
-    SWIZZLE_32_4_4,
+    Swizzle_32_4_4,
     SwizzleType,
     _validate_elem_dtype,
 )
@@ -116,8 +116,8 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
     # How to store block scales.
-    # CUDA uses SWIZZLE_32_4_4 (blocked layout), XPU uses NO_SWIZZLE.
-    swizzle_type: SwizzleType = SWIZZLE_32_4_4()
+    # CUDA uses Swizzle_32_4_4 (blocked layout), XPU uses NoSwizzle.
+    swizzle_type: SwizzleType = Swizzle_32_4_4()
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -15,7 +15,6 @@ from torch import Tensor
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import (
-    NoSwizzle,
     Swizzle_32_4_4,
     SwizzleGranularity,
     _validate_elem_dtype,

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -12,6 +12,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn.functional import SwizzleType
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import _validate_elem_dtype
@@ -85,7 +86,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     This module provides support for running inference with float8 quantization using MX formats.
 
     Requirements:
-    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
+    - NVIDIA SM100+ hardware (Blackwell or newer) or Intel XPU (BMG or newer)
     - PyTorch 2.5+ for proper serialization support
 
     Example (mxfp8):
@@ -110,6 +111,10 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
 
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
+
+    # How to store block scales.
+    # CUDA uses SWIZZLE_32_4_4 (blocked layout), XPU uses NO_SWIZZLE.
+    swizzle_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -139,7 +144,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 
@@ -150,7 +155,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 
@@ -409,3 +414,37 @@ torch.serialization.add_safe_globals(
         ScaleCalculationMode,
     ]
 )
+
+
+import torch.nn as nn
+
+
+def _auto_filter_for_nfp4(mod: nn.Module, fqn: str) -> bool:
+    """Generic Filter fn for NVFP4 that is best practice for most models."""
+    # Define any FQNs you want to exclude directly in the function
+    filter_fqns = ["embedder", "embed", "embedding", "time_text_embed"]
+
+    # Only support Linear modules
+    if not isinstance(mod, nn.Linear):
+        return False
+
+    # If the fqn matches any filtered fqn, then we should not convert this module
+    is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
+    if is_filtered_fqn:
+        return False
+
+    # All dims must be divisible by 16 due to float8 hardware requirements.
+    N, K = mod.weight.shape
+    dims_multiples_of_16 = K % 16 == 0 and N % 16 == 0
+    if not dims_multiples_of_16:
+        return False
+    if N <= 64:
+        print("skiping small linear layer")
+        # TODO cublas doesn't like this one
+        return False
+
+    # Dims below these thresholds may result in worse performance
+    if K <= 1024 and N <= 1024:
+        print("skiping small linear layer")
+        return False
+    return True

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -15,8 +15,8 @@ from torch import Tensor
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import (
-    Swizzle_32_4_4,
-    SwizzleGranularity,
+    SWIZZLE_32_4_4,
+    SwizzleType,
     _validate_elem_dtype,
 )
 from torchao.prototype.mx_formats.mx_tensor import (
@@ -116,8 +116,8 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
     # How to store block scales.
-    # CUDA uses Swizzle_32_4_4 (blocked layout), XPU uses NoSwizzle.
-    swizzle_type: SwizzleGranularity = Swizzle_32_4_4()
+    # CUDA uses SWIZZLE_32_4_4 (blocked layout), XPU uses NO_SWIZZLE.
+    swizzle_type: SwizzleType = SWIZZLE_32_4_4()
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -414,37 +414,3 @@ torch.serialization.add_safe_globals(
         ScaleCalculationMode,
     ]
 )
-
-
-import torch.nn as nn
-
-
-def _auto_filter_for_nfp4(mod: nn.Module, fqn: str) -> bool:
-    """Generic Filter fn for NVFP4 that is best practice for most models."""
-    # Define any FQNs you want to exclude directly in the function
-    filter_fqns = ["embedder", "embed", "embedding", "time_text_embed"]
-
-    # Only support Linear modules
-    if not isinstance(mod, nn.Linear):
-        return False
-
-    # If the fqn matches any filtered fqn, then we should not convert this module
-    is_filtered_fqn = any(filter_fqn in fqn for filter_fqn in filter_fqns)
-    if is_filtered_fqn:
-        return False
-
-    # All dims must be divisible by 16 due to float8 hardware requirements.
-    N, K = mod.weight.shape
-    dims_multiples_of_16 = K % 16 == 0 and N % 16 == 0
-    if not dims_multiples_of_16:
-        return False
-    if N <= 64:
-        print("skiping small linear layer")
-        # TODO cublas doesn't like this one
-        return False
-
-    # Dims below these thresholds may result in worse performance
-    if K <= 1024 and N <= 1024:
-        print("skiping small linear layer")
-        return False
-    return True

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -12,10 +12,14 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn.functional import SwizzleType
 
 from torchao.core.config import AOBaseConfig
-from torchao.prototype.mx_formats.config import _validate_elem_dtype
+from torchao.prototype.mx_formats.config import (
+    NoSwizzle,
+    Swizzle_32_4_4,
+    SwizzleGranularity,
+    _validate_elem_dtype,
+)
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     QuantizeTensorToMXKwargs,
@@ -113,8 +117,8 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
     # How to store block scales.
-    # CUDA uses SWIZZLE_32_4_4 (blocked layout), XPU uses NO_SWIZZLE.
-    swizzle_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
+    # CUDA uses Swizzle_32_4_4 (blocked layout), XPU uses NoSwizzle.
+    swizzle_type: SwizzleGranularity = Swizzle_32_4_4()
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -761,7 +761,7 @@ def maybe_dtensor_to_blocked(t: torch.Tensor) -> torch.Tensor:
 
 
 def _to_pytorch_swizzle(swizzle: SwizzleGranularity) -> SwizzleType:
-    """Convert SwizzleGranularity to PyTorch's SwizzleType for scaled_mm calls."""
+    """Convert SwizzleGranularity to PyTorch's SwizzleType."""
     if isinstance(swizzle, Swizzle_32_4_4):
         return SwizzleType.SWIZZLE_32_4_4
     return SwizzleType.NO_SWIZZLE

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -101,6 +101,14 @@ _TORCH_VERSION_AT_LEAST_2_13 = torch_version_at_least("2.13.0.dev0")
 _TORCH_VERSION_AT_LEAST_2_14 = torch_version_at_least("2.14.0.dev0")
 
 
+def _migrate_is_swizzled_scales(d: dict) -> None:
+    """In-place migration of old ``is_swizzled_scales: bool`` to ``swizzle_type``."""
+    if "is_swizzled_scales" in d and "swizzle_type" not in d:
+        d["swizzle_type"] = (
+            Swizzle_32_4_4() if d.pop("is_swizzled_scales") else NoSwizzle()
+        )
+
+
 @dataclass
 class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     elem_dtype: Union[torch.dtype, str] = torch.float8_e4m3fn
@@ -111,10 +119,7 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     swizzle_type: SwizzleType = NoSwizzle()
 
     def __setstate__(self, state):
-        # Backward compat: migrate old is_swizzled_scales to swizzle_type
-        if "is_swizzled_scales" in state and "swizzle_type" not in state:
-            is_swizzled = state.pop("is_swizzled_scales")
-            state["swizzle_type"] = Swizzle_32_4_4() if is_swizzled else NoSwizzle()
+        _migrate_is_swizzled_scales(state)
         self.__dict__.update(state)
 
 
@@ -583,15 +588,8 @@ class MXTensor(TorchAOBaseTensor):
     def __tensor_unflatten__(
         cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
     ):
-        # Backward compat: convert old is_swizzled_scales to swizzle_type
-        if (
-            "is_swizzled_scales" in tensor_attributes
-            and "swizzle_type" not in tensor_attributes
-        ):
-            is_swizzled = tensor_attributes.pop("is_swizzled_scales")
-            tensor_attributes["swizzle_type"] = (
-                Swizzle_32_4_4() if is_swizzled else NoSwizzle()
-            )
+        # Backward compat: __tensor_unflatten__ is called by Dynamo tracing.
+        _migrate_is_swizzled_scales(tensor_attributes)
         return super().__tensor_unflatten__(
             tensor_data_dict, tensor_attributes, outer_size, outer_stride
         )
@@ -716,6 +714,20 @@ class MXTensor(TorchAOBaseTensor):
 
 
 implements = MXTensor.implements
+
+
+# Override __setstate__ set by TorchAOBaseTensor.__init_subclass__ to add
+# backward compat for old checkpoints with is_swizzled_scales bool.
+_base_setstate = MXTensor.__setstate__
+
+
+def _mx_tensor_setstate(self, state):
+    if isinstance(state, dict):
+        _migrate_is_swizzled_scales(state)
+    _base_setstate(self, state)
+
+
+MXTensor.__setstate__ = _mx_tensor_setstate
 
 
 @implements([aten.detach.default, aten.alias.default])

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,7 +36,15 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
+from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
+    _rebuild_swizzle_type,
+)
 from torch.nn.functional import ScalingType, SwizzleType
+
+# pybind11 SwizzleType can't be pickled by default. The inductor import
+# above patches __reduce__; register the reconstructor as safe for
+# weights_only torch.load.
+torch.serialization.add_safe_globals([_rebuild_swizzle_type])
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
@@ -105,7 +113,7 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    is_swizzled_scales: bool = False
+    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -230,7 +238,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    is_swizzled_scales: bool = False,
+    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -399,10 +407,10 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if is_swizzled_scales:
+    if swizzle_type != SwizzleType.NO_SWIZZLE:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
-        scale = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
         scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
         scale_e8m0_biased = scale.view(*leading_dims, scale_M, scale_K)
 
@@ -513,7 +521,7 @@ class MXTensor(TorchAOBaseTensor):
         "orig_dtype",
         "kernel_preference",
         "act_quant_kwargs",
-        "is_swizzled_scales",
+        "swizzle_type",
     ]
 
     def __new__(
@@ -525,7 +533,7 @@ class MXTensor(TorchAOBaseTensor):
         orig_dtype,
         kernel_preference,
         act_quant_kwargs,
-        is_swizzled_scales,
+        swizzle_type,
     ):
         new_size = qdata.size()
         if elem_dtype == torch.float4_e2m1fn_x2:
@@ -566,22 +574,29 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        self.is_swizzled_scales = is_swizzled_scales
+        # Accept SwizzleType, int, or bool — normalize to SwizzleType.
+        # int/bool needed for torch.compile (@allow_in_graph) compatibility.
+        self.swizzle_type = SwizzleType(int(swizzle_type))
         return self
 
     def __repr__(self):
         # TODO better elem dtype print for fp4
-        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, is_swizzled_scales={self.is_swizzled_scales}"  # noqa: E501
+        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, swizzle_type={self.swizzle_type}"  # noqa: E501
 
     def _quantization_type(self):
         return f"{self.elem_dtype=}, {self.block_size=}, {self.orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
+
+    @property
+    def is_swizzled_scales(self):
+        """Backward-compat property for shared code in utils.py."""
+        return self.swizzle_type != SwizzleType.NO_SWIZZLE
 
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:
             output_dtype = self.dtype
 
         scale = self.scale
-        if self.is_swizzled_scales:
+        if self.swizzle_type != SwizzleType.NO_SWIZZLE:
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -613,7 +628,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -629,7 +644,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            int(swizzle_type),  # int for dynamo compat
         )
 
     @staticmethod
@@ -643,7 +658,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -654,18 +669,18 @@ class MXTensor(TorchAOBaseTensor):
         )
 
         triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
+            elem_dtype == torch.float8_e4m3fn and swizzle_type == SwizzleType.NO_SWIZZLE
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
             or kernel_preference == KernelPreference.EMULATED
         ):
             scale_e8m0_biased, data_lp = to_mx(
-                data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+                data_hp, elem_dtype, block_size, scaling_mode, swizzle_type
             )
         else:
             assert triton_kernel_supported, (
-                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
+                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {swizzle_type=}"
             )
             data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
                 data_hp,
@@ -680,7 +695,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            int(swizzle_type),  # int for dynamo compat
         )
 
     # Do not force the MXTensor type on the returned tensor
@@ -713,7 +728,7 @@ def mx_pin_memory(func, types, args, kwargs):
         tensor.orig_dtype,
         tensor.kernel_preference,
         tensor.act_quant_kwargs,
-        tensor.is_swizzled_scales,
+        tensor.swizzle_type,
     )
 
 
@@ -773,7 +788,7 @@ def _addmm_mx_dispatch(
             k.block_size,
             k.scaling_mode,
             k.kernel_preference,
-            k.is_swizzled_scales,
+            swizzle_type=k.swizzle_type,
         )
 
     gemm_choice = _get_gemm_choice(a.kernel_preference, b.kernel_preference)
@@ -786,32 +801,37 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.is_swizzled_scales:
-            a_scale_block = a.scale
-        else:
-            a_scale = a.scale.view(M, K // a.block_size)
-            a_scale_block = maybe_dtensor_to_blocked(a_scale)
+        match a.swizzle_type:
+            case SwizzleType.SWIZZLE_32_4_4:
+                a_scale_block = a.scale
+            case SwizzleType.NO_SWIZZLE:
+                a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if b.is_swizzled_scales:
-            b_scale_block = b.scale.t()
-        else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            b_scale_block = maybe_dtensor_to_blocked(b_scale)
+        match b.swizzle_type:
+            case SwizzleType.SWIZZLE_32_4_4:
+                b_scale_block = b.scale.t()
+            case SwizzleType.NO_SWIZZLE:
+                b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
+            a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
+            b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
+            if b.swizzle_type == SwizzleType.NO_SWIZZLE:
+                # Row-major scales: v1 API expects scale_b as (K//32, N)
+                b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
+                a_scale_v1,
+                b_scale_v1,
                 bias=bias,
                 out_dtype=torch.bfloat16,
             )
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            # FP4 operations using F.scaled_mm
+            swizzle = a.swizzle_type
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -819,8 +839,8 @@ def _addmm_mx_dispatch(
                 scale_recipe_a=ScalingType.BlockWise1x32,
                 scale_b=b_scale_block,
                 scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
                 bias=bias,
                 output_dtype=torch.bfloat16,
             )
@@ -894,7 +914,7 @@ def mx_t(func, types, args, kwargs):
         old.orig_dtype,
         old.kernel_preference,
         old.act_quant_kwargs,
-        old.is_swizzled_scales,
+        old.swizzle_type,
     )
     return new
 
@@ -935,7 +955,7 @@ def mx_view_op(func, types, args, kwargs):
         args[0].orig_dtype,
         args[0].kernel_preference,
         args[0].act_quant_kwargs,
-        args[0].is_swizzled_scales,
+        args[0].swizzle_type,
     )
 
 
@@ -960,7 +980,7 @@ def mx_slice(func, types, args, kwargs):
             x.orig_dtype,
             x.kernel_preference,
             x.act_quant_kwargs,
-            x.is_swizzled_scales,
+            x.swizzle_type,
         ),
     )
 
@@ -985,7 +1005,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert not old_mx_tensor.is_swizzled_scales, "unsupported"
+    assert old_mx_tensor.swizzle_type == SwizzleType.NO_SWIZZLE, "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],
@@ -994,7 +1014,7 @@ def mx_select(func, types, args, kwargs):
         old_mx_tensor.orig_dtype,
         old_mx_tensor.kernel_preference,
         old_mx_tensor.act_quant_kwargs,
-        old_mx_tensor.is_swizzled_scales,
+        old_mx_tensor.swizzle_type,
     )
     return return_and_correct_aliasing(func, args, kwargs, new_mx_tensor)
 
@@ -1043,7 +1063,7 @@ def mx_all_gather(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )
 
 
@@ -1074,5 +1094,5 @@ def mx_wait_tensor(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -39,10 +39,10 @@ if torch_version_at_least("2.12.0.dev0"):
 from torch.nn.functional import ScalingType
 
 from torchao.prototype.mx_formats.config import (
-    NO_SWIZZLE,
-    SWIZZLE_32_4_4,
     MXFP8Dim0CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
     SwizzleType,
 )
 from torchao.prototype.mx_formats.constants import (
@@ -108,13 +108,13 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    swizzle_type: SwizzleType = NO_SWIZZLE()
+    swizzle_type: SwizzleType = NoSwizzle()
 
     def __setstate__(self, state):
         # Backward compat: migrate old is_swizzled_scales to swizzle_type
         if "is_swizzled_scales" in state and "swizzle_type" not in state:
             is_swizzled = state.pop("is_swizzled_scales")
-            state["swizzle_type"] = SWIZZLE_32_4_4() if is_swizzled else NO_SWIZZLE()
+            state["swizzle_type"] = Swizzle_32_4_4() if is_swizzled else NoSwizzle()
         self.__dict__.update(state)
 
 
@@ -240,7 +240,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    swizzle_type: SwizzleType = NO_SWIZZLE(),
+    swizzle_type: SwizzleType = NoSwizzle(),
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -409,7 +409,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if isinstance(swizzle_type, SWIZZLE_32_4_4):
+    if isinstance(swizzle_type, Swizzle_32_4_4):
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -590,7 +590,7 @@ class MXTensor(TorchAOBaseTensor):
         ):
             is_swizzled = tensor_attributes.pop("is_swizzled_scales")
             tensor_attributes["swizzle_type"] = (
-                SWIZZLE_32_4_4() if is_swizzled else NO_SWIZZLE()
+                Swizzle_32_4_4() if is_swizzled else NoSwizzle()
             )
         return super().__tensor_unflatten__(
             tensor_data_dict, tensor_attributes, outer_size, outer_stride
@@ -608,7 +608,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if isinstance(self.swizzle_type, SWIZZLE_32_4_4):
+        if isinstance(self.swizzle_type, Swizzle_32_4_4):
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -640,7 +640,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleType = NO_SWIZZLE(),
+        swizzle_type: SwizzleType = NoSwizzle(),
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -670,7 +670,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleType = NO_SWIZZLE(),
+        swizzle_type: SwizzleType = NoSwizzle(),
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -681,7 +681,7 @@ class MXTensor(TorchAOBaseTensor):
         )
 
         triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and isinstance(
-            swizzle_type, NO_SWIZZLE
+            swizzle_type, NoSwizzle
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
@@ -814,12 +814,12 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if isinstance(a.swizzle_type, SWIZZLE_32_4_4):
+        if isinstance(a.swizzle_type, Swizzle_32_4_4):
             a_scale_block = a.scale
         else:
             a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if isinstance(b.swizzle_type, SWIZZLE_32_4_4):
+        if isinstance(b.swizzle_type, Swizzle_32_4_4):
             b_scale_block = b.scale.t()
         else:
             b_scale_block = b.scale.view(N, K // b.block_size)
@@ -828,7 +828,7 @@ def _addmm_mx_dispatch(
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if isinstance(b.swizzle_type, NO_SWIZZLE):
+            if isinstance(b.swizzle_type, NoSwizzle):
                 # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
@@ -844,7 +844,7 @@ def _addmm_mx_dispatch(
             assert b.elem_dtype == torch.float4_e2m1fn_x2
             swizzle = (
                 F.SwizzleType.SWIZZLE_32_4_4
-                if isinstance(a.swizzle_type, SWIZZLE_32_4_4)
+                if isinstance(a.swizzle_type, Swizzle_32_4_4)
                 else F.SwizzleType.NO_SWIZZLE
             )
             res = F.scaled_mm(
@@ -1020,7 +1020,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert isinstance(old_mx_tensor.swizzle_type, NO_SWIZZLE), "unsupported"
+    assert isinstance(old_mx_tensor.swizzle_type, NoSwizzle), "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -586,11 +586,6 @@ class MXTensor(TorchAOBaseTensor):
     def _quantization_type(self):
         return f"{self.elem_dtype=}, {self.block_size=}, {self.orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
 
-    @property
-    def is_swizzled_scales(self):
-        """Backward-compat property for shared code in utils.py."""
-        return self.swizzle_type != SwizzleType.NO_SWIZZLE
-
     def dequantize(self, output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         if output_dtype is None:
             output_dtype = self.dtype
@@ -811,6 +806,7 @@ def _addmm_mx_dispatch(
             case SwizzleType.SWIZZLE_32_4_4:
                 b_scale_block = b.scale.t()
             case SwizzleType.NO_SWIZZLE:
+                # Row-major: (N, K//32) for fp4, transposed to (K//32, N) for fp8 v1
                 b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
 
         if a.elem_dtype == torch.float8_e4m3fn:
@@ -818,7 +814,7 @@ def _addmm_mx_dispatch(
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
             if b.swizzle_type == SwizzleType.NO_SWIZZLE:
-                # Row-major scales: v1 API expects scale_b as (K//32, N)
+                # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
                 a.qdata,

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -40,7 +40,10 @@ from torch.nn.functional import ScalingType, SwizzleType
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
+    SwizzleGranularity,
 )
 from torchao.prototype.mx_formats.constants import (
     BLOCK_SIZE_DEFAULT,
@@ -105,11 +108,7 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    swizzle_type: int = int(SwizzleType.NO_SWIZZLE)
-
-    def __post_init__(self):
-        # Normalize pybind11 SwizzleType to int for serialization safety
-        self.swizzle_type = int(self.swizzle_type)
+    swizzle_type: SwizzleGranularity = NoSwizzle()
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -234,7 +233,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
+    swizzle_type: SwizzleGranularity = NoSwizzle(),
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -403,7 +402,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if swizzle_type == SwizzleType.SWIZZLE_32_4_4:
+    if isinstance(swizzle_type, Swizzle_32_4_4):
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -570,7 +569,7 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        self.swizzle_type = int(swizzle_type)
+        self.swizzle_type = swizzle_type
         return self
 
     def __repr__(self):
@@ -585,7 +584,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if SwizzleType(self.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
+        if isinstance(self.swizzle_type, Swizzle_32_4_4):
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -617,7 +616,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
+        swizzle_type: SwizzleGranularity = NoSwizzle(),
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -633,7 +632,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            int(swizzle_type),
+            swizzle_type,
         )
 
     @staticmethod
@@ -647,7 +646,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE,
+        swizzle_type: SwizzleGranularity = NoSwizzle(),
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -657,8 +656,8 @@ class MXTensor(TorchAOBaseTensor):
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
 
-        triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and swizzle_type == SwizzleType.NO_SWIZZLE
+        triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and isinstance(
+            swizzle_type, NoSwizzle
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
@@ -677,9 +676,6 @@ class MXTensor(TorchAOBaseTensor):
                 scaling_mode=scaling_mode.value,
             )
 
-        swizzle_type = (
-            swizzle_type.value if hasattr(swizzle_type, "value") else int(swizzle_type)
-        )
         return MXTensor(
             data_lp,
             scale_e8m0_biased,
@@ -764,6 +760,13 @@ def maybe_dtensor_to_blocked(t: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _to_pytorch_swizzle(swizzle: SwizzleGranularity) -> SwizzleType:
+    """Convert SwizzleGranularity to PyTorch's SwizzleType for scaled_mm calls."""
+    if isinstance(swizzle, Swizzle_32_4_4):
+        return SwizzleType.SWIZZLE_32_4_4
+    return SwizzleType.NO_SWIZZLE
+
+
 def _addmm_mx_dispatch(
     a: torch.Tensor, b: MXTensor, aten_op, bias: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
@@ -794,12 +797,12 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if SwizzleType(a.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
+        if isinstance(a.swizzle_type, Swizzle_32_4_4):
             a_scale_block = a.scale
         else:
             a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if SwizzleType(b.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
+        if isinstance(b.swizzle_type, Swizzle_32_4_4):
             b_scale_block = b.scale.t()
         else:
             b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
@@ -808,7 +811,7 @@ def _addmm_mx_dispatch(
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if SwizzleType(b.swizzle_type) == SwizzleType.NO_SWIZZLE:
+            if isinstance(b.swizzle_type, NoSwizzle):
                 # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
@@ -822,7 +825,7 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            swizzle = SwizzleType(a.swizzle_type)
+            swizzle = _to_pytorch_swizzle(a.swizzle_type)
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -996,9 +999,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert SwizzleType(old_mx_tensor.swizzle_type) == SwizzleType.NO_SWIZZLE, (
-        "unsupported"
-    )
+    assert isinstance(old_mx_tensor.swizzle_type, NoSwizzle), "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -105,7 +105,11 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    swizzle_type: SwizzleType = SwizzleType.NO_SWIZZLE
+    swizzle_type: int = int(SwizzleType.NO_SWIZZLE)
+
+    def __post_init__(self):
+        # Normalize pybind11 SwizzleType to int for serialization safety
+        self.swizzle_type = int(self.swizzle_type)
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -399,7 +403,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if swizzle_type != SwizzleType.NO_SWIZZLE:
+    if int(swizzle_type) != int(SwizzleType.NO_SWIZZLE):
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -566,7 +570,7 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        self.swizzle_type = swizzle_type
+        self.swizzle_type = int(swizzle_type)
         return self
 
     def __repr__(self):
@@ -581,7 +585,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if self.swizzle_type != SwizzleType.NO_SWIZZLE:
+        if self.swizzle_type != int(SwizzleType.NO_SWIZZLE):
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -629,7 +633,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            swizzle_type,
+            int(swizzle_type),
         )
 
     @staticmethod
@@ -653,9 +657,9 @@ class MXTensor(TorchAOBaseTensor):
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
 
-        triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and swizzle_type == SwizzleType.NO_SWIZZLE
-        )
+        triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and int(
+            swizzle_type
+        ) == int(SwizzleType.NO_SWIZZLE)
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
             or kernel_preference == KernelPreference.EMULATED
@@ -680,7 +684,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            swizzle_type,
+            int(swizzle_type),
         )
 
     # Do not force the MXTensor type on the returned tensor
@@ -786,24 +790,21 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        match a.swizzle_type:
-            case SwizzleType.SWIZZLE_32_4_4:
-                a_scale_block = a.scale
-            case SwizzleType.NO_SWIZZLE:
-                a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
+        if a.swizzle_type == int(SwizzleType.SWIZZLE_32_4_4):
+            a_scale_block = a.scale
+        else:
+            a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        match b.swizzle_type:
-            case SwizzleType.SWIZZLE_32_4_4:
-                b_scale_block = b.scale.t()
-            case SwizzleType.NO_SWIZZLE:
-                # Row-major: (N, K//32) for fp4, transposed to (K//32, N) for fp8 v1
-                b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
+        if b.swizzle_type == int(SwizzleType.SWIZZLE_32_4_4):
+            b_scale_block = b.scale.t()
+        else:
+            b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if b.swizzle_type == SwizzleType.NO_SWIZZLE:
+            if b.swizzle_type == int(SwizzleType.NO_SWIZZLE):
                 # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
@@ -817,7 +818,7 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            swizzle = a.swizzle_type
+            swizzle = SwizzleType(int(a.swizzle_type))
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -991,7 +992,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert old_mx_tensor.swizzle_type == SwizzleType.NO_SWIZZLE, "unsupported"
+    assert old_mx_tensor.swizzle_type == int(SwizzleType.NO_SWIZZLE), "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -403,7 +403,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if swizzle_type != SwizzleType.NO_SWIZZLE:
+    if swizzle_type == SwizzleType.SWIZZLE_32_4_4:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -585,7 +585,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if SwizzleType(self.swizzle_type) != SwizzleType.NO_SWIZZLE:
+        if SwizzleType(self.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -403,7 +403,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if int(swizzle_type) != int(SwizzleType.NO_SWIZZLE):
+    if swizzle_type != SwizzleType.NO_SWIZZLE:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -585,7 +585,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if self.swizzle_type != int(SwizzleType.NO_SWIZZLE):
+        if SwizzleType(self.swizzle_type) != SwizzleType.NO_SWIZZLE:
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -657,9 +657,9 @@ class MXTensor(TorchAOBaseTensor):
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
 
-        triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and int(
-            swizzle_type
-        ) == int(SwizzleType.NO_SWIZZLE)
+        triton_kernel_supported = (
+            elem_dtype == torch.float8_e4m3fn and swizzle_type == SwizzleType.NO_SWIZZLE
+        )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
             or kernel_preference == KernelPreference.EMULATED
@@ -676,6 +676,13 @@ class MXTensor(TorchAOBaseTensor):
                 inner_block_size=block_size,
                 scaling_mode=scaling_mode.value,
             )
+        # Convert SwizzleType enum to int before passing to MXTensor.
+        # swizzle_type.value avoids calling int() on a pybind11 enum in Dynamo.
+        # Falls back to int() when swizzle_type is already an int (e.g. from
+        # QuantizeTensorToMXKwargs, which stores as int for serialization).
+        swizzle_type = (
+            swizzle_type.value if hasattr(swizzle_type, "value") else int(swizzle_type)
+        )
         return MXTensor(
             data_lp,
             scale_e8m0_biased,
@@ -684,7 +691,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            int(swizzle_type),
+            swizzle_type,
         )
 
     # Do not force the MXTensor type on the returned tensor
@@ -790,12 +797,12 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.swizzle_type == int(SwizzleType.SWIZZLE_32_4_4):
+        if SwizzleType(a.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
             a_scale_block = a.scale
         else:
             a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if b.swizzle_type == int(SwizzleType.SWIZZLE_32_4_4):
+        if SwizzleType(b.swizzle_type) == SwizzleType.SWIZZLE_32_4_4:
             b_scale_block = b.scale.t()
         else:
             b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
@@ -804,7 +811,7 @@ def _addmm_mx_dispatch(
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if b.swizzle_type == int(SwizzleType.NO_SWIZZLE):
+            if SwizzleType(b.swizzle_type) == SwizzleType.NO_SWIZZLE:
                 # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
@@ -818,7 +825,7 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            swizzle = SwizzleType(int(a.swizzle_type))
+            swizzle = SwizzleType(a.swizzle_type)
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -992,7 +999,9 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert old_mx_tensor.swizzle_type == int(SwizzleType.NO_SWIZZLE), "unsupported"
+    assert SwizzleType(old_mx_tensor.swizzle_type) == SwizzleType.NO_SWIZZLE, (
+        "unsupported"
+    )
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,15 +36,7 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
-from torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils import (
-    _rebuild_swizzle_type,
-)
 from torch.nn.functional import ScalingType, SwizzleType
-
-# pybind11 SwizzleType can't be pickled by default. The inductor import
-# above patches __reduce__; register the reconstructor as safe for
-# weights_only torch.load.
-torch.serialization.add_safe_globals([_rebuild_swizzle_type])
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
@@ -574,9 +566,7 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        # Accept SwizzleType, int, or bool — normalize to SwizzleType.
-        # int/bool needed for torch.compile (@allow_in_graph) compatibility.
-        self.swizzle_type = SwizzleType(int(swizzle_type))
+        self.swizzle_type = swizzle_type
         return self
 
     def __repr__(self):
@@ -639,7 +629,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            int(swizzle_type),  # int for dynamo compat
+            swizzle_type,
         )
 
     @staticmethod
@@ -690,7 +680,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            int(swizzle_type),  # int for dynamo compat
+            swizzle_type,
         )
 
     # Do not force the MXTensor type on the returned tensor

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -676,10 +676,7 @@ class MXTensor(TorchAOBaseTensor):
                 inner_block_size=block_size,
                 scaling_mode=scaling_mode.value,
             )
-        # Convert SwizzleType enum to int before passing to MXTensor.
-        # swizzle_type.value avoids calling int() on a pybind11 enum in Dynamo.
-        # Falls back to int() when swizzle_type is already an int (e.g. from
-        # QuantizeTensorToMXKwargs, which stores as int for serialization).
+
         swizzle_type = (
             swizzle_type.value if hasattr(swizzle_type, "value") else int(swizzle_type)
         )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,14 +36,14 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
-from torch.nn.functional import ScalingType, SwizzleType
+from torch.nn.functional import ScalingType
 
 from torchao.prototype.mx_formats.config import (
+    NO_SWIZZLE,
+    SWIZZLE_32_4_4,
     MXFP8Dim0CastKernelChoice,
-    NoSwizzle,
     ScaleCalculationMode,
-    Swizzle_32_4_4,
-    SwizzleGranularity,
+    SwizzleType,
 )
 from torchao.prototype.mx_formats.constants import (
     BLOCK_SIZE_DEFAULT,
@@ -108,7 +108,7 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    swizzle_type: SwizzleGranularity = NoSwizzle()
+    swizzle_type: SwizzleType = NO_SWIZZLE()
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -233,7 +233,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    swizzle_type: SwizzleGranularity = NoSwizzle(),
+    swizzle_type: SwizzleType = NO_SWIZZLE(),
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -402,7 +402,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if isinstance(swizzle_type, Swizzle_32_4_4):
+    if isinstance(swizzle_type, SWIZZLE_32_4_4):
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -572,6 +572,23 @@ class MXTensor(TorchAOBaseTensor):
         self.swizzle_type = swizzle_type
         return self
 
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        # Backward compat: convert old is_swizzled_scales to swizzle_type
+        if (
+            "is_swizzled_scales" in tensor_attributes
+            and "swizzle_type" not in tensor_attributes
+        ):
+            is_swizzled = tensor_attributes.pop("is_swizzled_scales")
+            tensor_attributes["swizzle_type"] = (
+                SWIZZLE_32_4_4() if is_swizzled else NO_SWIZZLE()
+            )
+        return super().__tensor_unflatten__(
+            tensor_data_dict, tensor_attributes, outer_size, outer_stride
+        )
+
     def __repr__(self):
         # TODO better elem dtype print for fp4
         return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, swizzle_type={self.swizzle_type}"  # noqa: E501
@@ -584,7 +601,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if isinstance(self.swizzle_type, Swizzle_32_4_4):
+        if isinstance(self.swizzle_type, SWIZZLE_32_4_4):
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -616,7 +633,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleGranularity = NoSwizzle(),
+        swizzle_type: SwizzleType = NO_SWIZZLE(),
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -646,7 +663,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        swizzle_type: SwizzleGranularity = NoSwizzle(),
+        swizzle_type: SwizzleType = NO_SWIZZLE(),
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -657,7 +674,7 @@ class MXTensor(TorchAOBaseTensor):
         )
 
         triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and isinstance(
-            swizzle_type, NoSwizzle
+            swizzle_type, NO_SWIZZLE
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
@@ -760,13 +777,6 @@ def maybe_dtensor_to_blocked(t: torch.Tensor) -> torch.Tensor:
     return out
 
 
-def _to_pytorch_swizzle(swizzle: SwizzleGranularity) -> SwizzleType:
-    """Convert SwizzleGranularity to PyTorch's SwizzleType."""
-    if isinstance(swizzle, Swizzle_32_4_4):
-        return SwizzleType.SWIZZLE_32_4_4
-    return SwizzleType.NO_SWIZZLE
-
-
 def _addmm_mx_dispatch(
     a: torch.Tensor, b: MXTensor, aten_op, bias: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
@@ -797,21 +807,21 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if isinstance(a.swizzle_type, Swizzle_32_4_4):
+        if isinstance(a.swizzle_type, SWIZZLE_32_4_4):
             a_scale_block = a.scale
         else:
             a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
-        if isinstance(b.swizzle_type, Swizzle_32_4_4):
+        if isinstance(b.swizzle_type, SWIZZLE_32_4_4):
             b_scale_block = b.scale.t()
         else:
-            b_scale_block = b.scale.t().view(N, K // b.block_size).contiguous()
+            b_scale_block = b.scale.view(N, K // b.block_size)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
             a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if isinstance(b.swizzle_type, NoSwizzle):
+            if isinstance(b.swizzle_type, NO_SWIZZLE):
                 # v1 API expects scale_b as (K//32, N)
                 b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
@@ -825,7 +835,11 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            swizzle = _to_pytorch_swizzle(a.swizzle_type)
+            swizzle = (
+                F.SwizzleType.SWIZZLE_32_4_4
+                if isinstance(a.swizzle_type, SWIZZLE_32_4_4)
+                else F.SwizzleType.NO_SWIZZLE
+            )
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -999,7 +1013,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert isinstance(old_mx_tensor.swizzle_type, NoSwizzle), "unsupported"
+    assert isinstance(old_mx_tensor.swizzle_type, NO_SWIZZLE), "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -110,6 +110,13 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     kernel_preference: KernelPreference = KernelPreference.EMULATED
     swizzle_type: SwizzleType = NO_SWIZZLE()
 
+    def __setstate__(self, state):
+        # Backward compat: migrate old is_swizzled_scales to swizzle_type
+        if "is_swizzled_scales" in state and "swizzle_type" not in state:
+            is_swizzled = state.pop("is_swizzled_scales")
+            state["swizzle_type"] = SWIZZLE_32_4_4() if is_swizzled else NO_SWIZZLE()
+        self.__dict__.update(state)
+
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
     # We can't just use value.to(float8_e8m0fnu) because it doesn't support

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -10,10 +10,10 @@ from typing import Tuple
 import torch
 
 from torchao.prototype.mx_formats.config import (
+    NO_SWIZZLE,
+    SWIZZLE_32_4_4,
     MXFP8Dim1CastKernelChoice,
-    NoSwizzle,
     ScaleCalculationMode,
-    Swizzle_32_4_4,
 )
 from torchao.prototype.mx_formats.kernels import (
     triton_mx_block_rearrange,
@@ -160,7 +160,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    swizzle_type = NoSwizzle()
+    swizzle_type = NO_SWIZZLE()
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -209,7 +209,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        swizzle_type = Swizzle_32_4_4()
+        swizzle_type = SWIZZLE_32_4_4()
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
         # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NO_SWIZZLE
         # (no tcgen05 blocked layout on AMD).
@@ -261,7 +261,7 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
+    if isinstance(getattr(x, "swizzle_type", None), SWIZZLE_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         scale_rows = M
@@ -430,7 +430,7 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
+    if isinstance(getattr(x, "swizzle_type", None), SWIZZLE_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         if x.block_size == 16:

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -20,6 +20,7 @@ from torchao.prototype.mx_formats.kernels import (
 )
 from torchao.quantization.quantize_.common import KernelPreference
 
+
 Tensor = torch.Tensor
 
 aten = torch.ops.aten
@@ -260,7 +261,7 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if getattr(x, "swizzle_type", None) == SwizzleType.SWIZZLE_32_4_4 or getattr(
+    if getattr(x, "swizzle_type", None) == int(SwizzleType.SWIZZLE_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         scale_rows = M
@@ -429,7 +430,7 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if getattr(x, "swizzle_type", None) == SwizzleType.SWIZZLE_32_4_4 or getattr(
+    if getattr(x, "swizzle_type", None) == int(SwizzleType.SWIZZLE_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         if x.block_size == 16:

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -10,10 +10,10 @@ from typing import Tuple
 import torch
 
 from torchao.prototype.mx_formats.config import (
-    NO_SWIZZLE,
-    SWIZZLE_32_4_4,
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
 )
 from torchao.prototype.mx_formats.kernels import (
     triton_mx_block_rearrange,
@@ -160,7 +160,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    swizzle_type = NO_SWIZZLE()
+    swizzle_type = NoSwizzle()
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -209,9 +209,9 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        swizzle_type = SWIZZLE_32_4_4()
+        swizzle_type = Swizzle_32_4_4()
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
-        # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NO_SWIZZLE
+        # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NoSwizzle
         # (no tcgen05 blocked layout on AMD).
         assert scale_calculation_mode in (
             ScaleCalculationMode.FLOOR,
@@ -261,7 +261,9 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if isinstance(getattr(x, "swizzle_type", None), SWIZZLE_32_4_4) or getattr(
+    # Check both SwizzleType (MXTensor) and is_swizzled_scales bool
+    # (NVFP4Tensor, which still uses the old bool field).
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         scale_rows = M
@@ -430,7 +432,9 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if isinstance(getattr(x, "swizzle_type", None), SWIZZLE_32_4_4) or getattr(
+    # Check both SwizzleType (MXTensor) and is_swizzled_scales bool
+    # (NVFP4Tensor, which still uses the old bool field).
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         if x.block_size == 16:

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -260,7 +260,9 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if x.is_swizzled_scales:
+    if getattr(x, "swizzle_type", None) == SwizzleType.SWIZZLE_32_4_4 or getattr(
+        x, "is_swizzled_scales", False
+    ):
         scale_rows = M
         scale_cols = K // x.block_size
         n_row_blocks = ceil_div(scale_rows, 128)
@@ -427,7 +429,9 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if x.is_swizzled_scales:
+    if getattr(x, "swizzle_type", None) == SwizzleType.SWIZZLE_32_4_4 or getattr(
+        x, "is_swizzled_scales", False
+    ):
         if x.block_size == 16:
             scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_nvfp4(
                 sliced_M, sliced_K

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -8,11 +8,12 @@ import sys
 from typing import Tuple
 
 import torch
-from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
 )
 from torchao.prototype.mx_formats.kernels import (
     triton_mx_block_rearrange,
@@ -159,7 +160,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    swizzle_type = SwizzleType.NO_SWIZZLE
+    swizzle_type = NoSwizzle()
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -208,7 +209,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        swizzle_type = SwizzleType.SWIZZLE_32_4_4
+        swizzle_type = Swizzle_32_4_4()
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
         # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NO_SWIZZLE
         # (no tcgen05 blocked layout on AMD).
@@ -260,7 +261,7 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if getattr(x, "swizzle_type", None) == int(SwizzleType.SWIZZLE_32_4_4) or getattr(
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         scale_rows = M
@@ -429,7 +430,7 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if getattr(x, "swizzle_type", None) == int(SwizzleType.SWIZZLE_32_4_4) or getattr(
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
         x, "is_swizzled_scales", False
     ):
         if x.block_size == 16:

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -8,6 +8,7 @@ import sys
 from typing import Tuple
 
 import torch
+from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
@@ -158,7 +159,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    is_swizzled_scales = False
+    swizzle_type = SwizzleType.NO_SWIZZLE
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -207,9 +208,9 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        is_swizzled_scales = True
+        swizzle_type = SwizzleType.SWIZZLE_32_4_4
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
-        # AMD via FlyDSL. FlyDSL kernels leave is_swizzled_scales=False
+        # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NO_SWIZZLE
         # (no tcgen05 blocked layout on AMD).
         assert scale_calculation_mode in (
             ScaleCalculationMode.FLOOR,
@@ -239,7 +240,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
         hp_dtype,
         kernel_preference,
         None,
-        is_swizzled_scales,
+        swizzle_type,
     )
     return mx_tensor
 

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -20,7 +20,6 @@ from torchao.prototype.mx_formats.kernels import (
 )
 from torchao.quantization.quantize_.common import KernelPreference
 
-
 Tensor = torch.Tensor
 
 aten = torch.ops.aten


### PR DESCRIPTION
## Description

Refactors MXTensor to use a pure-Python `SwizzleType` class hierarchy for scale layout decisions, replacing the previous `is_swizzled_scales: bool` flag and eliminating device-specific dispatch paths.

**Motivation:** As discussed in #4801, the MXTensor dispatch logic previously used boolean flags and device checks to determine scale tensor layouts. This is fragile and doesn't scale to new devices or swizzle formats. This PR introduces `SwizzleType` — a frozen dataclass hierarchy following the same pattern as `torchao.quantization.granularity` (`PerTensor`, `PerRow`, etc.) — providing clean extensibility for future swizzle formats.

## Changes
**New types (`config.py`):**
```python
@dataclass(frozen=True)
class SwizzleType:
    """Base class for scale swizzle layout."""
    pass

@dataclass(frozen=True)
class NoSwizzle(SwizzleType):
    """No swizzling."""
    pass

@dataclass(frozen=True)
class Swizzle_32_4_4(SwizzleType):
    """32x4x4 blocked scale layout for NVIDIA."""
    pass
```

**Core refactor (`mx_tensor.py`):**
- `QuantizeTensorToMXKwargs.is_swizzled_scales: bool` → `swizzle_type: SwizzleType = NoSwizzle()`
- `MXTensor` stores `swizzle_type: SwizzleType` as a direct attribute

**Config (`inference_workflow.py`):**
- `MXDynamicActivationMXWeightConfig` gains `swizzle_type: SwizzleType = Swizzle_32_4_4()`
  - Default: `Swizzle_32_4_4()` (CUDA Blackwell)
  - XPU users set: `NoSwizzle()`

## Usage

```python
from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4

# CUDA (default — blocked/swizzled scales)
config = MXDynamicActivationMXWeightConfig(
    swizzle_type=Swizzle_32_4_4(),
)

# XPU (row-major scales)
config = MXDynamicActivationMXWeightConfig(
    swizzle_type=NoSwizzle(),
)
```


