### PR TITLE
Stop PruneOptimizer.__getattribute__ recursing (#4833)

### DIFF
--- a/test/prototype/pat/test_pat_pruneopt.py
+++ b/test/prototype/pat/test_pat_pruneopt.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
+import pickle
 import random
 import unittest
 
@@ -20,13 +22,21 @@ class TestPruneOptimizer(common_utils.TestCase):
         self.reg_lambda = 1.0
         self.prox_map = ProxLasso(self.reg_lambda)
 
+    def _create_prune_optimizer(self):
+        model = TwoLayerMLP(input_size=10, output_size=2)
+        param_groups = get_param_groups(
+            model, model._linear_prune_config(), verbose=False
+        )
+        base_optimizer = torch.optim.SGD(param_groups, lr=0.1, foreach=True)
+        return PruneOptimizer(base_optimizer, reg_lambda=self.reg_lambda)
+
     @common_utils.parametrize("warmup_steps", [0, 5])
     def test_warmup_steps(self, warmup_steps=0, total_steps=10):
         model = TwoLayerMLP(input_size=10, output_size=2)
         prune_config = model._linear_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
         optimizer = PruneOptimizer(
-            torch.optim.SGD(param_groups, lr=0.1),
+            torch.optim.SGD(param_groups, lr=0.1, foreach=True),
             reg_lambda=self.reg_lambda,
             warmup_steps=warmup_steps,
         )
@@ -54,7 +64,7 @@ class TestPruneOptimizer(common_utils.TestCase):
         prune_config = model._linear_prune_config()
         param_groups = get_param_groups(model, prune_config, verbose=False)
         optimizer = PruneOptimizer(
-            torch.optim.AdamW(param_groups, lr=0.01),
+            torch.optim.AdamW(param_groups, lr=0.01, foreach=True),
             reg_lambda=self.reg_lambda,
             warmup_steps=0,
             healing_start_step=healing_start_step,
@@ -79,6 +89,44 @@ class TestPruneOptimizer(common_utils.TestCase):
                             self.assertTrue(p.grad[zero_mask].eq(0).all())
                             self.assertTrue(p[zero_mask].eq(0).all())
         self.assertFalse(prev_pruned_p is None)
+
+    def test_missing_base_optimizer_raises_instead_of_recursing(self):
+        # __new__ without __init__ is what pickle and copy produce.
+        optimizer = PruneOptimizer.__new__(PruneOptimizer)
+
+        with self.assertRaises(AttributeError):
+            optimizer.base_optimizer
+
+        with self.assertRaises(AttributeError):
+            optimizer.anything_at_all
+
+        with self.assertRaises(AttributeError):
+            optimizer.__setstate__({})
+
+    def test_copy_raises_missing_base_optimizer_instead_of_recursing(self):
+        optimizer = self._create_prune_optimizer()
+
+        with self.assertRaisesRegex(AttributeError, "base_optimizer"):
+            copy.copy(optimizer)
+
+    def test_pickle_raises_missing_base_optimizer_instead_of_recursing(self):
+        optimizer = self._create_prune_optimizer()
+        serialized_optimizer = pickle.dumps(optimizer)
+
+        with self.assertRaisesRegex(AttributeError, "base_optimizer"):
+            pickle.loads(serialized_optimizer)
+
+    def test_getattribute_still_delegates_to_base_optimizer(self):
+        optimizer = self._create_prune_optimizer()
+        base_optimizer = optimizer.base_optimizer
+
+        self.assertIs(optimizer.base_optimizer, base_optimizer)
+        # Neither is defined on PruneOptimizer; both resolve via the fallback.
+        self.assertIs(optimizer.defaults, base_optimizer.defaults)
+        self.assertIs(optimizer.param_groups, base_optimizer.param_groups)
+
+        with self.assertRaises(AttributeError):
+            optimizer.definitely_not_an_attribute
 
 
 common_utils.instantiate_parametrized_tests(TestPruneOptimizer)

--- a/torchao/prototype/pat/optim/pruneopt.py
+++ b/torchao/prototype/pat/optim/pruneopt.py
@@ -75,10 +75,13 @@ class PruneOptimizer(Optimizer):
 
     def __getattribute__(self, name: str):
         try:
-            attr = super(Optimizer, self).__getattribute__(name)
+            return super(Optimizer, self).__getattribute__(name)
         except AttributeError:
-            attr = self.base_optimizer.__getattribute__(name)
-        return attr
+            # Not `self.base_optimizer`: that re-enters this method, so on an
+            # instance built by __new__ without __init__ (pickle, copy) the
+            # lookup recurses until the stack overflows.
+            base_optimizer = object.__getattribute__(self, "base_optimizer")
+            return base_optimizer.__getattribute__(name)
 
     def __repr__(self) -> str:
         base_optimizer = "\n    ".join(self.base_optimizer.__repr__().split("\n"))


### PR DESCRIPTION
Summary:

`__getattribute__`'s fallback goes through `self.base_optimizer`, which re-enters `__getattribute__`! When that attribute is unset (what pickle and copy produce) it recurses into a `RecursionError`, chaining an identical `AttributeError` at every level, so the ~400KB traceback blows the 50k log cap and Scuba shows 121 copies of one frame with the real error truncated off the end. 113 jobs, 2026-06-19 to 07-03.

[Scuba query showing affected jobs](https://our.intern.facebook.com/intern/scuba/query/?dataset=dai_modelstore&drillstate=%7B%22purposes%22%3A%5B%5D%2C%22end%22%3A%22now%22%2C%22start%22%3A%22-168+hours%22%2C%22filterMode%22%3A%22DEFAULT%22%2C%22sampleCols%22%3A%5B%22device_region%22%2C%22duration%22%2C%22entitlement%22%2C%22event%22%2C%22exception_message%22%2C%22host_name%22%2C%22is_anchor%22%2C%22is_async_checkpoint%22%2C%22is_dcp_stack%22%2C%22job_owner_unixname%22%2C%22lsst%22%2C%22mast_job_attempt_index%22%2C%22mast_job_name%22%2C%22mast_job_version%22%2C%22num_trainer%22%2C%22oncall%22%2C%22time%22%5D%2C%22cols%22%3A%5B%5D%2C%22derivedCols%22%3A%5B%5D%2C%22mappedCols%22%3A%5B%5D%2C%22enumCols%22%3A%5B%5D%2C%22return_remainder%22%3Afalse%2C%22should_pivot%22%3Afalse%2C%22is_timeseries%22%3Afalse%2C%22native_compatible_mode%22%3Afalse%2C%22hideEmptyColumns%22%3Afalse%2C%22timezone%22%3A%22America%2FLos_Angeles%22%2C%22compare%22%3A%5B%5D%2C%22samplingRatio%22%3A1%2C%22minBucketSamples%22%3A%22%22%2C%22top%22%3A50%2C%22dimensions%22%3A%5B%22mast_job_name%22%2C%22device_region%22%2C%22pkg_version%22%5D%2C%22metric%22%3A%22count%22%2C%22show_sample_cols%22%3A%22both%22%2C%22num_samples%22%3A%22100%22%2C%22aggregateList%22%3A%5B%5D%2C%22param_dimensions%22%3A%5B%5D%2C%22order%22%3A%22none%22%2C%22order_desc%22%3Atrue%2C%22constraints%22%3A%5B%5B%7B%22column%22%3A%22event%22%2C%22op%22%3A%22eq%22%2C%22value%22%3A%5B%22%5B%5C%22CheckpointLoadFailure%5C%22%5D%22%5D%2C%22is_included_in_query%22%3Atrue%7D%2C%7B%22column%22%3A%22exception_message%22%2C%22op%22%3A%22substr%22%2C%22value%22%3A%5B%22%5B%5C%22PruneOptimizer%27+object+has+no+attribute+%27base_optimizer%27%5C%22%5D%22%5D%2C%22is_included_in_query%22%3Atrue%7D%2C%7B%22column%22%3A%22is_preemption_detected%22%2C%22op%22%3A%22eq%22%2C%22value%22%3A%5B%22%5B%5C%220%5C%22%5D%22%5D%2C%22is_included_in_query%22%3Atrue%7D%2C%7B%22column%22%3A%22mast_job_name%22%2C%22op%22%3A%22%21substr%22%2C%22value%22%3A%5B%22%5B%5C%22sw-%5C%22%5D%22%5D%2C%22is_included_in_query%22%3Atrue%7D%2C%7B%22column%22%3A%22entitlement%22%2C%22op%22%3A%22neq%22%2C%22value%22%3A%5B%22%5B%5C%22dper_int%5C%22%5D%22%5D%2C%22is_included_in_query%22%3Atrue%7D%5D%5D%2C%22c_constraints%22%3A%5B%5B%5D%5D%2C%22b_constraints%22%3A%5B%5B%5D%5D%2C%22ignoreGroupByInComparison%22%3Afalse%7D&view=samples_client&pool=uber)

Resolve `base_optimizer` through `object.__getattribute__` to break the cycle. Makes the failure legible, not loadable.

Differential Revision: D114652149


