### PR TITLE
[a16-support] Persist static fake-quantizer state

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -422,6 +422,63 @@ class TestQAT(TestCase):
         )
         torch.testing.assert_close(actual, expected, atol=0, rtol=0)
 
+    def test_fake_quantizer_static_state_dict(self):
+        config = IntxFakeQuantizeConfig(
+            torch.int16,
+            PerTensor(),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=False,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        fake_quantizer(torch.randn(4, 8))
+        state_dict = copy.deepcopy(fake_quantizer.state_dict())
+
+        restored = IntxFakeQuantizer(config)
+        restored.load_state_dict(state_dict)
+        x = torch.randn(4, 8)
+        torch.testing.assert_close(restored(x), fake_quantizer(x), atol=0, rtol=0)
+        self.assertIn("scale", dict(restored.named_buffers()))
+        self.assertIn("zero_point", dict(restored.named_buffers()))
+
+        moved_restored = IntxFakeQuantizer(config).to(dtype=torch.float64)
+        moved_restored.load_state_dict(state_dict)
+        self.assertEqual(moved_restored.scale.dtype, torch.float64)
+
+        legacy_state_dict = copy.deepcopy(state_dict)
+        legacy_state_dict.pop("scale")
+        legacy_state_dict.pop("zero_point")
+        legacy_restored = IntxFakeQuantizer(config)
+        legacy_restored.load_state_dict(legacy_state_dict)
+        self.assertNotIn("scale", legacy_state_dict)
+        self.assertNotIn("zero_point", legacy_state_dict)
+        # Empty buffers have zero elements and trigger qparam initialization.
+        self.assertEqual(legacy_restored.scale.numel(), 0)
+        self.assertEqual(legacy_restored.zero_point.numel(), 0)
+        x = torch.randn(4, 8)
+        expected = IntxFakeQuantizer(config)(x)
+        torch.testing.assert_close(legacy_restored(x), expected, atol=0, rtol=0)
+        self.assertEqual(legacy_restored.scale.numel(), 1)
+        self.assertEqual(legacy_restored.zero_point.numel(), 1)
+
+    def test_fake_quantizer_static_state_dict_per_group(self):
+        config = IntxFakeQuantizeConfig(
+            torch.int4,
+            PerGroup(4),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=False,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        x = torch.randn(4, 8)
+        expected = fake_quantizer(x)
+        self.assertGreater(fake_quantizer.scale.numel(), 1)
+        self.assertGreater(fake_quantizer.zero_point.numel(), 1)
+
+        restored = IntxFakeQuantizer(config)
+        restored.load_state_dict(copy.deepcopy(fake_quantizer.state_dict()))
+        torch.testing.assert_close(restored(x), expected, atol=0, rtol=0)
+        torch.testing.assert_close(restored.scale, fake_quantizer.scale)
+        torch.testing.assert_close(restored.zero_point, fake_quantizer.zero_point)
+
     def _set_ptq_weight(
         self,
         ptq_linear: torch.nn.Module,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -198,8 +198,18 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         torch._C._log_api_usage_once("torchao.quantization.qat.IntxFakeQuantizer")
         self.config = config
         self.enabled = True
-        self.scale: Optional[torch.Tensor] = None
-        self.zero_point: Optional[torch.Tensor] = None
+        self.scale: Optional[torch.Tensor]
+        self.zero_point: Optional[torch.Tensor]
+        if config.is_dynamic or config.range_learning:
+            self.scale = None
+            self.zero_point = None
+        else:
+            self.register_buffer(
+                "scale", torch.empty(0, dtype=config.scale_precision)
+            )
+            self.register_buffer(
+                "zero_point", torch.empty(0, dtype=config.zero_point_precision)
+            )
 
         # For range learning only
         # TODO: make this configurable?
@@ -344,7 +354,13 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         """
         Return whether we need to compute new scales and zero points.
         """
-        return self.config.is_dynamic or self.scale is None or self.zero_point is None
+        return (
+            self.config.is_dynamic
+            or self.scale is None
+            or self.zero_point is None
+            or self.scale.numel() == 0
+            or self.zero_point.numel() == 0
+        )
 
     def _maybe_update_qparams_for_range_learning(self) -> None:
         """
@@ -368,6 +384,36 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             zero_point = _Round.apply(zero_point)
             zero_point = torch.clamp(zero_point, qmin, qmax)
             self.zero_point = torch.nn.Parameter(zero_point, requires_grad=True)
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        for name in ("scale", "zero_point"):
+            key = prefix + name
+            if name in self._buffers and key not in state_dict:
+                state_dict[key] = self._buffers[name]
+            elif (
+                key in state_dict
+                and name in self._buffers
+                and self._buffers[name].numel() == 0
+            ):
+                self._buffers[name].resize_(state_dict[key].shape)
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
 
 # For BC


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* #4888
* #4887
* __->__ #4886
* #4885
* #4884
* #4883



Static IntxFakeQuantizer scale and zero point values are plain attributes, so state_dict omits them and module moves leave them behind.

Register them as buffers for static non-range-learning configurations. Materialize the buffer slots when initialized state is loaded. Dynamic and range-learning behavior remains unchanged.

Older checkpoints without these qparams load with empty buffers and retain first-use initialization.
@exported-using-ghexport

Differential Revision: [D117772566](https://our.internmc.facebook.com/intern/diff/D117772566/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117772566/)!

Differential Revision: [D117772566](https://our.internmc.facebook.com/intern/diff/D117772566)