### PR TITLE
Fix generate_permute_indices max_len bounds

### DIFF
--- a/test/prototype/moe_training/ep/test_kernels.py
+++ b/test/prototype/moe_training/ep/test_kernels.py
@@ -16,8 +16,59 @@ if not (
 ):
     pytest.skip("Test requires CUDA 12.8+ with SM >= 100", allow_module_level=True)
 
-from torchao.prototype.moe_training.ep.kernels import generate_permute_indices
+from torchao.prototype.moe_training.ep.kernels import (
+    _fill_indices_kernel,
+    generate_permute_indices,
+)
 from torchao.prototype.moe_training.ep.permute import _triton_permute_bwd
+
+
+@pytest.mark.parametrize(
+    "experts_per_rank,num_ranks,counts,max_len,alignment",
+    [
+        (2, 2, [4, 4, 4, 4], 12, 4),
+        (4, 2, [3, 3, 3, 3, 3, 3, 3, 3], 20, 2),
+        (1, 4, [8, 8, 8, 8], 16, 8),
+    ],
+)
+def test_generate_permute_indices_respects_max_len(
+    experts_per_rank, num_ranks, counts, max_len, alignment
+):
+    token_counts = torch.tensor(counts, dtype=torch.int32, device="cuda")
+    start_indices = torch.cumsum(token_counts, 0) - token_counts
+    total = torch.clamp_min(token_counts.view(num_ranks, -1).sum(0), alignment)
+    m_sizes = ((total + alignment - 1) // alignment * alignment).to(torch.int32)
+    write_offsets = torch.cumsum(m_sizes, 0) - m_sizes
+
+    sentinel = -999
+    guarded_output = torch.full(
+        (max_len + 64,), sentinel, dtype=torch.int32, device="cuda"
+    )
+    _fill_indices_kernel[(min(experts_per_rank, 1024),)](
+        token_counts,
+        start_indices,
+        write_offsets,
+        guarded_output[:max_len],
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        BLOCK_SIZE=128,
+    )
+    torch.cuda.synchronize()
+    assert torch.all(guarded_output[max_len:] == sentinel)
+
+    gpu_indices, _, _ = generate_permute_indices(
+        token_counts, experts_per_rank, num_ranks, max_len, alignment
+    )
+    cpu_indices, _, _ = generate_permute_indices(
+        token_counts.cpu(),
+        experts_per_rank,
+        num_ranks,
+        max_len,
+        alignment,
+        use_cpu=True,
+    )
+    torch.testing.assert_close(gpu_indices.cpu(), cpu_indices)
 
 
 @pytest.mark.parametrize(

--- a/test/prototype/moe_training/reference_moe.py
+++ b/test/prototype/moe_training/reference_moe.py
@@ -41,6 +41,7 @@ def _fill_indices_kernel(
     output_ptr,
     experts_per_rank: tl.constexpr,
     num_ranks: tl.constexpr,
+    max_len,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
@@ -58,9 +59,9 @@ def _fill_indices_kernel(
 
             for chunk_start in range(0, length, BLOCK_SIZE):
                 chunk_offsets = chunk_start + offsets
-                mask = chunk_offsets < length
                 values = start_index + chunk_offsets
                 dest_indices = write_offset + chunk_offsets
+                mask = (chunk_offsets < length) & (dest_indices < max_len)
                 tl.store(output_ptr + dest_indices, values, mask=mask)
 
             write_offset += length
@@ -90,6 +91,7 @@ def fill_indices_wrapper(
         permuted_indices,
         experts_per_rank,
         num_ranks,
+        max_len,
         BLOCK_SIZE=block_size,
     )
     return permuted_indices
@@ -114,7 +116,7 @@ def fill_indices_cpu(
             i = r * experts_per_rank + e
             start_index = start_index_values[i].item()
             length = tokens_per_expert_group[i].item()
-            if length > 0:
+            if length > 0 and write_start < max_len:
                 end_idx = min(write_start + length, max_len)
                 permuted_indices[write_start:end_idx] = torch.arange(
                     start_index,

--- a/torchao/prototype/moe_training/ep/kernels.py
+++ b/torchao/prototype/moe_training/ep/kernels.py
@@ -23,6 +23,7 @@ def _fill_indices_kernel(
     output_ptr,
     experts_per_rank: tl.constexpr,
     num_ranks: tl.constexpr,
+    max_len,
     BLOCK_SIZE: tl.constexpr,  # Number of threads per block
 ):
     pid = tl.program_id(axis=0)
@@ -48,13 +49,11 @@ def _fill_indices_kernel(
             for chunk_start in range(0, length, BLOCK_SIZE):
                 chunk_offsets = chunk_start + offsets
 
-                # mask valid indices
-                mask = chunk_offsets < length
-
                 values = start_index + chunk_offsets
 
                 # destination
                 dest_indices = write_offset + chunk_offsets
+                mask = (chunk_offsets < length) & (dest_indices < max_len)
 
                 # store
                 tl.store(output_ptr + dest_indices, values, mask=mask)
@@ -97,6 +96,7 @@ def fill_indices_wrapper(
         permuted_indices,
         experts_per_rank,
         num_ranks,
+        max_len,
         BLOCK_SIZE=block_size,
     )
     return permuted_indices
@@ -127,7 +127,7 @@ def fill_indices_cpu(
             start_index = start_index_values[i].item()
             length = tokens_per_expert_group[i].item()
             # Fill in the indices
-            if length > 0:
+            if length > 0 and write_start < max_len:
                 end_idx = min(write_start + length, max_len)
                 permuted_indices[write_start:end_idx] = torch.arange(
                     start_index,


### PR DESCRIPTION
## Summary

`generate_permute_indices` allocates an output of length `max_len`, but the Triton kernel previously masked stores only by each run length. When aligned expert offsets extended past `max_len`, the kernel wrote beyond the output allocation. The CPU reference also raised when a later expert started beyond the limit.

This change:

- passes `max_len` into the Triton kernel and masks every store by the destination bound;
- skips CPU writes whose starting offset is already outside the output;
- keeps the vendored test reference implementation in sync; and
- adds guard-band and CPU/GPU parity coverage for three truncation shapes.

I searched open PRs by issue number, `generate_permute_indices max_len`, and `fill_indices` out-of-bounds keywords and found no existing implementation.

Fixes #4825.

## Validation

RTX 5090, PyTorch 2.10.0+cu128, Triton 3.6.0:

```text
Baseline:
max_len=12 guard writes= 4; gpu == cpu: True
max_len=20 guard writes= 4; CPU raised RuntimeError
max_len=16 guard writes=16; CPU raised RuntimeError

Patched:
max_len=12 guard writes= 0; gpu == cpu: True
max_len=20 guard writes= 0; gpu == cpu: True
max_len=16 guard writes= 0; gpu == cpu: True
```

Focused and adjacent tests:

```text
pytest test/prototype/moe_training/ep/test_kernels.py -vv
12 passed in 3.93s
```

Compilation smoke:

```text
torch.compile(fullgraph=True), two repeated calls
torch.compile repeated-call parity: PASS
```

Additional checks:

```text
pre-commit: passed
python compileall: passed
git diff --check: passed
```

AI assistance was used for implementation suggestions and test preparation. I reviewed and understand every change and will maintain the contribution and address reviewer feedback.
