### PR TITLE
Add code owners for low-bit CPU kernels

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,8 +25,8 @@
 /torchao/csrc/ @jerryzh168 @vkuzo @andrewor14
 
 # Low-bit CPU kernels
-/torchao/csrc/cpu/shared_kernels/ @digantdesai @metascroy @jerryzh168 @vkuzo @andrewor14
-/torchao/csrc/cpu/torch_free_kernels/ @digantdesai @metascroy @jerryzh168 @vkuzo @andrewor14
+/torchao/csrc/cpu/shared_kernels/ @digantdesai @metascroy
+/torchao/csrc/cpu/torch_free_kernels/ @digantdesai @metascroy
 
 # Docs
 /docs/ @vkuzo @jerryzh168 @andrewor14
@@ -45,4 +45,3 @@ torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py @Xia-Weiwen @jerry
 /torchao/quantization/quantize_/workflows/int4/int4_plain_int32_tensor.py @liangan1 @vkuzo @jerryzh168 @andrewor14
 .github/scripts/ci_test_xpu.sh @liangan1 @vkuzo @jerryzh168 @andrewor14
 .github/workflows/xpu_test.yml @liangan1 @vkuzo @jerryzh168 @andrewor14
-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,8 +25,8 @@
 /torchao/csrc/ @jerryzh168 @vkuzo @andrewor14
 
 # Low-bit CPU kernels
-/torchao/csrc/cpu/shared_kernels/ @digantdesai @metascroy
-/torchao/csrc/cpu/torch_free_kernels/ @digantdesai @metascroy
+/torchao/csrc/cpu/shared_kernels/ @digantdesai @metascroy @vkuzo @andrewor14
+/torchao/csrc/cpu/torch_free_kernels/ @digantdesai @metascroy @vkuzo @andrewor14
 
 # Docs
 /docs/ @vkuzo @jerryzh168 @andrewor14

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,10 @@
 /torchao/kernel/ @jerryzh168 @vkuzo @andrewor14
 /torchao/csrc/ @jerryzh168 @vkuzo @andrewor14
 
+# Low-bit CPU kernels
+/torchao/csrc/cpu/shared_kernels/ @digantdesai @metascroy @jerryzh168 @vkuzo @andrewor14
+/torchao/csrc/cpu/torch_free_kernels/ @digantdesai @metascroy @jerryzh168 @vkuzo @andrewor14
+
 # Docs
 /docs/ @vkuzo @jerryzh168 @andrewor14
 
@@ -41,5 +45,4 @@ torchao/quantization/pt2e/quantizer/x86_inductor_quantizer.py @Xia-Weiwen @jerry
 /torchao/quantization/quantize_/workflows/int4/int4_plain_int32_tensor.py @liangan1 @vkuzo @jerryzh168 @andrewor14
 .github/scripts/ci_test_xpu.sh @liangan1 @vkuzo @jerryzh168 @andrewor14
 .github/workflows/xpu_test.yml @liangan1 @vkuzo @jerryzh168 @andrewor14
-
 


### PR DESCRIPTION
Adds @digantdesai and @metascroy as the code owners for the low-bit CPU kernel implementation under:

- torchao/csrc/cpu/shared_kernels/
- torchao/csrc/cpu/torch_free_kernels/

These specific rules override the broader torchao/csrc ownership rule for those trees.


Related W3 activation-packing parallelization: #4854