### PR TITLE
[a16-support] Add int16 fake quantization

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -310,9 +310,7 @@ class TestQAT(TestCase):
 
     @parametrize("quant_dtype", [torch.int8, torch.int16])
     @parametrize("is_dynamic", [True, False])
-    def test_fake_quantize_per_tensor(
-        self, quant_dtype: torch.dtype, is_dynamic: bool
-    ):
+    def test_fake_quantize_per_tensor(self, quant_dtype: torch.dtype, is_dynamic: bool):
         torch.manual_seed(self.SEED)
         x = torch.randn(4, 8)
         block_size = tuple(x.shape)

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -78,6 +78,7 @@ from torchao.quantization.quant_api import (
     IntxWeightOnlyConfig,
 )
 from torchao.quantization.quant_primitives import (
+    _DTYPE_TO_QVALUE_BOUNDS,
     MappingType,
     TorchAODType,
     ZeroPointDomain,
@@ -307,13 +308,17 @@ class TestQAT(TestCase):
         )
         torch.testing.assert_close(out, out_ptq, atol=0, rtol=0)
 
+    @parametrize("quant_dtype", [torch.int8, torch.int16])
     @parametrize("is_dynamic", [True, False])
-    def test_fake_quantize_per_tensor(self, is_dynamic: bool):
+    def test_fake_quantize_per_tensor(
+        self, quant_dtype: torch.dtype, is_dynamic: bool
+    ):
         torch.manual_seed(self.SEED)
         x = torch.randn(4, 8)
         block_size = tuple(x.shape)
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[quant_dtype]
         config = IntxFakeQuantizeConfig(
-            torch.int8,
+            quant_dtype,
             PerTensor(),
             is_dynamic=is_dynamic,
         )
@@ -322,9 +327,9 @@ class TestQAT(TestCase):
             x,
             mapping_type=MappingType.SYMMETRIC,
             block_size=block_size,
-            target_dtype=torch.int8,
-            quant_min=-128,
-            quant_max=127,
+            target_dtype=quant_dtype,
+            quant_min=qmin,
+            quant_max=qmax,
             scale_dtype=torch.float32,
             zero_point_dtype=torch.int32,
         )
@@ -336,9 +341,9 @@ class TestQAT(TestCase):
             block_size,
             scale,
             zero_point,
-            torch.int8,
-            -128,
-            127,
+            quant_dtype,
+            qmin,
+            qmax,
         )
         actual = fake_quantizer(x)
         torch.testing.assert_close(actual, expected, atol=0, rtol=0)
@@ -1006,8 +1011,6 @@ class TestQAT(TestCase):
         """
         msg = "Unsupported dtype"
         with self.assertRaisesRegex(ValueError, msg):
-            IntxFakeQuantizeConfig(torch.int16, "per_token")
-        with self.assertRaisesRegex(ValueError, msg):
             IntxFakeQuantizeConfig(torch.int32, "per_token")
         with self.assertRaisesRegex(ValueError, msg):
             IntxFakeQuantizeConfig(torch.bfloat16, "per_token")
@@ -1030,6 +1033,7 @@ class TestQAT(TestCase):
         IntxFakeQuantizeConfig(TorchAODType.INT6, "per_token")
         IntxFakeQuantizeConfig(TorchAODType.INT7, "per_token")
         IntxFakeQuantizeConfig(torch.int8, "per_token")
+        IntxFakeQuantizeConfig(torch.int16, "per_tensor")
 
     def test_fake_quantize_config_dynamic_and_range_learning(self):
         """

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -105,7 +105,7 @@ class Int4WeightFakeQuantizeConfig(FakeQuantizeConfigBase):
 class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
     """
     Config for how to fake quantize weights or activations,
-    targeting integer dtypes up to torch.int8.
+    targeting integer dtypes up to torch.int16.
 
     Args:
         dtype: dtype to simulate during fake quantization, e.g. torch.int8.
@@ -192,7 +192,7 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         self.eps = eps
 
         # Validate dtype
-        all_dtypes = [torch.int8, torch.uint8]
+        all_dtypes = [torch.int8, torch.uint8, torch.int16]
         all_dtypes.extend(list(_SUB_BYTE_INT_BOUNDS.keys()))
         all_dtypes.extend(list(_SUB_BYTE_UINT_BOUNDS.keys()))
         if dtype not in all_dtypes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* #4888
* #4887
* #4886
* #4885
* __->__ #4884
* #4883



IntxFakeQuantizeConfig rejects torch.int16 even though the affine primitives define its quantization bounds and bit width.

Allow torch.int16 and extend the per-tensor numerical test to cover dynamic and first-use static fake quantization.

Calibration and conversion behavior remain out of scope.
@exported-using-ghexport

Differential Revision: [D117600354](https://our.internmc.facebook.com/intern/diff/D117600354/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117600354/)!

Differential Revision: [D117600354](https://our.internmc.facebook.com/intern/diff/D117600354)