### PR TITLE
Make float8 autograd Function allow_in_graph opt-in via config

### DIFF
--- a/test/float8/test_compile.py
+++ b/test/float8/test_compile.py
@@ -252,6 +252,11 @@ def test_inductor_aot_autograd_cache_rowwise_with_gw_hp():
     config = Float8LinearConfig.from_recipe_name(
         Float8LinearRecipeName.ROWWISE_WITH_GW_HP
     )
+    # AOTAutograd caching requires the plain (undecorated) autograd Functions;
+    # the `allow_in_graph` trampolines are not cacheable. Opt out of
+    # `allow_in_graph` so the cache path under test is exercised.
+    # hack around config being frozen
+    object.__setattr__(config, "_autograd_fn_allow_in_graph", False)
     model = Float8Linear.from_float(
         nn.Linear(16, 32, bias=True, device=device, dtype=torch.bfloat16),
         config,

--- a/torchao/float8/config.py
+++ b/torchao/float8/config.py
@@ -245,6 +245,22 @@ class Float8LinearConfig:
     # same value in the forward pass as the backward passes.
     round_scales_to_power_of_2: bool = False
 
+    # If True (the default), the float8 `torch.autograd.Function`s used in the
+    # training path (matmul, casts, and the grad_output cast in tensor parallel)
+    # are decorated with `@torch._dynamo.allow_in_graph`. This keeps them opaque
+    # to Dynamo (Dynamo does not trace their Python bodies) while still letting
+    # AOTAutograd trace through them and Inductor fuse across the boundary.
+    #
+    # If False, the plain (undecorated) autograd Functions are used. Dynamo then
+    # routes them through the `AutogradFunctionApply` HOP, tracing forward and
+    # backward into static fx subgraphs. This is compatible with AOTAutograd
+    # caching, but the static subgraphs freeze any data-dependent Python branches
+    # (e.g. `tensor_already_casted_to_fp8`) at trace time, which can be incorrect
+    # when the runtime dtype differs from what was traced (see
+    # https://github.com/pytorch/ao/pull/4840). Set to False only if you
+    # understand this tradeoff.
+    _autograd_fn_allow_in_graph: bool = True
+
     def __post_init__(self):
         # Populate the additional cast overrides, if the user did not specify them
         # Note: this hacks around the frozen-ness of this dataclass

--- a/torchao/float8/float8_linear.py
+++ b/torchao/float8/float8_linear.py
@@ -25,12 +25,16 @@ from torchao.float8.float8_training_tensor import (
 from torchao.float8.fsdp_utils import WeightWithDynamicFloat8CastTensor
 
 
-class matmul_with_hp_or_float8_args(torch.autograd.Function):
+class _matmul_with_hp_or_float8_args_impl(torch.autograd.Function):
     """
     Like torch.matmul, but with the arguments in either high precision or float8.
     * if the arguments are in high precision, they are cast to float8 according
       to the specified config
     * if the arguments are in float8, we assume the cast honored the config
+
+    This is the undecorated implementation. See `matmul_with_hp_or_float8_args`
+    for the `allow_in_graph`-decorated variant. Which one is used at runtime is
+    controlled by `Float8LinearConfig._autograd_fn_allow_in_graph`.
     """
 
     @staticmethod
@@ -62,6 +66,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     -1, c.cast_config_input.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         if tensor_already_casted_to_fp8(weight_hp_t):
@@ -79,6 +84,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     0, c.cast_config_weight.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         # the reshapes are needed in order to make the shapes compatible with
@@ -119,6 +125,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     -1, c.cast_config_grad_output.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         if tensor_already_casted_to_fp8(weight_hp_t):
@@ -137,6 +144,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     -1, c.cast_config_weight_for_grad_input.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         grad_input = torch.mm(
@@ -173,6 +181,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     0, c.cast_config_grad_output_for_grad_weight.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         if tensor_already_casted_to_fp8(input_hp_reshaped):
@@ -191,6 +200,7 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
                     0, c.cast_config_input_for_grad_weight.scaling_granularity
                 ),
                 round_scales_to_power_of_2=c.round_scales_to_power_of_2,
+                allow_in_graph=c._autograd_fn_allow_in_graph,
             )
 
         grad_weight = torch.mm(
@@ -201,6 +211,16 @@ class matmul_with_hp_or_float8_args(torch.autograd.Function):
         empty_grads = None, None
 
         return grad_input, grad_weight.t(), *empty_grads
+
+
+@torch._dynamo.allow_in_graph
+class matmul_with_hp_or_float8_args(_matmul_with_hp_or_float8_args_impl):
+    """
+    `allow_in_graph`-decorated variant of `_matmul_with_hp_or_float8_args_impl`.
+    See that class for the implementation.
+    """
+
+    pass
 
 
 class Float8Linear(torch.nn.Linear):
@@ -260,7 +280,12 @@ class Float8Linear(torch.nn.Linear):
             autocast_dtype = torch.get_autocast_gpu_dtype()
             input = input.to(autocast_dtype)
 
-        output = matmul_with_hp_or_float8_args.apply(
+        autograd_fn = (
+            matmul_with_hp_or_float8_args
+            if self.config._autograd_fn_allow_in_graph
+            else _matmul_with_hp_or_float8_args_impl
+        )
+        output = autograd_fn.apply(
             input,
             self.weight.t(),
             self.linear_mm_config,

--- a/torchao/float8/float8_scaling_utils.py
+++ b/torchao/float8/float8_scaling_utils.py
@@ -36,6 +36,7 @@ def hp_tensor_to_float8_dynamic(
     scaling_granularity: ScalingGranularity = ScalingGranularity.TENSORWISE,
     axiswise_dim: Optional[int] = None,
     round_scales_to_power_of_2: bool = False,
+    allow_in_graph: bool = True,
 ) -> Float8TrainingTensor:
     """
     Given a high precision tensor `hp_tensor`,
@@ -52,6 +53,8 @@ def hp_tensor_to_float8_dynamic(
         scaling_granularity: Defines the scaling granularity
         axiswise_dim: if axiswise granularity is used, defines the dim to scale across
         round_scales_to_power_of_2: if true, round scaling factor down to the nearest power of 2.
+        allow_in_graph: if True, use the `allow_in_graph`-decorated autograd Function
+          for the fp8 cast, otherwise use the plain implementation.
     """
     scale = tensor_to_scale(
         hp_tensor,
@@ -69,6 +72,7 @@ def hp_tensor_to_float8_dynamic(
         linear_mm_config,
         gemm_input_role,
         axiswise_dim,
+        allow_in_graph,
     )
 
 
@@ -87,10 +91,14 @@ def get_maybe_axiswise_dim(
     return None
 
 
-class NoopFwToFloat8BwDynamic(torch.autograd.Function):
+class _NoopFwToFloat8BwDynamic_impl(torch.autograd.Function):
     """
     Forward: no-op
     Backward: convert to float8_e5m2 with dynamic scaling
+
+    This is the undecorated implementation. See `NoopFwToFloat8BwDynamic` for the
+    `allow_in_graph`-decorated variant. Which one is used at runtime is
+    controlled by `Float8LinearConfig._autograd_fn_allow_in_graph`.
     """
 
     @staticmethod
@@ -99,15 +107,17 @@ class NoopFwToFloat8BwDynamic(torch.autograd.Function):
         tensor,
         linear_mm_config: LinearMMConfig,
         target_dtype: torch.dtype,
+        allow_in_graph: bool = True,
     ):
         ctx.linear_mm_config = linear_mm_config
         ctx.target_dtype = target_dtype
+        ctx.allow_in_graph = allow_in_graph
         return tensor
 
     @staticmethod
     def backward(ctx, gradY):
         if tensor_already_casted_to_fp8(gradY):
-            return gradY, None, None
+            return gradY, None, None, None
         gradY_scale = tensor_to_scale(gradY, ctx.target_dtype)
         fp8_tensor = hp_tensor_and_scale_to_float8(
             gradY,
@@ -115,5 +125,16 @@ class NoopFwToFloat8BwDynamic(torch.autograd.Function):
             ctx.target_dtype,
             ctx.linear_mm_config,
             GemmInputRole.GRAD_OUTPUT,
+            allow_in_graph=ctx.allow_in_graph,
         )
-        return fp8_tensor, None, None
+        return fp8_tensor, None, None, None
+
+
+@torch._dynamo.allow_in_graph
+class NoopFwToFloat8BwDynamic(_NoopFwToFloat8BwDynamic_impl):
+    """
+    `allow_in_graph`-decorated variant of `_NoopFwToFloat8BwDynamic_impl`. See
+    that class for the implementation.
+    """
+
+    pass

--- a/torchao/float8/float8_tensor_parallel.py
+++ b/torchao/float8/float8_tensor_parallel.py
@@ -17,6 +17,7 @@ from torchao.float8.config import ScalingType, e4m3_dtype
 from torchao.float8.distributed_utils import tensor_already_casted_to_fp8
 from torchao.float8.float8_scaling_utils import (
     NoopFwToFloat8BwDynamic,
+    _NoopFwToFloat8BwDynamic_impl,
     hp_tensor_to_float8_dynamic,
 )
 from torchao.float8.float8_training_tensor import GemmInputRole
@@ -62,6 +63,7 @@ class Float8ColwiseParallel(ColwiseParallel):
                 mod.config.cast_config_input.target_dtype,
                 mod.linear_mm_config,
                 gemm_input_role=GemmInputRole.INPUT,
+                allow_in_graph=mod.config._autograd_fn_allow_in_graph,
             )  # DTensor(Float8TrainingTensor)
 
         # transform the input layouts to the desired layouts of ColwiseParallel
@@ -80,10 +82,15 @@ class Float8ColwiseParallel(ColwiseParallel):
             )  # DTensor(torch.Tensor)
 
         # fwd noop bwd cast to DTensor(Float8TrainingTensor)
-        outputs = NoopFwToFloat8BwDynamic.apply(
+        allow_in_graph = mod.config._autograd_fn_allow_in_graph
+        autograd_fn = (
+            NoopFwToFloat8BwDynamic if allow_in_graph else _NoopFwToFloat8BwDynamic_impl
+        )
+        outputs = autograd_fn.apply(
             outputs,
             mod.linear_mm_config,
             mod.config.cast_config_grad_output.target_dtype,
+            allow_in_graph,
         )
 
         # back to local tensor
@@ -126,6 +133,7 @@ class Float8RowwiseParallel(RowwiseParallel):
                 mod.config.cast_config_input.target_dtype,
                 mod.linear_mm_config,
                 gemm_input_role=GemmInputRole.INPUT,
+                allow_in_graph=mod.config._autograd_fn_allow_in_graph,
             )  # DTensor(Float8TrainingTensor)
 
         if input_layouts != desired_input_layouts:
@@ -143,10 +151,15 @@ class Float8RowwiseParallel(RowwiseParallel):
             outputs = outputs.redistribute(placements=output_layouts, async_op=True)
 
         # fwd noop bwd cast to DTensor(Float8TrainingTensor)
-        outputs = NoopFwToFloat8BwDynamic.apply(
+        allow_in_graph = mod.config._autograd_fn_allow_in_graph
+        autograd_fn = (
+            NoopFwToFloat8BwDynamic if allow_in_graph else _NoopFwToFloat8BwDynamic_impl
+        )
+        outputs = autograd_fn.apply(
             outputs,
             mod.linear_mm_config,
             mod.config.cast_config_grad_output.target_dtype,
+            allow_in_graph,
         )
 
         # back to local tensor if use_local_output is True

--- a/torchao/float8/float8_training_tensor.py
+++ b/torchao/float8/float8_training_tensor.py
@@ -119,11 +119,15 @@ def choose_scaled_mm_config(
         raise AssertionError(f"unexpected a_role {a_role} and b_role {b_role}")
 
 
-class _ToFloat8ConstrFunc(torch.autograd.Function):
+class _ToFloat8ConstrFunc_impl(torch.autograd.Function):
     """
     A differentiable conversion to fp8.
     * forward: convert from high precision to float8
     * backward: pass the gradient without changes
+
+    This is the undecorated implementation. See `_ToFloat8ConstrFunc` for the
+    `allow_in_graph`-decorated variant. Which one is used at runtime is
+    controlled by `Float8LinearConfig._autograd_fn_allow_in_graph`.
     """
 
     @staticmethod
@@ -191,11 +195,24 @@ class _ToFloat8ConstrFunc(torch.autograd.Function):
         return g, None, None, None, None, None
 
 
-class _FromFloat8ConstrFunc(torch.autograd.Function):
+@torch._dynamo.allow_in_graph
+class _ToFloat8ConstrFunc(_ToFloat8ConstrFunc_impl):
+    """
+    `allow_in_graph`-decorated variant of `_ToFloat8ConstrFunc_impl`. See that
+    class for the implementation.
+    """
+
+    pass
+
+
+class _FromFloat8ConstrFunc_impl(torch.autograd.Function):
     """
     A differentiable conversion from fp8.
     * forward: convert from float8 to high precision
     * backward: pass the gradient without changes
+
+    This is the undecorated implementation. See `_FromFloat8ConstrFunc` for the
+    `allow_in_graph`-decorated variant.
     """
 
     @staticmethod
@@ -207,6 +224,16 @@ class _FromFloat8ConstrFunc(torch.autograd.Function):
         return g, None, None
 
 
+@torch._dynamo.allow_in_graph
+class _FromFloat8ConstrFunc(_FromFloat8ConstrFunc_impl):
+    """
+    `allow_in_graph`-decorated variant of `_FromFloat8ConstrFunc_impl`. See that
+    class for the implementation.
+    """
+
+    pass
+
+
 def hp_tensor_and_scale_to_float8(
     hp_tensor: torch.Tensor,
     s: torch.Tensor,
@@ -214,6 +241,7 @@ def hp_tensor_and_scale_to_float8(
     linear_mm_config: Optional[LinearMMConfig] = None,
     gemm_input_role: Optional[GemmInputRole] = GemmInputRole.INPUT,
     axiswise_dim: Optional[int] = None,
+    allow_in_graph: bool = True,
 ):
     """
     Given a high precision tensor `hp_tensor` and a precalculated scale `s`,
@@ -231,8 +259,11 @@ def hp_tensor_and_scale_to_float8(
         gemm_input_role: Defines the role of this tensor (input, weight or grad_output) in
           the 3 fwd/bwd gemms of linear
         axiswise_dim: for rowwise scaling, contains the axis scaled across
+        allow_in_graph: if True, use the `allow_in_graph`-decorated autograd
+          Function, otherwise use the plain implementation
     """
-    return _ToFloat8ConstrFunc.apply(
+    autograd_fn = _ToFloat8ConstrFunc if allow_in_graph else _ToFloat8ConstrFunc_impl
+    return autograd_fn.apply(
         hp_tensor, s, float8_dtype, linear_mm_config, gemm_input_role, axiswise_dim
     )
 
@@ -340,8 +371,11 @@ class Float8TrainingTensor(torch.Tensor):
             metadata["_axiswise_dim"],
         )
 
-    def to_original_precision(self):
-        return _FromFloat8ConstrFunc.apply(self)
+    def to_original_precision(self, allow_in_graph: bool = True):
+        autograd_fn = (
+            _FromFloat8ConstrFunc if allow_in_graph else _FromFloat8ConstrFunc_impl
+        )
+        return autograd_fn.apply(self)
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args, kwargs=None):


### PR DESCRIPTION
Summary:

PR #4840 removed the `@torch._dynamo.allow_in_graph` decorators from the
float8 training-path autograd Functions so that AOTAutograd could cache
the compiled graphs. Without the decorator, Dynamo routes these Functions
through the `AutogradFunctionApply` HOP and traces their forward/backward
into static fx subgraphs. This freezes data-dependent Python branches
(e.g. `tensor_already_casted_to_fp8`) at trace time: the backward is
traced in isolation with a synthesized high-precision cotangent, so the
`grad_output` fp8 guard is constant-folded into an unconditional
high-precision cast. At runtime (e.g. tensor parallel, where
`NoopFwToFloat8BwDynamic.backward` casts the grad to fp8 first) a
`Float8TrainingTensor` flows into that frozen `torch.abs` node and fails
with `NotImplementedError: aten.abs.default`, which broke the distributed
CI job.

This change makes the behavior opt-in instead of a hard switch:

- Add `Float8LinearConfig._autograd_fn_allow_in_graph`, defaulting to
  `True` (the pre-#4840 behavior).
- Restore the `@torch._dynamo.allow_in_graph` decorators, but split each
  Function into an undecorated `_*_impl` holding the logic plus a thin
  decorated subclass. This covers `matmul_with_hp_or_float8_args`,
  `NoopFwToFloat8BwDynamic`, `_ToFloat8ConstrFunc`, and
  `_FromFloat8ConstrFunc`.
- Call sites select the decorated class vs. the `_impl` based on
  `config._autograd_fn_allow_in_graph`, threading the flag through
  `hp_tensor_to_float8_dynamic` / `hp_tensor_and_scale_to_float8` and the
  tensor-parallel input/output prepare hooks.

With the default (`True`), fusion and the data-dependent branches behave
correctly (fixing the CI regression). Users who want AOTAutograd caching
can set the flag to `False` and accept the static-graph limitations. The
`test_inductor_aot_autograd_cache_rowwise_with_gw_hp` cache test is
updated to opt into `False`, since caching is the path it exercises.

Test Plan:

pytest test/float8/test_compile.py::test_inductor_aot_autograd_cache_rowwise_with_gw_hp
NCCL_DEBUG=WARN torchrun --nproc_per_node 2 test/float8/test_dtensor.py

Both pass. Also verified eager forward/backward for both flag values.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>