### PR TITLE
docs: remove stale MXFP4 training entry

### DIFF
--- a/docs/source/workflows/training.md
+++ b/docs/source/workflows/training.md
@@ -291,15 +291,13 @@ in native PyTorch.
 
 | workflow | emulation | performance | accuracy | API polish |
 | --- | --- | --- | --- | --- |
-| training for `torch.nn.Linear` | ✅ | 🔴 | 🟡 | 🟡 |
-| QAT for `torch.nn.Linear` | planned | n/a | planned | planned |
+| QAT for `torch.nn.Linear` | ✅ | n/a | 🟡 | 🟡 |
 | inference for `torch.nn.Linear` | ✅ | 🔴 | 🟢 | 🟡 |
 
 #### planned improvements
 
 * mxfp8 support for grouped_gemm and all2all for MoE training (see https://github.com/pytorch/ao/tree/main/torchao/prototype/moe_training ).
 * mxfp8, nvfp4, mxfp4 performance optimizations for inference
-* polish the nvpf4 QAT recipe, and enable mxfp4 QAT
 * blocked formats for faster training
 * stochastic rounding and hadamard transforms for improved fp4 training numerics
 


### PR DESCRIPTION
## Summary

- remove the obsolete MXFP4 quantized-training row left over from the former `MXLinearConfig` workflow
- update MXFP4 QAT from planned to its current prototype status
- remove the obsolete planned-improvement item about enabling MXFP4 QAT

The current MXFP4 workflows are QAT and inference; the public low-precision MX training path is MXFP8-specific. This documentation-only change does not alter or make a policy decision about runtime support.

Fixes #4841.

## Test plan

- `git diff --check`
- verified that every modified Markdown table row retains five columns

No GPU runtime claims are made.
