### PR TITLE
Warn when Int4WeightOnlyConfig uses the PLAIN packing format

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -10,6 +10,7 @@ import copy
 import gc
 import tempfile
 import unittest
+import warnings
 
 import torch
 from torch.testing._internal import common_utils
@@ -477,6 +478,26 @@ class TestQuantFlow(TestCase):
         model(*example_inputs)
         assert isinstance(model.linear1.weight, Int4TilePackedTo4dTensor)
         assert isinstance(model.linear2.weight, Int4TilePackedTo4dTensor)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
+    def test_int4_weight_only_plain_packing_format_warns(self):
+        """int4_packing_format=PLAIN (the default) has known compatibility issues
+        on several GPU architectures, including consumer Blackwell (RTX 50-series)
+        and some Ampere GPUs -- see https://github.com/pytorch/ao/issues/3842.
+        Applying it should warn rather than fail silently until a crash deep in a
+        forward pass; TILE_PACKED_TO_4D should not warn.
+        """
+        model = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
+        with self.assertWarnsRegex(UserWarning, "TILE_PACKED_TO_4D"):
+            quantize_(model, Int4WeightOnlyConfig(int4_packing_format="plain"))
+
+        model2 = ToyLinearModel().cuda().to(dtype=torch.bfloat16)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            quantize_(
+                model2,
+                Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"),
+            )
 
     @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_module_fqn_to_config_regex_precedence(self):

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -620,6 +620,22 @@ def _int4_weight_only_quantize_tensor(weight, config):
         raise ValueError(f"Unsupported int4 packing format: {int4_packing_format}")
 
 
+def _maybe_warn_int4_plain_packing_format(config: Int4WeightOnlyConfig) -> None:
+    if config.int4_packing_format != Int4PackingFormat.PLAIN:
+        return
+    warnings.warn(
+        "Int4WeightOnlyConfig with int4_packing_format=PLAIN (the default) has known "
+        "compatibility issues on several GPU architectures, including consumer "
+        "Blackwell (RTX 50-series, e.g. RTX 5090) and some Ampere GPUs, where it can "
+        "fail at inference/forward time rather than at config-construction time, with "
+        "errors such as 'cutlass cannot initialize' or 'ImportError: Requires mslk "
+        ">= 1.0.0'. If you hit either of those, try "
+        "int4_packing_format=Int4PackingFormat.TILE_PACKED_TO_4D instead. "
+        "See https://github.com/pytorch/ao/issues/3842 for details.",
+        stacklevel=2,
+    )
+
+
 @register_quantize_module_handler(Int4WeightOnlyConfig)
 def _int4_weight_only_transform(
     module: torch.nn.Module,
@@ -627,6 +643,7 @@ def _int4_weight_only_transform(
     *,
     parameter_name: str = "weight",
 ) -> torch.nn.Module:
+    _maybe_warn_int4_plain_packing_format(config)
     if config.set_inductor_config:
         torchao.quantization.utils.recommended_inductor_config_setter()
 


### PR DESCRIPTION
## Note on warning scope

This warning currently fires whenever `int4_packing_format=PLAIN` is
selected, regardless of GPU. I didn't gate it on compute capability
(e.g. excluding Hopper, where PLAIN reportedly works fine) for two
reasons:

1. TILE_PACKED_TO_4D is already the packing format recommended by
   default in the project's own quickstart docs/README, independent
   of hardware compatibility issues -- so nudging all PLAIN users
   toward it seems reasonable even on hardware where PLAIN currently
   works.
2. Capability-gating would require maintaining a list of "known good"
   vs "known bad" compute capabilities, which adds ongoing maintenance
   burden and could go stale as new GPU generations ship.

Open to adding `torch.cuda.get_device_capability()` gating if
maintainers would prefer a narrower warning that only fires on
affected hardware -- happy to make that change if so.
