### PR TITLE
[a16-support] Add no-clipping symmetric mapping

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -355,6 +355,73 @@ class TestQAT(TestCase):
         else:
             self.assertIs(fake_quantizer.scale, scale)
 
+    def test_fake_quantize_per_tensor_symmetric_no_clipping_err(self):
+        x = torch.tensor([[-5.0, -1.0, 0.0, 3.0], [-2.0, 0.0, 1.0, 4.0]])
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int16]
+        config = IntxFakeQuantizeConfig(
+            torch.int16,
+            PerTensor(),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        actual = fake_quantizer(x)
+        expected_scale, expected_zero_point = choose_qparams_affine(
+            x,
+            mapping_type=MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            block_size=tuple(x.shape),
+            target_dtype=torch.int16,
+            quant_min=qmin,
+            quant_max=qmax,
+            scale_dtype=torch.float32,
+            zero_point_dtype=torch.int32,
+        )
+        expected = _fake_quantize_affine(
+            x,
+            tuple(x.shape),
+            expected_scale,
+            expected_zero_point,
+            torch.int16,
+            qmin,
+            qmax,
+        )
+        torch.testing.assert_close(fake_quantizer.scale, expected_scale)
+        torch.testing.assert_close(fake_quantizer.zero_point, expected_zero_point)
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+    def test_fake_quantize_per_group_symmetric_no_clipping_err(self):
+        x = torch.tensor([[-5.0, -1.0, 0.0, 3.0], [-2.0, 0.0, 1.0, 4.0]])
+        group_size = x.shape[-1]
+        group_config = IntxFakeQuantizeConfig(
+            torch.int4,
+            PerGroup(group_size),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        group_fake_quantizer = IntxFakeQuantizer(group_config)
+        actual = group_fake_quantizer(x)
+        expected_scale, expected_zero_point = get_group_qparams_symmetric(
+            x,
+            4,
+            group_size,
+            mapping_type=MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        expected_zero_point = expected_zero_point.to(
+            group_config.zero_point_precision
+        )
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int4]
+        expected = _fake_quantize_per_channel_group(
+            x,
+            expected_scale,
+            expected_zero_point,
+            qmin,
+            qmax,
+            group_size,
+        )
+        torch.testing.assert_close(group_fake_quantizer.scale, expected_scale)
+        torch.testing.assert_close(
+            group_fake_quantizer.zero_point, expected_zero_point
+        )
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
     def _set_ptq_weight(
         self,
         ptq_linear: torch.nn.Module,
@@ -987,6 +1054,25 @@ class TestQAT(TestCase):
         self.assertFalse(asymmetric_config1.is_symmetric)
         self.assertFalse(asymmetric_config2.is_symmetric)
 
+        no_clipping_config = IntxFakeQuantizeConfig(
+            torch.int8,
+            "per_tensor",
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        self.assertEqual(
+            no_clipping_config.mapping_type,
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        self.assertTrue(no_clipping_config.is_symmetric)
+        no_clipping_config.is_symmetric = True
+        self.assertEqual(
+            no_clipping_config.mapping_type,
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        no_clipping_config.is_symmetric = False
+        self.assertEqual(no_clipping_config.mapping_type, MappingType.ASYMMETRIC)
+        self.assertFalse(no_clipping_config.is_symmetric)
+
         # set `is_symmetric` after initialization
         asymmetric_config1.is_symmetric = True
         self.assertEqual(asymmetric_config1.mapping_type, MappingType.SYMMETRIC)
@@ -998,11 +1084,11 @@ class TestQAT(TestCase):
             IntxFakeQuantizeConfig(
                 torch.int8, "per_token", MappingType.SYMMETRIC, is_symmetric=False
             )
-
-        # bad config2: not supported
-        with self.assertRaisesRegex(ValueError, "not supported"):
+        with self.assertRaisesRegex(ValueError, "not supported for per-token"):
             IntxFakeQuantizeConfig(
-                torch.int8, "per_token", MappingType.SYMMETRIC_NO_CLIPPING_ERR
+                torch.int8,
+                "per_token",
+                MappingType.SYMMETRIC_NO_CLIPPING_ERR,
             )
 
     def test_fake_quantize_config_dtype(self):

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -117,7 +117,10 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
                    with separate `group_size` kwarg, Alternatively, just set the
                    `group_size` kwarg and leave this field empty.
                4) 'per_tensor': equivalent to PerTensor()
-        mapping_type: whether to use symmetric (default) or asymmetric quantization
+        mapping_type: mapping from floating-point values to integers. Supported
+            values are `MappingType.SYMMETRIC`,
+            `MappingType.SYMMETRIC_NO_CLIPPING_ERR`, and
+            `MappingType.ASYMMETRIC`.
             Alternatively, set `is_symmetric` (bool) and leave this field empty.
         scale_precision: scale dtype (default torch.fp32)
         zero_point_precision: zero point dtype (default torch.int32)
@@ -129,8 +132,8 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
     Keyword args:
         group_size: size of each group in per group fake quantization,
             can be set instead of `granularity`
-        is_symmetric: whether to use symmetric or asymmetric quantization,
-            can be set instead of `mapping_type`
+        is_symmetric: whether to use symmetric or asymmetric quantization.
+            Use `mapping_type` to select `MappingType.SYMMETRIC_NO_CLIPPING_ERR`.
 
     Example usage::
 
@@ -198,6 +201,14 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         if dtype not in all_dtypes:
             raise ValueError(
                 "Unsupported dtype '%s', choose from %s" % (dtype, all_dtypes)
+            )
+        if (
+            isinstance(self.granularity, PerToken)
+            and self.mapping_type == MappingType.SYMMETRIC_NO_CLIPPING_ERR
+        ):
+            raise ValueError(
+                "MappingType.SYMMETRIC_NO_CLIPPING_ERR is not supported "
+                "for per-token quantization"
             )
 
         # Dynamic is not compatible with range learning
@@ -286,7 +297,7 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         Parse the `MappingType` represented in the args.
 
         Mapping type can be specified in one of two ways:
-            1): `MappingType` object: one of SYMMETRIC or ASYMMETRIC
+            1): `MappingType` object: one of SYMMETRIC, SYMMETRIC_NO_CLIPPING_ERR, or ASYMMETRIC
             2): is_symmetric bool
         """
         if mapping_type is not None and is_symmetric is not None:
@@ -298,7 +309,11 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
 
         # Case 1: MappingType object
         if mapping_type is not None:
-            if mapping_type not in [MappingType.SYMMETRIC, MappingType.ASYMMETRIC]:
+            if mapping_type not in [
+                MappingType.SYMMETRIC,
+                MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+                MappingType.ASYMMETRIC,
+            ]:
                 raise ValueError("MappingType '%s' is not supported" % mapping_type)
             return mapping_type
 
@@ -325,9 +340,16 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
     @property
     def is_symmetric(self) -> bool:
         """
-        Return True if mapping type is symmetric, else False (asymmetric).
+        Return True for either symmetric mapping type.
+
+        Setting this property to True preserves an existing symmetric mapping,
+        including SYMMETRIC_NO_CLIPPING_ERR. Setting it to False selects
+        ASYMMETRIC. Set mapping_type directly to choose a specific symmetric mode.
         """
-        return self.mapping_type == MappingType.SYMMETRIC
+        return self.mapping_type in [
+            MappingType.SYMMETRIC,
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        ]
 
     def __setattr__(self, name: str, value: Any):
         """
@@ -336,6 +358,11 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         if name == "group_size":
             super().__setattr__("granularity", PerGroup(value))
         elif name == "is_symmetric":
+            if value and getattr(self, "mapping_type", None) in (
+                MappingType.SYMMETRIC,
+                MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            ):
+                return
             mapping_type = MappingType.SYMMETRIC if value else MappingType.ASYMMETRIC
             super().__setattr__("mapping_type", mapping_type)
         else:

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -287,6 +287,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
                     bit_width,
                     group_size,
                     scale_precision,
+                    mapping_type=self.config.mapping_type,
                     eps=self.config.eps,
                 )
             else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* #4888
* #4887
* #4886
* __->__ #4885
* #4884
* #4883



IntxFakeQuantizeConfig rejects MappingType.SYMMETRIC_NO_CLIPPING_ERR even though the affine primitives already implement it.

Allow the mapping, preserve symmetric classification, and propagate it through grouped parameter selection. Add A16 per-tensor coverage for the Quanty scale rule and grouped propagation coverage.

Calibration and conversion behavior remain out of scope.
@exported-using-ghexport

Differential Revision: [D117600355](https://our.internmc.facebook.com/intern/diff/D117600355/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117600355/)!

Differential Revision: [D117600355](https://our.internmc.facebook.com/intern/diff/D117600355)