### PR TITLE
Refactor MXTensor: align the swizzle execution with the configured swizzle setting

### DIFF
--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -68,6 +68,7 @@ def cuda_kernel_profiler(kernel_pattern):
 @pytest.mark.parametrize("emulate", [True, False])
 @pytest.mark.parametrize("use_inference_mode", [True, False])
 @pytest.mark.parametrize("x_rank", [2, 3])
+@pytest.mark.parametrize("k", [64, 128, 256])
 @torch.no_grad()
 @skip_if_rocm(
     "ROCm float4 gemm require gfx950"
@@ -79,6 +80,7 @@ def test_inference_workflow_mx(
     emulate: bool,
     use_inference_mode: bool,
     x_rank: int,
+    k: int,
 ):
     """
     Smoke test for inference compile
@@ -98,7 +100,7 @@ def test_inference_workflow_mx(
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
 
-    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device=device)
+    m = nn.Linear(k, 128, bias=bias, dtype=torch.bfloat16, device=device)
     m_mx = copy.deepcopy(m)
 
     if emulate:
@@ -117,7 +119,7 @@ def test_inference_workflow_mx(
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True)
 
-    x = torch.randn(128, 32, device=device, dtype=torch.bfloat16)
+    x = torch.randn(128, k, device=device, dtype=torch.bfloat16)
     if x_rank == 3:
         x = x.unsqueeze(0)
 

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn.functional import SwizzleType
 from torch.profiler import ProfilerActivity, profile
 
 from torchao.prototype.mx_formats.inference_workflow import (
@@ -108,7 +109,9 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
-        is_swizzled_scales=device != "xpu",
+        swizzled_type=SwizzleType.SWIZZLE_32_4_4
+        if device == "cuda"
+        else SwizzleType.NO_SWIZZLE,
     )
     quantize_(m_mx, config=config)
     if compile:

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -57,7 +57,10 @@ def cuda_kernel_profiler(kernel_pattern):
     result["found"] = any(kernel_pattern in name for name in kernel_names)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float4_e2m1fn_x2])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("compile", [True, False])
@@ -79,21 +82,22 @@ def test_inference_workflow_mx(
     """
     Smoke test for inference compile
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future): figure out why these CUDA capability conditions are not properly
     # applied when inside `pytest.mark.skipif` for this test
-    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2) and device == "cuda":
         if not is_sm_at_least_89():
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
         elif not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp8 gemm")
-    elif elem_dtype == torch.float4_e2m1fn_x2:
+    elif elem_dtype == torch.float4_e2m1fn_x2 and device == "cuda":
         if not is_sm_at_least_100() and not emulate:
             pytest.skip("CUDA capability >= 10.0 required for mxfp4 gemm")
         elif compile:
             # TODO(future PR): investigate and fix this
             pytest.skip("mxfp4 + compile currently does not work, low SQNR")
 
-    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device="cuda")
+    m = nn.Linear(32, 128, bias=bias, dtype=torch.bfloat16, device=device)
     m_mx = copy.deepcopy(m)
 
     if emulate:
@@ -104,12 +108,13 @@ def test_inference_workflow_mx(
         activation_dtype=elem_dtype,
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
+        is_swizzled_scales=device != "xpu",
     )
     quantize_(m_mx, config=config)
     if compile:
         m_mx = torch.compile(m_mx, fullgraph=True)
 
-    x = torch.randn(128, 32, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(128, 32, device=device, dtype=torch.bfloat16)
     if x_rank == 3:
         x = x.unsqueeze(0)
 
@@ -445,8 +450,9 @@ def test_grouped_mm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, GroupedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, GroupedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"
@@ -505,8 +511,9 @@ def test_bmm_nvfp4():
         NVFP4DynamicActivationNVFP4WeightConfig(
             use_triton_kernel=False,
         ),
-        filter_fn=lambda mod, *args: isinstance(mod, BatchedMMModel)
-        and hasattr(mod, "weight"),
+        filter_fn=lambda mod, *args: (
+            isinstance(mod, BatchedMMModel) and hasattr(mod, "weight")
+        ),
     )
     assert isinstance(model.weight, NVFP4Tensor), (
         f"Expected NVFP4Tensor weight, got {type(model.weight)}"

--- a/test/prototype/mx_formats/test_inference_workflow.py
+++ b/test/prototype/mx_formats/test_inference_workflow.py
@@ -24,6 +24,7 @@ from torchao.quantization.quantize_.common import KernelPreference
 from torchao.quantization.utils import compute_error
 from torchao.testing.utils import TorchAOIntegrationTestCase, skip_if_rocm
 from torchao.utils import (
+    is_ROCM,
     is_sm_at_least_89,
     is_sm_at_least_100,
 )
@@ -112,7 +113,7 @@ def test_inference_workflow_mx(
         weight_dtype=elem_dtype,
         kernel_preference=kernel_choice,
         swizzled_type=SwizzleType.SWIZZLE_32_4_4
-        if device == "cuda"
+        if device == "cuda" and not is_ROCM()
         else SwizzleType.NO_SWIZZLE,
     )
     quantize_(m_mx, config=config)

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -13,7 +13,7 @@ from torch.nn.functional import ScalingType, SwizzleType
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.mx_formats.mx_tensor import MXTensor
 from torchao.prototype.mx_formats.utils import to_blocked
-from torchao.utils import is_sm_at_least_100
+from torchao.utils import is_ROCM, is_sm_at_least_100
 
 
 def _mxfp4_scaled_mm(
@@ -68,7 +68,11 @@ def _mxfp8_scaled_mm(
 
 def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    swizzle = SwizzleType.NO_SWIZZLE if device == "xpu" else SwizzleType.SWIZZLE_32_4_4
+    swizzle = (
+        SwizzleType.SWIZZLE_32_4_4
+        if device == "cuda" and not is_ROCM()
+        else SwizzleType.NO_SWIZZLE
+    )
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -22,6 +22,7 @@ def _mxfp4_scaled_mm(
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
     match swizzle:
         case SwizzleType.NO_SWIZZLE:
+            assert a_scale.is_contiguous()
             a_scale_block = a_scale
             b_scale_block = b_scale
         case SwizzleType.SWIZZLE_32_4_4:
@@ -48,6 +49,7 @@ def _mxfp8_scaled_mm(
     """Wrapper for torch._scaled_mm with MXFP8 configuration."""
     match swizzle:
         case SwizzleType.NO_SWIZZLE:
+            assert a_scale.is_contiguous()
             a_scale_block = a_scale
             b_scale_block = b_scale.t()
         case SwizzleType.SWIZZLE_32_4_4:

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -16,8 +16,19 @@ from torchao.prototype.mx_formats.utils import to_blocked
 from torchao.utils import is_sm_at_least_100
 
 
-def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
+def _mxfp4_scaled_mm(
+    a_data, b_data, a_scale, b_scale, swizzle=SwizzleType.SWIZZLE_32_4_4
+):
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
+    match swizzle:
+        case SwizzleType.NO_SWIZZLE:
+            a_scale_block = a_scale.contiguous()
+            b_scale_block = b_scale.contiguous()
+        case SwizzleType.SWIZZLE_32_4_4:
+            a_scale_block = to_blocked(a_scale)
+            b_scale_block = to_blocked(b_scale)
+        case _:
+            raise ValueError(f"Unsupported swizzle type: {swizzle}")
     return F.scaled_mm(
         a_data.view(torch.float4_e2m1fn_x2),
         b_data.view(torch.float4_e2m1fn_x2),
@@ -25,24 +36,47 @@ def _mxfp4_scaled_mm(a_data, b_data, a_scale_block, b_scale_block):
         scale_recipe_a=ScalingType.BlockWise1x32,
         scale_b=b_scale_block,
         scale_recipe_b=ScalingType.BlockWise1x32,
-        swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-        swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+        swizzle_a=swizzle,
+        swizzle_b=swizzle,
         output_dtype=torch.bfloat16,
     )
 
 
-def run_matrix_test(M: int, K: int, N: int, format) -> float:
+def _mxfp8_scaled_mm(
+    a_data, b_data, a_scale, b_scale, swizzle=SwizzleType.SWIZZLE_32_4_4
+):
+    """Wrapper for torch._scaled_mm with MXFP8 configuration."""
+    match swizzle:
+        case SwizzleType.NO_SWIZZLE:
+            a_scale_block = a_scale.contiguous()
+            b_scale_block = b_scale.t().contiguous()
+        case SwizzleType.SWIZZLE_32_4_4:
+            a_scale_block = to_blocked(a_scale)
+            b_scale_block = to_blocked(b_scale)
+        case _:
+            raise ValueError(f"Unsupported swizzle type: {swizzle}")
+    return torch._scaled_mm(
+        a_data,
+        b_data,
+        a_scale_block,
+        b_scale_block,
+        out_dtype=torch.bfloat16,
+    )
+
+
+def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
     dtype = torch.bfloat16
-    device = torch.device("cuda")
+    swizzle = SwizzleType.NO_SWIZZLE if device == "xpu" else SwizzleType.SWIZZLE_32_4_4
 
     a = torch.rand((M, K), dtype=dtype, device=device)
     b = torch.rand((N, K), dtype=dtype, device=device)
 
     fmt = torch.float8_e4m3fn if format == "fp8" else torch.float4_e2m1fn_x2
+
     mx_func = (
-        partial(torch._scaled_mm, out_dtype=torch.bfloat16)
+        partial(_mxfp8_scaled_mm, swizzle=swizzle)
         if format == "fp8"
-        else _mxfp4_scaled_mm
+        else partial(_mxfp4_scaled_mm, swizzle=swizzle)
     )
 
     a_mx = MXTensor.to_mx(a, fmt, 32)
@@ -56,20 +90,22 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
     a_scale = a_mx.scale.view(M, K // 32)
     b_scale = b_mx.scale.view(N, K // 32)
 
-    a_scale_block = to_blocked(a_scale)
-    b_scale_block = to_blocked(b_scale)
-
     out_hp = a_mx.dequantize(torch.bfloat16) @ b_mx.dequantize(
         torch.bfloat16
     ).transpose(-1, -2)
-    out = mx_func(a_data, b_data, a_scale_block, b_scale_block)
+
+    out = mx_func(a_data, b_data, a_scale, b_scale)
 
     return compute_error(out_hp, out).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_100(), reason="CUDA capability >= 10.0 required for mxfloat8"
+    not torch.accelerator.is_available(),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="CUDA capability >= 10.0 required for mxfloat8",
 )
 @pytest.mark.parametrize(
     "size",
@@ -90,8 +126,9 @@ def run_matrix_test(M: int, K: int, N: int, format) -> float:
 )
 @pytest.mark.parametrize("format", ["fp8", "fp4"])
 def test_matrix_multiplication(size, format):
+    device = torch.accelerator.current_accelerator().type
     M, K, N = size
-    sqnr = run_matrix_test(M, K, N, format)
+    sqnr = run_matrix_test(M, K, N, format, device=device)
     threshold = 80.0
     assert sqnr >= threshold, (
         f"{format} SQNR {sqnr} below threshold for dims {M}x{K}x{N}"

--- a/test/prototype/mx_formats/test_mx_mm.py
+++ b/test/prototype/mx_formats/test_mx_mm.py
@@ -22,8 +22,8 @@ def _mxfp4_scaled_mm(
     """Wrapper for F.scaled_mm with MXFP4 configuration."""
     match swizzle:
         case SwizzleType.NO_SWIZZLE:
-            a_scale_block = a_scale.contiguous()
-            b_scale_block = b_scale.contiguous()
+            a_scale_block = a_scale
+            b_scale_block = b_scale
         case SwizzleType.SWIZZLE_32_4_4:
             a_scale_block = to_blocked(a_scale)
             b_scale_block = to_blocked(b_scale)
@@ -48,8 +48,8 @@ def _mxfp8_scaled_mm(
     """Wrapper for torch._scaled_mm with MXFP8 configuration."""
     match swizzle:
         case SwizzleType.NO_SWIZZLE:
-            a_scale_block = a_scale.contiguous()
-            b_scale_block = b_scale.t().contiguous()
+            a_scale_block = a_scale
+            b_scale_block = b_scale.t()
         case SwizzleType.SWIZZLE_32_4_4:
             a_scale_block = to_blocked(a_scale)
             b_scale_block = to_blocked(b_scale)
@@ -84,6 +84,7 @@ def run_matrix_test(M: int, K: int, N: int, format, device="cuda") -> float:
 
     a_data = a_mx.qdata
     b_data = b_mx.qdata
+    assert a_data.is_contiguous()
     assert b_data.is_contiguous()
     b_data = b_data.transpose(-1, -2)
 

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -19,7 +19,7 @@ from torchao.prototype.mx_formats.inference_workflow import (
 )
 from torchao.quantization import quantize_
 from torchao.quantization.quantize_.common import KernelPreference
-from torchao.utils import is_sm_at_least_100
+from torchao.utils import is_ROCM, is_sm_at_least_100
 
 
 @pytest.mark.skipif(
@@ -49,7 +49,7 @@ def test_serialization(recipe_name):
                 weight_dtype=torch.float8_e4m3fn,
                 kernel_preference=KernelPreference.EMULATED,
                 swizzled_type=SwizzleType.SWIZZLE_32_4_4
-                if device == "cuda"
+                if device == "cuda" and not is_ROCM()
                 else SwizzleType.NO_SWIZZLE,
             )
         else:

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -21,8 +21,14 @@ from torchao.quantization.quantize_.common import KernelPreference
 from torchao.utils import is_sm_at_least_100
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_100(), reason="needs CUDA capability 10.0+")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_100(),
+    reason="needs CUDA capability 10.0+",
+)
 @pytest.mark.parametrize("recipe_name", ["mxfp8", "nvfp4"])
 def test_serialization(recipe_name):
     """
@@ -30,7 +36,10 @@ def test_serialization(recipe_name):
     and NV checkpoints.
     """
 
-    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    if recipe_name == "nvfp4" and device == "xpu":
+        pytest.skip("NVFP4 is not supported on XPU")
+    m = nn.Linear(32, 128, bias=False, dtype=torch.bfloat16, device=device)
     fname = None
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as f:
         if recipe_name == "mxfp8":

--- a/test/prototype/mx_formats/test_mx_serialization.py
+++ b/test/prototype/mx_formats/test_mx_serialization.py
@@ -11,6 +11,7 @@ import tempfile
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn.functional import SwizzleType
 
 from torchao.prototype.mx_formats.inference_workflow import (
     MXDynamicActivationMXWeightConfig,
@@ -47,6 +48,9 @@ def test_serialization(recipe_name):
                 activation_dtype=torch.float8_e4m3fn,
                 weight_dtype=torch.float8_e4m3fn,
                 kernel_preference=KernelPreference.EMULATED,
+                swizzled_type=SwizzleType.SWIZZLE_32_4_4
+                if device == "cuda"
+                else SwizzleType.NO_SWIZZLE,
             )
         else:
             assert recipe_name == "nvfp4", "unsupported"

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -942,10 +942,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    if torch.cuda.is_available() or torch.xpu.is_available():
-        device = torch.accelerator.current_accelerator().type
-    else:
-        device = "cpu"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
 
     original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 

--- a/test/prototype/mx_formats/test_mx_tensor.py
+++ b/test/prototype/mx_formats/test_mx_tensor.py
@@ -65,11 +65,15 @@ def test_e8m0_scale_to_reciprocal_fp32(monkeypatch, use_direct_cast):
     assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
-def test_e8m0_scale_to_reciprocal_fp32_cuda_fallback(monkeypatch, use_compile):
+def test_e8m0_scale_to_reciprocal_fp32_gpu_fallback(monkeypatch, use_compile):
+    device = torch.accelerator.current_accelerator().type
     monkeypatch.setattr(mx_tensor_module, "_TORCH_VERSION_AT_LEAST_2_14", False)
-    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device="cuda")
+    scale_e8m0_biased = torch.arange(256, dtype=torch.uint8, device=device)
     convert = (
         torch.compile(_e8m0_scale_to_reciprocal_fp32, fullgraph=True)
         if use_compile
@@ -134,55 +138,78 @@ def _test_mx(
     assert data_mx.scale.shape == (*prev_dims, K // block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_hello_world(elem_dtype):
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("scale_calculation_mode", [s for s in ScaleCalculationMode])
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_realistic_numerics(elem_dtype, scale_calculation_mode):
-    data = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     block_size = 32
     _test_mx(data, elem_dtype, block_size, scale_calculation_mode)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_zeros(elem_dtype):
-    data = torch.zeros(4, 4, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.zeros(4, 4, device=device, dtype=torch.bfloat16)
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_some_zeros(elem_dtype):
-    data = torch.randn(4, 4, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(4, 4, device=device, dtype=torch.bfloat16)
     data[0, :] = 0.0
     data[:, 2] = 0.0
     block_size = 4
     _test_mx(data, elem_dtype, block_size)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 @pytest.mark.parametrize(
     "scaling_mode", (ScaleCalculationMode.FLOOR, ScaleCalculationMode.RCEIL)
 )
 @pytest.mark.parametrize("use_compile", (False, True), ids=("eager", "compiled"))
 def test_mxfp8_corner_case_bytes(input_dtype, scaling_mode, use_compile):
-    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    cases = make_mxfp8_semantic_cases(input_dtype, scaling_mode, device=device)
     quantize = torch.compile(to_mx, fullgraph=True) if use_compile else to_mx
     scales, qdata = quantize(cases.inputs, torch.float8_e4m3fn, 32, scaling_mode)
     assert_mxfp8_semantics(qdata, scales, cases)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_to_mx_rceil():
     # nan
     # fmt: off
@@ -431,15 +458,19 @@ def test_to_mx_rceil_fallback_nan_branch_is_cse_compatible(monkeypatch):
     assert nan_branches[0].args[0] == 0x7F800001
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_in(elem_dtype):
     """
     If high precision block values has a NaN, the exponent block
     value is set to is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     tensor_hp = torch.tensor(
-        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device="cuda", dtype=torch.bfloat16
+        [float("nan"), 1, 2, 3, 4, 5, 6, 7], device=device, dtype=torch.bfloat16
     )
     block_size = 4
     tensor_mx = MXTensor.to_mx(tensor_hp, elem_dtype, block_size)
@@ -447,7 +478,10 @@ def test_exponent_nan_in(elem_dtype):
     assert not torch.any(torch.isnan(tensor_mx.scale[1:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_all_nan_blocks(elem_dtype):
     """
@@ -455,12 +489,13 @@ def test_all_nan_blocks(elem_dtype):
     - Mixed real + NaN: scale = NaN
     - All NaN: scale = NaN
     """
+    device = torch.accelerator.current_accelerator().type
     block_size = 4
 
     # Test case 1: Mixed NaN + real values
     mixed_tensor = torch.tensor(
         [float("nan"), 2.0, float("nan"), 4.0, 1.0, 3.0, 5.0, 2.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     mixed_mx = MXTensor.to_mx(mixed_tensor, elem_dtype, block_size)
@@ -476,7 +511,7 @@ def test_all_nan_blocks(elem_dtype):
     # Test case 2: All NaN blocks (should return NaN scale)
     all_nan_tensor = torch.tensor(
         [float("nan"), float("nan"), float("nan"), float("nan"), 1.0, 2.0, 3.0, 4.0],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     all_nan_mx = MXTensor.to_mx(all_nan_tensor, elem_dtype, block_size)
@@ -502,7 +537,7 @@ def test_all_nan_blocks(elem_dtype):
             float("nan"),
             float("nan"),
         ],
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
     completely_nan_mx = MXTensor.to_mx(completely_nan_tensor, elem_dtype, block_size)
@@ -513,29 +548,33 @@ def test_all_nan_blocks(elem_dtype):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_exponent_nan_out(elem_dtype):
     """
     If block exponent value is NaN, the MX tensor block value is NaN
     """
+    device = torch.accelerator.current_accelerator().type
     scale_e8m0 = torch.tensor(
-        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device="cuda"
+        [float("nan"), 1.0], dtype=torch.float8_e8m0fnu, device=device
     )
 
     block_size = 4
 
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=elem_dtype, device=device
         )  # noqa: E501
     elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
     elif elem_dtype == torch.float4_e2m1fn_x2:
         data_bits = torch.tensor(
-            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device="cuda"
+            [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8, device=device
         )  # noqa: E501
         data_bits = pack_uint4(data_bits)
     else:
@@ -556,37 +595,49 @@ def test_exponent_nan_out(elem_dtype):
     assert not torch.any(torch.isnan(tensor_hp.flatten()[4:]))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_ranks(elem_dtype):
     """
     The reshaping logic works for various ranks
     """
+    device = torch.accelerator.current_accelerator().type
     B = 4
     shapes = ((B * 4,), (B * 4, 4), (B * 4, 4, 4), (B * 4, 4, 4, 4))
     for s in shapes:
-        tensor_hp = torch.randn(*s, device="cuda", dtype=torch.bfloat16)
+        tensor_hp = torch.randn(*s, device=device, dtype=torch.bfloat16)
         _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("B", [1, 4, 32])
 def test_block_sizes(elem_dtype, B):
     """
     Smoke test for various block sizes
     """
+    device = torch.accelerator.current_accelerator().type
     if B == 1 and elem_dtype == torch.float4_e2m1fn_x2:
         pytest.skip("unsupported configuration")
     elif B % 4 != 0 and elem_dtype in [DTYPE_FP6_E2M3, DTYPE_FP6_E3M2]:
         pytest.skip("unsupported configuration")
-    tensor_hp = torch.randn(B, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(B, device=device, dtype=torch.bfloat16)
     _test_mx(tensor_hp, elem_dtype, B)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_round_trip():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -608,9 +659,13 @@ def test_from_qdata_and_scales_round_trip():
     assert rebuilt.orig_dtype == tensor_mx.orig_dtype
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -626,9 +681,13 @@ def test_from_qdata_and_scales_requires_float8_e8m0_scale_dtype():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
-    tensor_hp = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    tensor_hp = torch.randn(128, 128, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         torch.float8_e4m3fn,
@@ -644,15 +703,19 @@ def test_from_qdata_and_scales_rejects_packed_uint8_qdata():
         )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_transpose(elem_dtype):
     """
     Verify that transposing an MX tensor works
     """
+    device = torch.accelerator.current_accelerator().type
     M, K = 128, 256
     block_size = 32
-    tensor_hp = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    tensor_hp = torch.randn(M, K, device=device, dtype=torch.bfloat16)
     tensor_mx = MXTensor.to_mx(
         tensor_hp,
         elem_dtype,
@@ -667,18 +730,26 @@ def test_transpose(elem_dtype):
     torch.testing.assert_close(tensor_mx_dq_t, tensor_mx_t_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 def test_view(elem_dtype):
-    x = torch.randn(1, 2, 4, device="cuda")
+    device = torch.accelerator.current_accelerator().type
+    x = torch.randn(1, 2, 4, device=device)
     block_size = 4
     x_mx = MXTensor.to_mx(x, elem_dtype, block_size)
     x_mx_2 = x_mx.view(2, 4)  # noqa: F841
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 def test_clone():
-    data = torch.randn(8, 8, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    data = torch.randn(8, 8, device=device, dtype=torch.bfloat16)
     block_size = 4
     data_mx = MXTensor.to_mx(data, torch.float8_e4m3fn, block_size)
     data_mx_c = data_mx.clone()
@@ -690,7 +761,10 @@ def test_clone():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", SUPPORTED_ELEM_DTYPES)
 @pytest.mark.parametrize("hp_dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("all_zeros", [False, True])
@@ -698,16 +772,17 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     """
     Verifies that compile does not change numerics of MX casts
     """
+    device = torch.accelerator.current_accelerator().type
     if elem_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-        if not is_sm_at_least_89():
+        if torch.cuda.is_available() and not is_sm_at_least_89():
             # separate ifs because flake8 is outsmarting me
             pytest.skip("CUDA capability >= 8.9 required for float8 in triton")
 
     shape = 4, 8
     if not all_zeros:
-        x = torch.randn(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.randn(*shape, dtype=hp_dtype, device=device)
     else:
-        x = torch.zeros(*shape, dtype=hp_dtype, device="cuda")
+        x = torch.zeros(*shape, dtype=hp_dtype, device=device)
     block_size = 4
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
 
@@ -740,9 +815,12 @@ def test_to_mx_from_mx_compile_numerics(elem_dtype, hp_dtype, all_zeros):
     torch.testing.assert_close(x_mx_dq, x_mx_c_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 def test_to_mx_inductor_single_kernel():
@@ -750,17 +828,24 @@ def test_to_mx_inductor_single_kernel():
     Verify that inductor can fuse the cast of a high precision tensor to mx
     into a single kernel
     """
+    device = torch.accelerator.current_accelerator().type
     # TODO(future PR): add fp4 and fp6 here
     # TODO(#1773): add swizzled scale format here
-    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device="cuda")
+    x = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
     block_size = 32
     to_mx_c = torch.compile(MXTensor.to_mx, fullgraph=True)
     out, code = run_and_get_code(to_mx_c, x, torch.float8_e4m3fn, block_size)
     FileCheck().check("def call(").check_count(".run(", 1, exactly=True).run(code[0])
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.skipif(not is_sm_at_least_90(), reason="Need sm90+")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_90(),
+    reason="Need sm90+",
+)
 def test_index_select():
     """
     test that `x_0 = x[0]` works when `x` is a 3D `MXTensor`. This is
@@ -769,8 +854,9 @@ def test_index_select():
     use 2D and 3D parameters for their expert weights.
     """
 
+    device = torch.accelerator.current_accelerator().type
     E, K, N = 128, 256, 512
-    x = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(E, N, K, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x, torch.float8_e4m3fn, 32)
 
     x_mx_1 = x_mx[1]
@@ -779,9 +865,12 @@ def test_index_select():
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(
-    not is_sm_at_least_89(),
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
+@pytest.mark.skipif(
+    torch.cuda.is_available() and not is_sm_at_least_89(),
     reason="float8 in triton requires CUDA capability 8.9 or greater",
 )
 @pytest.mark.skipif(
@@ -790,6 +879,7 @@ def test_index_select():
 )
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))
 def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
+    device = torch.accelerator.current_accelerator().type
     max_val = torch.finfo(torch.float8_e4m3fn).max
 
     # create example data inside the representable range
@@ -799,7 +889,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * max_val,
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # create example data outside the representable range
@@ -809,7 +899,7 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
             -1 * (max_val * 2),
         ],
         dtype=input_dtype,
-        device="cuda",
+        device=device,
     )
 
     # PyTorch core saturates finite-overflow e4m3fn casts as of
@@ -852,7 +942,10 @@ def test_cast_to_float8_e4m3fn_saturation_behavior(input_dtype):
 )
 def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     rows, cols = shape
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available() or torch.xpu.is_available():
+        device = torch.accelerator.current_accelerator().type
+    else:
+        device = "cpu"
 
     original = torch.randint(0, 255, (rows, cols), device=device, dtype=torch.uint8)
 
@@ -868,7 +961,10 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("transpose", [False, True])
 @pytest.mark.parametrize(
     "shape",
@@ -878,12 +974,13 @@ def test_to_blocked_from_blocked_roundtrip(shape, use_triton_kernel: bool):
     ),
 )
 def test_scale_shape_matches_qdata(transpose, shape):
+    device = torch.accelerator.current_accelerator().type
     if len(shape) == 3 and transpose:
         pytest.skip("transpose not yet implemented for 3D MXTensor")
 
     block_size = 32
 
-    x_hp = torch.randn(*shape, device="cuda")
+    x_hp = torch.randn(*shape, device=device)
     x = MXTensor.to_mx(
         x_hp,
         torch.float8_e4m3fn,
@@ -985,10 +1082,14 @@ def test_swizzle(elem_dtype, transpose, shape):
     torch.testing.assert_close(x_dq, xs_dq, atol=0, rtol=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() or torch.xpu.is_available()),
+    reason="CUDA or XPU not available",
+)
 @pytest.mark.parametrize("elem_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 def test_mx_pin_memory(elem_dtype):
-    x_hp = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+    device = torch.accelerator.current_accelerator().type
+    x_hp = torch.randn(128, 256, device=device, dtype=torch.bfloat16)
     x_mx = MXTensor.to_mx(x_hp, elem_dtype, block_size=32)
     x_cpu = x_mx.cpu()
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -111,8 +111,8 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
-    # Whether to store block scales in swizzled (blocked) layout.
-    # CUDA uses True (blocked layout), XPU uses False (row-major).
+    # How to store block scales.
+    # CUDA uses swizzle layout, XPU uses not swizzle.
     is_swizzled_scales: bool = True
 
     def __post_init__(self):

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -114,7 +114,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
 
     # How to store block scales.
     # CUDA uses swizzle layout, XPU uses not swizzle.
-    swizzled_type: bool = SwizzleType.SWIZZLE_32_4_4
+    swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -144,9 +144,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True
-        if config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
-        else False,
+        is_swizzled_scales=config.swizzled_type == SwizzleType.SWIZZLE_32_4_4,
         scaling_mode=config.scaling_mode,
     )
 
@@ -157,9 +155,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True
-        if config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
-        else False,
+        is_swizzled_scales=config.swizzled_type == SwizzleType.SWIZZLE_32_4_4,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -12,6 +12,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn.functional import SwizzleType
 
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import _validate_elem_dtype
@@ -113,7 +114,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
 
     # How to store block scales.
     # CUDA uses swizzle layout, XPU uses not swizzle.
-    is_swizzled_scales: bool = True
+    swizzled_type: bool = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -143,7 +144,9 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=config.is_swizzled_scales,
+        is_swizzled_scales=True
+        if config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
+        else False,
         scaling_mode=config.scaling_mode,
     )
 
@@ -154,7 +157,9 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=config.is_swizzled_scales,
+        is_swizzled_scales=True
+        if config.swizzled_type == SwizzleType.SWIZZLE_32_4_4
+        else False,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -113,7 +113,6 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
     # How to store block scales.
-    # CUDA uses swizzle layout, XPU uses not swizzle.
     swizzled_type: SwizzleType = SwizzleType.SWIZZLE_32_4_4
 
     def __post_init__(self):

--- a/torchao/prototype/mx_formats/inference_workflow.py
+++ b/torchao/prototype/mx_formats/inference_workflow.py
@@ -85,7 +85,7 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
     This module provides support for running inference with float8 quantization using MX formats.
 
     Requirements:
-    - NVIDIA SM100+ hardware (Blackwell or newer) is required for execution
+    - NVIDIA SM100+ hardware (Blackwell or newer) or Intel XPU (BMG or newer)
     - PyTorch 2.5+ for proper serialization support
 
     Example (mxfp8):
@@ -110,6 +110,10 @@ class MXDynamicActivationMXWeightConfig(AOBaseConfig):
 
     # How to calculate the block scales
     scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
+
+    # Whether to store block scales in swizzled (blocked) layout.
+    # CUDA uses True (blocked layout), XPU uses False (row-major).
+    is_swizzled_scales: bool = True
 
     def __post_init__(self):
         assert self.activation_dtype == self.weight_dtype, (
@@ -139,7 +143,7 @@ def _mx_inference_linear_transform(
         elem_dtype=config.activation_dtype,
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
-        is_swizzled_scales=True,
+        is_swizzled_scales=config.is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 
@@ -150,7 +154,7 @@ def _mx_inference_linear_transform(
         block_size=config.block_size,
         kernel_preference=config.kernel_preference,
         act_quant_kwargs=act_quant_kwargs,
-        is_swizzled_scales=True,
+        is_swizzled_scales=config.is_swizzled_scales,
         scaling_mode=config.scaling_mode,
     )
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -802,7 +802,7 @@ def _addmm_mx_dispatch(
             b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
             if not b.is_swizzled_scales:
                 # v1 API expects scale_b as (K//32, N)
-                b_scale_v1 = b_scale_v1.t().contiguous()
+                b_scale_v1 = b_scale_v1.t()
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -785,6 +785,7 @@ def _addmm_mx_dispatch(
         assert b.qdata.t().is_contiguous()
         assert a.block_size == 32, f"Invalid block size {a.block_size}"
         assert b.block_size == 32, f"Invalid block size {b.block_size}"
+        assert a.is_swizzled_scales == b.is_swizzled_scales
 
         if a.is_swizzled_scales:
             a_scale_block = a.scale
@@ -798,6 +799,7 @@ def _addmm_mx_dispatch(
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
+            # torch._scaled_mm expects scale_b as (K//32, N)
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
@@ -809,13 +811,13 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
-            assert a.is_swizzled_scales == b.is_swizzled_scales
             # FP4 operations using F.scaled_mm
             swizzle = (
                 SwizzleType.SWIZZLE_32_4_4
                 if a.is_swizzled_scales
                 else SwizzleType.NO_SWIZZLE
             )
+            # F.scaled_mm expects scale_b as (N, K//32)
             if not b.is_swizzled_scales:
                 b_scale_block = b_scale_block.t()
             res = F.scaled_mm(

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -809,6 +809,7 @@ def _addmm_mx_dispatch(
         else:
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
+            assert a.is_swizzled_scales == b.is_swizzled_scales
             # FP4 operations using F.scaled_mm
             swizzle = (
                 SwizzleType.SWIZZLE_32_4_4

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -790,7 +790,7 @@ def _addmm_mx_dispatch(
         if a.is_swizzled_scales:
             a_scale_block = a.scale
         else:
-            a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
+            a_scale_block = a.scale.view(M, K // a.block_size)
 
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -402,7 +402,7 @@ def to_mx(
     if is_swizzled_scales:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
-        scale = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
         scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
         scale_e8m0_biased = scale.view(*leading_dims, scale_M, scale_K)
 
@@ -789,22 +789,25 @@ def _addmm_mx_dispatch(
         if a.is_swizzled_scales:
             a_scale_block = a.scale
         else:
-            a_scale = a.scale.view(M, K // a.block_size)
-            a_scale_block = maybe_dtensor_to_blocked(a_scale)
+            a_scale_block = a.scale.view(M, K // a.block_size).contiguous()
 
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale = b.scale.t().view(N, K // b.block_size)
-            b_scale_block = maybe_dtensor_to_blocked(b_scale)
+            b_scale_block = b.scale.view(N, K // b.block_size)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
+            a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
+            b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
+            if not b.is_swizzled_scales:
+                # v1 API expects scale_b as (K//32, N)
+                b_scale_v1 = b_scale_v1.t().contiguous()
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
+                a_scale_v1,
+                b_scale_v1,
                 bias=bias,
                 out_dtype=torch.bfloat16,
             )
@@ -812,6 +815,11 @@ def _addmm_mx_dispatch(
             assert a.elem_dtype == torch.float4_e2m1fn_x2
             assert b.elem_dtype == torch.float4_e2m1fn_x2
             # FP4 operations using F.scaled_mm
+            swizzle = (
+                SwizzleType.SWIZZLE_32_4_4
+                if a.is_swizzled_scales
+                else SwizzleType.NO_SWIZZLE
+            )
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),
@@ -819,8 +827,8 @@ def _addmm_mx_dispatch(
                 scale_recipe_a=ScalingType.BlockWise1x32,
                 scale_b=b_scale_block,
                 scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
-                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_a=swizzle,
+                swizzle_b=swizzle,
                 bias=bias,
                 output_dtype=torch.bfloat16,
             )

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -794,20 +794,15 @@ def _addmm_mx_dispatch(
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale_block = b.scale.view(N, K // b.block_size)
+            b_scale_block = b.scale.view(K // b.block_size, N)
 
         if a.elem_dtype == torch.float8_e4m3fn:
             assert b.elem_dtype == torch.float8_e4m3fn
-            a_scale_v1 = a_scale_block.view(torch.float8_e8m0fnu)
-            b_scale_v1 = b_scale_block.view(torch.float8_e8m0fnu)
-            if not b.is_swizzled_scales:
-                # v1 API expects scale_b as (K//32, N)
-                b_scale_v1 = b_scale_v1.t()
             res = torch._scaled_mm(
                 a.qdata,
                 b.qdata,
-                a_scale_v1,
-                b_scale_v1,
+                a_scale_block.view(torch.float8_e8m0fnu),
+                b_scale_block.view(torch.float8_e8m0fnu),
                 bias=bias,
                 out_dtype=torch.bfloat16,
             )
@@ -820,6 +815,9 @@ def _addmm_mx_dispatch(
                 if a.is_swizzled_scales
                 else SwizzleType.NO_SWIZZLE
             )
+            if not b.is_swizzled_scales:
+                # v1 API expects scale_b as (K//32, N)
+                b_scale_block = b_scale_block.t()
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),
                 b.qdata.view(torch.float4_e2m1fn_x2),

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -795,43 +795,25 @@ def _addmm_mx_dispatch(
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale_block = b.scale.view(K // b.block_size, N)
+            b_scale_block = b.scale.view(K // b.block_size, N).t()
 
-        if a.elem_dtype == torch.float8_e4m3fn:
-            assert b.elem_dtype == torch.float8_e4m3fn
-            # torch._scaled_mm expects scale_b as (K//32, N)
-            res = torch._scaled_mm(
-                a.qdata,
-                b.qdata,
-                a_scale_block.view(torch.float8_e8m0fnu),
-                b_scale_block.view(torch.float8_e8m0fnu),
-                bias=bias,
-                out_dtype=torch.bfloat16,
-            )
-        else:
-            assert a.elem_dtype == torch.float4_e2m1fn_x2
-            assert b.elem_dtype == torch.float4_e2m1fn_x2
-            # FP4 operations using F.scaled_mm
-            swizzle = (
-                SwizzleType.SWIZZLE_32_4_4
-                if a.is_swizzled_scales
-                else SwizzleType.NO_SWIZZLE
-            )
-            # F.scaled_mm expects scale_b as (N, K//32)
-            if not b.is_swizzled_scales:
-                b_scale_block = b_scale_block.t()
-            res = F.scaled_mm(
-                a.qdata.view(torch.float4_e2m1fn_x2),
-                b.qdata.view(torch.float4_e2m1fn_x2),
-                scale_a=a_scale_block,
-                scale_recipe_a=ScalingType.BlockWise1x32,
-                scale_b=b_scale_block,
-                scale_recipe_b=ScalingType.BlockWise1x32,
-                swizzle_a=swizzle,
-                swizzle_b=swizzle,
-                bias=bias,
-                output_dtype=torch.bfloat16,
-            )
+        swizzle = (
+            SwizzleType.SWIZZLE_32_4_4
+            if a.is_swizzled_scales
+            else SwizzleType.NO_SWIZZLE
+        )
+        res = F.scaled_mm(
+            a.qdata.view(a.elem_dtype),
+            b.qdata.view(b.elem_dtype),
+            scale_a=a_scale_block.view(torch.float8_e8m0fnu),
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            scale_b=b_scale_block.view(torch.float8_e8m0fnu),
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_a=swizzle,
+            swizzle_b=swizzle,
+            bias=bias,
+            output_dtype=torch.bfloat16,
+        )
 
     else:
         assert gemm_choice == KernelPreference.EMULATED, "unimplemented"

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -795,7 +795,7 @@ def _addmm_mx_dispatch(
         if b.is_swizzled_scales:
             b_scale_block = b.scale.t()
         else:
-            b_scale_block = b.scale.view(K // b.block_size, N).t()
+            b_scale_block = b.scale.t().view(N, K // b.block_size)
 
         swizzle = (
             SwizzleType.SWIZZLE_32_4_4

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -816,7 +816,6 @@ def _addmm_mx_dispatch(
                 else SwizzleType.NO_SWIZZLE
             )
             if not b.is_swizzled_scales:
-                # v1 API expects scale_b as (K//32, N)
                 b_scale_block = b_scale_block.t()
             res = F.scaled_mm(
                 a.qdata.view(torch.float4_e2m1fn_x2),

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -402,7 +402,7 @@ def to_mx(
     if is_swizzled_scales:
         leading_dims, M, K = orig_shape[:-2], orig_shape[-2], orig_shape[-1]
         scale_shape = (math.prod(leading_dims) * M, K // block_size)
-        scale = maybe_dtensor_to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
+        scale = to_blocked(scale_e8m0_biased.view(scale_shape)).flatten()
         scale_M, scale_K = hp_data_dims_to_swizzled_scale_dims_mx(M, K)
         scale_e8m0_biased = scale.view(*leading_dims, scale_M, scale_K)
 

--- a/torchao/prototype/mx_formats/mx_tensor.py
+++ b/torchao/prototype/mx_formats/mx_tensor.py
@@ -24,8 +24,7 @@ from typing import Optional, Union
 import torch
 import torch.nn.functional as F
 from torch._subclasses.fake_tensor import is_fake
-from torch.distributed.tensor import DTensor, Replicate, Shard
-from torch.distributed.tensor.experimental import local_map
+from torch.distributed.tensor import DTensor
 from torch.utils._python_dispatch import (
     return_and_correct_aliasing,
 )
@@ -731,29 +730,6 @@ def _get_gemm_choice(
         "At least one gemm choice must be specified"
     )
     return choice_a if choice_a is not None else choice_b
-
-
-def maybe_dtensor_to_blocked(t: torch.Tensor) -> torch.Tensor:
-    # redistribute to Replicate or Shard(0); to_blocked will view/permute/flatten into a 1d tensor
-    # sharding is only preservable on the first dimension.
-    if isinstance(t, DTensor):
-        t_placements = [
-            x if x in (Replicate(), Shard(0)) else Replicate() for x in t.placements
-        ]
-        if t_placements != t.placements:  # can't perform collectives in float8
-            t = (
-                t.view(torch.uint8)
-                .redistribute(placements=t_placements)
-                .view(torch.float8_e8m0fnu)
-            )
-        out = local_map(
-            to_blocked,
-            in_placements=(t_placements,),
-            out_placements=t_placements,
-        )(t)
-    else:
-        out = to_blocked(t)
-    return out
 
 
 def _addmm_mx_dispatch(


### PR DESCRIPTION
## Summary

This PR refactors `MXTensor`'s scaled-mm dispatch so it actually follows the configured `swizzled_type`. Previous designs always produced swizzled scales regardless of the config. This made `swizzled_type=SwizzleType.NO_SWIZZLE` silently ignored. But, the config itself is meant to be device-agnostic. PyTorch already models this correctly: F.scaled_mm takes the scale layout as explicit swizzle_a / swizzle_b arguments. This PR aligns ao with that contract by ensuring the configured layouts are honored consistently; in particular, swizzle_a and swizzle_b remain consistent, and NO_SWIZZLE skips both to_block and maybe_dtensor_to_blocked, allowing ao to inherit PyTorch’s backend support matrix instead of re-encoding backend-specific behavior.

## Align with PyTorch's API
**What each backend accepts of PyTorch**

| | CUDA | ROCm | XPU |
|---|---|---|---|
| `A` (activation) | `[M, K]` | `[M, K]` | `[M, K]` |
| `B` (weight) | `[K, N]`  | same | same |
| `scale` dtype | `float8_e8m0fnu` | same | same |
| `scale` logical shape | to_blocked | `scale_a: [M, K/32]`, `scale_b: [N, K/32]`  | `scale_a: [M, K/32]`, `scale_b: [N, K/32]`  |
| **`swizzle_a` / `swizzle_b`** | **`SWIZZLE_32_4_4`** | **`NO_SWIZZLE`** | **`NO_SWIZZLE`** |

## Usage

```python
# default — blocked/swizzled scales
config = MXDynamicActivationMXWeightConfig(
    swizzled_type = SwizzleType.SWIZZLE_32_4_4,
)

# no swizzle
config = MXDynamicActivationMXWeightConfig(
    swizzled_type = SwizzleType.NO_SWIZZLE,
)
```