### PR TITLE
Optimize Arm NEON W3A8 decode

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -157,16 +157,31 @@ void register_ukernel_config_universal(
                  has_lut>});
       } else {
         constexpr bool has_weight_zeros = false;
-        uk.linear_configs[0] = UKernelConfig::linear_config_type(
-            {m_step,
-             mr,
-             &kernel::packed_activations_size,
-             &kernel::packed_activations_offset,
-             &kernel::pack_activations<mr, kr, sr>,
-             &kernel::kernel_1x8x16_f32_neondot<
-                 weight_nbit,
-                 has_weight_zeros,
-                 has_lut>});
+        if constexpr (weight_nbit == 3) {
+          constexpr bool has_activation_qvals_sum = true;
+          uk.linear_configs[0] = UKernelConfig::linear_config_type(
+              {m_step,
+               mr,
+               &kernel::packed_activations_with_qvals_sum_size,
+               &kernel::packed_activations_with_qvals_sum_offset,
+               &kernel::pack_activations_with_qvals_sum<mr, kr, sr>,
+               &kernel::kernel_1x8x16_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros,
+                   has_lut,
+                   has_activation_qvals_sum>});
+        } else {
+          uk.linear_configs[0] = UKernelConfig::linear_config_type(
+              {m_step,
+               mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<mr, kr, sr>,
+               &kernel::kernel_1x8x16_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros,
+                   has_lut>});
+        }
       }
 
       table.register_ukernel_config(format, uarch, std::move(uk));

--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -141,7 +141,13 @@ void register_ukernel_config_universal(
 
 #if defined(TORCHAO_ENABLE_ARM_NEON_DOT)
     if (cpuinfo_has_arm_neon_dot()) {
-      log_registration(format, "universal: kernel_1x8x16_f32_neondot");
+      if constexpr (weight_nbit == 3) {
+        log_registration(
+            format,
+            "universal: kernel_1x8x16_f32_neondot, kernel_8x8x16_f32_neondot");
+      } else {
+        log_registration(format, "universal: kernel_1x8x16_f32_neondot");
+      }
 
       if (format.has_weight_zeros) {
         constexpr bool has_weight_zeros = true;
@@ -155,6 +161,21 @@ void register_ukernel_config_universal(
                  weight_nbit,
                  has_weight_zeros,
                  has_lut>});
+        if constexpr (weight_nbit == 3) {
+          constexpr int large_prefill_mr = 8;
+          constexpr int large_prefill_m_step = 8;
+          uk.linear_configs[1] = UKernelConfig::linear_config_type(
+              {large_prefill_m_step,
+               large_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations_interleaved<
+                   large_prefill_mr,
+                   kr,
+                   sr>,
+               &kernel::
+                   kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
+        }
       } else {
         constexpr bool has_weight_zeros = false;
         if constexpr (weight_nbit == 3) {
@@ -181,6 +202,21 @@ void register_ukernel_config_universal(
                    weight_nbit,
                    has_weight_zeros,
                    has_lut>});
+        }
+        if constexpr (weight_nbit == 3) {
+          constexpr int large_prefill_mr = 8;
+          constexpr int large_prefill_m_step = 8;
+          uk.linear_configs[1] = UKernelConfig::linear_config_type(
+              {large_prefill_m_step,
+               large_prefill_mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations_interleaved<
+                   large_prefill_mr,
+                   kr,
+                   sr>,
+               &kernel::
+                   kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>});
         }
       }
 

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -77,6 +77,18 @@ UKernelConfig get_ukernel_config() {
             kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
   }
 
+  if constexpr (weight_nbit == 3 && !has_lut) {
+    constexpr int large_prefill_mr = 8;
+    constexpr int large_prefill_m_step = 8;
+    uk.linear_configs[1] = UKernelConfig::linear_config_type{
+        large_prefill_m_step,
+        large_prefill_mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations_interleaved<large_prefill_mr, kr, sr>,
+        &kernel::kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>};
+  }
+
   if constexpr (has_lut) {
     uk.packed_weights_size = &kernel::packed_weights_with_lut_size;
     uk.packed_weights_offset = &kernel::packed_weights_with_lut_offset;
@@ -456,6 +468,86 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedSymmetricWeights) {
       true /*has_bias*/,
       true /*has_clamp*/>(
       /*m=*/3, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefill) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/16, /*n=*/8 * 4, /*k=*/16 * 8, /*group_size=*/64);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitSmallPrefill) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/3, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/7, /*n=*/8 * 2 + 1, /*k=*/16 * 4, /*group_size=*/32);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPaddedMTails) {
+  for (int m = 8; m < 16; m++) {
+    test_linear_8bit_act_xbit_weight<
+        3 /*weight_nbit*/,
+        true /*has_weight_zeros*/,
+        true /*has_bias*/,
+        true /*has_clamp*/>(
+        m, /*n=*/8 * 2 + 3, /*k=*/16 * 4, /*group_size=*/32);
+  }
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillWeightZeros) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      false /*has_bias*/,
+      false /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 4, /*group_size=*/32);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillBiasClamp) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitPrefillAllOptions) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/15, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/17, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/31, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -53,14 +53,29 @@ UKernelConfig get_ukernel_config() {
       &torchao::weight_packing::pack_weights<weight_nbit, nr, kr, sr>,
       /*linear_configs*/ {});
 
-  uk.linear_configs[0] = UKernelConfig::linear_config_type{
-      m_step,
-      mr,
-      &kernel::packed_activations_size,
-      &kernel::packed_activations_offset,
-      &kernel::pack_activations<mr, kr, sr>,
-      &kernel::
-          kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
+  if constexpr (weight_nbit == 3 && !has_weight_zeros && !has_lut) {
+    constexpr bool has_activation_qvals_sum = true;
+    uk.linear_configs[0] = UKernelConfig::linear_config_type{
+        m_step,
+        mr,
+        &kernel::packed_activations_with_qvals_sum_size,
+        &kernel::packed_activations_with_qvals_sum_offset,
+        &kernel::pack_activations_with_qvals_sum<mr, kr, sr>,
+        &kernel::kernel_1x8x16_f32_neondot<
+            weight_nbit,
+            has_weight_zeros,
+            has_lut,
+            has_activation_qvals_sum>};
+  } else {
+    uk.linear_configs[0] = UKernelConfig::linear_config_type{
+        m_step,
+        mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations<mr, kr, sr>,
+        &kernel::
+            kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
+  }
 
   if constexpr (has_lut) {
     uk.packed_weights_size = &kernel::packed_weights_with_lut_size;
@@ -432,6 +447,15 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedWeights) {
       true /*has_bias*/,
       true /*has_clamp*/>(
       /*m=*/1, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedSymmetricWeights) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/3, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -425,6 +425,15 @@ TEST(test_linear_8bit_act_xbit_weight, Standard) {
       /*m=*/13, /*n=*/8 * 10 + 3, /*k=*/16 * 3, /*group_size=*/16);
 }
 
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedWeights) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      true /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/1, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+}
+
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {
   test_linear_8bit_act_xbit_weight<
       4 /*weight_nbit*/,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -50,6 +50,35 @@ inline size_t packed_activations_offset(
   return (m_idx / mr) * packed_activations_size_mr_rows;
 }
 
+// The symmetric W3 decode kernel keeps packed weights in their unsigned 0..7
+// representation. Store activation sums so it can remove the resulting +4
+// offset after the dot product without changing the weight format.
+inline size_t packed_activations_with_qvals_sum_size(
+    int m,
+    int k,
+    int group_size,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  return packed_activations_size(
+      m, k, group_size, true, mr, kr, sr);
+}
+
+inline size_t packed_activations_with_qvals_sum_offset(
+    int m_idx,
+    int k,
+    int group_size,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  return packed_activations_offset(
+      m_idx, k, group_size, true, mr, kr, sr);
+}
+
 template <int mr_, int kr_, int sr_>
 void pack_activations(
     void* packed_activations,
@@ -66,6 +95,25 @@ void pack_activations(
   (void)sr; // unused
   activation_packing::pack_activations<mr_, kr_, sr_>(
       packed_activations, m, k, group_size, activations, has_weight_zeros);
+}
+
+template <int mr_, int kr_, int sr_>
+void pack_activations_with_qvals_sum(
+    void* packed_activations,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  (void)mr;
+  (void)kr;
+  (void)sr;
+  activation_packing::pack_activations<mr_, kr_, sr_>(
+      packed_activations, m, k, group_size, activations, true);
 }
 
 template <int weight_nbit, int nr_, int kr_, int sr_>
@@ -205,7 +253,11 @@ void kernel_1x4x16_f32_neondot(
       has_clamp);
 }
 
-template <int weight_nbit, bool has_weight_zeros, bool has_lut>
+template <
+    int weight_nbit,
+    bool has_weight_zeros,
+    bool has_lut,
+    bool has_activation_qvals_sum = has_weight_zeros>
 void kernel_1x8x16_f32_neondot(
     // Outputs
     float32_t* output,
@@ -224,7 +276,11 @@ void kernel_1x8x16_f32_neondot(
     bool has_bias,
     bool has_clamp) {
   (void)has_weight_zeros_; // unused
-  kernel::kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>(
+  kernel::kernel_1x8x16_f32_neondot<
+      weight_nbit,
+      has_weight_zeros,
+      has_lut,
+      has_activation_qvals_sum>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -14,6 +14,7 @@
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_weights.h>
 #include <torchao/csrc/cpu/torch_free_kernels/weight_packing/weight_packing.h>
 
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x1x32_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x4x16_f32_neondot-impl.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
@@ -29,9 +30,11 @@ inline size_t packed_activations_size(
     int mr,
     int kr,
     int sr) {
-  (void)mr; // unused
   (void)kr; // unused
   (void)sr; // unused
+  if (mr > 1) {
+    m = ((m + mr - 1) / mr) * mr;
+  }
   return activation_packing::packed_activations_size(
       m, k, group_size, has_weight_zeros);
 }
@@ -114,6 +117,24 @@ void pack_activations_with_qvals_sum(
   (void)sr;
   activation_packing::pack_activations<mr_, kr_, sr_>(
       packed_activations, m, k, group_size, activations, true);
+}
+
+template <int mr_, int kr_, int sr_>
+void pack_activations_interleaved(
+    void* packed_activations,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)mr;
+  (void)kr;
+  (void)sr;
+  activation_packing::pack_activations_interleaved<mr_, kr_, sr_>(
+      packed_activations, m, k, group_size, activations, has_weight_zeros);
 }
 
 template <int weight_nbit, int nr_, int kr_, int sr_>
@@ -281,6 +302,38 @@ void kernel_1x8x16_f32_neondot(
       has_weight_zeros,
       has_lut,
       has_activation_qvals_sum>(
+      output,
+      output_m_stride,
+      m,
+      n,
+      k,
+      group_size,
+      packed_weights,
+      packed_activations,
+      clamp_min,
+      clamp_max,
+      has_bias,
+      has_clamp);
+}
+
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_8x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* packed_weights,
+    const void* packed_activations,
+    float clamp_min,
+    float clamp_max,
+    bool has_weight_zeros_,
+    bool has_bias,
+    bool has_clamp) {
+  (void)has_weight_zeros_;
+  static_assert(weight_nbit == 3);
+  kernel::kernel_8x8x16_f32_neondot<weight_nbit, has_weight_zeros>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
@@ -58,7 +58,11 @@ vec_clamp(float32x4_t x, float32x4_t vec_min, float32x4_t vec_max) {
 // Roughly inspired by
 // https://gitlab.arm.com/kleidi/kleidiai/-/blob/main/kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi4cxp8x8_1x8x32_neon_dotprod.c?ref_type=heads
 
-template <int weight_nbit, bool has_weight_zeros, bool has_lut>
+template <
+    int weight_nbit,
+    bool has_weight_zeros,
+    bool has_lut,
+    bool has_activation_qvals_sum = has_weight_zeros>
 void kernel_1x8x16_f32_neondot(
     // Outputs
     float32_t* output,
@@ -77,6 +81,10 @@ void kernel_1x8x16_f32_neondot(
     bool has_clamp) {
   assert(k % group_size == 0);
   assert(group_size % 16 == 0);
+  static_assert(!has_weight_zeros || has_activation_qvals_sum);
+
+  constexpr bool use_unsigned_w3 =
+      weight_nbit == 3 && !has_lut && has_activation_qvals_sum;
 
   int8x16_t lut;
   if constexpr (!has_lut) {
@@ -190,7 +198,7 @@ void kernel_1x8x16_f32_neondot(
                 weight_q_cols67_1,
                 (uint8_t*)weight_data_byte_ptr,
                 lut);
-          } else if constexpr (weight_nbit == 3 && has_weight_zeros) {
+          } else if constexpr (use_unsigned_w3) {
             uint8x16_t unsigned_weights[8];
             torchao::bitpacking::vec_unpack_128_uintx_values<3>(
                 unsigned_weights[0],
@@ -286,17 +294,20 @@ void kernel_1x8x16_f32_neondot(
 
         int32x4_t term1_4567 = vmulq_n_s32(weight_qvals_sum, activation_zero);
 
+        int32_t activation_qvals_sum = 0;
+        if constexpr (has_activation_qvals_sum) {
+          activation_qvals_sum = *((int32_t*)activation_ptr);
+          activation_ptr += sizeof(int32_t);
+        }
+
         if constexpr (has_weight_zeros) {
           // Compute term2 and term3
-
-          int32_t activation_qvals_sum = *((int32_t*)activation_ptr);
-          activation_ptr += sizeof(int32_t);
 
           int32x4_t weight_zeros = vld1q_s32((int32_t*)weight_data_byte_ptr);
           weight_data_byte_ptr += 16;
 
           int32x4_t term2_0123;
-          if constexpr (weight_nbit == 3 && !has_lut) {
+          if constexpr (use_unsigned_w3) {
             term2_0123 = vmulq_n_s32(
                 vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
           } else {
@@ -310,7 +321,7 @@ void kernel_1x8x16_f32_neondot(
           weight_data_byte_ptr += 16;
 
           int32x4_t term2_4567;
-          if constexpr (weight_nbit == 3 && !has_lut) {
+          if constexpr (use_unsigned_w3) {
             term2_4567 = vmulq_n_s32(
                 vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
           } else {
@@ -333,9 +344,17 @@ void kernel_1x8x16_f32_neondot(
         } else {
           // Do updates
           int32x4_t tmp = vsubq_s32(qval_dot_0123, term1_0123);
+          if constexpr (use_unsigned_w3) {
+            tmp = vsubq_s32(
+                tmp, vdupq_n_s32(4 * activation_qvals_sum));
+          }
           res_0123 = vmlaq_f32(res_0123, scale_factor_0123, vcvtq_f32_s32(tmp));
 
           tmp = vsubq_s32(qval_dot_4567, term1_4567);
+          if constexpr (use_unsigned_w3) {
+            tmp = vsubq_s32(
+                tmp, vdupq_n_s32(4 * activation_qvals_sum));
+          }
           res_4567 = vmlaq_f32(res_4567, scale_factor_4567, vcvtq_f32_s32(tmp));
         }
 

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
@@ -190,6 +190,26 @@ void kernel_1x8x16_f32_neondot(
                 weight_q_cols67_1,
                 (uint8_t*)weight_data_byte_ptr,
                 lut);
+          } else if constexpr (weight_nbit == 3 && has_weight_zeros) {
+            uint8x16_t unsigned_weights[8];
+            torchao::bitpacking::vec_unpack_128_uintx_values<3>(
+                unsigned_weights[0],
+                unsigned_weights[1],
+                unsigned_weights[2],
+                unsigned_weights[3],
+                unsigned_weights[4],
+                unsigned_weights[5],
+                unsigned_weights[6],
+                unsigned_weights[7],
+                reinterpret_cast<const uint8_t*>(weight_data_byte_ptr));
+            weight_q_cols01_0 = vreinterpretq_s8_u8(unsigned_weights[0]);
+            weight_q_cols23_0 = vreinterpretq_s8_u8(unsigned_weights[1]);
+            weight_q_cols45_0 = vreinterpretq_s8_u8(unsigned_weights[2]);
+            weight_q_cols67_0 = vreinterpretq_s8_u8(unsigned_weights[3]);
+            weight_q_cols01_1 = vreinterpretq_s8_u8(unsigned_weights[4]);
+            weight_q_cols23_1 = vreinterpretq_s8_u8(unsigned_weights[5]);
+            weight_q_cols45_1 = vreinterpretq_s8_u8(unsigned_weights[6]);
+            weight_q_cols67_1 = vreinterpretq_s8_u8(unsigned_weights[7]);
           } else {
             torchao::bitpacking::vec_unpack_128_lowbit_values<weight_nbit>(
                 weight_q_cols01_0,
@@ -275,8 +295,13 @@ void kernel_1x8x16_f32_neondot(
           int32x4_t weight_zeros = vld1q_s32((int32_t*)weight_data_byte_ptr);
           weight_data_byte_ptr += 16;
 
-          int32x4_t term2_0123 =
-              vmulq_n_s32(weight_zeros, activation_qvals_sum);
+          int32x4_t term2_0123;
+          if constexpr (weight_nbit == 3 && !has_lut) {
+            term2_0123 = vmulq_n_s32(
+                vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
+          } else {
+            term2_0123 = vmulq_n_s32(weight_zeros, activation_qvals_sum);
+          }
 
           int32x4_t term3_0123 =
               vmulq_n_s32(weight_zeros, group_size * activation_zero);
@@ -284,8 +309,13 @@ void kernel_1x8x16_f32_neondot(
           weight_zeros = vld1q_s32((int32_t*)weight_data_byte_ptr);
           weight_data_byte_ptr += 16;
 
-          int32x4_t term2_4567 =
-              vmulq_n_s32(weight_zeros, activation_qvals_sum);
+          int32x4_t term2_4567;
+          if constexpr (weight_nbit == 3 && !has_lut) {
+            term2_4567 = vmulq_n_s32(
+                vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
+          } else {
+            term2_4567 = vmulq_n_s32(weight_zeros, activation_qvals_sum);
+          }
 
           int32x4_t term3_4567 =
               vmulq_n_s32(weight_zeros, group_size * activation_zero);

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_8x8x16_f32_neondot-impl.h
@@ -1,0 +1,930 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#if defined(__aarch64__) || defined(__ARM_NEON)
+
+#include <torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h>
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+
+namespace torchao::kernels::cpu::aarch64::linear::
+    channelwise_8bit_activation_groupwise_lowbit_weight::kernel {
+namespace internal {
+
+constexpr int kMr = 8;
+constexpr int kNr = 8;
+constexpr int kBytesPer128W3Values = 48;
+
+// Accumulator lanes represent four rows. Select four weight bytes at a time so
+// the same two output columns can be accumulated for all four rows.
+TORCHAO_ALWAYS_INLINE inline void dot_4_rows_2_cols(
+    int32x4_t& accumulator0,
+    int32x4_t& accumulator1,
+    const int8x16_t (&activations)[4],
+    int8x16_t weights_0_7,
+    int8x16_t weights_8_15) {
+  accumulator0 = vdotq_laneq_s32(accumulator0, activations[0], weights_0_7, 0);
+  accumulator0 = vdotq_laneq_s32(accumulator0, activations[1], weights_0_7, 1);
+  accumulator0 = vdotq_laneq_s32(accumulator0, activations[2], weights_8_15, 0);
+  accumulator0 = vdotq_laneq_s32(accumulator0, activations[3], weights_8_15, 1);
+  accumulator1 = vdotq_laneq_s32(accumulator1, activations[0], weights_0_7, 2);
+  accumulator1 = vdotq_laneq_s32(accumulator1, activations[1], weights_0_7, 3);
+  accumulator1 = vdotq_laneq_s32(accumulator1, activations[2], weights_8_15, 2);
+  accumulator1 = vdotq_laneq_s32(accumulator1, activations[3], weights_8_15, 3);
+}
+
+// Convert four column vectors into four row vectors for contiguous stores.
+inline void transpose_4x4_f32(
+    float32x4_t col0,
+    float32x4_t col1,
+    float32x4_t col2,
+    float32x4_t col3,
+    float32x4_t& row0,
+    float32x4_t& row1,
+    float32x4_t& row2,
+    float32x4_t& row3) {
+  float32x4_t cols01_lo = vzip1q_f32(col0, col1);
+  float32x4_t cols01_hi = vzip2q_f32(col0, col1);
+  float32x4_t cols23_lo = vzip1q_f32(col2, col3);
+  float32x4_t cols23_hi = vzip2q_f32(col2, col3);
+
+  row0 = vcombine_f32(vget_low_f32(cols01_lo), vget_low_f32(cols23_lo));
+  row1 = vcombine_f32(vget_high_f32(cols01_lo), vget_high_f32(cols23_lo));
+  row2 = vcombine_f32(vget_low_f32(cols01_hi), vget_low_f32(cols23_hi));
+  row3 = vcombine_f32(vget_high_f32(cols01_hi), vget_high_f32(cols23_hi));
+}
+
+// Store one row of an 8-column tile without writing past an N tail.
+inline void store_8_f32(
+    float* output,
+    int remaining,
+    float32x4_t values_0123,
+    float32x4_t values_4567) {
+  if (remaining >= 8) {
+    vst1q_f32(output, values_0123);
+    vst1q_f32(output + 4, values_4567);
+  } else if (remaining == 7) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+    output[6] = vgetq_lane_f32(values_4567, 2);
+  } else if (remaining == 6) {
+    vst1q_f32(output, values_0123);
+    vst1_f32(output + 4, vget_low_f32(values_4567));
+  } else if (remaining == 5) {
+    vst1q_f32(output, values_0123);
+    output[4] = vgetq_lane_f32(values_4567, 0);
+  } else if (remaining == 4) {
+    vst1q_f32(output, values_0123);
+  } else if (remaining == 3) {
+    vst1_f32(output, vget_low_f32(values_0123));
+    output[2] = vgetq_lane_f32(values_0123, 2);
+  } else if (remaining == 2) {
+    vst1_f32(output, vget_low_f32(values_0123));
+  } else {
+    output[0] = vgetq_lane_f32(values_0123, 0);
+  }
+}
+
+template <int column_half, bool shift_weights_to_signed>
+TORCHAO_ALWAYS_INLINE inline void decode_4_cols_w3(
+    int8x16_t& weights01_0,
+    int8x16_t& weights01_1,
+    int8x16_t& weights23_0,
+    int8x16_t& weights23_1,
+    const uint8_t* packed_weights) {
+  static_assert(column_half == 0 || column_half == 1);
+  // An 8-column by 16-K W3 panel occupies 48 bytes. Decode either four-column
+  // half into the layout consumed by the lane dot-product instructions.
+  const uint8x16_t packed0 = vld1q_u8(packed_weights);
+  const uint8x16_t packed1 = vld1q_u8(packed_weights + 16);
+  const uint8x16_t packed2 = vld1q_u8(packed_weights + 32);
+  const uint8x16_t mask7 = vdupq_n_u8(7);
+
+  if constexpr (column_half == 0) {
+    weights01_0 = vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(packed0, 3), mask7));
+    weights01_1 = vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(packed2, 3), mask7));
+    weights23_0 = vreinterpretq_s8_u8(vandq_u8(packed0, mask7));
+    weights23_1 = vreinterpretq_s8_u8(vandq_u8(packed2, mask7));
+  } else {
+    weights01_0 = vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(packed1, 3), mask7));
+    uint8x16_t weights45_1 = vandq_u8(vshrq_n_u8(packed2, 5), vdupq_n_u8(4));
+    weights45_1 = vorrq_u8(weights45_1, vshrq_n_u8(packed0, 6));
+    weights01_1 = vreinterpretq_s8_u8(weights45_1);
+    weights23_0 = vreinterpretq_s8_u8(vandq_u8(packed1, mask7));
+    uint8x16_t weights67_1 = vandq_u8(vshrq_n_u8(packed2, 4), vdupq_n_u8(4));
+    weights67_1 = vorrq_u8(weights67_1, vshrq_n_u8(packed1, 6));
+    weights23_1 = vreinterpretq_s8_u8(weights67_1);
+  }
+
+  if constexpr (shift_weights_to_signed) {
+    // Packed W3 codes are 0..7; symmetric weights use signed values -4..3.
+    const int8x16_t unshift = vdupq_n_s8(-4);
+    weights01_0 = vaddq_s8(weights01_0, unshift);
+    weights01_1 = vaddq_s8(weights01_1, unshift);
+    weights23_0 = vaddq_s8(weights23_0, unshift);
+    weights23_1 = vaddq_s8(weights23_1, unshift);
+  }
+}
+
+template <
+    int row_blocks,
+    int column_blocks,
+    int first_column_half,
+    bool shift_weights_to_signed>
+TORCHAO_ALWAYS_INLINE inline void dot_rows_cols_w3(
+    int32x4_t (&accumulators)[row_blocks][column_blocks * 4],
+    const uint8_t* packed_weights,
+    const char* const (&activation_ptrs)[(row_blocks + 1) / 2]) {
+  static_assert(row_blocks == 1 || row_blocks == 2 || row_blocks == 4);
+  static_assert(column_blocks == 1 || column_blocks == 2);
+  static_assert(first_column_half == 0 || first_column_half == 1);
+  static_assert(first_column_half + column_blocks <= 2);
+
+  int8x16_t weights01_0;
+  int8x16_t weights01_1;
+  int8x16_t weights23_0;
+  int8x16_t weights23_1;
+  if constexpr (column_blocks == 1) {
+    decode_4_cols_w3<first_column_half, shift_weights_to_signed>(
+        weights01_0,
+        weights01_1,
+        weights23_0,
+        weights23_1,
+        packed_weights);
+    for (int block = 0; block < row_blocks; block++) {
+      const int8_t* ptr = reinterpret_cast<const int8_t*>(
+          activation_ptrs[block / 2] + (block % 2) * 64);
+      int8x16_t activations[4] = {
+          vld1q_s8(ptr),
+          vld1q_s8(ptr + 16),
+          vld1q_s8(ptr + 32),
+          vld1q_s8(ptr + 48)};
+      dot_4_rows_2_cols(
+          accumulators[block][0],
+          accumulators[block][1],
+          activations,
+          weights01_0,
+          weights01_1);
+      dot_4_rows_2_cols(
+          accumulators[block][2],
+          accumulators[block][3],
+          activations,
+          weights23_0,
+          weights23_1);
+    }
+  } else {
+    // For an eight-column tile, keep up to eight activation vectors live and
+    // reuse them across both four-column weight halves.
+    int8x16_t activations[row_blocks][4];
+    for (int block = 0; block < row_blocks; block++) {
+      const int8_t* ptr = reinterpret_cast<const int8_t*>(
+          activation_ptrs[block / 2] + (block % 2) * 64);
+      activations[block][0] = vld1q_s8(ptr);
+      activations[block][1] = vld1q_s8(ptr + 16);
+      activations[block][2] = vld1q_s8(ptr + 32);
+      activations[block][3] = vld1q_s8(ptr + 48);
+    }
+#define TORCHAO_DOT_COLUMN_BLOCK(COLUMN_BLOCK, COLUMN_HALF)          \
+  decode_4_cols_w3<COLUMN_HALF, shift_weights_to_signed>(           \
+      weights01_0,                                                   \
+      weights01_1,                                                   \
+      weights23_0,                                                   \
+      weights23_1,                                                   \
+      packed_weights);                                               \
+  for (int block = 0; block < row_blocks; block++) {                 \
+    dot_4_rows_2_cols(                                               \
+        accumulators[block][COLUMN_BLOCK * 4],                       \
+        accumulators[block][COLUMN_BLOCK * 4 + 1],                   \
+        activations[block],                                          \
+        weights01_0,                                                 \
+        weights01_1);                                                \
+    dot_4_rows_2_cols(                                               \
+        accumulators[block][COLUMN_BLOCK * 4 + 2],                   \
+        accumulators[block][COLUMN_BLOCK * 4 + 3],                   \
+        activations[block],                                          \
+        weights23_0,                                                 \
+        weights23_1);                                                \
+  }
+    TORCHAO_DOT_COLUMN_BLOCK(0, first_column_half);
+    TORCHAO_DOT_COLUMN_BLOCK(1, first_column_half + 1);
+#undef TORCHAO_DOT_COLUMN_BLOCK
+  }
+}
+
+template <
+    int row_blocks,
+    int cols,
+    int col,
+    int lane,
+    bool has_weight_zeros>
+TORCHAO_ALWAYS_INLINE inline void accumulate_rows_column(
+    volatile float32x4_t (&results)[cols][row_blocks],
+    int32x4_t (&accumulators)[row_blocks][cols],
+    const int32x4_t (&activation_zero_vec)[row_blocks],
+    const float32x4_t (&activation_scale_vec)[row_blocks],
+    const int32x4_t& weight_qvals_sum_vec,
+    const float32x4_t& weight_scale_vec,
+    const int32x4_t& weight_zero_vec,
+    const int32x4_t (&activation_qvals_sum_vec)[row_blocks]) {
+  // Correct the integer dot product, apply both quantization scales, and add
+  // this K group's contribution to the FP32 result.
+  for (int block = 0; block < row_blocks; block++) {
+    int32x4_t corrected = vmlsq_laneq_s32(
+        accumulators[block][col],
+        activation_zero_vec[block],
+        weight_qvals_sum_vec,
+        lane);
+    if constexpr (has_weight_zeros) {
+      corrected = vmlsq_laneq_s32(
+          corrected, activation_qvals_sum_vec[block], weight_zero_vec, lane);
+    }
+    const float32x4_t scale_factor =
+        vmulq_laneq_f32(activation_scale_vec[block], weight_scale_vec, lane);
+    results[col][block] = vmlaq_f32(
+        results[col][block], scale_factor, vcvtq_f32_s32(corrected));
+  }
+}
+
+template <int row_blocks, int cols, int first_col, bool has_weight_zeros>
+TORCHAO_ALWAYS_INLINE inline void accumulate_4_columns(
+    volatile float32x4_t (&results)[cols][row_blocks],
+    int32x4_t (&accumulators)[row_blocks][cols],
+    const int32x4_t (&activation_zero_vec)[row_blocks],
+    const float32x4_t (&activation_scale_vec)[row_blocks],
+    const int32x4_t& weight_qvals_sum_vec,
+    const float32x4_t& weight_scale_vec,
+    const int32x4_t& weight_zero_vec,
+    const int32x4_t (&activation_qvals_sum_vec)[row_blocks]) {
+#define TORCHAO_ACCUMULATE_COLUMN(OFFSET)                \
+  accumulate_rows_column<                                \
+      row_blocks, cols, first_col + OFFSET, OFFSET,       \
+      has_weight_zeros>(                                  \
+      results,                                            \
+      accumulators,                                       \
+      activation_zero_vec,                                \
+      activation_scale_vec,                               \
+      weight_qvals_sum_vec,                               \
+      weight_scale_vec,                                   \
+      weight_zero_vec,                                    \
+      activation_qvals_sum_vec)
+  TORCHAO_ACCUMULATE_COLUMN(0);
+  TORCHAO_ACCUMULATE_COLUMN(1);
+  TORCHAO_ACCUMULATE_COLUMN(2);
+  TORCHAO_ACCUMULATE_COLUMN(3);
+#undef TORCHAO_ACCUMULATE_COLUMN
+}
+
+inline void store_4_f32(float* output, int remaining, float32x4_t values) {
+  if (remaining >= 4) {
+    vst1q_f32(output, values);
+  } else if (remaining == 3) {
+    vst1_f32(output, vget_low_f32(values));
+    output[2] = vgetq_lane_f32(values, 2);
+  } else if (remaining == 2) {
+    vst1_f32(output, vget_low_f32(values));
+  } else if (remaining == 1) {
+    output[0] = vgetq_lane_f32(values, 0);
+  }
+}
+
+template <int column_blocks>
+struct WeightGroupMetadata {
+  float32x4_t scales[column_blocks];
+  int32x4_t qvals_sums[column_blocks];
+  int32x4_t zeros[column_blocks];
+};
+
+template <int column_blocks, int column_offset, bool has_weight_zeros>
+TORCHAO_ALWAYS_INLINE inline WeightGroupMetadata<column_blocks>
+load_weight_group_metadata(const char*& weight_ptr, int group_size) {
+  static_assert(column_blocks == 1 || column_blocks == 2);
+  static_assert(column_offset == 0 || column_offset == 4);
+  static_assert(column_offset + column_blocks * 4 <= kNr);
+
+  WeightGroupMetadata<column_blocks> metadata;
+  const float* scales = reinterpret_cast<const float*>(weight_ptr);
+  for (int block = 0; block < column_blocks; block++) {
+    metadata.scales[block] =
+        vld1q_f32(scales + column_offset + block * 4);
+  }
+  weight_ptr += kNr * sizeof(float);
+
+  const int32_t* qvals_sums = reinterpret_cast<const int32_t*>(weight_ptr);
+  for (int block = 0; block < column_blocks; block++) {
+    metadata.qvals_sums[block] =
+        vld1q_s32(qvals_sums + column_offset + block * 4);
+    metadata.zeros[block] = vdupq_n_s32(0);
+  }
+  weight_ptr += kNr * sizeof(int32_t);
+
+  if constexpr (has_weight_zeros) {
+    const int32_t* zeros = reinterpret_cast<const int32_t*>(weight_ptr);
+    for (int block = 0; block < column_blocks; block++) {
+      metadata.zeros[block] =
+          vld1q_s32(zeros + column_offset + block * 4);
+      metadata.qvals_sums[block] = vmlsq_n_s32(
+          metadata.qvals_sums[block], metadata.zeros[block], group_size);
+      metadata.zeros[block] =
+          vaddq_s32(metadata.zeros[block], vdupq_n_s32(4));
+    }
+    weight_ptr += kNr * sizeof(int32_t);
+  }
+  return metadata;
+}
+
+template <int cols, int row_blocks, int column_offset>
+TORCHAO_ALWAYS_INLINE inline void apply_post_ops(
+    volatile float32x4_t (&results)[cols][row_blocks],
+    const char* weight_ptr,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  if (has_bias) {
+    const float* bias =
+        reinterpret_cast<const float*>(weight_ptr) + column_offset;
+    for (int col = 0; col < cols; col++) {
+      const float32x4_t bias_vec = vdupq_n_f32(bias[col]);
+      for (int block = 0; block < row_blocks; block++) {
+        results[col][block] = vaddq_f32(results[col][block], bias_vec);
+      }
+    }
+  }
+  if (has_clamp) {
+    const float32x4_t vec_min = vdupq_n_f32(clamp_min);
+    const float32x4_t vec_max = vdupq_n_f32(clamp_max);
+    for (int col = 0; col < cols; col++) {
+      for (int block = 0; block < row_blocks; block++) {
+        results[col][block] =
+            vec_clamp(results[col][block], vec_min, vec_max);
+      }
+    }
+  }
+}
+
+template <int column_blocks, int row_blocks, int column_offset = 0>
+TORCHAO_ALWAYS_INLINE inline void store_results(
+    float* output,
+    int output_m_stride,
+    int remaining_n,
+    int valid_rows,
+    volatile float32x4_t (&results)[column_blocks * 4][row_blocks]) {
+  static_assert(column_blocks == 1 || column_blocks == 2);
+  float32x4_t rows[column_blocks][4];
+  for (int row_block = 0; row_block < row_blocks; row_block++) {
+    const int block_rows = std::min(4, valid_rows - row_block * 4);
+    if (block_rows <= 0) {
+      break;
+    }
+    for (int column_block = 0; column_block < column_blocks; column_block++) {
+      const int col = column_block * 4;
+      transpose_4x4_f32(
+          results[col][row_block],
+          results[col + 1][row_block],
+          results[col + 2][row_block],
+          results[col + 3][row_block],
+          rows[column_block][0],
+          rows[column_block][1],
+          rows[column_block][2],
+          rows[column_block][3]);
+    }
+    for (int row = 0; row < block_rows; row++) {
+      float* row_output =
+          output + (row_block * 4 + row) * output_m_stride + column_offset;
+      if constexpr (column_blocks == 2) {
+        store_8_f32(
+            row_output, remaining_n, rows[0][row], rows[1][row]);
+      } else {
+        store_4_f32(
+            row_output, remaining_n - column_offset, rows[0][row]);
+      }
+    }
+  }
+}
+
+template <
+    int row_blocks,
+    int column_blocks,
+    int column_offset,
+    bool has_weight_zeros>
+__attribute__((noinline)) void kernel_rows_w3(
+    float* output,
+    int output_m_stride,
+    int remaining_n,
+    int k,
+    int group_size,
+    const char* weight_panel,
+    const char* activation_block_0,
+    const char* activation_block_1,
+    int valid_rows,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  static_assert(row_blocks == 1 || row_blocks == 2 || row_blocks == 4);
+  static_assert(column_blocks == 1 || column_blocks == 2);
+  static_assert(
+      (row_blocks == 4 && column_blocks == 1) ||
+      (row_blocks <= 2 && column_blocks == 2));
+  static_assert(column_offset == 0 || column_offset == 4);
+  static_assert(column_offset + column_blocks * 4 <= kNr);
+  constexpr int activation_blocks = (row_blocks + 1) / 2;
+  assert(valid_rows >= 1 && valid_rows <= row_blocks * 4);
+
+  const char* activation_block[activation_blocks];
+  activation_block[0] = activation_block_0;
+  if constexpr (activation_blocks == 2) {
+    activation_block[1] = activation_block_1;
+  }
+
+  // Read the per-row quantization headers from the packed eight-row blocks.
+  float32x4_t activation_scale_vec[row_blocks];
+  int32x4_t activation_zero_vec[row_blocks];
+  const char* activation_ptrs[activation_blocks];
+  for (int block = 0; block < activation_blocks; block++) {
+    const float* scales =
+        reinterpret_cast<const float*>(activation_block[block]);
+    const int16x8_t zeros = vmovl_s8(vld1_s8(
+        reinterpret_cast<const int8_t*>(
+            activation_block[block] + kMr * sizeof(float))));
+    activation_scale_vec[block * 2] = vld1q_f32(scales);
+    activation_zero_vec[block * 2] = vmovl_s16(vget_low_s16(zeros));
+    if constexpr (row_blocks > 1) {
+      if (block * 2 + 1 < row_blocks) {
+        activation_scale_vec[block * 2 + 1] = vld1q_f32(scales + 4);
+        activation_zero_vec[block * 2 + 1] =
+            vmovl_s16(vget_high_s16(zeros));
+      }
+    }
+    activation_ptrs[block] =
+        activation_block[block] + kMr * (sizeof(float) + sizeof(int8_t));
+  }
+
+  const char* weight_ptr = weight_panel;
+  volatile float32x4_t results[column_blocks * 4][row_blocks];
+  for (int col = 0; col < column_blocks * 4; col++) {
+#pragma unroll(4)
+    for (int block = 0; block < row_blocks; block++) {
+      results[col][block] = vdupq_n_f32(0.0f);
+    }
+  }
+
+  // Accumulate and dequantize one K group at a time.
+  for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+    int32x4_t accumulators[row_blocks][column_blocks * 4];
+    for (int block = 0; block < row_blocks; block++) {
+      for (int col = 0; col < column_blocks * 4; col++) {
+        accumulators[block][col] = vdupq_n_s32(0);
+      }
+    }
+
+    for (int i = 0; i < group_size; i += 16) {
+      dot_rows_cols_w3<
+          row_blocks,
+          column_blocks,
+          column_offset / 4,
+          !has_weight_zeros>(
+          accumulators,
+          reinterpret_cast<const uint8_t*>(weight_ptr),
+          activation_ptrs);
+      weight_ptr += kBytesPer128W3Values;
+      for (int block = 0; block < activation_blocks; block++) {
+        activation_ptrs[block] += kMr * 16;
+      }
+    }
+
+    // Packed group metadata follows the W3 values for this group.
+    const auto weight_metadata =
+        load_weight_group_metadata<
+            column_blocks,
+            column_offset,
+            has_weight_zeros>(
+            weight_ptr, group_size);
+
+    int32x4_t activation_qvals_sum_vec[row_blocks];
+    for (int block = 0; block < row_blocks; block++) {
+      activation_qvals_sum_vec[block] = vdupq_n_s32(0);
+    }
+    if constexpr (has_weight_zeros) {
+      for (int block = 0; block < row_blocks; block++) {
+        activation_qvals_sum_vec[block] = vld1q_s32(
+            reinterpret_cast<const int32_t*>(
+                activation_ptrs[block / 2] + (block % 2) * 16));
+      }
+      for (int block = 0; block < activation_blocks; block++) {
+        activation_ptrs[block] += kMr * sizeof(int32_t);
+      }
+    }
+
+    accumulate_4_columns<
+        row_blocks,
+        column_blocks * 4,
+        0,
+        has_weight_zeros>(
+        results,
+        accumulators,
+        activation_zero_vec,
+        activation_scale_vec,
+        weight_metadata.qvals_sums[0],
+        weight_metadata.scales[0],
+        weight_metadata.zeros[0],
+        activation_qvals_sum_vec);
+    if constexpr (column_blocks == 2) {
+      accumulate_4_columns<row_blocks, 8, 4, has_weight_zeros>(
+          results,
+          accumulators,
+          activation_zero_vec,
+          activation_scale_vec,
+          weight_metadata.qvals_sums[1],
+          weight_metadata.scales[1],
+          weight_metadata.zeros[1],
+          activation_qvals_sum_vec);
+    }
+  }
+
+  // Apply optional post-ops after all K groups have accumulated.
+  apply_post_ops<column_blocks * 4, row_blocks, column_offset>(
+      results, weight_ptr, clamp_min, clamp_max, has_bias, has_clamp);
+
+  // Accumulators are column-major; transpose them before row-major stores.
+  store_results<column_blocks, row_blocks, column_offset>(
+      output, output_m_stride, remaining_n, valid_rows, results);
+}
+
+template <bool has_weight_zeros>
+__attribute__((noinline)) void kernel_1x8x16_w3_interleaved(
+    float* output,
+    int remaining_n,
+    int k,
+    int group_size,
+    const char* weight_panel,
+    const char* activation_block,
+    int row,
+    float clamp_min,
+    float clamp_max,
+  bool has_bias,
+  bool has_clamp) {
+  // Extract one requested row from the same eight-row interleaved layout.
+  const float activation_scale =
+      reinterpret_cast<const float*>(activation_block)[row];
+  const int32_t activation_zero = static_cast<int32_t>(
+      reinterpret_cast<const int8_t*>(
+          activation_block + kMr * sizeof(float))[row]);
+  const char* activation_ptr =
+      activation_block + kMr * (sizeof(float) + sizeof(int8_t));
+  const char* weight_ptr = weight_panel;
+  float32x4_t result_0123 = vdupq_n_f32(0.0f);
+  float32x4_t result_4567 = vdupq_n_f32(0.0f);
+
+  for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+    int32x4_t accumulators[4] = {
+        vdupq_n_s32(0),
+        vdupq_n_s32(0),
+        vdupq_n_s32(0),
+        vdupq_n_s32(0)};
+    for (int i = 0; i < group_size; i += 16) {
+      // Deinterleave four rows and select the row needed by this tail path.
+      const int32x4x4_t rows = vld4q_s32(
+          reinterpret_cast<const int32_t*>(
+              activation_ptr + (row / 4) * 64));
+      const int8x16_t activation =
+          vreinterpretq_s8_s32(rows.val[row % 4]);
+      const int8x16_t activation_lo =
+          vcombine_s8(vget_low_s8(activation), vget_low_s8(activation));
+      const int8x16_t activation_hi =
+          vcombine_s8(vget_high_s8(activation), vget_high_s8(activation));
+      int8x16_t weights01_0;
+      int8x16_t weights01_1;
+      int8x16_t weights23_0;
+      int8x16_t weights23_1;
+      decode_4_cols_w3<0, !has_weight_zeros>(
+          weights01_0,
+          weights01_1,
+          weights23_0,
+          weights23_1,
+          reinterpret_cast<const uint8_t*>(weight_ptr));
+      accumulators[0] =
+          vdotq_s32(accumulators[0], weights01_0, activation_lo);
+      accumulators[0] =
+          vdotq_s32(accumulators[0], weights01_1, activation_hi);
+      accumulators[1] =
+          vdotq_s32(accumulators[1], weights23_0, activation_lo);
+      accumulators[1] =
+          vdotq_s32(accumulators[1], weights23_1, activation_hi);
+      decode_4_cols_w3<1, !has_weight_zeros>(
+          weights01_0,
+          weights01_1,
+          weights23_0,
+          weights23_1,
+          reinterpret_cast<const uint8_t*>(weight_ptr));
+      accumulators[2] =
+          vdotq_s32(accumulators[2], weights01_0, activation_lo);
+      accumulators[2] =
+          vdotq_s32(accumulators[2], weights01_1, activation_hi);
+      accumulators[3] =
+          vdotq_s32(accumulators[3], weights23_0, activation_lo);
+      accumulators[3] =
+          vdotq_s32(accumulators[3], weights23_1, activation_hi);
+      weight_ptr += kBytesPer128W3Values;
+      activation_ptr += kMr * 16;
+    }
+
+    const auto weight_metadata =
+        load_weight_group_metadata<2, 0, has_weight_zeros>(
+            weight_ptr, group_size);
+
+    int32x4_t corrected_0123 = vsubq_s32(
+        vpaddq_s32(accumulators[0], accumulators[1]),
+        vmulq_n_s32(weight_metadata.qvals_sums[0], activation_zero));
+    int32x4_t corrected_4567 = vsubq_s32(
+        vpaddq_s32(accumulators[2], accumulators[3]),
+        vmulq_n_s32(weight_metadata.qvals_sums[1], activation_zero));
+    if constexpr (has_weight_zeros) {
+      const int32_t activation_qvals_sum =
+          reinterpret_cast<const int32_t*>(activation_ptr)[row];
+      corrected_0123 = vmlsq_n_s32(
+          corrected_0123,
+          weight_metadata.zeros[0],
+          activation_qvals_sum);
+      corrected_4567 = vmlsq_n_s32(
+          corrected_4567,
+          weight_metadata.zeros[1],
+          activation_qvals_sum);
+      activation_ptr += kMr * sizeof(int32_t);
+    }
+    const float32x4_t activation_scale_vec =
+        vdupq_n_f32(activation_scale);
+    result_0123 = vmlaq_f32(
+        result_0123,
+        vmulq_f32(weight_metadata.scales[0], activation_scale_vec),
+        vcvtq_f32_s32(corrected_0123));
+    result_4567 = vmlaq_f32(
+        result_4567,
+        vmulq_f32(weight_metadata.scales[1], activation_scale_vec),
+        vcvtq_f32_s32(corrected_4567));
+  }
+
+  if (has_bias) {
+    result_0123 = vaddq_f32(
+        result_0123, vld1q_f32(reinterpret_cast<const float*>(weight_ptr)));
+    result_4567 = vaddq_f32(
+        result_4567,
+        vld1q_f32(reinterpret_cast<const float*>(weight_ptr) + 4));
+  }
+  if (has_clamp) {
+    const float32x4_t vec_min = vdupq_n_f32(clamp_min);
+    const float32x4_t vec_max = vdupq_n_f32(clamp_max);
+    result_0123 = vec_clamp(result_0123, vec_min, vec_max);
+    result_4567 = vec_clamp(result_4567, vec_min, vec_max);
+  }
+  store_8_f32(output, remaining_n, result_0123, result_4567);
+}
+
+template <bool has_weight_zeros>
+TORCHAO_ALWAYS_INLINE inline void run_16_row_tile(
+    float* output,
+    int output_m_stride,
+    int n,
+    int k,
+    int group_size,
+    const char* weight_data,
+    std::size_t weight_panel_size,
+    const char* activation_block_0,
+    std::size_t activation_block_size,
+    int valid_rows,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  const char* activation_block_1 =
+      activation_block_0 + activation_block_size;
+  const char* weight_panel = weight_data;
+  for (int n_idx = 0; n_idx < n; n_idx += kNr) {
+    const int remaining_n = n - n_idx;
+    kernel_rows_w3<4, 1, 0, has_weight_zeros>(
+        output + n_idx,
+        output_m_stride,
+        remaining_n,
+        k,
+        group_size,
+        weight_panel,
+        activation_block_0,
+        activation_block_1,
+        valid_rows,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+    if (remaining_n > 4) {
+      kernel_rows_w3<4, 1, 4, has_weight_zeros>(
+          output + n_idx,
+          output_m_stride,
+          remaining_n,
+          k,
+          group_size,
+          weight_panel,
+          activation_block_0,
+          activation_block_1,
+          valid_rows,
+          clamp_min,
+          clamp_max,
+          has_bias,
+          has_clamp);
+    }
+    weight_panel += weight_panel_size;
+  }
+}
+
+template <int row_blocks, bool has_weight_zeros>
+TORCHAO_ALWAYS_INLINE inline void run_up_to_8_row_tile(
+    float* output,
+    int output_m_stride,
+    int n,
+    int k,
+    int group_size,
+    const char* weight_data,
+    std::size_t weight_panel_size,
+    const char* activation_block,
+    int valid_rows,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  const char* weight_panel = weight_data;
+  for (int n_idx = 0; n_idx < n; n_idx += kNr) {
+    kernel_rows_w3<row_blocks, 2, 0, has_weight_zeros>(
+        output + n_idx,
+        output_m_stride,
+        n - n_idx,
+        k,
+        group_size,
+        weight_panel,
+        activation_block,
+        nullptr,
+        valid_rows,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+    weight_panel += weight_panel_size;
+  }
+}
+
+} // namespace internal
+
+// Public eight-row-granularity entry point. It pairs packed activation blocks
+// for a 16-row fast path, then uses dedicated 8-, 4-, and 1-row tail paths.
+template <int weight_nbit, bool has_weight_zeros>
+void kernel_8x8x16_f32_neondot(
+    float32_t* output,
+    int output_m_stride,
+    int m,
+    int n,
+    int k,
+    int group_size,
+    const void* weight_data,
+    const void* activation_data,
+    float clamp_min,
+    float clamp_max,
+    bool has_bias,
+    bool has_clamp) {
+  assert(k % group_size == 0);
+  assert(group_size % 16 == 0);
+  static_assert(weight_nbit == 3);
+
+  constexpr int mr = 8;
+  constexpr int nr = 8;
+  const std::size_t activation_row_size = sizeof(float) + sizeof(int8_t) + k +
+      (has_weight_zeros ? (k / group_size) * sizeof(int32_t) : 0);
+  const std::size_t activation_block_size = mr * activation_row_size;
+  const std::size_t weight_panel_size = k * weight_nbit +
+      (k / group_size) * nr *
+          (sizeof(float) + sizeof(int32_t) +
+           (has_weight_zeros ? sizeof(int32_t) : 0)) +
+      (has_bias ? nr * sizeof(float) : 0);
+  const auto* activation_data_bytes = static_cast<const char*>(activation_data);
+  const auto* weight_data_bytes = static_cast<const char*>(weight_data);
+
+  // Process complete pairs of eight-row activation blocks.
+  int m_idx = 0;
+  for (; m_idx + 16 <= m; m_idx += 16) {
+    const char* activation_block_0 =
+        activation_data_bytes + m_idx * activation_row_size;
+    internal::run_16_row_tile<has_weight_zeros>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        n,
+        k,
+        group_size,
+        weight_data_bytes,
+        weight_panel_size,
+        activation_block_0,
+        activation_block_size,
+        16,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+  }
+
+  // A 9..15-row tail uses the 16-row path with padded activation rows.
+  if (m - m_idx > 8) {
+    const int tail_rows = m - m_idx;
+    const char* activation_block_0 =
+        activation_data_bytes + m_idx * activation_row_size;
+    internal::run_16_row_tile<has_weight_zeros>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        n,
+        k,
+        group_size,
+        weight_data_bytes,
+        weight_panel_size,
+        activation_block_0,
+        activation_block_size,
+        tail_rows,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+    m_idx += tail_rows;
+  } else if (m - m_idx > 4) {
+    // A 5..8-row tail uses the eight-row path.
+    const int tail_rows = m - m_idx;
+    const char* activation_block =
+        activation_data_bytes + m_idx * activation_row_size;
+    internal::run_up_to_8_row_tile<2, has_weight_zeros>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        n,
+        k,
+        group_size,
+        weight_data_bytes,
+        weight_panel_size,
+        activation_block,
+        tail_rows,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+    m_idx += tail_rows;
+  }
+
+  // A 2..4-row tail uses one four-row accumulator block.
+  if (m - m_idx > 1) {
+    const int tail_rows = m - m_idx;
+    const int activation_block_idx = m_idx / mr;
+    const char* activation_block = activation_data_bytes +
+        activation_block_idx * activation_block_size;
+    internal::run_up_to_8_row_tile<1, has_weight_zeros>(
+        output + m_idx * output_m_stride,
+        output_m_stride,
+        n,
+        k,
+        group_size,
+        weight_data_bytes,
+        weight_panel_size,
+        activation_block,
+        tail_rows,
+        clamp_min,
+        clamp_max,
+        has_bias,
+        has_clamp);
+    m_idx += tail_rows;
+  }
+
+  // Handle the possible final row without repacking its interleaved block.
+  if (m_idx < m) {
+    const int activation_block_idx = m_idx / mr;
+    const int row_in_block = m_idx % mr;
+    const char* activation_block = activation_data_bytes +
+        activation_block_idx * activation_block_size;
+    const char* weight_panel = weight_data_bytes;
+    for (int n_idx = 0; n_idx < n; n_idx += nr) {
+      internal::kernel_1x8x16_w3_interleaved<has_weight_zeros>(
+          output + m_idx * output_m_stride + n_idx,
+          n - n_idx,
+          k,
+          group_size,
+          weight_panel,
+          activation_block,
+          row_in_block,
+          clamp_min,
+          clamp_max,
+          has_bias,
+          has_clamp);
+      weight_panel += weight_panel_size;
+    }
+  }
+}
+
+} // namespace
+  // torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::kernel
+
+#endif // defined(__aarch64__) || defined(__ARM_NEON)

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/pack_activations.h
@@ -8,9 +8,12 @@
 
 #if defined(__aarch64__) || defined(__ARM_NEON)
 
+#include <arm_neon.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/quantization/quantize.h>
 #include <torchao/csrc/cpu/torch_free_kernels/aarch64/reduction/reduction.h>
+#include <algorithm>
 #include <cassert>
+#include <cstring>
 
 namespace torchao::kernels::cpu::aarch64::linear::channelwise_8bit_activation_groupwise_lowbit_weight::activation_packing {
 
@@ -61,7 +64,7 @@ void inline pack_activations(
     int group_size,
     const float* activations,
     bool has_weight_zeros) {
-  // when mr == 1, kr/sr do not matter
+  // kr/sr do not affect activation packing for this kernel.
   static_assert(mr == 1);
 
   auto activation_data_byte_ptr = (char*)activation_data;
@@ -118,6 +121,119 @@ void inline pack_activations(
       activation_data_byte_ptr += k;
       activations += k;
     }
+  }
+}
+
+namespace internal {
+
+inline void store_interleaved_4x16(
+    char*& packed,
+    const int8_t* row0,
+    const int8_t* row1,
+    const int8_t* row2,
+    const int8_t* row3) {
+  int32x4_t row0_s32 = vreinterpretq_s32_s8(vld1q_s8(row0));
+  int32x4_t row1_s32 = vreinterpretq_s32_s8(vld1q_s8(row1));
+  int32x4_t row2_s32 = vreinterpretq_s32_s8(vld1q_s8(row2));
+  int32x4_t row3_s32 = vreinterpretq_s32_s8(vld1q_s8(row3));
+
+  int32x4x4_t rows = {row0_s32, row1_s32, row2_s32, row3_s32};
+  vst4q_s32(reinterpret_cast<int32_t*>(packed), rows);
+  packed += 64;
+}
+
+template <int mr>
+void inline pack_interleaved_block(
+    char*& packed,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int valid_rows = mr) {
+  static_assert(mr == 8);
+  assert(valid_rows >= 1 && valid_rows <= mr);
+
+  float scales[mr]{};
+  int zeros[mr]{};
+  int qmin, qmax;
+  torchao::quantization::get_qvals_range(
+      qmin, qmax, /*nbit=*/8, /*is_symmetric=*/false);
+
+  for (int row = 0; row < valid_rows; row++) {
+    float vmin, vmax;
+    torchao::kernels::cpu::aarch64::reduction::find_min_and_max(
+        vmin, vmax, activations + row * k, k);
+    torchao::quantization::get_scale_and_zero(
+        scales[row], zeros[row], vmin, vmax, qmin, qmax);
+  }
+  for (int row = 0; row < mr; row++) {
+    std::memcpy(packed, &scales[row], sizeof(float));
+    packed += sizeof(float);
+  }
+  for (int row = 0; row < mr; row++) {
+    *reinterpret_cast<int8_t*>(packed++) = static_cast<int8_t>(zeros[row]);
+  }
+
+  for (int k_idx = 0; k_idx < k; k_idx += group_size) {
+    int32_t qvals_sums[mr]{};
+    for (int i = 0; i < group_size; i += 16) {
+      int8_t qvals[mr][16]{};
+      for (int row = 0; row < valid_rows; row++) {
+        torchao::kernels::cpu::aarch64::quantization::quantize(
+            qvals[row],
+            activations + row * k + k_idx + i,
+            /*size=*/16,
+            scales[row],
+            zeros[row],
+            qmin,
+            qmax);
+        if (has_weight_zeros) {
+          qvals_sums[row] +=
+              torchao::kernels::cpu::aarch64::reduction::compute_sum(
+                  qvals[row], 16);
+        }
+      }
+
+      for (int row_block = 0; row_block < mr; row_block += 4) {
+        store_interleaved_4x16(
+            packed,
+            qvals[row_block],
+            qvals[row_block + 1],
+            qvals[row_block + 2],
+            qvals[row_block + 3]);
+      }
+    }
+    if (has_weight_zeros) {
+      std::memcpy(packed, qvals_sums, mr * sizeof(int32_t));
+      packed += mr * sizeof(int32_t);
+    }
+  }
+}
+
+} // namespace internal
+
+template <int mr, int kr, int sr>
+void inline pack_activations_interleaved(
+    void* activation_data,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros) {
+  static_assert(mr == 8);
+  (void)kr;
+  (void)sr;
+
+  auto* packed = static_cast<char*>(activation_data);
+  for (int m_idx = 0; m_idx < m; m_idx += mr) {
+    const int valid_rows = std::min(mr, m - m_idx);
+    internal::pack_interleaved_block<mr>(
+        packed,
+        k,
+        group_size,
+        activations + m_idx * k,
+        has_weight_zeros,
+        valid_rows);
   }
 }
 


### PR DESCRIPTION
This optimizes the existing Arm NEON 1x8x16 W3A8 decode path for both asymmetric weights with groupwise zero points and symmetric weights without weight zero points.

A signed W3 weight wᵢ is stored as an unsigned value uᵢ from 0 through 7:

wᵢ = uᵢ − 4

Previously, the kernel converted every unpacked weight vector from uᵢ to wᵢ inside the inner K loop.

The original symmetric-weight integer computation is:

Y = Σᵢ(aᵢ − zₐ)wᵢ

Here, aᵢ is an activation qvalue and zₐ is the activation zero point. Substituting wᵢ = uᵢ − 4 gives:

Y = Σᵢ(aᵢ − zₐ)(uᵢ − 4)

Expanding gives:

Y = Σᵢaᵢuᵢ − zₐΣᵢuᵢ − 4Σᵢaᵢ + 4Kzₐ

The signed weight sum is:

Σᵢwᵢ = Σᵢuᵢ − 4K

Therefore:

−zₐΣᵢwᵢ = −zₐΣᵢuᵢ + 4Kzₐ

Substituting this into the expanded expression gives:

Y = Σᵢaᵢuᵢ − zₐΣᵢwᵢ − 4Σᵢaᵢ

This lets the kernel use the unpacked unsigned weights directly. For asymmetric weights, the offset is folded into the existing weight-zero correction. For symmetric weights, activation packing stores one int32 activation sum per quantization group, and the kernel applies the final correction by subtracting 4Σᵢaᵢ. The activation zero correction remains −zₐΣᵢwᵢ because activation dequantization uses aᵢ − zₐ.

The packed-weight format and AOT weight packing remain unchanged. The implementation continues to use Arm NEON dot-product instructions and does not require i8mm.

On an M5 Max at M=1 and K=4096, the asymmetric path improved compute-only latency by approximately 1.09 to 1.14 times at group size 32, 1.22 to 1.24 times at group size 128, and 1.25 to 1.29 times at group size 256 across N values of 1024, 4096, and 11008.

For symmetric weights at N=K=4096 with per-channel quantization, the complete single-panel operator, including activation quantization and packing but excluding weight packing, improved from approximately 257 microseconds to 197 microseconds, or approximately 1.30 times. Output checksums matched exactly.

Correctness coverage includes symmetric and asymmetric W3 weights, multiple output-channel tiles, multiple quantization groups, output-channel tails, bias, and clamp.

This is pull request 1 of 3.