### PR TITLE
[a16-support] Document repeatable static A16W4 QAT workflow

### DIFF
--- a/docs/source/workflows/qat.md
+++ b/docs/source/workflows/qat.md
@@ -135,6 +135,62 @@ train_loop(model)
 # convert: (not shown, same as before)
 ```
 
+Static per-tensor activations require calibration before training. The following
+example keeps activation fake quantization disabled while each quantizer collects
+ranges. Weight fake quantization remains enabled during these model passes.
+
+```python
+from torchao.quantization.granularity import PerGroup, PerTensor
+from torchao.quantization.quant_primitives import MappingType
+from torchao.quantization.qat import FakeQuantizedLinear
+
+activation_config = IntxFakeQuantizeConfig(
+    torch.int16,
+    PerTensor(),
+    MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+    is_dynamic=False,
+)
+
+weight_config = IntxFakeQuantizeConfig(
+    torch.int4,
+    PerGroup(32),
+    MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+)
+quantize_(
+    model,
+    QATConfig(
+        activation_config=activation_config,
+        weight_config=weight_config,
+        step="prepare",
+    ),
+)
+
+fake_quantized_linears = [
+    module for module in model.modules() if isinstance(module, FakeQuantizedLinear)
+]
+for module in fake_quantized_linears:
+    module.activation_fake_quantizer.enable_calibration()
+
+with torch.no_grad():
+    for batch in calibration_data:
+        model(batch)
+
+for module in fake_quantized_linears:
+    quantizer = module.activation_fake_quantizer
+    min_val, max_val = quantizer.get_running_min_max()
+    # The training application can reduce these values across workers here.
+    quantizer.set_running_min_max(min_val, max_val)
+    quantizer.finalize_calibration()
+
+train_loop(model)
+```
+
+To recalibrate, repeat the same enable, data-forward, range-exchange, and
+finalize sequence. Calling `enable_calibration()` resets the previously collected
+ranges, and `finalize_calibration()` replaces the fixed activation qparams. The
+training application controls when to repeat this sequence and any distributed
+reduction.
+
 To fake quantize embedding in addition to linear, you can additionally call
 the following with a filter function during the prepare step:
 

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -1721,6 +1721,126 @@ class TestQAT(TestCase):
         baseline_out = baseline_model(*x2)
         torch.testing.assert_close(out, baseline_out, atol=0, rtol=0)
 
+    def test_static_a16w4_qat_workflow(self):
+        activation_config = IntxFakeQuantizeConfig(
+            torch.int16,
+            PerTensor(),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+            is_dynamic=False,
+        )
+        weight_config = IntxFakeQuantizeConfig(
+            torch.int4,
+            PerGroup(2),
+            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
+        )
+
+        def prepare_model():
+            model = torch.nn.Sequential(
+                torch.nn.Linear(4, 4, bias=False),
+                torch.nn.ReLU(),
+                torch.nn.Linear(4, 2, bias=False),
+            )
+            quantize_(
+                model,
+                QATConfig(
+                    activation_config=activation_config,
+                    weight_config=weight_config,
+                ),
+            )
+            return model
+
+        torch.manual_seed(self.SEED)
+        model = prepare_model()
+        fake_quantized_linears = [
+            module
+            for module in model.modules()
+            if isinstance(module, FakeQuantizedLinear)
+        ]
+        for module in fake_quantized_linears:
+            module.activation_fake_quantizer.enable_calibration()
+
+        calibration_inputs = [torch.randn(2, 4), torch.randn(2, 4)]
+        with torch.no_grad():
+            for x in calibration_inputs:
+                model(x)
+        for module in fake_quantized_linears:
+            module.activation_fake_quantizer.finalize_calibration()
+
+        activation_scales = [
+            module.activation_fake_quantizer.scale.clone()
+            for module in fake_quantized_linears
+        ]
+        weight_before = fake_quantized_linears[0].weight.detach().clone()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, foreach=True)
+        loss = model(torch.randn(2, 4)).square().mean()
+        loss.backward()
+        optimizer.step()
+
+        self.assertFalse(torch.equal(fake_quantized_linears[0].weight, weight_before))
+        for module, scale in zip(fake_quantized_linears, activation_scales):
+            torch.testing.assert_close(
+                module.activation_fake_quantizer.scale, scale, atol=0, rtol=0
+            )
+
+        for module in fake_quantized_linears:
+            module.activation_fake_quantizer.enable_calibration()
+        recalibration_inputs = [x * 16 for x in calibration_inputs]
+        with torch.no_grad():
+            for x in recalibration_inputs:
+                model(x)
+        for module in fake_quantized_linears:
+            module.activation_fake_quantizer.finalize_calibration()
+
+        expected_min = torch.stack([x.min() for x in recalibration_inputs]).min()
+        expected_max = torch.stack([x.max() for x in recalibration_inputs]).max()
+        recalibrated_min, recalibrated_max = (
+            fake_quantized_linears[0]
+            .activation_fake_quantizer.get_running_min_max()
+        )
+        torch.testing.assert_close(recalibrated_min, expected_min, atol=0, rtol=0)
+        torch.testing.assert_close(recalibrated_max, expected_max, atol=0, rtol=0)
+        self.assertFalse(
+            torch.equal(
+                fake_quantized_linears[0].activation_fake_quantizer.scale,
+                activation_scales[0],
+            )
+        )
+
+        state_dict = copy.deepcopy(model.state_dict())
+        torch.manual_seed(self.SEED)
+        restored = prepare_model()
+        restored.load_state_dict(state_dict)
+        x = torch.randn(2, 4)
+        torch.testing.assert_close(restored(x), model(x), atol=0, rtol=0)
+
+        restored_linears = [
+            module
+            for module in restored.modules()
+            if isinstance(module, FakeQuantizedLinear)
+        ]
+        for module, restored_module in zip(
+            fake_quantized_linears, restored_linears
+        ):
+            torch.testing.assert_close(
+                restored_module.activation_fake_quantizer.scale,
+                module.activation_fake_quantizer.scale,
+                atol=0,
+                rtol=0,
+            )
+            torch.testing.assert_close(
+                restored_module.activation_fake_quantizer.min_val,
+                module.activation_fake_quantizer.min_val,
+                atol=0,
+                rtol=0,
+            )
+
+        restored.to(dtype=torch.float64)
+        for module in restored_linears:
+            self.assertEqual(module.activation_fake_quantizer.scale.dtype, torch.float64)
+            self.assertEqual(
+                module.activation_fake_quantizer.min_val.dtype, torch.float64
+            )
+
     def test_quantize_api_errors(self):
         """
         Test that we throw exceptions with helpful error messages if `quantize_`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4891
* __->__ #4890
* #4889
* #4888
* #4887
* #4886
* #4885
* #4884
* #4883



Static per-tensor activations require calibration before training. Applications can also repeat calibration when activation distributions change.

Document and test a workflow that:
- prepares a model with symmetric static per-tensor A16 and dynamic per-group W4 fake quantization;
- calibrates activations across multiple batches;
- trains with fixed activation qparams while weights continue to update;
- repeats the complete calibration cycle with new data;
- verifies that new ranges and activation qparams replace the old values;
- saves and restores the recalibrated fixed qparams; and
- moves restored qparams between dtypes.

The training application controls the recalibration schedule and any distributed range reduction. TorchAO exposes the repeatable calibration lifecycle.
@exported-using-ghexport

Differential Revision: [D117799886](https://our.internmc.facebook.com/intern/diff/D117799886/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117799886/)!

Differential Revision: [D117799886](https://our.internmc.facebook.com/intern/diff/D117799886)