### PR TITLE
[a16-support] Add calibration range exchange

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -518,6 +518,27 @@ class TestQAT(TestCase):
         self.assertFalse(activation_fake_quantizer.enabled)
         self.assertTrue(weight_fake_quantizer.enabled)
 
+        local_min, local_max = activation_fake_quantizer.get_running_min_max()
+        torch.testing.assert_close(local_min, expected_min)
+        torch.testing.assert_close(local_max, expected_max)
+        expected_min = torch.tensor(-8.0)
+        expected_max = torch.tensor(10.0)
+        with self.assertRaisesRegex(ValueError, "Calibration ranges must be finite"):
+            activation_fake_quantizer.set_running_min_max(
+                torch.tensor(float("nan")), expected_max
+            )
+        with self.assertWarnsRegex(UserWarning, "Converting calibration ranges"):
+            activation_fake_quantizer.set_running_min_max(
+                expected_min.to(torch.float64), expected_max.to(torch.float64)
+            )
+        self.assertEqual(activation_fake_quantizer.min_val.dtype, torch.float32)
+        self.assertEqual(activation_fake_quantizer.max_val.dtype, torch.float32)
+        min_buffer = activation_fake_quantizer.min_val
+        max_buffer = activation_fake_quantizer.max_val
+        activation_fake_quantizer.set_running_min_max(expected_min, expected_max)
+        self.assertIs(activation_fake_quantizer.min_val, min_buffer)
+        self.assertIs(activation_fake_quantizer.max_val, max_buffer)
+
         qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int16]
         expected_scale, expected_zero_point = choose_qparams_affine_with_min_max(
             expected_min,
@@ -601,6 +622,8 @@ class TestQAT(TestCase):
             fake_quantizer.enable_calibration()
         with self.assertRaisesRegex(ValueError, error):
             fake_quantizer.finalize_calibration()
+        with self.assertRaisesRegex(ValueError, error):
+            fake_quantizer.get_running_min_max()
 
     def _set_ptq_weight(
         self,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from typing import Optional
 
 import torch
@@ -298,6 +299,47 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         )
         self.observer_enabled = False
         self.enabled = True
+
+    def get_running_min_max(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return copies of the collected calibration range."""
+        self._validate_calibration_config()
+        if (
+            self.min_val is None
+            or self.max_val is None
+            or self.min_val.numel() == 0
+            or self.max_val.numel() == 0
+        ):
+            raise ValueError("No calibration data was collected")
+        return self.min_val.clone(), self.max_val.clone()
+
+    def set_running_min_max(
+        self, min_val: torch.Tensor, max_val: torch.Tensor
+    ) -> None:
+        """Replace the collected calibration range."""
+        self._validate_calibration_config()
+        if min_val.numel() != 1 or max_val.numel() != 1:
+            raise ValueError("Calibration ranges must contain one value")
+        assert self.min_val is not None
+        assert self.max_val is not None
+        if (
+            min_val.device != self.min_val.device
+            or max_val.device != self.max_val.device
+            or min_val.dtype != self.min_val.dtype
+            or max_val.dtype != self.max_val.dtype
+        ):
+            warnings.warn(
+                "Converting calibration ranges to match the quantizer buffer "
+                "dtype and device",
+                stacklevel=2,
+            )
+        min_val = min_val.detach().to(self.min_val).reshape(())
+        max_val = max_val.detach().to(self.max_val).reshape(())
+        if not torch.isfinite(min_val).item() or not torch.isfinite(max_val).item():
+            raise ValueError("Calibration ranges must be finite")
+        if min_val.item() > max_val.item():
+            raise ValueError("Calibration minimum must not exceed the maximum")
+        self.min_val.resize_(()).copy_(min_val)
+        self.max_val.resize_(()).copy_(max_val)
 
     def _validate_calibration_config(self) -> None:
         if (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* #4889
* __->__ #4888
* #4887
* #4886
* #4885
* #4884
* #4883



Static calibration stores temporary ranges inside each IntxFakeQuantizer. Distributed or partitioned calibration must combine local ranges before finalization.

Add APIs that let callers:
- read copies of scalar or shaped running ranges;
- combine ranges outside TorchAO; and
- write validated combined ranges back into each quantizer.

TorchAO performs no communication. The existing single-process calibration flow remains unchanged.
@exported-using-ghexport

Differential Revision: [D117798573](https://our.internmc.facebook.com/intern/diff/D117798573/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117798573/)!

Differential Revision: [D117798573](https://our.internmc.facebook.com/intern/diff/D117798573)