### PR TITLE
Refactor MXTensor: replace is_swizzled_scales bool with SwizzleType class hierarchy

### DIFF
--- a/test/prototype/moe_training/test_mxfp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_mxfp8_grouped_mm.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.utils import (
     is_MI300,
     is_MI350,
@@ -370,7 +370,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_matches_dynamic():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=NoSwizzle(),
     )
     out = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -440,7 +440,7 @@ def test_mxfp8_grouped_gemm_from_qdata_and_scales_forward():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=NoSwizzle(),
     )
     out_mx = _to_mxfp8_then_scaled_grouped_mm(
         x_mx,
@@ -494,7 +494,7 @@ def test_mxfp8_grouped_gemm_mxtensor_requires_wgrad_with_hp():
         x_scale,
         orig_dtype=x.dtype,
         block_size=block_size,
-        is_swizzled_scales=False,
+        swizzle_type=NoSwizzle(),
     )
 
     with pytest.raises(AssertionError, match="wgrad_with_hp"):

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -12,25 +12,36 @@ import pytest
 import torch
 import torch.nn as nn
 
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
     NVFP4DynamicActivationNVFP4WeightConfig,
 )
+from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_100(), reason="needs CUDA capability 10.0+")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):
     """
     Ensure that only `import torchao.prototype.mx_formats` is needed to load MX
     and NV checkpoints.
     """
+    device = torch.accelerator.current_accelerator().type
+    if recipe_name == "nvfp4" and device == "xpu":
+        pytest.skip("NVFP4 is not supported on XPU")
 
-    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device=device)
     fname = None
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
         if recipe_name == "mxfp8":
@@ -61,3 +72,111 @@ _ = torch.load('{fname}', weights_only=True)
     subprocess_out = subprocess.run(["python"], input=code, text=True)
     os.remove(fname)
     assert subprocess_out.returncode == 0, "failed weights-only load"
+
+
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
+@pytest.mark.parametrize("old_is_swizzled", [False, True])
+def test_setstate_migrates_old_is_swizzled_scales(old_is_swizzled):
+    """
+    Regression: old checkpoints stored ``is_swizzled_scales: bool`` instead of
+    ``swizzle_type``.  We can't produce old-format files from current code, so
+    we call ``__setstate__`` directly with simulated old-format data (this is
+    the exact code path ``torch.load``).
+    """
+    device = torch.accelerator.current_accelerator().type
+    # NoSwizzle() is used here only to create valid tensor data for the test;
+    # the actual backward-compat migration is driven by old_is_swizzled below.
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
+    config = MXDynamicActivationMXWeightConfig(
+        activation_dtype=torch.float8_e4m3fn,
+        weight_dtype=torch.float8_e4m3fn,
+        kernel_preference=KernelPreference.EMULATED,
+        swizzle_type=NoSwizzle(),
+    )
+    quantize_(m, config=config)
+
+    weight = m.weight
+    assert isinstance(weight, MXTensor)
+
+    # Build an old-format state dict (as torch.load would pass to __setstate__)
+    old_state = {
+        "qdata": weight.qdata,
+        "scale": weight.scale,
+        "elem_dtype": weight.elem_dtype,
+        "block_size": weight.block_size,
+        "orig_dtype": weight.orig_dtype,
+        "kernel_preference": weight.kernel_preference,
+        "act_quant_kwargs": weight.act_quant_kwargs,
+        "is_swizzled_scales": old_is_swizzled,  # old bool field
+    }
+
+    # Create a shell MXTensor and apply __setstate__ (simulates torch.load path)
+    shell = torch.Tensor._make_wrapper_subclass(
+        MXTensor,
+        weight.shape,
+        strides=weight.stride(),
+        dtype=weight.orig_dtype,
+        device=weight.device,
+    )
+    shell.__setstate__(old_state)
+
+    # Verify top-level migration
+    expected = Swizzle_32_4_4 if old_is_swizzled else NoSwizzle
+    assert isinstance(shell.swizzle_type, expected), (
+        f"Top-level: expected {expected.__name__}, got {type(shell.swizzle_type).__name__}"
+    )
+
+
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
+@pytest.mark.parametrize("old_is_swizzled", [False, True])
+def test_tensor_unflatten_migrates_old_is_swizzled_scales(old_is_swizzled):
+    """
+    Regression: old checkpoints stored ``is_swizzled_scales: bool`` instead of
+    ``swizzle_type``.  We can't produce old-format files from current code, so
+    we call ``__tensor_unflatten__`` directly with simulated old-format metadata
+    (this is the exact code path Dynamo tracing takes).
+    """
+    device = torch.accelerator.current_accelerator().type
+    # NoSwizzle() is used here only to create valid tensor data for the test;
+    # the actual backward-compat migration is driven by old_is_swizzled below.
+    m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
+    config = MXDynamicActivationMXWeightConfig(
+        activation_dtype=torch.float8_e4m3fn,
+        weight_dtype=torch.float8_e4m3fn,
+        kernel_preference=KernelPreference.EMULATED,
+        swizzle_type=NoSwizzle(),
+    )
+    quantize_(m, config=config)
+
+    weight = m.weight
+    assert isinstance(weight, MXTensor)
+
+    tensor_data = {"qdata": weight.qdata, "scale": weight.scale}
+    old_attrs = {
+        "elem_dtype": weight.elem_dtype,
+        "block_size": weight.block_size,
+        "orig_dtype": weight.orig_dtype,
+        "kernel_preference": weight.kernel_preference,
+        "act_quant_kwargs": weight.act_quant_kwargs,
+        "is_swizzled_scales": old_is_swizzled,
+    }
+
+    expected = Swizzle_32_4_4 if old_is_swizzled else NoSwizzle
+    restored = MXTensor.__tensor_unflatten__(
+        tensor_data, dict(old_attrs), weight.shape, None
+    )
+    assert isinstance(restored.swizzle_type, expected)

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -91,14 +91,11 @@ def test_setstate_migrates_old_is_swizzled_scales(old_is_swizzled):
     the exact code path ``torch.load``).
     """
     device = torch.accelerator.current_accelerator().type
-    # NoSwizzle() is used here only to create valid tensor data for the test;
-    # the actual backward-compat migration is driven by old_is_swizzled below.
     m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,
         kernel_preference=KernelPreference.EMULATED,
-        swizzle_type=NoSwizzle(),
     )
     quantize_(m, config=config)
 
@@ -151,14 +148,11 @@ def test_tensor_unflatten_migrates_old_is_swizzled_scales(old_is_swizzled):
     (this is the exact code path Dynamo tracing takes).
     """
     device = torch.accelerator.current_accelerator().type
-    # NoSwizzle() is used here only to create valid tensor data for the test;
-    # the actual backward-compat migration is driven by old_is_swizzled below.
     m = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16, device=device)
     config = MXDynamicActivationMXWeightConfig(
         activation_dtype=torch.float8_e4m3fn,
         weight_dtype=torch.float8_e4m3fn,
         kernel_preference=KernelPreference.EMULATED,
-        swizzle_type=NoSwizzle(),
     )
     quantize_(m, config=config)
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -15,6 +15,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing import FileCheck
 
 import torchao.prototype.mx_formats.mx_tensor as mx_tensor_module
+from torchao.prototype.mx_formats.config import NoSwizzle, Swizzle_32_4_4
 from torchao.prototype.mx_formats.constants import (
     DTYPE_FP6_E2M3,
     DTYPE_FP6_E3M2,
@@ -549,7 +550,7 @@ def test_exponent_nan_out(elem_dtype):
         torch.float,
         KernelPreference.EMULATED,
         None,
-        False,
+        NoSwizzle(),
     )
     tensor_hp = tensor_mx.dequantize(torch.float)
     assert torch.all(torch.isnan(tensor_hp.flatten()[0:4]))
@@ -950,7 +951,7 @@ def test_swizzle(elem_dtype, transpose, shape):
         elem_dtype,
         block_size,
         ScaleCalculationMode.FLOOR,
-        is_swizzled_scales=True,
+        swizzle_type=Swizzle_32_4_4(),
     )
 
     if transpose:

--- a/test/prototype/mx_formats/test_mxfp8_allgather.py
+++ b/test/prototype/mx_formats/test_mxfp8_allgather.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 
+from torchao.prototype.mx_formats.config import NoSwizzle
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.utils import is_sm_at_least_90
 
@@ -37,7 +38,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=NoSwizzle(),
     )
 
     local_rank = torch.distributed.get_rank()
@@ -57,7 +58,7 @@ def _test_allgather(local_rank):
         orig_dtype=torch.float32,
         kernel_preference=None,
         act_quant_kwargs=None,
-        is_swizzled_scales=None,
+        swizzle_type=NoSwizzle(),
     )
 
     # Perform all_gather

--- a/torchao/prototype/moe_training/ep/a2a_combine.py
+++ b/torchao/prototype/moe_training/ep/a2a_combine.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -142,7 +142,7 @@ class _A2ACombineHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=ctx.hp_dtype,
                 kernel_preference=None,
                 act_quant_kwargs=None,
-                is_swizzled_scales=False,
+                swizzle_type=NoSwizzle(),
             )
         else:
             # BF16 backward path: Just do inverse all-to-all in bf16

--- a/torchao/prototype/moe_training/ep/a2a_dispatch.py
+++ b/torchao/prototype/moe_training/ep/a2a_dispatch.py
@@ -10,7 +10,7 @@ from torch.distributed._functional_collectives import all_to_all_single
 from torch.distributed.distributed_c10d import _resolve_process_group
 
 from torchao.prototype.moe_training.utils import conditional_nostrict_trace
-from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.config import NoSwizzle, ScaleCalculationMode
 from torchao.prototype.mx_formats.kernels import triton_to_mxfp8_dim0
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 
@@ -102,7 +102,7 @@ class _A2ADispatchMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=input.dtype,
             kernel_preference=None,
             act_quant_kwargs=None,
-            is_swizzled_scales=False,
+            swizzle_type=NoSwizzle(),
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/permute.py
+++ b/torchao/prototype/moe_training/ep/permute.py
@@ -105,7 +105,7 @@ class _PermuteMXFP8FwdHPBwd(torch.autograd.Function):
             orig_dtype=mx_tensor.orig_dtype,
             kernel_preference=mx_tensor.kernel_preference,
             act_quant_kwargs=mx_tensor.act_quant_kwargs,
-            is_swizzled_scales=mx_tensor.is_swizzled_scales,
+            swizzle_type=mx_tensor.swizzle_type,
         )
 
         # Save for backward

--- a/torchao/prototype/moe_training/ep/unpermute.py
+++ b/torchao/prototype/moe_training/ep/unpermute.py
@@ -96,7 +96,7 @@ class _UnpermuteHPFwdMXFP8Bwd(torch.autograd.Function):
                 orig_dtype=grad_output.orig_dtype,
                 kernel_preference=grad_output.kernel_preference,
                 act_quant_kwargs=grad_output.act_quant_kwargs,
-                is_swizzled_scales=grad_output.is_swizzled_scales,
+                swizzle_type=grad_output.swizzle_type,
             )
         else:
             # BF16 tensor path: permute directly

--- a/torchao/prototype/moe_training/mxfp8_grouped_mm.py
+++ b/torchao/prototype/moe_training/mxfp8_grouped_mm.py
@@ -26,6 +26,7 @@ from torchao.prototype.moe_training.utils import (
 )
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
 )
 from torchao.prototype.mx_formats.kernels import (
@@ -519,7 +520,7 @@ def _compute_fwd_sm100(
             padded_input_act.qdata,
             padded_input_act.scale,
         )
-        if not padded_input_act.is_swizzled_scales:
+        if isinstance(padded_input_act.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             input_act_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 padded_input_act.scales, padded_group_end_offsets
@@ -619,7 +620,7 @@ def _compute_dgrad_sm100(
     # Quantize grad_output along dim0
     if isinstance(grad_output, MXTensor):
         grad_out_e4m3, grad_output_scales_blocked = grad_output.qdata, grad_output.scale
-        if not grad_output.is_swizzled_scales:
+        if isinstance(grad_output.swizzle_type, NoSwizzle):
             # Convert scales to blocked layout for SM100 kernels
             grad_output_scales_blocked = mx_block_rearrange_2d_M_groups_cuda(
                 grad_output.scales, group_end_offsets
@@ -1074,7 +1075,7 @@ def _validate_grouped_mm_input_act(
     assert input_act.block_size == block_size, (
         f"Expected MXTensor block_size={block_size}, but got {input_act.block_size}"
     )
-    assert not input_act.is_swizzled_scales, (
+    assert isinstance(input_act.swizzle_type, NoSwizzle), (
         "MXTensor input scales must be unswizzled for grouped GEMM"
     )
     assert input_act.qdata.ndim == 2, "MXTensor input_act data must be 2D"

--- a/torchao/prototype/mx_formats/config.py
+++ b/torchao/prototype/mx_formats/config.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass
 from enum import Enum
 
 import torch
@@ -11,6 +12,30 @@ import torch
 from torchao.prototype.mx_formats.constants import SUPPORTED_ELEM_DTYPES
 from torchao.quantization.quantize_.common.kernel_preference import KernelPreference
 from torchao.utils import register_as_pytree_constant
+
+
+@dataclass(frozen=True)
+class SwizzleType:
+    """Base class for scale swizzle layout."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class NoSwizzle(SwizzleType):
+    """No swizzling."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class Swizzle_32_4_4(SwizzleType):
+    """32x4x4 blocked scale layout for NVIDIA."""
+
+    pass
+
+
+torch.serialization.add_safe_globals([NoSwizzle, Swizzle_32_4_4])
 
 
 class MXFP8Dim0CastKernelChoice(Enum):

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -16,7 +16,6 @@ from torch import Tensor
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import (
     Swizzle_32_4_4,
-    SwizzleType,
     _validate_elem_dtype,
 )
 from torchao.prototype.mx_formats.mx_tensor import (
@@ -115,10 +114,6 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
-    # How to store block scales.
-    # CUDA uses Swizzle_32_4_4 (blocked layout), XPU uses NoSwizzle.
-    swizzle_type: SwizzleType = Swizzle_32_4_4()
-
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
             "For now - we only support matching input/weight dtypes."
@@ -147,7 +142,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        swizzle_type=config.swizzle_type,
+        swizzle_type=Swizzle_32_4_4(),
         scaling_mode=config.scaling_mode,
     )
 
@@ -158,7 +153,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        swizzle_type=config.swizzle_type,
+        swizzle_type=Swizzle_32_4_4(),
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -88,7 +88,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     This module provides support for running inference with float8 quantization using MX formats.
 
     Requirements:
-    - NVIDIA SM100+ hardware (Blackwell or newer) or Intel XPU (BMG or newer)
+    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
     - PyTorch 2.5+ for proper serialization support
 
     Example (mxfp8):

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -14,7 +14,11 @@ import torch.nn.functional as F
 from torch import Tensor
 
 from torchao.core.config import AOBaseConfig
-from torchao.prototype.mx_formats.config import _validate_elem_dtype
+from torchao.prototype.mx_formats.config import (
+    Swizzle_32_4_4,
+    SwizzleType,
+    _validate_elem_dtype,
+)
 from torchao.prototype.mx_formats.mx_tensor import (
     MXTensor,
     QuantizeTensorToMXKwargs,
@@ -85,7 +89,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     This module provides support for running inference with float8 quantization using MX formats.
 
     Requirements:
-    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
+    - NVIDIA SM100+ hardware (Blackwell or newer) or Intel XPU (BMG or newer)
     - PyTorch 2.5+ for proper serialization support
 
     Example (mxfp8):
@@ -110,6 +114,10 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
 
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
+
+    # How to store block scales.
+    # CUDA uses Swizzle_32_4_4 (blocked layout), XPU uses NoSwizzle.
+    swizzle_type: SwizzleType = Swizzle_32_4_4()
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -139,7 +147,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 
@@ -150,7 +158,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        swizzle_type=config.swizzle_type,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -36,11 +36,14 @@ from torchao.utils import is_sm_at_least_100, torch_version_at_least
 if torch_version_at_least("2.12.0.dev0"):
     from torch._higher_order_ops.inline_asm_elementwise import inline_asm_elementwise
 
-from torch.nn.functional import ScalingType, SwizzleType
+from torch.nn.functional import ScalingType
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim0CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
+    SwizzleType,
 )
 from torchao.prototype.mx_formats.constants import (
     BLOCK_SIZE_DEFAULT,
@@ -98,6 +101,14 @@ _TORCH_VERSION_AT_LEAST_2_13 = torch_version_at_least("2.13.0.dev0")
 _TORCH_VERSION_AT_LEAST_2_14 = torch_version_at_least("2.14.0.dev0")
 
 
+def _migrate_is_swizzled_scales(d: dict) -> None:
+    """In-place migration of old ``is_swizzled_scales: bool`` to ``swizzle_type``."""
+    if "is_swizzled_scales" in d and "swizzle_type" not in d:
+        d["swizzle_type"] = (
+            Swizzle_32_4_4() if d.pop("is_swizzled_scales") else NoSwizzle()
+        )
+
+
 @dataclass
 class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     elem_dtype: Union[torch.dtype, str] = torch.float8_e4m3fn
@@ -105,7 +116,11 @@ class QuantizeTensorToMXKwargs(QuantizeTensorKwargs):
     # TODO(future PR): flip the scaling_mode default to RCEIL
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR
     kernel_preference: KernelPreference = KernelPreference.EMULATED
-    is_swizzled_scales: bool = False
+    swizzle_type: SwizzleType = NoSwizzle()
+
+    def __setstate__(self, state):
+        _migrate_is_swizzled_scales(state)
+        self.__dict__.update(state)
 
 
 def _f32_to_e8m0_rceil(value: torch.Tensor) -> torch.Tensor:
@@ -230,7 +245,7 @@ def to_mx(
     elem_dtype: Union[torch.dtype, str],
     block_size: int,
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.FLOOR,
-    is_swizzled_scales: bool = False,
+    swizzle_type: SwizzleType = NoSwizzle(),
 ):
     """
     Takes a high precision tensor and converts to MX scale and raw data, in
@@ -399,7 +414,7 @@ def to_mx(
     scale_e8m0_biased = scale_e8m0_biased.squeeze(-1)
 
     # if user requested scale swizzling, do it here
-    if is_swizzled_scales:
+    if isinstance(swizzle_type, Swizzle_32_4_4):
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
         scale = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
@@ -513,7 +528,7 @@ class MXTensor(TorchAOBaseTensor):
         "orig_dtype",
         "kernel_preference",
         "act_quant_kwargs",
-        "is_swizzled_scales",
+        "swizzle_type",
     ]
 
     def __new__(
@@ -525,7 +540,7 @@ class MXTensor(TorchAOBaseTensor):
         orig_dtype,
         kernel_preference,
         act_quant_kwargs,
-        is_swizzled_scales,
+        swizzle_type,
     ):
         new_size = qdata.size()
         if elem_dtype == torch.float4_e2m1fn_x2:
@@ -566,12 +581,22 @@ class MXTensor(TorchAOBaseTensor):
         self.orig_dtype = orig_dtype
         self.kernel_preference = kernel_preference
         self.act_quant_kwargs = act_quant_kwargs
-        self.is_swizzled_scales = is_swizzled_scales
+        self.swizzle_type = swizzle_type
         return self
+
+    @classmethod
+    def __tensor_unflatten__(
+        cls, tensor_data_dict, tensor_attributes, outer_size, outer_stride
+    ):
+        # Backward compat: __tensor_unflatten__ is called by Dynamo tracing.
+        _migrate_is_swizzled_scales(tensor_attributes)
+        return super().__tensor_unflatten__(
+            tensor_data_dict, tensor_attributes, outer_size, outer_stride
+        )
 
     def __repr__(self):
         # TODO better elem dtype print for fp4
-        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, is_swizzled_scales={self.is_swizzled_scales}"  # noqa: E501
+        return f"MXTensor: elem_dtype: {self.elem_dtype}, s_e8m0: {self.scale}, d: {self.qdata}, act_quant_kwargs: {self.act_quant_kwargs}, swizzle_type={self.swizzle_type}"  # noqa: E501
 
     def _quantization_type(self):
         return f"{self.elem_dtype=}, {self.block_size=}, {self.orig_dtype=}, {self.kernel_preference=}, {self.act_quant_kwargs=}"
@@ -581,7 +606,7 @@ class MXTensor(TorchAOBaseTensor):
             output_dtype = self.dtype
 
         scale = self.scale
-        if self.is_swizzled_scales:
+        if isinstance(self.swizzle_type, Swizzle_32_4_4):
             is_transposed = self.qdata.stride(-2) < self.qdata.stride(-1)
             if is_transposed:
                 leading_dims, M, K = self.shape[:-2], self.shape[-1], self.shape[-2]
@@ -613,7 +638,7 @@ class MXTensor(TorchAOBaseTensor):
         block_size: int = BLOCK_SIZE_DEFAULT,
         kernel_preference: Optional[KernelPreference] = None,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = NoSwizzle(),
     ) -> Union["MXTensor", DTensor]:
         assert qdata.dtype != torch.uint8, (
             "from_qdata_and_scales only supports typed MX qdata; "
@@ -629,7 +654,7 @@ class MXTensor(TorchAOBaseTensor):
             orig_dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            swizzle_type,
         )
 
     @staticmethod
@@ -643,7 +668,7 @@ class MXTensor(TorchAOBaseTensor):
         # TODO(future PR): switch default gemm to cublas
         kernel_preference: KernelPreference = KernelPreference.EMULATED,
         act_quant_kwargs: Optional[QuantizeTensorToMXKwargs] = None,
-        is_swizzled_scales: bool = False,
+        swizzle_type: SwizzleType = NoSwizzle(),
         mxfp8_dim0_cast_kernel_choice: MXFP8Dim0CastKernelChoice = MXFP8Dim0CastKernelChoice.TORCH,
     ):
         assert mxfp8_dim0_cast_kernel_choice in (
@@ -653,25 +678,26 @@ class MXTensor(TorchAOBaseTensor):
             f"unsupported kernel choice for mxfp8_dim0_cast_kernel_choice: {mxfp8_dim0_cast_kernel_choice}"
         )
 
-        triton_kernel_supported = (
-            elem_dtype == torch.float8_e4m3fn and not is_swizzled_scales
+        triton_kernel_supported = elem_dtype == torch.float8_e4m3fn and isinstance(
+            swizzle_type, NoSwizzle
         )
         if (
             mxfp8_dim0_cast_kernel_choice == MXFP8Dim0CastKernelChoice.TORCH
             or kernel_preference == KernelPreference.EMULATED
         ):
             scale_e8m0_biased, data_lp = to_mx(
-                data_hp, elem_dtype, block_size, scaling_mode, is_swizzled_scales
+                data_hp, elem_dtype, block_size, scaling_mode, swizzle_type
             )
         else:
             assert triton_kernel_supported, (
-                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {is_swizzled_scales=}"
+                f"triton kernel unsupported for {data_hp.dtype=}, {elem_dtype=}, {scaling_mode=}, {swizzle_type=}"
             )
             data_lp, scale_e8m0_biased = triton_to_mxfp8_dim0(
                 data_hp,
                 inner_block_size=block_size,
                 scaling_mode=scaling_mode.value,
             )
+
         return MXTensor(
             data_lp,
             scale_e8m0_biased,
@@ -680,7 +706,7 @@ class MXTensor(TorchAOBaseTensor):
             data_hp.dtype,
             kernel_preference,
             act_quant_kwargs,
-            is_swizzled_scales,
+            swizzle_type,
         )
 
     # Do not force the MXTensor type on the returned tensor
@@ -688,6 +714,20 @@ class MXTensor(TorchAOBaseTensor):
 
 
 implements = MXTensor.implements
+
+
+# Override __setstate__ set by TorchAOBaseTensor.__init_subclass__ to add
+# backward compat for old checkpoints with is_swizzled_scales bool.
+_base_setstate = MXTensor.__setstate__
+
+
+def _mx_tensor_setstate(self, state):
+    if isinstance(state, dict):
+        _migrate_is_swizzled_scales(state)
+    _base_setstate(self, state)
+
+
+MXTensor.__setstate__ = _mx_tensor_setstate
 
 
 @implements([aten.detach.default, aten.alias.default])
@@ -713,7 +753,7 @@ def mx_pin_memory(func, types, args, kwargs):
         tensor.orig_dtype,
         tensor.kernel_preference,
         tensor.act_quant_kwargs,
-        tensor.is_swizzled_scales,
+        tensor.swizzle_type,
     )
 
 
@@ -773,7 +813,7 @@ def _addmm_mx_dispatch(
             k.block_size,
             k.scaling_mode,
             k.kernel_preference,
-            k.is_swizzled_scales,
+            swizzle_type=k.swizzle_type,
         )
 
     gemm_choice = _get_gemm_choice(a.kernel_preference, b.kernel_preference)
@@ -786,13 +826,13 @@ def _addmm_mx_dispatch(
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
 
-        if a.is_swizzled_scales:
+        if isinstance(a.swizzle_type, Swizzle_32_4_4):
             a_scale_block = a.scale
         else:
             a_scale = a.scale.view(M, K // a.block_size)
             a_scale_block = maybe_dtensor_to_blocked(a_scale)
 
-        if b.is_swizzled_scales:
+        if isinstance(b.swizzle_type, Swizzle_32_4_4):
             b_scale_block = b.scale.t()
         else:
             b_scale = b.scale.t().view(N, K // b.block_size)
@@ -811,7 +851,11 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            # FP4 operations using F.scaled_mm
+            swizzle = (
+                F.SwizzleType.SWIZZLE_32_4_4
+                if isinstance(a.swizzle_type, Swizzle_32_4_4)
+                else F.SwizzleType.NO_SWIZZLE
+            )
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -819,8 +863,8 @@ def _addmm_mx_dispatch(
                 scale_recipe_a=ScalingType.BlockWise1x32,
                 scale_b=b_scale_block,
                 scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
                 bias=bias,
                 output_dtype=torch.bfloat16,
             )
@@ -894,7 +938,7 @@ def mx_t(func, types, args, kwargs):
         old.orig_dtype,
         old.kernel_preference,
         old.act_quant_kwargs,
-        old.is_swizzled_scales,
+        old.swizzle_type,
     )
     return new
 
@@ -935,7 +979,7 @@ def mx_view_op(func, types, args, kwargs):
         args[0].orig_dtype,
         args[0].kernel_preference,
         args[0].act_quant_kwargs,
-        args[0].is_swizzled_scales,
+        args[0].swizzle_type,
     )
 
 
@@ -960,7 +1004,7 @@ def mx_slice(func, types, args, kwargs):
             x.orig_dtype,
             x.kernel_preference,
             x.act_quant_kwargs,
-            x.is_swizzled_scales,
+            x.swizzle_type,
         ),
     )
 
@@ -985,7 +1029,7 @@ def mx_select(func, types, args, kwargs):
     assert len(old_mx_tensor.qdata.shape) == len(old_mx_tensor.scale.shape), (
         "unsupported"
     )
-    assert not old_mx_tensor.is_swizzled_scales, "unsupported"
+    assert isinstance(old_mx_tensor.swizzle_type, NoSwizzle), "unsupported"
     new_mx_tensor = old_mx_tensor.__class__(
         old_mx_tensor.qdata[index],
         old_mx_tensor.scale[index],
@@ -994,7 +1038,7 @@ def mx_select(func, types, args, kwargs):
         old_mx_tensor.orig_dtype,
         old_mx_tensor.kernel_preference,
         old_mx_tensor.act_quant_kwargs,
-        old_mx_tensor.is_swizzled_scales,
+        old_mx_tensor.swizzle_type,
     )
     return return_and_correct_aliasing(func, args, kwargs, new_mx_tensor)
 
@@ -1043,7 +1087,7 @@ def mx_all_gather(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )
 
 
@@ -1074,5 +1118,5 @@ def mx_wait_tensor(func, types, args, kwargs):
         mx_tensor.orig_dtype,
         mx_tensor.kernel_preference,
         mx_tensor.act_quant_kwargs,
-        mx_tensor.is_swizzled_scales,
+        mx_tensor.swizzle_type,
     )

--- a/torchao/prototype/mx_formats/utils.py
+++ b/torchao/prototype/mx_formats/utils.py
@@ -11,7 +11,9 @@ import torch
 
 from torchao.prototype.mx_formats.config import (
     MXFP8Dim1CastKernelChoice,
+    NoSwizzle,
     ScaleCalculationMode,
+    Swizzle_32_4_4,
 )
 from torchao.prototype.mx_formats.kernels import (
     triton_mx_block_rearrange,
@@ -158,7 +160,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
     # TODO(future PR): split this utils file in two
     from torchao.prototype.mx_formats.mx_tensor import MXTensor, to_mx
 
-    is_swizzled_scales = False
+    swizzle_type = NoSwizzle()
 
     if kernel_preference == KernelPreference.EMULATED:
         a_scale, a_data = to_mx(
@@ -207,9 +209,9 @@ def _to_mxfp8_dim1_kernel_wrapper(
             scaling_mode=scale_calculation_mode.value,
             blocked_scale_output=True,
         )
-        is_swizzled_scales = True
+        swizzle_type = Swizzle_32_4_4()
     elif cast_kernel_choice == MXFP8Dim1CastKernelChoice.FLYDSL:
-        # AMD via FlyDSL. FlyDSL kernels leave is_swizzled_scales=False
+        # AMD via FlyDSL. FlyDSL kernels leave swizzle_type=NoSwizzle
         # (no tcgen05 blocked layout on AMD).
         assert scale_calculation_mode in (
             ScaleCalculationMode.FLOOR,
@@ -239,7 +241,7 @@ def _to_mxfp8_dim1_kernel_wrapper(
         hp_dtype,
         kernel_preference,
         None,
-        is_swizzled_scales,
+        swizzle_type,
     )
     return mx_tensor
 
@@ -259,7 +261,11 @@ def _swizzle_aware_slice(
     # it back to the format which matches the shape of `qdata`.
     # TODO(future PR): update this
 
-    if x.is_swizzled_scales:
+    # Check both SwizzleType (MXTensor) and is_swizzled_scales bool
+    # (NVFP4Tensor, which still uses the old bool field).
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
+        x, "is_swizzled_scales", False
+    ):
         scale_rows = M
         scale_cols = K // x.block_size
         n_row_blocks = ceil_div(scale_rows, 128)
@@ -426,7 +432,11 @@ def _swizzle_aware_slice(
     else:
         # multiply by 2 to convert from bytes to num_elements
         sliced_K = sliced_data.shape[1] * 2
-    if x.is_swizzled_scales:
+    # Check both SwizzleType (MXTensor) and is_swizzled_scales bool
+    # (NVFP4Tensor, which still uses the old bool field).
+    if isinstance(getattr(x, "swizzle_type", None), Swizzle_32_4_4) or getattr(
+        x, "is_swizzled_scales", False
+    ):
         if x.block_size == 16:
             scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_nvfp4(
                 sliced_M, sliced_K


### PR DESCRIPTION
Refactors MXTensor based on the design principles discussed in https://github.com/pytorch/ao/pull/4813 and https://github.com/pytorch/ao/issues/4801 to use a pure-Python SwizzleType class hierarchy for scale layout decisions, replacing the previous is_swizzled_scales: bool flag and eliminating device-specific dispatch paths.

## Changes
**New types (`config.py`):**
```python
@dataclass(frozen=True)
class SwizzleType:
    """Base class for scale swizzle layout."""
    pass

@dataclass(frozen=True)
class NoSwizzle(SwizzleType):
    """No swizzling."""
    pass

@dataclass(frozen=True)
class Swizzle_32_4_4(SwizzleType):
    """32x4x4 blocked scale layout for NVIDIA."""
    pass
```

**Core refactor (`mx_tensor.py`):**
- `QuantizeTensorToMXKwargs.is_swizzled_scales: bool` → `swizzle_type: SwizzleType = NoSwizzle()`
- `MXTensor` stores `swizzle_type: SwizzleType` as a direct attribute
