### PR TITLE
Fold away num_batches_tracked when the +1 is a lifted constant (#4834)

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -767,6 +767,114 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
         self.assertEqual(dq_qmax, 2**31 - 1)
         self.assertEqual(dq_dtype, torch.int32)
 
+    def test_is_one_accepts_lifted_constant(self):
+        """`_is_one` must accept the `+ 1` whether it is a literal or lifted.
+
+        `export` may lift the `1` of BatchNorm's `num_batches_tracked` increment
+        into a tensor constant, so the argument reaching `_fold_conv_bn_qat` is a
+        `get_attr` node. Comparing against the literal alone silently skips the
+        erase and leaves a live mutated buffer behind.
+        """
+        from torchao.quantization.pt2e.qat_utils import _is_one
+
+        root = torch.nn.Module()
+        root.register_buffer("_constant_one", torch.tensor(1))
+        root.register_buffer("_constant_two", torch.tensor(2))
+        root.register_buffer("_constant_ones", torch.tensor([1, 1]))
+        graph = torch.fx.Graph()
+        node_one = graph.get_attr("_constant_one")
+        node_two = graph.get_attr("_constant_two")
+        node_ones = graph.get_attr("_constant_ones")
+        graph.output(node_one)
+        gm = torch.fx.GraphModule(root, graph)
+
+        self.assertTrue(_is_one(1, gm))
+        self.assertTrue(_is_one(node_one, gm))
+        self.assertFalse(_is_one(2, gm))
+        self.assertFalse(_is_one(node_two, gm))
+        # a multi-element tensor is not the scalar 1
+        self.assertFalse(_is_one(node_ones, gm))
+
+    def test_qat_conv_bn_drops_num_batches_tracked(self):
+        """The folded-away BatchNorm must not leave its counter behind.
+
+        `_fold_conv_bn_qat` erases BatchNorm's `num_batches_tracked += 1` once the
+        BatchNorm is folded into the conv. `export` may lift that `1` into a
+        tensor constant, in which case the argument is a `get_attr` node rather
+        than the literal and the erase used to be skipped -- leaving a live,
+        *mutated* `num_batches_tracked` buffer in a graph whose BatchNorm no
+        longer exists. Backends that map mutated buffers to graph I/O then see one
+        spurious input and output per BatchNorm.
+
+        Captured in train mode on purpose: an eval-mode capture never increments
+        the counter, so it does not reproduce.
+        """
+        m = self._get_conv_bn_model().train()
+        example_inputs = self.example_inputs
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        quantizer = XNNPACKQuantizer()
+        quantizer.set_global(get_symmetric_quantization_config(is_qat=True))
+        m = prepare_qat_pt2e(m, quantizer)
+        m(*example_inputs)
+        m = convert_pt2e(m)
+
+        counters = [
+            n
+            for n in m.graph.nodes
+            if n.op == "get_attr" and "num_batches_tracked" in str(n.target)
+        ]
+        self.assertEqual(
+            counters,
+            [],
+            f"num_batches_tracked survived the fold: {counters}",
+        )
+        increments = [
+            n for n in m.graph.nodes if n.target is torch.ops.aten.add_.Tensor
+        ]
+        self.assertEqual(
+            increments,
+            [],
+            f"in-place BatchNorm counter increment survived the fold: {increments}",
+        )
+
+    def test_qat_conv_bn_keeps_read_num_batches_tracked(self):
+        """A model that reads the counter keeps it -- the increment is not dead.
+
+        `_fold_conv_bn_qat` erases the `num_batches_tracked += 1` on the
+        assumption that nothing consumes it. When the model reads the counter the
+        increment feeds real users, so erasing it raises out of `erase_node` and
+        takes down `convert_pt2e`.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self, conv_class, bn_class):
+                super().__init__()
+                self.conv = conv_class(3, 3, 3)
+                self.bn = bn_class(3)
+
+            def forward(self, x):
+                x = self.bn(self.conv(x))
+                counter = self.bn.num_batches_tracked
+                return x + counter.to(dtype=x.dtype)
+
+        m = M(self.conv_class, self.bn_class).train()
+        example_inputs = self.example_inputs
+        m = torch.export.export(m, example_inputs, strict=True).module()
+        quantizer = XNNPACKQuantizer()
+        quantizer.set_global(get_symmetric_quantization_config(is_qat=True))
+        m = prepare_qat_pt2e(m, quantizer)
+        m(*example_inputs)
+        m = convert_pt2e(m)
+
+        counters = [
+            n
+            for n in m.graph.nodes
+            if n.op == "get_attr" and "num_batches_tracked" in str(n.target)
+        ]
+        self.assertNotEqual(
+            counters, [], "a read num_batches_tracked must survive the fold"
+        )
+
     def _do_test_qat_conv_transpose_bn(self, has_relu: bool):
         # Use different in/out channel sizes to test if conv weight is
         # properly transposed in QAT pattern

--- a/torchao/quantization/pt2e/qat_utils.py
+++ b/torchao/quantization/pt2e/qat_utils.py
@@ -846,6 +846,45 @@ def _copy_over_q_dq_args(original_node: Node, replacement_node: Node):
     )
 
 
+_BATCH_NORM_QUALNAMES = (
+    "torch.nn.modules.batchnorm.BatchNorm1d",
+    "torch.nn.modules.batchnorm.BatchNorm2d",
+    "torch.nn.modules.batchnorm.BatchNorm3d",
+)
+
+
+def _is_from_batch_norm(node: Node) -> bool:
+    """Whether ``node`` was traced from a BatchNorm module.
+
+    ``nn_module_stack`` holds the module type either as a class or as its
+    qualified name depending on the capture path, so compare on the string.
+    """
+    stack = node.meta.get("nn_module_stack") or {}
+    return any(
+        any(qualname in str(entry[1]) for qualname in _BATCH_NORM_QUALNAMES)
+        for entry in stack.values()
+    )
+
+
+def _is_one(arg: Any, m: GraphModule) -> bool:
+    """Whether ``arg`` is the constant 1, literal or lifted.
+
+    ``export`` may lift the ``+ 1`` of BatchNorm's ``num_batches_tracked``
+    increment into a tensor constant, in which case the argument is a
+    ``get_attr`` node rather than the literal.
+    """
+    if arg == 1:
+        return True
+    if not isinstance(arg, Node) or arg.op != "get_attr":
+        return False
+    value = getattr(m, str(arg.target), None)
+    return (
+        isinstance(value, torch.Tensor)
+        and value.numel() == 1
+        and int(value.item()) == 1
+    )
+
+
 def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
     # Example inputs for quantized and folded conv-bn1d patterns used in convert
     _quantized_conv1d_bn_example_inputs = (
@@ -889,10 +928,12 @@ def _fold_conv_bn_qat(m: GraphModule) -> GraphModule:
     for node in m.graph.nodes:
         if (
             node.target == torch.ops.aten.add_.Tensor
+            # a model that reads num_batches_tracked keeps the increment live
+            and not node.users
+            and isinstance(node.args[0], Node)
             and node.args[0].op == "get_attr"
-            and node.args[1] == 1
-            and "torch.nn.modules.batchnorm.BatchNorm2d"
-            in [val[1] for _, val in node.meta["nn_module_stack"].items()]
+            and _is_one(node.args[1], m)
+            and _is_from_batch_norm(node)
         ):
             m.graph.erase_node(node)
 


### PR DESCRIPTION
Summary:

`_fold_conv_bn_qat` already tries to delete BatchNorm's
`num_batches_tracked += 1` once the BatchNorm has been folded into the conv:

```
if (
    node.target == torch.ops.aten.add_.Tensor
    and node.args[0].op == "get_attr"
    and node.args[1] == 1
    and "torch.nn.modules.batchnorm.BatchNorm2d" in [...nn_module_stack...]
):
    m.graph.erase_node(node)
```

`export` may lift that literal `1` into a tensor constant, so the argument is a
`get_attr` node rather than the int. `node.args[1] == 1` is then False, the
increment is never erased, and `num_batches_tracked` stays alive as a *mutated*
buffer in a graph whose BatchNorm no longer exists.

Instrumented on a conv(bias=False)+bn+relu model captured in training mode, every
other clause matches and only this one fails:

```
[add_] target=aten.add_.Tensor  is_add_Tensor=True  arg0.op=get_attr
       arg1=_tensor_constant_0        <-- get_attr, not the literal 1
       bn_in_stack=True
```

`_is_one()` accepts either form.

The dead counter is not cosmetic for backends that map mutated buffers to graph
I/O. On the QNN/HTP ExecuTorch backend, `get_tensor_type()` classifies a mutated
buffer as `QNN_TENSOR_TYPE_APP_WRITE`, so a 53-BatchNorm model produced a context
binary declaring 54 inputs and 56 outputs while the ExecuTorch program declared
1 and 3. The runtime indexed its 4 tensors with the QNN counts and segfaulted.

**Three more defects in the same clause, found while writing the test.**

`BatchNorm1d`/`3d` were never matched -- the check hardcoded
`"torch.nn.modules.batchnorm.BatchNorm2d"`, so the increment survived on every
1d/3d model even when the `+ 1` was a plain literal. `_fold_conv_bn_qat_helper`
runs for conv1d/conv2d/conv_transpose1d/conv_transpose2d and the repo has a
`TestQuantizePT2EQAT_ConvBn1d` class, so 1d is a supported path.
`_is_from_batch_norm()` now matches the BatchNorm family, and reads
`nn_module_stack` off the string form so it works whether the entry holds a
class or a qualified name.

It also indexed `node.meta["nn_module_stack"]` and `node.args[0].op` directly, so
an `add_.Tensor` node without that meta key, or with a non-Node first arg, raised
instead of being skipped. Both are now guarded.

The erase itself assumed the increment was dead. A model that *reads*
`num_batches_tracked` in its forward keeps the increment live, and
`Graph.erase_node` raises on a node that still has users, taking `convert_pt2e`
down with it. Latent before -- the hardcoded `BatchNorm2d` string kept the clause
away from the 1d model that exercises it -- and surfaced by widening the match:

```
RuntimeError: Tried to erase Node add_ but it still had 2 users in the graph:
{_assert_tensor_metadata_default: None, to: None}!
```

The clause now also requires `not node.users`, so a counter the model actually
consumes is preserved.

Reviewed By: psiddh, YIWENX14

Differential Revision: D117580221


