### PR TITLE
Remove Float8 allow-in-graph custom autograd wrappers (#4840)

### DIFF
--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -14,6 +14,11 @@ import torch
 import torch.nn as nn
 from torch._dynamo.test_case import TestCase as DynamoTestCase
 from torch._dynamo.testing import CompileCounterWithBackend
+from torch._dynamo.utils import counters
+from torch._functorch import config as functorch_config
+from torch._inductor import config as inductor_config
+from torch._inductor.codecache import PyCodeCache
+from torch._inductor.utils import fresh_cache
 
 from torchao.float8.config import (
     CastConfig,
@@ -220,6 +225,60 @@ def test_inductor_from_recipe(recipe_name):
         config,
         dtype,
     )
+
+
+@inductor_config.patch(
+    {
+        "compile_threads": 1,
+        "fx_graph_cache": True,
+        "fx_graph_remote_cache": False,
+    }
+)
+@functorch_config.patch(
+    {
+        "autograd_cache_allow_custom_autograd_functions": True,
+        "enable_autograd_cache": True,
+        "strict_autograd_cache": True,
+    }
+)
+@unittest.skipIf(not torch.accelerator.is_available(), "GPU not available")
+@unittest.skipIf(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    "CUDA with capability 9.0 or greater not available",
+)
+def test_inductor_aot_autograd_cache_rowwise_with_gw_hp():
+    torch._dynamo.reset()
+    device = torch.accelerator.current_accelerator()
+    config = Float8LinearConfig.from_recipe_name(
+        Float8LinearRecipeName.ROWWISE_WITH_GW_HP
+    )
+    model = Float8Linear.from_float(
+        nn.Linear(16, 32, bias=True, device=device, dtype=torch.bfloat16),
+        config,
+    )
+    compiled_model = torch.compile(model, backend="inductor", fullgraph=True)
+
+    counters.clear()
+    with fresh_cache():
+        x = torch.randn(16, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
+        compiled_model(x).sum().backward()
+
+        assert counters["aot_autograd"]["autograd_cache_miss"] == 1
+        assert counters["aot_autograd"]["autograd_cache_hit"] == 0
+        assert counters["aot_autograd"]["autograd_cache_saved"] == 1
+        assert counters["aot_autograd"]["autograd_cache_bypass"] == 0
+
+        torch._dynamo.reset()
+        PyCodeCache.cache_clear(purge=True)
+
+        model.zero_grad(set_to_none=True)
+        x = torch.randn(16, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
+        compiled_model(x).sum().backward()
+
+        assert counters["aot_autograd"]["autograd_cache_miss"] == 1
+        assert counters["aot_autograd"]["autograd_cache_hit"] == 1
+        assert counters["aot_autograd"]["autograd_cache_saved"] == 1
+        assert counters["aot_autograd"]["autograd_cache_bypass"] == 0
 
 
 class TestGraphBreaks(DynamoTestCase):

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -25,7 +25,6 @@ from torchao.float8.float8_training_tensor import (
 from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 
 
-@torch._dynamo.allow_in_graph
 class matmul_with_hp_or_float8_args(torch.autograd.Function):
     """
     Like torch.matmul, but with the arguments in either high precision or float8.

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -87,7 +87,6 @@ def get_maybe_axiswise_dim(
     return None
 
 
-@torch._dynamo.allow_in_graph
 class NoopFwToFloat8BwDynamic(torch.autograd.Function):
     """
     Forward: no-op

--- a/torchao/float8/float8_training_tensor.py
+++ b/torchao/float8/float8_training_tensor.py
@@ -119,7 +119,6 @@ def choose_scaled_mm_config(
         raise AssertionError(f"unexpected a_role {a_role} and b_role {b_role}")
 
 
-@torch._dynamo.allow_in_graph
 class _ToFloat8ConstrFunc(torch.autograd.Function):
     """
     A differentiable conversion to fp8.
@@ -192,7 +191,6 @@ class _ToFloat8ConstrFunc(torch.autograd.Function):
         return g, None, None, None, None, None
 
 
-@torch._dynamo.allow_in_graph
 class _FromFloat8ConstrFunc(torch.autograd.Function):
     """
     A differentiable conversion from fp8.


### PR DESCRIPTION
Summary:

Route four TorchAO Float8 autograd.Function classes through the standard Dynamo AutogradFunctionApply HOP so AOTAutograd cache can key and serialize them without local trampoline closures.

Post: https://fb.workplace.com/groups/1075192433118967/permalink/2032824680689066/

 {F1995106320}

Differential Revision: D117758450


