### PR TITLE
Refactor ToyConvModel into shared testing architectures

### DIFF
--- a/test/prototype/test_prototype_float8_tensor.py
+++ b/test/prototype/test_prototype_float8_tensor.py
@@ -29,32 +29,15 @@ from torchao.quantization import (
 from torchao.quantization.granularity import PerRow, PerTensor
 from torchao.quantization.quantize_.common import IsStaticQuantizationConfig
 from torchao.quantization.utils import compute_error
-from torchao.testing.model_architectures import ToySingleLinearModel, ToyTwoLinearModel
+from torchao.testing.model_architectures import (
+    ToyConvModel,
+    ToySingleLinearModel,
+    ToyTwoLinearModel,
+)
 from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
     is_sm_at_least_90,
 )
-
-
-# copied from test/quantization/quantize_/workflows/float8/test_float8_tensor.py
-class ToyConvModel(torch.nn.Module):
-    def __init__(
-        self, dim, in_channels, out_channels, kernel_size, bias, padding, dtype, device
-    ):
-        super().__init__()
-        convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
-        self.conv = convs[dim](
-            in_channels,
-            out_channels,
-            kernel_size,
-            bias=bias,
-            padding=padding,
-            dtype=dtype,
-            device=device,
-        )
-
-    def forward(self, x):
-        return self.conv(x)
 
 
 class ToyLinearSoftmaxModel(torch.nn.Module):

--- a/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
+++ b/test/quantization/quantize_/workflows/float8/test_float8_tensor.py
@@ -29,6 +29,7 @@ from torchao.quantization import (
 )
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
+from torchao.testing.model_architectures import ToyConvModel
 from torchao.testing.utils import TorchAOIntegrationTestCase
 from torchao.utils import (
     _is_mslk_available,
@@ -73,26 +74,6 @@ class ToyLinearModel(torch.nn.Module):
             assert granularity == (PerBlock([1, 128]), PerBlock([128, 128]))
             assert qs1.shape == (N // 128, K // 128)
             assert qs2.shape == (K // 128, N // 128)
-
-
-class ToyConvModel(torch.nn.Module):
-    def __init__(
-        self, dim, in_channels, out_channels, kernel_size, bias, padding, dtype, device
-    ):
-        super().__init__()
-        convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
-        self.conv = convs[dim](
-            in_channels,
-            out_channels,
-            kernel_size,
-            bias=bias,
-            padding=padding,
-            dtype=dtype,
-            device=device,
-        )
-
-    def forward(self, x):
-        return self.conv(x)
 
 
 class GroupedMMModel(torch.nn.Module):

--- a/torchao/testing/model_architectures.py
+++ b/torchao/testing/model_architectures.py
@@ -80,6 +80,26 @@ class ToyTwoLinearModel(torch.nn.Module):
         return x
 
 
+class ToyConvModel(torch.nn.Module):
+    def __init__(
+        self, dim, in_channels, out_channels, kernel_size, bias, padding, dtype, device
+    ):
+        super().__init__()
+        convs = {1: torch.nn.Conv1d, 2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
+        self.conv = convs[dim](
+            in_channels,
+            out_channels,
+            kernel_size,
+            bias=bias,
+            padding=padding,
+            dtype=dtype,
+            device=device,
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
+
 class ConvWithSharedWeightInExportedModel(nn.Module):
     def __init__(
         self,


### PR DESCRIPTION
## Summary

This PR addresses part of #2078 

- Move `ToyConvModel` into `torchao.testing.model_architectures`
- Replace duplicate definitions in the prototype and quantization float8 test suites with the shared model

## Testing
- `ruff check` and `ruff format --check` passed on all changed files. 
- Prototype float8 convolution tests collected successfully: 16 skipped because supported accelerator hardware was unavailable
- Quantization float8 convolution tests collected successfully: 80 skipped because supported accelerator hardware was unavailable