### PR TITLE
Fix invalid escape sequences and select W605 so they stay fixed

### DIFF
--- a/benchmarks/float8/utils.py
+++ b/benchmarks/float8/utils.py
@@ -131,7 +131,7 @@ def parse_bw_and_kernel_name(line):
         0.257ms         0.537 GB         2092.43GB/s     triton_red_fused_native_layer_norm_0
     Output: the bandwidth value and the kernel name, or None and None
     """
-    result = re.search(".* ([0-9\.]+)GB/s.*(triton_[a-z_0-9]+)", line)
+    result = re.search(r".* ([0-9\.]+)GB/s.*(triton_[a-z_0-9]+)", line)
     if result:
         return result.group(1), result.group(2)
     else:
@@ -321,7 +321,7 @@ def update_triton_kernels_in_prof_chome_trace_with_torch_logs(
     torch_logs_only = []
     for line in torch_logs_str:
         line = line.replace("\n", "")
-        match = re.match(".* \[__output_code\] (.*)", line)
+        match = re.match(r".* \[__output_code\] (.*)", line)
         if match:
             torch_logs_only.append(match.group(1))
 
@@ -338,16 +338,16 @@ def update_triton_kernels_in_prof_chome_trace_with_torch_logs(
     name_to_start_end = {}
     cur_start, cur_end, cur_name = None, None, None
     for line_num, line in enumerate(torch_logs_only):
-        match_start = re.match("\# kernel path: .*", line)
+        match_start = re.match(r"\# kernel path: .*", line)
         if match_start:
             cur_start = line_num
 
         # triton_red_fused_LayerNorm_3 = async_compile.triton('triton_', '''
-        match_name = re.match("([\w_]+) = async_compile.*", line)
+        match_name = re.match(r"([\w_]+) = async_compile.*", line)
         if match_name:
             cur_name = match_name.group(1)
 
-        match_end = re.match("''', device_str='cuda'\)", line)
+        match_end = re.match(r"''', device_str='cuda'\)", line)
         if match_end:
             cur_end = line_num
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 # NOTE: The AO repo is completely linted.
 # Add linting rules here
-lint.select = ["F", "I"]
+# W605 keeps invalid escape sequences out: they are only a SyntaxWarning
+# today but become a SyntaxError in Python 3.15.
+lint.select = ["F", "I", "W605"]
 lint.ignore = ["E731"]
 
 # Exclude third-party modules

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -1539,7 +1539,7 @@ def _intx_weight_only_transform(
 
 @dataclass
 class FqnToConfig(AOBaseConfig):
-    """Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
+    r"""Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
 
     Args:
         `fqn_to_config`: typing.OrderedDict[str, Optional[AOBaseConfig]]: an


### PR DESCRIPTION
Importing `torchao.quantization.quant_api` on Python 3.12+ prints:

```
torchao/quantization/quant_api.py:1542: SyntaxWarning: invalid escape sequence '\.'
```

There are six such literals in the repo, twelve escapes in total:

| file | what it is |
|---|---|
| `torchao/quantization/quant_api.py:1542` | `FqnToConfig` docstring, in the `re:` examples |
| `benchmarks/float8/utils.py` ×5 | regexes written as plain (non-raw) string literals |

The benchmark ones are the more interesting half. They are regexes — `re.match("\# kernel path: .*", line)`, `re.match("([\w_]+) = async_compile.*", line)` and so on — that happen to work only because Python passes an unrecognised escape through unchanged. Python has warned about this since 3.12 and [makes it a `SyntaxError` in 3.15](https://docs.python.org/3/whatsnew/3.12.html#deprecated), at which point `quant_api` stops importing at all.

## This changes nothing today

Making the literals raw is a no-op for current behaviour, because Python already kept the backslashes:

```
identical=True  compiled_identical=True   r'.* ([0-9\.]+)GB/s.*(triton_[a-z_0-9]+)'
identical=True  compiled_identical=True   r'.* \[__output_code\] (.*)'
identical=True  compiled_identical=True   r'\# kernel path: .*'
identical=True  compiled_identical=True   r'([\w_]+) = async_compile.*'
identical=True  compiled_identical=True   r"''', device_str='cuda'\)"
```

Same strings, same compiled patterns. The docstring becomes `r"""` so the documented regexes keep rendering as written rather than needing doubled backslashes.

## Why this also touches ruff.toml

The one-line `quant_api.py` fix has been submitted three times already — #3825 (closed), #4035 and #4363 (both still open) — and has not stuck. All three touch only that docstring; none touch the five benchmark regexes, and none touch the lint config. Nothing in CI can see this class of problem: `ruff.toml` selects `["F", "I"]`, and the rule that catches invalid escape sequences is `W605`, which lives in `W`.

So the file's own header, `# NOTE: The AO repo is completely linted.`, is not quite true for this class. Selecting `W605` makes it true and stops the next one from landing.

If you would rather take one of the existing PRs for the docstring, I am happy to rebase this down to the benchmark regexes plus the lint rule — the point of it is the rule.

## Verification

`ruff check` over the repo (venv excluded), pinned rule sets:

| | `["F", "I"]` | `["F", "I", "W605"]` |
|---|---|---|
| this branch | All checks passed | All checks passed |
| `main` | All checks passed | **Found 12 errors** |

So the added rule flags exactly what this PR fixes, and the fix introduces no findings under the existing selection. A `compile()` sweep over every `.py` in the repo reports zero `SyntaxWarning`s on this branch, against six on `main`.
