### PR TITLE
fix(tests/moe_training): float8_dtyep typo makes the fp8 rowwise grouped-mm test TypeError once unskipped

### DIFF
--- a/test/prototype/moe_training/test_fp8_grouped_mm.py
+++ b/test/prototype/moe_training/test_fp8_grouped_mm.py
@@ -88,7 +88,7 @@ def test_fp8_rowwise_scaled_grouped_mm(m, n, k, n_groups):
         b_t,
         offs=offs,
         out_dtype=config.out_dtype,
-        float8_dtyep=config.float8_dtype,
+        float8_dtype=config.float8_dtype,
     )
 
     # Validate result.


### PR DESCRIPTION
## Problem

`test_fp8_rowwise_scaled_grouped_mm` passes `float8_dtyep=` — a transposed-letter
typo for `float8_dtype`
(`test/prototype/moe_training/test_fp8_grouped_mm.py`):

```python
out = _to_fp8_rowwise_then_scaled_grouped_mm(
    a,
    b_t,
    offs=offs,
    out_dtype=config.out_dtype,
    float8_dtyep=config.float8_dtype,
)
```

`_to_fp8_rowwise_then_scaled_grouped_mm`
(`torchao/prototype/moe_training/fp8_grouped_mm.py:24`) declares

```python
def _to_fp8_rowwise_then_scaled_grouped_mm(
    A, B_t, offs,
    out_dtype: Optional[torch.dtype] = torch.bfloat16,
    float8_dtype: torch.dtype = torch.float8_e4m3fn,
    pad_token_groups_for_grouped_mm: bool = True,
) -> torch.Tensor:
```

and has no `**kwargs`, so the call raises

```
TypeError: _to_fp8_rowwise_then_scaled_grouped_mm() got an unexpected keyword argument 'float8_dtyep'
```

The sibling test in the same file already spells it correctly:

```python
# test_K_or_N_dim_not_multiple_of_16
float8_dtype=config.float8_dtype,
```

## Why CI is green

This test carries an unconditional skip:

```python
@pytest.mark.skipif(
    True,
    reason="Skipping FP8 rowwise test pending fix for https://github.com/pytorch/ao/issues/3957",
)
```

so the typo is latent rather than currently failing. It becomes a confusing
`TypeError` — nothing to do with the V-trace/GEMM issue being fixed — for
whoever removes that skip once #3963/#3957 lands.

## Fix

```diff
-        float8_dtyep=config.float8_dtype,
+        float8_dtype=config.float8_dtype,
```

Test-only, one keyword. No library code and no other test is touched, and the
skip marker is deliberately left in place — unskipping is for the #3957 fix, not
for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
