### PR TITLE
Honor range-learned scales in the tied embedding quantization path (#4863)

### DIFF
--- a/torchao/prototype/quantization/embedding/api.py
+++ b/torchao/prototype/quantization/embedding/api.py
@@ -294,10 +294,12 @@ class TiedEmbeddingQuantizer:
         weight_dtype: torch.dtype = torch.int4,
         granularity: Granularity = PerAxis(0),
         mapping_type: MappingType = MappingType.ASYMMETRIC,
+        range_learning: bool = False,
     ):
         self.weight_dtype = weight_dtype
         self.granularity = granularity
         self.mapping_type = mapping_type
+        self.range_learning = range_learning
 
     def quantize(
         self,
@@ -358,15 +360,26 @@ class TiedEmbeddingQuantizer:
             )
 
         # Quantize unembeddings
+        config = Int8DynamicActivationIntxWeightConfig(
+            weight_dtype=self.weight_dtype,
+            weight_granularity=self.granularity,
+            weight_mapping_type=self.mapping_type,
+            # Only universal layout is supported for shared embedding
+            intx_packing_format="opaque_torchao_lowbit",
+        )
+        if self.range_learning:
+            # Imported lazily: torchao.quantization.qat pulls in torchao.prototype.qat,
+            # which would cycle back through this module at import time.
+            from torchao.quantization.qat import QATConfig
+
+            # The unembedding carries the range-learned scale; the convert step
+            # forwards it as custom_scale instead of re-deriving qparams from the
+            # dequantized weight. The embedding side inherits it by construction,
+            # since it is tied to this quantized weight below.
+            config = QATConfig(config, step="convert")
         quantize_(
             model,
-            Int8DynamicActivationIntxWeightConfig(
-                weight_dtype=self.weight_dtype,
-                weight_granularity=self.granularity,
-                weight_mapping_type=self.mapping_type,
-                # Only universal layout is supported for shared embedding
-                intx_packing_format="opaque_torchao_lowbit",
-            ),
+            config,
             filter_fn=lambda m, fqn: isinstance(m, nn.Linear)
             and fqn in list(embedding_to_unembedding.values()),
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/executorch/pull/22476


For a `share_emb: true` checkpoint trained with
`weight_quantization_min_max_learning: true`, the tied embedding path silently
discarded every range-learned weight scale and re-derived qparams from the
dequantized weights. The untied path did not, so the same checkpoint exported
two ways differed by ~6.5 dB SNR against the rlformers reference.

Learned ranges survive export only via `QATConfig(step="convert")`, whose
transform pulls `custom_scale`/`custom_zero_point` off the module's
`weight_fake_quantizer` and disables qparam re-derivation. The untied path wraps
both its embedding and linear configs in it. `TiedEmbeddingQuantizer` used a bare
`Int8DynamicActivationIntxWeightConfig`, so the convert step never ran.

`_apply_embedding_quantization` already receives `range_learning`, but returned
early into `apply_torchao_embedding_quantization` without forwarding it. Thread
it through to `TiedEmbeddingQuantizer` and wrap its config the same way the
non-shared path does.

The `QATConfig` import in `TiedEmbeddingQuantizer` is function-local:
`torchao.quantization.qat` pulls in `torchao.prototype.qat`, which cycles back
through this module at import time.

Only the tied path changes. `EmbeddingQuantizer` (torchao embedding quantization
without shared embeddings) has the same gap and is left alone here.

Reviewed By: YIWENX14

Differential Revision: D118365125


