### PR TITLE
[CPU] Register the x86 inductor int8 lowering passes from quant_api

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -8,6 +8,8 @@
 # This test takes a long time to run
 import copy
 import gc
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -603,6 +605,33 @@ class TestQuantFlow(TestCase):
         assert isinstance(model.linear1.weight, Float8Tensor)
         assert not isinstance(model.linear2.weight, Float8Tensor)
 
+    @unittest.skipIf(
+        not torch.backends.mkldnn.is_available(), "onednn qlinear needs mkldnn"
+    )
+    def test_int8_dynamic_activation_cpu_lowers_to_qlinear(self):
+        # Importing the pt2e x86 quantizer registers the fusion patterns as a side
+        # effect and cannot undo, so a fresh process is needed
+        script = """
+import torch
+from torch._inductor import config
+from torch._inductor.utils import run_and_get_code
+from torchao.quantization import Int8DynamicActivationInt8WeightConfig, quantize_
+
+config.freezing = True
+m = torch.nn.Linear(64, 128, bias=False).to(torch.bfloat16).eval()
+quantize_(m, Int8DynamicActivationInt8WeightConfig(set_inductor_config=False))
+with torch.no_grad():
+    _, (code,) = run_and_get_code(
+        torch.compile(m), torch.randn(1, 1, 64, dtype=torch.bfloat16)
+    )
+if "qlinear_pointwise" not in code or "_int_mm" in code:
+    print(code)
+    raise AssertionError("int8 linear was not lowered to onednn::qlinear")
+"""
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        self.assertEqual(out.returncode, 0, out.stdout + out.stderr)
 
 common_utils.instantiate_parametrized_tests(TestQuantFlow)
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -908,7 +908,7 @@ def _int8_dynamic_activation_int8_weight_quantize_tensor(weight, config):
     return quantized_weight
 
 def _register_qlinear_cpu_lowering_passes(device):
-    # register inductor fusion partterns that lower int8 activation linears to onednn::qlinear on CPU
+    # register inductor fusion patterns that lower int8 activation linears to onednn::qlinear on CPU
     if device.type != "cpu":
         return
 

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -907,6 +907,16 @@ def _int8_dynamic_activation_int8_weight_quantize_tensor(weight, config):
 
     return quantized_weight
 
+def _register_qlinear_cpu_lowering_passes(device):
+    # register inductor fusion partterns that lower int8 activation linears to onednn::qlinear on CPU
+    if device.type != "cpu":
+        return
+
+    from torchao.quantization.pt2e.inductor_passes.x86 import (
+        _register_quantization_weight_pack_pass,
+    )
+
+    _register_quantization_weight_pack_pass()
 
 @register_quantize_module_handler(Int8DynamicActivationInt8WeightConfig)
 def _int8_dynamic_activation_int8_weight_transform(
@@ -922,6 +932,7 @@ def _int8_dynamic_activation_int8_weight_transform(
         f"applying int8 dynamic activation int8 weight quant requires module to have {parameter_name} attribute"
         + f" but {module} does not have one"
     )
+    _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
     new_weight = _int8_dynamic_activation_int8_weight_quantize_tensor(
         getattr(module, parameter_name), config
     )
@@ -1024,6 +1035,8 @@ def _int8_static_activation_int8_weight_transform(
     act_quant_zero_point = None
     if config.act_quant_zero_point is not None:
         act_quant_zero_point = config.act_quant_zero_point.detach()
+    
+    _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
 
     quantized_tensor = Int8Tensor.from_hp(
         getattr(module, parameter_name),

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -927,12 +927,13 @@ def _int8_dynamic_activation_int8_weight_transform(
 ) -> torch.nn.Module:
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
+        _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
 
     assert hasattr(module, parameter_name), (
         f"applying int8 dynamic activation int8 weight quant requires module to have {parameter_name} attribute"
         + f" but {module} does not have one"
     )
-    _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
+
     new_weight = _int8_dynamic_activation_int8_weight_quantize_tensor(
         getattr(module, parameter_name), config
     )
@@ -1031,12 +1032,11 @@ def _int8_static_activation_int8_weight_transform(
 
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
+        _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
 
     act_quant_zero_point = None
     if config.act_quant_zero_point is not None:
         act_quant_zero_point = config.act_quant_zero_point.detach()
-    
-    _register_qlinear_cpu_lowering_passes(getattr(module, parameter_name).device)
 
     quantized_tensor = Int8Tensor.from_hp(
         getattr(module, parameter_name),


### PR DESCRIPTION
[pytorch#178466](https://github.com/pytorch/pytorch/pull/178466) moved the CPU int8 fusion patterns out of inductor and into torchao. The fusion is now only registered when importing torchao.quantization.pt2e.quantizer.x86_inductor_quantizer. Without importing the file, eager quantize_ flow stopped lowering to onednn::qlinear and fell back to aten ops on cpu. The PR adds registrations from the int8 transforms in quant_api.