### PR TITLE
Interleave W3A8 activations for Arm NEON prefill

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -169,9 +169,10 @@ void register_ukernel_config_universal(
                small_prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<small_prefill_mr, kr, sr>,
-               &kernel::
-                   kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+               &kernel::pack_activations_small_prefill<kr, sr>,
+               &kernel::kernel_small_prefill_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros>});
           constexpr int prefill_mr = 4;
           constexpr int prefill_m_step = 4;
           uk.linear_configs[2] = UKernelConfig::linear_config_type(
@@ -216,9 +217,10 @@ void register_ukernel_config_universal(
                small_prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<small_prefill_mr, kr, sr>,
-               &kernel::
-                   kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+               &kernel::pack_activations_small_prefill<kr, sr>,
+               &kernel::kernel_small_prefill_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros>});
           constexpr int prefill_mr = 4;
           constexpr int prefill_m_step = 4;
           uk.linear_configs[2] = UKernelConfig::linear_config_type(

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -179,7 +179,7 @@ void register_ukernel_config_universal(
                prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<prefill_mr, kr, sr>,
+               &kernel::pack_activations_interleaved<prefill_mr, kr, sr>,
                &kernel::
                    kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
           constexpr int large_prefill_mr = 8;
@@ -189,7 +189,10 @@ void register_ukernel_config_universal(
                large_prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<large_prefill_mr, kr, sr>,
+               &kernel::pack_activations_interleaved<
+                   large_prefill_mr,
+                   kr,
+                   sr>,
                &kernel::
                    kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
@@ -223,7 +226,7 @@ void register_ukernel_config_universal(
                prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<prefill_mr, kr, sr>,
+               &kernel::pack_activations_interleaved<prefill_mr, kr, sr>,
                &kernel::
                    kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
           constexpr int large_prefill_mr = 8;
@@ -233,7 +236,10 @@ void register_ukernel_config_universal(
                large_prefill_mr,
                &kernel::packed_activations_size,
                &kernel::packed_activations_offset,
-               &kernel::pack_activations<large_prefill_mr, kr, sr>,
+               &kernel::pack_activations_interleaved<
+                   large_prefill_mr,
+                   kr,
+                   sr>,
                &kernel::
                    kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -477,6 +477,12 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
       false /*has_bias*/,
       false /*has_clamp*/>(
       /*m=*/3, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillWeightZeros) {
@@ -498,6 +504,12 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillBiasClamp) {
 }
 
 TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillAllOptions) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/15, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
   test_linear_8bit_act_xbit_weight<
       3 /*weight_nbit*/,
       true /*has_weight_zeros*/,

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -79,7 +79,7 @@ UKernelConfig get_ukernel_config() {
         prefill_mr,
         &kernel::packed_activations_size,
         &kernel::packed_activations_offset,
-        &kernel::pack_activations<prefill_mr, kr, sr>,
+        &kernel::pack_activations_interleaved<prefill_mr, kr, sr>,
         &kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
     constexpr int large_prefill_mr = 8;
     constexpr int large_prefill_m_step = 8;
@@ -88,7 +88,7 @@ UKernelConfig get_ukernel_config() {
         large_prefill_mr,
         &kernel::packed_activations_size,
         &kernel::packed_activations_offset,
-        &kernel::pack_activations<large_prefill_mr, kr, sr>,
+        &kernel::pack_activations_interleaved<large_prefill_mr, kr, sr>,
         &kernel::kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
   }
 

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -32,11 +32,15 @@ inline size_t packed_activations_size(
     int mr,
     int kr,
     int sr) {
-  (void)mr; // unused
   (void)kr; // unused
   (void)sr; // unused
-  return activation_packing::packed_activations_size(
+  size_t size = activation_packing::packed_activations_size(
       m, k, group_size, has_weight_zeros);
+  if (mr > 1 && m % 4 == 3) {
+    size += activation_packing::packed_activations_size(
+        1, k, group_size, has_weight_zeros);
+  }
+  return size;
 }
 
 inline size_t packed_activations_offset(
@@ -87,6 +91,30 @@ void pack_activations_interleaved(
   (void)sr;
   activation_packing::pack_activations_interleaved<mr_, kr_, sr_>(
       packed_activations, m, k, group_size, activations, has_weight_zeros);
+}
+
+template <int kr_, int sr_>
+void pack_activations_small_prefill(
+    void* packed_activations,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)mr;
+  (void)kr;
+  (void)sr;
+  assert(m >= 1 && m <= 3);
+  if (m == 3) {
+    activation_packing::pack_activations_interleaved<4, kr_, sr_>(
+        packed_activations, m, k, group_size, activations, has_weight_zeros);
+  } else {
+    activation_packing::pack_activations<2, kr_, sr_>(
+        packed_activations, m, k, group_size, activations, has_weight_zeros);
+  }
 }
 
 template <int weight_nbit, int nr_, int kr_, int sr_>
@@ -320,6 +348,54 @@ void kernel_4x8x16_f32_neondot(
       clamp_max,
       has_bias,
       has_clamp);
+}
+
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_small_prefill_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* packed_weights,
+    const void* packed_activations,
+    float clamp_min,
+    float clamp_max,
+    bool has_weight_zeros_,
+    bool has_bias,
+    bool has_clamp) {
+  (void)has_weight_zeros_;
+  assert(m >= 1 && m <= 3);
+  if (m == 3) {
+    kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+        output,
+        output_m_stride,
+        m,
+        n,
+        k,
+        group_size,
+        packed_weights,
+        packed_activations,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+  } else {
+    kernel::kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+        output,
+        output_m_stride,
+        m,
+        n,
+        k,
+        group_size,
+        packed_weights,
+        packed_activations,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+  }
 }
 
 template <int weight_nbit, bool has_weight_zeros>

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -71,6 +71,24 @@ void pack_activations(
       packed_activations, m, k, group_size, activations, has_weight_zeros);
 }
 
+template <int mr_, int kr_, int sr_>
+void pack_activations_interleaved(
+    void* packed_activations,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)mr;
+  (void)kr;
+  (void)sr;
+  activation_packing::pack_activations_interleaved<mr_, kr_, sr_>(
+      packed_activations, m, k, group_size, activations, has_weight_zeros);
+}
+
 template <int weight_nbit, int nr_, int kr_, int sr_>
 void pack_weights_with_lut(
     // Output

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
@@ -11,6 +11,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/bitpacking/bitpack.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h>
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 
@@ -211,7 +212,8 @@ void kernel_4x8x16_f32_neondot(
   const auto* activation_data_bytes = static_cast<const char*>(activation_data);
 
   int m_idx = 0;
-  for (; m_idx + mr <= m; m_idx += mr) {
+  for (; m_idx + 3 <= m; m_idx += mr) {
+    const int tile_m = std::min(mr, m - m_idx);
     const char* activation_block =
         activation_data_bytes + m_idx * activation_row_size;
     float32x4_t activation_scale_vec =
@@ -361,7 +363,7 @@ void kernel_4x8x16_f32_neondot(
           output_4567[2],
           output_4567[3]);
       const int remaining = n - n_idx;
-      for (int row = 0; row < mr; row++) {
+      for (int row = 0; row < tile_m; row++) {
         internal::store_8_f32(
             output + (m_idx + row) * output_m_stride + n_idx,
             remaining,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
@@ -99,8 +99,10 @@ inline void transpose_4x4_f32(
 
 TORCHAO_ALWAYS_INLINE inline void dot_4_rows_8_cols(
     int32x4_t* accumulators,
-    const char** activation_ptrs,
-    int row_base,
+    int8x16_t activations_0_3,
+    int8x16_t activations_4_7,
+    int8x16_t activations_8_11,
+    int8x16_t activations_12_15,
     int8x16_t weights01_0,
     int8x16_t weights23_0,
     int8x16_t weights45_0,
@@ -109,26 +111,6 @@ TORCHAO_ALWAYS_INLINE inline void dot_4_rows_8_cols(
     int8x16_t weights23_1,
     int8x16_t weights45_1,
     int8x16_t weights67_1) {
-  int8x16_t activation_rows[4];
-  for (int row = 0; row < 4; row++) {
-    activation_rows[row] = vld1q_s8(
-        reinterpret_cast<const int8_t*>(activation_ptrs[row_base + row]));
-    activation_ptrs[row_base + row] += 16;
-  }
-  int8x16_t activations_0_3;
-  int8x16_t activations_4_7;
-  int8x16_t activations_8_11;
-  int8x16_t activations_12_15;
-  transpose_4x16_s8(
-      activation_rows[0],
-      activation_rows[1],
-      activation_rows[2],
-      activation_rows[3],
-      activations_0_3,
-      activations_4_7,
-      activations_8_11,
-      activations_12_15);
-
   accumulators[0] =
       vdotq_laneq_s32(accumulators[0], activations_0_3, weights01_0, 0);
   accumulators[0] =
@@ -230,28 +212,24 @@ void kernel_4x8x16_f32_neondot(
 
   int m_idx = 0;
   for (; m_idx + mr <= m; m_idx += mr) {
-    float activation_scales[mr];
+    const char* activation_block =
+        activation_data_bytes + m_idx * activation_row_size;
+    float32x4_t activation_scale_vec =
+        vld1q_f32(reinterpret_cast<const float*>(activation_block));
+    activation_block += mr * sizeof(float);
     int32_t activation_zeros[mr];
-    const char* activation_qvals[mr];
     for (int row = 0; row < mr; row++) {
-      const char* row_data =
-          activation_data_bytes + (m_idx + row) * activation_row_size;
-      activation_scales[row] = *reinterpret_cast<const float*>(row_data);
-      row_data += sizeof(float);
       activation_zeros[row] =
-          static_cast<int32_t>(*reinterpret_cast<const int8_t*>(row_data));
-      activation_qvals[row] = row_data + sizeof(int8_t);
+          static_cast<int32_t>(*reinterpret_cast<const int8_t*>(
+              activation_block + row * sizeof(int8_t)));
     }
-    float32x4_t activation_scale_vec = vld1q_f32(activation_scales);
+    activation_block += mr * sizeof(int8_t);
     int32x4_t activation_zero_vec = vld1q_s32(activation_zeros);
 
     const char* weight_data_bytes = static_cast<const char*>(weight_data);
     for (int n_idx = 0; n_idx < n; n_idx += nr) {
-      const char* activation_ptrs[mr];
+      const char* activation_ptr = activation_block;
       float32x4_t results[nr];
-      for (int row = 0; row < mr; row++) {
-        activation_ptrs[row] = activation_qvals[row];
-      }
       for (int col = 0; col < nr; col++) {
         results[col] = vdupq_n_f32(0.0f);
       }
@@ -283,10 +261,21 @@ void kernel_4x8x16_f32_neondot(
               reinterpret_cast<const uint8_t*>(weight_data_bytes));
           weight_data_bytes += bytes_per_128_weight_values;
 
+          int8x16_t activations_0_3 =
+              vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr));
+          int8x16_t activations_4_7 =
+              vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 16));
+          int8x16_t activations_8_11 =
+              vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 32));
+          int8x16_t activations_12_15 =
+              vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 48));
+          activation_ptr += 64;
           internal::dot_4_rows_8_cols(
               accumulators,
-              activation_ptrs,
-              /*row_base=*/0,
+              activations_0_3,
+              activations_4_7,
+              activations_8_11,
+              activations_12_15,
               weights01_0,
               weights23_0,
               weights45_0,
@@ -311,13 +300,9 @@ void kernel_4x8x16_f32_neondot(
 
         int32x4_t activation_qvals_sum_vec;
         if constexpr (has_weight_zeros) {
-          int32_t activation_qvals_sums[mr];
-          for (int row = 0; row < mr; row++) {
-            activation_qvals_sums[row] =
-                *reinterpret_cast<const int32_t*>(activation_ptrs[row]);
-            activation_ptrs[row] += sizeof(int32_t);
-          }
-          activation_qvals_sum_vec = vld1q_s32(activation_qvals_sums);
+          activation_qvals_sum_vec =
+              vld1q_s32(reinterpret_cast<const int32_t*>(activation_ptr));
+          activation_ptr += mr * sizeof(int32_t);
         }
 
         for (int col = 0; col < nr; col++) {

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
@@ -46,29 +46,23 @@ void kernel_8x8x16_f32_neondot(
 
   int m_idx = 0;
   for (; m_idx + mr <= m; m_idx += mr) {
-    float activation_scales[mr];
-    int32_t activation_zeros[mr];
-    const char* activation_qvals[mr];
-    for (int row = 0; row < mr; row++) {
-      const char* row_data =
-          activation_data_bytes + (m_idx + row) * activation_row_size;
-      activation_scales[row] = *reinterpret_cast<const float*>(row_data);
-      row_data += sizeof(float);
-      activation_zeros[row] =
-          static_cast<int32_t>(*reinterpret_cast<const int8_t*>(row_data));
-      activation_qvals[row] = row_data + sizeof(int8_t);
-    }
+    const char* activation_block =
+        activation_data_bytes + m_idx * activation_row_size;
     float32x4_t activation_scale_vec[row_blocks] = {
-        vld1q_f32(activation_scales), vld1q_f32(activation_scales + 4)};
+        vld1q_f32(reinterpret_cast<const float*>(activation_block)),
+        vld1q_f32(reinterpret_cast<const float*>(activation_block + 16))};
+    activation_block += mr * sizeof(float);
+    int8x8_t activation_zeros_s8 =
+        vld1_s8(reinterpret_cast<const int8_t*>(activation_block));
+    activation_block += mr * sizeof(int8_t);
+    int16x8_t activation_zeros_s16 = vmovl_s8(activation_zeros_s8);
     int32x4_t activation_zero_vec[row_blocks] = {
-        vld1q_s32(activation_zeros), vld1q_s32(activation_zeros + 4)};
+        vmovl_s16(vget_low_s16(activation_zeros_s16)),
+        vmovl_s16(vget_high_s16(activation_zeros_s16))};
 
     const char* weight_data_bytes = static_cast<const char*>(weight_data);
     for (int n_idx = 0; n_idx < n; n_idx += nr) {
-      const char* activation_ptrs[mr];
-      for (int row = 0; row < mr; row++) {
-        activation_ptrs[row] = activation_qvals[row];
-      }
+      const char* activation_ptr = activation_block;
       float32x4_t results[row_blocks][nr];
       for (int block = 0; block < row_blocks; block++) {
         for (int col = 0; col < nr; col++) {
@@ -105,30 +99,31 @@ void kernel_8x8x16_f32_neondot(
               reinterpret_cast<const uint8_t*>(weight_data_bytes));
           weight_data_bytes += bytes_per_128_weight_values;
 
-          internal::dot_4_rows_8_cols(
-              accumulators[0],
-              activation_ptrs,
-              /*row_base=*/0,
-              weights01_0,
-              weights23_0,
-              weights45_0,
-              weights67_0,
-              weights01_1,
-              weights23_1,
-              weights45_1,
-              weights67_1);
-          internal::dot_4_rows_8_cols(
-              accumulators[1],
-              activation_ptrs,
-              /*row_base=*/4,
-              weights01_0,
-              weights23_0,
-              weights45_0,
-              weights67_0,
-              weights01_1,
-              weights23_1,
-              weights45_1,
-              weights67_1);
+          for (int block = 0; block < row_blocks; block++) {
+            int8x16_t activations_0_3 =
+                vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr));
+            int8x16_t activations_4_7 =
+                vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 16));
+            int8x16_t activations_8_11 =
+                vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 32));
+            int8x16_t activations_12_15 =
+                vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptr + 48));
+            activation_ptr += 64;
+            internal::dot_4_rows_8_cols(
+                accumulators[block],
+                activations_0_3,
+                activations_4_7,
+                activations_8_11,
+                activations_12_15,
+                weights01_0,
+                weights23_0,
+                weights45_0,
+                weights67_0,
+                weights01_1,
+                weights23_1,
+                weights45_1,
+                weights67_1);
+          }
         }
 
         const float* weight_scales =
@@ -145,14 +140,11 @@ void kernel_8x8x16_f32_neondot(
 
         int32x4_t activation_qvals_sum_vec[row_blocks];
         if constexpr (has_weight_zeros) {
-          int32_t activation_qvals_sums[mr];
-          for (int row = 0; row < mr; row++) {
-            activation_qvals_sums[row] =
-                *reinterpret_cast<const int32_t*>(activation_ptrs[row]);
-            activation_ptrs[row] += sizeof(int32_t);
-          }
-          activation_qvals_sum_vec[0] = vld1q_s32(activation_qvals_sums);
-          activation_qvals_sum_vec[1] = vld1q_s32(activation_qvals_sums + 4);
+          activation_qvals_sum_vec[0] =
+              vld1q_s32(reinterpret_cast<const int32_t*>(activation_ptr));
+          activation_qvals_sum_vec[1] =
+              vld1q_s32(reinterpret_cast<const int32_t*>(activation_ptr + 16));
+          activation_ptr += mr * sizeof(int32_t);
         }
 
         for (int block = 0; block < row_blocks; block++) {

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
@@ -63,10 +63,10 @@ void kernel_8x8x16_f32_neondot(
     const char* weight_data_bytes = static_cast<const char*>(weight_data);
     for (int n_idx = 0; n_idx < n; n_idx += nr) {
       const char* activation_ptr = activation_block;
-      float32x4_t results[row_blocks][nr];
-      for (int block = 0; block < row_blocks; block++) {
-        for (int col = 0; col < nr; col++) {
-          results[block][col] = vdupq_n_f32(0.0f);
+      float32x4_t results[nr][row_blocks];
+      for (int col = 0; col < nr; col++) {
+        for (int block = 0; block < row_blocks; block++) {
+          results[col][block] = vdupq_n_f32(0.0f);
         }
       }
 
@@ -147,12 +147,13 @@ void kernel_8x8x16_f32_neondot(
           activation_ptr += mr * sizeof(int32_t);
         }
 
-        for (int block = 0; block < row_blocks; block++) {
-          for (int col = 0; col < nr; col++) {
+        for (int col = 0; col < nr; col++) {
+          const int32_t weight_qvals_sum = weight_qvals_sums[col];
+          const float weight_scale = weight_scales[col];
+          for (int block = 0; block < row_blocks; block++) {
             int32x4_t corrected = vsubq_s32(
                 accumulators[block][col],
-                vmulq_n_s32(
-                    activation_zero_vec[block], weight_qvals_sums[col]));
+                vmulq_n_s32(activation_zero_vec[block], weight_qvals_sum));
             if constexpr (has_weight_zeros) {
               corrected = vsubq_s32(
                   corrected,
@@ -165,9 +166,9 @@ void kernel_8x8x16_f32_neondot(
                       group_size * weight_zeros[col]));
             }
             float32x4_t scale_factor =
-                vmulq_n_f32(activation_scale_vec[block], weight_scales[col]);
-            results[block][col] = vmlaq_f32(
-                results[block][col], scale_factor, vcvtq_f32_s32(corrected));
+                vmulq_n_f32(activation_scale_vec[block], weight_scale);
+            results[col][block] = vmlaq_f32(
+                results[col][block], scale_factor, vcvtq_f32_s32(corrected));
           }
         }
       }
@@ -175,10 +176,10 @@ void kernel_8x8x16_f32_neondot(
       if (has_bias) {
         const float* bias = reinterpret_cast<const float*>(weight_data_bytes);
         weight_data_bytes += nr * sizeof(float);
-        for (int block = 0; block < row_blocks; block++) {
-          for (int col = 0; col < nr; col++) {
-            results[block][col] =
-                vaddq_f32(results[block][col], vdupq_n_f32(bias[col]));
+        for (int col = 0; col < nr; col++) {
+          for (int block = 0; block < row_blocks; block++) {
+            results[col][block] =
+                vaddq_f32(results[col][block], vdupq_n_f32(bias[col]));
           }
         }
       }
@@ -187,8 +188,8 @@ void kernel_8x8x16_f32_neondot(
         float32x4_t vec_max = vdupq_n_f32(clamp_max);
         for (int block = 0; block < row_blocks; block++) {
           for (int col = 0; col < nr; col++) {
-            results[block][col] =
-                internal::vec_clamp(results[block][col], vec_min, vec_max);
+            results[col][block] =
+                internal::vec_clamp(results[col][block], vec_min, vec_max);
           }
         }
       }
@@ -197,19 +198,19 @@ void kernel_8x8x16_f32_neondot(
         float32x4_t output_0123[4];
         float32x4_t output_4567[4];
         internal::transpose_4x4_f32(
-            results[block][0],
-            results[block][1],
-            results[block][2],
-            results[block][3],
+            results[0][block],
+            results[1][block],
+            results[2][block],
+            results[3][block],
             output_0123[0],
             output_0123[1],
             output_0123[2],
             output_0123[3]);
         internal::transpose_4x4_f32(
-            results[block][4],
-            results[block][5],
-            results[block][6],
-            results[block][7],
+            results[4][block],
+            results[5][block],
+            results[6][block],
+            results[7][block],
             output_4567[0],
             output_4567[1],
             output_4567[2],

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -11,6 +11,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/quantization/quantize.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/reduction.h>
 #include <cassert>
+#include <cstring>
 
 namespace torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::activation_packing {
 
@@ -119,6 +120,115 @@ void inline pack_activations(
       activation_data_byte_ptr += k;
       activations += k;
     }
+  }
+}
+
+namespace internal {
+
+template <int mr>
+void inline pack_interleaved_block(
+    char*& packed,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros) {
+  static_assert(mr == 4 || mr == 8);
+
+  float scales[mr];
+  int zeros[mr];
+  int qmin, qmax;
+  torchao::quantization::get_qvals_range(
+      qmin, qmax, /*nbit=*/8, /*is_symmetric=*/false);
+
+  for (int row = 0; row < mr; row++) {
+    float vmin, vmax;
+    torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
+        vmin, vmax, activations + row * k, k);
+    torchao::quantization::get_scale_and_zero(
+        scales[row], zeros[row], vmin, vmax, qmin, qmax);
+    std::memcpy(packed, &scales[row], sizeof(float));
+    packed += sizeof(float);
+  }
+  for (int row = 0; row < mr; row++) {
+    *reinterpret_cast<int8_t*>(packed++) = static_cast<int8_t>(zeros[row]);
+  }
+
+  for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+    int32_t qvals_sums[mr]{};
+    for (int i = 0; i < group_size; i += 16) {
+      int8_t qvals[mr][16];
+      for (int row = 0; row < mr; row++) {
+        torchao::kernels::cpu::aarch64::quantization::quantize(
+            qvals[row],
+            activations + row * k + k_idx + i,
+            /*size=*/16,
+            scales[row],
+            zeros[row],
+            qmin,
+            qmax);
+        if (has_weight_zeros) {
+          qvals_sums[row] +=
+              torchao::kernels::cpu::aarch64::reduction::compute_sum(
+                  qvals[row], 16);
+        }
+      }
+
+      // Store four adjacent K values from each of four rows in one vector.
+      // This is the layout consumed directly by vdotq_laneq_s32.
+      for (int row_block = 0; row_block < mr; row_block += 4) {
+        for (int k_block = 0; k_block < 4; k_block++) {
+          for (int row = 0; row < 4; row++) {
+            std::memcpy(
+                packed,
+                qvals[row_block + row] + k_block * 4,
+                /*count=*/4);
+            packed += 4;
+          }
+        }
+      }
+    }
+    if (has_weight_zeros) {
+      std::memcpy(packed, qvals_sums, mr * sizeof(int32_t));
+      packed += mr * sizeof(int32_t);
+    }
+  }
+}
+
+} // namespace internal
+
+template <int mr, int kr, int sr>
+void inline pack_activations_interleaved(
+    void* activation_data,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros) {
+  static_assert(mr == 4 || mr == 8);
+  (void)kr;
+  (void)sr;
+
+  auto* packed = static_cast<char*>(activation_data);
+  int m_idx = 0;
+  for (; m_idx + mr <= m; m_idx += mr) {
+    internal::pack_interleaved_block<mr>(
+        packed, k, group_size, activations + m_idx * k, has_weight_zeros);
+  }
+  if constexpr (mr == 8) {
+    if (m_idx + 4 <= m) {
+      internal::pack_interleaved_block<4>(
+          packed, k, group_size, activations + m_idx * k, has_weight_zeros);
+      m_idx += 4;
+    }
+  }
+  if (m_idx < m) {
+    pack_activations<1, kr, sr>(
+        packed,
+        m - m_idx,
+        k,
+        group_size,
+        activations + m_idx * k,
+        has_weight_zeros);
   }
 }
 

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -131,21 +131,25 @@ void inline pack_interleaved_block(
     int k,
     int group_size,
     const float* activations,
-    bool has_weight_zeros) {
+    bool has_weight_zeros,
+    int valid_rows = mr) {
   static_assert(mr == 4 || mr == 8);
+  assert(valid_rows >= 1 && valid_rows <= mr);
 
-  float scales[mr];
-  int zeros[mr];
+  float scales[mr]{};
+  int zeros[mr]{};
   int qmin, qmax;
   torchao::quantization::get_qvals_range(
       qmin, qmax, /*nbit=*/8, /*is_symmetric=*/false);
 
-  for (int row = 0; row < mr; row++) {
+  for (int row = 0; row < valid_rows; row++) {
     float vmin, vmax;
     torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
         vmin, vmax, activations + row * k, k);
     torchao::quantization::get_scale_and_zero(
         scales[row], zeros[row], vmin, vmax, qmin, qmax);
+  }
+  for (int row = 0; row < mr; row++) {
     std::memcpy(packed, &scales[row], sizeof(float));
     packed += sizeof(float);
   }
@@ -156,8 +160,8 @@ void inline pack_interleaved_block(
   for (int k_idx = 0; k_idx < k; k_idx += group_size) {
     int32_t qvals_sums[mr]{};
     for (int i = 0; i < group_size; i += 16) {
-      int8_t qvals[mr][16];
-      for (int row = 0; row < mr; row++) {
+      int8_t qvals[mr][16]{};
+      for (int row = 0; row < valid_rows; row++) {
         torchao::kernels::cpu::aarch64::quantization::quantize(
             qvals[row],
             activations + row * k + k_idx + i,
@@ -220,6 +224,16 @@ void inline pack_activations_interleaved(
           packed, k, group_size, activations + m_idx * k, has_weight_zeros);
       m_idx += 4;
     }
+  }
+  if (m_idx + 3 == m) {
+    internal::pack_interleaved_block<4>(
+        packed,
+        k,
+        group_size,
+        activations + m_idx * k,
+        has_weight_zeros,
+        /*valid_rows=*/3);
+    m_idx += 3;
   }
   if (m_idx < m) {
     pack_activations<1, kr, sr>(


### PR DESCRIPTION
This interleaves packed int8 activations so NEON dot-product lanes map directly to M rows. It optimizes the 4-row and 8-row W3A8 kernels around that layout, adds dedicated handling for 3-row and other partial-M tails, and extends correctness coverage for awkward prefill shapes.\n\nThis is pull request 4 of 5 and depends on pull request 4858. Pull request 5 is 4854.