### PR TITLE
Reject unsupported wrap_with_set_grad_enabled subgraphs in PT2E prepare APIs

### DIFF
--- a/test/quantization/pt2e/test_quantize_pt2e.py
+++ b/test/quantization/pt2e/test_quantize_pt2e.py
@@ -3889,6 +3889,36 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
                 fold_quantize_into_mutable_buffers=True,
             )
 
+    def test_prepare_pt2e_apis_reject_set_grad_enabled_subgraph(self):
+        class NoGradLinear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(5, 5)
+
+            @torch.no_grad()
+            def forward(self, x):
+                return self.linear(x)
+
+        model = NoGradLinear().eval()
+        example_inputs = (torch.randn(1, 5),)
+        quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
+
+        exported = torch.export.export(model, example_inputs).module()
+        with self.assertRaisesRegex(
+            ValueError,
+            "prepare_pt2e does not support wrap_with_set_grad_enabled subgraphs",
+        ):
+            prepare_pt2e(exported, quantizer)
+        with self.assertRaisesRegex(
+            ValueError,
+            "prepare_qat_pt2e.*quantization-aware training requires autograd",
+        ):
+            prepare_qat_pt2e(exported, quantizer)
+
+        with torch.no_grad():
+            exported = torch.export.export(model, example_inputs).module()
+        prepare_pt2e(exported, quantizer)
+
     def test_scan_op_quantization(self):
         """Test that prepare_pt2e and convert_pt2e correctly quantize ops
         inside the combine_fn subgraph of torch._higher_order_ops.scan.

--- a/torchao/quantization/pt2e/quantize_pt2e.py
+++ b/torchao/quantization/pt2e/quantize_pt2e.py
@@ -37,6 +37,29 @@ __all__ = [
 ]
 
 
+def _reject_set_grad_enabled_subgraph(model: GraphModule, api_name: str) -> None:
+    for node in model.graph.nodes:
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.higher_order.wrap_with_set_grad_enabled
+        ):
+            if api_name == "prepare_qat_pt2e":
+                remediation = (
+                    "Remove or disable the model's no-grad context before export because "
+                    "quantization-aware training requires autograd."
+                )
+            else:
+                remediation = (
+                    "Export the model under a grad mode matching its forward method "
+                    "(for example, use `with torch.no_grad():` for a forward method "
+                    "decorated with `@torch.no_grad()`) before calling prepare_pt2e."
+                )
+            raise ValueError(
+                f"{api_name} does not support wrap_with_set_grad_enabled subgraphs. "
+                f"{remediation}"
+            )
+
+
 def prepare_pt2e(
     model: GraphModule,
     quantizer: Quantizer,
@@ -96,6 +119,7 @@ def prepare_pt2e(
         # calibrate(m, sample_inference_data)
     """
     torch._C._log_api_usage_once("torchao.quantization.pt2e.prepare_pt2e")
+    _reject_set_grad_enabled_subgraph(model, "prepare_pt2e")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
     # TODO: check qconfig_mapping to make sure conv and bn are both configured
@@ -200,6 +224,7 @@ def prepare_qat_pt2e(
 
     """
     torch._C._log_api_usage_once("torchao.quantization.pt2e.prepare_qat_pt2e")
+    _reject_set_grad_enabled_subgraph(model, "prepare_qat_pt2e")
     original_graph_meta = model.meta
     node_name_to_scope = _get_node_name_to_scope(model)
     model = quantizer.transform_for_annotation(model)


### PR DESCRIPTION
prepare_pt2e() and prepare_qat_pt2e() currently process only the top-level exported graph. When torch.export represents a grad-mode change as a wrap_with_set_grad_enabled higher-order operator, quantizable operations can be placed in its nested subgraph and silently receive no annotations, observers, or fake-quant modules.

This change detects that unsupported HOP before modifying the graph and raises an actionable error:

* PTQ users are instructed to export under the grad mode used by the model, such as wrapping export in torch.no_grad().
* QAT users are instructed to remove or disable the no-grad context because quantization-aware training requires autograd.
The regression test covers both rejection paths and verifies that PTQ preparation succeeds when a no-grad-decorated model is exported inside torch.no_grad().

Fixes pytorch/executorch#22069.