### PR TITLE
Avoid re-registering native Enum pytree constants

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,12 +4,39 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 import unittest
+from enum import Enum
 from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
 
-from torchao.utils import TorchAOBaseTensor, torch_version_at_least
+from torchao.utils import (
+    TorchAOBaseTensor,
+    register_as_pytree_constant,
+    torch_version_at_least,
+)
+
+
+class TestRegisterAsPytreeConstant(unittest.TestCase):
+    def test_enum_uses_native_opaque_support(self):
+        class Choice(Enum):
+            FIRST = 1
+
+        with patch.object(torch.utils._pytree, "register_constant") as register:
+            result = register_as_pytree_constant(Choice)
+
+        self.assertIs(result, Choice)
+        register.assert_not_called()
+
+    def test_non_enum_is_registered(self):
+        class Config:
+            pass
+
+        with patch.object(torch.utils._pytree, "register_constant") as register:
+            result = register_as_pytree_constant(Config)
+
+        self.assertIs(result, Config)
+        register.assert_called_once_with(Config)
 
 
 class TestTorchVersion(unittest.TestCase):

--- a/torchao/utils.py
+++ b/torchao/utils.py
@@ -8,6 +8,7 @@ import importlib
 import itertools
 import re
 import time
+from enum import Enum
 from functools import reduce
 from importlib.metadata import version
 from math import gcd
@@ -43,8 +44,9 @@ __all__ = [
 
 
 def register_as_pytree_constant(cls):
-    """Decorator to register a class as a pytree constant for dynamo non-strict trace mode."""
-    torch.utils._pytree.register_constant(cls)
+    """Register non-Enum classes as constants for Dynamo non-strict tracing."""
+    if not issubclass(cls, Enum):
+        torch.utils._pytree.register_constant(cls)
     return cls
 
 


### PR DESCRIPTION
## Summary

Current PyTorch handles `Enum` values as opaque pytree constants natively. `torchao.utils.register_as_pytree_constant` still calls `torch.utils._pytree.register_constant()` unconditionally, so importing decorated TorchAO Enum classes emits duplicate/native-registration warnings.

Skip the explicit registration for `Enum` subclasses while preserving the existing registration and decorator return value for ordinary classes.

This is intentionally limited to the compatibility helper; no decorated class or tracing call site changes.

Fixes #4848.

## Test plan

```bash
python3 -m pytest -q test/test_utils.py::TestRegisterAsPytreeConstant
```

Result in the CUDA serving image: `2 passed`.

The two regression cases verify that:

- an `Enum` subclass returns unchanged without calling `register_constant`;
- an ordinary class still calls `register_constant` exactly once and returns unchanged.

A fresh four-worker vLLM startup using the patched TorchAO module also completed without the pytree registration warning.