### PR TITLE
Add Arm NEON W3A8 8x8 prefill kernel

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -144,7 +144,7 @@ void register_ukernel_config_universal(
       if constexpr (weight_nbit == 3) {
         log_registration(
             format,
-            "universal: kernel_1x8x16_f32_neondot, kernel_2x8x16_f32_neondot, kernel_4x8x16_f32_neondot");
+            "universal: kernel_1x8x16_f32_neondot, kernel_2x8x16_f32_neondot, kernel_4x8x16_f32_neondot, kernel_8x8x16_f32_neondot");
       } else {
         log_registration(format, "universal: kernel_1x8x16_f32_neondot");
       }
@@ -182,6 +182,16 @@ void register_ukernel_config_universal(
                &kernel::pack_activations<prefill_mr, kr, sr>,
                &kernel::
                    kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+          constexpr int large_prefill_mr = 8;
+          constexpr int large_prefill_m_step = 8;
+          uk.linear_configs[3] = UKernelConfig::linear_config_type(
+              {large_prefill_m_step,
+               large_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<large_prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
       } else {
         constexpr bool has_weight_zeros = false;
@@ -216,6 +226,16 @@ void register_ukernel_config_universal(
                &kernel::pack_activations<prefill_mr, kr, sr>,
                &kernel::
                    kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+          constexpr int large_prefill_mr = 8;
+          constexpr int large_prefill_m_step = 8;
+          uk.linear_configs[3] = UKernelConfig::linear_config_type(
+              {large_prefill_m_step,
+               large_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<large_prefill_mr, kr, sr>,
+               &kernel::
+                   kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
       }
 

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -81,6 +81,15 @@ UKernelConfig get_ukernel_config() {
         &kernel::packed_activations_offset,
         &kernel::pack_activations<prefill_mr, kr, sr>,
         &kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
+    constexpr int large_prefill_mr = 8;
+    constexpr int large_prefill_m_step = 8;
+    uk.linear_configs[3] = UKernelConfig::linear_config_type{
+        large_prefill_m_step,
+        large_prefill_mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations<large_prefill_mr, kr, sr>,
+        &kernel::kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
   }
 
   if constexpr (has_lut) {
@@ -453,6 +462,12 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefill) {
       false /*has_bias*/,
       false /*has_clamp*/>(
       /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/16, /*n=*/8 * 4, /*k=*/16 * 8, /*group_size=*/64);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
@@ -480,6 +495,15 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillBiasClamp) {
       true /*has_bias*/,
       true /*has_clamp*/>(
       /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillAllOptions) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/17, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -19,6 +19,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_2x8x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h>
 
 namespace torchao::kernels::cpu::aarch64::linear::
     channelwise_8bit_activation_groupwise_lowbit_weight {
@@ -289,6 +290,37 @@ void kernel_4x8x16_f32_neondot(
     bool has_clamp) {
   (void)has_weight_zeros_;
   kernel::kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+      output,
+      output_m_stride,
+      m,
+      n,
+      k,
+      group_size,
+      packed_weights,
+      packed_activations,
+      clamp_min,
+      clamp_max,
+      has_bias,
+      has_clamp);
+}
+
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_8x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* packed_weights,
+    const void* packed_activations,
+    float clamp_min,
+    float clamp_max,
+    bool has_weight_zeros_,
+    bool has_bias,
+    bool has_clamp) {
+  (void)has_weight_zeros_;
+  kernel::kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
@@ -1,0 +1,257 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/bitpacking/bitpack.h>
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_4x8x16_f32_neondot-impl.h>
+#include <cassert>
+#include <cstddef>
+
+namespace torchao::kernels::cpu::aarch64::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight::kernel {
+
+// Computes two four-row blocks together, reusing each unpacked weight block
+// across all eight rows. FP32 partial results are kept separately from the
+// integer dot-product accumulators to limit pressure in the inner loop.
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_8x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const void* activation_data,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  assert(k % group_size == 0);
+  assert(group_size % 16 == 0);
+
+  constexpr int mr = 8;
+  constexpr int row_blocks = 2;
+  constexpr int nr = 8;
+  constexpr int bytes_per_128_weight_values = 16 * weight_nbit;
+  const std::size_t activation_row_size = sizeof(float) + sizeof(int8_t) + k +
+      (has_weight_zeros ? (k / group_size) * sizeof(int32_t) : 0);
+  const auto* activation_data_bytes = static_cast<const char*>(activation_data);
+
+  int m_idx = 0;
+  for (; m_idx + mr <= m; m_idx += mr) {
+    float activation_scales[mr];
+    int32_t activation_zeros[mr];
+    const char* activation_qvals[mr];
+    for (int row = 0; row < mr; row++) {
+      const char* row_data =
+          activation_data_bytes + (m_idx + row) * activation_row_size;
+      activation_scales[row] = *reinterpret_cast<const float*>(row_data);
+      row_data += sizeof(float);
+      activation_zeros[row] =
+          static_cast<int32_t>(*reinterpret_cast<const int8_t*>(row_data));
+      activation_qvals[row] = row_data + sizeof(int8_t);
+    }
+    float32x4_t activation_scale_vec[row_blocks] = {
+        vld1q_f32(activation_scales), vld1q_f32(activation_scales + 4)};
+    int32x4_t activation_zero_vec[row_blocks] = {
+        vld1q_s32(activation_zeros), vld1q_s32(activation_zeros + 4)};
+
+    const char* weight_data_bytes = static_cast<const char*>(weight_data);
+    for (int n_idx = 0; n_idx < n; n_idx += nr) {
+      const char* activation_ptrs[mr];
+      for (int row = 0; row < mr; row++) {
+        activation_ptrs[row] = activation_qvals[row];
+      }
+      float32x4_t results[row_blocks][nr];
+      for (int block = 0; block < row_blocks; block++) {
+        for (int col = 0; col < nr; col++) {
+          results[block][col] = vdupq_n_f32(0.0f);
+        }
+      }
+
+      for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+        int32x4_t accumulators[row_blocks][nr];
+        for (int block = 0; block < row_blocks; block++) {
+          for (int col = 0; col < nr; col++) {
+            accumulators[block][col] = vdupq_n_s32(0);
+          }
+        }
+
+        for (int i = 0; i < group_size; i += 16) {
+          int8x16_t weights01_0;
+          int8x16_t weights23_0;
+          int8x16_t weights45_0;
+          int8x16_t weights67_0;
+          int8x16_t weights01_1;
+          int8x16_t weights23_1;
+          int8x16_t weights45_1;
+          int8x16_t weights67_1;
+          torchao::bitpacking::vec_unpack_128_lowbit_values<weight_nbit>(
+              weights01_0,
+              weights23_0,
+              weights45_0,
+              weights67_0,
+              weights01_1,
+              weights23_1,
+              weights45_1,
+              weights67_1,
+              reinterpret_cast<const uint8_t*>(weight_data_bytes));
+          weight_data_bytes += bytes_per_128_weight_values;
+
+          internal::dot_4_rows_8_cols(
+              accumulators[0],
+              activation_ptrs,
+              /*row_base=*/0,
+              weights01_0,
+              weights23_0,
+              weights45_0,
+              weights67_0,
+              weights01_1,
+              weights23_1,
+              weights45_1,
+              weights67_1);
+          internal::dot_4_rows_8_cols(
+              accumulators[1],
+              activation_ptrs,
+              /*row_base=*/4,
+              weights01_0,
+              weights23_0,
+              weights45_0,
+              weights67_0,
+              weights01_1,
+              weights23_1,
+              weights45_1,
+              weights67_1);
+        }
+
+        const float* weight_scales =
+            reinterpret_cast<const float*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(float);
+        const int32_t* weight_qvals_sums =
+            reinterpret_cast<const int32_t*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(int32_t);
+        const int32_t* weight_zeros = nullptr;
+        if constexpr (has_weight_zeros) {
+          weight_zeros = reinterpret_cast<const int32_t*>(weight_data_bytes);
+          weight_data_bytes += nr * sizeof(int32_t);
+        }
+
+        int32x4_t activation_qvals_sum_vec[row_blocks];
+        if constexpr (has_weight_zeros) {
+          int32_t activation_qvals_sums[mr];
+          for (int row = 0; row < mr; row++) {
+            activation_qvals_sums[row] =
+                *reinterpret_cast<const int32_t*>(activation_ptrs[row]);
+            activation_ptrs[row] += sizeof(int32_t);
+          }
+          activation_qvals_sum_vec[0] = vld1q_s32(activation_qvals_sums);
+          activation_qvals_sum_vec[1] = vld1q_s32(activation_qvals_sums + 4);
+        }
+
+        for (int block = 0; block < row_blocks; block++) {
+          for (int col = 0; col < nr; col++) {
+            int32x4_t corrected = vsubq_s32(
+                accumulators[block][col],
+                vmulq_n_s32(
+                    activation_zero_vec[block], weight_qvals_sums[col]));
+            if constexpr (has_weight_zeros) {
+              corrected = vsubq_s32(
+                  corrected,
+                  vmulq_n_s32(
+                      activation_qvals_sum_vec[block], weight_zeros[col]));
+              corrected = vaddq_s32(
+                  corrected,
+                  vmulq_n_s32(
+                      activation_zero_vec[block],
+                      group_size * weight_zeros[col]));
+            }
+            float32x4_t scale_factor =
+                vmulq_n_f32(activation_scale_vec[block], weight_scales[col]);
+            results[block][col] = vmlaq_f32(
+                results[block][col], scale_factor, vcvtq_f32_s32(corrected));
+          }
+        }
+      }
+
+      if (has_bias) {
+        const float* bias = reinterpret_cast<const float*>(weight_data_bytes);
+        weight_data_bytes += nr * sizeof(float);
+        for (int block = 0; block < row_blocks; block++) {
+          for (int col = 0; col < nr; col++) {
+            results[block][col] =
+                vaddq_f32(results[block][col], vdupq_n_f32(bias[col]));
+          }
+        }
+      }
+      if (has_clamp) {
+        float32x4_t vec_min = vdupq_n_f32(clamp_min);
+        float32x4_t vec_max = vdupq_n_f32(clamp_max);
+        for (int block = 0; block < row_blocks; block++) {
+          for (int col = 0; col < nr; col++) {
+            results[block][col] =
+                internal::vec_clamp(results[block][col], vec_min, vec_max);
+          }
+        }
+      }
+
+      for (int block = 0; block < row_blocks; block++) {
+        float32x4_t output_0123[4];
+        float32x4_t output_4567[4];
+        internal::transpose_4x4_f32(
+            results[block][0],
+            results[block][1],
+            results[block][2],
+            results[block][3],
+            output_0123[0],
+            output_0123[1],
+            output_0123[2],
+            output_0123[3]);
+        internal::transpose_4x4_f32(
+            results[block][4],
+            results[block][5],
+            results[block][6],
+            results[block][7],
+            output_4567[0],
+            output_4567[1],
+            output_4567[2],
+            output_4567[3]);
+        const int remaining = n - n_idx;
+        for (int row = 0; row < 4; row++) {
+          internal::store_8_f32(
+              output + (m_idx + block * 4 + row) * output_m_stride + n_idx,
+              remaining,
+              output_0123[row],
+              output_4567[row]);
+        }
+      }
+    }
+  }
+
+  if (m_idx < m) {
+    kernel_4x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        m - m_idx,
+        n,
+        k,
+        group_size,
+        weight_data,
+        activation_data_bytes + m_idx * activation_row_size,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+  }
+}
+
+} // namespace
+  // torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::kernel
+
+#endif // defined(__aarch64__) || defined(__ARM_NEON)

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -63,7 +63,7 @@ void inline pack_activations(
     bool has_weight_zeros) {
   // The universal multi-row kernels use the same row-major packing.
   // kr/sr do not affect activation packing for these kernels.
-  static_assert(mr == 1 || mr == 2 || mr == 4);
+  static_assert(mr == 1 || mr == 2 || mr == 4 || mr == 8);
 
   auto activation_data_byte_ptr = (char*)activation_data;
 


### PR DESCRIPTION
This adds the native non-LUT Arm NEON W3A8 8x8 dot-product kernel. It extends activation packing to eight-row tiles, wires the kernel into dispatch, reuses the smaller kernels for row tails, and adds correctness coverage for larger prefill batches and combined operator options.\n\nThis is pull request 3 of 5 and depends on pull request 4857. Pull request 4 is 4856 and pull request 5 is 4854.