### PR TITLE
[a16-support] Add per-tensor fake quantization

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -307,6 +307,49 @@ class TestQAT(TestCase):
         )
         torch.testing.assert_close(out, out_ptq, atol=0, rtol=0)
 
+    @parametrize("is_dynamic", [True, False])
+    def test_fake_quantize_per_tensor(self, is_dynamic: bool):
+        torch.manual_seed(self.SEED)
+        x = torch.randn(4, 8)
+        block_size = tuple(x.shape)
+        config = IntxFakeQuantizeConfig(
+            torch.int8,
+            PerTensor(),
+            is_dynamic=is_dynamic,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        scale, zero_point = choose_qparams_affine(
+            x,
+            mapping_type=MappingType.SYMMETRIC,
+            block_size=block_size,
+            target_dtype=torch.int8,
+            quant_min=-128,
+            quant_max=127,
+            scale_dtype=torch.float32,
+            zero_point_dtype=torch.int32,
+        )
+        # Per-tensor quantization uses one scalar qparam pair.
+        self.assertEqual(scale.shape, torch.Size([]))
+        self.assertEqual(zero_point.shape, torch.Size([]))
+        expected = _fake_quantize_affine(
+            x,
+            block_size,
+            scale,
+            zero_point,
+            torch.int8,
+            -128,
+            127,
+        )
+        actual = fake_quantizer(x)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+        scale = fake_quantizer.scale
+        fake_quantizer(x * 2)
+        if is_dynamic:
+            torch.testing.assert_close(fake_quantizer.scale, scale * 2)
+        else:
+            self.assertIs(fake_quantizer.scale, scale)
+
     def _set_ptq_weight(
         self,
         ptq_linear: torch.nn.Module,
@@ -856,6 +899,12 @@ class TestQAT(TestCase):
         self.assertEqual(per_group_config1.group_size, 32)
         self.assertEqual(per_group_config2.group_size, 32)
         self.assertEqual(per_group_config3.group_size, 32)
+
+        # per tensor
+        per_tensor_config1 = IntxFakeQuantizeConfig(torch.int8, PerTensor())
+        per_tensor_config2 = IntxFakeQuantizeConfig(torch.int8, "per_tensor")
+        self.assertIsInstance(per_tensor_config1.granularity, PerTensor)
+        self.assertIsInstance(per_tensor_config2.granularity, PerTensor)
 
         # set `group_size` after initialization
         per_token_config1.group_size = 64

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -116,6 +116,7 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
                3) 'per_group': equivalent to PerGroup(group_size), must be combined
                    with separate `group_size` kwarg, Alternatively, just set the
                    `group_size` kwarg and leave this field empty.
+               4) 'per_tensor': equivalent to PerTensor()
         mapping_type: whether to use symmetric (default) or asymmetric quantization
             Alternatively, set `is_symmetric` (bool) and leave this field empty.
         scale_precision: scale dtype (default torch.fp32)
@@ -147,6 +148,10 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         IntxFakeQuantizeConfig(torch.int4, group_size=32, is_symmetric=True)
         IntxFakeQuantizeConfig(torch.int4, "per_group", group_size=32, is_symmetric=True)
         IntxFakeQuantizeConfig(torch.int4, PerGroup(32), MappingType.SYMMETRIC)
+
+        # Per tensor symmetric quantization
+        IntxFakeQuantizeConfig(torch.int8, "per_tensor")
+        IntxFakeQuantizeConfig(torch.int8, PerTensor())
     """
 
     dtype: Union[torch.dtype, "TorchAODType"]
@@ -216,8 +221,8 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         Parse the `Granularity` represented in the args.
 
         Granularity can be specified in one of three ways:
-            1) `Granularity` object: one of PerToken(), PerAxis(), and PerGroup(group_size)
-            2) str: one of 'per_token', 'per_channel', and 'per_group'
+            1) `Granularity` object: one of PerToken(), PerAxis(), PerGroup(group_size), and PerTensor()
+            2) str: one of 'per_token', 'per_channel', 'per_group', and 'per_tensor'
             3) None: `group_size` must be set instead, represents per group granularity
         """
         # If group_size is set, then granularity must be either "per_group" or None
@@ -232,7 +237,7 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
 
         # Case 1: Granularity object
         if isinstance(granularity, Granularity):
-            if not isinstance(granularity, (PerToken, PerAxis, PerGroup)):
+            if not isinstance(granularity, (PerToken, PerAxis, PerGroup, PerTensor)):
                 raise ValueError("Granularity '%s' is not supported" % granularity)
             if isinstance(granularity, PerAxis) and granularity.axis != 0:
                 raise ValueError("Only axis=0 is supported for PerAxis granularity")
@@ -249,10 +254,15 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
                     "Granularity was 'per_group' but no `group_size` was set"
                 )
             return PerGroup(group_size)
+        elif granularity == "per_tensor":
+            return PerTensor()
         elif isinstance(granularity, str):
             raise ValueError(
                 "Unexpected granularity: '%s', must be one of %s"
-                % (granularity, ["per_token", "per_channel", "per_group"])
+                % (
+                    granularity,
+                    ["per_token", "per_channel", "per_group", "per_tensor"],
+                )
             )
 
         # Case 3: None granularity + group_size was specified

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -12,6 +12,7 @@ from torchao.quantization.granularity import (
     PerAxis,
     PerGroup,
     PerRow,
+    PerTensor,
     PerToken,
 )
 from torchao.quantization.quant_primitives import (
@@ -228,6 +229,8 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             return self._per_token_forward(x)
         elif isinstance(self.config.granularity, (PerAxis, PerGroup)):
             return self._per_channel_or_group_forward(x)
+        elif isinstance(self.config.granularity, PerTensor):
+            return self._per_tensor_forward(x)
         else:
             raise ValueError("Unknown granularity '%s'" % self.config.granularity)
 
@@ -306,6 +309,34 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             qmax,
             group_size,
             zero_point_domain,
+        )
+
+    def _per_tensor_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Perform per-tensor fake quantization."""
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        block_size = get_block_size(x.shape, self.config.granularity)
+        if self._should_compute_qparams():
+            self.scale, self.zero_point = choose_qparams_affine(
+                x,
+                mapping_type=self.config.mapping_type,
+                block_size=block_size,
+                target_dtype=self.config.dtype,
+                quant_min=qmin,
+                quant_max=qmax,
+                eps=self.config.eps,
+                scale_dtype=self.config.scale_precision,
+                zero_point_dtype=self.config.zero_point_precision,
+            )
+            self._maybe_update_qparams_for_range_learning()
+        return _fake_quantize_affine(
+            x,
+            block_size,
+            self.scale,
+            self.zero_point,
+            self.config.dtype,
+            qmin,
+            qmax,
+            self.config.zero_point_domain,
         )
 
     def _should_compute_qparams(self) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* #4888
* #4887
* #4886
* #4885
* #4884
* __->__ #4883



IntxFakeQuantizeConfig rejects PerTensor even though the shared block-size and affine primitives support it.

Accept PerTensor objects and strings, then route IntxFakeQuantizer through the shared affine fake-quantization path. Preserve the existing dynamic and first-use static behavior.

Calibration and conversion behavior remain out of scope.
@exported-using-ghexport

Differential Revision: [D117600352](https://our.internmc.facebook.com/intern/diff/D117600352/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117600352/)!

Differential Revision: [D117600352](https://our.internmc.facebook.com/intern/diff/D117600352)