### PR TITLE
[CI] Run only accelerator PT2E tests on GPU

### DIFF
--- a/.github/scripts/ci_test_pt2e_gpu.sh
+++ b/.github/scripts/ci_test_pt2e_gpu.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The CPU PT2E workflow owns the full suite. Keep this list limited to tests
+# that exercise accelerator-specific paths.
+pt2e_gpu_tests=(
+  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn1d::test_qat_conv_bn_fusion_cuda
+  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn1d::test_qat_conv_bn_relu_fusion_cuda
+  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn2d::test_qat_conv_bn_fusion_cuda
+  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn2d::test_qat_conv_bn_relu_fusion_cuda
+  test/quantization/pt2e/test_quantize_pt2e.py::TestQuantizePT2E::test_move_exported_model_bn_device_cuda
+  test/quantization/pt2e/test_quantize_pt2e.py::TestQuantizePT2E::test_allow_exported_model_train_eval
+  test/quantization/pt2e/test_learnable_fake_quantize.py::TestLearnableFakeQuantizeIntegration::test_device_compatibility
+  test/quantization/pt2e/test_learnable_fake_quantize.py::TestLearnableFakeQuantizeComparison::test_numerical_consistency_per_tensor
+)
+
+pytest "${pt2e_gpu_tests[@]}" --verbose -s --durations=25 "$@"

--- a/.github/scripts/ci_test_pt2e_gpu.sh
+++ b/.github/scripts/ci_test_pt2e_gpu.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# The CPU PT2E workflow owns the full suite. Keep this list limited to tests
-# that exercise accelerator-specific paths.
+# These files own PT2E accelerator coverage; the remaining PT2E files are
+# exercised by the CPU workflow.
 pt2e_gpu_tests=(
-  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn1d::test_qat_conv_bn_fusion_cuda
-  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn1d::test_qat_conv_bn_relu_fusion_cuda
-  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn2d::test_qat_conv_bn_fusion_cuda
-  test/quantization/pt2e/test_quantize_pt2e_qat.py::TestQuantizePT2EQAT_ConvBn2d::test_qat_conv_bn_relu_fusion_cuda
-  test/quantization/pt2e/test_quantize_pt2e.py::TestQuantizePT2E::test_move_exported_model_bn_device_cuda
-  test/quantization/pt2e/test_quantize_pt2e.py::TestQuantizePT2E::test_allow_exported_model_train_eval
-  test/quantization/pt2e/test_learnable_fake_quantize.py::TestLearnableFakeQuantizeIntegration::test_device_compatibility
-  test/quantization/pt2e/test_learnable_fake_quantize.py::TestLearnableFakeQuantizeComparison::test_numerical_consistency_per_tensor
+  test/quantization/pt2e/test_quantize_pt2e_qat_with_gpu.py
+  test/quantization/pt2e/test_quantize_pt2e_with_gpu.py
+  test/quantization/pt2e/test_learnable_fake_quantize_with_gpu.py
 )
 
 pytest "${pt2e_gpu_tests[@]}" --verbose -s --durations=25 "$@"

--- a/.github/workflows/regression_test_pt2e_gpu.yml
+++ b/.github/workflows/regression_test_pt2e_gpu.yml
@@ -69,12 +69,7 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        # Run PT2E tests, excluding the slow CPU-only x86 Inductor tests (they
-        # are owned by regression_test_pt2e_cpu.yml). Everything else runs so the
-        # CUDA-specific PT2E paths get coverage.
-        pytest test/quantization/pt2e --verbose -s \
-          --ignore=test/quantization/pt2e/test_x86inductor_fusion.py \
-          --ignore=test/quantization/pt2e/test_x86inductor_quantizer.py
+        bash .github/scripts/ci_test_pt2e_gpu.sh
 
   # ROCm leg. Kept as a separate job (rather than a matrix row on `test`) because
   # ROCm needs a custom docker image and no-sudo, which the CUDA rows do not set.
@@ -113,8 +108,4 @@ jobs:
         pip install . --no-build-isolation
         export CONDA=$(dirname $(dirname $(which conda)))
         export LD_LIBRARY_PATH=$CONDA/lib/:$LD_LIBRARY_PATH
-        # Run PT2E tests, excluding the slow CPU-only x86 Inductor tests (they
-        # are owned by regression_test_pt2e_cpu.yml).
-        pytest test/quantization/pt2e --verbose -s \
-          --ignore=test/quantization/pt2e/test_x86inductor_fusion.py \
-          --ignore=test/quantization/pt2e/test_x86inductor_quantizer.py
+        bash .github/scripts/ci_test_pt2e_gpu.sh

--- a/test/quantization/pt2e/test_learnable_fake_quantize.py
+++ b/test/quantization/pt2e/test_learnable_fake_quantize.py
@@ -108,6 +108,59 @@ NP_RANDOM_SEED = 19
 tolerance = 1e-6
 
 
+class _LearnableFakeQuantizeAcceleratorAwareTestCase(TestCase):
+    def _test_device_compatibility(self, device: torch.device) -> None:
+        lfq = LearnableFakeQuantize(observer=MovingAverageMinMaxObserver).to(device)
+        x = torch.randn(4, 4, device=device)
+        output = lfq(x)
+
+        self.assertEqual(output.device, x.device)
+        self.assertEqual(output.shape, x.shape)
+
+    def _test_numerical_consistency_per_tensor(self, device: torch.device) -> None:
+        torch_types = [torch.qint8, torch.quint8]
+        float_types = [torch.float, torch.float16, torch.bfloat16, torch.float64]
+
+        for torch_type, float_type in itertools.product(torch_types, float_types):
+            with self.subTest(
+                torch_type=str(torch_type),
+                float_type=str(float_type),
+                device=str(device),
+            ):
+                X = torch.randn(3, 3, device=device).to(float_type)
+                scale = (10 * torch.randn(1, device=device)).abs().item()
+                zero_point = (10 * torch.randn(1, device=device)).abs().item()
+                quant_min = torch.iinfo(torch_type).min
+                quant_max = torch.iinfo(torch_type).max
+
+                # Quantize/dequantize operation
+                Y = (
+                    torch.dequantize(
+                        torch.quantize_per_tensor(
+                            X.to("cpu").to(torch.float),
+                            scale,
+                            int(zero_point),
+                            torch_type,
+                        )
+                    )
+                    .to(device)
+                    .to(float_type)
+                )
+
+                # Fake quantize operation
+                Y_prime = torch.fake_quantize_per_tensor_affine(
+                    X, scale, int(zero_point), quant_min, quant_max
+                )
+
+                torch.testing.assert_close(
+                    Y,
+                    Y_prime,
+                    rtol=tolerance,
+                    atol=tolerance,
+                    msg="Difference found between dequant+quant_per_tensor and fake_quantize_per_tensor",
+                )
+
+
 class TestLearnableFakeQuantize(TestCase):
     """Test cases for LearnableFakeQuantize module."""
 
@@ -535,7 +588,9 @@ class TestLearnableFakeQuantize(TestCase):
         # (though they might not change significantly with this data)
 
 
-class TestLearnableFakeQuantizeIntegration(TestCase):
+class TestLearnableFakeQuantizeIntegration(
+    _LearnableFakeQuantizeAcceleratorAwareTestCase
+):
     """Integration tests for LearnableFakeQuantize with neural network modules."""
 
     def setUp(self):
@@ -653,22 +708,8 @@ class TestLearnableFakeQuantizeIntegration(TestCase):
         self.assertEqual(output_eval.shape, (2, 3))
 
     def test_device_compatibility(self):
-        """Test LearnableFakeQuantize with different devices."""
-        devices = ["cpu"]
-        if torch.cuda.is_available():
-            devices.append("cuda")
-
-        for device in devices:
-            with self.subTest(device=device):
-                lfq = LearnableFakeQuantize(observer=MovingAverageMinMaxObserver).to(
-                    device
-                )
-
-                x = torch.randn(4, 4, device=device)
-                output = lfq(x)
-
-                self.assertEqual(output.device, x.device)
-                self.assertEqual(output.shape, x.shape)
+        """Test LearnableFakeQuantize on CPU."""
+        self._test_device_compatibility(torch.device("cpu"))
 
     def test_optimizer_updates_scale_and_zero_point(self):
         """Test that optimizer.step() actually updates scale and zero_point parameters."""
@@ -707,7 +748,9 @@ class TestLearnableFakeQuantizeIntegration(TestCase):
         )
 
 
-class TestLearnableFakeQuantizeComparison(TestCase):
+class TestLearnableFakeQuantizeComparison(
+    _LearnableFakeQuantizeAcceleratorAwareTestCase
+):
     """Test cases comparing LearnableFakeQuantize with reference implementations."""
 
     def setUp(self):
@@ -743,53 +786,8 @@ class TestLearnableFakeQuantizeComparison(TestCase):
         self.assertEqual(original_qparams[1], loaded_qparams[1])  # zero_point
 
     def test_numerical_consistency_per_tensor(self):
-        """Test numerical consistency of per-tensor quantization."""
-        torch_types = [torch.qint8, torch.quint8]
-        float_types = [torch.float, torch.float16, torch.bfloat16, torch.float64]
-        devices = [torch.device("cpu")]
-        if torch.cuda.is_available():
-            devices.append(torch.device("cuda"))
-
-        for torch_type, float_type, device in itertools.product(
-            torch_types, float_types, devices
-        ):
-            with self.subTest(
-                torch_type=str(torch_type),
-                float_type=str(float_type),
-                device=str(device),
-            ):
-                X = torch.randn(3, 3, device=device).to(float_type)
-                scale = (10 * torch.randn(1, device=device)).abs().item()
-                zero_point = (10 * torch.randn(1, device=device)).abs().item()
-                quant_min = torch.iinfo(torch_type).min
-                quant_max = torch.iinfo(torch_type).max
-
-                # Quantize/dequantize operation
-                Y = (
-                    torch.dequantize(
-                        torch.quantize_per_tensor(
-                            X.to("cpu").to(torch.float),
-                            scale,
-                            int(zero_point),
-                            torch_type,
-                        )
-                    )
-                    .to(device)
-                    .to(float_type)
-                )
-
-                # Fake quantize operation
-                Y_prime = torch.fake_quantize_per_tensor_affine(
-                    X, scale, int(zero_point), quant_min, quant_max
-                )
-
-                torch.testing.assert_close(
-                    Y,
-                    Y_prime,
-                    rtol=tolerance,
-                    atol=tolerance,
-                    msg="Difference found between dequant+quant_per_tensor and fake_quantize_per_tensor",
-                )
+        """Test numerical consistency of per-tensor quantization on CPU."""
+        self._test_numerical_consistency_per_tensor(torch.device("cpu"))
 
 
 if __name__ == "__main__":

--- a/test/quantization/pt2e/test_learnable_fake_quantize_with_gpu.py
+++ b/test/quantization/pt2e/test_learnable_fake_quantize_with_gpu.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import torch
+
+from test.quantization.pt2e.test_learnable_fake_quantize import (
+    NP_RANDOM_SEED,
+    _LearnableFakeQuantizeAcceleratorAwareTestCase,
+)
+
+
+class TestLearnableFakeQuantizeWithGPU(_LearnableFakeQuantizeAcceleratorAwareTestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        np.random.seed(NP_RANDOM_SEED)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA unavailable")
+    def test_device_compatibility(self):
+        self._test_device_compatibility(torch.device("cuda"))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA unavailable")
+    def test_numerical_consistency_per_tensor(self):
+        self._test_numerical_consistency_per_tensor(torch.device("cuda"))

--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -32,8 +32,7 @@ from torch.testing._internal.common_quantization import (
     skipIfNoQNNPACK,
 )
 from torch.testing._internal.common_utils import (
-    TEST_CUDA,
-    TEST_XPU,
+    TEST_HPU,
     TemporaryFileName,
     instantiate_parametrized_tests,
     parametrize,
@@ -74,19 +73,137 @@ from torchao.testing.pt2e._xnnpack_quantizer_utils import (
     QuantizationConfig,
 )
 from torchao.testing.pt2e.utils import PT2EQuantizationTestCase
-from torchao.utils import get_current_accelerator_device
 
-DEVICE_LIST = ["cpu"] + (["cuda"] if TEST_CUDA else []) + (["xpu"] if TEST_XPU else [])
 
-from torch.testing._internal.common_utils import (
-    TEST_HPU,
-)
+class _TestQuantizePT2EAcceleratorAware(PT2EQuantizationTestCase):
+    def _get_node(self, m: torch.fx.GraphModule, target: torch._ops.OpOverload):
+        """
+        Return the first node matching the specified target, throwing an exception
+        if no such batch norm node is found.
+        """
+        for n in m.graph.nodes:
+            if n.target == target:
+                return n
+        raise ValueError("Did not find node with target ", target)
 
-DEVICE_LIST += ["hpu"] if TEST_HPU else []
+    def _get_bn_train_eval_ops(self):
+        return (
+            torch.ops.aten.batch_norm.default,
+            torch.ops.aten.batch_norm.default,
+        )
+
+    def _test_move_exported_model_bn(self, device: torch.device) -> None:
+        """
+        Test switching batch_norm behavior between train and eval modes using
+        `move_exported_model_to_eval` and `move_exported_model_to_train` APIs.
+        """
+
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(3)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        m = M().train().to(device)
+        example_inputs = (torch.randn((1, 3, 3, 3), device=device),)
+        bn_train_op, bn_eval_op = self._get_bn_train_eval_ops()
+        m = torch.export.export(m, example_inputs, strict=True).module()
+
+        # Assert that batch norm op exists and is in train mode
+        bn_node = self._get_node(m, bn_train_op)
+        self.assertTrue(bn_node is not None)
+        self.assertTrue(bn_node.args[5])
+
+        # Move to eval
+        torchao.quantization.pt2e.move_exported_model_to_eval(m)
+
+        # Assert that batch norm op is now in eval mode
+        bn_node = self._get_node(m, bn_eval_op)
+        self.assertTrue(bn_node is not None)
+
+        # Move to train
+        torchao.quantization.pt2e.move_exported_model_to_train(m)
+
+        # Assert that batch norm op is now in train mode again
+        bn_node = self._get_node(m, bn_train_op)
+        self.assertTrue(bn_node is not None)
+        self.assertTrue(bn_node.args[5])
+
+    def _test_allow_exported_model_train_eval(self, device: torch.device) -> None:
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.bn = torch.nn.BatchNorm2d(3)
+                self.dropout = torch.nn.Dropout(0.5)
+
+            def forward(self, x):
+                x = self.bn(x)
+                x = self.dropout(x)
+                return x
+
+        m = M().train().to(device)
+        # Citrine C3: create the tensor directly on the target device.
+        example_inputs = (torch.randn(1, 3, 3, 3, device=device),)
+        bn_train_op, bn_eval_op = self._get_bn_train_eval_ops()
+        m = torch.export.export(m, example_inputs, strict=True).module()
+
+        def _assert_ops_are_correct(m: torch.fx.GraphModule, train: bool):
+            targets = [n.target for n in m.graph.nodes]
+            bn_op = bn_train_op if train else bn_eval_op
+            bn_node = self._get_node(m, bn_op)
+            self.assertTrue(bn_node is not None)
+            if device.type != "cpu":
+                self.assertEqual(bn_node.args[5], train)
+            dropout_node = self._get_node(m, torch.ops.aten.dropout.default)
+            self.assertEqual(dropout_node.args[2], train)
+
+        # Before wrapping: this is not OK
+        with self.assertRaises(NotImplementedError):
+            m.eval()
+        with self.assertRaises(NotImplementedError):
+            m.train()
+
+        # After wrapping: does not error and swaps the ops accordingly
+        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
+        m.eval()
+        _assert_ops_are_correct(m, train=False)
+        m.train()
+        _assert_ops_are_correct(m, train=True)
+
+        # After prepare but before wrapping: this is not OK
+        quantizer = XNNPACKQuantizer()
+        m = prepare_qat_pt2e(m, quantizer)
+        with self.assertRaises(NotImplementedError):
+            m.eval()
+        with self.assertRaises(NotImplementedError):
+            m.train()
+
+        # After prepare and after wrapping: does not error and swaps the ops accordingly
+        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
+        m.eval()
+        _assert_ops_are_correct(m, train=False)
+        m.train()
+        _assert_ops_are_correct(m, train=True)
+
+        # After convert but before wrapping: this is not OK
+        m = convert_pt2e(m, fold_quantize=True)
+        with self.assertRaises(NotImplementedError):
+            m.eval()
+        with self.assertRaises(NotImplementedError):
+            m.train()
+
+        # After convert and after wrapping: does not error and swaps the ops accordingly
+        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
+        m.eval()
+        _assert_ops_are_correct(m, train=False)
+        m.train()
+        _assert_ops_are_correct(m, train=True)
 
 
 @skipIfNoQNNPACK
-class TestQuantizePT2E(PT2EQuantizationTestCase):
+class TestQuantizePT2E(_TestQuantizePT2EAcceleratorAware):
     def test_simple_quantizer(self):
         # TODO: use OP_TO_ANNOTATOR
         class BackendAQuantizer(Quantizer):
@@ -2345,16 +2462,6 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             qconfig_mapping,
         )
 
-    def _get_node(self, m: torch.fx.GraphModule, target: torch._ops.OpOverload):
-        """
-        Return the first node matching the specified target, throwing an exception
-        if no such batch norm node is found.
-        """
-        for n in m.graph.nodes:
-            if n.target == target:
-                return n
-        raise ValueError("Did not find node with target ", target)
-
     def _test_move_exported_model_dropout(self, inplace: bool):
         """
         Test switching dropout behavior between train and eval modes using
@@ -2404,56 +2511,8 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
     def test_move_exported_model_dropout_inplace(self):
         self._test_move_exported_model_dropout(inplace=True)
 
-    def _get_bn_train_eval_ops(self):
-        return (
-            torch.ops.aten.batch_norm.default,
-            torch.ops.aten.batch_norm.default,
-        )
-
-    @parametrize("device", DEVICE_LIST)
-    def test_move_exported_model_bn(self, device):
-        """
-        Test switching batch_norm behavior between train and eval modes using
-        `move_exported_model_to_eval` and `move_exported_model_to_train` APIs.
-        """
-
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.bn = torch.nn.BatchNorm2d(3)
-
-            def forward(self, x):
-                return self.bn(x)
-
-        if TEST_CUDA or TEST_HPU or TEST_XPU:
-            m = M().train().to(device)
-            example_inputs = (torch.randn((1, 3, 3, 3), device=device),)
-
-        else:
-            m = M().train()
-            example_inputs = (torch.randn(1, 3, 3, 3),)
-        bn_train_op, bn_eval_op = self._get_bn_train_eval_ops()
-        m = torch.export.export(m, example_inputs, strict=True).module()
-
-        # Assert that batch norm op exists and is in train mode
-        bn_node = self._get_node(m, bn_train_op)
-        self.assertTrue(bn_node is not None)
-        self.assertTrue(bn_node.args[5])
-
-        # Move to eval
-        torchao.quantization.pt2e.move_exported_model_to_eval(m)
-
-        # Assert that batch norm op is now in eval mode
-        bn_node = self._get_node(m, bn_eval_op)
-        self.assertTrue(bn_node is not None)
-
-        # Move to train
-        torchao.quantization.pt2e.move_exported_model_to_train(m)
-
-        # Assert that batch norm op is now in train mode again
-        bn_node = self._get_node(m, bn_train_op)
-        self.assertTrue(bn_node is not None)
-        self.assertTrue(bn_node.args[5])
+    def test_move_exported_model_bn(self):
+        self._test_move_exported_model_bn(torch.device("cpu"))
 
     def test_disallow_eval_train(self):
         m = TestHelperModules.ConvWithBNRelu(relu=True)
@@ -2486,82 +2545,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
             m.train()
 
     def test_allow_exported_model_train_eval(self):
-        if TEST_HPU:
-            unittest.SkipTest("test doesn't currently work with HPU")
-
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.bn = torch.nn.BatchNorm2d(3)
-                self.dropout = torch.nn.Dropout(0.5)
-
-            def forward(self, x):
-                x = self.bn(x)
-                x = self.dropout(x)
-                return x
-
-        if TEST_CUDA or TEST_XPU:
-            device = get_current_accelerator_device()
-            m = M().train().to(device)
-            # Citrine C3: create the tensor directly on the target device.
-            example_inputs = (torch.randn(1, 3, 3, 3, device=device),)
-        else:
-            m = M().train()
-            example_inputs = (torch.randn(1, 3, 3, 3),)
-        bn_train_op, bn_eval_op = self._get_bn_train_eval_ops()
-        m = torch.export.export(m, example_inputs, strict=True).module()
-
-        def _assert_ops_are_correct(m: torch.fx.GraphModule, train: bool):
-            targets = [n.target for n in m.graph.nodes]
-            bn_op = bn_train_op if train else bn_eval_op
-            bn_node = self._get_node(m, bn_op)
-            self.assertTrue(bn_node is not None)
-            if TEST_CUDA or TEST_XPU:
-                self.assertEqual(bn_node.args[5], train)
-            dropout_node = self._get_node(m, torch.ops.aten.dropout.default)
-            self.assertEqual(dropout_node.args[2], train)
-
-        # Before wrapping: this is not OK
-        with self.assertRaises(NotImplementedError):
-            m.eval()
-        with self.assertRaises(NotImplementedError):
-            m.train()
-
-        # After wrapping: does not error and swaps the ops accordingly
-        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
-        m.eval()
-        _assert_ops_are_correct(m, train=False)
-        m.train()
-        _assert_ops_are_correct(m, train=True)
-
-        # After prepare but before wrapping: this is not OK
-        quantizer = XNNPACKQuantizer()
-        m = prepare_qat_pt2e(m, quantizer)
-        with self.assertRaises(NotImplementedError):
-            m.eval()
-        with self.assertRaises(NotImplementedError):
-            m.train()
-
-        # After prepare and after wrapping: does not error and swaps the ops accordingly
-        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
-        m.eval()
-        _assert_ops_are_correct(m, train=False)
-        m.train()
-        _assert_ops_are_correct(m, train=True)
-
-        # After convert but before wrapping: this is not OK
-        m = convert_pt2e(m, fold_quantize=True)
-        with self.assertRaises(NotImplementedError):
-            m.eval()
-        with self.assertRaises(NotImplementedError):
-            m.train()
-
-        # After convert and after wrapping: does not error and swaps the ops accordingly
-        torchao.quantization.pt2e.allow_exported_model_train_eval(m)
-        m.eval()
-        _assert_ops_are_correct(m, train=False)
-        m.train()
-        _assert_ops_are_correct(m, train=True)
+        self._test_allow_exported_model_train_eval(torch.device("cpu"))
 
     def test_allow_exported_model_train_eval_idempotent(self):
         class M(torch.nn.Module):

--- a/test/quantization/pt2e/test_quantize_pt2e_qat.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat.py
@@ -18,7 +18,6 @@ from torch.ao.quantization.qconfig import (
     default_symmetric_qnnpack_qat_qconfig,
 )
 from torch.ao.quantization.quantize_fx import prepare_qat_fx
-from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_quantization import (
     NodeSpec as ns,
 )
@@ -28,7 +27,7 @@ from torch.testing._internal.common_quantization import (
     skipIfNoQNNPACK,
 )
 from torch.testing._internal.common_quantized import override_quantized_engine
-from torch.testing._internal.common_utils import TEST_XPU, run_tests
+from torch.testing._internal.common_utils import run_tests
 
 import torchao
 from torchao.quantization.pt2e import (
@@ -53,7 +52,6 @@ from torchao.testing.pt2e._xnnpack_quantizer import (
     XNNPACKQuantizer,
     get_symmetric_quantization_config,
 )
-from torchao.utils import get_current_accelerator_device
 
 
 class PT2EQATTestCase(QuantizationTestCase):
@@ -109,6 +107,17 @@ class PT2EQATTestCase(QuantizationTestCase):
             has_relu,
             **conv_kwargs,
         )
+
+    def _test_qat_conv_bn_fusion(self, device: torch.device, has_relu: bool) -> None:
+        m = self._get_conv_bn_model(has_relu=has_relu).to(device)
+        example_inputs = (self.example_inputs[0].to(device),)
+        self._verify_symmetric_xnnpack_qat_graph(
+            m,
+            example_inputs,
+            has_relu=has_relu,
+            is_cuda=device.type != "cpu",
+        )
+        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
 
     def _verify_symmetric_xnnpack_qat_numerics(
         self,
@@ -449,22 +458,7 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
         self._verify_symmetric_xnnpack_qat_numerics(m2, self.example_inputs)
 
     def test_qat_conv_bn_fusion(self):
-        m = self._get_conv_bn_model()
-        self._verify_symmetric_xnnpack_qat_graph(m, self.example_inputs, has_relu=False)
-        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
-
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "GPU unavailable")
-    def test_qat_conv_bn_fusion_cuda(self):
-        device = get_current_accelerator_device()
-        m = self._get_conv_bn_model().to(device)
-        example_inputs = (self.example_inputs[0].to(device),)
-        self._verify_symmetric_xnnpack_qat_graph(
-            m,
-            example_inputs,
-            has_relu=False,
-            is_cuda=True,
-        )
-        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
+        self._test_qat_conv_bn_fusion(torch.device("cpu"), has_relu=False)
 
     def test_qat_conv_bn_fusion_literal_args(self):
         class M(torch.nn.Module):
@@ -537,22 +531,7 @@ class TestQuantizePT2EQAT_ConvBn_Base(PT2EQATTestCase):
         self._verify_symmetric_xnnpack_qat_numerics(m2, example_inputs)
 
     def test_qat_conv_bn_relu_fusion(self):
-        m = self._get_conv_bn_model(has_relu=True)
-        self._verify_symmetric_xnnpack_qat_graph(m, self.example_inputs, has_relu=True)
-        self._verify_symmetric_xnnpack_qat_numerics(m, self.example_inputs)
-
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "GPU unavailable")
-    def test_qat_conv_bn_relu_fusion_cuda(self):
-        device = get_current_accelerator_device()
-        m = self._get_conv_bn_model(has_relu=True).to(device)
-        example_inputs = (self.example_inputs[0].to(device),)
-        self._verify_symmetric_xnnpack_qat_graph(
-            m,
-            example_inputs,
-            has_relu=True,
-            is_cuda=True,
-        )
-        self._verify_symmetric_xnnpack_qat_numerics(m, example_inputs)
+        self._test_qat_conv_bn_fusion(torch.device("cpu"), has_relu=True)
 
     def test_qat_conv_bn_relu_fusion_no_conv_bias(self):
         m = self._get_conv_bn_model(has_conv_bias=False, has_relu=True)

--- a/test/quantization/pt2e/test_quantize_pt2e_qat_with_gpu.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_qat_with_gpu.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Owner(s): ["oncall: quantization"]
+import unittest
+
+import torch
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_quantization import skipIfNoQNNPACK
+from torch.testing._internal.common_utils import TEST_XPU
+
+from test.quantization.pt2e.test_quantize_pt2e_qat import PT2EQATTestCase
+from torchao.utils import get_current_accelerator_device
+
+
+class _TestQuantizePT2EQATConvBnWithGPU:
+    __test__ = False
+
+    @unittest.skipUnless(TEST_CUDA or TEST_XPU, "GPU unavailable")
+    def test_qat_conv_bn_fusion_cuda(self):
+        self._test_qat_conv_bn_fusion(get_current_accelerator_device(), has_relu=False)
+
+    @unittest.skipUnless(TEST_CUDA or TEST_XPU, "GPU unavailable")
+    def test_qat_conv_bn_relu_fusion_cuda(self):
+        self._test_qat_conv_bn_fusion(get_current_accelerator_device(), has_relu=True)
+
+
+@skipIfNoQNNPACK
+class TestQuantizePT2EQATConvBn1dWithGPU(
+    _TestQuantizePT2EQATConvBnWithGPU, PT2EQATTestCase
+):
+    __test__ = True
+    example_inputs = (torch.randn(1, 3, 5),)
+    conv_class = torch.nn.Conv1d
+    conv_transpose_class = torch.nn.ConvTranspose1d
+    bn_class = torch.nn.BatchNorm1d
+
+
+@skipIfNoQNNPACK
+class TestQuantizePT2EQATConvBn2dWithGPU(
+    _TestQuantizePT2EQATConvBnWithGPU, PT2EQATTestCase
+):
+    __test__ = True
+    example_inputs = (torch.randn(1, 3, 5, 5),)
+    conv_class = torch.nn.Conv2d
+    conv_transpose_class = torch.nn.ConvTranspose2d
+    bn_class = torch.nn.BatchNorm2d

--- a/test/quantization/pt2e/test_quantize_pt2e_with_gpu.py
+++ b/test/quantization/pt2e/test_quantize_pt2e_with_gpu.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Owner(s): ["oncall: quantization"]
+import unittest
+
+import torch
+from torch.testing._internal.common_quantization import skipIfNoQNNPACK
+from torch.testing._internal.common_utils import TEST_CUDA, TEST_HPU, TEST_XPU
+
+from test.quantization.pt2e.test_quantize_pt2e import (
+    _TestQuantizePT2EAcceleratorAware,
+)
+from torchao.utils import get_current_accelerator_device
+
+
+@skipIfNoQNNPACK
+class TestQuantizePT2EWithGPU(_TestQuantizePT2EAcceleratorAware):
+    @unittest.skipUnless(TEST_CUDA or TEST_XPU or TEST_HPU, "accelerator unavailable")
+    def test_move_exported_model_bn(self):
+        if TEST_HPU:
+            device = torch.device("hpu")
+        else:
+            device = get_current_accelerator_device()
+        self._test_move_exported_model_bn(device)
+
+    @unittest.skipUnless(TEST_CUDA or TEST_XPU, "CUDA or XPU unavailable")
+    def test_allow_exported_model_train_eval(self):
+        self._test_allow_exported_model_train_eval(get_current_accelerator_device())


### PR DESCRIPTION
## Summary

- keep the original PT2E test files CPU-only
- move the eight accelerator variants into three dedicated `*_with_gpu.py` files
- run those files through one shared CI script so CUDA and ROCm execute the same coverage
- report the 25 slowest test durations for future profiling

The four-worker CPU PT2E workflow continues to run the complete `test/quantization/pt2e` suite. This removes redundant CPU-oriented PT2E execution from expensive GPU runners without removing tests from CI.

## CI results

Compared [latest main](https://github.com/pytorch/ao/actions/runs/32980155475) with the [latest PR run](https://github.com/pytorch/ao/actions/runs/33096887298) on the same runner classes and matrix configurations:

| Environment | Metric | Before | After | Reduction |
| --- | --- | ---: | ---: | ---: |
| CUDA Nightly | pytest | 49:00 | [6:22](https://github.com/pytorch/ao/actions/runs/33096887298/job/98604023355) | 87.0% |
| CUDA Nightly | full job | 1:04:28 | 0:20:35 | 68.1% |
| CUDA 2.13 | pytest | 46:00 | [5:49](https://github.com/pytorch/ao/actions/runs/33096887298/job/98604023616) | 87.4% |
| CUDA 2.13 | full job | 1:02:31 | 0:20:27 | 67.3% |
| ROCm Nightly | pytest | 29:28 | [3:49](https://github.com/pytorch/ao/actions/runs/33096887298/job/98604023605) | 87.0% |
| ROCm Nightly | full job | 0:43:40 | 0:11:52 | 72.8% |

All three jobs collected and passed the eight accelerator tests:

- CUDA Nightly: `8 passed, 8 subtests passed` in `382.41s (0:06:22)`
- CUDA 2.13: `8 passed, 8 subtests passed` in `349.13s (0:05:49)`
- ROCm Nightly: `8 passed, 8 subtests passed` in `229.38s (0:03:49)`

Both complete PT2E CPU matrix jobs also passed after the file split.

## Coverage audit

The dedicated workflow exists for accelerator PT2E coverage but previously ran every non-x86 PT2E test. The accelerator variants are now explicit in:

- `test_quantize_pt2e_qat_with_gpu.py`: four conv-bn fusion tests
- `test_quantize_pt2e_with_gpu.py`: accelerator batch-norm and train/eval tests
- `test_learnable_fake_quantize_with_gpu.py`: device compatibility and numerical consistency tests

Shared helpers keep the CPU and accelerator variants on the same test logic. No same-GPU xdist is introduced, avoiding GPU-memory contention and distributed-test collisions.

## Test plan

- `bash .github/scripts/ci_test_pt2e_gpu.sh --collect-only -q` (8 tests collected)
- targeted original-file CPU variants (`8 passed`)
- accelerator files without a GPU (`8 skipped`)
- local CUDA accelerator run (`8 passed`)
- full PT2E collection (`617 tests collected`)
- `bash -n .github/scripts/ci_test_pt2e_gpu.sh`
- Ruff check and format
- `git diff --check`
- CUDA Nightly dedicated job: passed
- CUDA 2.13 dedicated job: passed
- ROCm Nightly dedicated job: passed
- CPU Nightly complete PT2E job: passed
- CPU 2.13 complete PT2E job: passed
