### PR TITLE
[BE] Use shared ToyTwoLinearModel in test_integration TestBenchmarkModel

### DIFF
--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -50,6 +50,7 @@ from torchao.quantization.utils import (
 from torchao.quantization.utils import (
     compute_error as SQNR,
 )
+from torchao.testing.model_architectures import ToyTwoLinearModel
 from torchao.testing.utils import skip_if_rocm, skip_if_xpu
 from torchao.utils import (
     benchmark_model,
@@ -824,30 +825,12 @@ class TestUtils(unittest.TestCase):
 
 
 class TestBenchmarkModel(unittest.TestCase):
-    class ToyLinearModel(torch.nn.Module):
-        def __init__(self, m=64, n=32, k=64):
-            super().__init__()
-            self.linear1 = torch.nn.Linear(m, n, bias=False)
-            self.linear2 = torch.nn.Linear(n, k, bias=False)
-
-        def example_inputs(self, batch_size=1, dtype=torch.float32, device="cpu"):
-            return (
-                torch.randn(
-                    batch_size, self.linear1.in_features, dtype=dtype, device=device
-                ),
-            )
-
-        def forward(self, x):
-            x = self.linear1(x)
-            x = self.linear2(x)
-            return x
-
     def run_benchmark_model(self, device):
         # params
         dtype = torch.bfloat16
-        m = self.ToyLinearModel(1024, 1024, 1024).eval().to(dtype).to(device)
+        m = ToyTwoLinearModel(1024, 1024, 1024, dtype, device).eval()
         m_bf16 = copy.deepcopy(m)
-        example_inputs = m.example_inputs(dtype=dtype, device=device)
+        example_inputs = m.example_inputs()
         m_bf16 = torch.compile(m_bf16, mode="max-autotune")
         num_runs = 1
         return benchmark_model(m_bf16, num_runs, example_inputs)


### PR DESCRIPTION
Continuation of the tracker in #2078.

This PR replaces the nested `ToyLinearModel` inside `TestBenchmarkModel` (`test/integration/test_integration.py`) with the shared `ToyTwoLinearModel` from `torchao.testing.model_architectures`.

## Test plan
- `pytest test/integration/test_integration.py` — CPU: 8 passed, 51 skipped
- `ruff check` / `ruff format --check` — clean
