### PR TITLE
Add Arm NEON W3A8 4x8 prefill kernel

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -144,7 +144,7 @@ void register_ukernel_config_universal(
       if constexpr (weight_nbit == 3) {
         log_registration(
             format,
-            "universal: kernel_1x8x16_f32_neondot, kernel_2x8x16_f32_neondot");
+            "universal: kernel_1x8x16_f32_neondot, kernel_2x8x16_f32_neondot, kernel_4x8x16_f32_neondot");
       } else {
         log_registration(format, "universal: kernel_1x8x16_f32_neondot");
       }
@@ -172,6 +172,16 @@ void register_ukernel_config_universal(
                &kernel::pack_activations<small_prefill_mr, kr, sr>,
                &kernel::
                    kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+          constexpr int prefill_mr = 4;
+          constexpr int prefill_m_step = 4;
+          uk.linear_configs[2] = UKernelConfig::linear_config_type(
+              {prefill_m_step,
+               prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
       } else {
         constexpr bool has_weight_zeros = false;
@@ -196,6 +206,16 @@ void register_ukernel_config_universal(
                &kernel::pack_activations<small_prefill_mr, kr, sr>,
                &kernel::
                    kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+          constexpr int prefill_mr = 4;
+          constexpr int prefill_m_step = 4;
+          uk.linear_configs[2] = UKernelConfig::linear_config_type(
+              {prefill_m_step,
+               prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
       }
 

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -141,7 +141,13 @@ void register_ukernel_config_universal(
 
 #if defined(TORCHAO_ENABLE_ARM_NEON_DOT)
     if (cpuinfo_has_arm_neon_dot()) {
-      log_registration(format, "universal: kernel_1x8x16_f32_neondot");
+      if constexpr (weight_nbit == 3) {
+        log_registration(
+            format,
+            "universal: kernel_1x8x16_f32_neondot, kernel_2x8x16_f32_neondot");
+      } else {
+        log_registration(format, "universal: kernel_1x8x16_f32_neondot");
+      }
 
       if (format.has_weight_zeros) {
         constexpr bool has_weight_zeros = true;
@@ -155,6 +161,18 @@ void register_ukernel_config_universal(
                  weight_nbit,
                  has_weight_zeros,
                  has_lut>});
+        if constexpr (weight_nbit == 3) {
+          constexpr int small_prefill_mr = 2;
+          constexpr int small_prefill_m_step = 2;
+          uk.linear_configs[1] = UKernelConfig::linear_config_type(
+              {small_prefill_m_step,
+               small_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<small_prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+        }
       } else {
         constexpr bool has_weight_zeros = false;
         uk.linear_configs[0] = UKernelConfig::linear_config_type(
@@ -167,6 +185,18 @@ void register_ukernel_config_universal(
                  weight_nbit,
                  has_weight_zeros,
                  has_lut>});
+        if constexpr (weight_nbit == 3) {
+          constexpr int small_prefill_mr = 2;
+          constexpr int small_prefill_m_step = 2;
+          uk.linear_configs[1] = UKernelConfig::linear_config_type(
+              {small_prefill_m_step,
+               small_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<small_prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+        }
       }
 
       table.register_ukernel_config(format, uarch, std::move(uk));

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -62,6 +62,18 @@ UKernelConfig get_ukernel_config() {
       &kernel::
           kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
 
+  if constexpr (weight_nbit == 3 && !has_lut) {
+    constexpr int small_prefill_mr = 2;
+    constexpr int small_prefill_m_step = 2;
+    uk.linear_configs[1] = UKernelConfig::linear_config_type{
+        small_prefill_m_step,
+        small_prefill_mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations<small_prefill_mr, kr, sr>,
+        &kernel::kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
+  }
+
   if constexpr (has_lut) {
     uk.packed_weights_size = &kernel::packed_weights_with_lut_size;
     uk.packed_weights_offset = &kernel::packed_weights_with_lut_offset;
@@ -423,6 +435,15 @@ TEST(test_linear_8bit_act_xbit_weight, Standard) {
       false /*has_bias*/,
       false /*has_clamp*/>(
       /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/3, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -72,6 +72,15 @@ UKernelConfig get_ukernel_config() {
         &kernel::packed_activations_offset,
         &kernel::pack_activations<small_prefill_mr, kr, sr>,
         &kernel::kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
+    constexpr int prefill_mr = 4;
+    constexpr int prefill_m_step = 4;
+    uk.linear_configs[2] = UKernelConfig::linear_config_type{
+        prefill_m_step,
+        prefill_mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations<prefill_mr, kr, sr>,
+        &kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
   }
 
   if constexpr (has_lut) {
@@ -437,6 +446,15 @@ TEST(test_linear_8bit_act_xbit_weight, Standard) {
       /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
 }
 
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefill) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
 TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
   test_linear_8bit_act_xbit_weight<
       3 /*weight_nbit*/,
@@ -444,6 +462,24 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
       false /*has_bias*/,
       false /*has_clamp*/>(
       /*m=*/3, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillWeightZeros) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 4, /*group_size=*/32);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillBiasClamp) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -17,6 +17,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x1x32_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x4x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h>
 
 namespace torchao::kernels::cpu::aarch64::linear::
     channelwise_8bit_activation_groupwise_lowbit_weight {
@@ -225,6 +226,37 @@ void kernel_1x8x16_f32_neondot(
     bool has_clamp) {
   (void)has_weight_zeros_; // unused
   kernel::kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>(
+      output,
+      output_m_stride,
+      m,
+      n,
+      k,
+      group_size,
+      packed_weights,
+      packed_activations,
+      clamp_min,
+      clamp_max,
+      has_bias,
+      has_clamp);
+}
+
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_2x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* packed_weights,
+    const void* packed_activations,
+    float clamp_min,
+    float clamp_max,
+    bool has_weight_zeros_,
+    bool has_bias,
+    bool has_clamp) {
+  (void)has_weight_zeros_;
+  kernel::kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -18,6 +18,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x4x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h>
 
 namespace torchao::kernels::cpu::aarch64::linear::
     channelwise_8bit_activation_groupwise_lowbit_weight {
@@ -257,6 +258,37 @@ void kernel_2x8x16_f32_neondot(
     bool has_clamp) {
   (void)has_weight_zeros_;
   kernel::kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+      output,
+      output_m_stride,
+      m,
+      n,
+      k,
+      group_size,
+      packed_weights,
+      packed_activations,
+      clamp_min,
+      clamp_max,
+      has_bias,
+      has_clamp);
+}
+
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_4x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* packed_weights,
+    const void* packed_activations,
+    float clamp_min,
+    float clamp_max,
+    bool has_weight_zeros_,
+    bool has_bias,
+    bool has_clamp) {
+  (void)has_weight_zeros_;
+  kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h
@@ -1,0 +1,289 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/bitpacking/bitpack.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
+#include <cassert>
+#include <cstddef>
+
+namespace torchao::kernels::cpu::aarch64::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight::kernel {
+namespace internal {
+
+inline void store_8_f32_2rows(
+    float* output,
+    int remaining,
+    float32x4_t values_0123,
+    float32x4_t values_4567) {
+  if (remaining >= 8) {
+    vst1q_f32(output, values_0123);
+    vst1q_f32(output + 4, values_4567);
+  } else if (remaining >= 7) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+    output[6] = vgetq_lane_f32(values_4567, 2);
+  } else if (remaining >= 6) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+  } else if (remaining >= 5) {
+    vst1q_f32(output, values_0123);
+    output[4] = vgetq_lane_f32(values_4567, 0);
+  } else if (remaining >= 4) {
+    vst1q_f32(output, values_0123);
+  } else if (remaining >= 3) {
+    vst1_f32(output, vget_low_f32(values_0123));
+    output[2] = vgetq_lane_f32(values_0123, 2);
+  } else if (remaining >= 2) {
+    vst1_f32(output, vget_low_f32(values_0123));
+  } else {
+    output[0] = vgetq_lane_f32(values_0123, 0);
+  }
+}
+
+} // namespace internal
+
+// Computes two activation rows together so that unpacked low-bit weights are
+// reused across the rows. The packed formats are identical to the 1x8x16
+// kernel. Any final partial M tile is handled by that kernel.
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_2x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const void* activation_data,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  assert(k % group_size == 0);
+  assert(group_size % 16 == 0);
+
+  constexpr int mr = 2;
+  constexpr int bytes_per_128_weight_values = 16 * weight_nbit;
+  const std::size_t activation_row_size = sizeof(float) + sizeof(int8_t) + k +
+      (has_weight_zeros ? (k / group_size) * sizeof(int32_t) : 0);
+  const auto* activation_data_bytes = static_cast<const char*>(activation_data);
+
+  int m_idx = 0;
+  for (; m_idx + mr <= m; m_idx += mr) {
+    float activation_scales[mr];
+    int activation_zeros[mr];
+    const char* activation_qvals[mr];
+
+    for (int row = 0; row < mr; row++) {
+      const char* row_data =
+          activation_data_bytes + (m_idx + row) * activation_row_size;
+      activation_scales[row] = *reinterpret_cast<const float*>(row_data);
+      row_data += sizeof(float);
+      activation_zeros[row] =
+          static_cast<int>(*reinterpret_cast<const int8_t*>(row_data));
+      row_data += sizeof(int8_t);
+      activation_qvals[row] = row_data;
+    }
+
+    const char* weight_data_bytes = static_cast<const char*>(weight_data);
+    for (int n_idx = 0; n_idx < n; n_idx += 8) {
+      const char* activation_ptrs[mr];
+      float32x4_t res_0123[mr];
+      float32x4_t res_4567[mr];
+      for (int row = 0; row < mr; row++) {
+        activation_ptrs[row] = activation_qvals[row];
+        res_0123[row] = vdupq_n_f32(0.0f);
+        res_4567[row] = vdupq_n_f32(0.0f);
+      }
+
+      for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+        int32x4_t acc_cols0011[mr];
+        int32x4_t acc_cols2233[mr];
+        int32x4_t acc_cols4455[mr];
+        int32x4_t acc_cols6677[mr];
+        for (int row = 0; row < mr; row++) {
+          acc_cols0011[row] = vdupq_n_s32(0);
+          acc_cols2233[row] = vdupq_n_s32(0);
+          acc_cols4455[row] = vdupq_n_s32(0);
+          acc_cols6677[row] = vdupq_n_s32(0);
+        }
+
+        for (int i = 0; i < group_size; i += 16) {
+          int8x16_t weight_q_cols01_0;
+          int8x16_t weight_q_cols23_0;
+          int8x16_t weight_q_cols45_0;
+          int8x16_t weight_q_cols67_0;
+          int8x16_t weight_q_cols01_1;
+          int8x16_t weight_q_cols23_1;
+          int8x16_t weight_q_cols45_1;
+          int8x16_t weight_q_cols67_1;
+
+          torchao::bitpacking::vec_unpack_128_lowbit_values<weight_nbit>(
+              weight_q_cols01_0,
+              weight_q_cols23_0,
+              weight_q_cols45_0,
+              weight_q_cols67_0,
+              weight_q_cols01_1,
+              weight_q_cols23_1,
+              weight_q_cols45_1,
+              weight_q_cols67_1,
+              reinterpret_cast<const uint8_t*>(weight_data_bytes));
+          weight_data_bytes += bytes_per_128_weight_values;
+
+          for (int row = 0; row < mr; row++) {
+            int8x16_t act_q =
+                vld1q_s8(reinterpret_cast<const int8_t*>(activation_ptrs[row]));
+            activation_ptrs[row] += 16;
+
+            int8x16_t act_q_dup =
+                vcombine_s8(vget_low_s8(act_q), vget_low_s8(act_q));
+            acc_cols0011[row] =
+                vdotq_s32(acc_cols0011[row], weight_q_cols01_0, act_q_dup);
+            acc_cols2233[row] =
+                vdotq_s32(acc_cols2233[row], weight_q_cols23_0, act_q_dup);
+            acc_cols4455[row] =
+                vdotq_s32(acc_cols4455[row], weight_q_cols45_0, act_q_dup);
+            acc_cols6677[row] =
+                vdotq_s32(acc_cols6677[row], weight_q_cols67_0, act_q_dup);
+
+            act_q_dup = vcombine_s8(vget_high_s8(act_q), vget_high_s8(act_q));
+            acc_cols0011[row] =
+                vdotq_s32(acc_cols0011[row], weight_q_cols01_1, act_q_dup);
+            acc_cols2233[row] =
+                vdotq_s32(acc_cols2233[row], weight_q_cols23_1, act_q_dup);
+            acc_cols4455[row] =
+                vdotq_s32(acc_cols4455[row], weight_q_cols45_1, act_q_dup);
+            acc_cols6677[row] =
+                vdotq_s32(acc_cols6677[row], weight_q_cols67_1, act_q_dup);
+          }
+        }
+
+        float32x4_t weight_scales_0123 =
+            vld1q_f32(reinterpret_cast<const float*>(weight_data_bytes));
+        weight_data_bytes += 16;
+        float32x4_t weight_scales_4567 =
+            vld1q_f32(reinterpret_cast<const float*>(weight_data_bytes));
+        weight_data_bytes += 16;
+        int32x4_t weight_qvals_sum_0123 =
+            vld1q_s32(reinterpret_cast<const int32_t*>(weight_data_bytes));
+        weight_data_bytes += 16;
+        int32x4_t weight_qvals_sum_4567 =
+            vld1q_s32(reinterpret_cast<const int32_t*>(weight_data_bytes));
+        weight_data_bytes += 16;
+
+        int32x4_t weight_zeros_0123;
+        int32x4_t weight_zeros_4567;
+        if constexpr (has_weight_zeros) {
+          weight_zeros_0123 =
+              vld1q_s32(reinterpret_cast<const int32_t*>(weight_data_bytes));
+          weight_data_bytes += 16;
+          weight_zeros_4567 =
+              vld1q_s32(reinterpret_cast<const int32_t*>(weight_data_bytes));
+          weight_data_bytes += 16;
+        }
+
+        for (int row = 0; row < mr; row++) {
+          int32x4_t qval_dot_0123 =
+              vpaddq_s32(acc_cols0011[row], acc_cols2233[row]);
+          int32x4_t qval_dot_4567 =
+              vpaddq_s32(acc_cols4455[row], acc_cols6677[row]);
+          int32x4_t corrected_0123 = vsubq_s32(
+              qval_dot_0123,
+              vmulq_n_s32(weight_qvals_sum_0123, activation_zeros[row]));
+          int32x4_t corrected_4567 = vsubq_s32(
+              qval_dot_4567,
+              vmulq_n_s32(weight_qvals_sum_4567, activation_zeros[row]));
+
+          if constexpr (has_weight_zeros) {
+            int32_t activation_qvals_sum =
+                *reinterpret_cast<const int32_t*>(activation_ptrs[row]);
+            activation_ptrs[row] += sizeof(int32_t);
+            corrected_0123 = vsubq_s32(
+                corrected_0123,
+                vmulq_n_s32(weight_zeros_0123, activation_qvals_sum));
+            corrected_0123 = vaddq_s32(
+                corrected_0123,
+                vmulq_n_s32(
+                    weight_zeros_0123, group_size * activation_zeros[row]));
+            corrected_4567 = vsubq_s32(
+                corrected_4567,
+                vmulq_n_s32(weight_zeros_4567, activation_qvals_sum));
+            corrected_4567 = vaddq_s32(
+                corrected_4567,
+                vmulq_n_s32(
+                    weight_zeros_4567, group_size * activation_zeros[row]));
+          }
+
+          float32x4_t activation_scale = vdupq_n_f32(activation_scales[row]);
+          float32x4_t scale_factor_0123 =
+              vmulq_f32(weight_scales_0123, activation_scale);
+          float32x4_t scale_factor_4567 =
+              vmulq_f32(weight_scales_4567, activation_scale);
+          res_0123[row] = vmlaq_f32(
+              res_0123[row], scale_factor_0123, vcvtq_f32_s32(corrected_0123));
+          res_4567[row] = vmlaq_f32(
+              res_4567[row], scale_factor_4567, vcvtq_f32_s32(corrected_4567));
+        }
+      }
+
+      if (has_bias) {
+        float32x4_t bias_0123 =
+            vld1q_f32(reinterpret_cast<const float*>(weight_data_bytes));
+        weight_data_bytes += 16;
+        float32x4_t bias_4567 =
+            vld1q_f32(reinterpret_cast<const float*>(weight_data_bytes));
+        weight_data_bytes += 16;
+        for (int row = 0; row < mr; row++) {
+          res_0123[row] = vaddq_f32(res_0123[row], bias_0123);
+          res_4567[row] = vaddq_f32(res_4567[row], bias_4567);
+        }
+      }
+
+      if (has_clamp) {
+        float32x4_t vec_min = vdupq_n_f32(clamp_min);
+        float32x4_t vec_max = vdupq_n_f32(clamp_max);
+        for (int row = 0; row < mr; row++) {
+          res_0123[row] = internal::vec_clamp(res_0123[row], vec_min, vec_max);
+          res_4567[row] = internal::vec_clamp(res_4567[row], vec_min, vec_max);
+        }
+      }
+
+      const int remaining = n - n_idx;
+      for (int row = 0; row < mr; row++) {
+        internal::store_8_f32_2rows(
+            output + (m_idx + row) * output_m_stride + n_idx,
+            remaining,
+            res_0123[row],
+            res_4567[row]);
+      }
+    }
+  }
+
+  if (m_idx < m) {
+    kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, false>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        m - m_idx,
+        n,
+        k,
+        group_size,
+        weight_data,
+        activation_data_bytes + m_idx * activation_row_size,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+  }
+}
+
+} // namespace
+  // torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::kernel
+
+#endif // defined(__aarch64__) || defined(__ARM_NEON)

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h
@@ -1,0 +1,425 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/bitpacking/bitpack.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h>
+#include <cassert>
+#include <cstddef>
+
+namespace torchao::kernels::cpu::aarch64::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight::kernel {
+namespace internal {
+
+inline void store_8_f32(
+    float* output,
+    int remaining,
+    float32x4_t values_0123,
+    float32x4_t values_4567) {
+  if (remaining >= 8) {
+    vst1q_f32(output, values_0123);
+    vst1q_f32(output + 4, values_4567);
+  } else if (remaining >= 7) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+    output[6] = vgetq_lane_f32(values_4567, 2);
+  } else if (remaining >= 6) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+  } else if (remaining >= 5) {
+    vst1q_f32(output, values_0123);
+    output[4] = vgetq_lane_f32(values_4567, 0);
+  } else if (remaining >= 4) {
+    vst1q_f32(output, values_0123);
+  } else if (remaining >= 3) {
+    vst1_f32(output, vget_low_f32(values_0123));
+    output[2] = vgetq_lane_f32(values_0123, 2);
+  } else if (remaining >= 2) {
+    vst1_f32(output, vget_low_f32(values_0123));
+  } else {
+    output[0] = vgetq_lane_f32(values_0123, 0);
+  }
+}
+
+inline void transpose_4x16_s8(
+    int8x16_t row0,
+    int8x16_t row1,
+    int8x16_t row2,
+    int8x16_t row3,
+    int8x16_t& cols_0_3,
+    int8x16_t& cols_4_7,
+    int8x16_t& cols_8_11,
+    int8x16_t& cols_12_15) {
+  int32x4_t row0_s32 = vreinterpretq_s32_s8(row0);
+  int32x4_t row1_s32 = vreinterpretq_s32_s8(row1);
+  int32x4_t row2_s32 = vreinterpretq_s32_s8(row2);
+  int32x4_t row3_s32 = vreinterpretq_s32_s8(row3);
+
+  int32x4_t rows01_lo = vzip1q_s32(row0_s32, row1_s32);
+  int32x4_t rows01_hi = vzip2q_s32(row0_s32, row1_s32);
+  int32x4_t rows23_lo = vzip1q_s32(row2_s32, row3_s32);
+  int32x4_t rows23_hi = vzip2q_s32(row2_s32, row3_s32);
+
+  cols_0_3 = vreinterpretq_s8_s64(vzip1q_s64(
+      vreinterpretq_s64_s32(rows01_lo), vreinterpretq_s64_s32(rows23_lo)));
+  cols_4_7 = vreinterpretq_s8_s64(vzip2q_s64(
+      vreinterpretq_s64_s32(rows01_lo), vreinterpretq_s64_s32(rows23_lo)));
+  cols_8_11 = vreinterpretq_s8_s64(vzip1q_s64(
+      vreinterpretq_s64_s32(rows01_hi), vreinterpretq_s64_s32(rows23_hi)));
+  cols_12_15 = vreinterpretq_s8_s64(vzip2q_s64(
+      vreinterpretq_s64_s32(rows01_hi), vreinterpretq_s64_s32(rows23_hi)));
+}
+
+inline void transpose_4x4_f32(
+    float32x4_t col0,
+    float32x4_t col1,
+    float32x4_t col2,
+    float32x4_t col3,
+    float32x4_t& row0,
+    float32x4_t& row1,
+    float32x4_t& row2,
+    float32x4_t& row3) {
+  float32x4_t cols01_lo = vzip1q_f32(col0, col1);
+  float32x4_t cols01_hi = vzip2q_f32(col0, col1);
+  float32x4_t cols23_lo = vzip1q_f32(col2, col3);
+  float32x4_t cols23_hi = vzip2q_f32(col2, col3);
+
+  row0 = vcombine_f32(vget_low_f32(cols01_lo), vget_low_f32(cols23_lo));
+  row1 = vcombine_f32(vget_high_f32(cols01_lo), vget_high_f32(cols23_lo));
+  row2 = vcombine_f32(vget_low_f32(cols01_hi), vget_low_f32(cols23_hi));
+  row3 = vcombine_f32(vget_high_f32(cols01_hi), vget_high_f32(cols23_hi));
+}
+
+TORCHAO_ALWAYS_INLINE inline void dot_4_rows_8_cols(
+    int32x4_t* accumulators,
+    const char** activation_ptrs,
+    int row_base,
+    int8x16_t weights01_0,
+    int8x16_t weights23_0,
+    int8x16_t weights45_0,
+    int8x16_t weights67_0,
+    int8x16_t weights01_1,
+    int8x16_t weights23_1,
+    int8x16_t weights45_1,
+    int8x16_t weights67_1) {
+  int8x16_t activation_rows[4];
+  for (int row = 0; row < 4; row++) {
+    activation_rows[row] = vld1q_s8(
+        reinterpret_cast<const int8_t*>(activation_ptrs[row_base + row]));
+    activation_ptrs[row_base + row] += 16;
+  }
+  int8x16_t activations_0_3;
+  int8x16_t activations_4_7;
+  int8x16_t activations_8_11;
+  int8x16_t activations_12_15;
+  transpose_4x16_s8(
+      activation_rows[0],
+      activation_rows[1],
+      activation_rows[2],
+      activation_rows[3],
+      activations_0_3,
+      activations_4_7,
+      activations_8_11,
+      activations_12_15);
+
+  accumulators[0] =
+      vdotq_laneq_s32(accumulators[0], activations_0_3, weights01_0, 0);
+  accumulators[0] =
+      vdotq_laneq_s32(accumulators[0], activations_4_7, weights01_0, 1);
+  accumulators[0] =
+      vdotq_laneq_s32(accumulators[0], activations_8_11, weights01_1, 0);
+  accumulators[0] =
+      vdotq_laneq_s32(accumulators[0], activations_12_15, weights01_1, 1);
+  accumulators[1] =
+      vdotq_laneq_s32(accumulators[1], activations_0_3, weights01_0, 2);
+  accumulators[1] =
+      vdotq_laneq_s32(accumulators[1], activations_4_7, weights01_0, 3);
+  accumulators[1] =
+      vdotq_laneq_s32(accumulators[1], activations_8_11, weights01_1, 2);
+  accumulators[1] =
+      vdotq_laneq_s32(accumulators[1], activations_12_15, weights01_1, 3);
+
+  accumulators[2] =
+      vdotq_laneq_s32(accumulators[2], activations_0_3, weights23_0, 0);
+  accumulators[2] =
+      vdotq_laneq_s32(accumulators[2], activations_4_7, weights23_0, 1);
+  accumulators[2] =
+      vdotq_laneq_s32(accumulators[2], activations_8_11, weights23_1, 0);
+  accumulators[2] =
+      vdotq_laneq_s32(accumulators[2], activations_12_15, weights23_1, 1);
+  accumulators[3] =
+      vdotq_laneq_s32(accumulators[3], activations_0_3, weights23_0, 2);
+  accumulators[3] =
+      vdotq_laneq_s32(accumulators[3], activations_4_7, weights23_0, 3);
+  accumulators[3] =
+      vdotq_laneq_s32(accumulators[3], activations_8_11, weights23_1, 2);
+  accumulators[3] =
+      vdotq_laneq_s32(accumulators[3], activations_12_15, weights23_1, 3);
+
+  accumulators[4] =
+      vdotq_laneq_s32(accumulators[4], activations_0_3, weights45_0, 0);
+  accumulators[4] =
+      vdotq_laneq_s32(accumulators[4], activations_4_7, weights45_0, 1);
+  accumulators[4] =
+      vdotq_laneq_s32(accumulators[4], activations_8_11, weights45_1, 0);
+  accumulators[4] =
+      vdotq_laneq_s32(accumulators[4], activations_12_15, weights45_1, 1);
+  accumulators[5] =
+      vdotq_laneq_s32(accumulators[5], activations_0_3, weights45_0, 2);
+  accumulators[5] =
+      vdotq_laneq_s32(accumulators[5], activations_4_7, weights45_0, 3);
+  accumulators[5] =
+      vdotq_laneq_s32(accumulators[5], activations_8_11, weights45_1, 2);
+  accumulators[5] =
+      vdotq_laneq_s32(accumulators[5], activations_12_15, weights45_1, 3);
+
+  accumulators[6] =
+      vdotq_laneq_s32(accumulators[6], activations_0_3, weights67_0, 0);
+  accumulators[6] =
+      vdotq_laneq_s32(accumulators[6], activations_4_7, weights67_0, 1);
+  accumulators[6] =
+      vdotq_laneq_s32(accumulators[6], activations_8_11, weights67_1, 0);
+  accumulators[6] =
+      vdotq_laneq_s32(accumulators[6], activations_12_15, weights67_1, 1);
+  accumulators[7] =
+      vdotq_laneq_s32(accumulators[7], activations_0_3, weights67_0, 2);
+  accumulators[7] =
+      vdotq_laneq_s32(accumulators[7], activations_4_7, weights67_0, 3);
+  accumulators[7] =
+      vdotq_laneq_s32(accumulators[7], activations_8_11, weights67_1, 2);
+  accumulators[7] =
+      vdotq_laneq_s32(accumulators[7], activations_12_15, weights67_1, 3);
+}
+
+} // namespace internal
+
+// Computes an output tile with one accumulator vector per output column. Each
+// vector lane corresponds to one of four activation rows. This layout reuses
+// unpacked weights across four rows without the register pressure of four
+// independent copies of the 1x8 accumulator set.
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_4x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const void* activation_data,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  assert(k % group_size == 0);
+  assert(group_size % 16 == 0);
+
+  constexpr int mr = 4;
+  constexpr int nr = 8;
+  constexpr int bytes_per_128_weight_values = 16 * weight_nbit;
+  const std::size_t activation_row_size = sizeof(float) + sizeof(int8_t) + k +
+      (has_weight_zeros ? (k / group_size) * sizeof(int32_t) : 0);
+  const auto* activation_data_bytes = static_cast<const char*>(activation_data);
+
+  int m_idx = 0;
+  for (; m_idx + mr <= m; m_idx += mr) {
+    float activation_scales[mr];
+    int32_t activation_zeros[mr];
+    const char* activation_qvals[mr];
+    for (int row = 0; row < mr; row++) {
+      const char* row_data =
+          activation_data_bytes + (m_idx + row) * activation_row_size;
+      activation_scales[row] = *reinterpret_cast<const float*>(row_data);
+      row_data += sizeof(float);
+      activation_zeros[row] =
+          static_cast<int32_t>(*reinterpret_cast<const int8_t*>(row_data));
+      activation_qvals[row] = row_data + sizeof(int8_t);
+    }
+    float32x4_t activation_scale_vec = vld1q_f32(activation_scales);
+    int32x4_t activation_zero_vec = vld1q_s32(activation_zeros);
+
+    const char* weight_data_bytes = static_cast<const char*>(weight_data);
+    for (int n_idx = 0; n_idx < n; n_idx += nr) {
+      const char* activation_ptrs[mr];
+      float32x4_t results[nr];
+      for (int row = 0; row < mr; row++) {
+        activation_ptrs[row] = activation_qvals[row];
+      }
+      for (int col = 0; col < nr; col++) {
+        results[col] = vdupq_n_f32(0.0f);
+      }
+
+      for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+        int32x4_t accumulators[nr];
+        for (int col = 0; col < nr; col++) {
+          accumulators[col] = vdupq_n_s32(0);
+        }
+
+        for (int i = 0; i < group_size; i += 16) {
+          int8x16_t weights01_0;
+          int8x16_t weights23_0;
+          int8x16_t weights45_0;
+          int8x16_t weights67_0;
+          int8x16_t weights01_1;
+          int8x16_t weights23_1;
+          int8x16_t weights45_1;
+          int8x16_t weights67_1;
+          torchao::bitpacking::vec_unpack_128_lowbit_values<weight_nbit>(
+              weights01_0,
+              weights23_0,
+              weights45_0,
+              weights67_0,
+              weights01_1,
+              weights23_1,
+              weights45_1,
+              weights67_1,
+              reinterpret_cast<const uint8_t*>(weight_data_bytes));
+          weight_data_bytes += bytes_per_128_weight_values;
+
+          internal::dot_4_rows_8_cols(
+              accumulators,
+              activation_ptrs,
+              /*row_base=*/0,
+              weights01_0,
+              weights23_0,
+              weights45_0,
+              weights67_0,
+              weights01_1,
+              weights23_1,
+              weights45_1,
+              weights67_1);
+        }
+
+        const float* weight_scales =
+            reinterpret_cast<const float*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(float);
+        const int32_t* weight_qvals_sums =
+            reinterpret_cast<const int32_t*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(int32_t);
+        const int32_t* weight_zeros = nullptr;
+        if constexpr (has_weight_zeros) {
+          weight_zeros = reinterpret_cast<const int32_t*>(weight_data_bytes);
+          weight_data_bytes += nr * sizeof(int32_t);
+        }
+
+        int32x4_t activation_qvals_sum_vec;
+        if constexpr (has_weight_zeros) {
+          int32_t activation_qvals_sums[mr];
+          for (int row = 0; row < mr; row++) {
+            activation_qvals_sums[row] =
+                *reinterpret_cast<const int32_t*>(activation_ptrs[row]);
+            activation_ptrs[row] += sizeof(int32_t);
+          }
+          activation_qvals_sum_vec = vld1q_s32(activation_qvals_sums);
+        }
+
+        for (int col = 0; col < nr; col++) {
+          int32x4_t corrected = vsubq_s32(
+              accumulators[col],
+              vmulq_n_s32(activation_zero_vec, weight_qvals_sums[col]));
+          if constexpr (has_weight_zeros) {
+            corrected = vsubq_s32(
+                corrected,
+                vmulq_n_s32(activation_qvals_sum_vec, weight_zeros[col]));
+            corrected = vaddq_s32(
+                corrected,
+                vmulq_n_s32(
+                    activation_zero_vec, group_size * weight_zeros[col]));
+          }
+          float32x4_t scale_factor =
+              vmulq_n_f32(activation_scale_vec, weight_scales[col]);
+          results[col] =
+              vmlaq_f32(results[col], scale_factor, vcvtq_f32_s32(corrected));
+        }
+      }
+
+      if (has_bias) {
+        const float* bias = reinterpret_cast<const float*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(float);
+        for (int col = 0; col < nr; col++) {
+          results[col] = vaddq_f32(results[col], vdupq_n_f32(bias[col]));
+        }
+      }
+      if (has_clamp) {
+        float32x4_t vec_min = vdupq_n_f32(clamp_min);
+        float32x4_t vec_max = vdupq_n_f32(clamp_max);
+        for (int col = 0; col < nr; col++) {
+          results[col] = internal::vec_clamp(results[col], vec_min, vec_max);
+        }
+      }
+
+      float32x4_t output_0123[mr];
+      float32x4_t output_4567[mr];
+      internal::transpose_4x4_f32(
+          results[0],
+          results[1],
+          results[2],
+          results[3],
+          output_0123[0],
+          output_0123[1],
+          output_0123[2],
+          output_0123[3]);
+      internal::transpose_4x4_f32(
+          results[4],
+          results[5],
+          results[6],
+          results[7],
+          output_4567[0],
+          output_4567[1],
+          output_4567[2],
+          output_4567[3]);
+      const int remaining = n - n_idx;
+      for (int row = 0; row < mr; row++) {
+        internal::store_8_f32(
+            output + (m_idx + row) * output_m_stride + n_idx,
+            remaining,
+            output_0123[row],
+            output_4567[row]);
+      }
+    }
+  }
+
+  if (m_idx < m) {
+    if (m - m_idx >= 2) {
+      kernel_2x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+          output + m_idx * output_m_stride,
+          output_m_stride,
+          m - m_idx,
+          n,
+          k,
+          group_size,
+          weight_data,
+          activation_data_bytes + m_idx * activation_row_size,
+          clamp_min,
+          clamp_max,
+          has_bias,
+          has_clamp);
+    } else {
+      kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, false>(
+          output + m_idx * output_m_stride,
+          output_m_stride,
+          m - m_idx,
+          n,
+          k,
+          group_size,
+          weight_data,
+          activation_data_bytes + m_idx * activation_row_size,
+          clamp_min,
+          clamp_max,
+          has_bias,
+          has_clamp);
+    }
+  }
+}
+
+} // namespace
+  // torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::kernel
+
+#endif // defined(__aarch64__) || defined(__ARM_NEON)

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -63,7 +63,7 @@ void inline pack_activations(
     bool has_weight_zeros) {
   // The universal multi-row kernels use the same row-major packing.
   // kr/sr do not affect activation packing for these kernels.
-  static_assert(mr == 1 || mr == 2);
+  static_assert(mr == 1 || mr == 2 || mr == 4);
 
   auto activation_data_byte_ptr = (char*)activation_data;
 

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -61,8 +61,9 @@ void inline pack_activations(
     int group_size,
     const float* activations,
     bool has_weight_zeros) {
-  // when mr == 1, kr/sr do not matter
-  static_assert(mr == 1);
+  // The universal multi-row kernels use the same row-major packing.
+  // kr/sr do not affect activation packing for these kernels.
+  static_assert(mr == 1 || mr == 2);
 
   auto activation_data_byte_ptr = (char*)activation_data;
 


### PR DESCRIPTION
This adds the native non-LUT Arm NEON W3A8 4x8 dot-product kernel. It extends activation packing to four-row tiles, wires the kernel into dispatch, reuses the 2x8 path for row tails, and adds correctness coverage for weight zero points, bias, clamp, and partial rows.\n\nThis is pull request 2 of 5 and depends on pull request 4855. Pull request 3 is 4858, pull request 4 is 4856, and pull request 5 is 4854.