### PR TITLE
Fix scalar collapse for all-ones block_size in tinygemm / dont_preserve_zero qparams

### DIFF
--- a/test/quantization/test_quant_primitives.py
+++ b/test/quantization/test_quant_primitives.py
@@ -14,6 +14,7 @@ from torchao.quantization.granularity import PerRow
 from torchao.quantization.quant_primitives import (
     MappingType,
     ZeroPointDomain,
+    _choose_qparams_affine_dont_preserve_zero,
     _choose_qparams_affine_tinygemm,
     _choose_qparams_and_quantize_scale_only_sinq,
     _choose_scale_float8,
@@ -628,6 +629,74 @@ class TestQuantPrimitives(unittest.TestCase):
         block_size = (1, 1)
         with self.assertRaisesRegex(RuntimeError, "is invalid for input of size 1"):
             _ = quantize_affine(input, block_size, scale, zero_point, dtype)
+
+    def test_choose_qparams_affine_all_ones_block_size(self):
+        """Regression test for https://github.com/pytorch/ao/issues/3458.
+
+        A ``block_size`` of all 1s (e.g. ``PerGroup(1)``) means every element is
+        its own block, so ``_get_reduction_params`` returns an empty
+        ``reduction_dims``. ``torch.amin``/``amax`` treat an empty ``dim`` the
+        same as ``dim=None`` -- reducing over *all* dims -- which collapses the
+        per-element min/max to a single scalar shared by the whole tensor, so
+        the returned scale/zero_point have one element instead of one per input
+        element and quantizing then raises a shape-mismatch ``RuntimeError``.
+
+        ``_choose_qparams_affine`` was fixed for this; the two specialized
+        variants exercised here (used by the tinygemm / ``preserve_zero=False``
+        paths) had the identical bug.
+        """
+        torch.manual_seed(0)
+        input = torch.randn(3, 4)
+        block_size = (1, 1)
+        for fn in (
+            _choose_qparams_affine_tinygemm,
+            _choose_qparams_affine_dont_preserve_zero,
+        ):
+            scale, zero_point = fn(
+                input,
+                MappingType.ASYMMETRIC,
+                block_size,
+                torch.int32,
+                quant_min=0,
+                quant_max=15,
+            )
+            # one scale/zero_point per input element, not a single shared scalar
+            self.assertEqual(scale.numel(), input.numel())
+            self.assertEqual(zero_point.numel(), input.numel())
+
+            # each element's qparams must equal computing that element on its
+            # own as a 1x1 block -- a formula-independent oracle for what an
+            # all-ones block_size means ("every element is its own block")
+            scale = scale.reshape(input.shape)
+            zero_point = zero_point.reshape(input.shape)
+            for i in range(input.shape[0]):
+                for j in range(input.shape[1]):
+                    s_ij, z_ij = fn(
+                        input[i : i + 1, j : j + 1],
+                        MappingType.ASYMMETRIC,
+                        block_size,
+                        torch.int32,
+                        quant_min=0,
+                        quant_max=15,
+                    )
+                    self.assertTrue(torch.allclose(scale[i, j], s_ij.reshape(())))
+                    self.assertTrue(
+                        torch.allclose(
+                            zero_point[i, j].float(), z_ij.reshape(()).float()
+                        )
+                    )
+
+            # end to end: quantizing with these qparams must not raise the
+            # shape-mismatch RuntimeError reported in the issue
+            _ = quantize_affine(
+                input,
+                block_size,
+                scale.reshape(-1),
+                zero_point.reshape(-1),
+                torch.int32,
+                quant_min=0,
+                quant_max=15,
+            )
 
     def test_get_groupwise_affine_qparams(self):
         input = torch.randn(10, 256)

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -1347,8 +1347,18 @@ def _choose_qparams_affine_tinygemm(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
+    if len(reduction_dims) == 0:
+        # `block_size` is 1 in every dim (e.g. `PerGroup(1)`), so every element
+        # is its own block and there is nothing to reduce over: each element is
+        # its own min/max. `torch.amin`/`amax` treat an empty `dim` like
+        # `dim=None` -- reducing over *all* dims -- which would otherwise
+        # collapse this to a single scalar shared by the whole tensor instead
+        # of one value per element (see https://github.com/pytorch/ao/issues/3458).
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
 
     # For preserve_zero=False, we don't ensure zero is exactly representable
     min_val_neg = min_val
@@ -1418,8 +1428,18 @@ def _choose_qparams_affine_dont_preserve_zero(
     )
     input = input.view(shape_for_reduction)
 
-    min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
-    max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
+    if len(reduction_dims) == 0:
+        # `block_size` is 1 in every dim (e.g. `PerGroup(1)`), so every element
+        # is its own block and there is nothing to reduce over: each element is
+        # its own min/max. `torch.amin`/`amax` treat an empty `dim` like
+        # `dim=None` -- reducing over *all* dims -- which would otherwise
+        # collapse this to a single scalar shared by the whole tensor instead
+        # of one value per element (see https://github.com/pytorch/ao/issues/3458).
+        min_val = input
+        max_val = input
+    else:
+        min_val = torch.amin(input, dim=reduction_dims, keepdim=False)
+        max_val = torch.amax(input, dim=reduction_dims, keepdim=False)
 
     # For no preserve zero, we don't ensure zero is exactly representable
     min_val_neg = min_val


### PR DESCRIPTION
## Summary

Fixes the all-ones `block_size` (`PerGroup(1)`) scalar-collapse bug (#3458) in the
two specialized qparam functions that #4812 does not touch:
`_choose_qparams_affine_tinygemm` and `_choose_qparams_affine_dont_preserve_zero`.

## Problem

Both functions compute per-block min/max with
`torch.amin(input, dim=reduction_dims)`. When `block_size` is `1` in every
dimension (e.g. `PerGroup(1)`, where each element is its own block),
`_get_reduction_params` returns an empty `reduction_dims`. `torch.amin`/`amax`
treat an empty `dim` the same as `dim=None` and reduce over *all* dimensions, so
instead of one min/max per element you get a single scalar shared by the whole
tensor. The returned scale/zero_point then have `1` element instead of
`input.numel()`, and quantizing raises:

```
RuntimeError: ... is invalid for input of size 1
```

This is the same root cause fixed for `_choose_qparams_affine` in #4812; these
two variants (used by the tinygemm int4 and `preserve_zero=False` paths) had the
identical bug.

## Fix

Short-circuit to `min_val = max_val = input` when `reduction_dims` is empty
(there is nothing to reduce over, so each element is its own min/max). Non-empty
`reduction_dims` is untouched, so every existing (non-all-ones) call takes the
original `torch.amin` path unchanged.

## Scope

`_choose_qparams_gguf` also calls `torch.amin(input, dim=reduction_dims)`, but it
is a specialized fixed-block (super-block) path where an all-ones `block_size` is
not a valid configuration and guarding `amin` alone would not make it correct end
to end; it is intentionally left out of scope.

## Test

`test_choose_qparams_affine_all_ones_block_size` verifies, for both functions,
that an all-ones `block_size`:

- yields one scale/zero_point per input element (not a single shared scalar),
- matches computing each element independently as its own `1x1` block
  (a formula-independent oracle for what an all-ones block means), and
- lets `quantize_affine` run without raising the shape-mismatch `RuntimeError`.

The test fails on `main` without this change and passes with it.

```
pytest test/quantization/test_quant_primitives.py -k all_ones_block_size
```

Closes part of #3458 (the two variants); complements #4812.
