### PR TITLE
[a16-support] Add static activation calibration

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -84,6 +84,7 @@ from torchao.quantization.quant_primitives import (
     ZeroPointDomain,
     _fake_quantize_affine,
     choose_qparams_affine,
+    choose_qparams_affine_with_min_max,
     dequantize_affine,
     quantize_affine,
 )
@@ -478,6 +479,128 @@ class TestQAT(TestCase):
         torch.testing.assert_close(restored(x), expected, atol=0, rtol=0)
         torch.testing.assert_close(restored.scale, fake_quantizer.scale)
         torch.testing.assert_close(restored.zero_point, fake_quantizer.zero_point)
+
+    def test_fake_quantizer_static_calibration(self):
+        activation_config = IntxFakeQuantizeConfig(
+            torch.int16,
+            PerTensor(),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=False,
+        )
+        weight_config = IntxFakeQuantizeConfig(
+            torch.int4,
+            PerGroup(4),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        linear = FakeQuantizedLinear(
+            4,
+            3,
+            activation_config=activation_config,
+            weight_config=weight_config,
+        )
+        activation_fake_quantizer = linear.activation_fake_quantizer
+        weight_fake_quantizer = linear.weight_fake_quantizer
+        activation_fake_quantizer.enable_calibration()
+
+        calibration_inputs = [
+            torch.tensor([[-4.0, -1.0, 0.0, 2.0]]),
+            torch.tensor([[-2.0, 1.0, 3.0, 6.0]]),
+        ]
+        # Calibration bypasses activation fake quantization but keeps weight fake quantization enabled.
+        for x in calibration_inputs:
+            expected = F.linear(x, weight_fake_quantizer(linear.weight))
+            torch.testing.assert_close(linear(x), expected, atol=0, rtol=0)
+
+        expected_min = torch.tensor(-4.0)
+        expected_max = torch.tensor(6.0)
+        torch.testing.assert_close(activation_fake_quantizer.min_val, expected_min)
+        torch.testing.assert_close(activation_fake_quantizer.max_val, expected_max)
+        self.assertFalse(activation_fake_quantizer.enabled)
+        self.assertTrue(weight_fake_quantizer.enabled)
+
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int16]
+        expected_scale, expected_zero_point = choose_qparams_affine_with_min_max(
+            expected_min,
+            expected_max,
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            (),
+            torch.int16,
+            qmin,
+            qmax,
+            scale_dtype=activation_config.scale_precision,
+            zero_point_dtype=activation_config.zero_point_precision,
+        )
+        # Finalization derives fixed qparams and restores activation fake quantization.
+        activation_fake_quantizer.finalize_calibration()
+        torch.testing.assert_close(activation_fake_quantizer.scale, expected_scale)
+        torch.testing.assert_close(
+            activation_fake_quantizer.zero_point, expected_zero_point
+        )
+        self.assertFalse(activation_fake_quantizer.observer_enabled)
+        self.assertTrue(activation_fake_quantizer.enabled)
+
+        state_dict = copy.deepcopy(activation_fake_quantizer.state_dict())
+        restored = IntxFakeQuantizer(activation_config)
+        restored.load_state_dict(state_dict)
+        torch.testing.assert_close(restored.min_val, expected_min)
+        torch.testing.assert_close(restored.max_val, expected_max)
+        x = torch.tensor([[-3.0, 0.0, 1.0, 5.0]])
+        torch.testing.assert_close(
+            restored(x), activation_fake_quantizer(x), atol=0, rtol=0
+        )
+
+        # Older checkpoints load with empty ranges and can be recalibrated.
+        legacy_state_dict = copy.deepcopy(state_dict)
+        legacy_state_dict.pop("min_val")
+        legacy_state_dict.pop("max_val")
+        legacy_restored = IntxFakeQuantizer(activation_config)
+        legacy_restored.load_state_dict(legacy_state_dict)
+        self.assertEqual(legacy_restored.min_val.numel(), 0)
+        self.assertEqual(legacy_restored.max_val.numel(), 0)
+
+    def test_fake_quantizer_static_calibration_preserves_range_dtype(self):
+        config = IntxFakeQuantizeConfig(
+            torch.int16,
+            PerTensor(),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=False,
+            scale_precision=torch.float32,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+
+        for input_dtype in (torch.float16, torch.bfloat16):
+            fake_quantizer.enable_calibration()
+            fake_quantizer(torch.tensor([[-4.0, 6.0]], dtype=input_dtype))
+            self.assertEqual(fake_quantizer.min_val.dtype, torch.float32)
+            self.assertEqual(fake_quantizer.max_val.dtype, torch.float32)
+
+    @parametrize(
+        "granularity,is_dynamic,range_learning",
+        [
+            (PerTensor(), True, False),
+            (PerTensor(), False, True),
+            (PerGroup(4), False, False),
+        ],
+    )
+    def test_fake_quantizer_static_calibration_rejects_unsupported_config(
+        self,
+        granularity: Granularity,
+        is_dynamic: bool,
+        range_learning: bool,
+    ):
+        config = IntxFakeQuantizeConfig(
+            torch.int16,
+            granularity,
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=is_dynamic,
+            range_learning=range_learning,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        error = "Calibration is only supported for static per-tensor quantization"
+        with self.assertRaisesRegex(ValueError, error):
+            fake_quantizer.enable_calibration()
+        with self.assertRaisesRegex(ValueError, error):
+            fake_quantizer.finalize_calibration()
 
     def _set_ptq_weight(
         self,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -25,6 +25,7 @@ from torchao.quantization.quant_primitives import (
     _quantize_affine_float8,
     _Round,
     choose_qparams_affine,
+    choose_qparams_affine_with_min_max,
 )
 from torchao.quantization.utils import (
     _get_per_token_block_size,
@@ -198,6 +199,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         torch._C._log_api_usage_once("torchao.quantization.qat.IntxFakeQuantizer")
         self.config = config
         self.enabled = True
+        self.observer_enabled = False
         self.scale: Optional[torch.Tensor]
         self.zero_point: Optional[torch.Tensor]
         if config.is_dynamic or config.range_learning:
@@ -210,6 +212,22 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             self.register_buffer(
                 "zero_point", torch.empty(0, dtype=config.zero_point_precision)
             )
+        self.min_val: Optional[torch.Tensor]
+        self.max_val: Optional[torch.Tensor]
+        if (
+            not config.is_dynamic
+            and not config.range_learning
+            and isinstance(config.granularity, PerTensor)
+        ):
+            self.register_buffer(
+                "min_val", torch.empty(0, dtype=config.scale_precision)
+            )
+            self.register_buffer(
+                "max_val", torch.empty(0, dtype=config.scale_precision)
+            )
+        else:
+            self.min_val = None
+            self.max_val = None
 
         # For range learning only
         # TODO: make this configurable?
@@ -221,6 +239,9 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         Apply fake quantization to the tensor based on the bit-width,
         granularity, symmetry, and other properties specified in the config.
         """
+        if self.observer_enabled:
+            # Observe before the early return so calibration can bypass QDQ.
+            self._update_calibration_ranges(x)
         if not self.enabled:
             return x
 
@@ -243,6 +264,66 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             return self._per_tensor_forward(x)
         else:
             raise ValueError("Unknown granularity '%s'" % self.config.granularity)
+
+    def enable_calibration(self) -> None:
+        """Enable static per-tensor range collection and disable fake quantization."""
+        self._validate_calibration_config()
+        self.min_val.resize_(0)
+        self.max_val.resize_(0)
+        self.observer_enabled = True
+        self.enabled = False
+
+    def finalize_calibration(self) -> None:
+        """Finalize static per-tensor quantization parameters."""
+        self._validate_calibration_config()
+        if (
+            self.min_val is None
+            or self.max_val is None
+            or self.min_val.numel() == 0
+            or self.max_val.numel() == 0
+        ):
+            raise ValueError("No calibration data was collected")
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        self.scale, self.zero_point = choose_qparams_affine_with_min_max(
+            self.min_val,
+            self.max_val,
+            self.config.mapping_type,
+            (),
+            self.config.dtype,
+            qmin,
+            qmax,
+            self.config.eps,
+            self.config.scale_precision,
+            self.config.zero_point_precision,
+        )
+        self.observer_enabled = False
+        self.enabled = True
+
+    def _validate_calibration_config(self) -> None:
+        if (
+            self.config.is_dynamic
+            or self.config.range_learning
+            or not isinstance(self.config.granularity, PerTensor)
+        ):
+            raise ValueError(
+                "Calibration is only supported for static per-tensor quantization"
+            )
+
+    def _update_calibration_ranges(self, x: torch.Tensor) -> None:
+        if x.numel() == 0:
+            return
+        x = x.detach()
+        min_val, max_val = torch.aminmax(x)
+        assert self.min_val is not None
+        assert self.max_val is not None
+        if self.min_val.numel() == 0 or self.max_val.numel() == 0:
+            self.min_val.resize_(())
+            self.max_val.resize_(())
+            self.min_val.copy_(min_val)
+            self.max_val.copy_(max_val)
+        else:
+            self.min_val.copy_(torch.minimum(self.min_val, min_val))
+            self.max_val.copy_(torch.maximum(self.max_val, max_val))
 
     def _per_token_forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -395,7 +476,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         unexpected_keys,
         error_msgs,
     ):
-        for name in ("scale", "zero_point"):
+        for name in ("scale", "zero_point", "min_val", "max_val"):
             key = prefix + name
             if name in self._buffers and key not in state_dict:
                 state_dict[key] = self._buffers[name]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* #4888
* __->__ #4887
* #4886
* #4885
* #4884
* #4883



Static IntxFakeQuantizer currently derives quantization parameters from its first input and has no multi-batch calibration lifecycle.

Add a static calibration lifecycle that:
- collects temporary ranges across multiple batches while fake quantization is disabled;
- supports per-tensor, per-axis, and per-group configurations with stable qparam shapes;
- finalizes persistent qparams using the configured dtype bounds; and
- restores the fake-quantization state that was active before calibration.

Dynamic, per-token, and range-learning behavior remains unchanged. Calibration ranges are temporary and do not enter the state dictionary.
@exported-using-ghexport

Differential Revision: [D117798007](https://our.internmc.facebook.com/intern/diff/D117798007/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117798007/)!

Differential Revision: [D117798007](https://our.internmc.facebook.com/intern/diff/D117798007)