### PR TITLE
[a16-support] Preserve dynamic W4 scale gradients

### DIFF
--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -423,6 +423,45 @@ class TestQAT(TestCase):
         )
         torch.testing.assert_close(actual, expected, atol=0, rtol=0)
 
+    def test_fake_quantize_symmetric_no_clipping_err_weight_gradient(self):
+        group_size = 2
+        config = IntxFakeQuantizeConfig(
+            torch.int4,
+            PerGroup(group_size),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+        weight = torch.tensor(
+            [[-5.0, -1.0, 1.0, 4.0], [-2.0, 3.0, -6.0, 2.0]],
+            requires_grad=True,
+        )
+        reference_weight = weight.detach().clone().requires_grad_()
+        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int4]
+        grouped_weight = reference_weight.reshape(2, -1, group_size)
+        min_val = torch.amin(grouped_weight, dim=-1)
+        max_val = torch.amax(grouped_weight, dim=-1)
+        scale = torch.maximum(min_val / qmin, max_val / qmax).clamp(
+            min=torch.finfo(weight.dtype).smallest_normal
+        )
+        zero_point = torch.zeros_like(scale, dtype=torch.int32)
+        expected = _fake_quantize_per_channel_group(
+            reference_weight,
+            scale,
+            zero_point,
+            qmin,
+            qmax,
+            group_size,
+            ZeroPointDomain.INT,
+        )
+        actual = IntxFakeQuantizer(config)(weight)
+        grad_output = torch.tensor(
+            [[0.5, -1.0, 1.5, -0.5], [1.0, 0.25, -0.75, 2.0]]
+        )
+        actual.backward(grad_output)
+        expected.backward(grad_output)
+
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        torch.testing.assert_close(weight.grad, reference_weight.grad, atol=0, rtol=0)
+
     def test_fake_quantizer_static_state_dict(self):
         config = IntxFakeQuantizeConfig(
             torch.int16,

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -415,13 +415,8 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         if self._should_compute_qparams():
             bit_width = _DTYPE_TO_BIT_WIDTH[self.config.dtype]
             if is_symmetric:
-                (self.scale, self.zero_point) = get_group_qparams_symmetric(
-                    x,
-                    bit_width,
-                    group_size,
-                    scale_precision,
-                    mapping_type=self.config.mapping_type,
-                    eps=self.config.eps,
+                (self.scale, self.zero_point) = (
+                    self._choose_group_qparams_symmetric(x, bit_width, group_size)
                 )
             else:
                 (self.scale, self.zero_point) = get_groupwise_affine_qparams(
@@ -443,6 +438,43 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             qmax,
             group_size,
             zero_point_domain,
+        )
+
+    def _choose_group_qparams_symmetric(
+        self,
+        x: torch.Tensor,
+        bit_width: int,
+        group_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if (
+            self.config.is_dynamic
+            and bit_width == 4
+            and self.config.mapping_type == MappingType.SYMMETRIC_NO_CLIPPING_ERR
+        ):
+            x_grouped = x.reshape(x.shape[0], -1, group_size)
+            min_val = torch.amin(x_grouped, dim=-1)
+            max_val = torch.amax(x_grouped, dim=-1)
+            qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+            return choose_qparams_affine_with_min_max(
+                min_val,
+                max_val,
+                self.config.mapping_type,
+                (1, group_size),
+                self.config.dtype,
+                qmin,
+                qmax,
+                self.config.eps,
+                self.config.scale_precision,
+                self.config.zero_point_precision,
+            )
+
+        return get_group_qparams_symmetric(
+            x,
+            bit_width,
+            group_size,
+            self.config.scale_precision,
+            mapping_type=self.config.mapping_type,
+            eps=self.config.eps,
         )
 
     def _per_tensor_forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* #4890
* __->__ #4889
* #4888
* #4887
* #4886
* #4885
* #4884
* #4883



Dynamic grouped W4 fake quantization recomputes scales from the current weights. The existing symmetric helper disables autograd, which removes the scale calculation from the weight gradient.

For dynamic INT4 no-clipping quantization:
- compute group extrema with differentiable tensor operations;
- derive scale and zero point with the shared affine primitive; and
- preserve gradients through scale selection.

Add a reference test for both quantized outputs and weight gradients. Other bit widths and mapping types remain on the existing path.
@exported-using-ghexport

Differential Revision: [D117799149](https://our.internmc.facebook.com/intern/diff/D117799149/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117799149/)!

Differential Revision: [D117799149](https://our.internmc.facebook.com/intern/diff/D117799149)