### PR TITLE
Gate MX/NVFP4 safetensors test configs on sm100

### DIFF
--- a/test/prototype/safetensors/test_safetensors_support.py
+++ b/test/prototype/safetensors/test_safetensors_support.py
@@ -59,8 +59,8 @@ else:
             (Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"), False),
         ]
 
-    # MX and NVFP4 configs require torch >= 2.11
-    if torch_version_at_least("2.11.0.dev"):
+    # MX and NVFP4 configs require torch >= 2.11 and sm100+
+    if torch_version_at_least("2.11.0.dev") and is_sm_at_least_100():
         _ALL_TEST_CONFIGS += [
             (MXDynamicActivationMXWeightConfig(), False),
             (NVFP4DynamicActivationNVFP4WeightConfig(), False),


### PR DESCRIPTION
`test/prototype/safetensors/test_safetensors_support.py` builds `_ALL_TEST_CONFIGS` and adds the MX / NVFP4 entries based on the torch version only:

```python
    # MX and NVFP4 configs require torch >= 2.11
    if torch_version_at_least("2.11.0.dev"):
        _ALL_TEST_CONFIGS += [
            (MXDynamicActivationMXWeightConfig(), False),
            (NVFP4DynamicActivationNVFP4WeightConfig(), False),
        ]
```

Both kernels need sm100+, but the class only gates on sm89:

```python
@unittest.skipIf(
    torch.cuda.is_available() and not is_sm_at_least_89(), "Need sm89+ for CUDA"
)
```

So on sm89/sm90 those parametrized cases run and fail instead of being skipped:

```
E  AssertionError: NVFP4 DYNAMIC mode is only supported on sm100+ machines
   torchao/prototype/mx_formats/inference_workflow.py:301

E  RuntimeError: CUDA error: CUBLAS_STATUS_NOT_SUPPORTED when calling
   `cublasLtMatmulAlgoGetHeuristic(...)`
   torchao/prototype/mx_formats/mx_tensor.py:803
```

The `Int4WeightOnlyConfig` block right above already gates on `is_sm_at_least_100()` for the same reason, and the helper is imported in this file, so this just applies the same guard to the MX/NVFP4 block.

The CPU path is unaffected — `test_safetensors` and `test_safetensors_sharded` both start with `if device == "cpu": self.skipTest("Need GPU available")`, so these configs never executed on CPU.

Before, on sm90:

```
7 failed, 13 passed, 20 skipped
```

After:

```
4 failed, 12 passed, 16 skipped
```

The 3 fixed cases are the MX/NVFP4 ones. The 4 that remain are `ImportError: Requires mslk >= 1.0.0` from `Int4WeightOnlyConfig` and are unrelated to this change (missing optional dependency in my environment).

`ruff check` and `ruff format --check` are clean on the file.

This is not covered by CI: `regression_test.yml` runs its CUDA job on `linux.g5.12xlarge.nvidia.gpu` (A10G, sm86), where the class-level `is_sm_at_least_89` skip hides the whole file.

Env: torch 2.13.0+cu130, H20 (sm90), single node.