### PR TITLE
fix(float8): handle aten.abs and amax-path ops in Float8TrainingTensor dispatch

### DIFF
--- a/test/float8/test_base.py
+++ b/test/float8/test_base.py
@@ -156,6 +156,50 @@ class TestFloat8TrainingTensor:
             assert fp8_a_transposed._axiswise_dim == expected_axiswise_dim
             assert fp8_b_t._axiswise_dim == expected_axiswise_dim
 
+    def test_abs_and_amax_dispatch(self):
+        # Tensorwise scaling
+        a = torch.randn((16, 16), dtype=torch.bfloat16)
+        scale_a = tensor_to_scale(a, e4m3_dtype)
+        fp8_a = hp_tensor_and_scale_to_float8(a, scale_a, e4m3_dtype)
+
+        abs_fp8 = torch.abs(fp8_a)
+        assert abs_fp8.dtype == torch.bfloat16
+        torch.testing.assert_close(abs_fp8, torch.abs(fp8_a.to_original_precision()))
+
+        max_fp8 = torch.max(abs_fp8)
+        torch.testing.assert_close(
+            max_fp8, torch.max(torch.abs(fp8_a.to_original_precision()))
+        )
+
+        amax_fp8 = torch.amax(abs_fp8, dim=-1, keepdim=True)
+        torch.testing.assert_close(
+            amax_fp8,
+            torch.amax(torch.abs(fp8_a.to_original_precision()), dim=-1, keepdim=True),
+        )
+
+        # Direct max and amax on Float8TrainingTensor
+        max_direct = torch.max(fp8_a)
+        torch.testing.assert_close(max_direct, torch.max(fp8_a.to_original_precision()))
+
+        # Axiswise scaling
+        for axiswise_dim in (0, -1):
+            fp8_axiswise = hp_tensor_and_scale_to_float8(
+                a, scale_a, e4m3_dtype, axiswise_dim=axiswise_dim
+            )
+            abs_axiswise = torch.abs(fp8_axiswise)
+            torch.testing.assert_close(
+                abs_axiswise, torch.abs(fp8_axiswise.to_original_precision())
+            )
+            amax_axiswise = torch.amax(abs_axiswise, dim=axiswise_dim, keepdim=True)
+            torch.testing.assert_close(
+                amax_axiswise,
+                torch.amax(
+                    torch.abs(fp8_axiswise.to_original_precision()),
+                    dim=axiswise_dim,
+                    keepdim=True,
+                ),
+            )
+
     @pytest.mark.parametrize("shape", [(8, 16), (4, 8, 16), (2, 4, 8, 16)])
     @pytest.mark.parametrize("axiswise_dim", [0, -1])
     @pytest.mark.parametrize("round_scales_to_power_of_2", [True, False])

--- a/torchao/float8/float8_ops.py
+++ b/torchao/float8/float8_ops.py
@@ -299,16 +299,27 @@ def float8_cat(aten_op, args, kwargs=None):
     return Float8TrainingTensor(new_data, scale, orig_dtype, mm_config, gemm_input_role)
 
 
-@implements([aten.sum.dim_IntList])
+@implements(
+    [
+        aten.sum.dim_IntList,
+        aten.abs.default,
+        aten.max.default,
+        aten.max.dim,
+        aten.amax.default,
+    ]
+)
 def float8_cast_up_op(aten_op, args, kwargs=None):
     """Be careful with this function, this is a "fallback" op that
     casts the output of the op to the original precision. And performs the op.
 
-    We currently need this to support the backward for admmm bias.
-    "addmm" -> out
-    "hp_gradBias" <-"sum" <- "identity" <- gradOut <- "hp_gradOut"
+    We currently need this to support:
+    - the backward for addmm bias:
+      "addmm" -> out
+      "hp_gradBias" <-"sum" <- "identity" <- gradOut <- "hp_gradOut"
+    - amax-path ops (abs, max, amax) during backward retrace under HOP
     """
-    _assert_tensorwise_scale(aten_op, args[0]._scale)
+    if aten_op == aten.sum.dim_IntList:
+        _assert_tensorwise_scale(aten_op, args[0]._scale)
 
     def unwrap(x):
         if isinstance(x, Float8TrainingTensor):
@@ -316,7 +327,7 @@ def float8_cast_up_op(aten_op, args, kwargs=None):
         return x
 
     new_args = tree_map(unwrap, args)
-    new_kwargs = tree_map(unwrap, kwargs)
+    new_kwargs = tree_map(unwrap, kwargs) if kwargs else {}
     return aten_op(*new_args, **new_kwargs)
 
 


### PR DESCRIPTION
## Summary
Fixes #4864.

In commit ca74881 ("Remove Float8 allow-in-graph custom autograd wrappers", #4840), the Float8 `autograd.Function` classes were routed through Dynamo's `AutogradFunctionApply` HOP. Under `torch.compile` + DTensor tensor parallelism, the backward pass is now captured and retraced by `make_fx` / FX `Interpreter`.

During that retrace, `tensor_to_amax` calls `torch.abs()` (and subsequently `torch.max` / `torch.amax`) on `Float8TrainingTensor`. Because `aten.abs.default` was absent from `FLOAT8_OPS_TABLE`, `Float8TrainingTensor.__torch_dispatch__` raised:
```
NotImplementedError: attempting to run aten.abs.default, this is not supported
```
This broke `_test_fp8_mlp_tensor_parallelism_compile` in `test/float8/test_dtensor.py` and caused recurring CI failures on `main` for 4xH100 and ROCm workflows.

## Changes
1. Registered `aten.abs.default`, `aten.max.default`, `aten.max.dim`, and `aten.amax.default` under `float8_cast_up_op` in `torchao/float8/float8_ops.py`. During backward retracing under HOP, these ops unwrap to the original high-precision tensor (`to_original_precision()`) and execute natively in high precision.
2. Removed the restrictive `_assert_tensorwise_scale` requirement for elementwise and reduction ops other than `aten.sum.dim_IntList`, ensuring rowwise and axiswise scaled tensors are handled without assertion errors.
3. Added unit tests in `test/float8/test_base.py` (`test_abs_and_amax_dispatch`) covering `torch.abs`, `torch.max`, and `torch.amax` dispatch for both tensorwise and axiswise `Float8TrainingTensor` instances.

## Test Plan
- Ran unit tests locally:
  ```bash
  pytest test/float8/test_base.py -k test_abs_and_amax_dispatch -v
  ```
  Result: PASSED.
- Ran lint and formatting checks:
  ```bash
  ruff format --check torchao/float8/float8_ops.py test/float8/test_base.py
  ruff check torchao/float8/float8_ops.py test/float8/test_base.py
  ```
  Result: All checks passed.