### PR TITLE
Optimize symmetric Arm NEON W3A8 decode

### DIFF
--- a/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
+++ b/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight/kernel_selector.h
@@ -157,16 +157,31 @@ void register_ukernel_config_universal(
                  has_lut>});
       } else {
         constexpr bool has_weight_zeros = false;
-        uk.linear_configs[0] = UKernelConfig::linear_config_type(
-            {m_step,
-             mr,
-             &kernel::packed_activations_size,
-             &kernel::packed_activations_offset,
-             &kernel::pack_activations<mr, kr, sr>,
-             &kernel::kernel_1x8x16_f32_neondot<
-                 weight_nbit,
-                 has_weight_zeros,
-                 has_lut>});
+        if constexpr (weight_nbit == 3) {
+          constexpr bool has_activation_qvals_sum = true;
+          uk.linear_configs[0] = UKernelConfig::linear_config_type(
+              {m_step,
+               mr,
+               &kernel::packed_activations_with_qvals_sum_size,
+               &kernel::packed_activations_with_qvals_sum_offset,
+               &kernel::pack_activations_with_qvals_sum<mr, kr, sr>,
+               &kernel::kernel_1x8x16_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros,
+                   has_lut,
+                   has_activation_qvals_sum>});
+        } else {
+          uk.linear_configs[0] = UKernelConfig::linear_config_type(
+              {m_step,
+               mr,
+               &kernel::packed_activations_size,
+               &kernel::packed_activations_offset,
+               &kernel::pack_activations<mr, kr, sr>,
+               &kernel::kernel_1x8x16_f32_neondot<
+                   weight_nbit,
+                   has_weight_zeros,
+                   has_lut>});
+        }
       }
 
       table.register_ukernel_config(format, uarch, std::move(uk));

--- a/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
+++ b/torchao/csrc/cpu/shared_kernels/tests/test_linear_8bit_act_xbit_weight.cpp
@@ -53,14 +53,29 @@ UKernelConfig get_ukernel_config() {
       &torchao::weight_packing::pack_weights<weight_nbit, nr, kr, sr>,
       /*linear_configs*/ {});
 
-  uk.linear_configs[0] = UKernelConfig::linear_config_type{
-      m_step,
-      mr,
-      &kernel::packed_activations_size,
-      &kernel::packed_activations_offset,
-      &kernel::pack_activations<mr, kr, sr>,
-      &kernel::
-          kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
+  if constexpr (weight_nbit == 3 && !has_weight_zeros && !has_lut) {
+    constexpr bool has_activation_qvals_sum = true;
+    uk.linear_configs[0] = UKernelConfig::linear_config_type{
+        m_step,
+        mr,
+        &kernel::packed_activations_with_qvals_sum_size,
+        &kernel::packed_activations_with_qvals_sum_offset,
+        &kernel::pack_activations_with_qvals_sum<mr, kr, sr>,
+        &kernel::kernel_1x8x16_f32_neondot<
+            weight_nbit,
+            has_weight_zeros,
+            has_lut,
+            has_activation_qvals_sum>};
+  } else {
+    uk.linear_configs[0] = UKernelConfig::linear_config_type{
+        m_step,
+        mr,
+        &kernel::packed_activations_size,
+        &kernel::packed_activations_offset,
+        &kernel::pack_activations<mr, kr, sr>,
+        &kernel::
+            kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>};
+  }
 
   if constexpr (has_lut) {
     uk.packed_weights_size = &kernel::packed_weights_with_lut_size;
@@ -432,6 +447,15 @@ TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedWeights) {
       true /*has_bias*/,
       true /*has_clamp*/>(
       /*m=*/1, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
+}
+
+TEST(test_linear_8bit_act_xbit_weight, ThreeBitDecodeUnsignedSymmetricWeights) {
+  test_linear_8bit_act_xbit_weight<
+      3 /*weight_nbit*/,
+      false /*has_weight_zeros*/,
+      true /*has_bias*/,
+      true /*has_clamp*/>(
+      /*m=*/3, /*n=*/8 * 3 + 5, /*k=*/16 * 8, /*group_size=*/64);
 }
 
 TEST(test_linear_8bit_act_xbit_weight, HasWeightZeros) {

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/channelwise_8bit_activation_groupwise_lowbit_weight.h
@@ -50,6 +50,35 @@ inline size_t packed_activations_offset(
   return (m_idx / mr) * packed_activations_size_mr_rows;
 }
 
+// The symmetric W3 decode kernel keeps packed weights in their unsigned 0..7
+// representation. Store activation sums so it can remove the resulting +4
+// offset after the dot product without changing the weight format.
+inline size_t packed_activations_with_qvals_sum_size(
+    int m,
+    int k,
+    int group_size,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  return packed_activations_size(
+      m, k, group_size, true, mr, kr, sr);
+}
+
+inline size_t packed_activations_with_qvals_sum_offset(
+    int m_idx,
+    int k,
+    int group_size,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  return packed_activations_offset(
+      m_idx, k, group_size, true, mr, kr, sr);
+}
+
 template <int mr_, int kr_, int sr_>
 void pack_activations(
     void* packed_activations,
@@ -66,6 +95,25 @@ void pack_activations(
   (void)sr; // unused
   activation_packing::pack_activations<mr_, kr_, sr_>(
       packed_activations, m, k, group_size, activations, has_weight_zeros);
+}
+
+template <int mr_, int kr_, int sr_>
+void pack_activations_with_qvals_sum(
+    void* packed_activations,
+    int m,
+    int k,
+    int group_size,
+    const float* activations,
+    bool has_weight_zeros,
+    int mr,
+    int kr,
+    int sr) {
+  (void)has_weight_zeros;
+  (void)mr;
+  (void)kr;
+  (void)sr;
+  activation_packing::pack_activations<mr_, kr_, sr_>(
+      packed_activations, m, k, group_size, activations, true);
 }
 
 template <int weight_nbit, int nr_, int kr_, int sr_>
@@ -205,7 +253,11 @@ void kernel_1x4x16_f32_neondot(
       has_clamp);
 }
 
-template <int weight_nbit, bool has_weight_zeros, bool has_lut>
+template <
+    int weight_nbit,
+    bool has_weight_zeros,
+    bool has_lut,
+    bool has_activation_qvals_sum = has_weight_zeros>
 void kernel_1x8x16_f32_neondot(
     // Outputs
     float32_t* output,
@@ -224,7 +276,11 @@ void kernel_1x8x16_f32_neondot(
     bool has_bias,
     bool has_clamp) {
   (void)has_weight_zeros_; // unused
-  kernel::kernel_1x8x16_f32_neondot<weight_nbit, has_weight_zeros, has_lut>(
+  kernel::kernel_1x8x16_f32_neondot<
+      weight_nbit,
+      has_weight_zeros,
+      has_lut,
+      has_activation_qvals_sum>(
       output,
       output_m_stride,
       m,

--- a/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
+++ b/torchao/csrc/cpu/torch_free_kernels/aarch64/linear/channelwise_8bit_activation_groupwise_lowbit_weight/kernel_1x8x16_f32_neondot-impl.h
@@ -58,7 +58,11 @@ vec_clamp(float32x4_t x, float32x4_t vec_min, float32x4_t vec_max) {
 // Roughly inspired by
 // https://gitlab.arm.com/kleidi/kleidiai/-/blob/main/kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi4cxp8x8_1x8x32_neon_dotprod.c?ref_type=heads
 
-template <int weight_nbit, bool has_weight_zeros, bool has_lut>
+template <
+    int weight_nbit,
+    bool has_weight_zeros,
+    bool has_lut,
+    bool has_activation_qvals_sum = has_weight_zeros>
 void kernel_1x8x16_f32_neondot(
     // Outputs
     float32_t* output,
@@ -77,6 +81,10 @@ void kernel_1x8x16_f32_neondot(
     bool has_clamp) {
   assert(k % group_size == 0);
   assert(group_size % 16 == 0);
+  static_assert(!has_weight_zeros || has_activation_qvals_sum);
+
+  constexpr bool use_unsigned_w3 =
+      weight_nbit == 3 && !has_lut && has_activation_qvals_sum;
 
   int8x16_t lut;
   if constexpr (!has_lut) {
@@ -190,7 +198,7 @@ void kernel_1x8x16_f32_neondot(
                 weight_q_cols67_1,
                 (uint8_t*)weight_data_byte_ptr,
                 lut);
-          } else if constexpr (weight_nbit == 3 && has_weight_zeros) {
+          } else if constexpr (use_unsigned_w3) {
             uint8x16_t unsigned_weights[8];
             torchao::bitpacking::vec_unpack_128_uintx_values<3>(
                 unsigned_weights[0],
@@ -286,17 +294,20 @@ void kernel_1x8x16_f32_neondot(
 
         int32x4_t term1_4567 = vmulq_n_s32(weight_qvals_sum, activation_zero);
 
+        int32_t activation_qvals_sum = 0;
+        if constexpr (has_activation_qvals_sum) {
+          activation_qvals_sum = *((int32_t*)activation_ptr);
+          activation_ptr += sizeof(int32_t);
+        }
+
         if constexpr (has_weight_zeros) {
           // Compute term2 and term3
-
-          int32_t activation_qvals_sum = *((int32_t*)activation_ptr);
-          activation_ptr += sizeof(int32_t);
 
           int32x4_t weight_zeros = vld1q_s32((int32_t*)weight_data_byte_ptr);
           weight_data_byte_ptr += 16;
 
           int32x4_t term2_0123;
-          if constexpr (weight_nbit == 3 && !has_lut) {
+          if constexpr (use_unsigned_w3) {
             term2_0123 = vmulq_n_s32(
                 vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
           } else {
@@ -310,7 +321,7 @@ void kernel_1x8x16_f32_neondot(
           weight_data_byte_ptr += 16;
 
           int32x4_t term2_4567;
-          if constexpr (weight_nbit == 3 && !has_lut) {
+          if constexpr (use_unsigned_w3) {
             term2_4567 = vmulq_n_s32(
                 vaddq_s32(weight_zeros, vdupq_n_s32(4)), activation_qvals_sum);
           } else {
@@ -333,9 +344,17 @@ void kernel_1x8x16_f32_neondot(
         } else {
           // Do updates
           int32x4_t tmp = vsubq_s32(qval_dot_0123, term1_0123);
+          if constexpr (use_unsigned_w3) {
+            tmp = vsubq_s32(
+                tmp, vdupq_n_s32(4 * activation_qvals_sum));
+          }
           res_0123 = vmlaq_f32(res_0123, scale_factor_0123, vcvtq_f32_s32(tmp));
 
           tmp = vsubq_s32(qval_dot_4567, term1_4567);
+          if constexpr (use_unsigned_w3) {
+            tmp = vsubq_s32(
+                tmp, vdupq_n_s32(4 * activation_qvals_sum));
+          }
           res_4567 = vmlaq_f32(res_4567, scale_factor_4567, vcvtq_f32_s32(tmp));
         }
 


### PR DESCRIPTION
This extends the unsigned W3 decode optimization to symmetric weights, which do not carry weight zero points.\n\nThe W3 decode activation packer now stores one int32 activation sum per quantization group. The kernel keeps packed 3-bit weights in their unsigned 0 through 7 representation and subtracts four times the activation sum after the dot product. The packed-weight format is unchanged. Other weight bit widths, LUT kernels, and asymmetric-weight configurations retain their existing activation packing paths.\n\nOn an M5 Max at M=1 and N=K=4096, compute-only latency improved from 293 to 302 microseconds to 241 to 246 microseconds at group size 32, from 263 to 265 microseconds to 205 to 206 microseconds at group size 128, from 258 to 263 microseconds to 199 to 206 microseconds at group size 256, and from 256 to 257 microseconds to 195 to 203 microseconds for per-channel quantization with group size 4096.\n\nFor the checkpoint discussed in this stack, weights are symmetric W3 with per-channel quantization, so the group-size-4096 result is the directly relevant case. The complete single-panel operator, including activation quantization and packing but excluding weight packing, improved from about 257 microseconds to 197 microseconds, approximately 1.30 times faster. Output checksums matched exactly.\n\nThis is pull request 2 of 4 and depends on pull request 4859.