### PR TITLE
Make quantize_ skip already-quantized weights

### DIFF
--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -185,6 +185,42 @@ class TestQuantFlow(TestCase):
         quantize_(m, Int8WeightOnlyConfig())
         self.assertEqual([b.fp32_precision for b in backends], before)
 
+    @common_utils.parametrize(
+        "config",
+        [
+            Int8WeightOnlyConfig(),
+            Float8WeightOnlyConfig(),
+        ],
+    )
+    def test_quantize_reapply_is_noop(self, config):
+        # Re-running quantize_() over a model whose weights are already quantized
+        # must be a no-op for those weights instead of re-quantizing them, which
+        # would send an already-quantized tensor back through from_hp() and hit
+        # unimplemented ops (aten.view for Int8Tensor, aten.abs for Float8Tensor).
+        # See https://github.com/pytorch/ao/issues/4845.
+        m = ToyLinearModel().eval()
+        example_inputs = m.example_inputs()
+
+        quantize_(m, config)
+        ref = m(*example_inputs)
+        w1_before = m.linear1.weight
+        w2_before = m.linear2.weight
+
+        # Second pass over the whole model, and directly on an already-quantized
+        # child, must both leave the quantized weights untouched (and warn).
+        with self.assertLogs("torchao.quantization.quant_api", level="WARNING") as cm:
+            quantize_(m, config)
+            quantize_(m.linear1, config)
+        self.assertTrue(
+            any("already quantized" in msg for msg in cm.output),
+            f"expected an 'already quantized' warning, got {cm.output}",
+        )
+
+        # Same parameter objects, same output.
+        self.assertIs(m.linear1.weight, w1_before)
+        self.assertIs(m.linear2.weight, w2_before)
+        self.assertEqual(m(*example_inputs), ref)
+
     def test_dynamic_quant_gpu_singleline(self):
         if is_ROCM():
             self.skipTest("Don't test CPU for ROCM version of torch")

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -167,6 +167,7 @@ def _replace_with_custom_fn_if_matches_filter(
 
 def _is_linear(mod, *args):
     # avoid circular dependencies
+    from torchao.prototype.gptq.observer import GPTQObserverTensor
     from torchao.quantization.qat.affine_fake_quantized_tensor import (
         _AffineFakeQuantizedTensor,
     )
@@ -184,10 +185,16 @@ def _is_linear(mod, *args):
     if isinstance(mod.weight, _AffineFakeQuantizedTensor):
         return False
 
-    # Skip weights that are already quantized by torchao so that a second
-    # quantize_() call is a no-op instead of re-running from_hp() on an
-    # already-quantized tensor, which hits unimplemented ops (see #4845).
     if isinstance(mod.weight, TorchAOBaseTensor):
+        # A GPTQ observer weight is an intermediate (non-final) tensor that the
+        # GPTQ convert step is meant to replace with a real quantized tensor, so
+        # let it through here rather than treating it as already quantized.
+        if isinstance(mod.weight, GPTQObserverTensor):
+            return True
+
+        # Skip weights that are already a final quantized tensor so that a second
+        # quantize_() call is a no-op instead of re-running from_hp() on an
+        # already-quantized tensor, which hits unimplemented ops (see #4845).
         fqn = args[0] if args and args[0] else "<root>"
         logger.warning(
             f"Skipping quantization of '{fqn}': weight is already quantized "

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -170,16 +170,33 @@ def _is_linear(mod, *args):
     from torchao.quantization.qat.affine_fake_quantized_tensor import (
         _AffineFakeQuantizedTensor,
     )
+    from torchao.utils import TorchAOBaseTensor
 
-    # adding weight tensor subclass isinstance check to make sure the weight is only quantized once
-    # when it is shared by multiple linear modules
-    # TODO: check isinstance(TorchAOBaseTensor)?
-    return (
+    if not (
         isinstance(mod, torch.nn.Linear)
         and hasattr(mod, "weight")
-        and not isinstance(mod.weight, _AffineFakeQuantizedTensor)
         and not isinstance(mod, nn.modules.linear.NonDynamicallyQuantizableLinear)
-    )
+    ):
+        return False
+
+    # Skip fake-quantized (QAT) weights. This is intended when a weight is shared
+    # by multiple linear modules, and is not an error, so skip silently.
+    if isinstance(mod.weight, _AffineFakeQuantizedTensor):
+        return False
+
+    # Skip weights that are already quantized by torchao so that a second
+    # quantize_() call is a no-op instead of re-running from_hp() on an
+    # already-quantized tensor, which hits unimplemented ops (see #4845).
+    if isinstance(mod.weight, TorchAOBaseTensor):
+        fqn = args[0] if args and args[0] else "<root>"
+        logger.warning(
+            f"Skipping quantization of '{fqn}': weight is already quantized "
+            f"({type(mod.weight).__name__}); quantize_() does not re-quantize "
+            "already-quantized weights."
+        )
+        return False
+
+    return True
 
 
 def _get_subclass_inserter(cls, enable_parametrization=False, **kwargs):


### PR DESCRIPTION
Summary:
A second quantize_() over a module whose weight is already a TorchAO
quantized tensor re-ran from_hp() on it, hitting unimplemented ops
(aten.view for Int8Tensor, aten.abs for Float8Tensor) and raising
NotImplementedError (#4845). This extends the default _is_linear filter
to skip any weight that is already a TorchAOBaseTensor (with a warning),
making re-application a no-op for all configs. The existing QAT
_AffineFakeQuantizedTensor skip is kept first and silent.

Test Plan:
pytest test/quantization/test_quant_api.py -k reapply
pytest test/quantization/test_qat.py -k "convert or prepare or ptq or api"