### PR TITLE
Make MXTensor subclass-friendly

### DIFF
--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -29,6 +29,10 @@ from torchao.prototype.mx_formats.mx_tensor import (
     _to_mx_rceil,
     to_dtype,
     to_mx,
+    get_default_mx_tensor_class,
+    make_mx_tensor,
+    set_default_mx_tensor_class,
+    to_mx_tensor,
 )
 from torchao.prototype.mx_formats.utils import from_blocked, to_blocked
 from torchao.quantization.quantize_.common import KernelPreference
@@ -1005,3 +1009,69 @@ def test_mx_pin_memory(elem_dtype):
     assert torch.equal(
         x_cpu.dequantize(torch.float32), x_pinned.dequantize(torch.float32)
     )
+
+
+def test_mx_tensor_factories():
+    def fake_to_mx_impl(data_hp, elem_dtype, block_size, *_):
+        scale = data_hp.new_zeros(
+            data_hp.shape[:-1] + (data_hp.shape[-1] // block_size,),
+            dtype=torch.uint8,
+        ).view(torch.float8_e8m0fnu)
+        qdata = data_hp.new_zeros(data_hp.shape, dtype=elem_dtype)
+        return scale, qdata
+
+    class MyMXTensor(MXTensor):
+        to_mx_impl_calls = 0
+
+        @staticmethod
+        def _to_mx_impl(*args, **kwargs):
+            MyMXTensor.to_mx_impl_calls += 1
+            return fake_to_mx_impl(*args, **kwargs)
+
+    previous_default = get_default_mx_tensor_class()
+    set_default_mx_tensor_class(MyMXTensor)
+    try:
+        data_hp = torch.randn(2, 32, dtype=torch.bfloat16)
+
+        assert (
+            type(MyMXTensor.to_mx(data_hp, torch.float8_e4m3fn, 32))
+            is MyMXTensor
+        )
+        assert (
+            type(to_mx_tensor(data_hp, torch.float8_e4m3fn, 32))
+            is MyMXTensor
+        )
+
+        scale, qdata = to_mx(data_hp, torch.float8_e4m3fn, 32)
+        assert MyMXTensor.to_mx_impl_calls == 3
+
+        assert (
+            type(
+                MyMXTensor.from_qdata_and_scales(
+                    qdata,
+                    scale,
+                    orig_dtype=data_hp.dtype,
+                    block_size=32,
+                    kernel_preference=KernelPreference.EMULATED,
+                )
+            )
+            is MyMXTensor
+        )
+        assert (
+            type(
+                make_mx_tensor(
+                    qdata,
+                    scale,
+                    torch.float8_e4m3fn,
+                    32,
+                    data_hp.dtype,
+                    KernelPreference.EMULATED,
+                    None,
+                    False,
+                    mx_tensor_cls=MXTensor,
+                )
+            )
+            is MXTensor
+        )
+    finally:
+        set_default_mx_tensor_class(previous_default)

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -12,7 +12,7 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, make_mx_tensor
 
 
 class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
@@ -133,8 +133,8 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
             # Convert scales back to float8_e8m0fnu
             grad_input_scales = grad_input_scales.view(torch.float8_e8m0fnu)
 
-            # Wrap as MXTensor
-            grad_input = MXTensor(
+            # Wrap as MX Tensor
+            grad_input = make_mx_tensor(
                 grad_input_data,
                 grad_input_scales,
                 elem_dtype=torch.float8_e4m3fn,

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -12,7 +12,7 @@ from torch.distributed.distributed_c10d import _resolve_process_group
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, make_mx_tensor
 
 
 class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
@@ -93,8 +93,8 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
         # Convert scales back to float8_e8m0fnu
         output_scales = output_scales.view(torch.float8_e8m0fnu)
 
-        # Wrap output as MXTensor
-        mx_output = MXTensor(
+        # Wrap output as MX Tensor
+        mx_output = make_mx_tensor(
             output_data,
             output_scales,
             elem_dtype=torch.float8_e4m3fn,

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from torch.library import triton_op, wrap_triton
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, make_mx_tensor
 
 from .kernels import generate_permute_indices
 
@@ -96,8 +96,8 @@ class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
         scales_padded = torch.vstack((scales, scales.new_zeros((scales.shape[-1],))))
         scales_permuted = scales_padded[permuted_indices, :]
 
-        # Wrap back into MXTensor
-        mx_output = MXTensor(
+        # Wrap back into MX Tensor
+        mx_output = make_mx_tensor(
             qdata_permuted,
             scales_permuted,
             elem_dtype=mx_tensor.elem_dtype,

--- a/torchao/prototype/moe_training/ep/unpermute.py
+++ b/torchao/prototype/moe_training/ep/unpermute.py
@@ -7,7 +7,7 @@
 import torch
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import MXTensor, make_mx_tensor
 
 
 class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
@@ -87,8 +87,8 @@ class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
             qdata_permuted = qdata_padded[permuted_indices, :]
             scales_permuted = scales_padded[permuted_indices, :]
 
-            # Wrap back into MXTensor with the correct shape
-            grad_input = MXTensor(
+            # Wrap back into MX Tensor with the correct shape
+            grad_input = make_mx_tensor(
                 qdata_permuted,
                 scales_permuted,
                 elem_dtype=grad_output.elem_dtype,

--- a/torchao/prototype/moe_training/mxfp8_linear.py
+++ b/torchao/prototype/moe_training/mxfp8_linear.py
@@ -18,7 +18,7 @@ from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
     ScaleCalculationMode,
 )
-from torchao.prototype.mx_formats.mx_tensor import MXTensor
+from torchao.prototype.mx_formats.mx_tensor import to_mx_tensor
 from torchao.prototype.mx_formats.utils import _to_mxfp8_dim1_kernel_wrapper
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
 
@@ -120,7 +120,7 @@ class mx_mm(torch.autograd.Function):
         input_orig_shape = input_hp.shape
         input_hp_r = input_hp.reshape(-1, input_orig_shape[-1])
 
-        input_mx_r_dim0 = MXTensor.to_mx(
+        input_mx_r_dim0 = to_mx_tensor(
             input_hp_r,
             in_elem_dtype,
             block_size,
@@ -128,7 +128,7 @@ class mx_mm(torch.autograd.Function):
             kernel_preference,
             mxfp8_dim0_cast_kernel_choice=mxfp8_dim0_cast_kernel_choice,
         )
-        weight_mx_dim0 = MXTensor.to_mx(
+        weight_mx_dim0 = to_mx_tensor(
             weight_hp,
             w_elem_dtype,
             block_size,
@@ -167,7 +167,7 @@ class mx_mm(torch.autograd.Function):
         input_hp_r = input_hp.reshape(-1, input_hp_orig_shape[-1])
 
         # grad_output @ weight = grad_input
-        grad_output_mx_dim0 = MXTensor.to_mx(
+        grad_output_mx_dim0 = to_mx_tensor(
             grad_output_hp_r,
             grad_elem_dtype,
             block_size,
@@ -181,7 +181,7 @@ class mx_mm(torch.autograd.Function):
             or mxfp8_dim1_cast_kernel_choice == MXFP8Dim1CastKernelChoice.TORCH
         ):
             weight_hp_t_c = weight_hp.t().contiguous()
-            weight_mx_dim1 = MXTensor.to_mx(
+            weight_mx_dim1 = to_mx_tensor(
                 weight_hp_t_c,
                 w_elem_dtype,
                 block_size,
@@ -222,7 +222,7 @@ class mx_mm(torch.autograd.Function):
                     scale_calculation_mode,
                 )
             else:
-                grad_output_mx_dim1 = MXTensor.to_mx(
+                grad_output_mx_dim1 = to_mx_tensor(
                     grad_output_hp_r.t().contiguous(),
                     grad_elem_dtype,
                     block_size,
@@ -243,7 +243,7 @@ class mx_mm(torch.autograd.Function):
                 )
                 input_t_mx_dim0 = input_t_mx_dim0_tmp.t()
             else:
-                input_t_mx_dim0_tmp = MXTensor.to_mx(
+                input_t_mx_dim0_tmp = to_mx_tensor(
                     input_hp_r.t().contiguous(),
                     in_elem_dtype,
                     block_size,

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -18,6 +18,7 @@ from torchao.prototype.mx_formats.config import _validate_elem_dtype
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     QuantizeTensorToMXKwargs,
+    to_mx_tensor,
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.nvfp4_tensor import (
@@ -144,7 +145,7 @@ def _mx_inference_linear_transform(
     )
 
     # Convert weight to MX Tensor
-    quantized_weight = MXTensor.to_mx(
+    quantized_weight = to_mx_tensor(
         weight,
         config.weight_dtype,
         block_size=config.block_size,

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -225,7 +225,10 @@ def _to_mx_rceil(
     return exponent, data_lp
 
 
-def to_mx(
+_DEFAULT_MX_TENSOR_CLASS = None
+
+
+def _to_mx_impl(
     data_hp: torch.Tensor,
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
@@ -409,6 +412,25 @@ def to_mx(
     return scale_e8m0_biased, data_lp
 
 
+def to_mx(
+    data_hp: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
+    is_swizzled_scales: bool = False,
+):
+    """
+    Takes a high precision tensor and converts to MX scale and raw data.
+
+    If a default MXTensor subclass has been registered, use its ``_to_mx_impl``
+    override so standalone ``to_mx`` imports follow the same quantization path
+    as ``MXTensor.to_mx``.
+    """
+    return get_default_mx_tensor_class()._to_mx_impl(
+        data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+    )
+
+
 def get_fp_scale(scale_e8m0):
     scale_e8m0 = scale_e8m0.view(torch.uint8)
     s_offset = scale_e8m0.to(torch.int16) - E8M0_EXPONENT_BIAS
@@ -515,6 +537,7 @@ class MXTensor(TorchAOBaseTensor):
         "act_quant_kwargs",
         "is_swizzled_scales",
     ]
+    _to_mx_impl = staticmethod(_to_mx_impl)
 
     def __new__(
         cls,
@@ -603,9 +626,10 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype,
         )
 
-    @staticmethod
+    @classmethod
     @torch._dynamo.allow_in_graph
     def from_qdata_and_scales(
+        cls,
         qdata: torch.Tensor,
         scales: torch.Tensor,
         orig_dtype: torch.dtype,
@@ -617,14 +641,12 @@ class MXTensor(TorchAOBaseTensor):
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
-            "use MXTensor(...) directly for packed uint8 payloads"
+            f"use {cls.__name__}(...) directly for packed uint8 payloads"
         )
-        elem_dtype = qdata.dtype
-
-        return MXTensor(
+        return cls(
             qdata,
             scales,
-            elem_dtype,
+            qdata.dtype,
             block_size,
             orig_dtype,
             kernel_preference,
@@ -632,9 +654,10 @@ class MXTensor(TorchAOBaseTensor):
             is_swizzled_scales,
         )
 
-    @staticmethod
+    @classmethod
     @torch._dynamo.allow_in_graph
     def to_mx(
+        cls,
         data_hp: torch.Tensor,
         elem_dtype: Union[torch.dtype, str],
         block_size: int = BLOCK_SIZE_DEFAULT,
@@ -646,45 +669,125 @@ class MXTensor(TorchAOBaseTensor):
         is_swizzled_scales: bool = False,
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
-        assert mxfp8_dim0_cast_kernel_choice in (
-            MXFP8Dim0CastKernelChoice.TRITON,
-            MXFP8Dim0CastKernelChoice.TORCH,
-        ), (
-            f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
-        )
-
-        triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
-        )
-        if (
-            mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
-            or kernel_preference == KernelPreference.EMULATED
-        ):
-            scale_e8m0_biased, data_lp = to_mx(
-                data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
-            )
-        else:
-            assert triton_kernel_supported, (
-                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
-            )
-            data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
-                data_hp,
-                inner_block_size=block_size,
-                scaling_mode=scaling_mode.value,
-            )
-        return MXTensor(
-            data_lp,
-            scale_e8m0_biased,
+        return to_mx_tensor(
+            data_hp,
             elem_dtype,
-            block_size,
-            data_hp.dtype,
-            kernel_preference,
-            act_quant_kwargs,
-            is_swizzled_scales,
+            block_size=block_size,
+            scaling_mode=scaling_mode,
+            kernel_preference=kernel_preference,
+            act_quant_kwargs=act_quant_kwargs,
+            is_swizzled_scales=is_swizzled_scales,
+            mxfp8_dim0_cast_kernel_choice=mxfp8_dim0_cast_kernel_choice,
+            mx_tensor_cls=cls,
         )
 
     # Do not force the MXTensor type on the returned tensor
     __torch_function__ = torch._C._disabled_torch_function_impl
+
+
+def set_default_mx_tensor_class(mx_tensor_cls: type[MXTensor]):
+    """Register the MXTensor subclass used by MX factory paths."""
+    assert issubclass(mx_tensor_cls, MXTensor), (
+        f"mx_tensor_cls must be a subclass of MXTensor, got {mx_tensor_cls}"
+    )
+    global _DEFAULT_MX_TENSOR_CLASS
+    _DEFAULT_MX_TENSOR_CLASS = mx_tensor_cls
+
+
+def get_default_mx_tensor_class() -> type[MXTensor]:
+    """Return the MXTensor subclass used by MX factory paths."""
+    return MXTensor if _DEFAULT_MX_TENSOR_CLASS is None else _DEFAULT_MX_TENSOR_CLASS
+
+
+def _resolve_mx_tensor_class(mx_tensor_cls: Optional[type[MXTensor]]):
+    # Omitting mx_tensor_cls means "use the configured default". Passing an
+    # explicit class, including MXTensor itself, constructs exactly that class.
+    if mx_tensor_cls is None:
+        mx_tensor_cls = get_default_mx_tensor_class()
+    assert issubclass(mx_tensor_cls, MXTensor), (
+        f"mx_tensor_cls must be a subclass of MXTensor, got {mx_tensor_cls}"
+    )
+    return mx_tensor_cls
+
+
+def make_mx_tensor(
+    qdata: torch.Tensor,
+    scale: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int,
+    orig_dtype: torch.dtype,
+    kernel_preference: Optional[KernelPreference],
+    act_quant_kwargs: Optional[QuantizeTensorToMXKwargs],
+    is_swizzled_scales: bool,
+    *,
+    mx_tensor_cls: Optional[type[MXTensor]] = None,
+) -> MXTensor:
+    """Wrap MX qdata/scales in the configured MXTensor class."""
+    mx_tensor_cls = _resolve_mx_tensor_class(mx_tensor_cls)
+    return mx_tensor_cls(
+        qdata,
+        scale,
+        elem_dtype,
+        block_size,
+        orig_dtype,
+        kernel_preference,
+        act_quant_kwargs,
+        is_swizzled_scales,
+    )
+
+
+def to_mx_tensor(
+    data_hp: torch.Tensor,
+    elem_dtype: Union[torch.dtype, str],
+    block_size: int = BLOCK_SIZE_DEFAULT,
+    scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
+    kernel_preference: KernelPreference = KernelPreference.EMULATED,
+    act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
+    is_swizzled_scales: bool = False,
+    mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
+    *,
+    mx_tensor_cls: Optional[type[MXTensor]] = None,
+) -> MXTensor:
+    """Convert high precision data to the configured MXTensor class."""
+    mx_tensor_cls = _resolve_mx_tensor_class(mx_tensor_cls)
+    assert mxfp8_dim0_cast_kernel_choice in (
+        MXFP8Dim0CastKernelChoice.TRITON,
+        MXFP8Dim0CastKernelChoice.TORCH,
+    ), (
+        f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
+    )
+
+    triton_kernel_supported = (
+        elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
+    )
+    if (
+        mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
+        or kernel_preference == KernelPreference.EMULATED
+    ):
+        scale_e8m0_biased, data_lp = mx_tensor_cls._to_mx_impl(
+            data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+        )
+    else:
+        assert triton_kernel_supported, (
+            f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
+        )
+        data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
+            data_hp,
+            inner_block_size=block_size,
+            scaling_mode=scaling_mode.value,
+        )
+
+    return make_mx_tensor(
+        data_lp,
+        scale_e8m0_biased,
+        elem_dtype,
+        block_size,
+        data_hp.dtype,
+        kernel_preference,
+        act_quant_kwargs,
+        is_swizzled_scales,
+        mx_tensor_cls=mx_tensor_cls,
+    )
 
 
 implements = MXTensor.implements
@@ -705,7 +808,8 @@ def mx_is_pinned(func, types, args, kwargs):
 @implements([aten._pin_memory.default])
 def mx_pin_memory(func, types, args, kwargs):
     tensor = args[0]
-    return MXTensor(
+    assert isinstance(tensor, MXTensor)
+    return type(tensor)(
         tensor.qdata.pin_memory(),
         tensor.scale.pin_memory(),
         tensor.elem_dtype,
@@ -767,13 +871,13 @@ def _addmm_mx_dispatch(
     if not isinstance(a, MXTensor):
         assert b.act_quant_kwargs is not None, "weight-only quant not yet supported"
         k = b.act_quant_kwargs
-        a = MXTensor.to_mx(
+        a = to_mx_tensor(
             a,
             k.elem_dtype,
             k.block_size,
-            k.scaling_mode,
-            k.kernel_preference,
-            k.is_swizzled_scales,
+            scaling_mode=k.scaling_mode,
+            kernel_preference=k.kernel_preference,
+            is_swizzled_scales=k.is_swizzled_scales,
         )
 
     gemm_choice = _get_gemm_choice(a.kernel_preference, b.kernel_preference)
@@ -886,7 +990,8 @@ def mx_linear(func, types, args, kwargs):
 def mx_t(func, types, args, kwargs):
     # For now, only transpose(input, 0, 1) is supported.
     old = args[0]
-    new = MXTensor(
+    assert isinstance(old, MXTensor)
+    new = type(old)(
         old.qdata.t(),
         old.scale.t(),
         old.elem_dtype,
@@ -921,27 +1026,30 @@ def mx_cast_up_op(func, types, args, kwargs):
 
 @implements([aten.view.default])
 def mx_view_op(func, types, args, kwargs):
-    data = args[0].qdata
+    mx_tensor = args[0]
+    assert isinstance(mx_tensor, MXTensor)
+    data = mx_tensor.qdata
     new_size = args[1]
-    if args[0].elem_dtype == torch.float4_e2m1fn_x2:
+    if mx_tensor.elem_dtype == torch.float4_e2m1fn_x2:
         # special case fp4 as we pack two elements per byte
         new_size = tensor_size_hp_to_fp4x2(new_size, data.is_contiguous())
     new_data = func(data, new_size, *args[2:], **kwargs)
-    return MXTensor(
+    return type(mx_tensor)(
         new_data,
-        args[0].scale,
-        args[0].elem_dtype,
-        args[0].block_size,
-        args[0].orig_dtype,
-        args[0].kernel_preference,
-        args[0].act_quant_kwargs,
-        args[0].is_swizzled_scales,
+        mx_tensor.scale,
+        mx_tensor.elem_dtype,
+        mx_tensor.block_size,
+        mx_tensor.orig_dtype,
+        mx_tensor.kernel_preference,
+        mx_tensor.act_quant_kwargs,
+        mx_tensor.is_swizzled_scales,
     )
 
 
 @implements([aten.slice.Tensor])
 def mx_slice(func, types, args, kwargs):
     x, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
+    assert isinstance(x, MXTensor)
 
     if step != 1:
         raise ValueError("Only support aten.slice with step=1")
@@ -952,7 +1060,7 @@ def mx_slice(func, types, args, kwargs):
         func,
         args,
         kwargs,
-        MXTensor(
+        type(x)(
             sliced_data,
             sliced_scale,
             x.elem_dtype,
@@ -986,7 +1094,7 @@ def mx_select(func, types, args, kwargs):
         "unsupported"
     )
     assert not old_mx_tensor.is_swizzled_scales, "unsupported"
-    new_mx_tensor = old_mx_tensor.__class__(
+    new_mx_tensor = type(old_mx_tensor)(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],
         old_mx_tensor.elem_dtype,
@@ -1011,6 +1119,7 @@ def mx_all_gather(func, types, args, kwargs):
         kwargs: Additional arguments
     """
     mx_tensor = args[0]
+    assert isinstance(mx_tensor, MXTensor)
     group_tag = args[1] if len(args) > 1 else "default"
 
     # TODO: Add support for concat CC as a future optimization
@@ -1035,7 +1144,7 @@ def mx_all_gather(func, types, args, kwargs):
     gathered_scale = gathered_scale.view(torch.float8_e8m0fnu)
 
     # Return new MXTensor with gathered data
-    return MXTensor(
+    return type(mx_tensor)(
         gathered_qdata,
         gathered_scale,
         mx_tensor.elem_dtype,
@@ -1056,6 +1165,7 @@ def mx_wait_tensor(func, types, args, kwargs):
     the operation has completed before using the tensor.
     """
     mx_tensor = args[0]
+    assert isinstance(mx_tensor, MXTensor)
 
     # Wait on both components
     waited_qdata = torch.ops._c10d_functional.wait_tensor.default(
@@ -1066,7 +1176,7 @@ def mx_wait_tensor(func, types, args, kwargs):
         mx_tensor.scale, *args[1:], **kwargs
     )
 
-    return MXTensor(
+    return type(mx_tensor)(
         waited_qdata,
         waited_scale,
         mx_tensor.elem_dtype,

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -156,7 +156,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
 ):
     # avoid circular import
     # TODO(future PR): split this utils file in two
-    from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
+    from torchao.prototype.mx_formats.mx_tensor import make_mx_tensor, to_mx
 
     is_swizzled_scales = False
 
@@ -231,7 +231,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
 
     # MXTensor wraps DTensor inner tensors directly (MXTensor(DTensor) ordering).
     # DTensor's .t() handles placement transposition automatically.
-    mx_tensor = MXTensor(
+    mx_tensor = make_mx_tensor(
         a_data.t(),
         a_scale,
         elem_dtype,

--- a/torchao/prototype/qat/mx.py
+++ b/torchao/prototype/qat/mx.py
@@ -32,6 +32,7 @@ from torchao.prototype.mx_formats.config import (
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     _addmm_mx_dispatch,
+    to_mx_tensor,
 )
 from torchao.quantization.qat import FakeQuantizeConfigBase
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
@@ -99,7 +100,7 @@ class _MXQuantizedForwardFakeQuantizedBackward(torch.autograd.Function):
         _input_2d = _input.view(-1, orig_shape[-1])
 
         # quantize input activations
-        _input_2d = MXTensor.to_mx(
+        _input_2d = to_mx_tensor(
             _input_2d,
             elem_dtype=activation_config.dtype,
             block_size=activation_config.block_size,
@@ -107,7 +108,7 @@ class _MXQuantizedForwardFakeQuantizedBackward(torch.autograd.Function):
             kernel_preference=activation_config.kernel_preference,
         )
 
-        weight = MXTensor.to_mx(
+        weight = to_mx_tensor(
             weight,
             elem_dtype=weight_config.dtype,
             block_size=weight_config.block_size,


### PR DESCRIPTION
**Summary**
This PR makes `MXTensor` subclass-friendly and modifies hard-coded internal construction paths that would otherwise force the base `MXTensor` type.

It does this in two layers:

1. Make `MXTensor` itself override-friendly.
2. Add explicit MX factory functions and migrate internal TorchAO call sites to use them.

The idea is, by calling `set_default_mx_tensor_class(MyMXTensor)`, the internals that call the new factory functions `to_mx_tensor(...)` and `make_mx_tensor(...)` instead of the explicit `MXTensor.to_mx` and `MXTensor(...)` will automatically use `MyMXTensor`.

It is insufficient to simply rely on changing the Config. For example, if we take `MXDynamicActivationMXWeightConfig`, we can specify the following info: `block_size, activation_dtype, weight_dtype, KernelPreference, ScaleCalculationMode`. However, the quantization algorithm itself in `MXTensor.to_mx` cannot be modified if needed. In this case, more flexibility is required than what can be specified in any Config.

Note that the behaviour of `MXTensor.to_mx` and `MXTensor(...)` remain untouched: If used explicitly, these will _always_ produce `MXTensor` with no implicit behaviour. Only the new factory functions will try to resolve which default `MXTensor` class to use.