### PR TITLE
[pt2e][qat] Fix qparams mismatch in FusedMovingAvgObsFakeQuantize

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -6,6 +6,7 @@
 
 # Owner(s): ["oncall: quantization"]
 import copy
+import dataclasses
 import operator
 import unittest
 from typing import Any, Optional, Tuple
@@ -60,6 +61,15 @@ class PT2EQATTestCase(QuantizationTestCase):
     """
     Base QuantizationTestCase for PT2E QAT with some helper methods.
     """
+
+    # Model weights are drawn from the ambient RNG when the test builds its
+    # model, so without seeding here the weights depend on which tests ran
+    # before, and numerics comparisons pass or fail depending on test order.
+    SEED = 0
+
+    def setUp(self):
+        super().setUp()
+        torch.manual_seed(self.SEED)
 
     class _BaseConvBnModel(torch.nn.Module):
         def __init__(
@@ -436,6 +446,7 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
     #   'QuantizationConfig' object has no attribute '__bool__'
 
     def setUp(self):
+        super().setUp()
         # NB: Skip the test if this is a base class, this is to handle the test
         # discovery logic in buck which finds and runs all tests here including
         # the base class which we don't want to run
@@ -1314,6 +1325,119 @@ class TestQuantizeMixQATAndPTQ(QuantizationTestCase):
         self.checkGraphModuleNodes(
             exported_model.graph_module, expected_node_occurrence=node_occurrence
         )
+
+
+class TestFusedMovingAvgObsFakeQuantizeQParams(QuantizationTestCase):
+    def _test_qparams_match_forward(self, per_channel: bool):
+        """
+        Test that calculate_qparams returns the same qparams that forward used.
+        """
+        if per_channel:
+            observer_kwargs = {
+                "observer": MovingAveragePerChannelMinMaxObserver,
+                "qscheme": torch.per_channel_symmetric,
+                "ch_axis": 0,
+            }
+            x = torch.tensor([[-1.149422, 2.533506], [0.3, -0.7]])
+        else:
+            observer_kwargs = {
+                "observer": MovingAverageMinMaxObserver,
+                "qscheme": torch.per_tensor_symmetric,
+            }
+            x = torch.tensor([-1.149422, 2.533506])
+
+        # Call fake quantize forward, save qparams
+        fq = FusedMovingAvgObsFakeQuantize(
+            quant_min=-8,
+            quant_max=7,
+            dtype=torch.qint8,
+            use_kernel_qparams=True,
+            **observer_kwargs,
+        )
+        fq(x)
+        scale, zero_point = fq.calculate_qparams()
+
+        # Test against reference qparams
+        ref_scale = torch.ones_like(fq.scale)
+        ref_zero_point = torch.zeros_like(fq.zero_point)
+        obs = fq.activation_post_process
+        torch.fused_moving_avg_obs_fake_quant(
+            x,
+            torch.zeros_like(fq.observer_enabled),  # freeze the observer
+            torch.ones_like(fq.fake_quant_enabled),
+            obs.min_val.clone(),
+            obs.max_val.clone(),
+            ref_scale,
+            ref_zero_point,
+            obs.averaging_constant,
+            obs.quant_min,
+            obs.quant_max,
+            fq.ch_axis,
+            fq.is_per_channel,
+            fq.is_symmetric_quant,
+        )
+        torch.testing.assert_close(scale, ref_scale, atol=0, rtol=0)
+        torch.testing.assert_close(zero_point, ref_zero_point, atol=0, rtol=0)
+
+        # The observer uses a different symmetric formula and should not match
+        obs_scale, _ = obs.calculate_qparams()
+        self.assertFalse(torch.equal(scale, obs_scale))
+
+    def test_qparams_match_forward_per_tensor(self):
+        self._test_qparams_match_forward(per_channel=False)
+
+    def test_qparams_match_forward_per_channel(self):
+        self._test_qparams_match_forward(per_channel=True)
+
+    def test_qparams_use_kernel_qparams_through_quantizer(self):
+        """
+        Test that prepare and convert numerics can be aligned exactly through
+        `use_kernel_qparams` in `FusedMovingAvgObsFakeQuantize`.
+        """
+        # Set `use_kernel_qparams` in the quantizer
+        quantization_config = get_symmetric_quantization_config(
+            is_per_channel=True, is_qat=True
+        )
+        weight = dataclasses.replace(
+            quantization_config.weight,
+            observer_or_fake_quant_ctr=FusedMovingAvgObsFakeQuantize.with_args(
+                observer=MovingAveragePerChannelMinMaxObserver,
+                use_kernel_qparams=True,
+            ),
+        )
+        quantization_config = dataclasses.replace(quantization_config, weight=weight)
+        quantizer = XNNPACKQuantizer().set_global(quantization_config)
+
+        # Instantiate model and prepare it
+        example_inputs = (torch.randn(1, 3, 5, 5),)
+        m = torch.nn.Conv2d(3, 3, 3)
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        m = prepare_qat_pt2e(m, quantizer)
+        m(*example_inputs)
+
+        # Grab kernel qparams and observer qparams
+        weight_fqs = [
+            mod
+            for mod in m.modules()
+            if isinstance(mod, FusedMovingAvgObsFakeQuantize) and mod.use_kernel_qparams
+        ]
+        self.assertEqual(len(weight_fqs), 1)
+        weight_fq = weight_fqs[0]
+        self.assertTrue(weight_fq.is_per_channel)
+        expected_scale = weight_fq.scale.clone()
+        obs_scale, _ = weight_fq.activation_post_process.calculate_qparams()
+
+        # Assert that the converted model uses kernel qparams, not observer qparams
+        m = convert_pt2e(m)
+        scale_nodes = [
+            n.args[1]
+            for n in m.graph.nodes
+            if n.target == torch.ops.quantized_decomposed.dequantize_per_channel.default
+        ]
+        self.assertEqual(len(scale_nodes), 1)
+        converted_scale = getattr(m, scale_nodes[0].target)
+        torch.testing.assert_close(converted_scale, expected_scale, atol=0, rtol=0)
+        self.assertFalse(torch.equal(converted_scale, obs_scale))
 
 
 if __name__ == "__main__":

--- a/torchao/quantization/pt2e/fake_quantize.py
+++ b/torchao/quantization/pt2e/fake_quantize.py
@@ -393,6 +393,15 @@ class FusedMovingAvgObsFakeQuantize(FakeQuantize):
     Similar to :class:`~torchao.quantization.pt2e.FakeQuantize`, and accepts the same attributes as the
     base class.
 
+    Args:
+        observer (class): Observer class for collecting statistics on input tensors
+        quant_min (int): Min quantized value
+        quant_max (int): Max quantized value
+        use_kernel_qparams (bool, default False): If True, `calculate_qparams` returns
+          the qparams computed by the fused kernel instead of the inner observer's.
+          Note: these qparams can be stale if fake quant was disabled during the last
+          forward, in which case the kernel stops updating our local qparam buffers.
+        observer_kwargs (optional): Arguments for the observer class
     """
 
     def __init__(
@@ -400,9 +409,11 @@ class FusedMovingAvgObsFakeQuantize(FakeQuantize):
         observer: Any = MovingAverageMinMaxObserver,
         quant_min: int = 0,
         quant_max: int = 255,
+        use_kernel_qparams: bool = False,
         **observer_kwargs: Any,
     ) -> None:
         super().__init__(observer, quant_min, quant_max, **observer_kwargs)
+        self.use_kernel_qparams = use_kernel_qparams
         assert isinstance(
             self.activation_post_process,
             (MovingAverageMinMaxObserver, MovingAveragePerChannelMinMaxObserver),
@@ -417,7 +428,17 @@ class FusedMovingAvgObsFakeQuantize(FakeQuantize):
 
     @torch.jit.export
     def calculate_qparams(self) -> tuple[torch.Tensor, torch.Tensor]:
-        return self.activation_post_process.calculate_qparams()
+        """
+        If `use_kernel_qparams` is True, return the last (scale, zero_point)
+        computed by the fused kernel in forward.
+
+        Otherwise, calculate them using the inner observer, which computes
+        qparams using a slightly different formula than the fused kernel.
+        """
+        if self.use_kernel_qparams:
+            return self.scale, self.zero_point
+        else:
+            return self.activation_post_process.calculate_qparams()
 
     @torch.jit.export
     def extra_repr(self) -> str:


### PR DESCRIPTION
**Summary:** In PT2E QAT, `FusedMovingAvgObsFakeQuantize` offers
two different qparams calculations with slightly differing numerics:

(1) `torch.fused_moving_avg_obs_fake_quant`

```
# aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
int symmetric_qmin = -((qmax - qmin) / 2 + 1);
int symmetric_qmax = (qmax - qmin) / 2;
double max_scale = std::max(
    fabs(min_val / symmetric_qmin), fabs(max_val / symmetric_qmax));
min_val = max_scale * symmetric_qmin;
max_val = max_scale * symmetric_qmax;
min_val = std::min(min_val, 0.f);
max_val = std::max(max_val, 0.f);
scale[i] = (static_cast<double>(max_val) - min_val) / (qmax - qmin);
```

(2) `MovingAverageMinMaxObserver.calculate_qparams`

```
max_val_pos = torch.max(-min_val_neg, max_val_pos)
scale = max_val_pos / (float(quant_max - quant_min) / 2)
scale = torch.max(scale, self.eps)
```

For [-8, 7], (1) divides by 8 or 7 while (2) divides by 7.5,
so e.g. min=-1.149422, max=2.533506 gives 0.361929 vs 0.337801.

Although only (1) is ever called during training, (2) is
actually called during `convert_pt2e` after training when
swapping the FakeQuantize classes to qdq ops, resulting in
slight numerical divergences.

This commit fixes this by adding a flag `use_kernel_params`
that allows convert to read the qparams from (1) the qparam
buffers set by the fused kernel. This resolves the duplicate
observer semantics in `FusedMovingAvgObsFakeQuantize`, which
was the root cause of the numerical divergence.

Note: this flag defaults to False and is opt-in only when
instantiating your own quantizer. Thus, existing behavior
is unchanged. An example of how to set this flag through
your quantizer can be found in
`test_qparams_use_kernel_qparams_through_quantizer`.

**Test Plan:**

```
pytest test/quantization/pt2e/test_quantize_pt2e_qat.py -k TestFusedMovingAvgObsFakeQuantizeQParams
```