### PR TITLE
Limit MXFP8 PyTorch version guard to DTensor usage

### DIFF
--- a/test/prototype/moe_training/test_conversion_utils.py
+++ b/test/prototype/moe_training/test_conversion_utils.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from torch import nn
+from torch.distributed.tensor import _dispatch, _ops
+
+import torchao.prototype.moe_training.tensor as tensor_mod
+from torchao.prototype.moe_training.config import MXFP8TrainingOpConfig
+from torchao.prototype.moe_training.tensor import (
+    MXFP8TrainingWeightWrapperTensor,
+)
+from torchao.quantization import quantize_
+
+
+def _remove_mxfp8_dtensor_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(_ops, "scaled_mm_single_dim_strategy", raising=False)
+    monkeypatch.delattr(_dispatch, "is_pinned_handler", raising=False)
+
+
+def test_mxfp8_non_dtensor_conversion_does_not_require_torch_2_12(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _remove_mxfp8_dtensor_support(monkeypatch)
+
+    config = MXFP8TrainingOpConfig()
+    model = nn.Linear(4, 4)
+    quantize_(model, config)
+
+    assert isinstance(model.weight, MXFP8TrainingWeightWrapperTensor)
+
+
+def test_mxfp8_dtensor_requires_torch_2_12(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _remove_mxfp8_dtensor_support(monkeypatch)
+    monkeypatch.setattr(tensor_mod, "DTensor", torch.Tensor)
+
+    with pytest.raises(
+        RuntimeError,
+        match="MXFP8 training with DTensor requires PyTorch 2.12 or later",
+    ):
+        MXFP8TrainingWeightWrapperTensor(torch.randn(4, 4), MXFP8TrainingOpConfig())

--- a/torchao/prototype/moe_training/README.md
+++ b/torchao/prototype/moe_training/README.md
@@ -123,6 +123,7 @@ quantize_(model, config=config, filter_fn=moe_module_filter_fn)
 ## System requirements
 - torchao 0.14+
 - For MXFP8 MoE training, CUDA 12.8+ and SM100+ GPU arch are required.
+- MXFP8 training with DTensor requires PyTorch 2.12+.
 - For FP8 rowwise MoE training, CUDA 12.4+ and SM89+ GPU arch are required.
 
 

--- a/torchao/prototype/moe_training/conversion_utils.py
+++ b/torchao/prototype/moe_training/conversion_utils.py
@@ -30,16 +30,6 @@ def _get_tensor_cls_for_config(
     )
 
     if isinstance(config, MXFP8TrainingOpConfig):
-        from torch.distributed.tensor import _dispatch, _ops
-
-        pytorch_version_supported = hasattr(
-            _ops, "scaled_mm_single_dim_strategy"
-        ) and hasattr(_dispatch, "is_pinned_handler")
-
-        assert pytorch_version_supported, (
-            "Please install the latest torch nightly build to use MXFP8 training"
-        )
-
         return MXFP8TrainingWeightWrapperTensor
     elif isinstance(config, Float8TrainingOpConfig):
         return Float8TrainingWeightWrapperTensor

--- a/torchao/prototype/moe_training/tensor.py
+++ b/torchao/prototype/moe_training/tensor.py
@@ -31,6 +31,19 @@ aten = torch.ops.aten
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+
+def _assert_mxfp8_dtensor_supported() -> None:
+    from torch.distributed.tensor import _dispatch, _ops
+
+    if not (
+        hasattr(_ops, "scaled_mm_single_dim_strategy")
+        and hasattr(_dispatch, "is_pinned_handler")
+    ):
+        raise RuntimeError(
+            "MXFP8 training with DTensor requires PyTorch 2.12 or later."
+        )
+
+
 _ops_to_preserve_subclass = {
     torch.ops.aten.empty_like.default,
     torch.ops.aten.new_zeros.default,
@@ -277,6 +290,16 @@ class MXFP8TrainingWeightWrapperTensor(TrainingWeightWrapperBaseTensor):
     to use dynamic quantization of inputs to MXFP8, then runs the MXFP8 grouped_mm/linear,
     based on the training config.
     """
+
+    @staticmethod
+    def __new__(
+        cls,
+        tensor: torch.Tensor,
+        config: MXFP8TrainingOpConfig,
+    ):
+        if isinstance(tensor, DTensor):
+            _assert_mxfp8_dtensor_supported()
+        return TrainingWeightWrapperBaseTensor.__new__(cls, tensor, config)
 
     @classmethod
     def __torch_function__(cls, func, types, args, kwargs={}):


### PR DESCRIPTION
## Summary

- allow non-DTensor MXFP8 parameter conversion when the PyTorch DTensor support required by pytorch/ao#4010 is unavailable
- check for `scaled_mm_single_dim_strategy` and `is_pinned_handler` only when an MXFP8 training wrapper is constructed around a DTensor
- replace the stale nightly-only assertion with an actionable PyTorch 2.12+ error for unsupported DTensor usage
- document the feature-specific DTensor requirement and add CPU regression coverage for the public `quantize_` entrypoint

This preserves the capability check required by pytorch/ao#4010 while avoiding an unconditional nightly requirement for non-DTensor paths, including the emulated path.

Fixes #4830.

## Test plan

```
python -m ruff check torchao/prototype/moe_training/conversion_utils.py torchao/prototype/moe_training/tensor.py test/prototype/moe_training/test_conversion_utils.py
python -m ruff format --check torchao/prototype/moe_training/conversion_utils.py torchao/prototype/moe_training/tensor.py test/prototype/moe_training/test_conversion_utils.py
pytest -q -p no:cacheprovider   test/prototype/moe_training/test_conversion_utils.py   test/prototype/moe_training/test_tensor.py   test/prototype/moe_training/test_training.py   test/prototype/moe_training/test_mxfp8_linear.py
```

Result: `2 passed, 3 skipped` on a CPU-only development machine; the skipped modules require CUDA.