### PR TITLE
[nvfp4 training][rl] Add the four-over-six grouped GEMM and dispatcher wiring

### DIFF
--- a/benchmarks/prototype/moe_training/nvfp4_training/bench_cutedsl_four_over_six_quantize.py
+++ b/benchmarks/prototype/moe_training/nvfp4_training/bench_cutedsl_four_over_six_quantize.py
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+# this benchmarking script is a modified version of the original script from: https://github.com/drisspg/transformer_nuggets/blob/main/transformer_nuggets/utils/benchmark.py
+
+import itertools
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+import torchao.prototype.moe_training.nvfp4_training.four_over_six as four_over_six_module
+from benchmarks.utils import benchmark_cuda_function_in_microseconds
+from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+    four_over_six_quantize,
+)
+
+device = torch.device("cuda")
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    input_shape: tuple[int, int]
+    block: str
+    row_scaled: bool
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    # time
+    cutedsl_us: float
+    torch_ref_us: float
+    # mem bw
+    cutedsl_gbps: float
+    torch_ref_gbps: float
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    result: ExperimentResult
+
+
+def get_configs() -> List[ExperimentConfig]:
+    input_shapes = [
+        # DeepSeekV3 671b shapes
+        (8192, 2048),
+        (8192, 7168),
+        (32768, 2048),
+        (32768, 7168),
+        (131072, 2048),
+        (131072, 7168),
+    ]
+    cases = [
+        ("1x16", False),  # activations, per-tensor amax
+        ("1x16", True),  # activations, row-scaled amax
+        ("16x16", False),  # weights
+    ]
+    configs = []
+    for shape, (block, row_scaled) in itertools.product(input_shapes, cases):
+        configs.append(
+            ExperimentConfig(input_shape=shape, block=block, row_scaled=row_scaled)
+        )
+    return configs
+
+
+def _reference_quantize(x, global_amax, **kwargs):
+    """Pure-PyTorch four_over_six_quantize body (dispatch gate disabled)."""
+    orig = four_over_six_module._cutedsl_quantize_eligible
+    four_over_six_module._cutedsl_quantize_eligible = lambda t: False
+    try:
+        return four_over_six_quantize(x, global_amax, **kwargs)
+    finally:
+        four_over_six_module._cutedsl_quantize_eligible = orig
+
+
+def run_experiment(config: ExperimentConfig) -> ExperimentResult:
+    x = torch.randn(*config.input_shape, dtype=torch.bfloat16, device=device)
+    if config.row_scaled:
+        amax = x.abs().amax(dim=1).to(torch.float32)
+    else:
+        amax = x.abs().amax().to(torch.float32)
+
+    quantize_kwargs = dict(block=config.block, err_mode="mae", e4m3_scale_bound=256)
+
+    # Correctness first: the CuTe DSL fast path must be bitwise identical.
+    assert four_over_six_module._cutedsl_quantize_eligible(x)
+    codes, scales = four_over_six_quantize(x, amax, **quantize_kwargs)
+    ref_codes, ref_scales = _reference_quantize(x, amax, **quantize_kwargs)
+    assert torch.equal(codes, ref_codes)
+    assert torch.equal(scales.view(torch.uint8), ref_scales.view(torch.uint8))
+
+    cutedsl_us = benchmark_cuda_function_in_microseconds(
+        four_over_six_quantize, x, amax, **quantize_kwargs
+    )
+    torch_ref_us = benchmark_cuda_function_in_microseconds(
+        _reference_quantize, x, amax, **quantize_kwargs
+    )
+
+    bytes_per_input_el = torch.finfo(torch.bfloat16).bits / 8
+    read_bytes = x.numel() * bytes_per_input_el
+    write_bytes = codes.numel() * 1 + scales.numel() * 1
+    cutedsl_gbps = ((read_bytes + write_bytes) / 1e9) / (cutedsl_us / 1e6)
+    torch_ref_gbps = ((read_bytes + write_bytes) / 1e9) / (torch_ref_us / 1e6)
+
+    return ExperimentResult(
+        cutedsl_us=cutedsl_us,
+        torch_ref_us=torch_ref_us,
+        cutedsl_gbps=cutedsl_gbps,
+        torch_ref_gbps=torch_ref_gbps,
+    )
+
+
+def print_results(experiments: List[Experiment]):
+    headers = [
+        "input_shape",
+        "block",
+        "row_scaled",
+        "cutedsl_us",
+        "torch_ref_us",
+        "speedup",
+        "cutedsl_gbps",
+        "torch_ref_gbps",
+    ]
+    rows = []
+    for experiment in experiments:
+        speedup = experiment.result.torch_ref_us / experiment.result.cutedsl_us
+        rows.append(
+            [
+                str(experiment.config.input_shape),
+                experiment.config.block,
+                experiment.config.row_scaled,
+                f"{experiment.result.cutedsl_us:.2f}",
+                f"{experiment.result.torch_ref_us:.2f}",
+                f"{speedup:.2f}x",
+                f"{experiment.result.cutedsl_gbps:.1f}",
+                f"{experiment.result.torch_ref_gbps:.1f}",
+            ]
+        )
+    print(tabulate(rows, headers=headers))
+
+
+def main():
+    torch.random.manual_seed(123)
+    configs = get_configs()
+    results = []
+    for config in tqdm(configs):
+        result = run_experiment(config)
+        results.append(Experiment(config=config, result=result))
+
+    # Use Tabulate to print results
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
+++ b/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
@@ -1,0 +1,496 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from torchao.float8.float8_utils import compute_error
+from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+    NVFP4FourOverSixLinear,
+    four_over_six_global_encode_scale,
+    four_over_six_linear,
+    four_over_six_quantize,
+    nvfp4_dequantize,
+)
+from torchao.prototype.moe_training.nvfp4_training.nvfp4_training import (
+    NVFP4Linear,
+    NVFP4TrainingConfig,
+)
+from torchao.prototype.mx_formats.kernels import f4_unpacked_to_f32, unpack_uint4
+from torchao.quantization import quantize_
+from torchao.utils import is_sm_at_least_100, torch_version_at_least
+
+_skip_no_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+_skip_no_sm100 = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and is_sm_at_least_100()
+        and torch_version_at_least("2.10.0")
+    ),
+    reason="requires SM100+ and PyTorch 2.10+ (FP4 scaled_mm)",
+)
+
+
+def _dequantize(codes, scales, global_amax, e4m3_scale_bound):
+    """Reconstruct FP32 values from packed codes, block scales, and global amax."""
+    rows = codes.shape[0]
+    values = f4_unpacked_to_f32(unpack_uint4(codes)).view(rows, -1, 16)
+    s_dec = 1.0 / four_over_six_global_encode_scale(global_amax, e4m3_scale_bound)
+    if s_dec.dim() == 1:
+        s_dec = s_dec.view(rows, 1, 1)
+    return (values * scales.to(torch.float32).unsqueeze(-1) * s_dec).view(rows, -1)
+
+
+def _map6_reference(x, global_amax, e4m3_scale_bound):
+    """Standard (map-to-6 only) encoding with the four-over-six scale chain."""
+    from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+        _FP32_MAX,
+        FP4_E2M1_MAX,
+        FP8_E4M3_MAX,
+        _fp4_rtne,
+    )
+
+    rows, cols = x.shape
+    xf = x.float().view(rows, cols // 16, 16)
+    s_enc = four_over_six_global_encode_scale(global_amax, e4m3_scale_bound)
+    fp4_max = torch.full((), FP4_E2M1_MAX, dtype=torch.float32, device=x.device)
+    base = (xf.abs().amax(dim=-1) / fp4_max) * s_enc
+    scale6 = base.clamp(max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    inv6 = (1.0 / (scale6.to(torch.float32) * (1.0 / s_enc))).clamp(max=_FP32_MAX)
+    _, values6 = _fp4_rtne(xf * inv6.unsqueeze(-1))
+    s_dec = (1.0 / s_enc).view(-1, 1, 1) if s_enc.dim() == 1 else 1.0 / s_enc
+    dequant6 = values6 * scale6.to(torch.float32).unsqueeze(-1) * s_dec
+    return dequant6.view(rows, cols)
+
+
+@_skip_no_cuda
+@pytest.mark.parametrize("err_mode", ["mae", "mse"])
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+@pytest.mark.parametrize("block", ["1x16", "16x16"])
+def test_scales_are_candidate_scales(err_mode, e4m3_scale_bound, block):
+    """Every stored block scale is one of the two candidate scales."""
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    amax = x.abs().amax().to(torch.float32)
+    _, scales = four_over_six_quantize(
+        x, amax, block=block, err_mode=err_mode, e4m3_scale_bound=e4m3_scale_bound
+    )
+
+    xf = x.float().view(128, 16, 16)
+    if block == "16x16":
+        tiles = x.float().abs().view(8, 16, 16, 16)
+        block_amax = tiles.amax(dim=(1, 3)).repeat_interleave(16, dim=0)
+    else:
+        block_amax = xf.abs().amax(dim=-1)
+    s_enc = four_over_six_global_encode_scale(amax, e4m3_scale_bound)
+    fp4_max = torch.full((), 6.0, dtype=torch.float32, device="cuda")
+    base = (block_amax / fp4_max) * s_enc
+    scale6 = base.clamp(max=448.0).to(torch.float8_e4m3fn).view(torch.uint8)
+    scale4 = (base * 1.5).clamp(max=448.0).to(torch.float8_e4m3fn).view(torch.uint8)
+    got = scales.view(torch.uint8)
+    assert ((got == scale6) | (got == scale4)).all()
+
+
+@_skip_no_cuda
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+def test_selection_not_worse_than_map6(e4m3_scale_bound):
+    """Per-block MAE of the stored encoding <= the map-to-6-only encoding."""
+    torch.manual_seed(0)
+    x = torch.randn(256, 512, dtype=torch.bfloat16, device="cuda")
+    amax = x.abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(
+        x, amax, block="1x16", err_mode="mae", e4m3_scale_bound=e4m3_scale_bound
+    )
+    dq = _dequantize(codes, scales, amax, e4m3_scale_bound)
+    dq6 = _map6_reference(x, amax, e4m3_scale_bound)
+    xf = x.float()
+    err = (dq - xf).abs().view(256, -1, 16).sum(dim=-1).double()
+    err6 = (dq6 - xf).abs().view(256, -1, 16).sum(dim=-1).double()
+    # Selection minimizes the FP32 sequential-sum error; allow FP32-vs-FP64
+    # summation slack on ties.
+    assert (err <= err6 + 1e-4).all()
+    # And the recipe must actually engage: some blocks pick map-to-4.
+    assert (err < err6 - 1e-4).any()
+
+
+@_skip_no_cuda
+@pytest.mark.parametrize("err_mode", ["mae", "mse"])
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+def test_selection_minimizes_err_mode(err_mode, e4m3_scale_bound):
+    """The stored encoding's per-block error is the minimum over both
+    candidates under the configured metric (the map-to-6 comparison above
+    only bounds the mae side)."""
+    from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+        _FP32_MAX,
+        FP4_E2M1_MAX,
+        FP8_E4M3_MAX,
+        _candidate_error,
+        _fp4_rtne,
+    )
+
+    torch.manual_seed(0)
+    rows, cols = 256, 512
+    x = torch.randn(rows, cols, dtype=torch.bfloat16, device="cuda")
+    amax = x.abs().amax().to(torch.float32)
+    _, scales = four_over_six_quantize(
+        x, amax, block="1x16", err_mode=err_mode, e4m3_scale_bound=e4m3_scale_bound
+    )
+
+    # Recompute both candidate encodings with the quantizer's own chain.
+    xf = x.float().view(rows, cols // 16, 16)
+    s_enc = four_over_six_global_encode_scale(amax, e4m3_scale_bound)
+    fp4_max = torch.full((), FP4_E2M1_MAX, dtype=torch.float32, device=x.device)
+    base = (xf.abs().amax(dim=-1) / fp4_max) * s_enc
+    scale6 = base.clamp(max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    scale4 = (base * 1.5).clamp(max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    s_dec = 1.0 / s_enc
+    inv6 = (1.0 / (scale6.to(torch.float32) * s_dec)).clamp(max=_FP32_MAX)
+    inv4 = (1.0 / (scale4.to(torch.float32) * s_dec)).clamp(max=_FP32_MAX)
+    _, values6 = _fp4_rtne(xf * inv6.unsqueeze(-1))
+    _, values4 = _fp4_rtne(xf * inv4.unsqueeze(-1))
+    err6 = _candidate_error(
+        values6, scale6.unsqueeze(-1), xf, amax, err_mode, e4m3_scale_bound
+    )
+    err4 = _candidate_error(
+        values4, scale4.unsqueeze(-1), xf, amax, err_mode, e4m3_scale_bound
+    )
+
+    # Every stored scale is one of the candidates, and its error is the
+    # candidate minimum (equal candidate bytes encode identically, so the
+    # attribution below is unambiguous).
+    stored = scales.view(torch.uint8)
+    scale6_u8 = scale6.view(torch.uint8)
+    scale4_u8 = scale4.view(torch.uint8)
+    assert ((stored == scale6_u8) | (stored == scale4_u8)).all()
+    stored_err = torch.where(stored == scale4_u8, err4, err6)
+    min_err = torch.where(err4 < err6, err4, err6)
+    torch.testing.assert_close(stored_err, min_err, atol=0, rtol=0)
+    # Both candidates must win somewhere for the check to bite.
+    assert (err4 < err6).any() and (err6 < err4).any()
+
+
+@_skip_no_cuda
+def test_row_scaled_matches_per_row_quantization():
+    """Row-scaled output == each row quantized alone with its own scalar amax."""
+    torch.manual_seed(0)
+    x = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda")
+    row_amax = x.abs().amax(dim=1).to(torch.float32)
+    codes, scales = four_over_six_quantize(x, row_amax, block="1x16")
+    for r in range(0, 64, 17):
+        codes_r, scales_r = four_over_six_quantize(x[r : r + 1], row_amax[r].view(()))
+        torch.testing.assert_close(codes[r : r + 1], codes_r, atol=0, rtol=0)
+        torch.testing.assert_close(
+            scales[r : r + 1].view(torch.uint8),
+            scales_r.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+
+
+@_skip_no_cuda
+def test_row_scaled_rejects_16x16():
+    x = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda")
+    row_amax = x.abs().amax(dim=1).to(torch.float32)
+    with pytest.raises(ValueError, match="1x16 blocks only"):
+        four_over_six_quantize(x, row_amax, block="16x16")
+
+
+@_skip_no_cuda
+@pytest.mark.parametrize("block", ["1x16", "16x16"])
+def test_dequant_sqnr(block):
+    torch.manual_seed(0)
+    x = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda")
+    amax = x.abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax, block=block)
+    dq = _dequantize(codes, scales, amax, 256)
+    assert compute_error(x.float(), dq).item() > 14.0
+
+
+@_skip_no_cuda
+@pytest.mark.parametrize("block", ["1x16", "16x16"])
+@pytest.mark.parametrize("row_scaled", [False, True])
+def test_dequantize_roundtrip(block, row_scaled):
+    """nvfp4_dequantize reconstructs the quantized values."""
+    if row_scaled and block == "16x16":
+        pytest.skip("row-scaled is 1x16 only")
+    torch.manual_seed(0)
+    x = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda")
+    amax = (x.abs().amax(dim=1) if row_scaled else x.abs().amax()).to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax, block=block)
+    dq = nvfp4_dequantize(codes, scales, amax, out_dtype=torch.float32)
+    assert compute_error(x.float(), dq).item() > 14.0
+    # Zero blocks reconstruct exactly: scale byte 0x00 makes the decode
+    # scale exactly zero regardless of the global amax.
+    x[:, :16] = 0.0
+    codes, scales = four_over_six_quantize(x, amax, block=block)
+    dq = nvfp4_dequantize(codes, scales, amax, out_dtype=torch.float32)
+    assert (dq[:, :16] == 0.0).all()
+
+
+@_skip_no_cuda
+def test_dequantize_validation():
+    codes = torch.zeros(32, 128, dtype=torch.uint8, device="cuda")
+    scales = torch.zeros(32, 16, dtype=torch.uint8, device="cuda").view(
+        torch.float8_e4m3fn
+    )
+    amax = torch.ones((), dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="e4m3_scale_bound"):
+        nvfp4_dequantize(codes, scales, amax, e4m3_scale_bound=128)
+    with pytest.raises(ValueError, match="scales must have shape"):
+        nvfp4_dequantize(codes, scales[:, :8], amax)
+    with pytest.raises(ValueError, match="row vector"):
+        nvfp4_dequantize(
+            codes, scales, torch.ones(7, dtype=torch.float32, device="cuda")
+        )
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+@pytest.mark.parametrize("bias", [False, True])
+def test_linear_forward_backward(row_scaled_activation, bias):
+    torch.manual_seed(0)
+    M, K, N = 256, 512, 384
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    w = (torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1).requires_grad_(
+        True
+    )
+    b = (
+        torch.randn(N, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        if bias
+        else None
+    )
+    y = four_over_six_linear(x, w, b, "mae", 256, row_scaled_activation)
+    assert y.shape == (M, N)
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    y_ref = x.detach().float() @ w.detach().float().t()
+    if bias:
+        y_ref = y_ref + b.detach().float()
+    dx_ref = dy.float() @ w.detach().float()
+    dw_ref = dy.float().t() @ x.detach().float()
+    assert compute_error(y_ref, y.float()).item() > 14.0
+    assert compute_error(dx_ref, x.grad.float()).item() > 14.0
+    assert compute_error(dw_ref, w.grad.float()).item() > 14.0
+    if bias:
+        # grad_bias is reduced in bf16, matching nvfp4_linear.
+        torch.testing.assert_close(b.grad, dy.sum(dim=0))
+
+
+@_skip_no_sm100
+def test_linear_module():
+    torch.manual_seed(0)
+    lin = NVFP4FourOverSixLinear(512, 384, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    y = lin(x)
+    y.sum().backward()
+    assert y.shape == (128, 384)
+    assert lin.weight.grad is not None
+
+
+@_skip_no_cuda
+def test_linear_rejects_unaligned_dims():
+    x = torch.randn(100, 512, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(384, 512, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(ValueError, match="divisible by 128"):
+        four_over_six_linear(x, w, None, "mae", 256, False)
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+def test_backward_override_high_precision(row_scaled_activation):
+    """dx/dw are the plain bf16 GEMMs on the original operands."""
+    torch.manual_seed(0)
+    M, K, N = 256, 512, 384
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    w = (torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1).requires_grad_(
+        True
+    )
+    y = four_over_six_linear(
+        x, w, None, "mae", 256, row_scaled_activation, "high_precision"
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+    torch.testing.assert_close(x.grad, dy @ w.detach(), atol=0, rtol=0)
+    torch.testing.assert_close(w.grad, dy.t() @ x.detach(), atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+@pytest.mark.parametrize("weight_block", ["16x16", "1x16"])
+def test_backward_override_dequantized(row_scaled_activation, weight_block):
+    """dx/dw are bf16 GEMMs on dequantizations of the rowwise fprop operands."""
+    torch.manual_seed(0)
+    M, K, N = 256, 512, 384
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    w = (torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1).requires_grad_(
+        True
+    )
+    y = four_over_six_linear(
+        x, w, None, "mae", 256, row_scaled_activation, "dequantized", weight_block
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    x_hp, w_hp = x.detach(), w.detach()
+    x_amax = (
+        x_hp.abs().amax(dim=1) if row_scaled_activation else x_hp.abs().amax()
+    ).to(torch.float32)
+    w_amax = w_hp.abs().amax().to(torch.float32)
+    x_codes, x_scales = four_over_six_quantize(x_hp, x_amax)
+    w_codes, w_scales = four_over_six_quantize(w_hp, w_amax, block=weight_block)
+    x_dq = nvfp4_dequantize(x_codes, x_scales, x_amax)
+    w_dq = nvfp4_dequantize(w_codes, w_scales, w_amax)
+    torch.testing.assert_close(x.grad, dy @ w_dq, atol=0, rtol=0)
+    torch.testing.assert_close(w.grad, dy.t() @ x_dq, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+def test_row_scaled_default_backward_is_high_precision():
+    """row_scaled + backward_override=None keeps the pre-override behavior."""
+    torch.manual_seed(0)
+    M, K, N = 256, 512, 384
+    x_hp = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    w_hp = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1
+    dy = torch.randn(M, N, dtype=torch.bfloat16, device="cuda")
+
+    def run(override):
+        x = x_hp.clone().requires_grad_(True)
+        w = w_hp.clone().requires_grad_(True)
+        y = four_over_six_linear(x, w, None, "mae", 256, True, override)
+        y.backward(dy)
+        return y.detach(), x.grad, w.grad
+
+    y0, dx0, dw0 = run(None)
+    y1, dx1, dw1 = run("high_precision")
+    torch.testing.assert_close(y0, y1, atol=0, rtol=0)
+    torch.testing.assert_close(dx0, dx1, atol=0, rtol=0)
+    torch.testing.assert_close(dw0, dw1, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+def test_weight_block_1x16_forward():
+    """weight_block='1x16' quantizes the fprop weight with 1x16 blocks."""
+    from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+        _global_decode_scale,
+        _scaled_mm_nvfp4,
+    )
+
+    torch.manual_seed(0)
+    M, K, N = 256, 512, 384
+    x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") * 0.1
+    y = four_over_six_linear(x, w, None, "mae", 256, False, None, "1x16")
+
+    x_amax = x.abs().amax().to(torch.float32)
+    w_amax = w.abs().amax().to(torch.float32)
+    x_codes, x_scales = four_over_six_quantize(x, x_amax)
+    w_codes, w_scales = four_over_six_quantize(w, w_amax, block="1x16")
+    y_ref = _scaled_mm_nvfp4(
+        x_codes,
+        x_scales,
+        _global_decode_scale(x_amax, 256),
+        w_codes.t(),
+        w_scales,
+        _global_decode_scale(w_amax, 256),
+        torch.bfloat16,
+    )
+    torch.testing.assert_close(y, y_ref, atol=0, rtol=0)
+
+
+@_skip_no_cuda
+def test_backward_override_validation():
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(ValueError, match="no quantized backward"):
+        four_over_six_linear(x, w, None, "mae", 256, True, "quantized")
+    with pytest.raises(ValueError, match="backward_override"):
+        four_over_six_linear(x, w, None, "mae", 256, False, "bf16")
+
+
+@_skip_no_sm100
+def test_linear_module_backward_override():
+    lin = NVFP4FourOverSixLinear(
+        512,
+        384,
+        backward_override="dequantized",
+        weight_block="1x16",
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    x = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+    y = lin(x)
+    y.sum().backward()
+    assert y.shape == (128, 384)
+    assert lin.weight.grad is not None
+    assert x.grad is not None
+
+
+def test_training_config_four_over_six_recipe_swap():
+    model = torch.nn.Sequential(
+        torch.nn.Linear(512, 384, bias=True), torch.nn.Linear(384, 512, bias=False)
+    )
+    weight = model[0].weight
+    quantize_(
+        model,
+        NVFP4TrainingConfig(
+            recipe="four_over_six",
+            err_mode="mse",
+            e4m3_scale_bound=448,
+            row_scaled_activation=True,
+            backward_override="dequantized",
+            weight_block="1x16",
+        ),
+    )
+    for mod in model:
+        assert type(mod) is NVFP4FourOverSixLinear
+        assert mod.err_mode == "mse"
+        assert mod.e4m3_scale_bound == 448
+        assert mod.row_scaled_activation is True
+        assert mod.backward_override == "dequantized"
+        assert mod.weight_block == "1x16"
+    assert model[0].weight is weight
+    assert model[0].bias is not None
+    assert model[1].bias is None
+    # Re-quantizing leaves already-converted modules alone — under the same
+    # recipe and under the other one (no silent cross-recipe rewrap).
+    converted = model[0]
+    quantize_(model, NVFP4TrainingConfig(recipe="four_over_six"))
+    assert model[0] is converted
+    quantize_(model, NVFP4TrainingConfig())
+    assert model[0] is converted
+
+
+def test_training_config_default_recipe_swap():
+    model = torch.nn.Sequential(torch.nn.Linear(512, 384, bias=False))
+    quantize_(model, NVFP4TrainingConfig())
+    assert type(model[0]) is NVFP4Linear
+    converted = model[0]
+    quantize_(model, NVFP4TrainingConfig(recipe="four_over_six"))
+    assert model[0] is converted
+
+
+def test_training_config_recipe_validation():
+    with pytest.raises(ValueError, match="recipe must be"):
+        NVFP4TrainingConfig(recipe="4over6")
+    with pytest.raises(ValueError, match="err_mode configures the 'four_over_six'"):
+        NVFP4TrainingConfig(err_mode="mse")
+    with pytest.raises(ValueError, match="stay at its default under recipe='default'"):
+        NVFP4TrainingConfig(backward_override="dequantized")
+    with pytest.raises(ValueError, match="err_mode must be"):
+        NVFP4TrainingConfig(recipe="four_over_six", err_mode="rmse")
+    with pytest.raises(ValueError, match="e4m3_scale_bound must be"):
+        NVFP4TrainingConfig(recipe="four_over_six", e4m3_scale_bound=384)
+    with pytest.raises(ValueError, match="backward_override must be"):
+        NVFP4TrainingConfig(recipe="four_over_six", backward_override="bf16")
+    with pytest.raises(ValueError, match="weight_block must be"):
+        NVFP4TrainingConfig(recipe="four_over_six", weight_block="32x32")
+    with pytest.raises(ValueError, match="world_size configures the 'default'"):
+        NVFP4TrainingConfig(recipe="four_over_six", world_size=2)

--- a/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
+++ b/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
@@ -9,6 +9,7 @@
 import pytest
 import torch
 
+import torchao.prototype.moe_training.nvfp4_training.four_over_six as four_over_six_module
 from torchao.float8.float8_utils import compute_error
 from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
     NVFP4FourOverSixLinear,
@@ -16,6 +17,9 @@ from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
     four_over_six_linear,
     four_over_six_quantize,
     nvfp4_dequantize,
+)
+from torchao.prototype.moe_training.nvfp4_training.hadamard_cutedsl_utils import (
+    cutedsl_nvfp4_kernels_available,
 )
 from torchao.prototype.moe_training.nvfp4_training.nvfp4_training import (
     NVFP4Linear,
@@ -36,6 +40,22 @@ _skip_no_sm100 = pytest.mark.skipif(
     ),
     reason="requires SM100+ and PyTorch 2.10+ (FP4 scaled_mm)",
 )
+_cutedsl_available = torch.cuda.is_available() and cutedsl_nvfp4_kernels_available()
+_skip_no_cutedsl = pytest.mark.skipif(
+    not _cutedsl_available,
+    reason="requires SM100+ and the CuTe DSL runtime packages",
+)
+
+
+def _reference_quantize(x, global_amax, **kwargs):
+    """Run the pure-PyTorch four_over_six_quantize body (the bitwise oracle)
+    by disabling the CuTe DSL dispatch gate for the duration of the call."""
+    orig = four_over_six_module._cutedsl_quantize_eligible
+    four_over_six_module._cutedsl_quantize_eligible = lambda t: False
+    try:
+        return four_over_six_quantize(x, global_amax, **kwargs)
+    finally:
+        four_over_six_module._cutedsl_quantize_eligible = orig
 
 
 def _dequantize(codes, scales, global_amax, e4m3_scale_bound):
@@ -68,6 +88,30 @@ def _map6_reference(x, global_amax, e4m3_scale_bound):
     s_dec = (1.0 / s_enc).view(-1, 1, 1) if s_enc.dim() == 1 else 1.0 / s_enc
     dequant6 = values6 * scale6.to(torch.float32).unsqueeze(-1) * s_dec
     return dequant6.view(rows, cols)
+
+
+def _make_test_data(init_data, shape, dtype):
+    """Deterministic input constructions for the kernel-vs-oracle tests."""
+    n = shape[0] * shape[1]
+    if init_data == "random":
+        return torch.randn(*shape, dtype=dtype, device="cuda")
+    if init_data == "boundary":
+        # A linspace across the FP4 range interleaved with the same values
+        # nudged outward by 1e-3, straddling every rounding-decision boundary.
+        base = torch.linspace(-12.0, 12.0, n // 2, dtype=torch.float32, device="cuda")
+        nudge = torch.where(base < 0, base - 1e-3, base + 1e-3)
+        return torch.stack((base, nudge), dim=1).view(shape).to(dtype)
+    if init_data == "maxes":
+        return torch.full(shape, torch.finfo(dtype).max, dtype=dtype, device="cuda")
+    if init_data == "denormal":
+        # bf16 subnormals with mixed signs (randn never generates them).
+        tiny = torch.finfo(torch.bfloat16).smallest_normal
+        x = (torch.rand(*shape, dtype=torch.float32, device="cuda") - 0.5) * tiny
+        return x.to(dtype)
+    assert init_data == "negzero"
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    x[::2, ::3] = -0.0
+    return x
 
 
 @_skip_no_cuda
@@ -494,3 +538,182 @@ def test_training_config_recipe_validation():
         NVFP4TrainingConfig(recipe="four_over_six", weight_block="32x32")
     with pytest.raises(ValueError, match="world_size configures the 'default'"):
         NVFP4TrainingConfig(recipe="four_over_six", world_size=2)
+
+
+@_skip_no_cutedsl
+@pytest.mark.parametrize("err_mode", ["mae", "mse"])
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+@pytest.mark.parametrize("block", ["1x16", "16x16"])
+@pytest.mark.parametrize("row_scaled", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "init_data", ["random", "boundary", "maxes", "denormal", "negzero"]
+)
+def test_cutedsl_bitwise_matches_reference(
+    err_mode, e4m3_scale_bound, block, row_scaled, dtype, init_data
+):
+    """CuTe DSL fast path is bitwise identical to the pure-PyTorch body.
+
+    Shapes cover R < the kernel's 128-row tile (TMA-clipped stores), R not a
+    multiple of 16 (1x16 only), multi-tile rows/columns, and R > 128 (a
+    grid.y > 1 launch). The data constructions target the encode edge
+    cases: rounding-boundary straddles, dtype-max saturation, bf16
+    subnormals, and negative zeros.
+    """
+    if row_scaled and block == "16x16":
+        pytest.skip("row-scaled is 1x16 only")
+    shapes = [(128, 256), (64, 1024), (384, 256)]
+    if block == "1x16":
+        shapes.append((100, 320))
+    for shape in shapes:
+        torch.manual_seed(0)
+        x = _make_test_data(init_data, shape, dtype)
+        amax = (x.abs().amax(dim=1) if row_scaled else x.abs().amax()).to(torch.float32)
+        assert four_over_six_module._cutedsl_quantize_eligible(x)
+        codes, scales = four_over_six_quantize(
+            x, amax, block=block, err_mode=err_mode, e4m3_scale_bound=e4m3_scale_bound
+        )
+        ref_codes, ref_scales = _reference_quantize(
+            x, amax, block=block, err_mode=err_mode, e4m3_scale_bound=e4m3_scale_bound
+        )
+        torch.testing.assert_close(codes, ref_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            scales.view(torch.uint8), ref_scales.view(torch.uint8), atol=0, rtol=0
+        )
+
+
+@_skip_no_cutedsl
+@pytest.mark.parametrize("block", ["1x16", "16x16"])
+def test_cutedsl_special_values(block):
+    """Zeros, Inf injections, and amax==0 rows stay bitwise vs the reference."""
+    torch.manual_seed(0)
+    # all zeros: S_enc falls back to 1.0, zero scales, zero codes
+    x = torch.zeros(64, 256, dtype=torch.bfloat16, device="cuda")
+    amax = x.abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax, block=block)
+    ref_codes, ref_scales = _reference_quantize(x, amax, block=block)
+    torch.testing.assert_close(codes, ref_codes, atol=0, rtol=0)
+    torch.testing.assert_close(
+        scales.view(torch.uint8), ref_scales.view(torch.uint8), atol=0, rtol=0
+    )
+    # Inf injections: block scale caps at 448, Inf encodes as +/-6, both
+    # candidate errors go Inf and the tie picks map-to-6
+    x = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda")
+    x[7, 32] = float("inf")
+    x[23, 100] = float("-inf")
+    amax = x.abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax, block=block)
+    ref_codes, ref_scales = _reference_quantize(x, amax, block=block)
+    torch.testing.assert_close(codes, ref_codes, atol=0, rtol=0)
+    torch.testing.assert_close(
+        scales.view(torch.uint8), ref_scales.view(torch.uint8), atol=0, rtol=0
+    )
+    if block == "1x16":
+        # row-scaled with amax == 0 rows over nonzero data: identity S_enc
+        x = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda")
+        row_amax = x.abs().amax(dim=1).to(torch.float32)
+        row_amax[::3] = 0.0
+        codes, scales = four_over_six_quantize(x, row_amax, block=block)
+        ref_codes, ref_scales = _reference_quantize(x, row_amax, block=block)
+        torch.testing.assert_close(codes, ref_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            scales.view(torch.uint8), ref_scales.view(torch.uint8), atol=0, rtol=0
+        )
+
+
+@_skip_no_cutedsl
+def test_cutedsl_nan_semantics():
+    """NaN handling is the kernel's one documented divergence from the
+    pure-PyTorch body (torch.amax propagates NaN into the block scales
+    while the kernel's fmaxf drops it): an all-NaN group gets amax 0 -> scale byte
+    0x00, and NaN elements encode to +6 (satfinite), i.e. code bytes 0x77."""
+    torch.manual_seed(0)
+    x = torch.randn(32, 256, dtype=torch.bfloat16, device="cuda")
+    x[3, 32:48] = float("nan")  # group (3, 2)
+    # a NaN-free global amax, as a NaN-dropping amax kernel produces
+    amax = torch.nan_to_num(x.float(), nan=0.0).abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax, block="1x16")
+    assert scales.view(torch.uint8)[3, 2].item() == 0x00
+    assert (codes[3, 16:24] == 0x77).all()
+    # NaN-free groups are still bitwise vs the reference
+    ref_codes, ref_scales = _reference_quantize(x, amax, block="1x16")
+    keep = torch.ones_like(codes, dtype=torch.bool)
+    keep[3, 16:24] = False
+    torch.testing.assert_close(codes[keep], ref_codes[keep], atol=0, rtol=0)
+
+
+@_skip_no_cutedsl
+def test_cutedsl_ineligible_falls_back():
+    """Ineligible shapes/layouts silently use the pure-PyTorch body."""
+    x = torch.randn(64, 272, dtype=torch.bfloat16, device="cuda")  # C % 64 != 0
+    assert not four_over_six_module._cutedsl_quantize_eligible(x)
+    amax = x.abs().amax().to(torch.float32)
+    codes, scales = four_over_six_quantize(x, amax)
+    assert codes.shape == (64, 136) and scales.shape == (64, 17)
+    x_t = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda").t()
+    assert not four_over_six_module._cutedsl_quantize_eligible(x_t)
+
+
+@_skip_no_sm100
+@pytest.mark.skipif(not _cutedsl_available, reason="requires the CuTe DSL runtime")
+def test_cutedsl_linear_compile():
+    """torch.compile traces through the dispatch (custom op + fake impl)."""
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(384, 256, dtype=torch.bfloat16, device="cuda") * 0.1
+
+    def fn(x, w):
+        return four_over_six_linear(x, w, None, "mae", 256, False)
+
+    y_eager = fn(x, w)
+    y_compiled = torch.compile(fn, fullgraph=True)(x, w)
+    torch.testing.assert_close(y_compiled, y_eager, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.skipif(not _cutedsl_available, reason="requires the CuTe DSL runtime")
+@pytest.mark.parametrize("backward_override", ["high_precision", "dequantized"])
+def test_linear_compile_backward_overrides(backward_override):
+    """fullgraph compile of the override backwards, bitwise vs eager.
+
+    The quantize stays an opaque custom op under compile; the override
+    backwards are bf16 GEMMs (on original or dequantized operands), so
+    compiled gradients must match eager exactly.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(384, 256, dtype=torch.bfloat16, device="cuda") * 0.1
+
+    def fn(x, w):
+        return four_over_six_linear(x, w, None, "mae", 256, False, backward_override)
+
+    x_e = x.clone().requires_grad_(True)
+    w_e = w.clone().requires_grad_(True)
+    y_eager = fn(x_e, w_e)
+    dy = torch.randn_like(y_eager)
+    y_eager.backward(dy)
+
+    x_c = x.clone().requires_grad_(True)
+    w_c = w.clone().requires_grad_(True)
+    y_compiled = torch.compile(fn, fullgraph=True)(x_c, w_c)
+    y_compiled.backward(dy)
+
+    torch.testing.assert_close(y_compiled, y_eager, atol=0, rtol=0)
+    torch.testing.assert_close(x_c.grad, x_e.grad, atol=0, rtol=0)
+    torch.testing.assert_close(w_c.grad, w_e.grad, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.skipif(not _cutedsl_available, reason="requires the CuTe DSL runtime")
+def test_linear_compile_weight_block_1x16():
+    """fullgraph compile of the 1x16-weight forward, bitwise vs eager."""
+    torch.manual_seed(0)
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(384, 256, dtype=torch.bfloat16, device="cuda") * 0.1
+
+    def fn(x, w):
+        return four_over_six_linear(x, w, None, "mae", 256, False, None, "1x16")
+
+    y_eager = fn(x, w)
+    y_compiled = torch.compile(fn, fullgraph=True)(x, w)
+    torch.testing.assert_close(y_compiled, y_eager, atol=0, rtol=0)

--- a/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
+++ b/test/prototype/moe_training/nvfp4_training/test_four_over_six.py
@@ -239,11 +239,28 @@ def test_row_scaled_matches_per_row_quantization():
 
 
 @_skip_no_cuda
-def test_row_scaled_rejects_16x16():
+def test_per_row_amax_16x16_matches_per_tile_slices():
+    """A tile-uniform per-row amax vector with 16x16 blocks == quantizing
+    each 16-row slice with its scalar amax (the stacked-expert-weight
+    contract)."""
+    torch.manual_seed(0)
     x = torch.randn(64, 256, dtype=torch.bfloat16, device="cuda")
-    row_amax = x.abs().amax(dim=1).to(torch.float32)
-    with pytest.raises(ValueError, match="1x16 blocks only"):
-        four_over_six_quantize(x, row_amax, block="16x16")
+    slice_amax = x.float().abs().view(4, 16 * 256).amax(dim=1)
+    expanded = slice_amax.repeat_interleave(16)
+    codes, scales = four_over_six_quantize(x, expanded, block="16x16")
+    for s in range(4):
+        ref_codes, ref_scales = four_over_six_quantize(
+            x[s * 16 : (s + 1) * 16].contiguous(), slice_amax[s], block="16x16"
+        )
+        torch.testing.assert_close(
+            codes[s * 16 : (s + 1) * 16], ref_codes, atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            scales[s * 16 : (s + 1) * 16].view(torch.uint8),
+            ref_scales.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
 
 
 @_skip_no_cuda
@@ -262,11 +279,16 @@ def test_dequant_sqnr(block):
 @pytest.mark.parametrize("row_scaled", [False, True])
 def test_dequantize_roundtrip(block, row_scaled):
     """nvfp4_dequantize reconstructs the quantized values."""
-    if row_scaled and block == "16x16":
-        pytest.skip("row-scaled is 1x16 only")
     torch.manual_seed(0)
     x = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda")
-    amax = (x.abs().amax(dim=1) if row_scaled else x.abs().amax()).to(torch.float32)
+    if row_scaled and block == "16x16":
+        # Per-row amaxes with 16x16 tiles follow the stacked-expert-weight
+        # contract: constant within every 16-row tile.
+        amax = x.float().abs().view(8, 16 * 512).amax(dim=1).repeat_interleave(16)
+    elif row_scaled:
+        amax = x.abs().amax(dim=1).to(torch.float32)
+    else:
+        amax = x.abs().amax().to(torch.float32)
     codes, scales = four_over_six_quantize(x, amax, block=block)
     dq = nvfp4_dequantize(codes, scales, amax, out_dtype=torch.float32)
     assert compute_error(x.float(), dq).item() > 14.0
@@ -560,8 +582,6 @@ def test_cutedsl_bitwise_matches_reference(
     cases: rounding-boundary straddles, dtype-max saturation, bf16
     subnormals, and negative zeros.
     """
-    if row_scaled and block == "16x16":
-        pytest.skip("row-scaled is 1x16 only")
     shapes = [(128, 256), (64, 1024), (384, 256)]
     if block == "1x16":
         shapes.append((100, 320))

--- a/test/prototype/moe_training/nvfp4_training/test_four_over_six_grouped.py
+++ b/test/prototype/moe_training/nvfp4_training/test_four_over_six_grouped.py
@@ -1,0 +1,625 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from torchao.utils import is_sm_at_least_100, torch_version_at_least
+
+if not torch_version_at_least("2.10.0"):
+    pytest.skip(
+        "four_over_six_grouped reads FP4 scaled_grouped_mm scale/swizzle "
+        "types at import time (torch 2.10+)",
+        allow_module_level=True,
+    )
+
+import torchao.prototype.moe_training.nvfp4_training.four_over_six as four_over_six_module
+from torchao.float8.float8_utils import compute_error
+from torchao.prototype.moe_training.config import NVFP4FourOverSixTrainingOpConfig
+from torchao.prototype.moe_training.nvfp4_training import four_over_six_grouped
+from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+    four_over_six_linear,
+    four_over_six_quantize,
+    nvfp4_dequantize,
+)
+from torchao.prototype.moe_training.nvfp4_training.four_over_six_grouped import (
+    four_over_six_grouped_mm,
+)
+from torchao.prototype.moe_training.utils import _quantize_then_scaled_grouped_mm
+
+_skip_no_sm100 = pytest.mark.skipif(
+    not (
+        torch.cuda.is_available()
+        and is_sm_at_least_100()
+        and torch_version_at_least("2.10.0")
+    ),
+    reason="requires SM100+ and PyTorch 2.10+ (FP4 scaled_grouped_mm)",
+)
+
+
+def _make_grouped_inputs(group_sizes, K, N, seed=0, device="cuda"):
+    """Packed activations, stacked expert weights, and end offsets."""
+    torch.manual_seed(seed)
+    M = sum(group_sizes)
+    E = len(group_sizes)
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(E, N, K, dtype=torch.bfloat16, device=device) * 0.1
+    offs = torch.tensor(group_sizes, dtype=torch.int32, device=device).cumsum(
+        0, dtype=torch.int32
+    )
+    return A, B, offs
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("err_mode", ["mae", "mse"])
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+def test_group_expanded_amax_matches_per_split_quantize(err_mode, e4m3_scale_bound):
+    """One quantize call with group-expanded amaxes == a per-split loop."""
+    group_sizes = [128, 384, 256]
+    A, _, offs = _make_grouped_inputs(group_sizes, K=256, N=128)
+    group_amax = torch.stack(
+        [
+            A[start:end].abs().amax().to(torch.float32)
+            for start, end in zip([0, *offs.tolist()[:-1]], offs.tolist())
+        ]
+    )
+    expanded = group_amax.repeat_interleave(torch.tensor(group_sizes, device=A.device))
+    codes, scales = four_over_six_quantize(
+        A, expanded, err_mode=err_mode, e4m3_scale_bound=e4m3_scale_bound
+    )
+    start = 0
+    for g, end in enumerate(offs.tolist()):
+        split_codes, split_scales = four_over_six_quantize(
+            A[start:end].contiguous(),
+            group_amax[g],
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+        )
+        torch.testing.assert_close(codes[start:end], split_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            scales[start:end].view(torch.uint8),
+            split_scales.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+        start = end
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("weight_block", ["16x16", "1x16"])
+def test_per_tensor_grouped_forward_matches_dense_loop(weight_block):
+    """Grouped forward vs dense four_over_six GEMMs per 128-aligned group.
+
+    The quantized operands are bitwise-identical by construction (pinned by
+    the amax-expansion test above); the GEMM outputs are compared bitwise
+    and fall back to an SQNR bound if the grouped and dense kernels reduce
+    in different orders.
+    """
+    group_sizes = [128, 256, 128]
+    K, N = 256, 384
+    A, B, offs = _make_grouped_inputs(group_sizes, K=K, N=N)
+    y = four_over_six_grouped_mm(A, B, offs, weight_block=weight_block)
+
+    start = 0
+    refs = []
+    for e, end in enumerate(offs.tolist()):
+        refs.append(
+            four_over_six_linear(
+                A[start:end].contiguous(),
+                B[e],
+                None,
+                "mae",
+                256,
+                False,
+                "high_precision",
+                weight_block,
+            )
+        )
+        start = end
+    y_ref = torch.cat(refs)
+    if not torch.equal(y, y_ref):
+        sqnr = compute_error(y_ref.float(), y.float())
+        assert sqnr > 85.0, f"grouped vs dense-loop forward SQNR {sqnr:.1f} dB"
+        print(f"\ngrouped GEMM reduction differs from dense: SQNR {sqnr:.1f} dB")
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize(
+    "group_sizes, pad",
+    [
+        pytest.param([128, 256, 128], False, id="uniform-128-aligned"),
+        pytest.param([128] * 64, False, id="uniform-128-rows-per-expert"),
+        pytest.param(
+            [128 if e % 8 == 0 else 0 for e in range(64)],
+            False,
+            id="decode-like-8-active-56-empty",
+        ),
+        pytest.param([1, 220, 77], True, id="ragged-padded"),
+    ],
+)
+def test_row_scaled_grouped_forward_matches_loop_oracle(group_sizes, pad, monkeypatch):
+    """Row-scaled fused single-GEMM forward vs per-group dense-GEMM oracles.
+
+    torch's grouped GEMM only emits bf16 high-precision output — one
+    rounding ahead of the fp32 row scale that a loop of dense FP32-output
+    GEMMs does not have. The exactness
+    check compares against the dense loop with that rounding emulated on
+    its GEMM outputs (bitwise, with the reduction-order SQNR fallback);
+    the raw-loop comparison bounds the rounding cost. The quantized
+    operands are identical by construction.
+    """
+    A, B, offs = _make_grouped_inputs(group_sizes, K=2048, N=768, seed=5)
+    N = B.shape[1]
+    y_fused = four_over_six_grouped_mm(
+        A, B, offs, row_scaled_activation=True, pad_token_groups_for_grouped_mm=pad
+    )
+
+    def _dense_loop():
+        refs = []
+        start = 0
+        for e, end in enumerate(offs.tolist()):
+            rows = A[start:end]
+            start = end
+            if rows.shape[0] == 0:
+                refs.append(A.new_zeros(0, N))
+                continue
+            padded_rows = 128 * ((rows.shape[0] + 127) // 128)
+            padded = torch.zeros(
+                padded_rows, A.shape[1], dtype=A.dtype, device=A.device
+            )
+            padded[: rows.shape[0]] = rows
+            ref = four_over_six_linear(padded, B[e], None, "mae", 256, True)
+            refs.append(ref[: rows.shape[0]])
+        return torch.cat(refs)
+
+    y_loop = _dense_loop()
+    dense_gemm = four_over_six_module._scaled_mm_nvfp4
+
+    def _bf16_rounded_gemm(*args):
+        return dense_gemm(*args).to(torch.bfloat16).to(torch.float32)
+
+    monkeypatch.setattr(four_over_six_module, "_scaled_mm_nvfp4", _bf16_rounded_gemm)
+    y_emul = _dense_loop()
+
+    assert y_fused.shape == y_loop.shape
+    if not torch.equal(y_fused, y_emul):
+        sqnr = compute_error(y_emul.float(), y_fused.float())
+        assert sqnr > 85.0, f"fused vs rounding-emulated oracle SQNR {sqnr:.1f} dB"
+        print(f"\nfused grouped GEMM reduction differs from dense: SQNR {sqnr:.1f} dB")
+    rounding_sqnr = compute_error(y_loop.float(), y_fused.float())
+    assert rounding_sqnr > 45.0, f"fused vs loop-oracle SQNR {rounding_sqnr:.1f} dB"
+    print(f"\nbf16 GEMM-output rounding cost vs loop: SQNR {rounding_sqnr:.1f} dB")
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("err_mode", ["mae", "mse"])
+@pytest.mark.parametrize("e4m3_scale_bound", [256, 448])
+@pytest.mark.parametrize("weight_block", ["1x16", "16x16"])
+def test_batched_weight_quantize_matches_per_expert_loop(
+    err_mode, e4m3_scale_bound, weight_block
+):
+    """The one-call flattened weight quantize == the per-expert loop."""
+    torch.manual_seed(2)
+    E, N, K = 5, 128, 256
+    B = torch.randn(E, N, K, dtype=torch.bfloat16, device="cuda") * 0.1
+    weight_amax = B.abs().amax(dim=(1, 2)).to(torch.float32)
+    codes, scales = four_over_six_grouped._quantize_expert_weights(
+        B, weight_amax, weight_block, err_mode, e4m3_scale_bound
+    )
+    for e in range(E):
+        ref_codes, ref_scales = four_over_six_quantize(
+            B[e],
+            weight_amax[e],
+            block=weight_block,
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+        )
+        torch.testing.assert_close(codes[e], ref_codes, atol=0, rtol=0)
+        torch.testing.assert_close(
+            scales[e].view(torch.uint8),
+            ref_scales.view(torch.uint8),
+            atol=0,
+            rtol=0,
+        )
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+def test_grouped_backward_high_precision(row_scaled_activation):
+    """dx/dw are bf16 grouped GEMMs on the original operands."""
+    group_sizes = [128, 256, 128]
+    A, B, offs = _make_grouped_inputs(group_sizes, K=256, N=384)
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    y = four_over_six_grouped_mm(
+        A, B, offs, row_scaled_activation=row_scaled_activation
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    dx_ref = torch._grouped_mm(dy, B.detach(), offs=offs, out_dtype=torch.bfloat16)
+    dw_ref = torch._grouped_mm(
+        dy.transpose(-2, -1), A.detach(), offs=offs, out_dtype=torch.bfloat16
+    )
+    torch.testing.assert_close(A.grad, dx_ref, atol=0, rtol=0)
+    torch.testing.assert_close(B.grad, dw_ref, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+@pytest.mark.parametrize("weight_block", ["16x16", "1x16"])
+def test_grouped_backward_dequantized(row_scaled_activation, weight_block):
+    """dx/dw are bf16 grouped GEMMs on dequantized fprop operands."""
+    group_sizes = [128, 256, 128]
+    K, N = 256, 384
+    A, B, offs = _make_grouped_inputs(group_sizes, K=K, N=N)
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    y = four_over_six_grouped_mm(
+        A,
+        B,
+        offs,
+        err_mode="mse",
+        row_scaled_activation=row_scaled_activation,
+        weight_block=weight_block,
+        backward_override="dequantized",
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    A_hp, B_hp = A.detach(), B.detach()
+    if row_scaled_activation:
+        x_amax = A_hp.abs().amax(dim=1).to(torch.float32)
+    else:
+        group_amax = []
+        start = 0
+        for end in offs.tolist():
+            group_amax.append(A_hp[start:end].abs().amax().to(torch.float32))
+            start = end
+        x_amax = torch.stack(group_amax).repeat_interleave(
+            torch.tensor(group_sizes, device=A.device)
+        )
+    x_codes, x_scales = four_over_six_quantize(A_hp, x_amax, err_mode="mse")
+    x_dq = nvfp4_dequantize(x_codes, x_scales, x_amax)
+    w_dq = []
+    for e in range(B.shape[0]):
+        w_amax = B_hp[e].abs().amax().to(torch.float32)
+        w_codes, w_scales = four_over_six_quantize(
+            B_hp[e], w_amax, block=weight_block, err_mode="mse"
+        )
+        w_dq.append(nvfp4_dequantize(w_codes, w_scales, w_amax))
+    w_dq = torch.stack(w_dq)
+
+    dx_ref = torch._grouped_mm(dy, w_dq, offs=offs, out_dtype=torch.bfloat16)
+    dw_ref = torch._grouped_mm(
+        dy.transpose(-2, -1), x_dq, offs=offs, out_dtype=torch.bfloat16
+    )
+    torch.testing.assert_close(A.grad, dx_ref, atol=0, rtol=0)
+    torch.testing.assert_close(B.grad, dw_ref, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("backward_override", ["high_precision", "dequantized"])
+def test_grouped_backward_empty_groups(backward_override):
+    """Decode-like offsets with zero-size groups, forward and backward.
+
+    dx/dw are bitwise vs the same grouped GEMMs on the reference operands;
+    experts that received no tokens get all-zero weight gradients.
+    """
+    group_sizes = [128, 0, 256, 0, 0, 128]
+    K, N = 256, 384
+    A, B, offs = _make_grouped_inputs(group_sizes, K=K, N=N, seed=9)
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    y = four_over_six_grouped_mm(
+        A,
+        B,
+        offs,
+        row_scaled_activation=True,
+        backward_override=backward_override,
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    A_hp, B_hp = A.detach(), B.detach()
+    if backward_override == "high_precision":
+        x_ref, w_ref = A_hp, B_hp
+    else:
+        x_amax = A_hp.abs().amax(dim=1).to(torch.float32)
+        x_codes, x_scales = four_over_six_quantize(A_hp, x_amax)
+        x_ref = nvfp4_dequantize(x_codes, x_scales, x_amax)
+        w_dq = []
+        for e in range(B.shape[0]):
+            w_amax = B_hp[e].abs().amax().to(torch.float32)
+            w_codes, w_scales = four_over_six_quantize(B_hp[e], w_amax, block="16x16")
+            w_dq.append(nvfp4_dequantize(w_codes, w_scales, w_amax))
+        w_ref = torch.stack(w_dq)
+
+    dx_ref = torch._grouped_mm(dy, w_ref, offs=offs, out_dtype=torch.bfloat16)
+    dw_ref = torch._grouped_mm(
+        dy.transpose(-2, -1), x_ref, offs=offs, out_dtype=torch.bfloat16
+    )
+    torch.testing.assert_close(A.grad, dx_ref, atol=0, rtol=0)
+    torch.testing.assert_close(B.grad, dw_ref, atol=0, rtol=0)
+    empty = [e for e, size in enumerate(group_sizes) if size == 0]
+    assert (B.grad[empty] == 0).all()
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+def test_grouped_padding_matches_aligned(row_scaled_activation, monkeypatch):
+    """Unaligned groups with padding == an aligned construction, per group.
+
+    The row-scaled dense references emulate the fused grouped GEMM's bf16
+    output rounding (see the loop-oracle test) so the comparison stays
+    bitwise; padding semantics are identical on every path.
+    """
+    if row_scaled_activation:
+        dense_gemm = four_over_six_module._scaled_mm_nvfp4
+        monkeypatch.setattr(
+            four_over_six_module,
+            "_scaled_mm_nvfp4",
+            lambda *args: dense_gemm(*args).to(torch.bfloat16).to(torch.float32),
+        )
+    K, N = 256, 384
+    aligned_sizes = [128, 256, 128]
+    ragged_sizes = [100, 220, 77]
+    A_al, B, offs_al = _make_grouped_inputs(aligned_sizes, K=K, N=N, seed=3)
+    # Ragged view: the first rows of each aligned group, so every ragged
+    # group's rows (and hence its amax and quantization) exist verbatim in
+    # the aligned run.
+    ragged_rows = []
+    start = 0
+    for size, ragged in zip(aligned_sizes, ragged_sizes):
+        ragged_rows.append(A_al[start : start + ragged])
+        start += size
+    A_rg = torch.cat(ragged_rows).contiguous()
+    offs_rg = torch.tensor(ragged_sizes, dtype=torch.int32, device=A_al.device).cumsum(
+        0, dtype=torch.int32
+    )
+
+    y_rg = four_over_six_grouped_mm(
+        A_rg,
+        B,
+        offs_rg,
+        row_scaled_activation=row_scaled_activation,
+        pad_token_groups_for_grouped_mm=True,
+    )
+    assert y_rg.shape == (sum(ragged_sizes), N)
+
+    # Reference: dense per-group forward on the ragged rows padded to 128.
+    start = 0
+    for e, ragged in enumerate(ragged_sizes):
+        rows = A_rg[start : start + ragged]
+        padded = torch.zeros(
+            128 * ((ragged + 127) // 128), K, dtype=rows.dtype, device=rows.device
+        )
+        padded[:ragged] = rows
+        if row_scaled_activation:
+            ref = four_over_six_linear(padded, B[e], None, "mae", 256, True)
+        else:
+            # Per-tensor group scale comes from the real rows' amax; the
+            # zero padding rows cannot change it.
+            ref = four_over_six_linear(
+                padded, B[e], None, "mae", 256, False, "high_precision"
+            )
+        torch.testing.assert_close(
+            y_rg[start : start + ragged], ref[:ragged], atol=0, rtol=0
+        )
+        start += ragged
+
+
+@_skip_no_sm100
+def test_grouped_validation():
+    group_sizes = [128, 128]
+    A, B, offs = _make_grouped_inputs(group_sizes, K=256, N=128)
+    with pytest.raises(ValueError, match="no quantized backward"):
+        four_over_six_grouped_mm(A, B, offs, backward_override="quantized")
+    with pytest.raises(ValueError, match="1D int32"):
+        four_over_six_grouped_mm(A, B, offs.to(torch.int64))
+    with pytest.raises(ValueError, match="one group-end offset per expert"):
+        four_over_six_grouped_mm(A, B, offs[:1])
+    with pytest.raises(ValueError, match="divisible by 128"):
+        four_over_six_grouped_mm(A[:, :144], B[:, :, :144].contiguous(), offs)
+
+
+@_skip_no_sm100
+def test_grouped_rl_rollout_recipe_point():
+    """The RL rollout recipe point: row-scaled + MSE + bound 256 + 1x16
+    weights + dequantized backward, on ragged token groups."""
+    group_sizes = [100, 220, 77]
+    A, B, offs = _make_grouped_inputs(group_sizes, K=256, N=384, seed=7)
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    y = four_over_six_grouped_mm(
+        A,
+        B,
+        offs,
+        err_mode="mse",
+        e4m3_scale_bound=256,
+        row_scaled_activation=True,
+        weight_block="1x16",
+        backward_override="dequantized",
+        pad_token_groups_for_grouped_mm=True,
+    )
+    assert y.shape == (sum(group_sizes), 384)
+    y.backward(torch.randn_like(y))
+    assert A.grad is not None and A.grad.shape == A.shape
+    assert B.grad is not None and B.grad.shape == B.shape
+    sqnr = compute_error(
+        torch._grouped_mm(A.detach(), B.detach().transpose(-2, -1), offs=offs).float(),
+        y.float(),
+    )
+    assert sqnr > 14.0, f"quantization noise floor too high: {sqnr:.1f} dB"
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+@pytest.mark.parametrize("weight_block", ["16x16", "1x16"])
+def test_grouped_backward_dequantized_ragged(row_scaled_activation, weight_block):
+    """Ragged groups + padding + dequantized backward, value-checked.
+
+    This is the composition the torchtitan grouped-experts hook ships;
+    the padded rows quantize to zeros and are unpadded away before the
+    backward GEMMs, so the reference can quantize the ragged rows directly.
+    """
+    group_sizes = [100, 220, 77]
+    K, N = 256, 384
+    A, B, offs = _make_grouped_inputs(group_sizes, K=K, N=N, seed=7)
+    A.requires_grad_(True)
+    B.requires_grad_(True)
+    y = four_over_six_grouped_mm(
+        A,
+        B,
+        offs,
+        err_mode="mse",
+        row_scaled_activation=row_scaled_activation,
+        weight_block=weight_block,
+        backward_override="dequantized",
+        pad_token_groups_for_grouped_mm=True,
+    )
+    dy = torch.randn_like(y)
+    y.backward(dy)
+
+    A_hp, B_hp = A.detach(), B.detach()
+    if row_scaled_activation:
+        x_amax = A_hp.abs().amax(dim=1).to(torch.float32)
+    else:
+        # Group amaxes come from the real rows; zero padding cannot raise them.
+        group_amax = []
+        start = 0
+        for end in offs.tolist():
+            group_amax.append(A_hp[start:end].abs().amax().to(torch.float32))
+            start = end
+        x_amax = torch.stack(group_amax).repeat_interleave(
+            torch.tensor(group_sizes, device=A.device)
+        )
+    x_codes, x_scales = four_over_six_quantize(A_hp, x_amax, err_mode="mse")
+    x_dq = nvfp4_dequantize(x_codes, x_scales, x_amax)
+    w_dq = []
+    for e in range(B.shape[0]):
+        w_amax = B_hp[e].abs().amax().to(torch.float32)
+        w_codes, w_scales = four_over_six_quantize(
+            B_hp[e], w_amax, block=weight_block, err_mode="mse"
+        )
+        w_dq.append(nvfp4_dequantize(w_codes, w_scales, w_amax))
+    w_dq = torch.stack(w_dq)
+
+    dx_ref = torch._grouped_mm(dy, w_dq, offs=offs, out_dtype=torch.bfloat16)
+    dw_ref = torch._grouped_mm(
+        dy.transpose(-2, -1), x_dq, offs=offs, out_dtype=torch.bfloat16
+    )
+    torch.testing.assert_close(A.grad, dx_ref, atol=0, rtol=0)
+    torch.testing.assert_close(B.grad, dw_ref, atol=0, rtol=0)
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("tail_rows", [0, 128])
+def test_dispatcher_grouped_mm_four_over_six(tail_rows):
+    """NVFP4FourOverSixTrainingOpConfig drives this op through the grouped
+    GEMM dispatcher, bitwise vs a direct call.
+
+    The dispatcher hands weights over as B_t = (E, K, N). Activation
+    buffers over-allocated past offs[-1] (padded token dispatchers
+    over-allocate to worst-case capacity) come back zero-extended with
+    zero tail gradients, and the logical rows match the exact-shape
+    reference — proof the garbage tail cannot feed the per-group amaxes.
+    """
+    group_sizes = [128, 256, 128]
+    K, N = 256, 384
+    A, B, offs = _make_grouped_inputs(group_sizes, K=K, N=N, seed=17)
+    M_logical = A.shape[0]
+    if tail_rows:
+        # Garbage tail: any leak into the last group's amax would flip its
+        # scale chain and break the bitwise comparison below.
+        tail = torch.full((tail_rows, K), 123.0, dtype=A.dtype, device=A.device)
+        A = torch.cat([A, tail])
+    kwargs = dict(
+        err_mode="mse",
+        e4m3_scale_bound=256,
+        row_scaled_activation=False,
+        weight_block="1x16",
+        backward_override="dequantized",
+        pad_token_groups_for_grouped_mm=False,
+    )
+    config = NVFP4FourOverSixTrainingOpConfig(**kwargs)
+
+    A_d = A.clone().requires_grad_(True)
+    B_d = B.clone().requires_grad_(True)
+    y_d = _quantize_then_scaled_grouped_mm(
+        A_d, B_d.transpose(-2, -1), config=config, offs=offs
+    )
+    assert y_d.shape == (A.shape[0], N)
+    dy = torch.randn_like(y_d)
+    y_d.backward(dy)
+
+    A_r = A[:M_logical].clone().requires_grad_(True)
+    B_r = B.clone().requires_grad_(True)
+    y_r = four_over_six_grouped_mm(A_r, B_r, offs, **kwargs)
+    y_r.backward(dy[:M_logical])
+
+    torch.testing.assert_close(y_d[:M_logical], y_r, atol=0, rtol=0)
+    torch.testing.assert_close(A_d.grad[:M_logical], A_r.grad, atol=0, rtol=0)
+    torch.testing.assert_close(B_d.grad, B_r.grad, atol=0, rtol=0)
+    if tail_rows:
+        assert (y_d[M_logical:] == 0).all()
+        assert (A_d.grad[M_logical:] == 0).all()
+
+
+@_skip_no_sm100
+@pytest.mark.parametrize("backward_override", ["high_precision", "dequantized"])
+@pytest.mark.parametrize("row_scaled_activation", [False, True])
+def test_grouped_compile(backward_override, row_scaled_activation):
+    """fullgraph compile of the grouped op, forward and backward.
+
+    The op is nonstrict-traced under compile, so eager numerics carry over
+    bitwise. Both scale granularities compile: the row-scaled forward is a
+    single fused grouped GEMM with no host reads.
+    """
+    group_sizes = [128, 256, 128]
+    A, B, offs = _make_grouped_inputs(group_sizes, K=256, N=384, seed=11)
+
+    # Compile the decorated op directly (the mxfp8 grouped test's pattern);
+    # calling a nonstrict-traced function from a compiled frame is rejected.
+    A_e = A.clone().requires_grad_(True)
+    B_e = B.clone().requires_grad_(True)
+    y_eager = four_over_six_grouped_mm(
+        A_e,
+        B_e,
+        offs,
+        err_mode="mse",
+        row_scaled_activation=row_scaled_activation,
+        backward_override=backward_override,
+    )
+    dy = torch.randn_like(y_eager)
+    y_eager.backward(dy)
+
+    A_c = A.clone().requires_grad_(True)
+    B_c = B.clone().requires_grad_(True)
+    try:
+        y_compiled = torch.compile(four_over_six_grouped_mm, fullgraph=True)(
+            A_c,
+            B_c,
+            offs,
+            err_mode="mse",
+            row_scaled_activation=row_scaled_activation,
+            backward_override=backward_override,
+        )
+    except torch._dynamo.exc.Unsupported as e:
+        if "nonstrict_trace" in str(e):
+            pytest.skip(
+                "this torch build rejects autograd.Function outputs from "
+                "nonstrict_trace-ed functions (the mxfp8 grouped compile "
+                "test's pattern); coverage resumes on builds that accept it"
+            )
+        raise
+    y_compiled.backward(dy)
+
+    torch.testing.assert_close(y_compiled, y_eager, atol=0, rtol=0)
+    torch.testing.assert_close(A_c.grad, A_e.grad, atol=0, rtol=0)
+    torch.testing.assert_close(B_c.grad, B_e.grad, atol=0, rtol=0)

--- a/torchao/prototype/moe_training/README.md
+++ b/torchao/prototype/moe_training/README.md
@@ -13,6 +13,7 @@
   - [End-to-end training benchmark with TorchTitan: Llama4 Scout vs bfloat16 baseline](#end-to-end-training-benchmark-with-torchtitan-llama4-scout-vs-bfloat16-baseline)
 - [Implementation details for developers](#implementation-details-for-developers)
 - [Limitations](#limitations)
+- [NVFP4 four-over-six MoE training](#nvfp4-four-over-six-moe-training)
 
 ## Overview
 This prototype provides:
@@ -317,3 +318,29 @@ For all other ops, these training tensor subclasses behave like regular torch.Te
 
 ## Limitations
 - The new CUDA kernel for MXFP8 quantization of the non-transposed expert weights in the backwards pass does not support TP yet.
+
+## NVFP4 four-over-six MoE training
+NVFP4 four-over-six is a prototype adaptive block-scaling recipe: per
+16-value block, the standard map-to-6 encoding competes with a 1.5x-scale
+map-to-4 candidate and the lower-error one is kept. Forward grouped
+GEMMs run in NVFP4 (each token group quantized as its own tensor); backwards
+are high-precision or dequantized grouped GEMMs only (no quantized backward). Requires SM100+, PyTorch 2.10+, the CuTe DSL runtime packages
+(`nvidia-cutlass-dsl`, `cuda-python`, `apache-tvm-ffi`) for the quantize
+fast path, and K/N % 128 == 0 with 128-row-aligned token groups (or
+`pad_token_groups_for_grouped_mm=True`).
+The grouped op is traceable under `torch.compile` (nonstrict trace) in
+both scale granularities; the grouped GEMM dispatcher branch is eager-only
+(it reads `offs[-1]` on the host for the over-allocation tail slice).
+```python
+import torch
+from torchao.prototype.moe_training.nvfp4_training.four_over_six_grouped import (
+    four_over_six_grouped_mm,
+)
+
+# A: (M, K) packed token groups, B: (E, N, K) expert weights,
+# offs: cumulative int32 group-end offsets.
+out = four_over_six_grouped_mm(A, B, offs, row_scaled_activation=True)
+```
+Framework integrations drive the same op through the grouped GEMM
+dispatcher with `NVFP4FourOverSixTrainingOpConfig` (see the torchtitan
+converters); `quantize_` model conversion for this config is future work.

--- a/torchao/prototype/moe_training/config.py
+++ b/torchao/prototype/moe_training/config.py
@@ -227,6 +227,67 @@ class MXFP8TrainingOpConfig(TrainingOpBaseConfig):
         )
 
 
+# register as pytree constant so we can use dynamo nonstrict trace in torchao.prototype.moe_training.ep
+@register_as_pytree_constant
+@dataclass
+class NVFP4FourOverSixTrainingOpConfig(TrainingOpBaseConfig):
+    """
+    The NVFP4FourOverSixTrainingOpConfig defines the NVFP4 four-over-six
+    training config for grouped GEMM ops.
+
+    Four-over-six scores two candidate encodings per 16-value block and keeps
+    the lower-error one; the knobs mirror
+    ``torchao.prototype.moe_training.nvfp4_training.four_over_six_grouped.four_over_six_grouped_mm``,
+    which the grouped GEMM dispatcher drives from this config.
+    """
+
+    # Candidate-selection error metric for four-over-six, "mae" or "mse".
+    err_mode: str = "mae"
+
+    # Global E4M3 scale bound; 256 leaves map-to-4 headroom, 448 uses the full range.
+    e4m3_scale_bound: int = 256
+
+    # Whether to derive one FP32 global scale per activation row instead of per token group.
+    row_scaled_activation: bool = False
+
+    # Weight quantization block shape, "16x16" or "1x16".
+    weight_block: str = "16x16"
+
+    # Backward computation override for the grouped GEMM. None or "high_precision"
+    # computes both gradients with plain grouped GEMMs on the saved high-precision
+    # operands. "dequantized" computes them from the dequantized forward operands.
+    # Grouped four-over-six has no quantized backward.
+    backward_override: Optional[str] = None
+
+    # Whether to pad the token group sizes to multiples of 128 (the grouped GEMM alignment).
+    pad_token_groups_for_grouped_mm: bool = False
+
+    def __eq__(self, other):
+        if isinstance(other, NVFP4FourOverSixTrainingOpConfig):
+            return (
+                self.err_mode == other.err_mode
+                and self.e4m3_scale_bound == other.e4m3_scale_bound
+                and self.row_scaled_activation == other.row_scaled_activation
+                and self.weight_block == other.weight_block
+                and self.backward_override == other.backward_override
+                and self.pad_token_groups_for_grouped_mm
+                == other.pad_token_groups_for_grouped_mm
+            )
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(
+            (
+                self.err_mode,
+                self.e4m3_scale_bound,
+                self.row_scaled_activation,
+                self.weight_block,
+                self.backward_override,
+                self.pad_token_groups_for_grouped_mm,
+            )
+        )
+
+
 @register_quantize_module_handler(Float8TrainingOpConfig)
 @register_quantize_module_handler(MXFP8TrainingOpConfig)
 def _moe_training_transform(

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
@@ -82,6 +82,11 @@ from torchao.prototype.mx_formats.kernels import (
 )
 from torchao.prototype.mx_formats.utils import to_blocked
 
+from .four_over_six_cutedsl import (
+    _cutedsl_quantize_eligible,
+    four_over_six_quantize_cutedsl,
+)
+
 FP4_E2M1_MAX = 6.0
 FP8_E4M3_MAX = 448.0
 _FP32_MAX = torch.finfo(torch.float32).max
@@ -213,6 +218,17 @@ def four_over_six_quantize(
         raise ValueError(
             f"global_amax must be a scalar or a ({rows},) row vector, "
             f"got shape {tuple(global_amax.shape)}"
+        )
+
+    # Fast path: the CuTe DSL kernel is an op-for-op reimplementation of the
+    # arithmetic below with bitwise-identical codes and scales — except NaN
+    # inputs, which take NaN-dropping block amaxes and +6 codes in the
+    # kernel while this body's torch.amax propagates NaN into the scales;
+    # see the op docstring. Ineligible shapes/dtypes and pre-SM100 devices
+    # silently fall through to the pure-PyTorch body.
+    if _cutedsl_quantize_eligible(x):
+        return four_over_six_quantize_cutedsl(
+            x, global_amax, block, err_mode, e4m3_scale_bound
         )
 
     xf = x.float().view(rows, cols // 16, 16)

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
@@ -1,0 +1,713 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""NVFP4 four-over-six quantization and the linear layer that consumes it.
+
+Four-over-six is an adaptive NVFP4 block-scaling recipe: every quantization
+block is encoded twice and the candidate with the lower dequantization error
+is stored.
+
+* The **map-to-6** candidate is the standard NVFP4 encoding: the E4M3 block
+  scale maps the block amax to FP4 value 6.
+* The **map-to-4** candidate expands the E4M3 block scale by 1.5x, so FP4
+  value 4 reaches the range that value 6 reaches in the standard encoding.
+  The FP4 grid is denser around 4 than around 6, which lowers error for
+  blocks whose mass sits below the amax.
+
+Errors are compared per block with a configurable metric (mean-absolute or
+mean-squared, computed in the input domain); ties select map-to-6. To leave
+E4M3 headroom for the 1.5x scale expansion, the global (per-tensor) scale is
+derived from a reduced E4M3 bound of 256 by default instead of 448.
+
+Two global-scale granularities are supported for activations:
+
+* per-tensor: one FP32 scale for the whole tensor (the default), and
+* row-wise: one FP32 scale per tensor row, derived from that row's amax.
+
+The reference arithmetic pins every rounding step, so results are
+reproducible bit for bit across implementations. Two details are
+load-bearing:
+
+* The block-scale association is ``(block_amax / 6) * S_enc`` — one division
+  then one multiply. The standard NVFP4 path uses
+  ``block_amax * (S_enc * (1/6))``, which rounds differently on a fraction of
+  blocks.
+* The per-block error is accumulated sequentially in element order with FP32
+  round-to-nearest adds, and 16x16 tiles reduce their 16 row-group errors in
+  a pairwise halving tree. Both orders affect candidate selection on ties
+  near the FP32 rounding boundary.
+
+``four_over_six_linear`` mirrors the recipe's training semantics:
+
+* forward GEMM: activations quantized 1x16 four-over-six (optionally
+  row-scaled), weights quantized 16x16 four-over-six;
+* backward with per-tensor activations: gradients use standard NVFP4
+  round-to-nearest-even (four-over-six never applies to gradients), and the
+  saved columnwise activation/weight codes are four-over-six;
+* backward with row-scaled activations: high-precision (bf16) GEMMs. A
+  row-scaled four-over-six tensor has no columnwise form — the per-row scales
+  do not transpose — so the quantized wgrad operand cannot be produced.
+
+Those backward defaults can be overridden with ``backward_override``:
+
+* ``"quantized"``: the standard-NVFP4-gradient backward above (the
+  per-tensor default; rejected for row-scaled activations);
+* ``"high_precision"``: bf16 GEMMs on the saved original operands (the
+  row-scaled default);
+* ``"dequantized"``: bf16 GEMMs on dequantizations of the rowwise operands
+  the forward GEMM consumed, so the gradients differentiate the
+  quantized-forward function itself — the RL train/inference-consistency
+  mode. Only 4-bit codes and scales are saved for backward, which also
+  cuts activation memory.
+
+Weights quantize with 16x16 tiles by default; ``weight_block="1x16"`` selects
+rowwise blocks instead.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torchao.prototype.mx_formats.kernels import (
+    f4_unpacked_to_f32,
+    f32_to_f4_unpacked,
+    pack_uint4,
+    unpack_uint4,
+)
+from torchao.prototype.mx_formats.utils import to_blocked
+
+FP4_E2M1_MAX = 6.0
+FP8_E4M3_MAX = 448.0
+_FP32_MAX = torch.finfo(torch.float32).max
+
+__all__ = [
+    "four_over_six_global_encode_scale",
+    "four_over_six_quantize",
+    "nvfp4_dequantize",
+    "four_over_six_mm",
+    "four_over_six_linear",
+    "NVFP4FourOverSixLinear",
+]
+
+
+def four_over_six_global_encode_scale(
+    global_amax: torch.Tensor, e4m3_scale_bound: int = 256
+) -> torch.Tensor:
+    """Global encode scale: bound * 6 / amax.
+
+    ``global_amax`` may be a scalar (per-tensor) or a 1-D per-row vector.
+    ``amax == 0`` gives inf and an enormous amax underflows the scale to
+    zero; both fall back to the identity scale.
+    """
+    amax = global_amax.to(torch.float32)
+    candidate = torch.full_like(amax, float(e4m3_scale_bound) * FP4_E2M1_MAX) / amax
+    candidate = candidate.clamp(max=_FP32_MAX)
+    return torch.where(
+        (amax == 0.0) | (candidate == 0.0), torch.ones_like(candidate), candidate
+    )
+
+
+def _fp4_rtne(scaled: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Round-to-nearest-even FP4 codes and their exact FP32 values.
+
+    Reproduces ``cvt.rn.satfinite.e2m1x2.f32`` followed by
+    ``cvt.rn.f16x2.e2m1x2`` (E2M1 values are exact in FP16 and FP32).
+    """
+    clamped = scaled.clamp(-FP4_E2M1_MAX, FP4_E2M1_MAX)
+    codes = f32_to_f4_unpacked(clamped)
+    return codes, f4_unpacked_to_f32(codes)
+
+
+def _candidate_error(
+    values: torch.Tensor,
+    scale_fp8: torch.Tensor,
+    xf: torch.Tensor,
+    global_amax: torch.Tensor,
+    err_mode: str,
+    e4m3_scale_bound: int,
+) -> torch.Tensor:
+    """Per-block dequantization error: FP32 adds in element order, per 1x16 group.
+
+    values/xf: (rows, num_groups, 16); scale_fp8: (rows, num_groups, 1);
+    global_amax broadcastable against (rows, num_groups).
+    """
+    sf = scale_fp8.to(torch.float32)[..., 0]
+    # The denominator must be a tensor: dividing by a python scalar lowers to a
+    # multiply by its (inexact) reciprocal, which double-rounds and flips
+    # candidate picks near error ties. Tensor-tensor division is a true
+    # correctly-rounded FP32 division.
+    err_denom = torch.full(
+        (),
+        FP4_E2M1_MAX * float(e4m3_scale_bound),
+        dtype=torch.float32,
+        device=xf.device,
+    )
+    err = torch.zeros_like(xf[..., 0])
+    for idx in range(16):
+        val = ((values[..., idx] * sf) * global_amax) / err_denom
+        diff = val - xf[..., idx]
+        if err_mode == "mse":
+            err = err + diff * diff
+        else:
+            err = err + diff.abs()
+    return err
+
+
+def _tile_error_tree_sum(err: torch.Tensor) -> torch.Tensor:
+    """Reduce 16 row-group errors per 16x16 tile in the warp-shuffle tree order.
+
+    err: (rows, num_groups) with rows % 16 == 0 -> (rows // 16, num_groups).
+    """
+    rows = err.view(err.shape[0] // 16, 16, err.shape[1])
+    rows = rows[:, 0:8] + rows[:, 8:16]
+    rows = rows[:, 0:4] + rows[:, 4:8]
+    rows = rows[:, 0:2] + rows[:, 2:4]
+    return rows[:, 0] + rows[:, 1]
+
+
+def four_over_six_quantize(
+    x: torch.Tensor,
+    global_amax: torch.Tensor,
+    *,
+    block: str = "1x16",
+    err_mode: str = "mae",
+    e4m3_scale_bound: int = 256,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2-D tensor to NVFP4 with four-over-six block selection.
+
+    Args:
+        x: (R, C) bfloat16 or float32, C % 16 == 0 (R % 16 == 0 for 16x16).
+        global_amax: scalar FP32 amax, or a (R,) per-row amax vector for the
+            row-scaled variant (1x16 blocks only).
+        block: "1x16" (activations/gradient operands) or "16x16" (weights).
+        err_mode: "mae" or "mse" candidate-selection error metric.
+        e4m3_scale_bound: 256 (default, leaves map-to-4 headroom) or 448.
+
+    Returns:
+        (codes, scales): (R, C//2) uint8 packed FP4 codes (low nibble = even
+        element) and (R, C//16) float8_e4m3fn block scales.
+    """
+    if block not in ("1x16", "16x16"):
+        raise ValueError(f"block must be '1x16' or '16x16', got {block!r}")
+    if err_mode not in ("mae", "mse"):
+        raise ValueError(f"err_mode must be 'mae' or 'mse', got {err_mode!r}")
+    if e4m3_scale_bound not in (256, 448):
+        raise ValueError(f"e4m3_scale_bound must be 256 or 448, got {e4m3_scale_bound}")
+    if x.dim() != 2:
+        raise ValueError(f"x must be 2D, got {x.dim()}D")
+    rows, cols = x.shape
+    if cols % 16 != 0:
+        raise ValueError(f"C must be divisible by 16, got C={cols}")
+    if block == "16x16" and rows % 16 != 0:
+        raise ValueError(f"16x16 blocks require R divisible by 16, got R={rows}")
+    row_scaled = global_amax.dim() == 1 and global_amax.numel() == rows
+    if row_scaled and block != "1x16":
+        raise ValueError("row-scaled four-over-six supports 1x16 blocks only")
+    if not row_scaled and global_amax.numel() != 1:
+        raise ValueError(
+            f"global_amax must be a scalar or a ({rows},) row vector, "
+            f"got shape {tuple(global_amax.shape)}"
+        )
+
+    xf = x.float().view(rows, cols // 16, 16)
+    s_enc = four_over_six_global_encode_scale(global_amax, e4m3_scale_bound)
+    if row_scaled:
+        s_enc = s_enc.view(rows, 1)
+        err_amax = global_amax.to(torch.float32).view(rows, 1)
+    else:
+        err_amax = global_amax.to(torch.float32)
+
+    if block == "16x16":
+        tiles = xf.abs().view(rows // 16, 16, cols // 16, 16)
+        block_amax = tiles.amax(dim=(1, 3)).repeat_interleave(16, dim=0)
+    else:
+        block_amax = xf.abs().amax(dim=-1)
+
+    # Scale-pair construction: base = (block_amax / 6) * S_enc, then the 1.5x
+    # map-to-4 expansion; both capped at the full E4M3 range. The divisor is a
+    # tensor for a true correctly-rounded FP32 division (a python-scalar
+    # divisor lowers to a reciprocal multiply, which double-rounds).
+    fp4_max = torch.full((), FP4_E2M1_MAX, dtype=torch.float32, device=xf.device)
+    base = (block_amax / fp4_max) * s_enc
+    scale6 = base.clamp(max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    scale4 = (base * 1.5).clamp(max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    s_dec = 1.0 / s_enc
+    inv6 = (1.0 / (scale6.to(torch.float32) * s_dec)).clamp(max=_FP32_MAX)
+    inv4 = (1.0 / (scale4.to(torch.float32) * s_dec)).clamp(max=_FP32_MAX)
+
+    codes6, values6 = _fp4_rtne(xf * inv6.unsqueeze(-1))
+    codes4, values4 = _fp4_rtne(xf * inv4.unsqueeze(-1))
+    err6 = _candidate_error(
+        values6, scale6.unsqueeze(-1), xf, err_amax, err_mode, e4m3_scale_bound
+    )
+    err4 = _candidate_error(
+        values4, scale4.unsqueeze(-1), xf, err_amax, err_mode, e4m3_scale_bound
+    )
+    if block == "16x16":
+        pick4 = (
+            _tile_error_tree_sum(err4) < _tile_error_tree_sum(err6)
+        ).repeat_interleave(16, dim=0)
+    else:
+        pick4 = err4 < err6
+
+    codes = torch.where(pick4.unsqueeze(-1), codes4, codes6)
+    scales = torch.where(pick4, scale4, scale6)
+    return pack_uint4(codes.view(rows, cols)), scales
+
+
+def nvfp4_dequantize(
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_amax: torch.Tensor,
+    *,
+    e4m3_scale_bound: int = 256,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize packed NVFP4 codes and block scales back to high precision.
+
+    This is the standard NVFP4 decode — four-over-six changes only the
+    encode-side scale selection. It is a pure-PyTorch correctness helper,
+    not an optimized kernel; a fused decode kernel is future work (TODO).
+    The per-block decode scale is ``(f32(scale) * amax) *
+    factor_inv`` with ``factor_inv = 1 / (6 * bound)`` a correctly-rounded
+    FP32 reciprocal, and each element is ``f32(code) * decode_scale`` cast to
+    ``out_dtype``. Scales from either block granularity dequantize
+    identically (a 16x16 tile stores its scale byte on every row).
+
+    Args:
+        codes: (R, C//2) uint8 packed FP4 codes.
+        scales: (R, C//16) float8_e4m3fn block scales.
+        global_amax: scalar FP32 amax, or a (R,) per-row amax vector for the
+            row-scaled variant.
+        e4m3_scale_bound: the bound the codes were quantized with (this
+            recipe family defaults to 256; standard NVFP4 uses 448).
+        out_dtype: output dtype (the kernel's OType cast).
+    """
+    if e4m3_scale_bound not in (256, 448):
+        raise ValueError(f"e4m3_scale_bound must be 256 or 448, got {e4m3_scale_bound}")
+    rows, packed_cols = codes.shape
+    cols = packed_cols * 2
+    if scales.shape != (rows, cols // 16):
+        raise ValueError(
+            f"scales must have shape ({rows}, {cols // 16}), got {tuple(scales.shape)}"
+        )
+    row_scaled = global_amax.dim() == 1 and global_amax.numel() == rows
+    if not row_scaled and global_amax.numel() != 1:
+        raise ValueError(
+            f"global_amax must be a scalar or a ({rows},) row vector, "
+            f"got shape {tuple(global_amax.shape)}"
+        )
+    return _nvfp4_dequantize_op(codes, scales, global_amax, e4m3_scale_bound, out_dtype)
+
+
+# Registered as a custom op so torch.compile keeps the eager decode: inductor
+# codegen of the fused unpack + broadcast-scale graph miscompiles the
+# low-nibble lane (torch 2.14 nightly), and the dequantized backward's whole
+# contract is bitwise parity with the fprop operands.
+# TODO: file the upstream pytorch inductor issue and cite it here as the
+# removal trigger for this workaround.
+@torch.library.custom_op("torchao::nvfp4_dequantize", mutates_args=())
+def _nvfp4_dequantize_op(
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_amax: torch.Tensor,
+    e4m3_scale_bound: int,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    rows, packed_cols = codes.shape
+    cols = packed_cols * 2
+    row_scaled = global_amax.dim() == 1 and global_amax.numel() == rows
+    values = f4_unpacked_to_f32(unpack_uint4(codes)).view(rows, cols // 16, 16)
+    amax = global_amax.to(torch.float32)
+    if row_scaled:
+        amax = amax.view(rows, 1)
+    # The reciprocal must come from a true FP32 division (see _candidate_error
+    # on why a python-scalar denominator double-rounds).
+    factor_inv = torch.ones((), dtype=torch.float32, device=codes.device) / torch.full(
+        (),
+        FP4_E2M1_MAX * float(e4m3_scale_bound),
+        dtype=torch.float32,
+        device=codes.device,
+    )
+    decode_scale = (scales.to(torch.float32) * amax) * factor_inv
+    return (values * decode_scale.unsqueeze(-1)).to(out_dtype).view(rows, cols)
+
+
+@_nvfp4_dequantize_op.register_fake
+def _(codes, scales, global_amax, e4m3_scale_bound, out_dtype):
+    return codes.new_empty((codes.shape[0], codes.shape[1] * 2), dtype=out_dtype)
+
+
+def _standard_rtne_quantize(
+    x: torch.Tensor, global_amax: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Standard NVFP4 1x16 round-to-nearest-even quantize for gradient operands.
+
+    The gradient scale chain keeps the standard association
+    ``block_amax * (S_enc * (1/6))`` and the full 448 E4M3 bound; only
+    non-gradient four-over-six tensors use the ``(block_amax / 6) * S_enc``
+    association above.
+    """
+    rows, cols = x.shape
+    xf = x.float().view(rows, cols // 16, 16)
+    s_enc = four_over_six_global_encode_scale(global_amax, e4m3_scale_bound=448)
+    block_amax = xf.abs().amax(dim=-1)
+    scales = (
+        (block_amax * (s_enc * (1.0 / FP4_E2M1_MAX)))
+        .clamp(max=FP8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+    )
+    enc = (1.0 / (scales.to(torch.float32) * (1.0 / s_enc))).clamp(max=_FP32_MAX)
+    codes, _ = _fp4_rtne(xf * enc.unsqueeze(-1))
+    return pack_uint4(codes.view(rows, cols)), scales
+
+
+def _global_decode_scale(amax: torch.Tensor, e4m3_scale_bound: int) -> torch.Tensor:
+    """Per-tensor decode scale consumed by the GEMM: amax / (bound * 6).
+
+    The scalar divisor (a reciprocal-multiply lowering) is fine here, unlike
+    the encode chain's tensor divisors: this factor never enters the encode
+    arithmetic — consumers reconstruct it for the GEMM's per-tensor scale
+    slot — so it sits outside the div.rn encode contract, and the
+    linear-level tests pin the resulting GEMM outputs.
+    """
+    return amax.to(torch.float32) / (float(e4m3_scale_bound) * FP4_E2M1_MAX)
+
+
+def _scaled_mm_nvfp4(
+    a_codes: torch.Tensor,
+    a_scales: torch.Tensor,
+    a_global: torch.Tensor,
+    b_codes_t: torch.Tensor,
+    b_scales: torch.Tensor,
+    b_global: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Block-scaled FP4 GEMM with per-tensor second-level scales.
+
+    a_codes: (M, K//2) uint8; b_codes_t: (K//2, N) transposed uint8 view;
+    a_scales/b_scales: plain (rows, K//16) float8 block scales (swizzled here).
+    """
+    return F.scaled_mm(
+        a_codes.view(torch.float4_e2m1fn_x2),
+        b_codes_t.view(torch.float4_e2m1fn_x2),
+        scale_a=[to_blocked(a_scales).flatten(), a_global],
+        scale_recipe_a=[F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
+        scale_b=[to_blocked(b_scales).flatten(), b_global],
+        scale_recipe_b=[F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise],
+        swizzle_a=[F.SwizzleType.SWIZZLE_32_4_4, F.SwizzleType.NO_SWIZZLE],
+        swizzle_b=[F.SwizzleType.SWIZZLE_32_4_4, F.SwizzleType.NO_SWIZZLE],
+        output_dtype=out_dtype,
+    )
+
+
+@torch._dynamo.allow_in_graph
+class four_over_six_mm(torch.autograd.Function):
+    """NVFP4 four-over-six quantized matmul.
+
+    3 GEMMs:
+      forward:   x_row @ W.T  = output       (1x16 four-over-six x, 16x16 four-over-six W)
+      backward:  dy_row @ W.T = grad_input   (standard-NVFP4 dy; saved columnwise W)
+      backward:  dy_col.T @ x_col = grad_weight (standard-NVFP4 dy; saved columnwise x)
+
+    With row-scaled activations the backward runs in bf16 instead (see the
+    module docstring), saving the high-precision operands.
+
+    ``backward_override`` selects among the quantized, high-precision, and
+    dequantized backwards described in the module docstring; ``None`` keeps
+    the defaults above. ``weight_block`` selects the weight tile granularity.
+
+    Requires: M % 128 == 0, K % 128 == 0, N % 128 == 0. Non-bf16 inputs are
+    cast to bf16 and gradients are always bf16, so leaves that require grad
+    must be bf16 (matching ``nvfp4_mm_triton``).
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        input_hp: torch.Tensor,
+        weight_hp: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        err_mode: str = "mae",
+        e4m3_scale_bound: int = 256,
+        row_scaled_activation: bool = False,
+        backward_override: Optional[str] = None,
+        weight_block: str = "16x16",
+    ):
+        M = input_hp.shape[:-1].numel()
+        K = input_hp.shape[-1]
+        N = weight_hp.shape[0]
+        if input_hp.dtype != torch.bfloat16:
+            input_hp = input_hp.to(torch.bfloat16)
+        if weight_hp.dtype != torch.bfloat16:
+            weight_hp = weight_hp.to(torch.bfloat16)
+        if M % 128 != 0 or K % 128 != 0 or N % 128 != 0:
+            raise ValueError(
+                f"four_over_six_mm requires M, K, N all divisible by 128; "
+                f"got M={M}, K={K}, N={N}"
+            )
+        if backward_override is None:
+            backward_override = (
+                "high_precision" if row_scaled_activation else "quantized"
+            )
+        if backward_override not in ("quantized", "high_precision", "dequantized"):
+            raise ValueError(
+                f"backward_override must be 'quantized', 'high_precision', or "
+                f"'dequantized', got {backward_override!r}"
+            )
+        if backward_override == "quantized" and row_scaled_activation:
+            raise ValueError(
+                "row-scaled four-over-six has no quantized backward; use "
+                "'high_precision' or 'dequantized'"
+            )
+        input_2d = input_hp.reshape(-1, K).contiguous()
+
+        if row_scaled_activation:
+            x_amax = input_2d.abs().amax(dim=1).to(torch.float32)
+        else:
+            x_amax = input_2d.abs().amax().to(torch.float32)
+        w_amax = weight_hp.abs().amax().to(torch.float32)
+
+        x_codes, x_scales = four_over_six_quantize(
+            input_2d,
+            x_amax,
+            block="1x16",
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+        )
+        w_codes, w_scales = four_over_six_quantize(
+            weight_hp,
+            w_amax,
+            block=weight_block,
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+        )
+        w_global = _global_decode_scale(w_amax, e4m3_scale_bound)
+
+        if row_scaled_activation:
+            # The GEMM's per-tensor slot cannot hold a per-row scale: run it
+            # with the constant 1/(6*bound) factor, then apply the raw per-row
+            # amaxes on the FP32 output before the bf16 cast.
+            x_global = torch.full(
+                (),
+                1.0 / (FP4_E2M1_MAX * float(e4m3_scale_bound)),
+                dtype=torch.float32,
+                device=input_2d.device,
+            )
+            output = _scaled_mm_nvfp4(
+                x_codes,
+                x_scales,
+                x_global,
+                w_codes.t(),
+                w_scales,
+                w_global,
+                torch.float32,
+            )
+            output = (output * x_amax.view(-1, 1)).to(torch.bfloat16)
+        else:
+            x_global = _global_decode_scale(x_amax, e4m3_scale_bound)
+            output = _scaled_mm_nvfp4(
+                x_codes,
+                x_scales,
+                x_global,
+                w_codes.t(),
+                w_scales,
+                w_global,
+                torch.bfloat16,
+            )
+        output = output.reshape(*input_hp.shape[:-1], N)
+        if bias is not None:
+            output = output + bias.to(output.dtype)
+
+        if backward_override == "high_precision":
+            ctx.save_for_backward(input_2d, weight_hp)
+        elif backward_override == "dequantized":
+            # The rowwise operands the forward GEMM just consumed; backward
+            # dequantizes them, differentiating the quantized-forward function.
+            ctx.save_for_backward(
+                x_codes,
+                x_scales,
+                x_amax,
+                w_codes,
+                w_scales,
+                w_amax,
+            )
+        else:
+            x_col_codes, x_col_scales = four_over_six_quantize(
+                input_2d.t().contiguous(),
+                x_amax,
+                block="1x16",
+                err_mode=err_mode,
+                e4m3_scale_bound=e4m3_scale_bound,
+            )
+            w_col_codes, w_col_scales = four_over_six_quantize(
+                weight_hp.t().contiguous(),
+                w_amax,
+                block=weight_block,
+                err_mode=err_mode,
+                e4m3_scale_bound=e4m3_scale_bound,
+            )
+            ctx.save_for_backward(
+                x_col_codes,
+                x_col_scales,
+                x_amax,
+                w_col_codes,
+                w_col_scales,
+                w_amax,
+            )
+        ctx.backward_override = backward_override
+        ctx.e4m3_scale_bound = e4m3_scale_bound
+        ctx.input_orig_shape = input_hp.shape
+        ctx.has_bias = bias is not None
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_output = grad_output.contiguous()
+        grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+
+        if ctx.backward_override == "high_precision":
+            input_2d, weight_hp = ctx.saved_tensors
+            grad_input = (grad_output_2d @ weight_hp).reshape(ctx.input_orig_shape)
+            grad_weight = grad_output_2d.t() @ input_2d
+        elif ctx.backward_override == "dequantized":
+            (
+                x_codes,
+                x_scales,
+                x_amax,
+                w_codes,
+                w_scales,
+                w_amax,
+            ) = ctx.saved_tensors
+            weight_dq = nvfp4_dequantize(
+                w_codes, w_scales, w_amax, e4m3_scale_bound=ctx.e4m3_scale_bound
+            )
+            input_dq = nvfp4_dequantize(
+                x_codes, x_scales, x_amax, e4m3_scale_bound=ctx.e4m3_scale_bound
+            )
+            grad_input = (grad_output_2d @ weight_dq).reshape(ctx.input_orig_shape)
+            grad_weight = grad_output_2d.t() @ input_dq
+        else:
+            (
+                x_col_codes,
+                x_col_scales,
+                x_amax,
+                w_col_codes,
+                w_col_scales,
+                w_amax,
+            ) = ctx.saved_tensors
+            dy_amax = grad_output_2d.abs().amax().to(torch.float32)
+            dy_row_codes, dy_row_scales = _standard_rtne_quantize(
+                grad_output_2d, dy_amax
+            )
+            dy_col_codes, dy_col_scales = _standard_rtne_quantize(
+                grad_output_2d.t().contiguous(), dy_amax
+            )
+            dy_global = _global_decode_scale(dy_amax, 448)
+            grad_input = _scaled_mm_nvfp4(
+                dy_row_codes,
+                dy_row_scales,
+                dy_global,
+                w_col_codes.t(),
+                w_col_scales,
+                _global_decode_scale(w_amax, ctx.e4m3_scale_bound),
+                torch.bfloat16,
+            ).reshape(ctx.input_orig_shape)
+            grad_weight = _scaled_mm_nvfp4(
+                dy_col_codes,
+                dy_col_scales,
+                dy_global,
+                x_col_codes.t(),
+                x_col_scales,
+                _global_decode_scale(x_amax, ctx.e4m3_scale_bound),
+                torch.bfloat16,
+            )
+
+        grad_bias = (
+            grad_output.sum(dim=tuple(range(grad_output.dim() - 1)))
+            if ctx.has_bias
+            else None
+        )
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None
+
+
+four_over_six_linear = four_over_six_mm.apply
+
+
+class NVFP4FourOverSixLinear(nn.Linear):
+    """Linear layer with NVFP4 four-over-six quantized GEMMs.
+
+    Drop-in replacement for nn.Linear implementing the four-over-six recipe:
+    forward GEMM operands use four-over-six NVFP4, gradients use standard
+    NVFP4 (or bf16 when ``row_scaled_activation`` is set — see the module
+    docstring for why row-scaled has no quantized backward).
+    ``backward_override`` and ``weight_block`` pass through to
+    :class:`four_over_six_mm`. ``bias`` defaults off, matching the recipe's
+    usage (unlike nn.Linear).
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        err_mode: str = "mae",
+        e4m3_scale_bound: int = 256,
+        row_scaled_activation: bool = False,
+        backward_override: Optional[str] = None,
+        weight_block: str = "16x16",
+        device=None,
+        dtype=None,
+    ):
+        super().__init__(in_features, out_features, bias, device=device, dtype=dtype)
+        self.err_mode = err_mode
+        self.e4m3_scale_bound = e4m3_scale_bound
+        self.row_scaled_activation = row_scaled_activation
+        self.backward_override = backward_override
+        self.weight_block = weight_block
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return four_over_six_linear(
+            x,
+            self.weight,
+            self.bias,
+            self.err_mode,
+            self.e4m3_scale_bound,
+            self.row_scaled_activation,
+            self.backward_override,
+            self.weight_block,
+        )
+
+    @classmethod
+    def from_linear(
+        cls,
+        mod: nn.Linear,
+        err_mode: str = "mae",
+        e4m3_scale_bound: int = 256,
+        row_scaled_activation: bool = False,
+        backward_override: Optional[str] = None,
+        weight_block: str = "16x16",
+    ) -> "NVFP4FourOverSixLinear":
+        new = cls(
+            mod.in_features,
+            mod.out_features,
+            mod.bias is not None,
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+            row_scaled_activation=row_scaled_activation,
+            backward_override=backward_override,
+            weight_block=weight_block,
+            device=mod.weight.device,
+            dtype=mod.weight.dtype,
+        )
+        if mod.weight.device != torch.device("meta"):
+            new.weight = mod.weight
+            if mod.bias is not None:
+                new.bias = mod.bias
+        return new

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six.py
@@ -188,8 +188,13 @@ def four_over_six_quantize(
 
     Args:
         x: (R, C) bfloat16 or float32, C % 16 == 0 (R % 16 == 0 for 16x16).
-        global_amax: scalar FP32 amax, or a (R,) per-row amax vector for the
-            row-scaled variant (1x16 blocks only).
+        global_amax: scalar FP32 amax, or a (R,) per-row amax vector — the
+            row-scaled activation variant for 1x16 blocks, or per-expert
+            amaxes expanded over expert rows for stacked expert weights.
+            With 16x16 blocks the vector must be constant within every
+            16-row tile (each row of a tile derives the tile's scale chain
+            from its own amax entry; the grouped path's expert boundaries
+            keep tiles amax-uniform).
         block: "1x16" (activations/gradient operands) or "16x16" (weights).
         err_mode: "mae" or "mse" candidate-selection error metric.
         e4m3_scale_bound: 256 (default, leaves map-to-4 headroom) or 448.
@@ -212,8 +217,6 @@ def four_over_six_quantize(
     if block == "16x16" and rows % 16 != 0:
         raise ValueError(f"16x16 blocks require R divisible by 16, got R={rows}")
     row_scaled = global_amax.dim() == 1 and global_amax.numel() == rows
-    if row_scaled and block != "1x16":
-        raise ValueError("row-scaled four-over-six supports 1x16 blocks only")
     if not row_scaled and global_amax.numel() != 1:
         raise ValueError(
             f"global_amax must be a scalar or a ({rows},) row vector, "

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six_cutedsl.py
@@ -606,7 +606,8 @@ def four_over_six_quantize_cutedsl(
 
     Args:
         x:                (R, C) bfloat16 or float32, contiguous, C % 64 == 0.
-        global_amax:      scalar FP32 amax, or (R,) per-row amax (1x16 only).
+        global_amax:      scalar FP32 amax, or (R,) per-row amax (with 16x16
+            blocks, constant within every 16-row tile; see the quantizer).
         block:            "1x16" or "16x16".
         err_mode:         "mae" or "mse".
         e4m3_scale_bound: 256 or 448.

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six_cutedsl.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six_cutedsl.py
@@ -1,0 +1,701 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CuTe DSL NVFP4 four-over-six quantize kernel (SM100+).
+
+Fast path for ``four_over_six_quantize``: an op-for-op reimplementation of the
+pure-PyTorch reference body, producing bitwise-identical codes and scales.
+The load-bearing arithmetic is pinned with inline PTX so no compiler lowering
+choice can change a rounding:
+
+* every division is a real ``div.rn.f32`` (the ``(block_amax / 6) * S_enc``
+  association, ``S_enc``/``S_dec``, the encode reciprocals, and the
+  dequant-error denominator) — never a reciprocal multiply;
+* the E4M3 scale cast is ``cvt.rn.satfinite.e4m3x2.f32`` and its exact decode
+  ``cvt.rn.f16x2.e4m3x2``;
+* the FP4 cast is ``cvt.rn.satfinite.e2m1x2.f32`` (NaN -> +6) and the error
+  path dequantizes with the exact ``cvt.rn.f16x2.e2m1x2``;
+* block amaxes use NaN-dropping ``max.f32`` (``fmaxf``: an all-NaN group
+  yields amax 0) and the 448 caps use NaN-dropping ``min.f32`` (``fminf``);
+* the per-group dequant error is accumulated strictly sequentially in element
+  order 0..15 with scalar FP32 round-to-nearest adds (no reduction trees), and
+  16x16 tiles reduce their 16 row errors with the exact width-16
+  shuffle-down tree ``(((e0+e8)+(e4+e12))+((e2+e10)+(e6+e14))) +
+  (((e1+e9)+(e5+e13))+((e3+e11)+(e7+e15)))`` broadcast from the segment base.
+
+Tiling: one (128, 64) input tile per CTA, 128 threads, one tile row per
+thread, so lanes 0-15 / 16-31 of each warp hold 16 consecutive rows — the
+16-lane segments the 16x16 (2D) mode reduces over. The tile is loaded with
+one TMA G2S copy, packed FP4 codes leave via TMA S2G (rows past R are
+clipped by the TMA bounds check; zero-filled OOB rows compute garbage that
+is never stored), and the four scale bytes per tile row leave as one u32.
+
+Eligibility (the dispatch gate in ``four_over_six_quantize``): SM100+, CUDA
+bf16 or fp32 input, contiguous, C % 64 == 0 (the tile width; also makes the
+u32 scale store aligned). Ineligible calls fall through to the pure-PyTorch
+body. The CuTe DSL runtime packages are assumed to be installed wherever the
+gate passes.
+"""
+
+import functools
+from typing import Tuple
+
+import torch
+
+from torchao.utils import ceil_div, is_sm_at_least_100
+
+TILE_ROWS = 128
+TILE_COLS = 64  # 4 1x16 groups per tile row; the C % 64 dispatch gate
+_FP32_MAX = torch.finfo(torch.float32).max
+# shfl.sync c-operand for width-16 segments: segmask 0x10 | clamp 0x1f, the
+# same ((32 - width) << 8) | 0x1f encoding __shfl_down_sync(..., 16) uses.
+_SHFL_WIDTH16 = 0x101F
+
+
+def _cutedsl_quantize_eligible(x: torch.Tensor) -> bool:
+    """True iff ``four_over_six_quantize`` may dispatch ``x`` to the CuTe DSL kernel.
+
+    Shape/dtype gates come first so FakeTensor tracing takes the same branch
+    as eager. Ineligible inputs silently use the pure-PyTorch body.
+    """
+    return (
+        x.is_cuda
+        and x.dtype in (torch.bfloat16, torch.float32)
+        and x.shape[0] > 0
+        and x.shape[0] <= 65535 * TILE_ROWS  # grid.y limit
+        and x.shape[1] > 0
+        and x.shape[1] % TILE_COLS == 0
+        and x.is_contiguous()
+        and is_sm_at_least_100()
+    )
+
+
+@functools.cache
+def _compile_four_over_six_quantize_cutedsl(
+    input_dtype_name: str,
+    block_16x16: bool,
+    err_mode: str,
+    e4m3_scale_bound: int,
+    row_scaled: bool,
+    device_index: int,
+):
+    """Compile one (dtype, block, err_mode, bound, row_scaled) kernel variant.
+
+    ``device_index`` is a cache key only (per-device cache separation, as in
+    the sibling ``_compile_fused_kernel``); the body never reads it.
+    """
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.utils as utils
+    from cutlass._mlir.dialects import llvm
+    from cutlass.cute.nvgpu import cpasync, tcgen05
+    from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+    from cutlass.cutlass_dsl import T, dsl_user_op
+
+    from ._cutedsl_kernels_impl import (
+        _abs_f32,
+        _cvt_rn_satfinite_e2m1x2_f32_pack4,
+        _min_f32,
+    )
+
+    if input_dtype_name == "torch.float32":
+        INPUT_CUTLASS_DTYPE = cutlass.Float32
+    elif input_dtype_name == "torch.bfloat16":
+        INPUT_CUTLASS_DTYPE = cutlass.BFloat16
+    else:
+        raise ValueError(
+            f"Unsupported input dtype for CuTe DSL four_over_six_quantize: {input_dtype_name}"
+        )
+
+    BLOCK_16X16 = block_16x16
+    USE_MSE = err_mode == "mse"
+    ROW_SCALED = row_scaled
+    # bound * 6: the S_enc numerator AND the slow-path error denominator
+    # (1536.0 for bound 256, 2688.0 for bound 448) — both exact in FP32.
+    BOUND_TIMES_FP4MAX = float(e4m3_scale_bound) * 6.0
+
+    GROUPS_PER_ROW = TILE_COLS // 16
+    CODE_TILE_BYTES = TILE_COLS // 2
+    THREADS_PER_BLOCK = TILE_ROWS  # one tile row per thread
+    input_elem_bytes = INPUT_CUTLASS_DTYPE.width // 8
+    TILE_COPY_BYTES = TILE_ROWS * TILE_COLS * input_elem_bytes
+
+    @dsl_user_op
+    def _div_rn_f32(
+        a: cutlass.Float32, b: cutlass.Float32, *, loc=None, ip=None
+    ) -> cutlass.Float32:
+        """Correctly-rounded FP32 division (``__fdiv_rn``), pinned with inline PTX.
+
+        The bitwise contract needs real divisions — a reciprocal multiply
+        double-rounds and flips candidate picks near error ties — so we never
+        rely on how the DSL lowers ``/``.
+        """
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [a.ir_value(loc=loc, ip=ip), b.ir_value(loc=loc, ip=ip)],
+                "div.rn.f32 $0, $1, $2;",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def _fmax_f32(
+        a: cutlass.Float32, b: cutlass.Float32, *, loc=None, ip=None
+    ) -> cutlass.Float32:
+        # Plain max.f32 = fmaxf: NaN inputs are silently dropped, so an
+        # all-NaN group yields amax 0. This is NOT the NaN-propagating
+        # _max_f32 the RHT kernels use.
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [a.ir_value(loc=loc, ip=ip), b.ir_value(loc=loc, ip=ip)],
+                "max.f32 $0, $1, $2;",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def _mul_rn_f32(
+        a: cutlass.Float32, b: cutlass.Float32, *, loc=None, ip=None
+    ) -> cutlass.Float32:
+        """``__fmul_rn`` pinned with inline PTX so it can never fuse into an FMA.
+
+        Used for the MSE ``diff * diff`` feeding the sequential error adds —
+        the one mul+add pair a contraction would double-round.
+        """
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [a.ir_value(loc=loc, ip=ip), b.ir_value(loc=loc, ip=ip)],
+                "mul.rn.f32 $0, $1, $2;",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def _e4m3x2_rn_satfinite_with_decode(
+        c6: cutlass.Float32, c4: cutlass.Float32, *, loc=None, ip=None
+    ):
+        """E4M3-cast both candidate scales and decode them back, all exactly.
+
+        ``cvt.rn.satfinite.e4m3x2.f32`` packs e4m3(c4) in the high byte and
+        e4m3(c6) in the low byte (matching ``__nv_cvt_float_to_fp8`` RN
+        satfinite); ``cvt.rn.f16x2.e4m3x2`` + ``cvt.f32.f16`` recover the
+        exact FP32 value of each scale byte. Returns (packed_u32, f6, f4).
+        """
+        res = llvm.inline_asm(
+            llvm.StructType.get_literal([T.i32(), T.f32(), T.f32()]),
+            [c6.ir_value(loc=loc, ip=ip), c4.ir_value(loc=loc, ip=ip)],
+            (
+                "{\n"
+                ".reg .b16 sp, s6, s4;\n"
+                ".reg .b32 dp;\n"
+                "cvt.rn.satfinite.e4m3x2.f32 sp, $4, $3;\n"
+                "cvt.u32.u16 $0, sp;\n"
+                "cvt.rn.f16x2.e4m3x2 dp, sp;\n"
+                "mov.b32 {s6, s4}, dp;\n"
+                "cvt.f32.f16 $1, s6;\n"
+                "cvt.f32.f16 $2, s4;\n"
+                "}"
+            ),
+            "=r,=f,=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+        pair = cutlass.Uint32(llvm.extractvalue(T.i32(), res, [0]))
+        f6 = cutlass.Float32(llvm.extractvalue(T.f32(), res, [1]))
+        f4 = cutlass.Float32(llvm.extractvalue(T.f32(), res, [2]))
+        return pair, f6, f4
+
+    @dsl_user_op
+    def _dequant_e2m1x8_f32(w: cutlass.Uint32, *, loc=None, ip=None):
+        """Exact dequant of 8 packed FP4 codes to 8 FP32s in element order.
+
+        ``cvt.rn.f16x2.e2m1x2`` per byte (low nibble -> low half) then exact
+        ``cvt.f32.f16`` — the slow-path error dequant.
+        """
+        res = llvm.inline_asm(
+            llvm.StructType.get_literal([T.f32()] * 8),
+            [w.ir_value(loc=loc, ip=ip)],
+            (
+                "{\n"
+                ".reg .b8 q0, q1, q2, q3;\n"
+                ".reg .b32 r0, r1, r2, r3;\n"
+                ".reg .b16 ha, hb;\n"
+                "mov.b32 {q0, q1, q2, q3}, $8;\n"
+                "cvt.rn.f16x2.e2m1x2 r0, q0;\n"
+                "mov.b32 {ha, hb}, r0;\n"
+                "cvt.f32.f16 $0, ha;\n"
+                "cvt.f32.f16 $1, hb;\n"
+                "cvt.rn.f16x2.e2m1x2 r1, q1;\n"
+                "mov.b32 {ha, hb}, r1;\n"
+                "cvt.f32.f16 $2, ha;\n"
+                "cvt.f32.f16 $3, hb;\n"
+                "cvt.rn.f16x2.e2m1x2 r2, q2;\n"
+                "mov.b32 {ha, hb}, r2;\n"
+                "cvt.f32.f16 $4, ha;\n"
+                "cvt.f32.f16 $5, hb;\n"
+                "cvt.rn.f16x2.e2m1x2 r3, q3;\n"
+                "mov.b32 {ha, hb}, r3;\n"
+                "cvt.f32.f16 $6, ha;\n"
+                "cvt.f32.f16 $7, hb;\n"
+                "}"
+            ),
+            "=f,=f,=f,=f,=f,=f,=f,=f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+        return tuple(
+            cutlass.Float32(llvm.extractvalue(T.f32(), res, [i])) for i in range(8)
+        )
+
+    @cute.struct
+    class SharedStorage:
+        tma_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1]
+        in_smem: cute.struct.Align[
+            cute.struct.MemRange[INPUT_CUTLASS_DTYPE, TILE_ROWS * TILE_COLS], 128
+        ]
+        out_smem: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Uint8, TILE_ROWS * CODE_TILE_BYTES], 128
+        ]
+
+    # The helpers below are plain (undecorated) python functions traced inline
+    # from the kernel body — the _cutedsl_kernels_impl convention — so their
+    # loops unroll at trace time (the sequential error adds stay 16 dependent
+    # scalar FP32 RN adds) and python tuples stay indexable.
+
+    def _load_group(sIN, m_rel, k_base):
+        """Load one 1x16 group from SMEM, upconverting to FP32 exactly once."""
+        raw = cute.make_rmem_tensor((16,), INPUT_CUTLASS_DTYPE)
+        cute.autovec_copy(
+            cute.make_tensor(
+                (sIN.iterator + (m_rel * TILE_COLS + k_base)).align(16),
+                cute.make_layout(16),
+            ),
+            raw,
+        )
+        vals = cute.make_rmem_tensor((16,), cutlass.Float32)
+        for i in range(16):
+            vals[i] = cutlass.Float32(raw[i])
+        return vals
+
+    def _group_amax(vals):
+        """fmaxf chain over |vals| from 0.0 (NaN-dropping; order-insensitive)."""
+        amax = cutlass.Float32(0.0)
+        for i in range(16):
+            amax = _fmax_f32(amax, _abs_f32(vals[i]))
+        return amax
+
+    def _tile_reduce_max16(v):
+        """16-lane-segment max: shuffle-down offsets 8/4/2/1, broadcast from base."""
+        for delta in (8, 4, 2, 1):
+            v = _fmax_f32(
+                v, cute.arch.shuffle_sync_down(v, delta, mask_and_clamp=_SHFL_WIDTH16)
+            )
+        return cute.arch.shuffle_sync(v, 0, mask_and_clamp=_SHFL_WIDTH16)
+
+    def _tile_reduce_sum16(v):
+        """The pinned error tree: value(l) += value(l+8), +=(l+4), +=(l+2),
+        +=(l+1) (clamped shuffle-down, NOT butterfly), broadcast from the
+        segment base. Summation shape
+        (((e0+e8)+(e4+e12))+((e2+e10)+(e6+e14))) + (((e1+e9)+(e5+e13))+((e3+e11)+(e7+e15)))."""
+        for delta in (8, 4, 2, 1):
+            v = v + cute.arch.shuffle_sync_down(v, delta, mask_and_clamp=_SHFL_WIDTH16)
+        return cute.arch.shuffle_sync(v, 0, mask_and_clamp=_SHFL_WIDTH16)
+
+    def _scale_pair(block_amax, s_enc, s_dec):
+        """compute_scale_pair: base = (block_amax / 6) * S_enc — a real div.rn
+        THEN mul.rn — the 1.5x map-to-4 expansion, both capped at the full
+        448 E4M3 range, and the exact-division encode multipliers."""
+        base = _div_rn_f32(block_amax, cutlass.Float32(6.0)) * s_enc
+        c6 = _min_f32(base, cutlass.Float32(448.0))
+        c4 = _min_f32(base * cutlass.Float32(1.5), cutlass.Float32(448.0))
+        pair, f6, f4 = _e4m3x2_rn_satfinite_with_decode(c6, c4)
+        inv6 = _min_f32(
+            _div_rn_f32(cutlass.Float32(1.0), f6 * s_dec),
+            cutlass.Float32(_FP32_MAX),
+        )
+        inv4 = _min_f32(
+            _div_rn_f32(cutlass.Float32(1.0), f4 * s_dec),
+            cutlass.Float32(_FP32_MAX),
+        )
+        b6 = pair & 0xFF
+        b4 = (pair >> 8) & 0xFF
+        return b6, b4, f6, f4, inv6, inv4
+
+    def _encode_and_error(vals, inv, f_dec, gamax):
+        """One candidate: FP4-encode 16 values and accumulate the dequant
+        error strictly sequentially in element order 0..15 (16 dependent
+        FP32 RN adds — never a reduction tree). Returns (w0, w1, err)."""
+        q = cute.make_rmem_tensor((16,), cutlass.Float32)
+        for i in range(16):
+            q[i] = vals[i] * inv
+        # Even element -> low nibble: byte j = cvt(hi=q[2j+1], lo=q[2j]).
+        w0 = _cvt_rn_satfinite_e2m1x2_f32_pack4(
+            q[0], q[2], q[4], q[6], q[1], q[3], q[5], q[7]
+        )
+        w1 = _cvt_rn_satfinite_e2m1x2_f32_pack4(
+            q[8], q[10], q[12], q[14], q[9], q[11], q[13], q[15]
+        )
+        err = cutlass.Float32(0.0)
+        for half in range(2):
+            dq = _dequant_e2m1x8_f32(w0 if half == 0 else w1)
+            for i in range(8):
+                # val = div.rn(mul.rn(mul.rn(dequant, (f32)scale_byte),
+                #              global_amax), 6*bound) in the input domain.
+                val = _div_rn_f32(
+                    (dq[i] * f_dec) * gamax,
+                    cutlass.Float32(BOUND_TIMES_FP4MAX),
+                )
+                diff = val - vals[half * 8 + i]
+                if USE_MSE:
+                    err = err + _mul_rn_f32(diff, diff)
+                else:
+                    err = err + _abs_f32(diff)
+        return w0, w1, err
+
+    class FourOverSixQuantizeKernel:
+        @cute.kernel
+        def kernel(
+            self,
+            tma_atom_in: cute.CopyAtom,
+            tma_tensor_in: cute.Tensor,
+            tma_atom_out: cute.CopyAtom,
+            tma_tensor_out: cute.Tensor,
+            scales_u32: cute.Tensor,
+            amax_f32: cute.Tensor,
+            R: cutlass.Int32,
+        ):
+            tidx, _, _ = cute.arch.thread_idx()
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+            bidx, bidy, _ = cute.arch.block_idx()
+
+            smem_allocator = utils.SmemAllocator()
+            storage = smem_allocator.allocate(SharedStorage)
+            tma_mbar_ptr = storage.tma_mbar_ptr.data_ptr()
+
+            smem_layout_in = cute.make_layout(
+                (TILE_ROWS, TILE_COLS), stride=(TILE_COLS, 1)
+            )
+            smem_layout_out = cute.make_layout(
+                (TILE_ROWS, CODE_TILE_BYTES), stride=(CODE_TILE_BYTES, 1)
+            )
+            sIN = storage.in_smem.get_tensor(smem_layout_in)
+            sOUT = storage.out_smem.get_tensor(smem_layout_out)
+            # u64 view of the code tile: one 8-byte store per 1x16 group.
+            sOUT_u64 = cute.recast_tensor(sOUT, cutlass.Uint64)
+
+            if tidx == 0:
+                cpasync.prefetch_descriptor(tma_atom_in)
+                cpasync.prefetch_descriptor(tma_atom_out)
+                cute.arch.mbarrier_init(tma_mbar_ptr, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.sync_threads()
+
+            m_tile = cutlass.Int64(bidy)
+            c_tile = cutlass.Int64(bidx)
+
+            gIN_tile = cute.local_tile(
+                tma_tensor_in, (TILE_ROWS, TILE_COLS), (m_tile, c_tile)
+            )
+            if warp_idx == 0:
+                cta_layout = cute.make_layout((1,))
+                tINs, tINg = cpasync.tma_partition(
+                    tma_atom_in,
+                    0,
+                    cta_layout,
+                    cute.group_modes(sIN, 0, 2),
+                    cute.group_modes(gIN_tile, 0, 2),
+                )
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        tma_mbar_ptr, TILE_COPY_BYTES
+                    )
+                cute.copy(tma_atom_in, tINg[None], tINs[None], tma_bar_ptr=tma_mbar_ptr)
+
+            m_rel = tidx
+            m = m_tile * TILE_ROWS + m_rel
+
+            # Global scale chain, once per thread (per row when row-scaled):
+            # S_enc = fminf(bound*6 / global_amax, FLT_MAX), falling back to
+            # 1.0 when global_amax == 0 or S_enc == 0; S_dec = 1 / S_enc.
+            gamax = cutlass.Float32(0.0)
+            if cutlass.const_expr(ROW_SCALED):
+                if m < R:
+                    gamax = amax_f32[m]
+            else:
+                gamax = amax_f32[0]
+            s_enc_raw = _min_f32(
+                _div_rn_f32(cutlass.Float32(BOUND_TIMES_FP4MAX), gamax),
+                cutlass.Float32(_FP32_MAX),
+            )
+            s_enc = s_enc_raw
+            if gamax == 0.0:
+                s_enc = cutlass.Float32(1.0)
+            if s_enc_raw == 0.0:
+                s_enc = cutlass.Float32(1.0)
+            s_dec = _div_rn_f32(cutlass.Float32(1.0), s_enc)
+
+            cute.arch.mbarrier_wait(tma_mbar_ptr, 0)
+
+            scale_word = cutlass.Uint32(0)
+            for gc in cutlass.range_constexpr(GROUPS_PER_ROW):
+                vals = _load_group(sIN, m_rel, gc * 16)
+                block_amax = _group_amax(vals)
+                if cutlass.const_expr(BLOCK_16X16):
+                    block_amax = _tile_reduce_max16(block_amax)
+                b6, b4, f6, f4, inv6, inv4 = _scale_pair(block_amax, s_enc, s_dec)
+                w6_0, w6_1, err6 = _encode_and_error(vals, inv6, f6, gamax)
+                w4_0, w4_1, err4 = _encode_and_error(vals, inv4, f4, gamax)
+                if cutlass.const_expr(BLOCK_16X16):
+                    err6 = _tile_reduce_sum16(err6)
+                    err4 = _tile_reduce_sum16(err4)
+                # Strict < with map4 on the left: ties and NaN errors pick map6.
+                w0 = w6_0
+                w1 = w6_1
+                sbyte = b6
+                if err4 < err6:
+                    w0 = w4_0
+                    w1 = w4_1
+                    sbyte = b4
+                sOUT_u64[m_rel, gc] = cutlass.Uint64(w0) | (cutlass.Uint64(w1) << 32)
+                scale_word = scale_word | (sbyte << (8 * gc))
+
+            if m < R:
+                scales_u32[m, c_tile] = scale_word
+
+            cute.arch.fence_proxy("async.shared", space="cta")
+            cute.arch.sync_threads()
+            if warp_idx == 0:
+                gOUT_tile = cute.local_tile(
+                    tma_tensor_out, (TILE_ROWS, CODE_TILE_BYTES), (m_tile, c_tile)
+                )
+                cta_layout = cute.make_layout((1,))
+                tOUTs, tOUTg = cpasync.tma_partition(
+                    tma_atom_out,
+                    0,
+                    cta_layout,
+                    cute.group_modes(sOUT, 0, 2),
+                    cute.group_modes(gOUT_tile, 0, 2),
+                )
+                cute.copy(tma_atom_out, tOUTs[None], tOUTg[None])
+
+        @cute.jit
+        def __call__(
+            self,
+            inp_rc: cute.Tensor,
+            out_codes: cute.Tensor,
+            scales_u32: cute.Tensor,
+            amax_f32: cute.Tensor,
+            R: cutlass.Int32,
+            r_tiles: cutlass.Int32,
+            c_tiles: cutlass.Int32,
+            stream: cuda.CUstream,
+        ):
+            smem_layout_in = cute.make_layout(
+                (TILE_ROWS, TILE_COLS), stride=(TILE_COLS, 1)
+            )
+            smem_layout_out = cute.make_layout(
+                (TILE_ROWS, CODE_TILE_BYTES), stride=(CODE_TILE_BYTES, 1)
+            )
+            g2s_op = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+            tma_atom_in, tma_tensor_in = cpasync.make_tiled_tma_atom(
+                g2s_op,
+                inp_rc,
+                smem_layout_in,
+                (TILE_ROWS, TILE_COLS),
+            )
+            tma_atom_out, tma_tensor_out = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                out_codes,
+                smem_layout_out,
+                (TILE_ROWS, CODE_TILE_BYTES),
+            )
+            self.kernel(
+                tma_atom_in,
+                tma_tensor_in,
+                tma_atom_out,
+                tma_tensor_out,
+                scales_u32,
+                amax_f32,
+                R,
+            ).launch(
+                grid=(c_tiles, r_tiles, 1),
+                block=(THREADS_PER_BLOCK, 1, 1),
+                cluster=(1, 1, 1),
+                smem=SharedStorage.size_in_bytes(),  # pyrefly: ignore [missing-attribute]
+                stream=stream,
+            )
+
+    kernel = FourOverSixQuantizeKernel()
+
+    r = cute.sym_int()
+    c = cute.sym_int(divisibility=64)
+    ch = cute.sym_int(divisibility=32)
+    cs = cute.sym_int()
+    fake_inp = make_fake_tensor(
+        INPUT_CUTLASS_DTYPE,
+        (r, c),
+        stride=(cute.sym_int(), cute.sym_int()),
+    )
+    fake_out = make_fake_tensor(
+        cutlass.Uint8,
+        (r, ch),
+        stride=(cute.sym_int(), cute.sym_int()),
+    )
+    fake_scales = make_fake_tensor(
+        cutlass.Uint32,
+        (r, cs),
+        stride=(cute.sym_int(), cute.sym_int()),
+    )
+    fake_amax = make_fake_tensor(
+        cutlass.Float32,
+        (cute.sym_int(),),
+        stride=(cute.sym_int(),),
+    )
+    fake_stream = make_fake_stream()
+
+    return cute.compile(
+        kernel,
+        inp_rc=fake_inp,
+        out_codes=fake_out,
+        scales_u32=fake_scales,
+        amax_f32=fake_amax,
+        R=0,
+        r_tiles=1,
+        c_tiles=1,
+        stream=fake_stream,
+        options="--enable-tvm-ffi",
+    )
+
+
+@torch.library.custom_op(
+    "torchao::four_over_six_quantize_cutedsl", mutates_args=(), device_types="cuda"
+)
+def four_over_six_quantize_cutedsl(
+    x: torch.Tensor,
+    global_amax: torch.Tensor,
+    block: str,
+    err_mode: str,
+    e4m3_scale_bound: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """NVFP4 four-over-six quantize (CuTe DSL, SM100+).
+
+    Bitwise-identical to the pure-PyTorch ``four_over_six_quantize`` body for
+    every (block, err_mode, e4m3_scale_bound, per-tensor/row-scaled) mode,
+    with one documented exception: NaN inputs take NaN-dropping block
+    amaxes and encode to +6 FP4 codes here, while torch's ``amax``
+    propagates NaN into the reference's block scales.
+
+    Args:
+        x:                (R, C) bfloat16 or float32, contiguous, C % 64 == 0.
+        global_amax:      scalar FP32 amax, or (R,) per-row amax (1x16 only).
+        block:            "1x16" or "16x16".
+        err_mode:         "mae" or "mse".
+        e4m3_scale_bound: 256 or 448.
+
+    Returns:
+        (codes, scales): (R, C//2) uint8 packed FP4 codes (low nibble = even
+        element) and (R, C//16) float8_e4m3fn block scales.
+    """
+    if not is_sm_at_least_100():
+        raise NotImplementedError("four_over_six_quantize_cutedsl requires SM100+")
+    if x.ndim != 2:
+        raise ValueError("x must be 2-D")
+    # Direct torch.ops callers bypass the dispatch gate and the python
+    # wrapper, so mirror their checks here as errors rather than TMA/launch
+    # failures or silently wrong scales.
+    if x.dtype not in (torch.bfloat16, torch.float32):
+        raise ValueError(f"x must be bfloat16 or float32, got {x.dtype}")
+    if not x.is_contiguous():
+        raise ValueError("x must be contiguous")
+    if block not in ("1x16", "16x16"):
+        raise ValueError(f"block must be '1x16' or '16x16', got {block!r}")
+    if err_mode not in ("mae", "mse"):
+        raise ValueError(f"err_mode must be 'mae' or 'mse', got {err_mode!r}")
+    if e4m3_scale_bound not in (256, 448):
+        raise ValueError(f"e4m3_scale_bound must be 256 or 448, got {e4m3_scale_bound}")
+    rows, cols = x.shape
+    if rows == 0 or cols == 0:
+        raise ValueError(f"x must be non-empty, got shape {tuple(x.shape)}")
+    if global_amax.numel() not in (1, rows):
+        raise ValueError(
+            f"global_amax must have 1 or {rows} elements, got {global_amax.numel()}"
+        )
+    if rows > 65535 * TILE_ROWS:
+        raise ValueError(
+            f"R must be at most {65535 * TILE_ROWS} (grid.y limit), got {rows}"
+        )
+    if cols % TILE_COLS != 0:
+        raise ValueError(
+            f"four_over_six_quantize_cutedsl requires C % {TILE_COLS} == 0, got {cols}"
+        )
+    if block == "16x16" and rows % 16:
+        raise ValueError(f"16x16 blocks need rows divisible by 16, got {rows}")
+    row_scaled = global_amax.dim() == 1 and global_amax.numel() == rows
+
+    codes = torch.empty_strided(
+        (rows, cols // 2), (cols // 2, 1), device=x.device, dtype=torch.uint8
+    )
+    scales_u8 = torch.empty_strided(
+        (rows, cols // 16), (cols // 16, 1), device=x.device, dtype=torch.uint8
+    )
+    scales_u32 = scales_u8.view(torch.uint32)
+    # The kernel reads the amax through a raw device pointer, so a CPU scalar
+    # amax (fine for the pure-PyTorch body) must be moved to x's device here.
+    amax_f32 = (
+        global_amax.to(device=x.device, dtype=torch.float32).reshape(-1).contiguous()
+    )
+
+    device_index = x.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+
+    import cuda.bindings.driver as cuda
+
+    with torch.cuda.device(x.device):
+        compiled = _compile_four_over_six_quantize_cutedsl(
+            str(x.dtype),
+            block == "16x16",
+            err_mode,
+            int(e4m3_scale_bound),
+            row_scaled,
+            device_index,
+        )
+        stream = cuda.CUstream(int(torch.cuda.current_stream().cuda_stream))
+        compiled(
+            x,
+            codes,
+            scales_u32,
+            amax_f32,
+            int(rows),
+            int(ceil_div(rows, TILE_ROWS)),
+            int(cols // TILE_COLS),
+            stream,
+        )
+    return codes, scales_u8.view(torch.float8_e4m3fn)
+
+
+@four_over_six_quantize_cutedsl.register_fake
+def _(x, global_amax, block, err_mode, e4m3_scale_bound):
+    rows, cols = x.shape
+    codes = x.new_empty((rows, cols // 2), dtype=torch.uint8)
+    scales = x.new_empty((rows, cols // 16), dtype=torch.float8_e4m3fn)
+    return codes, scales

--- a/torchao/prototype/moe_training/nvfp4_training/four_over_six_grouped.py
+++ b/torchao/prototype/moe_training/nvfp4_training/four_over_six_grouped.py
@@ -1,0 +1,468 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) 2026, NVIDIA CORPORATION.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Differentiable NVFP4 four-over-six grouped GEMM for MoE training.
+
+Grouped counterpart of ``four_over_six_mm`` for routed-expert layers:
+``A`` holds token groups packed along dim 0, ``B`` holds one weight matrix
+per expert, and ``offs`` marks each group's end row. Every token group is
+quantized as its own tensor:
+
+* per-tensor activations (the default): each token group gets its own
+  global scale from that group's amax. The group amaxes are expanded to a
+  per-row amax vector so the whole packed tensor quantizes in one
+  ``four_over_six_quantize`` call — bitwise identical to quantizing each
+  group separately, because the quantizer derives every row's scale chain
+  from that row's amax entry. The forward GEMM is one
+  ``F.scaled_grouped_mm`` with per-group second-level scales.
+* row-scaled activations: one global scale per token row. The forward is a
+  single ``F.scaled_grouped_mm`` carrying the constant per-tensor factor in
+  every group's slot, its bf16 output upcast and scaled by the raw per-row
+  amaxes (torch's grouped GEMM only emits bf16 high-precision output). That
+  is one GEMM-output rounding away from a per-group loop of dense
+  four-over-six GEMMs, and the tests pin the fused output against a
+  rounding-emulated loop oracle.
+
+Weights always quantize per expert with per-tensor scales
+(``weight_block`` selects 16x16 tiles or 1x16 blocks, as in the dense op).
+
+Gradients never quantize with four-over-six, so the grouped backward
+supports only the high-precision and dequantized overrides of
+``four_over_six_mm``:
+
+* ``"high_precision"`` (the default): bf16 grouped GEMMs on the saved
+  original operands;
+* ``"dequantized"``: bf16 grouped GEMMs on dequantizations of the rowwise
+  operands the forward consumed — the RL train/inference-consistency mode.
+
+``"quantized"`` raises. Requires K % 128 == 0 and N % 128 == 0; token
+groups must be 128-row aligned unless ``pad_token_groups_for_grouped_mm``
+is set, which zero-pads each group to the next 128 multiple before
+quantization (zero rows quantize to zero codes and are sliced away from the
+output).
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+    FP4_E2M1_MAX,
+    _global_decode_scale,
+    four_over_six_quantize,
+    nvfp4_dequantize,
+)
+from torchao.prototype.moe_training.nvfp4_training.group_hadamard_utils import (
+    _DEVICE_ASSERTS,
+)
+from torchao.prototype.moe_training.utils import (
+    conditional_nostrict_trace,
+    pad_token_groups,
+    unpad_token_groups,
+)
+from torchao.prototype.mx_formats.utils import to_blocked
+from torchao.quantization.quantize_.common import KernelPreference
+from torchao.utils import is_sm_at_least_100
+
+_ALIGNMENT = 128
+_SCALE_RECIPE = [F.ScalingType.BlockWise1x16, F.ScalingType.TensorWise]
+_SWIZZLE = [F.SwizzleType.SWIZZLE_32_4_4, F.SwizzleType.NO_SWIZZLE]
+
+__all__ = ["four_over_six_grouped_mm"]
+
+
+@conditional_nostrict_trace
+def four_over_six_grouped_mm(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    offs: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    *,
+    err_mode: str = "mae",
+    e4m3_scale_bound: int = 256,
+    row_scaled_activation: bool = False,
+    weight_block: str = "16x16",
+    backward_override: Optional[str] = None,
+    pad_token_groups_for_grouped_mm: bool = False,
+) -> torch.Tensor:
+    """Quantize grouped activations and expert weights with four-over-six.
+
+    ``A`` has shape ``(M, K)``, ``B`` has shape ``(E, N, K)``, and ``offs``
+    contains the cumulative row-end offset for each expert. Knobs match
+    ``four_over_six_mm``; see the module docstring for the grouped-specific
+    backward and alignment semantics.
+    """
+    output = _FourOverSixGroupedMM.apply(
+        A,
+        B,
+        offs,
+        err_mode,
+        e4m3_scale_bound,
+        row_scaled_activation,
+        weight_block,
+        backward_override,
+        pad_token_groups_for_grouped_mm,
+    )
+    if bias is not None:
+        output = output + bias.to(output.dtype)
+    return output
+
+
+def _expand_group_amax(
+    row_amax: torch.Tensor, group_end_offsets: torch.Tensor, num_experts: int
+) -> torch.Tensor:
+    """Per-row amax vector holding each row's group amax.
+
+    Rows past the final offset (the pad-helper's over-allocated tail) take
+    the last group's amax; they are all-zero and never enter the GEMM.
+    """
+    group_idx = torch.searchsorted(
+        group_end_offsets,
+        torch.arange(row_amax.shape[0], device=row_amax.device, dtype=torch.int32),
+        right=True,
+    ).clamp_(max=num_experts - 1)
+    group_amax = torch.zeros(
+        num_experts, dtype=torch.float32, device=row_amax.device
+    ).scatter_reduce_(
+        0, group_idx, row_amax.to(torch.float32), reduce="amax", include_self=True
+    )
+    return group_amax[group_idx], group_amax
+
+
+def _quantize_expert_weights(
+    weight: torch.Tensor,
+    weight_amax: torch.Tensor,
+    weight_block: str,
+    err_mode: str,
+    e4m3_scale_bound: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-expert four-over-six quantization of a stacked (E, N, K) weight.
+
+    Flattening experts along rows and expanding each expert's amax over its
+    rows quantizes the whole stack in one call — bitwise identical to a
+    per-expert loop, because the quantizer derives every row's scale chain
+    from that row's amax entry, 1x16 blocks never cross rows, and 16x16
+    tiles never cross experts (N % 128 == 0 keeps expert boundaries 16-row
+    aligned, and every row of a tile carries the same expert's amax).
+    """
+    num_experts, N, K = weight.shape
+    flat_codes, flat_scales = four_over_six_quantize(
+        weight.reshape(num_experts * N, K),
+        weight_amax.repeat_interleave(N),
+        block=weight_block,
+        err_mode=err_mode,
+        e4m3_scale_bound=e4m3_scale_bound,
+    )
+    return (
+        flat_codes.view(num_experts, N, K // 2),
+        flat_scales.view(num_experts, N, K // 16),
+    )
+
+
+def _dequantize_expert_weights(
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    weight_amax: torch.Tensor,
+    e4m3_scale_bound: int,
+) -> torch.Tensor:
+    """Dequantize stacked per-expert codes back to a bf16 (E, N, K) weight.
+
+    Flattening experts along rows and expanding each expert's amax over its
+    rows reproduces the per-expert scalar dequantization exactly — the
+    decode chain reads one amax entry per row either way.
+    """
+    num_experts, N = codes.shape[0], codes.shape[1]
+    row_amax = weight_amax.to(torch.float32).repeat_interleave(N)
+    flat = nvfp4_dequantize(
+        codes.reshape(num_experts * N, -1),
+        scales.reshape(num_experts * N, -1),
+        row_amax,
+        e4m3_scale_bound=e4m3_scale_bound,
+    )
+    return flat.view(num_experts, N, -1)
+
+
+def _row_scaled_single_grouped_gemm(
+    x_codes: torch.Tensor,
+    x_scales: torch.Tensor,
+    x_amax: torch.Tensor,
+    x_global: torch.Tensor,
+    w_codes: torch.Tensor,
+    w_scales: torch.Tensor,
+    w_global: torch.Tensor,
+    padded_group_end_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """One ``F.scaled_grouped_mm`` covering every group of the row-scaled
+    forward.
+
+    The GEMM epilogue applies the E4M3 block scales and the per-tensor
+    factors — the constant 1/(6*bound) in every group's activation slot and
+    each expert's amax/(6*bound) — and the raw per-row amax multiply plus
+    the final bf16 cast happen on the upcast output. The GEMM emits bf16
+    (torch's grouped GEMM has no FP32 output mode), which costs one
+    rounding before the row scale relative to a loop of dense FP32-output
+    GEMMs per group. Rows past the final offset may hold garbage; the pad
+    helper's unpad drops them.
+    """
+    num_experts = w_codes.shape[0]
+    output = F.scaled_grouped_mm(
+        x_codes.view(torch.float4_e2m1fn_x2),
+        w_codes.view(torch.float4_e2m1fn_x2).transpose(-2, -1),
+        # scaled_grouped_mm consumes swizzled scale bytes viewed at the
+        # logical 2D shape, as in the per-tensor forward; the view needs
+        # the 128-row alignment the forward enforces. One to_blocked over
+        # the row-flattened expert scales equals the per-expert stack
+        # bitwise because N % 128 == 0 keeps expert boundaries on swizzle
+        # row-block boundaries.
+        scale_a=[
+            to_blocked(x_scales).view(x_scales.shape),
+            x_global.expand(num_experts).contiguous(),
+        ],
+        scale_recipe_a=_SCALE_RECIPE,
+        scale_b=[
+            to_blocked(w_scales.reshape(-1, w_scales.shape[-1])).view(num_experts, -1),
+            w_global,
+        ],
+        scale_recipe_b=_SCALE_RECIPE,
+        swizzle_a=_SWIZZLE,
+        swizzle_b=_SWIZZLE,
+        offs=padded_group_end_offsets,
+        output_dtype=torch.bfloat16,
+    )
+    return (output.to(torch.float32) * x_amax.view(-1, 1)).to(torch.bfloat16)
+
+
+class _FourOverSixGroupedMM(torch.autograd.Function):
+    """NVFP4 four-over-six grouped forward with override-only backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        input_act: torch.Tensor,
+        weight: torch.Tensor,
+        group_end_offsets: torch.Tensor,
+        err_mode: str,
+        e4m3_scale_bound: int,
+        row_scaled_activation: bool,
+        weight_block: str,
+        backward_override: Optional[str],
+        pad_token_groups_for_grouped_mm: bool,
+    ) -> torch.Tensor:
+        if group_end_offsets.ndim != 1 or group_end_offsets.dtype != torch.int32:
+            raise ValueError("offs must be a 1D int32 tensor")
+        if not group_end_offsets.is_contiguous():
+            raise ValueError("offs must be contiguous")
+        if group_end_offsets.numel() != weight.shape[0]:
+            raise ValueError("offs must contain one group-end offset per expert")
+        if not is_sm_at_least_100():
+            raise NotImplementedError(
+                "NVFP4 four-over-six grouped GEMM requires SM100+"
+            )
+        if backward_override is None:
+            backward_override = "high_precision"
+        if backward_override not in ("high_precision", "dequantized"):
+            if backward_override == "quantized":
+                raise ValueError(
+                    "grouped four-over-six has no quantized backward; use "
+                    "'high_precision' or 'dequantized'"
+                )
+            raise ValueError(
+                f"backward_override must be 'high_precision' or 'dequantized', "
+                f"got {backward_override!r}"
+            )
+
+        num_tokens, K = input_act.shape
+        num_experts, N, _ = weight.shape
+        if K % _ALIGNMENT != 0 or N % _ALIGNMENT != 0:
+            raise ValueError(
+                f"K and N must be divisible by {_ALIGNMENT}; got K={K}, N={N}"
+            )
+        if _DEVICE_ASSERTS:
+            group_sizes = torch.diff(
+                group_end_offsets, prepend=group_end_offsets.new_zeros(1)
+            )
+            torch.ops.aten._assert_async.msg(
+                torch.all(group_sizes >= 0), "offs must be non-decreasing"
+            )
+            torch.ops.aten._assert_async.msg(
+                group_end_offsets[-1] == num_tokens,
+                "the final group-end offset must equal A.shape[0]",
+            )
+            if not pad_token_groups_for_grouped_mm:
+                torch.ops.aten._assert_async.msg(
+                    torch.all(group_sizes % _ALIGNMENT == 0),
+                    "every token group must be 128-row aligned when padding is disabled",
+                )
+
+        input_act = input_act.to(torch.bfloat16).contiguous()
+        weight = weight.to(torch.bfloat16).contiguous()
+        original_input = input_act
+
+        padded_group_start_offsets = None
+        if pad_token_groups_for_grouped_mm:
+            # The fused pad/unpad CUDA kernels only accept alignment_size 32
+            # and at most 32 groups; this op needs 128-row alignment with any
+            # expert count, so it pins the pure-torch path.
+            input_act, padded_group_start_offsets, padded_group_end_offsets = (
+                pad_token_groups(
+                    input_act,
+                    group_end_offsets,
+                    alignment_size=_ALIGNMENT,
+                    kernel_preference=KernelPreference.EMULATED,
+                )
+            )
+        else:
+            padded_group_end_offsets = group_end_offsets
+
+        row_amax = input_act.abs().amax(dim=1)
+        group_amax = None
+        if row_scaled_activation:
+            x_amax = row_amax.to(torch.float32)
+        else:
+            x_amax, group_amax = _expand_group_amax(
+                row_amax, padded_group_end_offsets, num_experts
+            )
+        weight_amax = weight.abs().amax(dim=(1, 2)).to(torch.float32)
+
+        x_codes, x_scales = four_over_six_quantize(
+            input_act,
+            x_amax,
+            block="1x16",
+            err_mode=err_mode,
+            e4m3_scale_bound=e4m3_scale_bound,
+        )
+        w_codes, w_scales = _quantize_expert_weights(
+            weight, weight_amax, weight_block, err_mode, e4m3_scale_bound
+        )
+        w_global = _global_decode_scale(weight_amax, e4m3_scale_bound)
+
+        if row_scaled_activation:
+            # The row-scaled forward carries the constant 1/(6*bound) factor
+            # in every group's per-tensor slot and scales the GEMM output by
+            # the raw per-row amaxes; one F.scaled_grouped_mm covers all
+            # groups.
+            x_global = torch.full(
+                (),
+                1.0 / (FP4_E2M1_MAX * float(e4m3_scale_bound)),
+                dtype=torch.float32,
+                device=input_act.device,
+            )
+            output = _row_scaled_single_grouped_gemm(
+                x_codes,
+                x_scales,
+                x_amax,
+                x_global,
+                w_codes,
+                w_scales,
+                w_global,
+                padded_group_end_offsets,
+            )
+        else:
+            output = F.scaled_grouped_mm(
+                x_codes.view(torch.float4_e2m1fn_x2),
+                w_codes.view(torch.float4_e2m1fn_x2).transpose(-2, -1),
+                # scaled_grouped_mm consumes swizzled scale bytes viewed at the
+                # logical 2D shape (the layout the group quantize kernels
+                # return); the view needs the 128-row alignment enforced above.
+                scale_a=[
+                    to_blocked(x_scales).view(x_scales.shape),
+                    _global_decode_scale(group_amax, e4m3_scale_bound),
+                ],
+                scale_recipe_a=_SCALE_RECIPE,
+                # One flattened to_blocked covers all experts, bitwise equal
+                # to a per-expert stack (see _row_scaled_single_grouped_gemm).
+                scale_b=[
+                    to_blocked(w_scales.reshape(-1, w_scales.shape[-1])).view(
+                        num_experts, -1
+                    ),
+                    w_global,
+                ],
+                scale_recipe_b=_SCALE_RECIPE,
+                swizzle_a=_SWIZZLE,
+                swizzle_b=_SWIZZLE,
+                offs=padded_group_end_offsets,
+                output_dtype=torch.bfloat16,
+            )
+
+        if pad_token_groups_for_grouped_mm:
+            output = unpad_token_groups(
+                output,
+                group_end_offsets,
+                padded_group_start_offsets,
+                num_tokens,
+                alignment_size=_ALIGNMENT,
+                kernel_preference=KernelPreference.EMULATED,
+            )
+
+        if backward_override == "high_precision":
+            ctx.save_for_backward(original_input, weight, group_end_offsets)
+        else:
+            if padded_group_start_offsets is None:
+                padded_group_start_offsets = group_end_offsets.new_zeros(0)
+            ctx.save_for_backward(
+                x_codes,
+                x_scales,
+                x_amax,
+                w_codes,
+                w_scales,
+                weight_amax,
+                group_end_offsets,
+                padded_group_start_offsets,
+            )
+        ctx.backward_override = backward_override
+        ctx.e4m3_scale_bound = e4m3_scale_bound
+        ctx.pad_token_groups_for_grouped_mm = pad_token_groups_for_grouped_mm
+        ctx.num_tokens = num_tokens
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        grad_output = grad_output.to(torch.bfloat16).contiguous()
+
+        if ctx.backward_override == "high_precision":
+            input_act, weight, group_end_offsets = ctx.saved_tensors
+        else:
+            (
+                x_codes,
+                x_scales,
+                x_amax,
+                w_codes,
+                w_scales,
+                weight_amax,
+                group_end_offsets,
+                padded_group_start_offsets,
+            ) = ctx.saved_tensors
+            input_act = nvfp4_dequantize(
+                x_codes, x_scales, x_amax, e4m3_scale_bound=ctx.e4m3_scale_bound
+            )
+            if ctx.pad_token_groups_for_grouped_mm:
+                input_act = unpad_token_groups(
+                    input_act,
+                    group_end_offsets,
+                    padded_group_start_offsets,
+                    ctx.num_tokens,
+                    alignment_size=_ALIGNMENT,
+                    kernel_preference=KernelPreference.EMULATED,
+                )
+            weight = _dequantize_expert_weights(
+                w_codes, w_scales, weight_amax, ctx.e4m3_scale_bound
+            )
+
+        grad_input = torch._grouped_mm(
+            grad_output,
+            weight,
+            offs=group_end_offsets,
+            out_dtype=torch.bfloat16,
+        )
+        grad_weight = torch._grouped_mm(
+            grad_output.transpose(-2, -1),
+            input_act,
+            offs=group_end_offsets,
+            out_dtype=torch.bfloat16,
+        )
+        return grad_input, grad_weight, None, None, None, None, None, None, None

--- a/torchao/prototype/moe_training/nvfp4_training/nvfp4_training.py
+++ b/torchao/prototype/moe_training/nvfp4_training/nvfp4_training.py
@@ -71,12 +71,12 @@ def _make_rht_sign_vector(
 class NVFP4TrainingConfig(AOBaseConfig):
     """Configuration for NVFP4 quantized training.
 
-    When passed to quantize_(), replaces nn.Linear modules with
-    NVFP4Linear, which quantizes all three GEMMs (forward
-    and backward) to NVFP4.
+    When passed to quantize_(), replaces nn.Linear modules with the module
+    implementing the selected recipe, which quantizes all three GEMMs
+    (forward and backward) to NVFP4.
 
     Args:
-        kernel_preference: Backend for quantization kernels.
+        kernel_preference: ("default" recipe) Backend for quantization kernels.
             TRITON: Pure-Triton RHT + stochastic rounding path.
             CUTEDSL: CuteDSL kernels for the full quantize path (amax, forward
                 RTNE quantize, SR backward quantize, and 2D weight quantize).
@@ -84,11 +84,13 @@ class NVFP4TrainingConfig(AOBaseConfig):
                 by 256. Under tensor parallel the same constraints apply to each
                 per-rank shard, and the per-rank M shard must be divisible by 256.
             Default: TRITON.
-        process_group: Optional ProcessGroup for tensor-parallel TP.
+        process_group: ("default" recipe) Optional ProcessGroup for
+            tensor-parallel TP.
             When set, forward dispatches to the selected NVFP4 tensor-parallel
             path (TRITON or CUTEDSL).
-        world_size: TP world size.  Inferred from process_group if None.
-        rht_sign_vector: Optional {-1, 1} sign vector of length 16 for the
+        world_size: ("default" recipe) TP world size.  Inferred from
+            process_group if None.
+        rht_sign_vector: ("default" recipe) Optional {-1, 1} sign vector of length 16 for the
             randomized Hadamard transform.  When None, each NVFP4Linear draws
             its own random vector.  In multi-rank settings (FSDP) replicas will
             therefore have different bases — harmless for convergence but
@@ -96,12 +98,90 @@ class NVFP4TrainingConfig(AOBaseConfig):
             consistency should broadcast a single vector before calling
             quantize_() and pass it here.  The TP path always enforces
             consistency via _replicate_rht_sign_vector regardless of this field.
+        recipe: Which NVFP4 training recipe to install.
+            "default": NVFP4Linear — randomized Hadamard transform + stochastic
+                rounding, configured by the fields above.
+            "four_over_six": NVFP4FourOverSixLinear — adaptive per-block
+                candidate selection between the standard map-to-6 encoding and
+                a 1.5x-scale map-to-4 encoding, configured by the fields below.
+                Stateless (no RHT/SR buffers, no TP support).
+            Each recipe's fields must stay at their defaults under the other
+            recipe.
+        err_mode: ("four_over_six" recipe) Candidate-selection error metric,
+            "mae" or "mse".
+        e4m3_scale_bound: ("four_over_six" recipe) Global E4M3 scale bound;
+            256 leaves map-to-4 headroom, 448 uses the full range.
+        row_scaled_activation: ("four_over_six" recipe) Derive one FP32 global
+            scale per activation row instead of per tensor.
+        backward_override: ("four_over_six" recipe) Backward mode — None
+            (recipe default), "quantized", "high_precision", or "dequantized".
+        weight_block: ("four_over_six" recipe) Weight block granularity,
+            "16x16" or "1x16".
     """
 
     kernel_preference: KernelPreference = KernelPreference.TRITON
     process_group: Optional[object] = field(default=None, compare=False)
     world_size: Optional[int] = None
     rht_sign_vector: Optional[object] = field(default=None, compare=False)
+    recipe: str = "default"
+    err_mode: str = "mae"
+    e4m3_scale_bound: int = 256
+    row_scaled_activation: bool = False
+    backward_override: Optional[str] = None
+    weight_block: str = "16x16"
+
+    def __post_init__(self):
+        if self.recipe not in ("default", "four_over_six"):
+            raise ValueError(
+                f"recipe must be 'default' or 'four_over_six', got {self.recipe!r}"
+            )
+        if self.recipe == "default":
+            four_over_six_defaults = (
+                ("err_mode", self.err_mode, "mae"),
+                ("e4m3_scale_bound", self.e4m3_scale_bound, 256),
+                ("row_scaled_activation", self.row_scaled_activation, False),
+                ("backward_override", self.backward_override, None),
+                ("weight_block", self.weight_block, "16x16"),
+            )
+            for name, value, default in four_over_six_defaults:
+                if value != default:
+                    raise ValueError(
+                        f"{name} configures the 'four_over_six' recipe and must "
+                        f"stay at its default under recipe='default', got {value!r}"
+                    )
+            return
+        if self.err_mode not in ("mae", "mse"):
+            raise ValueError(f"err_mode must be 'mae' or 'mse', got {self.err_mode!r}")
+        if self.e4m3_scale_bound not in (256, 448):
+            raise ValueError(
+                f"e4m3_scale_bound must be 256 or 448, got {self.e4m3_scale_bound}"
+            )
+        if self.backward_override not in (
+            None,
+            "quantized",
+            "high_precision",
+            "dequantized",
+        ):
+            raise ValueError(
+                f"backward_override must be None, 'quantized', 'high_precision', "
+                f"or 'dequantized', got {self.backward_override!r}"
+            )
+        if self.weight_block not in ("1x16", "16x16"):
+            raise ValueError(
+                f"weight_block must be '1x16' or '16x16', got {self.weight_block!r}"
+            )
+        default_recipe_defaults = (
+            ("kernel_preference", self.kernel_preference, KernelPreference.TRITON),
+            ("process_group", self.process_group, None),
+            ("world_size", self.world_size, None),
+            ("rht_sign_vector", self.rht_sign_vector, None),
+        )
+        for name, value, default in default_recipe_defaults:
+            if value is not default and value != default:
+                raise ValueError(
+                    f"{name} configures the 'default' recipe and must stay at "
+                    f"its default under recipe='four_over_six', got {value!r}"
+                )
 
 
 class NVFP4Linear(nn.Linear):
@@ -242,15 +322,31 @@ def _nvfp4_training_transform(
     config: NVFP4TrainingConfig,
     parameter_name: Optional[str] = None,
 ) -> nn.Module:
-    """Handler for quantize_(): replaces nn.Linear with NVFP4Linear."""
-    if isinstance(module, NVFP4Linear):
+    """Handler for quantize_(): replaces nn.Linear with config.recipe's module.
+
+    Modules already converted to either recipe are left alone.
+    """
+    from torchao.prototype.moe_training.nvfp4_training.four_over_six import (
+        NVFP4FourOverSixLinear,
+    )
+
+    if isinstance(module, (NVFP4Linear, NVFP4FourOverSixLinear)):
         return module
-    if isinstance(module, nn.Linear):
-        return NVFP4Linear.from_linear(
+    if not isinstance(module, nn.Linear):
+        return module
+    if config.recipe == "four_over_six":
+        return NVFP4FourOverSixLinear.from_linear(
             module,
-            kernel_preference=config.kernel_preference,
-            process_group=config.process_group,
-            world_size=config.world_size,
-            rht_sign_vector=config.rht_sign_vector,
+            err_mode=config.err_mode,
+            e4m3_scale_bound=config.e4m3_scale_bound,
+            row_scaled_activation=config.row_scaled_activation,
+            backward_override=config.backward_override,
+            weight_block=config.weight_block,
         )
-    return module
+    return NVFP4Linear.from_linear(
+        module,
+        kernel_preference=config.kernel_preference,
+        process_group=config.process_group,
+        world_size=config.world_size,
+        rht_sign_vector=config.rht_sign_vector,
+    )

--- a/torchao/prototype/moe_training/utils.py
+++ b/torchao/prototype/moe_training/utils.py
@@ -10,6 +10,7 @@ from torchao.float8.float8_utils import tensor_to_scale, to_fp8_saturated
 from torchao.prototype.moe_training.config import (
     Float8TrainingOpConfig,
     MXFP8TrainingOpConfig,
+    NVFP4FourOverSixTrainingOpConfig,
     TrainingOpBaseConfig,
 )
 from torchao.prototype.mx_formats.mx_tensor import to_mx
@@ -405,6 +406,36 @@ def _quantize_then_scaled_grouped_mm(
             offs,
             **kwargs,
         )
+    elif isinstance(config, NVFP4FourOverSixTrainingOpConfig):
+        from torchao.prototype.moe_training.nvfp4_training.four_over_six_grouped import (
+            four_over_six_grouped_mm,
+        )
+
+        # The dispatcher hands expert weights over as B_t with shape (E, K, N);
+        # the four-over-six op takes them in their stored (E, N, K) layout.
+        # Callers with padded token dispatchers over-allocate A past offs[-1],
+        # while the op requires offs[-1] == A.shape[0] and the unwritten tail
+        # rows must not feed its per-group amaxes: slice to the logical rows
+        # and zero-extend the output, which also routes zero gradients to the
+        # tail. The host read of offs[-1] keeps this dispatcher branch
+        # eager-only (the op itself is nonstrict-traced under compile).
+        num_tokens = int(offs[-1])
+        tail_rows = A.shape[0] - num_tokens
+        output = four_over_six_grouped_mm(
+            A[:num_tokens] if tail_rows > 0 else A,
+            B_t.transpose(-2, -1),
+            offs,
+            bias,
+            err_mode=config.err_mode,
+            e4m3_scale_bound=config.e4m3_scale_bound,
+            row_scaled_activation=config.row_scaled_activation,
+            weight_block=config.weight_block,
+            backward_override=config.backward_override,
+            pad_token_groups_for_grouped_mm=config.pad_token_groups_for_grouped_mm,
+        )
+        if tail_rows > 0:
+            output = torch.nn.functional.pad(output, (0, 0, 0, tail_rows))
+        return output
     else:
         raise ValueError(f"Unsupported config type: {type(config)}")
 


### PR DESCRIPTION
Stacked on #4851 / #4852 — this PR's diff includes their commits; the change to review here is the top commit. Integrates the four-over-six recipe with MoE training for routed-expert layers, reusing existing pieces rather than adding kernels: the #4852 quantizer (its CuTe DSL fast path dispatches automatically) and the existing `F.scaled_grouped_mm` for the GEMMs.

- Per-tensor activations: each token group's amax expands to a per-row vector so the whole packed tensor quantizes in one call — bitwise identical to quantizing each group separately — and one `scaled_grouped_mm` with per-group second-level scales runs the forward.
- Expert weights quantize in one flattened call for both block shapes (the quantizer accepts a per-row amax with 16x16 blocks under a tile-uniform contract): one kernel launch regardless of expert count.
- Row-scaled activations: one `scaled_grouped_mm` carrying the constant per-tensor factor in every group's slot, its bf16 output upcast and scaled by the raw per-row amaxes. The grouped GEMM emits bf16 only, which costs one output rounding vs per-group dense GEMMs; tests emulate that rounding in a loop oracle and compare bitwise (with a reduction-order SQNR fallback), and separately bound the rounding cost.
- Backward: `high_precision` or `dequantized` grouped GEMMs (four-over-six has no quantized backward); `dequantized` differentiates the quantized forward itself from the saved 4-bit codes and scales.

Wiring mirrors the Float8/MXFP8 recipes exactly: `NVFP4FourOverSixTrainingOpConfig(TrainingOpBaseConfig)` — a pytree-constant dataclass with explicit `__eq__`/`__hash__` — plus an `isinstance` branch in `_quantize_then_scaled_grouped_mm`. The dispatcher branch owns the `offs[-1]` tail slice / zero-extend for padded token dispatchers that over-allocate `A` past the logical rows. `quantize_()` model conversion for the grouped config is future work; framework integrations drive the grouped GEMM dispatcher (see the torchtitan converters). Adds an NVFP4 four-over-six section to the moe_training README.

**Tests**: 40 grouped tests (grouped-vs-dense forward parity, row-scaled fused-vs-oracle, backward bitwise references including empty groups and ragged padding, dispatcher round-trip with over-allocated tails, fullgraph compile in both scale granularities) plus the dense suite with the relaxed quantizer combinations, all green on GB200.

**Reference**
NVFP4 RL training recipe roadmap references from Ziang Li from humans&: https://humansand.ai/blog/nvfp4-rl, https://github.com/radixark/miles/issues/615, https://github.com/NVIDIA/TransformerEngine/pull/2972

Stack: #4851 ← #4852 ← this PR.