### PR TITLE
Fix MXFP8 quantize failing when it is the first CUDA call on a thread

### DIFF
--- a/test/prototype/mx_formats/test_kernels.py
+++ b/test/prototype/mx_formats/test_kernels.py
@@ -601,6 +601,41 @@ def test_rearrange(shape):
     not is_cuda_version_at_least(12, 8),
     reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
 )
+def test_cuda_mx_quantize_on_a_fresh_thread():
+    """The kernel must work when it is the first CUDA call on its thread.
+
+    It encodes TMA descriptors through the driver API, which needs a current
+    context. A thread that has not used CUDA yet does not have one, and a
+    DeviceGuard does not bind it when the device already matches. Autograd runs
+    backward on worker threads, so this is the common case for an MXFP8
+    backward. Without the fix the kernel raises a cudaErrorIllegalInstruction.
+    """
+    import threading
+
+    x = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
+    failure = []
+
+    def run():
+        try:
+            mxfp8_quantize_cuda(x, rowwise=False, colwise=True, scaling_mode="rceil")
+            torch.cuda.synchronize()
+        except Exception as e:  # noqa: BLE001
+            failure.append(e)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join()
+    assert not failure, f"quantize failed on a fresh thread: {failure[0]}"
+
+
+@pytest.mark.skipif(
+    not is_sm_at_least_100(),
+    reason="MXFP8 requires CUDA capability 10.0 or greater",
+)
+@pytest.mark.skipif(
+    not is_cuda_version_at_least(12, 8),
+    reason="CUDA version >= 12.8 required for MXFP8 CUDA kernels",
+)
 @pytest.mark.parametrize("M", (32, 256))
 @pytest.mark.parametrize("K", (32, 256))
 @pytest.mark.parametrize("input_dtype", (torch.float32, torch.bfloat16))

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_cuda.cu
@@ -65,6 +65,11 @@ void mxfp8_quantize_cuda(const Tensor &input,
                          const std::string &fp8_format,
                          const std::string &scaling_mode) {
 
+  // This op encodes TMA descriptors through the driver API, which needs a
+  // current context on the calling thread. Autograd backward runs on a worker
+  // thread that may not have used CUDA yet, so bind it before going further.
+  ensure_current_context();
+
   // Get tensor properties
   const int64_t rows = input.size(0);
   const int64_t cols = input.size(1);

--- a/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
+++ b/torchao/csrc/cuda/mx_kernels/mxfp8_quantize.cuh
@@ -49,6 +49,19 @@ do {                                                                          \
     }                                                                         \
 } while (0)
 
+// An unchecked cuTensorMapEncodeTiled leaves the descriptor unpopulated and the
+// kernel then executes TMA instructions against garbage, which surfaces as a
+// cudaErrorIllegalInstruction inside the kernel -- or, worse, as a sticky error
+// on some unrelated later launch. Fail here instead.
+#define CHECK_TMA_ENCODE(res)                                                 \
+do {                                                                          \
+    if ((res) != CUDA_SUCCESS) {                                              \
+        fprintf(stderr, "cuTensorMapEncodeTiled failed in %s at line %d: %d\n", \
+                __FILE__, __LINE__, static_cast<int>(res));                   \
+        throw std::runtime_error("cuTensorMapEncodeTiled failed");            \
+    }                                                                         \
+} while (0)
+
 enum class DType {
   kByte,
   kFloat32,
@@ -297,6 +310,19 @@ inline CUtensorMapDataType get_dtype_for_tma(DType dtype) {
   }
 }
 
+// cuTensorMapEncodeTiled is a driver API and needs a current CUDA context.
+// A thread that has not yet used CUDA does not have one: the runtime binds the
+// primary context lazily, and c10's DeviceGuard deliberately skips
+// cudaSetDevice when the requested device already matches the current one, so
+// merely constructing a guard does not bind it either. Autograd runs backward
+// on worker threads, so this is reached in practice on the first MXFP8
+// backward of a process. cudaSetDevice forces the binding.
+inline void ensure_current_context() {
+  int device = 0;
+  CUDA_CHECK(cudaGetDevice(&device));
+  CUDA_CHECK(cudaSetDevice(device));
+}
+
 void* get_driver_ptr() {
   // Only initialize driver_ptr once during the lifetime of the program.
   static void *driver_ptr = nullptr;
@@ -350,11 +376,12 @@ inline void create_3D_tensor_map_output(CUtensorMap &tensorMap,
   // Element strides within the tile (box). For a contiguous copy, this is always 1.
   uint32_t elemStride[rank] = {1, 1, 1};
 
-  cuTensorMapEncodeTiled(
+  CUresult res = cuTensorMapEncodeTiled(
       &tensorMap, get_dtype_for_tma(dtype), rank, data_ptr, size, stride,
       boxSize, elemStride, CU_TENSOR_MAP_INTERLEAVE_NONE,
       CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  CHECK_TMA_ENCODE(res);
 }
 
 // Reference:
@@ -378,11 +405,12 @@ inline void create_2D_tensor_map(CUtensorMap &tensorMap, void *data_ptr,
   uint32_t boxSize[rank] = {shmem_x, shmem_y};
   uint32_t elemStride[rank] = {1, 1};
 
-  cuTensorMapEncodeTiled(
+  CUresult res = cuTensorMapEncodeTiled(
       &tensorMap, get_dtype_for_tma(dtype), rank, data_ptr, size, stride,
       boxSize, elemStride, CU_TENSOR_MAP_INTERLEAVE_NONE,
       CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  CHECK_TMA_ENCODE(res);
 }
 
 


### PR DESCRIPTION
Written by Agent

## Summary

`mxfp8_quantize_cuda` fails with `CUDA error: an illegal instruction was encountered`
whenever it is the **first CUDA kernel launched on a given thread**. Any prior CUDA op
on that thread avoids it. Shape, dtype, alignment and scaling orientation are all
irrelevant.

This is easy to hit in practice because **autograd runs backward on worker threads**.

## Repro

Fails on `main`, passes with this PR. Use a fresh process: the fault leaves the CUDA
context in a sticky error state.

```python
import threading
import torch
from torchao.prototype.mx_formats.kernels import mxfp8_quantize_cuda

t = torch.randn(64, 128, device="cuda", dtype=torch.bfloat16)
err = []

def target():
    try:
        mxfp8_quantize_cuda(t, rowwise=False, colwise=True, scaling_mode="rceil")
        torch.cuda.synchronize()
    except Exception as e:
        err.append(e)

th = threading.Thread(target=target)
th.start()
th.join()
print("FAULT" if err else "ok")
```

`compute-sanitizer` attributes it to the TMA kernel:

```
========= Illegal instruction
=========     at void mxfp8_quantize_kernel<__nv_bfloat16, __nv_fp8_e4m3, 32ul, 1ul,
              (ScaleCalculationMode)1>(CUtensorMap_st, CUtensorMap_st, CUtensorMap_st, ...)+0x270
=========     Host Frame: MXFP8Quantizer::quantize(...) in _C_mxfp8...so
```

## Root cause

The op encodes TMA descriptors with `cuTensorMapEncodeTiled`, a **driver** API that
requires a current CUDA context. The runtime binds the primary context to a thread
lazily, so a thread that has not used CUDA has none:

```
main thread          : cuCtxGetCurrent -> 0xaaab0d10e1b0
fresh thread, before : cuCtxGetCurrent -> NULL      <- descriptors are encoded here
fresh thread, after  : cuCtxGetCurrent -> 0xaaab0d10e1b0
```

`mxfp8_quantize` does already construct a `tsa::DeviceGuard` before encoding, but that
does not force the binding: `c10::cuda::ExchangeDevice` returns early without calling
`cudaSetDevice` when the requested device already equals the current one, which is
exactly the single-device case.

```cpp
if (cur_device < 0) {
    C10_CUDA_CHECK(cudaGetDevice(&tmp_device));
    cur_device = static_cast<DeviceIndex>(tmp_device);
    if (to_device == cur_device) {
      return cur_device;      // no cudaSetDevice, so no context is bound
    }
}
```

Encoding then returns `CUDA_ERROR_INVALID_CONTEXT`, and because the result was
discarded the kernel launched with an unpopulated `CUtensorMap` and executed TMA
instructions against a garbage descriptor.

## Changes

1. **Bind the context explicitly** before encoding, in `mxfp8_quantize_cuda`.
2. **Check the `cuTensorMapEncodeTiled` result** in `create_2D_tensor_map` and
   `create_3D_tensor_map_output`. Both discarded it, which is why a failed encode
   surfaced as an illegal instruction inside the kernel -- or, worse, as a sticky error
   on an unrelated later launch, which makes this very hard to diagnose.
   `mx_block_rearrange_2d_M_groups.cu` already checks its result; this makes the two
   paths consistent.

## Test plan

New `test_cuda_mx_quantize_on_a_fresh_thread` runs the quantize from a fresh
`threading.Thread`; it fails on `main` and passes here.

| check | before | after |
| --- | --- | --- |
| cold-thread repro | FAULT | ok |
| autograd-backward repro | FAULT | ok |
| warm-with matrix (none / current_device / kernel) | `none` FAULT | all ok |
| `test/prototype/mx_formats/test_kernels.py` | -- | 150 passed, 2 skipped |

Verified on NVIDIA GB200 (sm_100), CUDA 13.0, driver 580.126.20. The same code path
also serves sm_90a, which I was not able to test.
