### PR TITLE
Fix MoE FP8 Triton autotune key

### DIFF
--- a/torchao/prototype/moe_training/kernels/float8_rowwise.py
+++ b/torchao/prototype/moe_training/kernels/float8_rowwise.py
@@ -208,7 +208,7 @@ if has_triton():
         else:
             tl.atomic_min(scales_ptr + scales_offs, scales[None, :], mask=scales_mask)
 
-    @triton.autotune(configs=atomic_kernel_configs_2D, key=["num_elements"])
+    @triton.autotune(configs=atomic_kernel_configs_2D, key=["K", "N"])
     @triton.jit
     def _triton_fp8_rowwise_3d_transpose_cast_rhs_kernel(
         input_ptr,


### PR DESCRIPTION
## Summary

- replace the stale `num_elements` autotune key with the kernel `K` and `N` shape arguments. `num_elements` is not actually an argument in the kernel
- this is functionally a no-op with the current single `atomic_kernel_configs_2D` configuration. it only makes the metadata valid so newer Triton does not reject the kernel during import

## Context

Triton PR https://github.com/triton-lang/triton/pull/11602 validates that every autotune key names a kernel argument. The MoE FP8 transpose cast kernel does not have a `num_elements` argument, which causes TorchAO import to fail in https://github.com/pytorch/pytorch/pull/190440.

## Test plan

- imported `torchao.prototype.moe_training.kernels.float8_rowwise` using PyTorch `831416dd0`, Triton `4e15616d25`, and an NVIDIA H100
- `git diff --check`

Authored with assistance from Codex.