### PR TITLE
[WIP][MX] Add FSDP2 support for inference weights

### DIFF
--- a/test/prototype/mx_formats/test_mx_fsdp2.py
+++ b/test/prototype/mx_formats/test_mx_fsdp2.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed._composable.fsdp import fully_shard
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor
+
+from torchao.prototype.mx_formats import MXDynamicActivationMXWeightConfig
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.quantization import quantize_
+from torchao.quantization.quantize_.common import KernelPreference
+
+
+@pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
+def test_mx_inference_weight_fsdp2(tmp_path, elem_dtype):
+    if dist.is_initialized():
+        pytest.skip("Test requires ownership of the default process group")
+    init_file = tmp_path / f"dist_init_{elem_dtype}"
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=0,
+        world_size=1,
+    )
+    try:
+        torch.manual_seed(1)
+        model = torch.nn.Linear(64, 256, bias=False, dtype=torch.bfloat16)
+        config = MXDynamicActivationMXWeightConfig(
+            block_size=32,
+            activation_dtype=elem_dtype,
+            weight_dtype=elem_dtype,
+            kernel_preference=KernelPreference.EMULATED,
+            scaling_mode=ScaleCalculationMode.FLOOR,
+        )
+        quantize_(model, config)
+        assert isinstance(model.weight, MXTensor)
+
+        torch.manual_seed(2)
+        input_tensor = torch.randn(2, 64, dtype=torch.bfloat16)
+        expected = model(input_tensor)
+
+        mesh = init_device_mesh("cpu", (1,))
+        fully_shard(model, mesh=mesh)
+        assert isinstance(model.weight, DTensor)
+        assert isinstance(model.weight.to_local(), MXTensor)
+
+        actual_first = model(input_tensor)
+        actual_second = model(input_tensor)
+        torch.testing.assert_close(actual_first, expected, atol=0, rtol=0)
+        torch.testing.assert_close(actual_second, expected, atol=0, rtol=0)
+    finally:
+        dist.destroy_process_group()

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -1005,3 +1005,87 @@ def test_mx_pin_memory(elem_dtype):
     assert torch.equal(
         x_cpu.dequantize(torch.float32), x_pinned.dequantize(torch.float32)
     )
+
+
+@pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
+@pytest.mark.parametrize("is_swizzled_scales", [False, True])
+def test_mx_fsdp_sharding_ops(elem_dtype, is_swizzled_scales):
+    x_hp = torch.randn(256, 64, dtype=torch.bfloat16)
+    x_mx = MXTensor.to_mx(
+        x_hp,
+        elem_dtype,
+        block_size=32,
+        kernel_preference=KernelPreference.EMULATED,
+        is_swizzled_scales=is_swizzled_scales,
+    )
+    assert x_mx.is_contiguous()
+    assert x_mx.stride() == (64, 1)
+
+    chunks = torch.chunk(x_mx, 2, dim=0)
+    assert [chunk.shape for chunk in chunks] == [(128, 64), (128, 64)]
+    torch.testing.assert_close(
+        chunks[0].dequantize(), x_mx.dequantize()[:128], atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        chunks[1].dequantize(), x_mx.dequantize()[128:], atol=0, rtol=0
+    )
+
+    padded = chunks[0].new_zeros(x_mx.shape)
+    restored_chunk = padded.narrow(0, 0, chunks[0].shape[0])
+    restored_chunk.copy_(chunks[0])
+    assert torch.equal(restored_chunk.qdata, chunks[0].qdata)
+    assert torch.equal(
+        restored_chunk.scale.view(torch.uint8), chunks[0].scale.view(torch.uint8)
+    )
+    assert padded.view(-1).shape == (256 * 64,)
+
+    restored = torch.as_strided(
+        chunks[0], chunks[0].shape, chunks[0].stride(), storage_offset=0
+    )
+    torch.testing.assert_close(
+        restored.dequantize(), chunks[0].dequantize(), atol=0, rtol=0
+    )
+
+
+@pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
+@pytest.mark.parametrize("is_swizzled_scales", [False, True])
+def test_mx_fsdp_all_gather_hooks(elem_dtype, is_swizzled_scales):
+    x_hp = torch.randn(256, 64, dtype=torch.bfloat16)
+    x_mx = MXTensor.to_mx(
+        x_hp,
+        elem_dtype,
+        block_size=32,
+        kernel_preference=KernelPreference.EMULATED,
+        is_swizzled_scales=is_swizzled_scales,
+    )
+    chunks = torch.chunk(x_mx, 2, dim=0)
+
+    (rank0_inputs, metadata) = chunks[0].fsdp_pre_all_gather(mesh=None)
+    (rank1_inputs, rank1_metadata) = chunks[1].fsdp_pre_all_gather(mesh=None)
+    assert rank1_metadata == metadata
+    gathered_input = torch.cat((rank0_inputs[0], rank1_inputs[0]))
+    gathered, _ = chunks[0].fsdp_post_all_gather(
+        (gathered_input,), metadata, torch.bfloat16
+    )
+
+    assert isinstance(gathered, MXTensor)
+    torch.testing.assert_close(gathered.dequantize(), x_mx.dequantize(), atol=0, rtol=0)
+
+    out = MXTensor(
+        torch.empty_like(gathered.qdata),
+        torch.empty_like(gathered.scale),
+        gathered.elem_dtype,
+        gathered.block_size,
+        gathered.orig_dtype,
+        gathered.kernel_preference,
+        gathered.act_quant_kwargs,
+        gathered.is_swizzled_scales,
+    )
+    assert (
+        chunks[0].fsdp_post_all_gather(
+            (gathered_input,), metadata, torch.bfloat16, out=out
+        )
+        is None
+    )
+    assert torch.equal(out.qdata, gathered.qdata)
+    assert torch.equal(out.scale, gathered.scale)

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -528,6 +528,7 @@ class MXTensor(TorchAOBaseTensor):
         is_swizzled_scales,
     ):
         new_size = qdata.size()
+        new_strides = qdata.stride()
         if elem_dtype == torch.float4_e2m1fn_x2:
             # set the tensor size to what it would be without 2x4 packing
             # Note: `is_contiguous` is going to return True for a tensor of size
@@ -538,10 +539,17 @@ class MXTensor(TorchAOBaseTensor):
                 new_size,
                 qdata.is_contiguous(),
             )
+            if qdata.is_contiguous():
+                stride = 1
+                contiguous_strides = []
+                for size in reversed(new_size):
+                    contiguous_strides.append(stride)
+                    stride *= size
+                new_strides = tuple(reversed(contiguous_strides))
         self = torch.Tensor._make_wrapper_subclass(
             cls,
             new_size,
-            strides=qdata.stride(),
+            strides=new_strides,
             storage_offset=qdata.storage_offset(),
             layout=qdata.layout,
             dtype=orig_dtype,
@@ -602,6 +610,79 @@ class MXTensor(TorchAOBaseTensor):
             self.block_size,
             output_dtype,
         )
+
+    def fsdp_pre_all_gather(self, mesh):
+        """Pack the MX payload and scale into one byte all-gather input."""
+        qdata_uint8 = self.qdata.contiguous().view(torch.uint8)
+        scale_uint8 = self.scale.contiguous().view(torch.uint8)
+        packed = torch.cat((qdata_uint8.flatten(), scale_uint8.flatten()))
+        return (packed,), (
+            self.qdata.dtype,
+            self.qdata.shape,
+            self.scale.shape,
+            self.elem_dtype,
+            self.block_size,
+            self.kernel_preference,
+            self.act_quant_kwargs,
+            self.is_swizzled_scales,
+        )
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs,
+        metadata,
+        param_dtype,
+        *,
+        out=None,
+    ):
+        """Rebuild an MXTensor from the gathered payload/scale byte buffer."""
+        (packed,) = all_gather_outputs
+        (
+            qdata_dtype,
+            local_qdata_shape,
+            local_scale_shape,
+            elem_dtype,
+            block_size,
+            kernel_preference,
+            act_quant_kwargs,
+            is_swizzled_scales,
+        ) = metadata
+        local_qdata_numel = math.prod(local_qdata_shape)
+        local_scale_numel = math.prod(local_scale_shape)
+        local_packed_numel = local_qdata_numel + local_scale_numel
+        if packed.numel() % local_packed_numel != 0:
+            raise RuntimeError(
+                "The gathered MXTensor buffer size must be divisible by the "
+                f"local packed size, got {packed.numel()} and {local_packed_numel}"
+            )
+        world_size = packed.numel() // local_packed_numel
+        packed = packed.view(world_size, local_packed_numel)
+        qdata = (
+            packed[:, :local_qdata_numel]
+            .reshape(world_size * local_qdata_shape[0], *local_qdata_shape[1:])
+            .view(qdata_dtype)
+        )
+        scale_uint8 = packed[:, local_qdata_numel:]
+        scale = scale_uint8.reshape(
+            world_size * local_scale_shape[0], *local_scale_shape[1:]
+        ).view(torch.float8_e8m0fnu)
+        if out is not None:
+            if not isinstance(out, MXTensor):
+                raise TypeError(f"Expected MXTensor output, got {type(out)}")
+            out.qdata.copy_(qdata)
+            out.scale.view(torch.uint8).copy_(scale.view(torch.uint8))
+            return
+        mx_tensor = MXTensor(
+            qdata,
+            scale,
+            elem_dtype,
+            block_size,
+            param_dtype,
+            kernel_preference,
+            act_quant_kwargs,
+            is_swizzled_scales,
+        )
+        return mx_tensor, (qdata, scale)
 
     @staticmethod
     @torch._dynamo.allow_in_graph
@@ -963,6 +1044,74 @@ def mx_slice(func, types, args, kwargs):
             x.is_swizzled_scales,
         ),
     )
+
+
+@implements([aten.split.Tensor])
+def mx_split(func, types, args, kwargs):
+    x, split_size = args[:2]
+    dim = args[2] if len(args) > 2 else kwargs.get("dim", 0)
+    dim = dim if dim >= 0 else dim + x.dim()
+    if not isinstance(split_size, int) or split_size <= 0:
+        raise ValueError(f"Expected a positive integer split size, got {split_size}")
+    if dim != 0:
+        raise NotImplementedError(
+            f"MXTensor aten.split.Tensor only supports dim=0, got dim={dim}"
+        )
+    return [
+        aten.slice.Tensor(x, dim, start, min(start + split_size, x.size(dim)), 1)
+        for start in range(0, x.size(dim), split_size)
+    ]
+
+
+@implements([aten.new_zeros.default])
+def mx_new_zeros(func, types, args, kwargs):
+    x, size = args[:2]
+    size = torch.Size(size)
+    if len(size) != 2 or size[1:] != x.shape[1:] or not x.is_contiguous():
+        raise NotImplementedError(
+            f"MXTensor aten.new_zeros only supports resizing dim 0 of a "
+            f"contiguous 2D tensor, got "
+            f"input shape {tuple(x.shape)} and output shape {tuple(size)}"
+        )
+    if "dtype" in kwargs and kwargs["dtype"] != x.dtype:
+        raise NotImplementedError(
+            "MXTensor aten.new_zeros does not support dtype changes"
+        )
+    device = kwargs.get("device", x.device)
+    qdata_size = size
+    if x.elem_dtype == torch.float4_e2m1fn_x2:
+        qdata_size = torch.Size(tensor_size_hp_to_fp4x2(size, True))
+    if x.is_swizzled_scales:
+        scale_size = hp_data_dims_to_swizzled_scale_dims_mx(size[0], size[1])
+    else:
+        scale_size = (size[0], size[1] // x.block_size)
+    return MXTensor(
+        x.qdata.new_zeros(qdata_size, device=device),
+        x.scale.new_zeros(scale_size, device=device),
+        x.elem_dtype,
+        x.block_size,
+        x.orig_dtype,
+        x.kernel_preference,
+        x.act_quant_kwargs,
+        x.is_swizzled_scales,
+    )
+
+
+@implements([aten.as_strided.default])
+def mx_as_strided(func, types, args, kwargs):
+    x, size, stride = args[:3]
+    storage_offset = args[3] if len(args) > 3 else kwargs.get("storage_offset", None)
+    if (
+        torch.Size(size) != x.shape
+        or tuple(stride) != x.stride()
+        or storage_offset not in (None, 0)
+    ):
+        raise NotImplementedError(
+            "MXTensor aten.as_strided only supports preserving the logical shape "
+            "and stride with zero storage offset"
+        )
+    result = x._apply_fn_to_data(aten.alias.default)
+    return return_and_correct_aliasing(func, args, kwargs, result)
 
 
 @implements([aten.clone.default])


### PR DESCRIPTION
Fixes #4837

## Summary

- report the logical contiguous stride for packed MXFP4 wrapper tensors so
  FSDP2 accepts them as contiguous parameters
- implement the dimension-0 sharding operations used by FSDP2 (`split`,
  `new_zeros`, and `as_strided`) while retaining the existing swizzled-scale
  alignment checks
- add FSDP all-gather extension hooks that communicate the compressed qdata and
  E8M0 scale in one byte buffer and reconstruct the full MXTensor
- cover MXFP8 and MXFP4, swizzled and non-swizzled scales, the cached `out=`
  path, and an end-to-end CPU/Gloo FSDP2 forward

## Context

`MXDynamicActivationMXWeightConfig` replaces a linear weight with a static
`MXTensor`. FSDP2 initially calls `torch.chunk` on that tensor, which currently
fails at `aten.split.Tensor`. Supporting only that operator is insufficient:
FSDP2 also pads/views the local shard and needs the tensor-subclass all-gather
protocol to reconstruct both the quantized payload and its scale.

The all-gather path preserves compressed communication. Packing both components
as byte views avoids issuing a collective directly on `float8_e8m0fnu` while
retaining enough metadata to recover the original qdata dtype and layouts.

## Testing

```text
PYTHONPATH=. python -m pytest -q test/prototype/mx_formats/test_mx_tensor.py
18 passed, 133 skipped

PYTHONPATH=. python -m pytest -q test/prototype/mx_formats/test_mx_fsdp2.py
2 passed

python -m ruff format --check \
  torchao/prototype/mx_formats/mx_tensor.py \
  test/prototype/mx_formats/test_mx_tensor.py \
  test/prototype/mx_formats/test_mx_fsdp2.py
3 files already formatted

python -m ruff check \
  torchao/prototype/mx_formats/mx_tensor.py \
  test/prototype/mx_formats/test_mx_tensor.py \
  test/prototype/mx_formats/test_mx_fsdp2.py
All checks passed!
```

I also ran a two-rank CPU/Gloo FSDP2 smoke test for both MXFP8 and MXFP4. Each
case ran two forwards and exactly matched the pre-FSDP emulated result. The
validation environment was CPU-only, so accelerator kernels were not exercised.
