### PR TITLE
[a16-support] Add asymmetric A16 fake quantization

### DIFF
--- a/docs/source/workflows/qat.md
+++ b/docs/source/workflows/qat.md
@@ -185,6 +185,20 @@ for module in fake_quantized_linears:
 train_loop(model)
 ```
 
+For asymmetric A16, replace `activation_config` above with the following
+configuration. The INT32 carrier contains a logical UINT16 range.
+
+```python
+activation_config = IntxFakeQuantizeConfig(
+    torch.int32,
+    PerTensor(),
+    MappingType.ASYMMETRIC,
+    is_dynamic=False,
+    quant_min=0,
+    quant_max=2**16 - 1,
+)
+```
+
 To recalibrate, repeat the same enable, data-forward, range-exchange, and
 finalize sequence. Calling `enable_calibration()` resets the previously collected
 ranges, and `finalize_calibration()` replaces the fixed activation qparams. The

--- a/test/quantization/test_qat.py
+++ b/test/quantization/test_qat.py
@@ -356,6 +356,27 @@ class TestQAT(TestCase):
         else:
             self.assertIs(fake_quantizer.scale, scale)
 
+    def test_fake_quantize_per_tensor_asymmetric_custom_range(self):
+        x = torch.tensor([[1.0, 2.0, 4.0], [2.0, 3.0, 3.0]])
+        qmin, qmax = 0, 2**16 - 1
+        config = IntxFakeQuantizeConfig(
+            torch.int32,
+            PerTensor(),
+            MappingType.ASYMMETRIC,
+            quant_min=qmin,
+            quant_max=qmax,
+            eps=1e-9,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+
+        actual = fake_quantizer(x)
+
+        expected_scale = torch.tensor(4.0 / (qmax - qmin))
+        expected_zero_point = torch.tensor(0, dtype=torch.int32)
+        torch.testing.assert_close(fake_quantizer.scale, expected_scale)
+        torch.testing.assert_close(fake_quantizer.zero_point, expected_zero_point)
+        torch.testing.assert_close(actual, x, atol=float(expected_scale), rtol=0)
+
     def test_fake_quantize_per_tensor_symmetric_no_clipping_err(self):
         x = torch.tensor([[-5.0, -1.0, 0.0, 3.0], [-2.0, 0.0, 1.0, 4.0]])
         qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[torch.int16]
@@ -633,6 +654,28 @@ class TestQAT(TestCase):
             fake_quantizer(torch.tensor([[-4.0, 6.0]], dtype=input_dtype))
             self.assertEqual(fake_quantizer.min_val.dtype, torch.float32)
             self.assertEqual(fake_quantizer.max_val.dtype, torch.float32)
+
+    def test_fake_quantizer_static_asymmetric_calibration(self):
+        qmin, qmax = 0, 2**16 - 1
+        config = IntxFakeQuantizeConfig(
+            torch.int32,
+            PerTensor(),
+            MappingType.ASYMMETRIC,
+            is_dynamic=False,
+            eps=1e-9,
+            quant_min=qmin,
+            quant_max=qmax,
+        )
+        fake_quantizer = IntxFakeQuantizer(config)
+        fake_quantizer.enable_calibration()
+        fake_quantizer(torch.tensor([[1.0, 2.0]]))
+        fake_quantizer(torch.tensor([[3.0, 4.0]]))
+        fake_quantizer.finalize_calibration()
+
+        expected_scale = torch.tensor(4.0 / (qmax - qmin))
+        expected_zero_point = torch.tensor(0, dtype=torch.int32)
+        torch.testing.assert_close(fake_quantizer.scale, expected_scale)
+        torch.testing.assert_close(fake_quantizer.zero_point, expected_zero_point)
 
     @parametrize(
         "granularity,is_dynamic,range_learning",
@@ -1339,8 +1382,6 @@ class TestQAT(TestCase):
         """
         msg = "Unsupported dtype"
         with self.assertRaisesRegex(ValueError, msg):
-            IntxFakeQuantizeConfig(torch.int32, "per_token")
-        with self.assertRaisesRegex(ValueError, msg):
             IntxFakeQuantizeConfig(torch.bfloat16, "per_token")
         with self.assertRaisesRegex(ValueError, msg):
             IntxFakeQuantizeConfig(torch.float32, "per_token")
@@ -1363,6 +1404,32 @@ class TestQAT(TestCase):
         IntxFakeQuantizeConfig(torch.int8, "per_token")
         IntxFakeQuantizeConfig(torch.int16, "per_tensor")
 
+        with self.assertRaisesRegex(ValueError, "explicit quantization range"):
+            IntxFakeQuantizeConfig(torch.int32, "per_tensor")
+        IntxFakeQuantizeConfig(
+            torch.int32,
+            "per_tensor",
+            quant_min=0,
+            quant_max=2**16 - 1,
+        )
+
+    def test_fake_quantize_config_custom_range(self):
+        with self.assertRaisesRegex(ValueError, "must be set together"):
+            IntxFakeQuantizeConfig(torch.int16, "per_tensor", quant_min=0)
+        with self.assertRaisesRegex(ValueError, "invalid for dtype"):
+            IntxFakeQuantizeConfig(
+                torch.int16,
+                "per_tensor",
+                quant_min=0,
+                quant_max=2**16 - 1,
+            )
+        with self.assertRaisesRegex(ValueError, "only supported for per-tensor"):
+            IntxFakeQuantizeConfig(
+                torch.int32,
+                "per_token",
+                quant_min=0,
+                quant_max=2**16 - 1,
+            )
     def test_fake_quantize_config_dynamic_and_range_learning(self):
         """
         Test that `is_dynamic` and `range_learning` cannot both be set.
@@ -1721,13 +1788,27 @@ class TestQAT(TestCase):
         baseline_out = baseline_model(*x2)
         torch.testing.assert_close(out, baseline_out, atol=0, rtol=0)
 
-    def test_static_a16w4_qat_workflow(self):
-        activation_config = IntxFakeQuantizeConfig(
-            torch.int16,
-            PerTensor(),
-            MappingType.SYMMETRIC_NO_CLIPPING_ERR,
-            is_dynamic=False,
-        )
+    @parametrize(
+        "activation_mapping",
+        [MappingType.SYMMETRIC_NO_CLIPPING_ERR, MappingType.ASYMMETRIC],
+    )
+    def test_static_a16w4_qat_workflow(self, activation_mapping: MappingType):
+        if activation_mapping == MappingType.ASYMMETRIC:
+            activation_config = IntxFakeQuantizeConfig(
+                torch.int32,
+                PerTensor(),
+                activation_mapping,
+                is_dynamic=False,
+                quant_min=0,
+                quant_max=2**16 - 1,
+            )
+        else:
+            activation_config = IntxFakeQuantizeConfig(
+                torch.int16,
+                PerTensor(),
+                activation_mapping,
+                is_dynamic=False,
+            )
         weight_config = IntxFakeQuantizeConfig(
             torch.int4,
             PerGroup(2),

--- a/torchao/quantization/qat/fake_quantize_config.py
+++ b/torchao/quantization/qat/fake_quantize_config.py
@@ -25,6 +25,7 @@ from torchao.quantization.granularity import (
     PerToken,
 )
 from torchao.quantization.quant_primitives import (
+    _DTYPE_TO_QVALUE_BOUNDS,
     _SUB_BYTE_INT_BOUNDS,
     _SUB_BYTE_UINT_BOUNDS,
     MappingType,
@@ -105,7 +106,8 @@ class Int4WeightFakeQuantizeConfig(FakeQuantizeConfigBase):
 class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
     """
     Config for how to fake quantize weights or activations,
-    targeting integer dtypes up to torch.int16.
+    targeting integer dtypes up to torch.int16. torch.int32 can be used as a
+    carrier for a smaller explicit quantization range.
 
     Args:
         dtype: dtype to simulate during fake quantization, e.g. torch.int8.
@@ -134,6 +136,10 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
             can be set instead of `granularity`
         is_symmetric: whether to use symmetric or asymmetric quantization.
             Use `mapping_type` to select `MappingType.SYMMETRIC_NO_CLIPPING_ERR`.
+        quant_min: optional lower bound for the quantized values. Must be set
+            together with `quant_max`.
+        quant_max: optional upper bound for the quantized values. Explicit bounds
+            are required for torch.int32 and supported only for per-tensor granularity.
 
     Example usage::
 
@@ -155,6 +161,15 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         # Per tensor symmetric quantization
         IntxFakeQuantizeConfig(torch.int8, "per_tensor")
         IntxFakeQuantizeConfig(torch.int8, PerTensor())
+
+        # Per tensor asymmetric quantization with a logical uint16 range
+        IntxFakeQuantizeConfig(
+            torch.int32,
+            PerTensor(),
+            MappingType.ASYMMETRIC,
+            quant_min=0,
+            quant_max=2**16 - 1,
+        )
     """
 
     dtype: Union[torch.dtype, "TorchAODType"]
@@ -163,6 +178,8 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
     scale_precision: torch.dtype
     zero_point_precision: torch.dtype
     zero_point_domain: ZeroPointDomain
+    quant_min: int
+    quant_max: int
     is_dynamic: bool = True
     range_learning: bool = False
     eps: Optional[float] = None
@@ -181,6 +198,8 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         *,
         group_size: Optional[int] = None,
         is_symmetric: Optional[bool] = None,
+        quant_min: Optional[int] = None,
+        quant_max: Optional[int] = None,
     ):
         if zero_point_domain is None:
             raise ValueError("Please use ZeroPointDomain.NONE instead of None")
@@ -195,7 +214,7 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
         self.eps = eps
 
         # Validate dtype
-        all_dtypes = [torch.int8, torch.uint8, torch.int16]
+        all_dtypes = [torch.int8, torch.uint8, torch.int16, torch.int32]
         all_dtypes.extend(list(_SUB_BYTE_INT_BOUNDS.keys()))
         all_dtypes.extend(list(_SUB_BYTE_UINT_BOUNDS.keys()))
         if dtype not in all_dtypes:
@@ -210,6 +229,29 @@ class IntxFakeQuantizeConfig(FakeQuantizeConfigBase):
                 "MappingType.SYMMETRIC_NO_CLIPPING_ERR is not supported "
                 "for per-token quantization"
             )
+
+        has_custom_qrange = quant_min is not None or quant_max is not None
+        if (quant_min is None) != (quant_max is None):
+            raise ValueError("`quant_min` and `quant_max` must be set together")
+        if dtype == torch.int32 and not has_custom_qrange:
+            raise ValueError("torch.int32 requires an explicit quantization range")
+        if has_custom_qrange and not isinstance(self.granularity, PerTensor):
+            raise ValueError(
+                "An explicit quantization range is only supported for per-tensor quantization"
+            )
+
+        dtype_qmin, dtype_qmax = _DTYPE_TO_QVALUE_BOUNDS[dtype]
+        if quant_min is None:
+            quant_min, quant_max = dtype_qmin, dtype_qmax
+        else:
+            assert quant_max is not None
+        if not dtype_qmin <= quant_min < quant_max <= dtype_qmax:
+            raise ValueError(
+                "Quantization range [%s, %s] is invalid for dtype %s"
+                % (quant_min, quant_max, dtype)
+            )
+        self.quant_min = quant_min
+        self.quant_max = quant_max
 
         # Dynamic is not compatible with range learning
         if is_dynamic and range_learning:

--- a/torchao/quantization/qat/fake_quantizer.py
+++ b/torchao/quantization/qat/fake_quantizer.py
@@ -284,7 +284,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             or self.max_val.numel() == 0
         ):
             raise ValueError("No calibration data was collected")
-        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        qmin, qmax = self.config.quant_min, self.config.quant_max
         self.scale, self.zero_point = choose_qparams_affine_with_min_max(
             self.min_val,
             self.max_val,
@@ -373,7 +373,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         """
         if self.config.is_symmetric:
             raise NotImplementedError("Symmetric per token is not supported yet")
-        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        qmin, qmax = self.config.quant_min, self.config.quant_max
         if self._should_compute_qparams():
             self.scale, self.zero_point = choose_qparams_affine(
                 x,
@@ -429,7 +429,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             self.zero_point = self.zero_point.to(zero_point_precision)
             self._maybe_update_qparams_for_range_learning()
 
-        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        qmin, qmax = self.config.quant_min, self.config.quant_max
         return _fake_quantize_per_channel_group(
             x,
             self.scale,
@@ -454,7 +454,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
             x_grouped = x.reshape(x.shape[0], -1, group_size)
             min_val = torch.amin(x_grouped, dim=-1)
             max_val = torch.amax(x_grouped, dim=-1)
-            qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+            qmin, qmax = self.config.quant_min, self.config.quant_max
             return choose_qparams_affine_with_min_max(
                 min_val,
                 max_val,
@@ -479,7 +479,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
 
     def _per_tensor_forward(self, x: torch.Tensor) -> torch.Tensor:
         """Perform per-tensor fake quantization."""
-        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        qmin, qmax = self.config.quant_min, self.config.quant_max
         block_size = get_block_size(x.shape, self.config.granularity)
         if self._should_compute_qparams():
             self.scale, self.zero_point = choose_qparams_affine(
@@ -529,7 +529,7 @@ class IntxFakeQuantizer(FakeQuantizerBase):
         ):
             return
         scale, zero_point = self.scale, self.zero_point
-        qmin, qmax = _DTYPE_TO_QVALUE_BOUNDS[self.config.dtype]
+        qmin, qmax = self.config.quant_min, self.config.quant_max
         # Stabilize range learning
         scale = torch.clamp(scale, min=self._scale_eps)
         self.scale = torch.nn.Parameter(scale, requires_grad=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4891
* #4890
* #4889
* #4888
* #4887
* #4886
* #4885
* #4884
* #4883



The static A16W4 stack supports signed symmetric activations. Add an optional logical UINT16 asymmetric mode that:
- accepts explicit per-tensor quantization bounds through an INT32 carrier;
- uses zero-preserving range selection that matches current Quanty;
- applies the same behavior during direct fake quantization and calibration finalization; and
- covers the asymmetric calibration-to-training workflow in tests and documentation.

Existing configurations retain dtype-derived bounds and behavior.
@exported-using-ghexport

Differential Revision: [D117934172](https://our.internmc.facebook.com/intern/diff/D117934172/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D117934172/)!

Differential Revision: [D117934172](https://our.internmc.facebook.com/intern/diff/D117934172)