### PR TITLE
Fix bitpacking default unpack dimension

### DIFF
--- a/test/dtypes/test_bitpacking.py
+++ b/test/dtypes/test_bitpacking.py
@@ -88,3 +88,14 @@ def test_pack_example_CPU():
     assert torch.tensor([39, 146], dtype=torch.uint8).allclose(shard_2)
     unpacked = unpack([shard_4, shard_2], 6)
     assert unpacked.allclose(test_tensor)
+
+
+@pytest.mark.parametrize("bit_width", bit_widths)
+def test_default_dim_roundtrip(bit_width):
+    test_tensor = torch.randint(0, 2**bit_width, (3, 16), dtype=torch.uint8)
+
+    packed = pack(test_tensor, bit_width)
+    unpacked = unpack(packed, bit_width)
+
+    assert unpacked.shape == test_tensor.shape
+    assert unpacked.allclose(test_tensor)

--- a/torchao/prototype/dtypes/uintx/bitpacking.py
+++ b/torchao/prototype/dtypes/uintx/bitpacking.py
@@ -248,7 +248,7 @@ def pack(
 
 
 def unpack(
-    data: List[torch.Tensor], elem_size: int, dim: Optional[int] = 0
+    data: List[torch.Tensor], elem_size: int, dim: Optional[int] = -1
 ) -> torch.Tensor:
     """
     a less branching but more compute version so better for gpu


### PR DESCRIPTION
Fixes #4815.

## Summary

The optimized bitpacking pair had incompatible defaults: `pack()` operated on the last dimension (`dim=-1`), while `unpack()` expanded the first dimension (`dim=0`). A default round trip therefore transposed the packed extent for multidimensional tensors—for example, an `(8, 16)` input became `(16, 8)`.

This change makes `unpack()` default to `dim=-1`, matching:

- `pack()`;
- the `pack_cpu()` / `unpack_cpu()` reference pair; and
- the usual convention that packing operates on the innermost dimension.

TorchAO's internal `UIntxTensor` call sites already pass `pack_dim` explicitly, so they are unaffected.

The regression test performs default multidimensional round trips for every supported element width from 1 through 7 bits and verifies both values and shape.

## Validation

- `pytest test/dtypes/test_bitpacking.py -q -k "CPU or default_dim_roundtrip"` — 29 passed
- `ruff check torchao/prototype/dtypes/uintx/bitpacking.py test/dtypes/test_bitpacking.py` (Ruff 0.11.6) — passed
- `ruff format --check torchao/prototype/dtypes/uintx/bitpacking.py test/dtypes/test_bitpacking.py` — passed
- `git diff --check` — passed

Disclosure: I used OpenAI Codex to assist with repository auditing, reproduction, and validation. I reviewed the one-line implementation change and the complete regression test.
