### PR TITLE
Add generalized int1-int8 weight-only MPS quantization with simdgroup GEMM

### DIFF
--- a/.github/workflows/metal_test.yml
+++ b/.github/workflows/metal_test.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - main
-      - 'gh/**'
+      - "gh/**"
   pull_request:
     branches:
       - main
-      - 'gh/**'
+      - "gh/**"
 
 jobs:
   test-mps-ops:
@@ -15,8 +15,8 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       runner: macos-m1-stable
-      python-version: '3.11'
-      submodules: 'recursive'
+      python-version: "3.11"
+      submodules: "recursive"
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       script: |
@@ -40,4 +40,8 @@ jobs:
 
         echo "::group::Run quantizer tests"
         ${CONDA_RUN} python -m pytest torchao/experimental/ops/mps/test/test_quantizer.py
+        echo "::endgroup::"
+
+        echo "::group::Run intN GEMM tests"
+        ${CONDA_RUN} python -m pytest torchao/experimental/ops/mps/test/test_intNgemm.py
         echo "::endgroup::"

--- a/benchmarks/benchmark_mps.py
+++ b/benchmarks/benchmark_mps.py
@@ -1,0 +1,1107 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+"""Benchmark int1-int8 weight-only quantization on MPS with a real model.
+
+Compares the new simdgroup-tiled GEMM kernel (intNgemm.metal) against the
+upstream per-bitwidth GEMM kernels (intNmm_opt.metal) for prefill (M > 1),
+and the new qmv kernel for decode (M == 1).  The kernel selection is
+controlled by the TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM environment variable:
+
+  - Not set (default): use the new simdgroup-tiled GEMM for prefill
+  - "1": use the upstream per-bitwidth GEMM kernels (no simdgroup MMA)
+
+Both paths use the same qmv kernel for decode (M == 1).
+
+The benchmark also demonstrates 8-bit support, which the upstream path
+did not provide (upstream supported bitwidths 1-7 only).
+
+Metrics: decode/prefill latency and top-1 next-token agreement with the
+bf16 baseline. Results are checkpointed to /tmp for incremental runs.
+"""
+
+import argparse
+import gc
+import json
+import math
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from torchao.experimental.quant_api import (
+    UIntxChooseQParamsAlgorithm,
+    UIntxWeightOnlyConfig,
+)
+from torchao.quantization import Int8WeightOnlyConfig, quantize_
+
+MODEL_ID = "Qwen/Qwen3.5-4B"
+BITWIDTHS = [2, 4, 6, 8]
+GROUP_SIZES = [64, 128]
+PREFILL_M_VALUES = [2048]
+ALGORITHMS = ["min_max", "hqq", "torch", "wo"]
+
+# Native PyTorch MPS int4 group sizes (macOS 15+)
+NATIVE_INT4_GROUP_SIZES = [64, 128]
+
+SEQ_LEN = 2048           # tokens per prefill window
+RUNS = 10                # timed runs per measurement
+WARMUP = 5               # warmup runs before timing
+NUM_WINDOWS = RUNS + WARMUP  # one window per run (warmup + timed)
+CHECKPOINT_FILE = "/tmp/benchmark_mps_checkpoint.json"
+RESULTS_MD_FILE = "/tmp/results.md"
+
+
+class Latency(NamedTuple):
+    """A latency measurement: mean and 95% CI half-width in ms."""
+    mean: float
+    ci: float
+
+
+class Result(NamedTuple):
+    """Benchmark result for one config."""
+    nbit: int
+    gs: int
+    dc: Latency
+    pf: dict[int, Latency]  # M -> Latency
+    top1: Latency           # top-1 next-token agreement with bf16 baseline (%)
+    algo: UIntxChooseQParamsAlgorithm
+
+
+class Baseline(NamedTuple):
+    """bf16 baseline measurements."""
+    dc: Latency
+    pf: dict[int, Latency]  # M -> Latency
+    top1_argmax: list[torch.Tensor]  # per-window argmax of baseline logits (CPU)
+
+
+@dataclass
+class Args:
+    """Parsed CLI arguments."""
+    model: str
+    group_sizes: list[int]
+    prefill_m: list[int]
+    algorithms: list[str]
+    bits: list[int]
+    clear_cache: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint (save/load results for incremental runs)
+# ---------------------------------------------------------------------------
+
+def _result_to_dict(r: Result, category, nbit, gs, algorithm):
+    """Serialize a Result to a JSON-safe dict."""
+    if r is None:
+        return None
+    return {
+        "category": category,
+        "nbit": nbit,
+        "gs": gs,
+        "algorithm": algorithm.value if hasattr(algorithm, "value") else str(algorithm),
+        "dc_mean": r.dc.mean,
+        "dc_ci": r.dc.ci,
+        "pf_results": {str(m): [v.mean, v.ci] for m, v in r.pf.items()},
+        "top1_mean": r.top1.mean,
+        "top1_ci": r.top1.ci,
+    }
+
+
+def _dict_to_result(d) -> Result:
+    """Deserialize a checkpoint dict back to a Result."""
+    algo = UIntxChooseQParamsAlgorithm(d["algorithm"])
+    pf = {int(m): Latency(v[0], v[1]) for m, v in d["pf_results"].items()}
+    # Backward compat: old checkpoints stored top1 as a scalar
+    if isinstance(d.get("top1"), (int, float)):
+        top1 = Latency(d["top1"], 0.0)
+    else:
+        top1 = Latency(d["top1_mean"], d["top1_ci"])
+    return Result(
+        nbit=d["nbit"],
+        gs=d["gs"],
+        dc=Latency(d["dc_mean"], d["dc_ci"]),
+        pf=pf,
+        top1=top1,
+        algo=algo,
+    )
+
+
+def _load_checkpoint():
+    """Load checkpointed results. Returns dict of saved config results."""
+    if not os.path.exists(CHECKPOINT_FILE):
+        return {}
+    with open(CHECKPOINT_FILE, "r") as f:
+        data = json.load(f)
+    return data.get("results", {})
+
+
+def _save_checkpoint(results_dict):
+    """Save checkpointed results to disk."""
+    with open(CHECKPOINT_FILE, "w") as f:
+        json.dump({"results": results_dict}, f, indent=2)
+
+
+def _checkpoint_key(category, nbit, gs, algorithm):
+    """Build a unique key for a config."""
+    return f"{category}_{nbit}_{gs}_{algorithm}"
+
+
+def _run_with_checkpoint(category, key, nbit, gs, algorithm, run_fn, ckpt_results):
+    """Run a config, or return checkpointed result if available.
+
+    Saves each result to disk immediately after completion.
+    """
+    if key in ckpt_results:
+        print(
+            f"  [checkpoint] {category} nbit={nbit} gs={gs} "
+            f"algo={algorithm.value if hasattr(algorithm, 'value') else algorithm}",
+            flush=True,
+        )
+        return _dict_to_result(ckpt_results[key])
+    r = run_fn()
+    if r is not None:
+        ckpt_results[key] = _result_to_dict(r, category, nbit, gs, algorithm)
+        _save_checkpoint(ckpt_results)
+    return r
+
+
+def _run_specs(category, specs, run_fn_factory, ckpt_results):
+    """Run a list of ``(nbit, gs, algorithm)`` specs under one checkpoint category.
+
+    ``run_fn_factory(nbit, gs, algorithm)`` returns the callable that executes
+    the config. Results are returned in spec order; ``None`` indicates failure.
+    """
+    results = []
+    for nbit, gs, algorithm in specs:
+        key = _checkpoint_key(category, nbit, gs, algorithm.value)
+        run_fn = run_fn_factory(nbit, gs, algorithm)
+        results.append(
+            _run_with_checkpoint(category, key, nbit, gs, algorithm, run_fn,
+                                 ckpt_results)
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Native PyTorch MPS int4 quantization
+# ---------------------------------------------------------------------------
+
+def _quantize_int4_native(weight, group_size):
+    """Quantize a weight tensor for native PyTorch MPS int4 _weight_int4pack_mm.
+
+    Returns (packed_weight, qScaleAndZeros) on MPS.
+    Packing: pre-packed uint8 (2 int4 per byte, hi-nibble first).
+    Dequant: w = (q - 8) * scale + zero, where zero = w_min + 8*scale.
+    qScaleAndZeros: [K//gs, N, 2] with (scale, zero) in model dtype.
+
+    The fp32 working copy (w.float()) is kept on CPU to avoid doubling MPS
+    peak memory.  Only the small packed result is moved to MPS.
+    _convert_weight_to_int4pack is MPS-only, so w_packed is moved to MPS
+    just for that call.
+    """
+    model_dtype = weight.dtype
+    N, K = weight.shape
+    w = weight.cpu().float()
+    qmin, qmax = 0, 15
+    w_g = w.reshape(N, K // group_size, group_size)
+    w_min = w_g.amin(dim=2, keepdim=True)
+    w_max = w_g.amax(dim=2, keepdim=True)
+    scales = (w_max - w_min) / (qmax - qmin)
+    zeros = qmin - torch.round(w_min / scales)
+    # Quantize in the grouped shape to avoid materializing full-shaped
+    # scales_exp / zeros_exp (each ~4x the bf16 weight size in float32).
+    w_q_g = torch.clamp(torch.round(w_g / scales + zeros), qmin, qmax).to(
+        torch.uint8
+    )
+    w_q = w_q_g.reshape(N, K)
+    del w_g, w, w_q_g
+    # Keep small grouped tensors for qScaleAndZeros; free the rest.
+    scale_flat = scales.reshape(N, K // group_size)
+    w_min_flat = w_min.reshape(N, K // group_size)
+    del w_min, w_max, scales, zeros
+
+    # Pack: hi-nibble first
+    w_packed = ((w_q[:, 0::2] << 4) | w_q[:, 1::2]).to(torch.uint8)
+    del w_q
+    # _convert_weight_to_int4pack is MPS-only — move just this small tensor.
+    packed = torch.ops.aten._convert_weight_to_int4pack(w_packed.to("mps"), 8)
+
+    zero_native = w_min_flat + 8 * scale_flat
+    qScaleAndZeros = (
+        torch.stack([scale_flat.T, zero_native.T], dim=2)
+        .to("mps")
+        .to(model_dtype)
+    )
+    return packed, qScaleAndZeros
+
+
+class _NativeQuantizedLinear(torch.nn.Module):
+    """Base for native PyTorch MPS int4/int8 Linear wrappers.
+
+    Subclasses set ``in_features``/``out_features``, register their packed
+    parameters, call ``_setup_bias``, and implement ``_mm``.
+    """
+
+    def _mm(self, x_2d):
+        raise NotImplementedError
+
+    def _setup_bias(self, orig_linear):
+        self.has_bias = orig_linear.bias is not None
+        if self.has_bias:
+            self.bias = torch.nn.Parameter(
+                orig_linear.bias.data.clone(), requires_grad=False
+            )
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x):
+        orig_shape = x.shape
+        x_2d = x.reshape(-1, self.in_features)
+        y = self._mm(x_2d)
+        if self.has_bias:
+            y = y + self.bias
+        return y.reshape(*orig_shape[:-1], self.out_features)
+
+
+class _NativeInt4Linear(_NativeQuantizedLinear):
+    """nn.Linear wrapper using native PyTorch MPS int4 _weight_int4pack_mm."""
+
+    def __init__(self, orig_linear, group_size):
+        super().__init__()
+        self.in_features = orig_linear.in_features
+        self.out_features = orig_linear.out_features
+        self.group_size = group_size
+        packed, qSZ = _quantize_int4_native(orig_linear.weight.data, group_size)
+        self.packed_weight = torch.nn.Parameter(packed, requires_grad=False)
+        self.qScaleAndZeros = torch.nn.Parameter(qSZ, requires_grad=False)
+        self._setup_bias(orig_linear)
+
+    def _mm(self, x_2d):
+        return torch.ops.aten._weight_int4pack_mm(
+            x_2d, self.packed_weight, self.group_size, self.qScaleAndZeros
+        )
+
+
+def _replace_linears(model, wrapper_cls, *args):
+    """Recursively replace all nn.Linear modules with ``wrapper_cls(orig, *args)``."""
+    for name, module in model.named_children():
+        if isinstance(module, torch.nn.Linear):
+            setattr(model, name, wrapper_cls(module, *args))
+        else:
+            _replace_linears(module, wrapper_cls, *args)
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+_UL = "\033[4m"
+_UL_R = "\033[0m"
+
+
+def _ul(s: str, width: int = 0) -> str:
+    """Underline ``s``, right-padded to ``width``. Only the text is underlined,
+    not the padding."""
+    underlined = f"{_UL}{s}{_UL_R}"
+    if width > 0:
+        return " " * max(0, width - len(s)) + underlined
+    return underlined
+
+
+def _mean_ci(times):
+    """Return Latency(mean, 95% CI half-width) in ms."""
+    n = len(times)
+    mean = sum(times) / n
+    if n < 2:
+        return Latency(mean, 0.0)
+    var = sum((t - mean) ** 2 for t in times) / (n - 1)
+    se = math.sqrt(var / n)
+    # t critical values for 95% CI, common sample sizes
+    t_vals = {
+        2: 12.706, 3: 4.303, 4: 3.182, 5: 2.776, 6: 2.571,
+        7: 2.447, 8: 2.365, 9: 2.306, 10: 2.262, 15: 2.145,
+        20: 2.093, 30: 2.045,
+    }
+    t = t_vals.get(n, 1.96)
+    return Latency(mean, t * se)
+
+
+def _measure_latency(fn, runs=RUNS, warmup=WARMUP):
+    """Run ``fn`` under torch.no_grad with warmup + timed loop. Returns Latency."""
+    for _ in range(warmup):
+        with torch.no_grad():
+            out = fn()
+        del out
+    torch.mps.synchronize()
+    times = []
+    for _ in range(runs):
+        torch.mps.synchronize()
+        t0 = time.time()
+        with torch.no_grad():
+            out = fn()
+        torch.mps.synchronize()
+        times.append((time.time() - t0) * 1000)
+        del out
+    return _mean_ci(times)
+
+
+def measure_decode_latency(model, input_ids):
+    """Measure single-token decode latency on MPS. Returns Latency in ms."""
+    x = input_ids[:, :1]
+    return _measure_latency(lambda: model(x))
+
+
+def measure_prefill_latency_multi(model, windows_mps, prefill_m_values):
+    """Measure prefill latency across multiple windows. Returns dict[M -> Latency].
+
+    Each window is a separate [1, SEQ_LEN] input_ids tensor. We run
+    WARMUP + RUNS windows (one per run), timing the prefill.
+    """
+    pf = {}
+    for m in prefill_m_values:
+        lats = []
+        for i in range(WARMUP + RUNS):
+            w = windows_mps[i % len(windows_mps)][:, :m]
+            torch.mps.synchronize()
+            t0 = time.time()
+            with torch.no_grad():
+                out = model(w)
+            torch.mps.synchronize()
+            if i >= WARMUP:
+                lats.append((time.time() - t0) * 1000)
+            del out
+        pf[m] = _mean_ci(lats)
+    return pf
+
+
+def measure_top1_multi(model, windows_mps, baseline_argmax_list):
+    """Measure top-1 agreement across all windows. Returns Latency.
+
+    Runs one forward pass per window (all NUM_WINDOWS), captures argmax
+    and compares to baseline. Top-1 is deterministic per window, so all
+    windows contribute (no warmup discard). No logits are retained.
+    """
+    top1_scores = []
+    for i in range(len(windows_mps)):
+        w = windows_mps[i]
+        with torch.no_grad():
+            logits = model(w).logits
+        pred = logits[:, :-1, :].argmax(dim=-1)
+        base = baseline_argmax_list[i]
+        agreement = (pred == base.to(pred.device)).float().mean().item()
+        top1_scores.append(agreement * 100)
+        del logits, pred
+    return _mean_ci(top1_scores)
+
+
+def measure_prefill_with_top1(model, windows_mps, baseline_argmax_list, prefill_m_values):
+    """Measure prefill latency and top-1 agreement across multiple windows.
+
+    Convenience wrapper: runs prefill latency, then top-1 (which does its
+    own forward passes). Returns (pf_latencies, top1_latency).
+    """
+    pf = measure_prefill_latency_multi(model, windows_mps, prefill_m_values)
+    top1 = measure_top1_multi(model, windows_mps, baseline_argmax_list)
+    return pf, top1
+
+
+def cleanup():
+    """Force garbage collection and MPS cache clearing."""
+    gc.collect()
+    torch.mps.empty_cache()
+
+
+# ---------------------------------------------------------------------------
+# Quantization functions
+# ---------------------------------------------------------------------------
+
+def _quantize_uintx(nbit, gs, algorithm):
+    """Return a quantize_fn(model) using the UIntxWeightOnlyConfig path."""
+    def fn(model):
+        quantize_(
+            model,
+            UIntxWeightOnlyConfig(
+                bitwidth=nbit, group_size=gs,
+                uintx_choose_qparams_algorithm=algorithm,
+            ),
+        )
+    return fn
+
+
+def _quantize_native(nbit, gs):
+    """Return a quantize_fn(model) using native PyTorch MPS int4 ops."""
+    def fn(model):
+        if nbit == 4:
+            _replace_linears(model, _NativeInt4Linear, gs)
+        else:
+            raise ValueError(f"Native path only supports 4 bits, got {nbit}")
+    return fn
+
+
+def _quantize_int8wo():
+    """Return a quantize_fn(model) using stable Int8WeightOnlyConfig.
+
+    This produces Int8Tensor subclasses that do NOT dispatch to
+    _weight_int8pack_mm — they dequantize to float and use torch.mm.
+    Included to benchmark the gap vs the native int8 kernel.
+    """
+    def fn(model):
+        quantize_(model, Int8WeightOnlyConfig())
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Config execution
+# ---------------------------------------------------------------------------
+
+def _run_config(
+    nbit, gs, windows_mps, baseline_argmax_list, *,
+    model_id, quantize_fn, algorithm, desc, prefill_m_values,
+) -> Result | None:
+    """Load, quantize, and benchmark a single config. Returns None on failure."""
+    print(f"  Loading {model_id} ({desc})...", flush=True)
+    try:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, dtype=torch.bfloat16, low_cpu_mem_usage=True,
+            local_files_only=True,
+        )
+        model.eval()
+        quantize_fn(model)
+        model.to("mps")
+
+        dc = measure_decode_latency(model, windows_mps[0])
+        pf, top1 = measure_prefill_with_top1(
+            model, windows_mps, baseline_argmax_list, prefill_m_values,
+        )
+
+        del model
+        cleanup()
+        return Result(nbit, gs, dc, pf, top1, algorithm)
+    except Exception as e:
+        print(f"  FAILED: {e}", flush=True)
+        cleanup()
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+def load_dataset(tokenizer):
+    """Load wikitext-103 test split and return NUM_WINDOWS [1, SEQ_LEN] windows.
+
+    Windows are sampled uniformly from the full tokenized test split with
+    a fixed seed (42) for reproducibility, giving content diversity across
+    windows for top-1 measurement.
+    """
+    import random
+
+    from datasets import Dataset
+    arrow_path = os.path.expanduser(
+        "~/.cache/huggingface/datasets/Salesforce___wikitext/"
+        "wikitext-103-raw-v1/0.0.0/"
+        "b08601e04326c79dfdd32d625aee71d232d685c3/wikitext-test.arrow"
+    )
+    if os.path.exists(arrow_path):
+        ds = Dataset.from_file(arrow_path)
+        text = "\n\n".join([t for t in ds["text"] if t.strip()])
+    else:
+        from datasets import load_dataset
+        ds = load_dataset("wikitext", "wikitext-103-raw-v1", split="test")
+        text = "\n\n".join([t for t in ds["text"] if t.strip()])
+    # Tokenize the full test split (no truncation) so we can sample from it.
+    input_ids = tokenizer(text, return_tensors="pt").input_ids[0]
+    total_tokens = input_ids.shape[0]
+    if total_tokens < NUM_WINDOWS * SEQ_LEN:
+        raise ValueError(
+            f"Need at least {NUM_WINDOWS * SEQ_LEN} tokens for {NUM_WINDOWS} "
+            f"non-overlapping windows of {SEQ_LEN}, got {total_tokens}"
+        )
+    # Pick NUM_WINDOWS random non-overlapping start positions with seed 42.
+    rng = random.Random(42)
+    max_start = total_tokens - SEQ_LEN
+    starts = sorted(rng.sample(range(0, max_start + 1, SEQ_LEN), NUM_WINDOWS))
+    windows = [input_ids[s:s + SEQ_LEN].unsqueeze(0) for s in starts]
+    return windows
+
+
+# ---------------------------------------------------------------------------
+# Baseline
+# ---------------------------------------------------------------------------
+
+def measure_baseline(args, windows_mps) -> Baseline:
+    """Load bf16 model to MPS, measure speed, capture argmax per window for top-1."""
+    print(f"Loading {args.model} (bf16 baseline)...", flush=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        dtype=torch.bfloat16,
+        low_cpu_mem_usage=True,
+        local_files_only=True,
+    ).to("mps")
+    model.eval()
+    dc = measure_decode_latency(model, windows_mps[0])
+    pf = measure_prefill_latency_multi(model, windows_mps, args.prefill_m)
+
+    # Capture baseline argmax for each window (tiny: [1, SEQ_LEN-1] int64 each).
+    baseline_argmax_list = []
+    for w in windows_mps:
+        with torch.no_grad():
+            logits = model(w).logits
+        baseline_argmax_list.append(logits[:, :-1, :].argmax(dim=-1).cpu())
+        del logits
+
+    del model
+    cleanup()
+    return Baseline(dc, pf, baseline_argmax_list)
+
+
+# ---------------------------------------------------------------------------
+# Run all configs
+# ---------------------------------------------------------------------------
+
+def run_all_configs(args, windows_mps, baseline, ckpt_results):
+    """Run all quantized configs (old/new/native). Returns dict keyed by category."""
+    prefill_m_values = args.prefill_m
+    bitwidths = args.bits
+    group_sizes = args.group_sizes
+    algorithms = args.algorithms
+    model_id = args.model
+    baseline_argmax_list = baseline.top1_argmax
+
+    def uintx_factory(nbit, gs, algorithm):
+        algo_name = "hqq" if algorithm == UIntxChooseQParamsAlgorithm.HQQ else "minmax"
+        desc = f"{nbit}-bit gs={gs} {algo_name}"
+        return lambda: _run_config(
+            nbit, gs, windows_mps, baseline_argmax_list,
+            model_id=model_id,
+            quantize_fn=_quantize_uintx(nbit, gs, algorithm),
+            algorithm=algorithm, desc=desc,
+            prefill_m_values=prefill_m_values,
+        )
+
+    def native_factory(nbit, gs, algorithm):
+        desc = f"native {nbit}-bit gs={gs}"
+        return lambda: _run_config(
+            nbit, gs, windows_mps, baseline_argmax_list,
+            model_id=model_id,
+            quantize_fn=_quantize_native(nbit, gs),
+            algorithm=UIntxChooseQParamsAlgorithm.MIN_MAX, desc=desc,
+            prefill_m_values=prefill_m_values,
+        )
+
+    def int8wo_factory(nbit, gs, algorithm):
+        desc = f"Int8WeightOnlyConfig {nbit}-bit per-channel"
+        return lambda: _run_config(
+            nbit, gs, windows_mps, baseline_argmax_list,
+            model_id=model_id,
+            quantize_fn=_quantize_int8wo(),
+            algorithm=UIntxChooseQParamsAlgorithm.MIN_MAX, desc=desc,
+            prefill_m_values=prefill_m_values,
+        )
+
+    results = {}
+
+    # Old kernels: force fallback to upstream per-bitwidth GEMM (no simdgroup MMA)
+    print("\n=== Old prefill kernels (upstream, no simdgroup MMA) ===", flush=True)
+    os.environ["TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM"] = "1"
+    old_specs = []
+    if "min_max" in algorithms:
+        for nbit in [b for b in bitwidths if b != 8]:
+            for gs in group_sizes:
+                old_specs.append((nbit, gs, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    if "hqq" in algorithms and 4 in bitwidths and 64 in group_sizes:
+        old_specs.append((4, 64, UIntxChooseQParamsAlgorithm.HQQ))
+    if "min_max" in algorithms and 8 in bitwidths:
+        for gs in group_sizes:
+            old_specs.append((8, gs, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    results["old"] = _run_specs("old", old_specs, uintx_factory, ckpt_results)
+
+    # New kernels: use simdgroup-tiled GEMM (or native delegation for int8 per-ch)
+    print("\n=== New prefill kernels (simdgroup MMA) ===", flush=True)
+    os.environ["TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM"] = "0"
+    new_specs = []
+    if "min_max" in algorithms:
+        for nbit in bitwidths:
+            for gs in group_sizes:
+                new_specs.append((nbit, gs, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    # int8 per-channel: IntxMPSExperimentalTensor delegates to native _weight_int8pack_mm
+    if "min_max" in algorithms and 8 in bitwidths:
+        new_specs.append((8, -1, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    if "hqq" in algorithms and 4 in bitwidths and 64 in group_sizes:
+        new_specs.append((4, 64, UIntxChooseQParamsAlgorithm.HQQ))
+    results["new"] = _run_specs("new", new_specs, uintx_factory, ckpt_results)
+
+    # Native PyTorch MPS int4
+    print("\n=== Native PyTorch MPS int4 ===", flush=True)
+    native_specs = []
+    if "torch" in algorithms:
+        if 4 in bitwidths:
+            for gs in [g for g in NATIVE_INT4_GROUP_SIZES if g in group_sizes]:
+                native_specs.append((4, gs, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    results["torch"] = _run_specs("torch", native_specs, native_factory, ckpt_results)
+
+    # Stable Int8WeightOnlyConfig (Int8Tensor — does NOT use _weight_int8pack_mm)
+    print("\n=== Stable Int8WeightOnlyConfig (Int8Tensor) ===", flush=True)
+    os.environ["TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM"] = "0"
+    int8wo_specs = []
+    if "wo" in algorithms and 8 in bitwidths:
+        int8wo_specs.append((8, -1, UIntxChooseQParamsAlgorithm.MIN_MAX))
+    results["wo"] = _run_specs("wo", int8wo_specs, int8wo_factory, ckpt_results)
+
+    cleanup()
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def _make_label(nbit, suffix, algorithm):
+    if algorithm == UIntxChooseQParamsAlgorithm.HQQ:
+        return f"{nbit}{suffix}hqq"
+    return f"{nbit}{suffix}"
+
+
+def _prepare_report_data(results_by_category, prefill_m_values):
+    """Collect, sort rows and compute significant bests.
+
+    Shared by ``print_report`` (stdout) and ``write_markdown_report`` (file).
+    Returns ``(rows, rows_by_nbit, sig_best, sorted_m)``.
+    """
+    sorted_m = sorted(prefill_m_values)
+
+    # Collect results
+    category_priority = {"old": 0, "new": 1, "torch": 2, "wo": 3}
+    tagged = (
+        [(r, "old") for r in results_by_category.get("old", [])]
+        + [(r, "new") for r in results_by_category.get("new", [])]
+        + [(r, "torch") for r in results_by_category.get("torch", [])]
+        + [(r, "wo") for r in results_by_category.get("wo", [])]
+    )
+    rows = []
+    for r, suffix in tagged:
+        if r is None:
+            continue
+        label = _make_label(r.nbit, suffix, r.algo)
+        # int8 per-channel via the new class delegates to native
+        # _weight_int8pack_mm; label it as "8torch" to reflect this.
+        if r.nbit == 8 and suffix == "new" and r.gs == -1:
+            label = "8torch"
+        priority = category_priority[suffix]
+        is_hqq = 1 if "hqq" in label else 0
+        sort_key = (r.nbit, r.gs, priority, is_hqq)
+        rows.append((sort_key, r, label))
+    rows.sort(key=lambda x: x[0])
+
+    # Group rows by bitwidth to find best-within-bitwidth
+    rows_by_nbit = {}
+    for _, r, label in rows:
+        rows_by_nbit.setdefault(r.nbit, []).append((r, label))
+
+    # For each bitwidth group, find the best value per metric.
+    # "Best" = lowest mean for latency, highest for top1.
+    # Only underline if the best is significantly better than the
+    # second-best (CIs don't overlap).
+    def _is_significant_best(vals_cis, lower_is_better):
+        """Return set of indices that are significant bests.
+
+        Finds all entries tied for best (CIs overlap with the best) that
+        collectively beat the rest. If the best doesn't significantly beat
+        the second-best, returns empty (no underline).
+        """
+        if len(vals_cis) < 2:
+            return set()
+        sorted_idx = sorted(
+            range(len(vals_cis)),
+            key=lambda i: vals_cis[i][0] if lower_is_better else -vals_cis[i][0],
+        )
+        # Find the "best group": entries whose CIs overlap with the best.
+        # These are tied — we can't distinguish them.
+        best_mean, best_ci = vals_cis[sorted_idx[0]]
+        if lower_is_better:
+            best_upper = best_mean + best_ci
+        else:
+            best_lower = best_mean - best_ci
+
+        best_group = [sorted_idx[0]]
+        for idx in sorted_idx[1:]:
+            mean, ci = vals_cis[idx]
+            if lower_is_better:
+                # Tied if this entry's lower bound overlaps best's upper bound
+                if mean - ci <= best_upper:
+                    best_group.append(idx)
+                else:
+                    break
+            else:
+                # Tied if this entry's upper bound overlaps best's lower bound
+                if mean + ci >= best_lower:
+                    best_group.append(idx)
+                else:
+                    break
+
+        # Only underline if the best group significantly beats the rest.
+        # "The rest" = first entry not in the best group.
+        # If all entries are tied (best group covers everything), no underline.
+        if len(best_group) >= len(vals_cis):
+            return set()
+        rest_idx = sorted_idx[len(best_group)]
+        rest_mean, rest_ci = vals_cis[rest_idx]
+        if lower_is_better:
+            # Significant if best group's upper bound < rest's lower bound
+            if best_upper < rest_mean - rest_ci:
+                return set(best_group)
+        else:
+            # Significant if best group's lower bound > rest's upper bound
+            if best_lower > rest_mean + rest_ci:
+                return set(best_group)
+        return set()
+
+    # Compute significant bests per bitwidth group
+    # Keys: (nbit, metric_key) -> set of row indices that are tied for best
+    sig_best = {}
+    for nbit, group in rows_by_nbit.items():
+        # DCmean
+        dc_vals = [(r.dc.mean, r.dc.ci) for r, _ in group]
+        sig_best[(nbit, "dc")] = _is_significant_best(dc_vals, lower_is_better=True)
+        # Prefill M
+        for m in sorted_m:
+            pf_vals = [(r.pf[m].mean, r.pf[m].ci) for r, _ in group]
+            sig_best[(nbit, ("pf", m))] = _is_significant_best(pf_vals, lower_is_better=True)
+        # top1 — highest wins, must be significant
+        top1_vals = [(r.top1.mean, r.top1.ci) for r, _ in group]
+        sig_best[(nbit, "top1")] = _is_significant_best(top1_vals, lower_is_better=False)
+
+    return rows, rows_by_nbit, sig_best, sorted_m
+
+
+def print_report(device_name, model_id, baseline, results_by_category, prefill_m_values):
+    """Print the full report: speed table + top-1."""
+    print()
+    print(f"Device: {device_name}")
+    print(f"Model: {model_id}")
+    print("All latencies in ms; speedups vs bf16 eager baseline.")
+    print()
+    print("  DCmean     = decode latency (M=1)")
+    print("  DCsp       = decode speedup vs bf16")
+    print("  M=N        = prefill latency for N tokens")
+    print("  Msp        = prefill speedup vs bf16")
+    print("  top1       = next-token agreement with bf16 baseline (%)")
+    print()
+    print("  old        = upstream per-bitwidth GEMM (no simdgroup MMA)")
+    print("  new        = simdgroup-tiled GEMM (intNgemm.metal)")
+    print("  torch      = native PyTorch MPS (_weight_int4pack_mm / _weight_int8pack_mm)")
+    print("  wo         = stable Int8WeightOnlyConfig (Int8Tensor, no _weight_int8pack_mm)")
+    print("  hqq        = HQQ qparams algorithm (same _linear_fp_act kernel;")
+    print("               included to show the new GEMM speeds up HQQ too)")
+    print()
+    print("  Underlined = significantly best within bitwidth")
+    print("               (CIs don't overlap aside from ties)")
+    print()
+    print(f"  Samples: {RUNS} timed runs per latency measurement "
+          f"(after {WARMUP} warmup), {NUM_WINDOWS} windows for top-1.")
+    print("  CIs: 95% t-distribution (two-sided, Bessel-corrected).")
+    print()
+    print(f"  Data: wikitext-103 test split, {NUM_WINDOWS} non-overlapping")
+    print(f"         {SEQ_LEN}-token windows sampled uniformly with a fixed")
+    print("         seed (42). Latency runs cycle through these windows (one")
+    print("         per run); top-1 uses all windows (no warmup discard,")
+    print("         since top-1 is deterministic per window).")
+    print()
+    print("  Quality metric: top-1 next-token agreement with bf16 baseline.")
+    print("         KL divergence is not reported because it requires retaining")
+    print("         the full baseline logits tensor for every window (~970 MB")
+    print("         per window, ~14.5 GB for 15 windows) to compare against each")
+    print("         quantized config. Top-1 only needs the argmax (a [1, SEQ_LEN]")
+    print("         int64 tensor per window, ~16 KB), which is negligible.")
+    print()
+    print()
+
+    rows, rows_by_nbit, sig_best, sorted_m = _prepare_report_data(
+        results_by_category, prefill_m_values
+    )
+
+    # --- Results table ---
+    header = f"{'Bits':>8} {'gs':>6} {'DCmean':>7} {'DCsp':>6}"
+    for m in sorted_m:
+        header += f" {'M=' + str(m):>7} {'Msp':>5}"
+    header += f" {'top1':>6}"
+    print(header)
+    print("-" * len(header))
+
+    # Baseline row
+    base_parts = [
+        f"{'bf16':>8} {'-':>6} {baseline.dc.mean:>7.2f} {'1.00x':>6}"
+    ]
+    for m in sorted_m:
+        lat = baseline.pf[m]
+        base_parts.append(f" {lat.mean:>7.1f} {'1.00x':>5}")
+    base_parts.append(f" {'100.0%':>6}")
+    print("".join(base_parts))
+    # Baseline CI row
+    ci_parts = [f"{'':>8} {'':>6} {'±' + f'{baseline.dc.ci:.1f}':>7} {'':>6}"]
+    for m in sorted_m:
+        lat = baseline.pf[m]
+        ci_parts.append(f" {'±' + f'{lat.ci:.1f}':>7} {'':>5}")
+    ci_parts.append(f" {'':>6}")
+    print("".join(ci_parts))
+    print("-" * len(header))
+
+    prev_nbit = None
+    for _, r, label in rows:
+        if prev_nbit is not None and r.nbit != prev_nbit:
+            print("-" * len(header))
+        prev_nbit = r.nbit
+
+        # Find this row's index within its bitwidth group
+        group = rows_by_nbit[r.nbit]
+        row_idx = next(i for i, (gr, _) in enumerate(group) if gr is r)
+
+        dc_sp = baseline.dc.mean / r.dc.mean if r.dc.mean > 0 else 0
+        gs_str = "per-ch" if r.gs == -1 else str(r.gs)
+
+        # Underline significant bests (latency + speedup + top1)
+        dc_best = row_idx in sig_best.get((r.nbit, "dc"), set())
+        dc_str = _ul(f"{r.dc.mean:.2f}", 7) if dc_best else f"{r.dc.mean:>7.2f}"
+        dc_sp_str = _ul(f"{dc_sp:.2f}x", 6) if dc_best else f"{f'{dc_sp:.2f}x':>6}"
+        parts = [f"{label:>8} {gs_str:>6} {dc_str} {dc_sp_str}"]
+        for m in sorted_m:
+            lat = r.pf.get(m, Latency(0, 0))
+            base = baseline.pf.get(m, Latency(0, 0))
+            sp = base.mean / lat.mean if lat.mean > 0 else 0
+            pf_best = row_idx in sig_best.get((r.nbit, ("pf", m)), set())
+            lat_str = _ul(f"{lat.mean:.1f}", 7) if pf_best else f"{lat.mean:>7.1f}"
+            sp_str = _ul(f"{sp:.2f}x", 5) if pf_best else f"{f'{sp:.2f}x':>5}"
+            parts.append(f" {lat_str} {sp_str}")
+        top1_best = row_idx in sig_best.get((r.nbit, "top1"), set())
+        top1_str = _ul(f"{r.top1.mean:.1f}%", 6) if top1_best else f"{r.top1.mean:>5.1f}%"
+        parts.append(f" {top1_str}")
+        print("".join(parts))
+        # CI row
+        ci_parts = [f"{'':>8} {'':>6} {'±' + f'{r.dc.ci:.1f}':>7} {'':>6}"]
+        for m in sorted_m:
+            lat = r.pf.get(m, Latency(0, 0))
+            ci_parts.append(f" {'±' + f'{lat.ci:.1f}':>7} {'':>5}")
+        ci_parts.append(f" {'±' + f'{r.top1.ci:.1f}':>6}")
+        print("".join(ci_parts))
+
+
+def write_markdown_report(
+    path, device_name, model_id, baseline, results_by_category, prefill_m_values
+):
+    """Write the results table as GitHub-compatible markdown to ``path``.
+
+    Differences from ``print_report`` (stdout):
+    - Significant bests are **bold** instead of ANSI-underlined.
+    - CI half-widths are on a new line within each cell (``<br>±X.X``)
+      instead of on a separate row.
+    - The table uses GitHub markdown table syntax.
+    """
+    rows, rows_by_nbit, sig_best, sorted_m = _prepare_report_data(
+        results_by_category, prefill_m_values
+    )
+
+    lines = []
+    lines.append(f"**Device:** {device_name}")
+    lines.append("")
+    lines.append(f"**Model:** {model_id}")
+    lines.append("")
+    lines.append("All latencies in ms; speedups vs bf16 eager baseline.")
+    lines.append("")
+
+    # Legend as a small table
+    lines.append("| Key | Description |")
+    lines.append("|-----|-------------|")
+    lines.append("| `DCmean` | decode latency (M=1) |")
+    lines.append("| `DCsp` | decode speedup vs bf16 |")
+    lines.append("| `M=N` | prefill latency for N tokens |")
+    lines.append("| `Msp` | prefill speedup vs bf16 |")
+    lines.append("| `top1` | next-token agreement with bf16 baseline (%) |")
+    lines.append("| `old` | upstream per-bitwidth GEMM (no simdgroup MMA) |")
+    lines.append("| `new` | simdgroup-tiled GEMM (intNgemm.metal) |")
+    lines.append("| `torch` | native PyTorch MPS (_weight_int4pack_mm / _weight_int8pack_mm) |")
+    lines.append("| `wo` | stable Int8WeightOnlyConfig (Int8Tensor, no _weight_int8pack_mm) |")
+    lines.append("| `hqq` | HQQ qparams algorithm (same _linear_fp_act kernel) |")
+    lines.append("")
+    lines.append(
+        "**Bold** = significantly best within bitwidth "
+        "(CIs don't overlap aside from ties)"
+    )
+    lines.append("")
+    lines.append(
+        f"**Samples:** {RUNS} timed runs per latency measurement "
+        f"(after {WARMUP} warmup), {NUM_WINDOWS} windows for top-1. "
+        f"**CIs:** 95% t-distribution (two-sided, Bessel-corrected)."
+    )
+    lines.append("")
+    lines.append(
+        f"**Data:** wikitext-103 test split, {NUM_WINDOWS} non-overlapping "
+        f"{SEQ_LEN}-token windows sampled uniformly with a fixed seed (42). "
+        f"Latency runs cycle through these windows (one per run); top-1 uses "
+        f"all windows (no warmup discard, since top-1 is deterministic per "
+        f"window)."
+    )
+    lines.append("")
+    lines.append(
+        "**Quality metric:** top-1 next-token agreement with bf16 baseline. "
+        "KL divergence is not reported because it requires retaining the "
+        "full baseline logits tensor for every window (~970 MB per "
+        "window, ~14.5 GB for 15 windows) to compare against each quantized "
+        "config. Top-1 only needs the argmax (a [1, SEQ_LEN] int64 tensor "
+        "per window, ~16 KB), which is negligible."
+    )
+    lines.append("")
+
+    # --- Results table ---
+    header_cells = ["Bits", "gs", "DCmean", "DCsp"]
+    for m in sorted_m:
+        header_cells.append(f"M={m}")
+        header_cells.append("Msp")
+    header_cells.append("top1")
+
+    lines.append("| " + " | ".join(header_cells) + " |")
+    lines.append("|" + "|".join(["---"] * len(header_cells)) + "|")
+
+    # Baseline row
+    base_cells = ["bf16", "-"]
+    base_cells.append(f"{baseline.dc.mean:.2f}<br>±{baseline.dc.ci:.1f}")
+    base_cells.append("1.00x")
+    for m in sorted_m:
+        lat = baseline.pf[m]
+        base_cells.append(f"{lat.mean:.1f}<br>±{lat.ci:.1f}")
+        base_cells.append("1.00x")
+    base_cells.append("100.0%<br>±0.0")
+    lines.append("| " + " | ".join(base_cells) + " |")
+
+    # Data rows
+    for _, r, label in rows:
+        group = rows_by_nbit[r.nbit]
+        row_idx = next(i for i, (gr, _) in enumerate(group) if gr is r)
+
+        dc_sp = baseline.dc.mean / r.dc.mean if r.dc.mean > 0 else 0
+        gs_str = "per-ch" if r.gs == -1 else str(r.gs)
+
+        dc_best = row_idx in sig_best.get((r.nbit, "dc"), set())
+        dc_val = f"{r.dc.mean:.2f}"
+        dc_cell = (
+            f"**{dc_val}**<br>±{r.dc.ci:.1f}" if dc_best
+            else f"{dc_val}<br>±{r.dc.ci:.1f}"
+        )
+        dc_sp_val = f"{dc_sp:.2f}x"
+        dc_sp_cell = f"**{dc_sp_val}**" if dc_best else dc_sp_val
+
+        cells = [label, gs_str, dc_cell, dc_sp_cell]
+        for m in sorted_m:
+            lat = r.pf.get(m, Latency(0, 0))
+            base = baseline.pf.get(m, Latency(0, 0))
+            sp = base.mean / lat.mean if lat.mean > 0 else 0
+            pf_best = row_idx in sig_best.get((r.nbit, ("pf", m)), set())
+            lat_val = f"{lat.mean:.1f}"
+            lat_cell = (
+                f"**{lat_val}**<br>±{lat.ci:.1f}" if pf_best
+                else f"{lat_val}<br>±{lat.ci:.1f}"
+            )
+            sp_val = f"{sp:.2f}x"
+            sp_cell = f"**{sp_val}**" if pf_best else sp_val
+            cells.append(lat_cell)
+            cells.append(sp_cell)
+
+        top1_best = row_idx in sig_best.get((r.nbit, "top1"), set())
+        top1_val = f"{r.top1.mean:.1f}%"
+        top1_cell = (
+            f"**{top1_val}**<br>±{r.top1.ci:.1f}" if top1_best
+            else f"{top1_val}<br>±{r.top1.ci:.1f}"
+        )
+        cells.append(top1_cell)
+
+        lines.append("| " + " | ".join(cells) + " |")
+
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"\nResults table written to {path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args() -> Args:
+    """Parse CLI args; fall back to module-level defaults when unset."""
+    parser = argparse.ArgumentParser(description="Benchmark MPS weight-only quantization.")
+    parser.add_argument("--model", default=MODEL_ID, help="HuggingFace model ID")
+    parser.add_argument("-g", "--group-sizes", type=int, nargs="*", default=None,
+                        help="Override group sizes (default: 64 128)")
+    parser.add_argument("-m", "--prefill-m", type=int, nargs="*", default=None,
+                        help="Override prefill M values (default: 2048)")
+    parser.add_argument("-a", "--algorithms", nargs="*", default=None,
+                        help="Override algorithms (default: min_max hqq torch wo)")
+    parser.add_argument("-b", "--bits", type=int, nargs="*", default=None,
+                        help="Override bitwidths (default: 4 6 8)")
+    parser.add_argument("--clear-cache", action="store_true",
+                        help="Clear checkpoint cache before running")
+    ns = parser.parse_args()
+    return Args(
+        model=ns.model,
+        group_sizes=ns.group_sizes if ns.group_sizes is not None else list(GROUP_SIZES),
+        prefill_m=ns.prefill_m if ns.prefill_m is not None else list(PREFILL_M_VALUES),
+        algorithms=ns.algorithms if ns.algorithms is not None else list(ALGORITHMS),
+        bits=ns.bits if ns.bits is not None else list(BITWIDTHS),
+        clear_cache=ns.clear_cache,
+    )
+
+
+def main():
+    """Entry point: parse args, load data, measure, run, report."""
+    args = parse_args()
+
+    if args.clear_cache and os.path.exists(CHECKPOINT_FILE):
+        os.remove(CHECKPOINT_FILE)
+        print(f"Cleared checkpoint cache: {CHECKPOINT_FILE}")
+
+    # Compile the HQQ proximal solver for faster quantization.
+    if "hqq" in args.algorithms:
+        import torchao.quantization.quant_primitives as _qp
+        torch._dynamo.config.capture_scalar_outputs = True
+        _compiled_optimize = torch.compile(
+            _qp.optimize_weights_proximal_legacy, mode="reduce-overhead"
+        )
+        _fn = _qp._choose_qparams_and_quantize_affine_hqq
+        _fn.__defaults__ = (*_fn.__defaults__[:-1], _compiled_optimize)
+        print("HQQ quantization optimizer compiled (torch.compile, reduce-overhead)")
+
+    # Load checkpoint (if any) from previous runs
+    ckpt_results = _load_checkpoint()
+    if ckpt_results:
+        print(
+            f"Loaded {len(ckpt_results)} checkpointed results from {CHECKPOINT_FILE}",
+            flush=True,
+        )
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    windows = load_dataset(tokenizer)
+    windows_mps = [w.to("mps") for w in windows]
+
+    baseline = measure_baseline(args, windows_mps)
+
+    device_name = (
+        subprocess.check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"], text=True
+        ).strip()
+        or "Apple Silicon"
+    )
+
+    results = run_all_configs(args, windows_mps, baseline, ckpt_results)
+    cleanup()
+    print_report(device_name, args.model, baseline, results, args.prefill_m)
+    write_markdown_report(
+        RESULTS_MD_FILE, device_name, args.model, baseline, results, args.prefill_m
+    )
+
+
+if __name__ == "__main__" and torch.backends.mps.is_available():
+    main()

--- a/test/prototype/safetensors/test_safetensors_support.py
+++ b/test/prototype/safetensors/test_safetensors_support.py
@@ -163,7 +163,61 @@ class TestSafeTensors(TestCase):
                     assert key in leftover_tensor_data_dict
 
 
+@unittest.skipIf(
+    not torch.backends.mps.is_available(),
+    "Need MPS available",
+)
+class TestSafeTensorsMPS(TestCase):
+    """Test safetensors serialization for IntxMPSExperimentalTensor on MPS."""
+
+    def test_intx_mps_experimental_tensor(self):
+        import json
+        import struct
+
+        from torchao.experimental.ops.mps.utils import _load_torchao_mps_lib
+        from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+            IntxMPSExperimentalTensor,
+        )
+
+        _load_torchao_mps_lib()
+
+        device = "mps"
+        N, K, group_size, nbit = 128, 256, 64, 4
+        packed = torch.randint(
+            0, 255, (N, nbit * K // 8), dtype=torch.uint8, device=device
+        )
+        scales = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+        zeros = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+        tensor = IntxMPSExperimentalTensor(
+            packed, scales, zeros, nbit, [1, group_size], torch.Size([N, K])
+        )
+        state_dict = {"0.weight": tensor}
+
+        with tempfile.NamedTemporaryFile(suffix=".safetensors") as f:
+            tensors_data_dict, metadata = flatten_tensor_state_dict(state_dict)
+            save_file(tensors_data_dict, f.name, metadata=metadata)
+            loaded_tensors = load_file(f.name, device=device)
+            with open(f.name, "rb") as fh:
+                header_size = struct.unpack("<Q", fh.read(8))[0]
+                header = json.loads(fh.read(header_size))
+            loaded_metadata = header.get("__metadata__", {})
+            reconstructed, leftover = unflatten_tensor_state_dict(
+                loaded_tensors, loaded_metadata
+            )
+            assert not leftover, f"Leftover tensors: {leftover}"
+
+            rt = reconstructed["0.weight"]
+            assert isinstance(rt, IntxMPSExperimentalTensor)
+            assert rt.nbit == nbit
+            assert rt.block_size == [1, group_size]
+            assert list(rt.shape) == [N, K]
+            assert torch.equal(rt.packed_weight, packed)
+            assert torch.equal(rt.scales, scales)
+            assert torch.equal(rt.zeros, zeros)
+
+
 instantiate_parametrized_tests(TestSafeTensors)
+instantiate_parametrized_tests(TestSafeTensorsMPS)
 
 if __name__ == "__main__":
     run_tests()

--- a/torchao/experimental/kernels/mps/metal.yaml
+++ b/torchao/experimental/kernels/mps/metal.yaml
@@ -13,6 +13,9 @@
 - func: int4mm
   file: int4mm_opt.metal
 
+- func: intNgemm
+  file: intNgemm.metal
+
 - func: int5mm
   file: int5mm.metal
 

--- a/torchao/experimental/kernels/mps/metal/intNgemm.metal
+++ b/torchao/experimental/kernels/mps/metal/intNgemm.metal
@@ -1,0 +1,586 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD 3-Clause license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Generalized low-bit GEMM kernel using simdgroup matrix multiply accumulation.
+// Supports int1 through int8 weight-only quantization for the prefill case (M > 1).
+//
+// The tiling structure (32x64 output tiles, 4 simdgroups, outer-product
+// accumulation, threadgroup staging) is adapted from PyTorch's kernel_mul_mm
+// in aten/src/ATen/native/mps/kernels/Quantized.metal, which is itself
+// credited as "heavily inspired by llama.cpp" (MIT).
+//
+// The per-bitwidth dequantization logic (Dequant8<nbit>) is the bitwise
+// inverse of the packing functions in packing.h (same BSD-3-Clause license,
+// Meta). The packing format matches MLX's format (MLX MIT license, via
+// qmv.metal in this directory), but the dequantization code here is derived
+// from packing.h, not from MLX.
+//
+// Performance context:
+//   The primary benefits of low-bit weight-only quantization on Apple Silicon
+//   are (1) weight memory compression and (2) faster decode (M=1), which is
+//   memory-bound and handled by the qmv kernel.  Prefill (M>1) is
+//   compute-bound, so dequant + matmul is generally slower than a native
+//   bf16 matmul -- Apple Silicon has no low-bit MMA, and dequantization is
+//   pure overhead.  This kernel does NOT make low-bit prefill faster than
+//   bf16 prefill.  What it does is make low-bit prefill significantly faster
+//   than the previous per-bitwidth pack_mm paths (which were GEMV-shaped with
+//   no simdgroup MMA), so that choosing low-bit for memory/decode reasons is
+//   less penalizing at prefill.
+
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+#define BLOCK_SIZE_M 32
+#define BLOCK_SIZE_N 64
+#define BLOCK_SIZE_K 32
+#define THREAD_MAT_M 2
+#define THREAD_MAT_N 4
+#define THREAD_PER_ROW_A 4
+#define THREAD_PER_ROW_B 2
+#define SG_MAT_SIZE 64
+#define SG_MAT_ROW 8
+
+template <typename T> struct BlockType {};
+
+template <> struct BlockType<float> {
+  using simdgroup_type8x8 = simdgroup_float8x8;
+  using type4 = float4;
+};
+
+template <> struct BlockType<half> {
+  using simdgroup_type8x8 = simdgroup_half8x8;
+  using type4 = half4;
+};
+
+#if __METAL_VERSION__ >= 310
+template <> struct BlockType<bfloat> {
+  using simdgroup_type8x8 = simdgroup_bfloat8x8;
+  using type4 = bfloat4;
+};
+#endif
+
+// ---------------------------------------------------------------------------
+// Dequantization: extract 8 weight values from packed bytes.
+// Each specialization matches the packing format in packing.h.
+// All bit widths use the same final formula: weight = scale * val + zero
+// Uses struct specialization (proven pattern in Metal, same as BlockType).
+// ---------------------------------------------------------------------------
+template <int nbit>
+struct Dequant8 {
+  // Bytes consumed: 8 values * nbit bits / 8 bits = nbit bytes
+  static inline void apply(constant uchar* b, thread float* w);
+};
+
+// 1-bit: 8 values in 1 byte
+template <>
+struct Dequant8<1> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x01);
+    w[1] = float((b[0] & 0x02) >> 1);
+    w[2] = float((b[0] & 0x04) >> 2);
+    w[3] = float((b[0] & 0x08) >> 3);
+    w[4] = float((b[0] & 0x10) >> 4);
+    w[5] = float((b[0] & 0x20) >> 5);
+    w[6] = float((b[0] & 0x40) >> 6);
+    w[7] = float((b[0] & 0x80) >> 7);
+  }
+};
+
+// 2-bit: 4 values in 1 byte, 8 values in 2 bytes
+template <>
+struct Dequant8<2> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x03);
+    w[1] = float((b[0] & 0x0c) >> 2);
+    w[2] = float((b[0] & 0x30) >> 4);
+    w[3] = float((b[0] & 0xc0) >> 6);
+    w[4] = float(b[1] & 0x03);
+    w[5] = float((b[1] & 0x0c) >> 2);
+    w[6] = float((b[1] & 0x30) >> 4);
+    w[7] = float((b[1] & 0xc0) >> 6);
+  }
+};
+
+// 3-bit: 8 values in 3 bytes
+template <>
+struct Dequant8<3> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x07);
+    w[1] = float((b[0] & 0x38) >> 3);
+    w[2] = float(((b[0] & 0xc0) >> 6) | ((b[1] & 0x01) << 2));
+    w[3] = float((b[1] & 0x0e) >> 1);
+    w[4] = float((b[1] & 0x70) >> 4);
+    w[5] = float(((b[1] & 0x80) >> 7) | ((b[2] & 0x03) << 1));
+    w[6] = float((b[2] & 0x1c) >> 2);
+    w[7] = float((b[2] & 0xe0) >> 5);
+  }
+};
+
+// 4-bit: 2 values in 1 byte, 8 values in 4 bytes
+template <>
+struct Dequant8<4> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x0f);
+    w[1] = float((b[0] & 0xf0) >> 4);
+    w[2] = float(b[1] & 0x0f);
+    w[3] = float((b[1] & 0xf0) >> 4);
+    w[4] = float(b[2] & 0x0f);
+    w[5] = float((b[2] & 0xf0) >> 4);
+    w[6] = float(b[3] & 0x0f);
+    w[7] = float((b[3] & 0xf0) >> 4);
+  }
+};
+
+// 5-bit: 8 values in 5 bytes
+template <>
+struct Dequant8<5> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x1f);
+    w[1] = float(((b[0] & 0xe0) >> 5) | ((b[1] & 0x03) << 3));
+    w[2] = float((b[1] & 0x7c) >> 2);
+    w[3] = float(((b[1] & 0x80) >> 7) | ((b[2] & 0x0f) << 1));
+    w[4] = float(((b[2] & 0xf0) >> 4) | ((b[3] & 0x01) << 4));
+    w[5] = float((b[3] & 0x3e) >> 1);
+    w[6] = float(((b[3] & 0xc0) >> 6) | ((b[4] & 0x07) << 2));
+    w[7] = float((b[4] & 0xf8) >> 3);
+  }
+};
+
+// 6-bit: 4 values in 3 bytes, 8 values in 6 bytes
+template <>
+struct Dequant8<6> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x3f);
+    w[1] = float(((b[0] & 0xc0) >> 6) | ((b[1] & 0x0f) << 2));
+    w[2] = float(((b[1] & 0xf0) >> 4) | ((b[2] & 0x03) << 4));
+    w[3] = float((b[2] & 0xfc) >> 2);
+    w[4] = float(b[3] & 0x3f);
+    w[5] = float(((b[3] & 0xc0) >> 6) | ((b[4] & 0x0f) << 2));
+    w[6] = float(((b[4] & 0xf0) >> 4) | ((b[5] & 0x03) << 4));
+    w[7] = float((b[5] & 0xfc) >> 2);
+  }
+};
+
+// 7-bit: 8 values in 7 bytes
+template <>
+struct Dequant8<7> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0] & 0x7f);
+    w[1] = float((b[0] >> 7) | ((b[1] & 0x3f) << 1));
+    w[2] = float((b[1] >> 6) | ((b[2] & 0x1f) << 2));
+    w[3] = float((b[2] >> 5) | ((b[3] & 0x0f) << 3));
+    w[4] = float((b[3] >> 4) | ((b[4] & 0x07) << 4));
+    w[5] = float((b[4] >> 3) | ((b[5] & 0x03) << 5));
+    w[6] = float((b[5] >> 2) | ((b[6] & 0x01) << 6));
+    w[7] = float(b[6] >> 1);
+  }
+};
+
+// 8-bit: 1 value per byte, no extraction needed
+template <>
+struct Dequant8<8> {
+
+  static inline void apply(constant uchar* b, thread float* w) {
+    w[0] = float(b[0]);
+    w[1] = float(b[1]);
+    w[2] = float(b[2]);
+    w[3] = float(b[3]);
+    w[4] = float(b[4]);
+    w[5] = float(b[5]);
+    w[6] = float(b[6]);
+    w[7] = float(b[7]);
+  }
+};
+
+/**
+
+Generalized low-bit GEMM kernel
+A: [M, K] activation matrix
+B: [N, nbit*K/8] packed low-bit weight matrix
+S: [N, num_groups] scales
+Z: [N, num_groups] zeros, stored as the actual zero (bias) term, i.e.
+   Z = -scale * zero_point, so that weight = scale * nibble + Z.
+output_data: [M, N] output matrix
+
+Algorithm (adapted from PyTorch's kernel_mul_mm, which is heavily inspired
+by llama.cpp (MIT); see aten/src/ATen/native/mps/kernels/Quantized.metal):
+  1. Load A block (32x32) and B block (64x32 packed low-bit) into shared
+     memory, dequantizing B inline (scale * val + zero -> half) during the
+     load. (PyTorch loads raw int8 and dequantizes post-accumulation; we
+     dequantize inline because we support group-wise quantization with
+     non-zero zero points across 1-8 bits.)
+  2. In 4 simdgroups, calculate the outer product of the loaded blocks.
+     Each simdgroup produces a 2x4 arrangement of 8x8 result tiles.
+     For how to use outer product to perform matrix multiplication, refer to
+       https://web.archive.org/web/20230521063455/http://mlwiki.org/index.php/Matrix-Matrix_Multiplication#Sum_of_Outer_Products
+  3. Repeat steps 1 & 2 along the K axis (block size 32), accumulating
+     into the 2x4 8x8 result tiles.
+  4. After a threadgroup_barrier, reuse the A region to store the
+     accumulated result, then write to the output matrix. (No post-
+     accumulation dequant needed -- scale/zero were applied inline in
+     step 1; PyTorch's kernel_mul_mm applies scale post-accumulation via a
+     diagonal scale matrix.)
+
+ */
+template <typename T, unsigned group_size_template, int nbit>
+kernel void intNgemm_mm(
+    constant T *A [[buffer(0)]],
+    constant uchar *B [[buffer(1)]],
+    constant T *scales_ptr [[buffer(2)]],
+    constant T *zeros_ptr [[buffer(3)]],
+    device T *output_data [[buffer(4)]],
+    constant uint3 &sizes [[buffer(5)]], // M, K, N
+    threadgroup char *shared_memory [[threadgroup(0)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint tiitg [[thread_index_in_threadgroup]],
+    uint sgitg [[simdgroup_index_in_threadgroup]]) {
+
+  using T4 = typename BlockType<T>::type4;
+  using Tsimd8x8 = typename BlockType<T>::simdgroup_type8x8;
+
+  // group_size is a compile-time constant (template parameter).
+  const unsigned group_size = group_size_template;
+
+  const uint M = sizes.x;
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  const uint num_groups = (K + group_size - 1) / group_size;
+  // 8 values * nbit bits / 8 bits = nbit bytes per group of 8
+  constexpr int bytes_per_8_vals = nbit;
+  constexpr int bytes_per_16_vals = 2 * bytes_per_8_vals;
+
+  // Shared memory: dynamic allocation (size set by dispatch_gemm to 12288).
+  //   A: 8192 bytes (BLOCK_SIZE_M * BLOCK_SIZE_K * sizeof(T), worst case float)
+  //   B: 4096 bytes (BLOCK_SIZE_N * BLOCK_SIZE_K * sizeof(half))
+  // After the K-loop, A is dead and reused for the 32x64 result matrix
+  // (8192 bytes of float). This matches PyTorch's kernel_mul_mm layout.
+  // A threadgroup_barrier is required before the reuse (see result-store
+  // section below).
+  threadgroup T *shared_A = (threadgroup T *)(shared_memory);
+  threadgroup half *shared_B = (threadgroup half *)(shared_memory + 8192);
+
+  const uint threadgroup_M = tgpig.x;
+  const uint threadgroup_N = tgpig.y;
+
+  // Bound the number of rows for this block (edge case handling)
+  short n_rows_A = (short)min((uint)BLOCK_SIZE_M, M - threadgroup_M * BLOCK_SIZE_M);
+  short n_rows_B = (short)min((uint)BLOCK_SIZE_N, N - threadgroup_N * BLOCK_SIZE_N);
+
+  // A thread shouldn't load data outside the matrix
+  short thread_row_A = (short)min((int)(tiitg / THREAD_PER_ROW_A), (int)(n_rows_A - 1));
+  short thread_row_B = (short)min((int)(tiitg / THREAD_PER_ROW_B), (int)(n_rows_B - 1));
+
+  Tsimd8x8 simdgroup_A[2];
+  simdgroup_half8x8 simdgroup_B[4];
+  simdgroup_float8x8 simdgroup_C[8];
+
+  for (short i = 0; i < 8; i++) {
+    simdgroup_C[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+  }
+
+  // Pointer to A for this threadgroup's block (base, before K offset)
+  constant T *a_ptr_base = A
+    + (threadgroup_M * BLOCK_SIZE_M + thread_row_A) * K
+    + (BLOCK_SIZE_K / THREAD_PER_ROW_A) * (tiitg % THREAD_PER_ROW_A);
+
+  // Pointer to B for this threadgroup's block (base, before K offset)
+  // B is [N, nbit*K/8] packed bytes. Row stride = nbit*K/8 bytes.
+  // Each thread loads 16 k-values = bytes_per_16_vals bytes.
+  constant uchar *b_ptr_base = B
+    + (threadgroup_N * BLOCK_SIZE_N + thread_row_B) * (nbit * K / 8)
+    + bytes_per_16_vals * (tiitg % THREAD_PER_ROW_B);
+
+  /**
+
+  Tiling structure adapted from PyTorch's kernel_mul_mm
+  (aten/src/ATen/native/mps/kernels/Quantized.metal), which is heavily
+  inspired by llama.cpp (MIT).
+
+  Load weight and input into shared memory (2-region layout):
+  8192: BLOCK_SIZE_M x BLOCK_SIZE_K x 4 (max bytes per value) <----- numbers don't checkout, should be 4096. Changing it to 4096 gives wrong value.
+                                                                     (Same quirk as PyTorch's kernel_mul_mm.)
+  4096: BLOCK_SIZE_N x BLOCK_SIZE_K x 2 (storing dequantized weight in half)
+
+                            K
+                 +------------------------+              8192(A)             4096(B)
+                 |                        |   +------------------------+------------+
+                 |                        |   |++++++++++++++++++++++++|++++++++++++|
+                 |                        |   +------------------------+------------+
+                 |                        |
+                 |32(BLOCK_SIZE_K)        |
+                 +--+--+------------------+
+                 |++|  |                  |
+               64|++|  |...               |
+   (BLOCK_SIZE_N)|++|  |                  |
+                 +--+--+------------------+
+                 |                        |
+                 |      -------->         |                           K
+                 |       for loop         |               +------------------------+
+                 |                        |               |                        |
+                 |                        |               |                        |
+                 |                        |               |32(BLOCK_SIZE_K)        |
+                 |                        |               +--+--+------------------+
+                 |                        |             32|++|  | ...              |
+                 |                        | (BLOCK_SIZE_M)+--+--+------------------+
+                 |                        |               |         ----------->   |
+                 |                        |               |            for loop    |
+                 +------------------------+               +------------------------+
+                             B                                        A
+
+  During the K-loop: A and B are both live (loaded each iteration).
+  After the K-loop:  A is dead; its 8192 bytes are reused to stage the
+                     32x64 float result matrix before writing to device
+                     memory. A threadgroup_barrier is required before the
+                     reuse (see result-store section below).
+
+   */
+  for (uint loop_k = 0; loop_k < K; loop_k += BLOCK_SIZE_K) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    constant T *a_ptr = a_ptr_base + loop_k;
+    constant uchar *b_ptr = b_ptr_base + (nbit * loop_k / 8);
+
+    // --- Load B (low-bit weights) and dequantize to half in shared memory ---
+    // Each thread loads 16 weight values (= 2 groups of 8).
+    // All 16 values fall within the same group (BLOCK_SIZE_K=32 <= group_size).
+    //
+    // Deviation from PyTorch's kernel_mul_mm: we dequantize inline during the
+    // load (applying scale * val + zero here) rather than loading raw int8 and
+    // dequantizing post-accumulation. This is because we support group-wise
+    // quantization with non-zero zero points across 1-8 bits, which makes the
+    // post-accumulation diagonal-scale-matrix approach (used by PyTorch for
+    // per-channel symmetric int8) inapplicable.
+    uint n_abs = threadgroup_N * BLOCK_SIZE_N + thread_row_B;
+    float scale;
+    float zero;
+    {
+      uint k_block_index = loop_k / group_size;
+      uint sz_idx = n_abs * num_groups + k_block_index;
+      scale = float(scales_ptr[sz_idx]);
+      // Deviation from PyTorch's kernel_mul_mm: scales and zeros are passed as
+      // separate buffers (not interleaved into a single scales_and_zeros
+      // buffer). The stored zero is the actual zero (bias) term:
+      // Z = -scale * zero_point, so dequantization is weight = scale * nibble
+      // + zero.  This matches the format produced by
+      // IntxMPSExperimentalTensor.from_hp and is NOT the tinygemm convention
+      // (zero = scale * (8 - zero_point)).
+      zero = float(zeros_ptr[sz_idx]);
+    }
+
+    float w_vals[16];
+    Dequant8<nbit>::apply(b_ptr, w_vals);
+    Dequant8<nbit>::apply(b_ptr + bytes_per_8_vals, w_vals + 8);
+
+    #pragma unroll(16)
+    for (short i = 0; i < 16; i++) {
+      float weight = scale * w_vals[i] + zero;
+
+      // Store to shared_B in simdgroup matrix layout (same as kernel_mul_mm)
+      short sg_mat_grid_row_index = (tiitg % THREAD_PER_ROW_B) * THREAD_PER_ROW_B + i / 8;
+      short sg_mat_grid_col_index = tiitg / THREAD_PER_ROW_B / 8;
+      short row_offset = i % 8;
+      short col_offset = (tiitg / THREAD_PER_ROW_B) % 8;
+      short sb_offset = (sg_mat_grid_row_index * 8 + sg_mat_grid_col_index) * 64
+        + (row_offset * 8 + col_offset);
+      *(shared_B + sb_offset) = half(weight);
+    }
+
+    // --- Load A (activations) into shared memory ---
+    // Each thread loads 2 x T4 = 8 values
+    #pragma unroll(2)
+    for (short i = 0; i < 2; i++) {
+      *((threadgroup T4 *)(shared_A
+        + (tiitg % THREAD_PER_ROW_A) * 8 * 32
+        + 8 * (tiitg / THREAD_PER_ROW_A)) + i) = *((constant T4 *)a_ptr + i);
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    /**
+
+    Outer product accumulation.
+    Adapted from PyTorch's kernel_mul_mm (aten/src/ATen/native/mps/kernels/
+    Quantized.metal), which is heavily inspired by llama.cpp (MIT).
+
+    Outer product:
+                  K
+           ----------->
+         8    for loop              8   8
+       +---+---+---+---+          +---+---+---+---+---+---+---+---+
+     8 |+++|   |   |   |      |  8|+++|+++|+++|+++|###|###|###|###|
+       +---+---+---+---+      |   +---+---+---+---+---+---+---+---+
+       |+++|   |   |   |      |   |   |   |   |   |   |   |   |   |
+       +---+---+---+---+      | K +---+---+---+---+---+---+---+---+
+       |###|   |   |   |      |   |   |   |   |   |   |   |   |   |
+       +---+---+---+---+      |   +---+---+---+---+---+---+---+---+
+       |###|   |   |   |      |   |   |   |   |   |   |   |   |   |
+       +---+---+---+---+      v   +---+---+---+---+---+---+---+---+
+                           for loop
+        + simdgroup 0,1                + simdgroup 0,2
+        # simdgroup 2,3                # simdgroup 1,3
+
+     */
+    threadgroup T *simdgroup_A_ptr = shared_A + THREAD_MAT_M * SG_MAT_SIZE * (sgitg / 2);
+    threadgroup half *simdgroup_B_ptr = shared_B + THREAD_MAT_N * SG_MAT_SIZE * (sgitg % 2);
+
+    #pragma unroll(4)
+    for (short ik = 0; ik < BLOCK_SIZE_K / 8; ik++) {
+      #pragma unroll(4)
+      for (short i = 0; i < 4; i++) {
+        simdgroup_load(simdgroup_B[i], simdgroup_B_ptr + SG_MAT_SIZE * i);
+      }
+      simdgroup_barrier(mem_flags::mem_none);
+      #pragma unroll(2)
+      for (short i = 0; i < 2; i++) {
+        simdgroup_load(simdgroup_A[i], simdgroup_A_ptr + SG_MAT_SIZE * i);
+      }
+
+      simdgroup_A_ptr += BLOCK_SIZE_M / SG_MAT_ROW * SG_MAT_SIZE;
+      simdgroup_B_ptr += BLOCK_SIZE_N / SG_MAT_ROW * SG_MAT_SIZE;
+
+      #pragma unroll(8)
+      for (short i = 0; i < 8; i++) {
+        simdgroup_multiply_accumulate(
+            simdgroup_C[i], simdgroup_A[i / 4], simdgroup_B[i % 4], simdgroup_C[i]);
+      }
+    }
+  }
+
+  /**
+
+  Store results.
+  Adapted from PyTorch's kernel_mul_mm (aten/src/ATen/native/mps/kernels/
+  Quantized.metal). Each sgitg 0,1,2,3 handles a 2x4 arrangement of 8x8
+  result tiles:
+
+     8   8
+   +---+---+---+---+---+---+---+---+
+ 8 | 0 | 0 | 0 | 0 | 1 | 1 | 1 | 1 |
+   +---+---+---+---+---+---+---+---+
+   | 0 | 0 | 0 | 0 | 1 | 1 | 1 | 1 |
+   +---+---+---+---+---+---+---+---+
+   | 2 | 2 | 2 | 2 | 3 | 3 | 3 | 3 |
+   +---+---+---+---+---+---+---+---+
+   | 2 | 2 | 2 | 2 | 3 | 3 | 3 | 3 |
+   +---+---+---+---+---+---+---+---+
+
+  Deviation from PyTorch's kernel_mul_mm: PyTorch's diagram includes a
+  scale-diagonal-matrix part (it applies scale post-accumulation via a
+  diagonal scale matrix stored in shared_memory_B). We omit that because
+  we apply scale/zero inline during the B load (see step 1 of the
+  algorithm above), so no post-accumulation dequant is needed.
+
+  threadgroup_barrier required before reusing shared_A for results.
+  The K-loop's outer-product accumulation only uses simdgroup_barrier
+  (within-simdgroup sync), not threadgroup_barrier (across-simdgroup sync).
+  Without this barrier, one simdgroup could start writing results to
+  shared_A while another simdgroup is still reading from it in its last
+  simdgroup_load. This pattern follows PyTorch's kernel_mul_mm, which has
+  an equivalent threadgroup_barrier inside its post-K-loop dequant loop
+  (aten/src/ATen/native/mps/kernels/Quantized.metal, ~line 456).
+
+  Reuse the A region (offset 0) for the result matrix. A is dead after the
+  K-loop completes; the barrier above ensures all simdgroups have finished
+  reading from shared_A before any simdgroup writes to it.
+
+   */
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  threadgroup float *temp_str = (threadgroup float *)(shared_memory)
+    + 32 * (sgitg & 1) + (16 * (sgitg >> 1)) * BLOCK_SIZE_N;
+
+  for (int i = 0; i < 8; i++) {
+    simdgroup_store(
+        simdgroup_C[i],
+        temp_str + 8 * (i % 4) + 8 * BLOCK_SIZE_N * (i / 4),
+        BLOCK_SIZE_N);
+  }
+
+  // Ensure all simdgroup stores to threadgroup memory are visible.
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write to output_data [M, N]
+  device T *C = output_data + (BLOCK_SIZE_N * threadgroup_N)
+    + (BLOCK_SIZE_M * threadgroup_M) * N;
+  if (sgitg == 0) {
+    for (int i = 0; i < n_rows_B; i++) {
+      // Deviation note: PyTorch's kernel_mul_mm uses `j += BLOCK_SIZE_M` here.
+      // We use the same stride (BLOCK_SIZE_M = 32), which is equivalent to the
+      // previous `j += 128` since n_rows_A <= BLOCK_SIZE_M and there are 128
+      // threads per threadgroup (4 simdgroups x 32 threads). Using
+      // BLOCK_SIZE_M is self-documenting and matches PyTorch's convention.
+      for (int j = tiitg; j < n_rows_A; j += BLOCK_SIZE_M) {
+        float val = *(temp_str + i + j * BLOCK_SIZE_N);
+        *(C + i + j * N) = (device T)val;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Instantiation for all bit widths (1-8), group sizes, and dtypes.
+// The function name is intNgemm_mm_<nbit>bit_<group_size>_<dtype> so the
+// dispatch layer can select the right kernel.
+// ---------------------------------------------------------------------------
+#define INSTANTIATE_INTNGEMM(NBIT, DTYPE, GSIZE)                               \
+  template [[host_name("intNgemm_mm_" #NBIT "bit_" #GSIZE "_" #DTYPE)]]        \
+  kernel void intNgemm_mm<DTYPE, GSIZE, NBIT>(                                 \
+      constant DTYPE *A [[buffer(0)]],                                         \
+      constant uchar *B [[buffer(1)]],                                         \
+      constant DTYPE *scales_ptr [[buffer(2)]],                                \
+      constant DTYPE *zeros_ptr [[buffer(3)]],                                 \
+      device DTYPE *output_data [[buffer(4)]],                                 \
+      constant uint3 &sizes [[buffer(5)]],                                     \
+      threadgroup char *shared_memory [[threadgroup(0)]],                      \
+      uint3 tgpig [[threadgroup_position_in_grid]],                            \
+      uint tiitg [[thread_index_in_threadgroup]],                              \
+      uint sgitg [[simdgroup_index_in_threadgroup]])
+
+// Helper macro: instantiate one bit width for all group sizes and float/half
+#define INSTANTIATE_NBIT_FLOAT_HALF(NBIT)                                      \
+  INSTANTIATE_INTNGEMM(NBIT, float, 32);                                       \
+  INSTANTIATE_INTNGEMM(NBIT, half, 32);                                        \
+  INSTANTIATE_INTNGEMM(NBIT, float, 64);                                       \
+  INSTANTIATE_INTNGEMM(NBIT, half, 64);                                        \
+  INSTANTIATE_INTNGEMM(NBIT, float, 128);                                      \
+  INSTANTIATE_INTNGEMM(NBIT, half, 128);                                       \
+  INSTANTIATE_INTNGEMM(NBIT, float, 256);                                      \
+  INSTANTIATE_INTNGEMM(NBIT, half, 256)
+
+// Helper macro: add bfloat instantiations (requires Metal 3.1+)
+#define INSTANTIATE_NBIT_BFLOAT(NBIT)                                          \
+  INSTANTIATE_INTNGEMM(NBIT, bfloat, 32);                                      \
+  INSTANTIATE_INTNGEMM(NBIT, bfloat, 64);                                      \
+  INSTANTIATE_INTNGEMM(NBIT, bfloat, 128);                                     \
+  INSTANTIATE_INTNGEMM(NBIT, bfloat, 256)
+
+INSTANTIATE_NBIT_FLOAT_HALF(1);
+INSTANTIATE_NBIT_FLOAT_HALF(2);
+INSTANTIATE_NBIT_FLOAT_HALF(3);
+INSTANTIATE_NBIT_FLOAT_HALF(4);
+INSTANTIATE_NBIT_FLOAT_HALF(5);
+INSTANTIATE_NBIT_FLOAT_HALF(6);
+INSTANTIATE_NBIT_FLOAT_HALF(7);
+INSTANTIATE_NBIT_FLOAT_HALF(8);
+
+#if __METAL_VERSION__ >= 310
+INSTANTIATE_NBIT_BFLOAT(1);
+INSTANTIATE_NBIT_BFLOAT(2);
+INSTANTIATE_NBIT_BFLOAT(3);
+INSTANTIATE_NBIT_BFLOAT(4);
+INSTANTIATE_NBIT_BFLOAT(5);
+INSTANTIATE_NBIT_BFLOAT(6);
+INSTANTIATE_NBIT_BFLOAT(7);
+INSTANTIATE_NBIT_BFLOAT(8);
+#endif

--- a/torchao/experimental/kernels/mps/metal/qmv.metal
+++ b/torchao/experimental/kernels/mps/metal/qmv.metal
@@ -19,8 +19,8 @@ static constant constexpr const int SIMD_SIZE = 32;
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(constant T* x, thread U* x_thread) {
   static_assert(
-      1 <= bits && bits <= 7,
-      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7}");
+      1 <= bits && bits <= 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7, 8}");
 
   U sum = 0;
 
@@ -111,6 +111,15 @@ inline U load_vector(constant T* x, thread U* x_thread) {
       x_thread[i + 5] = x[i + 5] / 8.0f;
       x_thread[i + 6] = x[i + 6] / 4.0f;
       x_thread[i + 7] = x[i + 7] / 2.0f;
+    }
+  }
+
+  // 8-bit: no bit extraction needed, each byte is a full weight value.
+  // No pre-division of activations is needed since there's no bit shifting.
+  else if (bits == 8) {
+    for (int i = 0; i < values_per_thread; i++) {
+      sum += x[i];
+      x_thread[i] = x[i];
     }
   }
 
@@ -120,8 +129,8 @@ inline U load_vector(constant T* x, thread U* x_thread) {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(constant T* x, thread U* x_thread, int N) {
   static_assert(
-      1 <= bits && bits <= 7,
-      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7}");
+      1 <= bits && bits <= 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7, 8}");
 
   U sum = 0;
 
@@ -213,6 +222,14 @@ inline U load_vector_safe(constant T* x, thread U* x_thread, int N) {
       x_thread[i + 5] = x[i + 5] / 8.0f;
       x_thread[i + 6] = x[i + 6] / 4.0f;
       x_thread[i + 7] = x[i + 7] / 2.0f;
+    }
+  }
+
+  // 8-bit: no bit extraction, each byte is a full weight value.
+  else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      sum += x[i];
+      x_thread[i] = x[i];
     }
   }
 
@@ -231,8 +248,8 @@ inline U qdot(
     U bias,
     U sum) {
   static_assert(
-      1 <= bits && bits <= 7,
-      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7}");
+      1 <= bits && bits <= 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7, 8}");
 
   U accum = 0;
 
@@ -362,6 +379,13 @@ inline U qdot(
     }
   }
 
+  // 8-bit: each byte is a full weight value, no masking or shifting needed.
+  else if (bits == 8) {
+    for (int i = 0; i < values_per_thread; i++) {
+      accum += x_thread[i] * w[i];
+    }
+  }
+
   return scale * accum + sum * bias;
 }
 
@@ -374,8 +398,8 @@ inline U qdot_safe(
     U sum,
     int N) {
   static_assert(
-      1 <= bits && bits <= 7,
-      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7}");
+      1 <= bits && bits <= 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 7, 8}");
 
   U accum = 0;
 
@@ -505,10 +529,17 @@ inline U qdot_safe(
     }
   }
 
+  // 8-bit: each byte is a full weight value, no masking or shifting needed.
+  else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      accum += x_thread[i] * w[i];
+    }
+  }
+
   return scale * accum + sum * bias;
 }
 
-template <typename T, int group_size, int bits>
+template <typename T, int group_size_template, int bits>
 [[kernel]] void qmv_fast(
     constant T* x [[buffer(0)]],
     constant uchar* w [[buffer(1)]],
@@ -519,6 +550,8 @@ template <typename T, int group_size, int bits>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  // group_size is a compile-time constant (template parameter).
+  const int group_size = group_size_template;
   const int in_vec_size = static_cast<int>(sizes.y); // K
   const int out_vec_size = static_cast<int>(sizes.z); // N
 
@@ -530,7 +563,7 @@ template <typename T, int group_size, int bits>
   constexpr int bytes_per_pack = bits == 1 ? 2 : power_of_2_bits ? 4 : bits == 6 ? 3 : bits;
   constexpr int values_per_thread = pack_factor * packs_per_thread;
   constexpr int block_size = values_per_thread * SIMD_SIZE;
-  constexpr int scale_step_per_thread = group_size / values_per_thread;
+  const int scale_step_per_thread = group_size / values_per_thread;
 
   constant uint8_t* ws = (constant uint8_t*)w;
 
@@ -578,7 +611,7 @@ template <typename T, int group_size, int bits>
   }
 }
 
-template <typename T, int group_size, int bits>
+template <typename T, int group_size_template, int bits>
 [[kernel]] void qmv_impl(
     constant T* x [[buffer(0)]],
     constant uchar* w [[buffer(1)]],
@@ -589,6 +622,7 @@ template <typename T, int group_size, int bits>
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
+  const int group_size = group_size_template;
   const int in_vec_size = static_cast<int>(sizes.y); // K
   const int out_vec_size = static_cast<int>(sizes.z); // N
 
@@ -601,7 +635,7 @@ template <typename T, int group_size, int bits>
 
   constexpr int values_per_thread = pack_factor * packs_per_thread;
   constexpr int block_size = values_per_thread * SIMD_SIZE;
-  constexpr int scale_step_per_thread = group_size / values_per_thread;
+  const int scale_step_per_thread = group_size / values_per_thread;
 
   constant uint8_t* ws = (constant uint8_t*)w;
 
@@ -756,7 +790,8 @@ template <typename T, int group_size, int bits>
   INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 4);               \
   INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 5);               \
   INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 6);               \
-  INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 7);
+  INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 7);               \
+  INSTANTIATE_QMV_FAST(DTYPE, GSIZE, 8);
 
 #define INSTANTIATE_QMV_FAST_DTYPE(DTYPE)       \
   INSTANTIATE_QMV_FAST_DTYPE_GSIZE(DTYPE, 32);  \
@@ -790,7 +825,8 @@ INSTANTIATE_QMV_FAST_DTYPE(bfloat);
   INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 4);               \
   INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 5);               \
   INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 6);               \
-  INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 7);
+  INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 7);               \
+  INSTANTIATE_QMV_IMPL(DTYPE, GSIZE, 8);
 
 #define INSTANTIATE_QMV_IMPL_DTYPE(DTYPE)       \
   INSTANTIATE_QMV_IMPL_DTYPE_GSIZE(DTYPE, 32);  \

--- a/torchao/experimental/kernels/mps/src/dispatch.h
+++ b/torchao/experimental/kernels/mps/src/dispatch.h
@@ -48,4 +48,34 @@ inline void dispatch_qmv(
       threadsPerThreadgroup:MTLSizeMake(32, 2, 1)];
 }
 
+// Dispatch for the generalized intN GEMM kernel (intNgemm_mm).
+// Uses 32x64 output tiles with 128 threads per threadgroup (4 simdgroups).
+// Threadgroups: ceil(M/32) x ceil(N/64)
+// Threadgroup memory: 12288 bytes (8192 for A + 4096 for B). The result
+// matrix reuses the A region after the K-loop (see intNgemm.metal for the
+// threadgroup_barrier that makes this safe).
+inline void dispatch_gemm(
+    id<MTLComputeCommandEncoder> encoder,
+    int32_t maxThreadsPerGroup,
+    int32_t M,
+    int32_t N,
+    int32_t K) {
+  (void)K;
+  if (maxThreadsPerGroup < 128) {
+    throw std::runtime_error("Can't dispatch GEMM: need at least 128 threads per threadgroup");
+  }
+  // Set threadgroup memory length for the dynamic shared_memory allocation.
+  // A: 8192 bytes (over-allocated; 32*32*4=4096 used but 8192 required —
+  // same quirk as PyTorch's kernel_mul_mm, see intNgemm.metal comment),
+  // B: 4096 bytes (64*32*2).
+  // Results reuse the A region after the K-loop completes (requires
+  // threadgroup_barrier, see kernel comment). Total: 12288 bytes.
+  // Within Apple Silicon's 32KB threadgroup memory limit (Apple WWDC22
+  // "Scale compute workloads across Apple GPUs": "threads can share up to
+  // 32K of threadgroup memory" on all Apple GPUs).
+  [encoder setThreadgroupMemoryLength:12288 atIndex:0];
+  [encoder dispatchThreadgroups:MTLSizeMake((M + 31) / 32, (N + 63) / 64, 1)
+      threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+}
+
 } // namespace torchao::kernels::mps::lowbit::dispatch

--- a/torchao/experimental/kernels/mps/src/lowbit.h
+++ b/torchao/experimental/kernels/mps/src/lowbit.h
@@ -9,6 +9,9 @@
 #include <Metal/Metal.h>
 #include <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
+#include <cstdlib>
+#include <string>
+
 #include <torchao/experimental/kernels/mps/src/common.h>
 #include <torchao/experimental/kernels/mps/src/dispatch.h>
 #include <torchao/experimental/kernels/mps/src/metal_shader_lib.h> // metal_lowbit_quantized_lib
@@ -25,6 +28,9 @@ struct LowBitConfig<1> {
   static constexpr std::string_view func_prefix = "int1pack_mm_";
   static constexpr auto packing_fn = packing::pack<1>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm;
+  // GEMM kernel for M > 1 (prefill)
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_1bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -32,6 +38,8 @@ struct LowBitConfig<2> {
   static constexpr std::string_view func_prefix = "int2pack_mm_";
   static constexpr auto packing_fn = packing::pack<2>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm_Mr1xNr4_per_TG;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_2bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -39,6 +47,8 @@ struct LowBitConfig<3> {
   static constexpr std::string_view func_prefix = "int3pack_mm_";
   static constexpr auto packing_fn = packing::pack<3>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm_Mr1xNr4_per_TG;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_3bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -46,6 +56,8 @@ struct LowBitConfig<4> {
   static constexpr std::string_view func_prefix = "int4pack_mm_";
   static constexpr auto packing_fn = packing::pack<4>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm_Mr1xNr4_per_TG;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_4bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -53,6 +65,8 @@ struct LowBitConfig<5> {
   static constexpr std::string_view func_prefix = "int5pack_mm_";
   static constexpr auto packing_fn = packing::pack<5>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_5bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -60,6 +74,8 @@ struct LowBitConfig<6> {
   static constexpr std::string_view func_prefix = "int6pack_mm_";
   static constexpr auto packing_fn = packing::pack<6>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_6bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 template <>
@@ -67,6 +83,17 @@ struct LowBitConfig<7> {
   static constexpr std::string_view func_prefix = "int7pack_mm_";
   static constexpr auto packing_fn = packing::pack<7>;
   static constexpr auto dispatch_fn = dispatch::dispatch_mm;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_7bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
+};
+
+template <>
+struct LowBitConfig<8> {
+  static constexpr std::string_view func_prefix = "int8pack_mm_";
+  static constexpr auto packing_fn = packing::pack<8>;
+  static constexpr auto dispatch_fn = dispatch::dispatch_mm;
+  static constexpr std::string_view gemm_func_prefix = "intNgemm_mm_8bit_";
+  static constexpr auto gemm_dispatch_fn = dispatch::dispatch_gemm;
 };
 
 using DispatchFn =
@@ -118,6 +145,7 @@ std::tuple<const std::string, DispatchFn> get_shader_func_and_dispatch(
     int32_t M,
     int32_t N,
     int32_t K) {
+  // qmv (decode, M=1) is available for all bit widths 1-8.
   if (M == 1 && N % 8 == 0 && K % 512 == 0) {
     return std::make_tuple(
         std::string("qmv_fast_") + std::to_string(nbit) + "bit_" +
@@ -131,6 +159,23 @@ std::tuple<const std::string, DispatchFn> get_shader_func_and_dispatch(
             std::to_string(qGroupSize) + "_" + std::string(type_str),
         dispatch::dispatch_qmv);
   }
+  // For M > 1, use the simdgroup-tiled GEMM kernel (prefill).
+  // The GEMM kernel requires K to be a multiple of BLOCK_SIZE_K (32) and
+  // group_size to be a multiple of BLOCK_SIZE_K (32).  Fall back to the
+  // existing per-bitwidth pack_mm path for unaligned K or group_size.
+  // Set TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM=1 to force the fallback path
+  // (for benchmarking old vs new prefill kernels).
+  if (K % 32 == 0 && qGroupSize % 32 == 0) {
+    const char* env = std::getenv("TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM");
+    if (env == nullptr || std::string(env) != "1") {
+      return std::make_tuple(
+          std::string(LowBitConfig<nbit>::gemm_func_prefix) +
+              std::to_string(qGroupSize) + "_" + std::string(type_str),
+          LowBitConfig<nbit>::gemm_dispatch_fn);
+    }
+  }
+  // Fallback: per-bitwidth pack_mm path (no simdgroup MMA).
+  // Only has pre-compiled instantiations for {32, 64, 128, 256}.
   return std::make_tuple(
       std::string(LowBitConfig<nbit>::func_prefix) + std::to_string(qGroupSize) +
           "_" + std::string(type_str),
@@ -152,9 +197,22 @@ void linear_lowbit_quant_weights_mps(
     const std::string_view type_str) {
   assert(K % 8 == 0);
   assert(N % 4 == 0 || M == 1);
-  assert(
-      qGroupSize == 32 || qGroupSize == 64 || qGroupSize == 128 ||
-      qGroupSize == 256);
+  assert(qGroupSize > 0);
+  assert(qGroupSize % 32 == 0);
+  // The fallback pack_mm path only has pre-compiled instantiations for
+  // {32, 64, 128, 256}.  When simdgroup GEMM is disabled (or K is not a
+  // multiple of 32), assert the stricter restriction.
+  {
+    const char* env = std::getenv("TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM");
+    const bool simdgroup_disabled = (env != nullptr && std::string(env) == "1");
+    const bool using_fallback = simdgroup_disabled || (K % 32 != 0);
+    const bool using_qmv = (M == 1);
+    if (using_fallback && !using_qmv) {
+      assert(
+          qGroupSize == 32 || qGroupSize == 64 || qGroupSize == 128 ||
+          qGroupSize == 256);
+    }
+  }
   std::tuple<const std::string, DispatchFn> shader_func_and_dispatch =
       get_shader_func_and_dispatch<nbit>(qGroupSize, type_str, M, N, K);
   const std::string shader_func = std::get<0>(shader_func_and_dispatch);

--- a/torchao/experimental/kernels/mps/src/packing.h
+++ b/torchao/experimental/kernels/mps/src/packing.h
@@ -187,4 +187,18 @@ pack<7>(const uint8_t* w_ptr, uint8_t* b_ptr, int32_t N, int32_t K) {
   }
 }
 
+/**
+ * 8-bit packing. Each weight is a full byte, so packing is a direct copy.
+ */
+template <>
+inline void
+pack<8>(const uint8_t* w_ptr, uint8_t* b_ptr, int32_t N, int32_t K) {
+  for (int32_t n = 0; n < N; n++) {
+    int32_t row_base = n * K;
+    for (int32_t k = 0; k < K; k++) {
+      b_ptr[row_base + k] = w_ptr[n * K + k];
+    }
+  }
+}
+
 } // namespace torchao::kernels::mps::lowbit::packing

--- a/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_aten.mm
+++ b/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_aten.mm
@@ -54,7 +54,7 @@ void check_linear_mps_args(
       group_size == 32 || group_size == 64 || group_size == 128 ||
           group_size == 256,
       __func__,
-      ": expect group_size to be 32, 64, 128 or 256, got ",
+      ": expect group_size to be 32, 64, 128, or 256, got ",
       group_size);
 
   TORCH_CHECK(
@@ -174,6 +174,7 @@ TORCH_LIBRARY_FRAGMENT(torchao, m) {
   m.def("_pack_weight_5bit(Tensor W) -> Tensor");
   m.def("_pack_weight_6bit(Tensor W) -> Tensor");
   m.def("_pack_weight_7bit(Tensor W) -> Tensor");
+  m.def("_pack_weight_8bit(Tensor W) -> Tensor");
   m.def(
       "_linear_fp_act_1bit_weight(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z) -> Tensor");
   m.def(
@@ -189,6 +190,8 @@ TORCH_LIBRARY_FRAGMENT(torchao, m) {
   m.def(
       "_linear_fp_act_7bit_weight(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z) -> Tensor");
   m.def(
+      "_linear_fp_act_8bit_weight(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z) -> Tensor");
+  m.def(
       "_linear_fp_act_1bit_weight.out(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z, *, Tensor(a!) out) -> Tensor(a!)");
   m.def(
       "_linear_fp_act_2bit_weight.out(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z, *, Tensor(a!) out) -> Tensor(a!)");
@@ -202,6 +205,8 @@ TORCH_LIBRARY_FRAGMENT(torchao, m) {
       "_linear_fp_act_6bit_weight.out(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z, *, Tensor(a!) out) -> Tensor(a!)");
   m.def(
       "_linear_fp_act_7bit_weight.out(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z, *, Tensor(a!) out) -> Tensor(a!)");
+  m.def(
+      "_linear_fp_act_8bit_weight.out(Tensor A, Tensor B, int group_size, Tensor S, Tensor Z, *, Tensor(a!) out) -> Tensor(a!)");
 }
 
 TORCH_LIBRARY_IMPL(torchao, CPU, m) {
@@ -212,6 +217,7 @@ TORCH_LIBRARY_IMPL(torchao, CPU, m) {
   m.impl("_pack_weight_5bit", &pack_weights_cpu_kernel<5>);
   m.impl("_pack_weight_6bit", &pack_weights_cpu_kernel<6>);
   m.impl("_pack_weight_7bit", &pack_weights_cpu_kernel<7>);
+  m.impl("_pack_weight_8bit", &pack_weights_cpu_kernel<8>);
 }
 
 TORCH_LIBRARY_IMPL(torchao, MPS, m) {
@@ -222,6 +228,7 @@ TORCH_LIBRARY_IMPL(torchao, MPS, m) {
   m.impl("_linear_fp_act_5bit_weight", &linear_mps_kernel<5>);
   m.impl("_linear_fp_act_6bit_weight", &linear_mps_kernel<6>);
   m.impl("_linear_fp_act_7bit_weight", &linear_mps_kernel<7>);
+  m.impl("_linear_fp_act_8bit_weight", &linear_mps_kernel<8>);
   m.impl("_linear_fp_act_1bit_weight.out", &linear_mps_kernel_out<1>);
   m.impl("_linear_fp_act_2bit_weight.out", &linear_mps_kernel_out<2>);
   m.impl("_linear_fp_act_3bit_weight.out", &linear_mps_kernel_out<3>);
@@ -229,6 +236,7 @@ TORCH_LIBRARY_IMPL(torchao, MPS, m) {
   m.impl("_linear_fp_act_5bit_weight.out", &linear_mps_kernel_out<5>);
   m.impl("_linear_fp_act_6bit_weight.out", &linear_mps_kernel_out<6>);
   m.impl("_linear_fp_act_7bit_weight.out", &linear_mps_kernel_out<7>);
+  m.impl("_linear_fp_act_8bit_weight.out", &linear_mps_kernel_out<8>);
 }
 
 TORCH_LIBRARY_IMPL(torchao, Meta, m) {
@@ -239,6 +247,7 @@ TORCH_LIBRARY_IMPL(torchao, Meta, m) {
   m.impl("_linear_fp_act_5bit_weight", &linear_mps_kernel_meta<5>);
   m.impl("_linear_fp_act_6bit_weight", &linear_mps_kernel_meta<6>);
   m.impl("_linear_fp_act_7bit_weight", &linear_mps_kernel_meta<7>);
+  m.impl("_linear_fp_act_8bit_weight", &linear_mps_kernel_meta<8>);
 }
 
 } // namespace torchao::kernels::mps::lowbit::aten
@@ -283,3 +292,4 @@ DECLARE_LINEAR_FP_ACT_WEIGHT_FUNCTION(4)
 DECLARE_LINEAR_FP_ACT_WEIGHT_FUNCTION(5)
 DECLARE_LINEAR_FP_ACT_WEIGHT_FUNCTION(6)
 DECLARE_LINEAR_FP_ACT_WEIGHT_FUNCTION(7)
+DECLARE_LINEAR_FP_ACT_WEIGHT_FUNCTION(8)

--- a/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_executorch.mm
+++ b/torchao/experimental/ops/mps/linear_fp_act_xbit_weight_executorch.mm
@@ -63,7 +63,7 @@ bool check_linear_mps_args(
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
       group_size == 32 || group_size == 64 || group_size == 128 ||
           group_size == 256,
-      "Expect group_size to be 32, 64, 128 or 256");
+      "Expect group_size to be 32, 64, 128, or 256");
 
   ET_LOG_MSG_AND_RETURN_IF_FALSE(
       S.dim() == 2 && S.size(0) == N,
@@ -138,4 +138,8 @@ EXECUTORCH_LIBRARY(torchao, "_linear_fp_act_6bit_weight.out", linear_mps_kernel_
 
 namespace {
 EXECUTORCH_LIBRARY(torchao, "_linear_fp_act_7bit_weight.out", linear_mps_kernel_et_ctx_out<7>);
+}
+
+namespace {
+EXECUTORCH_LIBRARY(torchao, "_linear_fp_act_8bit_weight.out", linear_mps_kernel_et_ctx_out<8>);
 }

--- a/torchao/experimental/ops/mps/mps_op_lib.py
+++ b/torchao/experimental/ops/mps/mps_op_lib.py
@@ -9,7 +9,7 @@ from torch import Tensor
 from torch.library import impl
 
 torchao_lib = torch.library.Library("torchao", "IMPL")
-for nbit in range(1, 8):
+for nbit in range(1, 9):
 
     @impl(torchao_lib, f"_linear_fp_act_{nbit}bit_weight", "Meta")
     def _(

--- a/torchao/experimental/ops/mps/test/test_intNgemm.py
+++ b/torchao/experimental/ops/mps/test/test_intNgemm.py
@@ -1,0 +1,493 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the generalized int1-int8 MPS GEMM kernel.
+
+Tests the intNgemm_mm Metal kernel through the _linear_fp_act_{n}bit_weight
+ops for all bit widths 1-8, covering:
+  - Correctness vs reference dequant+matmul
+  - GEMM path (M > 1) and GEMV path (M == 1)
+  - Multiple group sizes (32, 64, 128, 256)
+  - float, half, and bfloat16 dtypes
+  - Edge cases (non-aligned N, uniform weights)
+  - End-to-end tensor subclass usage
+"""
+
+import pytest
+import torch
+
+# Load the experimental MPS library
+import torchao.experimental.ops.mps  # noqa: F401
+
+device = "mps"
+all_nbits = list(range(1, 9))
+all_group_sizes = [32, 64, 128, 256]
+
+
+def _reference_dequant_matmul(A, W_int, scales, zeros, group_size, nbit):
+    """Reference: dequantize weights and do float matmul on CPU."""
+    N, K = W_int.shape
+    W_f = W_int.float()
+    S_exp = scales.cpu().repeat_interleave(group_size, dim=1)[:, :K]
+    Z_exp = zeros.cpu().repeat_interleave(group_size, dim=1)[:, :K]
+    W_dequant = S_exp * W_f + Z_exp
+    return (A.cpu().float() @ W_dequant.T).to(A.device)
+
+
+def _pack_and_run(A, W_int, scales, zeros, group_size, nbit):
+    """Pack weights and run the MPS low-bit linear op."""
+    pack_op = getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+    linear_op = getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+    B = pack_op(W_int.cpu()).to(device)
+    return linear_op(A, B, group_size, scales, zeros)
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+@pytest.mark.parametrize("group_size", [32, 128])
+def test_gemm_correctness(nbit, group_size):
+    """Test GEMM path (M > 1) correctness for all bit widths."""
+    M, N, K = 64, 256, 256
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    # Tolerance scales with bit width (more bits = more precision but also
+    # larger values, so absolute error can be slightly larger)
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, f"int{nbit}bit gs={group_size}: max_err={max_err} > tol={tol}"
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+def test_gemv_correctness(nbit):
+    """Test GEMV path (M == 1, decode) correctness for all bit widths."""
+    M, N, K, group_size = 1, 256, 512, 128
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, f"int{nbit}bit GEMV: max_err={max_err} > tol={tol}"
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_dtypes(nbit, dtype):
+    """Test float and half dtype support."""
+    M, N, K, group_size = 32, 128, 256, 64
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=dtype, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=dtype, device=device
+    )
+    Z = (-Z_raw * S).to(dtype)
+    A = torch.randn(M, K, dtype=dtype, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    tol = max(0.05, max_val * 0.005)
+    assert max_err < tol, f"int{nbit}bit {dtype}: max_err={max_err} > tol={tol}"
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+def test_uniform_weights(nbit):
+    """Test with uniform weights (all same value) to catch off-by-one errors."""
+    M, N, K, group_size = 32, 128, 256, 64
+    val = (1 << nbit) // 2  # midpoint
+    W_int = torch.full((N, K), val, dtype=torch.uint8)
+    S = torch.ones(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.full((N, K // group_size), val, dtype=torch.float32, device=device)
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.ones(M, K, dtype=torch.float32, device=device)
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    assert max_err < 0.01, f"int{nbit}bit uniform: max_err={max_err}"
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+def test_group_sizes(nbit):
+    """Test all supported group sizes."""
+    M, N, K = 32, 128, 256
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    for gs in all_group_sizes:
+        if K % gs != 0:
+            continue
+        S = torch.randn(N, K // gs, dtype=torch.float32, device=device) * 0.01
+        Z_raw = torch.randint(
+            0, max_val + 1, (N, K // gs), dtype=torch.float32, device=device
+        )
+        Z = (-Z_raw * S).to(torch.float32)
+
+        result = _pack_and_run(A, W_int, S, Z, gs, nbit)
+        expected = _reference_dequant_matmul(A, W_int, S, Z, gs, nbit)
+
+        max_err = (result.float() - expected.float()).abs().max().item()
+        tol = max(0.01, max_val * 0.001)
+        assert max_err < tol, f"int{nbit}bit gs={gs}: max_err={max_err} > tol={tol}"
+
+
+@pytest.mark.parametrize("nbit", all_nbits)
+def test_large_m(nbit):
+    """Test with large M (prefill scenario)."""
+    M, N, K, group_size = 256, 512, 512, 128
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, f"int{nbit}bit large M: max_err={max_err} > tol={tol}"
+
+
+@pytest.mark.parametrize("K", [32, 64, 128, 256, 512, 1024, 2048, 4096])
+@pytest.mark.parametrize("nbit", [4, 8])
+def test_k_sweep_race_condition(nbit, K):
+    """K-sweep test to catch the shared-memory race condition.
+
+    In the matmul A [M,K] @ B [N,K]^T -> [M,N], K is the reduction dimension
+    (input features / current layer's hidden size). The kernel tiles K with
+    BLOCK_SIZE_K=32, so K/32 = number of K-loop iterations.
+
+    The race occurs when the result store reuses the A region (shared_memory
+    offset 0) without a threadgroup_barrier after the K-loop. It manifests at
+    K>=512 (>=16 K-loop iterations) because simdgroups desync across the
+    outer-product accumulation loop (which only uses simdgroup_barrier, not
+    threadgroup_barrier). Without the barrier, one simdgroup can start writing
+    results to shared_A while another simdgroup is still reading from it in
+    its last simdgroup_load.
+
+    This test covers K values from 32 (1 iteration) to 4096 (128 iterations).
+    Real LLM hidden sizes are 4096+, so the race would trigger in production
+    if the barrier were ever removed. GPU race timing varies by chip/driver,
+    but the race reliably triggers at K>=512 on Apple Silicon.
+    """
+    M, N, group_size = 64, 128, 64
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    num_groups = (K + group_size - 1) // group_size
+    S = torch.randn(N, num_groups, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, num_groups), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    assert not torch.isnan(result).any(), f"int{nbit}bit K={K}: NaN in result"
+    assert not torch.isinf(result).any(), f"int{nbit}bit K={K}: Inf in result"
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, (
+        f"int{nbit}bit K={K}: max_err={max_err} > tol={tol} "
+        f"(possible shared-memory race condition)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tensor subclass tests
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("nbit", all_nbits)
+@pytest.mark.parametrize("group_size", [32, 128])
+def test_gemv_matches_gemm_path(nbit, group_size):
+    """GEMM (M>1) and GEMV (M=1) paths should agree for the same input.
+
+    The two kernels accumulate in different orders, so exact equality is not
+    expected, but with scaled inputs the difference is negligible.
+    """
+    M, K, N = 32, 256, 256
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    pack_op = getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+    linear_op = getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+    B = pack_op(W_int.cpu()).to(device)
+
+    # Run M=1 for each row (GEMV path) and M=32 (GEMM path)
+    gemv_results = torch.stack(
+        [linear_op(A[i : i + 1], B, group_size, S, Z)[0] for i in range(M)]
+    )
+    gemm_result = linear_op(A, B, group_size, S, Z)
+
+    max_err = (gemm_result.float() - gemv_results.float()).abs().max().item()
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, (
+        f"int{nbit}bit gs={group_size}: GEMM vs GEMV max_err={max_err} > tol={tol}"
+    )
+
+
+@pytest.mark.parametrize("nbit", [4, 8])
+def test_is_deterministic_across_runs(nbit):
+    """Running the kernel multiple times should produce identical results."""
+    M, K, N, group_size = 128, 256, 512, 32
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    results = [_pack_and_run(A, W_int, S, Z, group_size, nbit) for _ in range(5)]
+    for i in range(1, 5):
+        torch.testing.assert_close(results[0], results[i], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("nbit", [4, 8])
+@pytest.mark.parametrize(
+    "M,N",
+    [
+        (32, 64),  # single threadgroup
+        (128, 512),  # many threadgroups (32 TGs)
+        (256, 512),  # 64 TGs — stress test
+    ],
+)
+def test_large_threadgroup_count(nbit, M, N):
+    """Large threadgroup counts previously exposed a race condition."""
+    K, group_size = 256, 32
+    max_val = (1 << nbit) - 1
+    W_int = torch.randint(0, max_val + 1, (N, K), dtype=torch.uint8)
+    S = torch.randn(N, K // group_size, dtype=torch.float32, device=device) * 0.01
+    Z_raw = torch.randint(
+        0, max_val + 1, (N, K // group_size), dtype=torch.float32, device=device
+    )
+    Z = (-Z_raw * S).to(torch.float32)
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    result = _pack_and_run(A, W_int, S, Z, group_size, nbit)
+    expected = _reference_dequant_matmul(A, W_int, S, Z, group_size, nbit)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    tol = max(0.01, max_val * 0.001)
+    assert max_err < tol, (
+        f"int{nbit}bit M={M} N={N}: max_err={max_err} > tol={tol}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tensor subclass tests
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("nbit", [1, 2, 3, 4, 5, 6, 7, 8])
+def test_tensor_subclass_linear(nbit):
+    """Test IntxMPSExperimentalTensor end-to-end linear."""
+    from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+        IntxMPSExperimentalTensor,
+    )
+
+    N, K, group_size = 128, 256, 64
+    M = 32
+    hp_weight = torch.randn(N, K, dtype=torch.float32, device=device) * 0.1
+    block_size = [1, group_size]
+
+    qweight = IntxMPSExperimentalTensor.from_hp(hp_weight, block_size, nbit=nbit)
+    assert qweight.nbit == nbit
+
+    # Reference: dequantize and matmul
+    ref_weight = qweight.dequantize()
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+    expected = torch.nn.functional.linear(A, ref_weight)
+
+    # Run through the tensor subclass dispatch
+    result = torch.nn.functional.linear(A, qweight)
+
+    max_err = (result.float() - expected.float()).abs().max().item()
+    max_val = (1 << nbit) - 1
+    tol = max(0.05, max_val * 0.01)
+    assert max_err < tol, f"int{nbit}bit subclass: max_err={max_err} > tol={tol}"
+
+
+# ---------------------------------------------------------------------------
+# Comparison with PyTorch's native MPS int4/int8 kernels (macOS 15+)
+#
+# PyTorch (PR #130715) added native MPS int4 groupwise and int8 per-channel
+# weight-only quantization starting with macOS 15.  These tests verify that
+# the experimental simdgroup GEMM kernel produces results within the same
+# tolerance as the native path.
+#
+# Native int4 convention:
+#   - Input to _convert_weight_to_int4pack is pre-packed uint8 (2 int4 per byte,
+#     hi-nibble first)
+#   - Dequant: w = (q - 8) * scale + zero, where zero = w_min + 8*scale
+#   - qScaleAndZeros: [K//gs, N, 2] with (scale, zero)
+#
+# Native int8 convention:
+#   - _weight_int8pack_mm takes int8 weights and per-channel scales
+#   - Dequant: w = q * scale  (symmetric, no zero point)
+#
+# For int4, both paths use the same min-max unsigned quantization (0-15), so
+# the direct experimental-vs-native comparison should be very tight (only
+# floating-point accumulation order differs).  For int8, the native path uses
+# symmetric quantization while the experimental path uses asymmetric min-max,
+# so both are compared against
+# the fp32 reference rather than directly against each other.
+# ---------------------------------------------------------------------------
+
+
+def _pack_int4_to_uint8(w_q_uint8):
+    """Pack individual uint8 int4 values (0-15) into packed uint8 (2 per byte).
+
+    Hi-nibble first: byte = (q_even << 4) | q_odd
+    """
+    N, K = w_q_uint8.shape
+    assert K % 2 == 0
+    return ((w_q_uint8[:, 0::2] << 4) | w_q_uint8[:, 1::2]).to(torch.uint8)
+
+
+@pytest.mark.parametrize("M", [1, 8])
+@pytest.mark.parametrize("group_size", [32, 64, 128])
+def test_int4_vs_native_mps(M, group_size):
+    """Compare the experimental int4 path against PyTorch's native _weight_int4pack_mm.
+
+    Both paths use min-max unsigned quantization (0-15), but the native path
+    internally shifts to signed (-8 to 7) and uses a slightly different
+    rounding/convention for scale and zero.  Both are compared against the
+    fp32 reference rather than directly against each other, since the
+    quantized values may differ slightly between the two conventions.
+    """
+    torch.manual_seed(42)
+    N, K = 128, 256
+
+    hp_weight = torch.randn(N, K, dtype=torch.float32, device=device) * 0.1
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    # --- Experimental path: IntxMPSExperimentalTensor ---
+    from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+        IntxMPSExperimentalTensor,
+    )
+
+    our_qweight = IntxMPSExperimentalTensor.from_hp(hp_weight, [1, group_size], nbit=4)
+    our_result = torch.nn.functional.linear(A, our_qweight)
+
+    # --- Native PyTorch MPS int4 ---
+    # Quantize with min-max (unsigned 0-15, same as the experimental path)
+    qmin, qmax = 0, 15
+    w = hp_weight.cpu()
+    w_g = w.reshape(N, K // group_size, group_size)
+    w_min = w_g.amin(dim=2, keepdim=True)
+    w_max = w_g.amax(dim=2, keepdim=True)
+    scales = (w_max - w_min) / (qmax - qmin)
+    zeros = qmin - torch.round(w_min / scales)
+    scales_exp = scales.repeat(1, 1, group_size).reshape(N, K)
+    zeros_exp = zeros.repeat(1, 1, group_size).reshape(N, K)
+    w_q = torch.clamp(torch.round(w / scales_exp + zeros_exp), qmin, qmax).to(
+        torch.uint8
+    )
+
+    # Pack and run native (pre-packed uint8, 2 int4 per byte)
+    w_q_packed = _pack_int4_to_uint8(w_q)
+    packed = torch.ops.aten._convert_weight_to_int4pack(w_q_packed.to(device), 8)
+
+    # Native dequant: w = (q - 8) * scale + zero, where zero = w_min + 8*scale
+    # This simplifies to w = q * scale + w_min, matching the experimental (q - zero_unsigned) * scale
+    scale_flat = scales.reshape(N, K // group_size)
+    w_min_flat = w_min.reshape(N, K // group_size)
+    zero_native = w_min_flat + 8 * scale_flat
+    qScaleAndZeros = (
+        torch.stack([scale_flat.T, zero_native.T], dim=2).to(device).to(torch.float32)
+    )
+
+    native_result = torch.ops.aten._weight_int4pack_mm(
+        A, packed, group_size, qScaleAndZeros
+    )
+
+    # Both should be close to the fp32 reference
+    ref = torch.nn.functional.linear(A, hp_weight)
+    our_err = (our_result.float() - ref.float()).abs().max().item()
+    native_err = (native_result.float() - ref.float()).abs().max().item()
+
+    # 4-bit quantization with 0.1-scale weights: vs-ref error is dominated by
+    # quantization granularity (16 levels), not kernel correctness.
+    assert our_err < 0.1, f"Experimental int4 error too high: {our_err}"
+    assert native_err < 0.1, f"Native int4 error too high: {native_err}"
+
+
+@pytest.mark.parametrize("M", [1, 8, 2048])
+def test_int8_delegated_to_native(M):
+    """Verify that int8 per-channel delegation to native _weight_int8pack_mm
+    produces correct results matching the native operator directly.
+
+    int8 per-channel always delegates to PyTorch's native _weight_int8pack_mm.
+    This test verifies the delegation path produces the same result as calling
+    native directly.
+    """
+    torch.manual_seed(42)
+    N, K = 128, 256
+
+    hp_weight = torch.randn(N, K, dtype=torch.float32, device=device) * 0.1
+    A = torch.randn(M, K, dtype=torch.float32, device=device) * 0.1
+
+    from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+        IntxMPSExperimentalTensor,
+    )
+
+    # int8 per-channel always delegates to native
+    qw_delegated = IntxMPSExperimentalTensor.from_hp(hp_weight, [1, K], nbit=8)
+    assert qw_delegated.use_native_int8, "Expected use_native_int8=True"
+    assert qw_delegated.packed_weight.dtype == torch.int8, (
+        f"Expected int8 packed weight, got {qw_delegated.packed_weight.dtype}"
+    )
+    assert qw_delegated.scales.ndim == 1, (
+        f"Expected 1D scales for native int8, got {qw_delegated.scales.ndim}D"
+    )
+
+    delegated_result = torch.nn.functional.linear(A, qw_delegated)
+
+    # Native directly
+    w = hp_weight.cpu()
+    w_max = w.abs().amax(dim=1, keepdim=True)
+    scales_native = w_max / 127.0
+    w_q_native = torch.round(w / scales_native).clamp(-128, 127).to(torch.int8)
+    scales_1d = scales_native.squeeze(1).to(device).to(torch.float32)
+    native_result = torch.ops.aten._weight_int8pack_mm(
+        A, w_q_native.to(device), scales_1d
+    )
+
+    # Should match native exactly (same quantization scheme)
+    err = (delegated_result.float() - native_result.float()).abs().max().item()
+    assert err < 1e-5, f"Delegated int8 should match native exactly, got err={err}"

--- a/torchao/experimental/ops/mps/test/test_quantizer.py
+++ b/torchao/experimental/ops/mps/test/test_quantizer.py
@@ -23,7 +23,7 @@ from torchao.quantization.quant_api import quantize_
 
 
 class TestUIntxWeightOnlyLinearQuantizer(unittest.TestCase):
-    BITWIDTHS = range(1, 8)
+    BITWIDTHS = range(1, 9)
     GROUPSIZES = [32, 64, 128, 256]
 
     # Currently, the quantization code in quant_api.py only supports K values
@@ -60,7 +60,14 @@ class TestUIntxWeightOnlyLinearQuantizer(unittest.TestCase):
         m = 3
         activations = torch.randn(m, k0, dtype=torch.float32, device="mps")
 
-        quantized_model = self._quantize_model(model, torch.float32, nbit, group_size)
+        config = UIntxWeightOnlyConfig(
+            bitwidth=nbit,
+            group_size=group_size,
+            uintx_choose_qparams_algorithm=UIntxChooseQParamsAlgorithm.HQQ,
+        )
+        quantized_model = copy.deepcopy(model)
+        quantized_model = quantized_model.to(device="mps", dtype=torch.float32)
+        quantize_(quantized_model, config)
         exported = torch.export.export(quantized_model, (activations,), strict=True)
 
         for node in exported.graph.nodes:
@@ -415,6 +422,165 @@ class TestUIntxWeightOnlyLinearQuantizer(unittest.TestCase):
             config_with_bitwidth.uintx_choose_qparams_algorithm,
             UIntxChooseQParamsAlgorithm.MIN_MAX,
         )
+
+
+def _compute_sqnr(original, quantized):
+    """Compute SQNR in dB between original and quantized tensors."""
+    mse = torch.mean((original - quantized) ** 2)
+    signal_power = torch.mean(original**2)
+    if mse == 0:
+        return float("inf")
+    return 10 * torch.log10(signal_power / mse).item()
+
+
+class TestIntxMPSExperimentalTensor(unittest.TestCase):
+    """Tests for the generalized int1-int8 MPS tensor subclass via quantize_."""
+
+    BITWIDTHS = range(1, 9)
+
+    def _make_model(self, k=128, n=256, bias=False):
+        return torch.nn.Linear(k, n, bias=bias)
+
+    def _quantize(self, model, nbit=4, group_size=64, precision=torch.float32):
+        config = UIntxWeightOnlyConfig(bitwidth=nbit, group_size=group_size)
+        quantized_model = copy.deepcopy(model)
+        quantized_model = quantized_model.to(device="mps", dtype=precision)
+        quantize_(quantized_model, config)
+        return quantized_model
+
+    @parameterized.expand([(4, 64), (8, 128), (6, 64)])
+    def test_linear_accuracy(self, nbit, group_size):
+        """Quantized linear output should be reasonably close to original."""
+        k = 4 * group_size
+        n = 256
+        m = 4
+        with torch.no_grad():
+            model = self._make_model(k=k, n=n).to(device="mps", dtype=torch.float32)
+            activations = torch.randn(m, k, dtype=torch.float32, device="mps")
+            original = model(activations)
+
+            quantized_model = self._quantize(model, nbit=nbit, group_size=group_size)
+            result = quantized_model(activations)
+
+            sqnr = _compute_sqnr(original.cpu(), result.cpu())
+            self.assertGreater(
+                sqnr, 15, f"SQNR too low for {nbit}-bit gs={group_size}: {sqnr:.1f} dB"
+            )
+
+    @parameterized.expand([(4, 64), (8, 128), (6, 64)])
+    def test_3d_input_shape(self, nbit, group_size):
+        """3D batched input should produce correct output shape."""
+        k = 4 * group_size
+        n = 256
+        leading = (3, 5)
+        with torch.no_grad():
+            model = self._make_model(k=k, n=n)
+            activations = torch.randn(*leading, k, dtype=torch.float32, device="mps")
+            quantized_model = self._quantize(model, nbit=nbit, group_size=group_size)
+            result = quantized_model(activations)
+            self.assertTrue(result.is_mps)
+            self.assertEqual(result.shape, (*leading, n))
+
+    @parameterized.expand([(4,), (8,), (6,)])
+    def test_export(self, nbit):
+        """torch.export should produce a graph containing the low-bit linear op."""
+        group_size = 64
+        k = 4 * group_size
+        n = 256
+        with torch.no_grad():
+            model = self._make_model(k=k, n=n)
+            activations = torch.randn(3, k, dtype=torch.float32, device="mps")
+            quantized_model = self._quantize(model, nbit=nbit, group_size=group_size)
+
+            exported = torch.export.export(quantized_model, (activations,), strict=True)
+            expected_target = f"torchao._linear_fp_act_{nbit}bit_weight.default"
+            found = any(
+                str(node.target) == expected_target
+                for node in exported.graph.nodes
+                if node.op == "call_function"
+            )
+            self.assertTrue(found, f"Expected {expected_target} in exported graph")
+
+    @parameterized.expand([(4, 64), (4, 128), (6, 64), (6, 128), (8, 64), (8, 128)])
+    def test_valid_group_sizes(self, nbit, group_size):
+        """Valid group sizes should run without error."""
+        k = 4 * group_size
+        n = 128
+        with torch.no_grad():
+            model = self._make_model(k=k, n=n)
+            activations = torch.randn(4, k, dtype=torch.float32, device="mps")
+            quantized_model = self._quantize(model, nbit=nbit, group_size=group_size)
+            result = quantized_model(activations)
+            self.assertEqual(result.shape, (4, n))
+
+    def test_invalid_group_size(self):
+        """Invalid group size should raise ValueError."""
+        model = self._make_model(k=48, n=128)
+        with self.assertRaises(ValueError):
+            self._quantize(model, nbit=4, group_size=16)
+
+    @parameterized.expand([(4,), (8,)])
+    def test_per_channel_group_size_neg1(self, nbit):
+        """group_size=-1 (per-channel) should quantize and run correctly."""
+        k = 256
+        n = 128
+        with torch.no_grad():
+            model = self._make_model(k=k, n=n)
+            activations = torch.randn(4, k, dtype=torch.float32, device="mps")
+            config = UIntxWeightOnlyConfig(bitwidth=nbit, group_size=-1)
+            quantized_model = copy.deepcopy(model).to(device="mps", dtype=torch.float32)
+            quantize_(quantized_model, config)
+            result = quantized_model(activations)
+            self.assertEqual(result.shape, (4, n))
+
+    @parameterized.expand(BITWIDTHS)
+    def test_dequantize_accuracy(self, nbit):
+        """dequantize() should recover the original weights within quantization error."""
+        from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+            IntxMPSExperimentalTensor,
+        )
+
+        k, n, group_size = 256, 128, 64
+        hp_weight = torch.randn(n, k, dtype=torch.float32, device="mps") * 0.1
+        qweight = IntxMPSExperimentalTensor.from_hp(hp_weight, [1, group_size], nbit=nbit)
+        dequant = qweight.dequantize()
+        sqnr = _compute_sqnr(hp_weight.cpu(), dequant.cpu())
+        # SQNR threshold scales with bitwidth: 1-bit is extremely lossy (~0 dB),
+        # 2-bit ~5 dB, 4-bit ~15 dB, 8-bit ~40 dB.  Use a conservative floor.
+        min_sqnr = {1: -1, 2: 4, 3: 8, 4: 12, 5: 18, 6: 24, 7: 30, 8: 36}[nbit]
+        self.assertGreater(
+            sqnr, min_sqnr, f"SQNR too low for {nbit}-bit dequantize: {sqnr:.1f} dB"
+        )
+
+    @parameterized.expand(BITWIDTHS)
+    def test_transpose_and_slice_ops(self, nbit):
+        """.t(), transpose, permute, and slice should dequantize and delegate correctly."""
+        from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+            IntxMPSExperimentalTensor,
+        )
+
+        k, n, group_size = 256, 128, 64
+        hp_weight = torch.randn(n, k, dtype=torch.float32, device="mps") * 0.1
+        qweight = IntxMPSExperimentalTensor.from_hp(hp_weight, [1, group_size], nbit=nbit)
+
+        # .t() — shape check (values are dequantized, so just verify shape
+        # and that it matches the transposed dequantized weight).
+        t = qweight.t()
+        self.assertEqual(t.shape, (k, n))
+        dequant = qweight.dequantize()
+        self.assertTrue(torch.allclose(t, dequant.t(), atol=1e-5))
+
+        # transpose
+        t2 = torch.transpose(qweight, 0, 1)
+        self.assertEqual(t2.shape, (k, n))
+
+        # permute
+        p = qweight.permute(1, 0)
+        self.assertEqual(p.shape, (k, n))
+
+        # slice
+        s = qweight[:32]
+        self.assertEqual(s.shape, (32, k))
 
 
 if __name__ == "__main__":

--- a/torchao/experimental/ops/mps/utils.py
+++ b/torchao/experimental/ops/mps/utils.py
@@ -49,7 +49,7 @@ def _get_torchao_mps_lib_path():
 def _load_torchao_mps_lib():
     """Load the MPS ops library."""
     try:
-        for nbit in range(1, 8):
+        for nbit in range(1, 9):
             getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
             getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
     except AttributeError:
@@ -64,6 +64,6 @@ def _load_torchao_mps_lib():
         except Exception as e:
             raise RuntimeError(f"Failed to load library {libpath}: {e}")
 
-        for nbit in range(1, 8):
+        for nbit in range(1, 9):
             getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
             getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")

--- a/torchao/experimental/quant_api.py
+++ b/torchao/experimental/quant_api.py
@@ -12,17 +12,13 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
-from torch.ao.quantization.fx._decomposed import (
-    quantize_per_channel_group,
-)
+from torch.ao.quantization.fx._decomposed import quantize_per_channel_group
 
 from torchao.core.config import AOBaseConfig
 from torchao.quantization.quant_primitives import (
     _choose_qparams_and_quantize_affine_hqq,
 )
-from torchao.quantization.transform_module import (
-    register_quantize_module_handler,
-)
+from torchao.quantization.transform_module import register_quantize_module_handler
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -190,7 +186,7 @@ def _replace_linear_with_quantized_linear_mps(module: nn.Module, kwargs={}):
     nbit = kwargs["nbit"]
 
     assert not isinstance(module, nn.Linear)
-    assert nbit >= 1 and nbit <= 7
+    assert nbit >= 1 and nbit <= 8
 
     for name, child in module.named_children():
         if not isinstance(child, nn.Linear):
@@ -242,9 +238,9 @@ class UIntxWeightOnlyLinearQuantizer:
         if bitwidth is None:
             bitwidth = 4
             logger.warning(f"bitwidth not specified, defaulting to {bitwidth}.")
-        if bitwidth not in range(1, 8):
+        if bitwidth not in range(1, 9):
             raise ValueError(
-                "Only bitwidts 1 to 7 are supported in UIntxWeightOnlyLinearQuantizer"
+                "Only bitwidths 1 to 8 are supported in UIntxWeightOnlyLinearQuantizer"
             )
         else:
             self.bitwidth = bitwidth
@@ -281,9 +277,10 @@ class UIntxWeightOnlyConfig(AOBaseConfig):
     to linear layers for MPS devices.
 
     Args:
-        bitwidth (int): Number of bits for quantization, must be between 1 and 7 inclusive.
+        bitwidth (int): Number of bits for quantization, must be between 1 and 8 inclusive.
             Default is 4.
-        group_size (int): Group size for quantization. Must be one of [32, 64, 128, 256].
+        group_size (int): Group size for quantization. Must be one of [32, 64, 128, 256],
+            or -1 for per-channel (int8 only, delegates to native _weight_int8pack_mm).
             Default is 128.
         uintx_choose_qparams_algorithm (Union[UIntxChooseQParamsAlgorithm, str]): Algorithm for
             choosing quantization parameters. Options:
@@ -298,13 +295,14 @@ class UIntxWeightOnlyConfig(AOBaseConfig):
     )
 
     def __post_init__(self):
-        if self.bitwidth not in range(1, 8):
+        if self.bitwidth not in range(1, 9):
             raise ValueError(
-                f"bitwidth must be between 1 and 7 inclusive, got {self.bitwidth}"
+                f"bitwidth must be between 1 and 8 inclusive, got {self.bitwidth}"
             )
-        if self.group_size not in [32, 64, 128, 256]:
+        if self.group_size not in [32, 64, 128, 256] and self.group_size != -1:
             raise ValueError(
-                f"group_size must be one of [32, 64, 128, 256], got {self.group_size}"
+                f"group_size must be one of [32, 64, 128, 256], or -1 for "
+                f"per-channel, got {self.group_size}"
             )
         # Convert string to enum if necessary
         if isinstance(self.uintx_choose_qparams_algorithm, str):
@@ -315,24 +313,53 @@ class UIntxWeightOnlyConfig(AOBaseConfig):
 
 @register_quantize_module_handler(UIntxWeightOnlyConfig)
 def _uintx_weight_only_mps_transform(
-    module: torch.nn.Module, config: UIntxWeightOnlyConfig
+    module: torch.nn.Module,
+    config: UIntxWeightOnlyConfig,
+    *,
+    parameter_name: str = "weight",
 ) -> torch.nn.Module:
     nbit = config.bitwidth
     group_size = config.group_size
     uintx_choose_qparams_algorithm = config.uintx_choose_qparams_algorithm
 
-    if not module.weight.is_contiguous():
+    weight = getattr(module, parameter_name)
+
+    if not weight.is_contiguous():
         raise ValueError(
-            "UIntxWeightOnlyQuantizedLinear requires contiguous weights. "
+            "UIntxWeightOnlyConfig requires contiguous weights. "
             "Please call .contiguous() on the weight tensor before quantization."
         )
 
-    qlinear = UIntxWeightOnlyQuantizedLinear(
-        pack_weight_op=getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit"),
-        linear_op=getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight"),
-        bias=module.bias,
-    )
-    qlinear.quantize_and_pack_weights(
-        module.weight, nbit, group_size, uintx_choose_qparams_algorithm
-    )
-    return qlinear
+    if uintx_choose_qparams_algorithm == UIntxChooseQParamsAlgorithm.MIN_MAX:
+        from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+            IntxMPSExperimentalTensor,
+        )
+
+        # group_size == -1 means per-channel: use K (in_features) as group_size
+        effective_group_size = weight.shape[-1] if group_size == -1 else group_size
+        block_size = [1 for _ in range(weight.ndim - 1)] + [effective_group_size]
+        quantized_weight = IntxMPSExperimentalTensor.from_hp(
+            weight,
+            block_size,
+            nbit=nbit,
+            choose_qparams_algorithm=uintx_choose_qparams_algorithm.value,
+        )
+        setattr(
+            module,
+            parameter_name,
+            torch.nn.Parameter(quantized_weight, requires_grad=False),
+        )
+        return module
+    else:
+        qlinear = UIntxWeightOnlyQuantizedLinear(
+            pack_weight_op=getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit"),
+            linear_op=getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight"),
+            bias=module.bias if parameter_name == "weight" else None,
+        )
+        qlinear.quantize_and_pack_weights(
+            weight,
+            nbit,
+            weight.shape[-1] if group_size == -1 else group_size,
+            uintx_choose_qparams_algorithm,
+        )
+        return qlinear

--- a/torchao/prototype/quantization/intx_mps/intx_mps_experimental_tensor.py
+++ b/torchao/prototype/quantization/intx_mps/intx_mps_experimental_tensor.py
@@ -1,0 +1,495 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generalized low-bit tensor subclass for the experimental MPS kernel path.
+
+Supports int1 through int8 weight-only quantization.  Uses
+``torchao._pack_weight_{n}bit`` for packing and
+``torchao._linear_fp_act_{n}bit_weight`` for matmul — the experimental
+MPS operators that include the simdgroup-tiled GEMM kernel for M > 1
+and the qmv kernel for M == 1 (decode).
+
+Packing format:
+    - packed_weight: [N, nbit*K/8] uint8 (nbit bits per weight, packed along K)
+    - scales:        [N, K/group_size] (activation dtype)
+    - zeros:         [N, K/group_size] (activation dtype, = -scale * zero_point)
+
+Dequantization: weight = scale * val + zero
+
+This is a lighter-weight alternative to ``Int4TilePackedTo4dTensor``:
+    - No K padding to 1024 (only K % 32 required for the GEMM kernel)
+    - No N padding to 8/16 (only N % 4 required for M > 1)
+    - Uses the simdgroup-tiled GEMM kernel for prefill (M > 1) and the
+      qmv kernel for decode (M == 1)
+"""
+
+from typing import List, Optional
+
+import torch
+
+from torchao.quantization.quant_primitives import (
+    MappingType,
+    _choose_qparams_affine,
+    _quantize_affine,
+)
+from torchao.utils import TorchAOBaseTensor, fill_defaults
+
+__all__ = [
+    "IntxMPSExperimentalTensor",
+]
+
+
+def _ensure_mps_experimental_lib_loaded(nbit: int = 4) -> None:
+    """Load the experimental MPS ops library if not already loaded."""
+    try:
+        getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+        getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+    except AttributeError:
+        from torchao.experimental.ops.mps.utils import _load_torchao_mps_lib
+
+        _load_torchao_mps_lib()
+
+
+class IntxMPSExperimentalTensor(TorchAOBaseTensor):
+    """Low-bit quantized tensor using the experimental MPS kernel path.
+
+    Supports int1 through int8 weight-only quantization.
+
+    Tensor Attributes:
+        packed_weight: [N, nbit*K/8] uint8 packed low-bit weights
+        scales: [N, K/group_size] scale tensor (activation dtype)
+        zeros: [N, K/group_size] zero tensor (activation dtype, = -scale * zero_point)
+
+    Non-Tensor Attributes:
+        nbit: number of bits per weight (1-8)
+        block_size: quantization block size, e.g. [1, group_size]
+        shape: original weight shape (out_features, in_features)
+    """
+
+    tensor_data_names = ["packed_weight", "scales", "zeros"]
+    tensor_attribute_names = [
+        "nbit",
+        "block_size",
+        "shape",
+        "use_native_int8",
+    ]
+
+    def __new__(
+        cls,
+        packed_weight: torch.Tensor,
+        scales: torch.Tensor,
+        zeros: torch.Tensor,
+        nbit: int,
+        block_size: List[int],
+        shape: torch.Size,
+        use_native_int8: bool = False,
+    ):
+        kwargs = {}
+        kwargs["device"] = packed_weight.device
+        kwargs["dtype"] = scales.dtype
+        kwargs["requires_grad"] = False
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        packed_weight: torch.Tensor,
+        scales: torch.Tensor,
+        zeros: torch.Tensor,
+        nbit: int,
+        block_size: List[int],
+        shape: torch.Size,
+        use_native_int8: bool = False,
+    ):
+        self.packed_weight = packed_weight
+        self.scales = scales
+        self.zeros = zeros
+        self.nbit = nbit
+        self.block_size = block_size
+        self.use_native_int8 = use_native_int8
+        # Note: shape is set by _make_wrapper_subclass in __new__, not here.
+
+    def _quantization_type(self):
+        return f"nbit={self.nbit}, shape={self.shape}, block_size={self.block_size}, device={self.device}"
+
+    @classmethod
+    def from_hp(
+        cls,
+        hp_tensor: torch.Tensor,
+        block_size: List[int],
+        nbit: Optional[int] = None,
+        choose_qparams_algorithm: Optional[str] = "min_max",
+    ) -> "IntxMPSExperimentalTensor":
+        """Quantize a high-precision weight tensor to low-bit experimental MPS format.
+
+        Quantization is performed on CPU to avoid MPS allocator
+        fragmentation.  The MPS allocator (aten/src/ATen/mps/
+        MPSAllocator.mm) places tensors into Metal heaps (MTLHeap).
+        torch.mps.empty_cache() only releases heaps where every block
+        is free. The source comment says: "a heap returns its memory
+        to the system only as a whole, so freeing single blocks
+        reclaims nothing; only heaps no allocation is left in can be
+        released."  When the intermediate quantization steps (padding,
+        choose_qparams, quantize_affine) run on MPS, they create
+        temporary tensors that share heaps with the final packed
+        weight.  After deleting the intermediates and calling
+        empty_cache(), the heaps still hold the packed weight and
+        cannot be released; the freed intermediate blocks within them
+        are not reusable for new allocations (confirmed empirically:
+        a fresh allocation after cleanup jumps current_allocated_memory
+        by its full size rather than reusing the freed space).  The net
+        effect is > 3x memory overhead on PyTorch <= 2.13, which uses
+        MTLHeapTypeAutomatic and cannot coalesce freed blocks within a
+        partially-occupied heap.  PyTorch 2.14 (PR #190438) switches to
+        MTLHeapTypePlacement with offset-ordered coalescing, which
+        resolves this issue: the bad path measures 1.00x (zero stuck
+        memory), matching the CPU path.  The CPU workaround is kept for
+        compatibility with PyTorch <= 2.13.  By moving the weight to
+        CPU, doing all quantization there, and only moving the final
+        packed result to MPS, the MPS allocator only ever holds the
+        packed weight, giving zero overhead on all versions.
+        See: https://github.com/pytorch/pytorch/pull/190438
+
+        Args:
+            hp_tensor: [N, K] weight tensor (bfloat16 or float32)
+            block_size: quantization block size, e.g. [1, group_size]
+            nbit: number of bits per weight (1-8).
+            choose_qparams_algorithm: "min_max" (default).
+                Uses simple min-max scaling for quantization parameters.
+
+        Returns:
+            IntxMPSExperimentalTensor with packed weights, scales, and zeros
+        """
+        if nbit is None:
+            nbit = getattr(cls, "default_nbit", 4)
+        _ensure_mps_experimental_lib_loaded(nbit)
+
+        assert 1 <= nbit <= 8, f"nbit must be 1-8, got {nbit}"
+        assert len(block_size) == hp_tensor.ndim
+        assert all(x == 1 for x in block_size[:-1]), (
+            f"Only per-group quantization supported, got block_size: {block_size}"
+        )
+
+        if choose_qparams_algorithm != "min_max":
+            raise ValueError(
+                f"Unsupported choose_qparams_algorithm: {choose_qparams_algorithm}. "
+                f"Only 'min_max' is supported."
+            )
+
+        group_size = block_size[-1]
+        orig_out_features, orig_in_features = hp_tensor.shape[-2:]
+        orig_device = hp_tensor.device
+        orig_dtype = hp_tensor.dtype
+
+        # The experimental kernel requires K % 8 == 0 and N % 4 == 0 (for M > 1).
+        # The simdgroup-tiled GEMM kernel (selected for M > 1) additionally
+        # requires K % 32 == 0 and group_size % 32 == 0.  Pad K to a multiple
+        # of 32 so the GEMM kernel is always selected for prefill rather than
+        # falling back to the slower pack_mm path.  The extra K padding is at
+        # most 31 columns and the extra N padding is at most 3 rows.  Both are
+        # filled with zeros, which dequantize back to exactly 0: quantize(0.0)
+        # yields zero_point, and dequantize(zero_point) = scale*zp + (-scale*zp)
+        # = 0 by cancellation (scale is clamped to eps, never 0).  So the padded
+        # region contributes nothing to the matmul.
+        in_features = (orig_in_features + 31) // 32 * 32
+        out_features = (orig_out_features + 3) // 4 * 4
+
+        # --- Native int8 per-channel delegation ---
+        # For int8 per-channel (group_size == K), delegate to PyTorch's
+        # native _weight_int8pack_mm, which uses a purpose-built Metal
+        # kernel achieving ~0.98x bf16 prefill speed.  The generalized
+        # kernel achieves ~0.95x because it stages dequantized weights
+        # through shared memory for compatibility with int1-int7.  At int8,
+        # symmetric per-channel (native pytorch) is slightly faster and
+        # almost as accurate as the generalized kernel (no zero-point float
+        # noise).
+        is_per_channel = group_size == orig_in_features
+        if nbit == 8 and is_per_channel:
+            return cls._from_hp_native_int8(
+                hp_tensor, block_size, orig_device, orig_dtype
+            )
+
+        # The generalized kernel only supports group sizes {32, 64, 128, 256}.
+        if group_size not in (32, 64, 128, 256):
+            raise ValueError(
+                f"group_size must be 32, 64, 128, or 256 (got {group_size}). "
+                f"For int8 per-channel, use group_size=K (={orig_in_features})."
+            )
+
+        if in_features % group_size != 0:
+            raise ValueError(
+                f"Padded K ({in_features}) must be divisible by group_size "
+                f"({group_size}). Original K={orig_in_features} was padded to a "
+                f"multiple of 32. Try a different group_size or a larger K."
+            )
+
+        # Do quantization on CPU to avoid MPS allocator fragmentation.
+        hp_tensor_cpu = hp_tensor.cpu()
+        hp_tensor_padded = torch.nn.functional.pad(
+            hp_tensor_cpu,
+            (0, in_features - orig_in_features, 0, out_features - orig_out_features),
+        )
+
+        # Quantization: asymmetric min-max (with zero point)
+        target_dtype = torch.uint8
+        quant_min = 0
+        quant_max = (1 << nbit) - 1
+
+        scale, zero_point = _choose_qparams_affine(
+            hp_tensor_padded,
+            mapping_type=MappingType.ASYMMETRIC.name,
+            block_size=block_size,
+            target_dtype=target_dtype,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            scale_dtype=hp_tensor_cpu.dtype,
+            zero_point_dtype=hp_tensor_cpu.dtype,
+        )
+
+        int_data = _quantize_affine(
+            hp_tensor_padded,
+            block_size,
+            scale,
+            zero_point,
+            target_dtype,
+            quant_min=quant_min,
+            quant_max=quant_max,
+        )
+
+        # Pack using the experimental _pack_weight_{nbit}bit op (CPU)
+        pack_op = getattr(torch.ops.torchao, f"_pack_weight_{nbit}bit")
+        packed_weight = pack_op(int_data)
+
+        # Reshape scales and zeros to [N, K/group_size]
+        num_groups = in_features // group_size
+        scale = scale.reshape(out_features, num_groups)
+        zero_point = zero_point.reshape(out_features, num_groups)
+
+        # The experimental kernel uses: weight = scale * val + zero
+        # where zero = -scale * zero_point
+        zeros = (-zero_point * scale).to(orig_dtype)
+
+        # Move only the final packed results to the original device
+        packed_weight = packed_weight.to(orig_device)
+        scale = scale.to(orig_device)
+        zeros = zeros.to(orig_device)
+
+        # Free CPU intermediates
+        del hp_tensor_cpu, hp_tensor_padded, zero_point, int_data
+
+        return cls(
+            packed_weight=packed_weight,
+            scales=scale,
+            zeros=zeros,
+            nbit=nbit,
+            block_size=block_size,
+            shape=hp_tensor.shape,  # original shape, not padded
+        )
+
+    @classmethod
+    def _from_hp_native_int8(
+        cls,
+        hp_tensor: torch.Tensor,
+        block_size: List[int],
+        orig_device: torch.device,
+        orig_dtype: torch.dtype,
+    ) -> "IntxMPSExperimentalTensor":
+        """Quantize to native PyTorch int8 per-channel format.
+
+        Stores int8 weights and 1D scales in the format expected by
+        _weight_int8pack_mm.  The linear dispatch detects use_native_int8
+        and routes to the native operator instead of the Metal kernel.
+        """
+        # Quantize on CPU to avoid MPS allocator fragmentation.
+        w_cpu = hp_tensor.cpu().float()
+        w_max_abs = w_cpu.abs().amax(dim=1, keepdim=True)
+        scales = w_max_abs / 127.0
+        # Clamp scales to avoid division by zero
+        scales = scales.clamp(min=1e-8)
+        w_q = torch.round(w_cpu / scales).clamp(-128, 127).to(torch.int8)
+        scales_1d = scales.squeeze(1).to(orig_dtype)
+
+        # Move to target device
+        w_q = w_q.to(orig_device)
+        scales_1d = scales_1d.to(orig_device)
+
+        # Store a dummy zeros tensor for format consistency (unused)
+        zeros = torch.zeros(scales_1d.shape[0], 1, dtype=orig_dtype, device=orig_device)
+
+        return cls(
+            packed_weight=w_q,  # [N, K] int8 (not packed — native format)
+            scales=scales_1d,  # [N] 1D scales
+            zeros=zeros,
+            nbit=8,
+            block_size=block_size,
+            shape=hp_tensor.shape,
+            use_native_int8=True,
+        )
+
+
+implements = IntxMPSExperimentalTensor.implements
+implements_torch_function = IntxMPSExperimentalTensor.implements_torch_function
+
+
+@implements(torch.ops.aten.linear.default)
+@implements_torch_function(torch.nn.functional.linear)
+def _(func, types, args, kwargs):
+    """Linear dispatch: route to _linear_fp_act_{nbit}bit_weight."""
+    input_tensor, weight_tensor, bias = (
+        args[0],
+        args[1],
+        args[2] if len(args) > 2 else None,
+    )
+
+    assert weight_tensor.block_size[0] == 1, (
+        f"Requires groupwise quantization, got block_size: {weight_tensor.block_size}"
+    )
+
+    nbit = weight_tensor.nbit
+    group_size = weight_tensor.block_size[-1]
+    packed_weight = weight_tensor.packed_weight
+    scales = weight_tensor.scales
+    zeros = weight_tensor.zeros
+    original_shape = weight_tensor.shape
+    use_native_int8 = getattr(weight_tensor, "use_native_int8", False)
+
+    orig_act_size = input_tensor.size()
+    orig_dtype = input_tensor.dtype
+    orig_k = input_tensor.shape[-1]
+
+    # Fold batch dimensions into the first dimension
+    act_mat = input_tensor.reshape(-1, input_tensor.shape[-1])
+
+    # The kernel requires activation dtype to match scale/zero dtype.
+    act_mat = act_mat.to(scales.dtype)
+
+    # --- Native int8 per-channel delegation ---
+    # When use_native_int8 is set, the weight is stored in native
+    # _weight_int8pack_mm format ([N, K] int8 + [N] 1D scales).
+    # Route directly to the native operator (see from_hp comment for why
+    # the generalized kernel cannot handle per-channel int8).
+    if use_native_int8:
+        k_padded = packed_weight.size(-1)
+        if k_padded != orig_k:
+            act_mat = torch.nn.functional.pad(act_mat, (0, k_padded - orig_k))
+        y = torch.ops.aten._weight_int8pack_mm(act_mat, packed_weight, scales)
+        orig_out_features = original_shape[-2]
+        y = y[:, :orig_out_features]
+        y = y.reshape(*orig_act_size[:-1], orig_out_features)
+        if bias is not None:
+            y = y + bias.to(y.dtype)
+        return y.to(orig_dtype)
+
+    # Pad the activation's K dimension to match the packed weight's K.
+    # from_hp pads K to a multiple of 32.
+    # packed_weight is [N_pad, nbit*K_pad/8]
+    # so K_pad = packed_weight.size(-1) * 8 / nbit >= orig_k.
+    # The padded K columns of the weight are quantized to zero, so they
+    # contribute nothing.
+    k_padded = packed_weight.size(-1) * 8 // nbit
+    if k_padded != orig_k:
+        act_mat = torch.nn.functional.pad(act_mat, (0, k_padded - orig_k))
+
+    # Run the experimental MPS low-bit linear
+    linear_op = getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+    y = linear_op(act_mat, packed_weight, group_size, scales, zeros)
+
+    # Trim output features (remove N padding)
+    orig_out_features = original_shape[-2]
+    y = y[:, :orig_out_features]
+
+    # Unfold batch dimensions
+    y = y.reshape(*orig_act_size[:-1], orig_out_features)
+
+    if bias is not None:
+        y = y + bias.to(y.dtype)
+
+    return y.to(orig_dtype)
+
+
+@implements(torch.ops.aten.t.default)
+def _(func, _types, args, _kwargs):
+    """.t() accessor — dequantize, transpose, return plain tensor."""
+    (self,) = args
+    dequant = self.dequantize()
+    return torch.ops.aten.t.default(dequant)
+
+
+@implements(torch.ops.aten.permute.default)
+def _(func, _types, args, _kwargs):
+    """Permute — dequantize, permute, return plain tensor."""
+    self, dims = args
+    dequant = self.dequantize()
+    return torch.ops.aten.permute.default(dequant, dims)
+
+
+@implements(torch.ops.aten.transpose.int)
+def _(func, _types, args, _kwargs):
+    """Transpose — dequantize, transpose, return plain tensor."""
+    self, dim0, dim1 = args
+    dequant = self.dequantize()
+    return torch.ops.aten.transpose.int(dequant, dim0, dim1)
+
+
+@implements(torch.ops.aten.slice.Tensor)
+def _(func, _types, args, _kwargs):
+    """Slice — dequantize, slice, return plain tensor.  Simple but correct."""
+    self, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
+    dequant = self.dequantize()
+    sliced = torch.ops.aten.slice.Tensor(dequant, dim, start, end, step)
+    return sliced
+
+
+def _dequantize_int_n_mps_experimental(
+    weight: "IntxMPSExperimentalTensor",
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """Dequantize to a plain tensor by unpacking and applying scale/zero.
+
+    Uses the experimental _linear_fp_act_{nbit}bit_weight with an identity
+    matrix to unpack the low-bit weights, similar to how
+    Int4TilePackedTo4dTensor dequantizes.
+    """
+    nbit = weight.nbit
+    _ensure_mps_experimental_lib_loaded(nbit)
+
+    orig_shape = weight.shape  # (out_features, in_features)
+    out_features, in_features = orig_shape[-2], orig_shape[-1]
+    packed_weight = weight.packed_weight
+    scales = weight.scales
+    zeros = weight.zeros
+    group_size = weight.block_size[-1]
+    device = packed_weight.device
+    dtype = scales.dtype
+
+    # Build identity matrix to extract weight rows
+    # packed_weight is [N_padded, nbit*K_padded/8]
+    k_padded = packed_weight.size(-1) * 8 // nbit
+    identity = torch.eye(in_features, k_padded, device=device, dtype=dtype)
+
+    # Run the linear op: identity @ packed_weight → [in_features, N_padded]
+    if getattr(weight, "use_native_int8", False):
+        # Native int8: packed_weight is [N, K] int8, scales is [N] 1D
+        y = torch.ops.aten._weight_int8pack_mm(identity, packed_weight, scales)
+    else:
+        linear_op = getattr(torch.ops.torchao, f"_linear_fp_act_{nbit}bit_weight")
+        y = linear_op(identity, packed_weight, group_size, scales, zeros)
+
+    # Trim to original shape and transpose
+    y = y[:in_features, :out_features].t().contiguous()
+
+    if output_dtype is not None:
+        y = y.to(output_dtype)
+    return y
+
+
+# Attach dequantize as a method on the tensor subclass
+IntxMPSExperimentalTensor.dequantize = _dequantize_int_n_mps_experimental
+
+IntxMPSExperimentalTensor.__module__ = "torchao.prototype.quantization.intx_mps"
+
+# Allow a model with IntxMPSExperimentalTensor weights to be loaded with `weights_only=True`
+torch.serialization.add_safe_globals([IntxMPSExperimentalTensor])
+

--- a/torchao/prototype/safetensors/safetensors_utils.py
+++ b/torchao/prototype/safetensors/safetensors_utils.py
@@ -12,6 +12,9 @@ from torchao.prototype.mx_formats.nvfp4_tensor import (
     NVFP4Tensor,
     QuantizeTensorToNVFP4Kwargs,
 )
+from torchao.prototype.quantization.intx_mps.intx_mps_experimental_tensor import (
+    IntxMPSExperimentalTensor,
+)
 from torchao.quantization import (
     Float8Tensor,
     Int4PlainInt32Tensor,
@@ -46,6 +49,7 @@ ALLOWED_CLASSES = {
     "ScaleCalculationMode": ScaleCalculationMode,
     "NVFP4Tensor": NVFP4Tensor,
     "QuantizeTensorToNVFP4Kwargs": QuantizeTensorToNVFP4Kwargs,
+    "IntxMPSExperimentalTensor": IntxMPSExperimentalTensor,
 }
 
 ALLOWED_TENSORS_SUBCLASSES = [
@@ -57,6 +61,7 @@ ALLOWED_TENSORS_SUBCLASSES = [
     "Int4PlainInt32Tensor",
     "MXTensor",
     "NVFP4Tensor",
+    "IntxMPSExperimentalTensor",
 ]
 
 __all__ = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

Currently, the inference speed of both stable and experimental torchao and pytorch MPS-based quantization is very slow for all but pytorch's 8-bit per-channel.

To address this, I added a new experimental simdgroup-tiled GEMM kernel to speed up prefill by **roughly 4-7x** relative to the older experimental MPS kernels and generalized the kernel to support int1-int8 quantization (see benchmarks below). I also compare performance against pytorch's native int4/8 kernel, as well as torchao's stable int8 quant, and further document the performance gaps that this PR addresses. 

> **A note about AI:** I used GLM 5.2 in Devin Desktop (formerly Windsurf) for implementation assistance. I have personally completed multiple rounds of review, refinement, and verification before submission. To the best of my knowledge all code, comments, and explanations are accurate and correct. I welcome any feedback or suggestions for improvement.

Below is an overview of the core MPS changes.

**Metal kernels:**

- **Modified Decode `qmv.metal`** (M=1): Added 8-bit support.
- **New Prefill `intNgemm.metal`** (M>1): Simdgroup MMA outer-product accumulation, generalized for int1-int8. Tiling adapted from PyTorch's `kernel_mul_mm`. Dequantization is the bitwise inverse of the packing functions in `packing.h`.
- **Old prefill per-bitwidth kernels** (`int1mm.metal`, `int2mm_opt.metal`, etc.) (M>1): Tree reduction without simdgroup MMA. Used when simdgroup GEMM is disabled for comparative benchmarking.

**Modified C++ dispatch and routing:**

- **`dispatch.h`**: New `dispatch_gemm()` function for the simdgroup GEMM threadgroup/memory layout.
- **`lowbit.h`**: Added `LowBitConfig<8>` specialization and `gemm_func_prefix`/`gemm_dispatch_fn` to all `LowBitConfig<1-8>`. New dispatch logic in `get_shader_func_and_dispatch` routes M>1 to the GEMM kernel when K and group_size are multiples of 32, with env-var fallback (`TORCHAO_MPS_DISABLE_SIMDGROUP_GEMM=1`) to the old per-bitwidth path.
- **`packing.h`**: Added `pack<8>` specialization (direct byte copy, since 8-bit needs no bit-packing).
- **`metal.yaml`**: Registered the `intNgemm` → `intNgemm.metal` shader mapping.

**Modified Op library registration:**

- **`linear_fp_act_xbit_weight_aten.mm`**, **`linear_fp_act_xbit_weight_executorch.mm`**, **`mps_op_lib.py`**, **`utils.py`**: Extended all op definitions, implementations, meta kernels, and loading from 1-7 bit to 1-8 bit (`_pack_weight_8bit`, `_linear_fp_act_8bit_weight`).

**Tensor and config:**

- **New Tensor `IntxMPSExperimentalTensor`**: Added support for int1-int8 with group sizes {32, 64, 128, 256}. int8 per-channel quantization (group_size=K) delegates to PyTorch's native `_weight_int8pack_mm`, which is faster for that case and uses simdgroup MMA too (see [PR #127646](https://github.com/pytorch/pytorch/pull/127646)).
- **Modified `quant_api.py`**: `UIntxWeightOnlyConfig` extended to 8-bit and per-channel (`group_size=-1`). The handler now routes `min_max` to `IntxMPSExperimentalTensor` instead of the old `UIntxWeightOnlyQuantizedLinear` path.

**Tangential changes:**

- **`safetensors_utils.py`** + test: Registered `IntxMPSExperimentalTensor` for safetensors serialization.
- **`metal_test.yml`**: Added CI for the new `test_intNgemm.py` test suite.
- **`test_quantizer.py`**: Extended bitwidth range to 1-8 and added `TestIntxMPSExperimentalTensor` with SQNR accuracy tests exercising the new tensor via `quantize_`.
- **`benchmarks/benchmark_mps.py`**: New benchmark harness measuring decode/prefill latency and top-1 next-token agreement, with checkpointing for incremental runs.

## State of MPS quantization in the PyTorch ecosystem

PyTorch is centralizing all quantization development into TorchAO (see [docs.pytorch.org/docs/main/quantization.html](https://docs.pytorch.org/docs/main/quantization.html)). `torch.ao.quantization` has been deprecated with a runtime warning since PyTorch 2.10, with pt2e quantization migrated to TorchAO. Full deletion was planned for 2.10 but has been deferred pending blockers; as of PyTorch 2.14 the legacy APIs are still present.

Separately from the pt2e migration, TorchAO's stable eager-mode `Int4WeightOnlyConfig` (the high-level API for weight-only int4 quantization) has its own MPS gap. With its default `int4_packing_format=PLAIN`, it hard-requires [MSLK](https://github.com/meta-pytorch/MSLK) (Meta Superintelligence Labs Kernels, formerly FBGEMM GenAI), which is CUDA/ROCm only and provides no MPS backend. The `Int4Tensor` it produces calls `torch.ops.mslk.bf16i4bf16_rowwise` for the linear op and `mslk.quantize.shuffle.int4_row_quantize_zp` for quantization, with no fallback to PyTorch's native MPS ops. (The `TILE_PACKED_TO_4D` packing format does use native PyTorch ops, but requires CUDA and is not available on MPS either.)

TorchAO's `Int8WeightOnlyConfig` does work on MPS but uses a generic `Int8Tensor` subclass that does not dispatch to PyTorch's native `_weight_int8pack_mm`. In the benchmark below, it was 6x slower on decode and 15% slower on prefill compared to directly calling the native op.

PyTorch core ships native MPS quantized ops (`_weight_int4pack_mm`, `_weight_int8pack_mm`) in `aten/src/ATen/native/mps/`, but these are low-level `aten` ops with no user-facing quantization flow. Since PyTorch is no longer building high-level quantization APIs, the gap between these native ops and TorchAO's config classes is unbridged on MPS.

This PR's experimental `UIntxWeightOnlyConfig` and `IntxMPSExperimentalTensor` bridge that gap by dispatching directly to the native MPS ops for int8 per-channel and to the `intNgemm.metal` kernel for int1-int8 groupwise quantization. This addresses the eager-mode weight-only quantization gap only; pt2e quantization on MPS (which targets deployment backends like ExecuTorch) is out of scope for this PR.

## Group size support

Like the old experimental Metal kernels, the new generalized kernel is templated on `group_size` as a compile-time constant (32, 64, 128, 256), which allows constant folding of expressions like `scale_step_per_thread = group_size / values_per_thread`. The generalized kernel supports these four group sizes for int1-int8. int8 per-channel (group_size=K) is handled by native delegation, not the generalized kernel.

## HQQ

I included 4-bit HQQ with gs=64 in the benchmark to verify it works with the new kernel with the prefill improvement. The other configs skip HQQ to save time running the benchmark since it is much slower to set up on the fly than the other quantization methods.

## Benchmarks

The benchmark measures decode latency (M=1), prefill latency (M=2048), and top-1 next-token agreement with the bf16 baseline. Results are checkpointed to `/tmp/benchmark_mps_checkpoint.json` for incremental runs (`--clear-cache` to reset).

**Device:** Apple M4 Pro

**Model:** Qwen/Qwen3.5-4B

All latencies in ms; speedups vs bf16 eager baseline.

| Key      | Description                                                       |
| -------- | ----------------------------------------------------------------- |
| `DCmean` | decode latency (M=1)                                              |
| `DCsp`   | decode speedup vs bf16                                            |
| `M=N`    | prefill latency for N tokens                                      |
| `Msp`    | prefill speedup vs bf16                                           |
| `top1`   | next-token agreement with bf16 baseline (%)                       |
| `old`    | upstream per-bitwidth GEMM (no simdgroup MMA)                     |
| `new`    | simdgroup-tiled GEMM (intNgemm.metal)                             |
| `torch`  | native PyTorch MPS (\_weight_int4pack_mm / \_weight_int8pack_mm)  |
| `wo`     | stable Int8WeightOnlyConfig (Int8Tensor, no \_weight_int8pack_mm) |
| `hqq`    | HQQ qparams algorithm (same \_linear_fp_act kernel)               |

**Bold** = significantly best within bitwidth (CIs don't overlap aside from ties)

**Samples:** 10 timed runs per latency measurement (after 5 warmup), 15 windows for top-1. **CIs:** 95% t-distribution (two-sided, Bessel-corrected).

**Data:** wikitext-103 test split, 15 non-overlapping 2048-token windows sampled uniformly with a fixed seed (42). Latency runs cycle through these windows (one per run); top-1 uses all windows (no warmup discard, since top-1 is deterministic per window).

**Quality metric:** top-1 next-token agreement with bf16 baseline. KL divergence is not reported because it requires retaining the full baseline logits tensor for every window (~970 MB per window, ~14.5 GB for 15 windows) to compare against each quantized config. Top-1 only needs the argmax (a [1, SEQ_LEN] int64 tensor per window, ~16 KB), which is negligible.

| Bits    | gs     | DCmean            | DCsp      | M=2048             | Msp       | top1              |
| ------- | ------ | ----------------- | --------- | ------------------ | --------- | ----------------- |
| bf16    | -      | 92.39<br>±0.4     | 1.00x     | 3950.8<br>±1.3     | 1.00x     | 100.0%<br>±0.0    |
| 2old    | 64     | 64.36<br>±0.2     | 1.44x     | 15138.3<br>±3.4    | 0.26x     | **8.1%**<br>±1.9  |
| 2new    | 64     | 63.42<br>±0.2     | 1.46x     | 4064.9<br>±0.5     | 0.97x     | **8.0%**<br>±1.9  |
| 2old    | 128    | 64.19<br>±0.2     | 1.44x     | 15123.6<br>±0.6    | 0.26x     | 3.3%<br>±0.9      |
| 2new    | 128    | **63.05**<br>±0.1 | **1.47x** | **4054.3**<br>±0.2 | **0.97x** | 3.3%<br>±0.9      |
| 4old    | 64     | 67.36<br>±0.3     | 1.37x     | 15197.1<br>±0.8    | 0.26x     | **86.9%**<br>±0.6 |
| 4oldhqq | 64     | 68.55<br>±0.1     | 1.35x     | 15221.4<br>±54.1   | 0.26x     | **87.5%**<br>±0.6 |
| 4new    | 64     | 67.31<br>±0.1     | 1.37x     | 4093.9<br>±5.5     | 0.97x     | **87.0%**<br>±0.6 |
| 4newhqq | 64     | 67.27<br>±0.2     | 1.37x     | 4254.5<br>±25.6    | 0.93x     | **87.5%**<br>±0.6 |
| 4torch  | 64     | 68.92<br>±0.1     | 1.34x     | 15522.0<br>±15.4   | 0.25x     | 81.4%<br>±0.8     |
| 4old    | 128    | **66.69**<br>±0.1 | **1.39x** | 15166.2<br>±0.4    | 0.26x     | 84.6%<br>±0.9     |
| 4new    | 128    | **66.72**<br>±0.1 | **1.38x** | **4074.5**<br>±0.5 | **0.97x** | 84.8%<br>±0.8     |
| 4torch  | 128    | 69.78<br>±0.3     | 1.32x     | 15520.8<br>±15.5   | 0.25x     | 79.1%<br>±0.9     |
| 6old    | 64     | 71.74<br>±0.2     | 1.29x     | 30281.9<br>±5.5    | 0.13x     | 96.2%<br>±0.3     |
| 6new    | 64     | 71.71<br>±0.2     | 1.29x     | 4149.4<br>±2.4     | 0.95x     | 96.2%<br>±0.3     |
| 6old    | 128    | 74.48<br>±0.3     | 1.24x     | 28656.5<br>±13.5   | 0.14x     | 95.8%<br>±0.3     |
| 6new    | 128    | **71.08**<br>±0.1 | **1.30x** | **4130.7**<br>±0.5 | **0.96x** | 95.8%<br>±0.4     |
| 8torch  | per-ch | **75.15**<br>±0.4 | **1.23x** | **4016.5**<br>±0.5 | **0.98x** | 97.6%<br>±0.3     |
| 8wo     | per-ch | 475.06<br>±0.9    | 0.19x     | 4670.9<br>±36.5    | 0.85x     | 97.5%<br>±0.3     |
| 8new    | 64     | 75.98<br>±0.4     | 1.22x     | 4158.5<br>±0.2     | 0.95x     | **98.3%**<br>±0.1 |
| 8new    | 128    | **75.48**<br>±0.3 | **1.22x** | 4149.4<br>±0.5     | 0.95x     | **98.1%**<br>±0.2 |

Copyright (c) 2026 Matthew Spinelli
